### PR TITLE
Fixes #33292 - modifications to enable ostree commit ref content uploads

### DIFF
--- a/app/controllers/katello/api/v2/content_uploads_controller.rb
+++ b/app/controllers/katello/api/v2/content_uploads_controller.rb
@@ -10,7 +10,7 @@ module Katello
     param :repository_id, :number, :required => true, :desc => N_("repository id")
     param :size, :number, :required => true, :desc => N_("Size of file to upload")
     param :checksum, String, :required => false, :desc => N_("Checksum of file to upload")
-    param :content_type, RepositoryTypeManager.uploadable_content_types(false).map(&:label), :required => false, :desc => N_("content type ('deb', 'docker_manifest', 'file', 'ostree', 'rpm', 'srpm')")
+    param :content_type, RepositoryTypeManager.uploadable_content_types(false).map(&:label), :required => false, :desc => N_("content type ('deb', 'docker_manifest', 'file', 'ostree_ref', 'rpm', 'srpm')")
     def create
       fail Katello::Errors::InvalidRepositoryContent, _("Cannot upload Ansible collections.") if @repository.ansible_collection?
       content_type = params[:content_type] || ::Katello::RepositoryTypeManager.find(@repository.content_type)&.default_managed_content_type&.label

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -421,10 +421,16 @@ module Katello
       end
 
       begin
+        upload_args = {
+          content_type: params[:content_type],
+          generate_metadata: generate_metadata,
+          sync_capsule: sync_capsule
+        }
+        upload_args.merge!(generic_content_type_import_upload_args)
+
         respond_for_async(resource: send(
           async ? :async_task : :sync_task,
-          ::Actions::Katello::Repository::ImportUpload, @repository, uploads,
-          generate_metadata: generate_metadata, sync_capsule: sync_capsule, content_type: params[:content_type]))
+          ::Actions::Katello::Repository::ImportUpload, @repository, uploads, upload_args))
       rescue => e
         raise HttpErrors::BadRequest, e.message
       end
@@ -615,6 +621,16 @@ module Katello
         generic_remote_options[option.name] = repo_params[option.name]
       end
       generic_remote_options
+    end
+
+    def generic_content_type_import_upload_args
+      args = {}
+      @repository.repository_type&.import_attributes&.collect do |import_attribute|
+        if params[import_attribute.api_param]
+          args[import_attribute.api_param] = params[import_attribute.api_param]
+        end
+      end
+      args
     end
 
     def check_import_parameters

--- a/app/lib/actions/pulp3/orchestration/repository/import_repository_upload.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/import_repository_upload.rb
@@ -1,0 +1,36 @@
+module Actions
+  module Pulp3
+    module Orchestration
+      module Repository
+        #Used for a different type of uploading where you are importing an entire repository, not a single content unit
+        # This workflow involves never actually creating a content unit directly, but instead importing the artifact directly into the repository
+        class ImportRepositoryUpload < Pulp3::Abstract
+          def plan(repository, smart_proxy, args)
+            file = {:filename => args.dig(:unit_key, :name), :sha256 => args.dig(:unit_key, :checksum) }
+            sequence do
+              upload_href = "/pulp/api/v3/uploads/#{args.dig(:upload_id)}/" if args.dig(:upload_id) && args.dig(:upload_id) != 'duplicate'
+              commit_output = plan_action(Pulp3::Repository::CommitUpload,
+                                          repository,
+                                          smart_proxy,
+                                          upload_href,
+                                          args.dig(:unit_key, :checksum)).output
+
+              artifact_output = plan_action(Pulp3::Repository::SaveArtifact,
+                                            file,
+                                            repository,
+                                            smart_proxy,
+                                            commit_output[:pulp_tasks],
+                                            args.dig(:unit_type_id), args).output
+              plan_self(:artifact_output => artifact_output)
+              plan_action(Pulp3::Repository::SaveVersion, repository, tasks: artifact_output[:pulp_tasks])
+            end
+          end
+
+          def run
+            output[:content_unit_href] = input[:artifact_output][:content_unit_href] || input[:artifact_output][:pulp_tasks].last[:created_resources].first
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/orchestration/repository/import_upload.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/import_upload.rb
@@ -33,7 +33,7 @@ module Actions
                                                 repository,
                                                 smart_proxy,
                                                 commit_output[:pulp_tasks],
-                                                args.dig(:unit_type_id)).output
+                                                args.dig(:unit_type_id), args).output
                 end
 
                 plan_self(:commit_output => commit_output[:pulp_tasks], :artifact_output => artifact_output)

--- a/app/lib/actions/pulp3/repository/commit_upload.rb
+++ b/app/lib/actions/pulp3/repository/commit_upload.rb
@@ -1,6 +1,7 @@
 module Actions
   module Pulp3
     module Repository
+      #Creates an artifacts
       class CommitUpload < Pulp3::AbstractAsyncTask
         def plan(repository, smart_proxy, upload_href, sha256)
           plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id, :upload_href => upload_href, :sha256 => sha256)
@@ -13,7 +14,7 @@ module Actions
           duplicate_sha_artifact_list = ::Katello::Pulp3::Api::Core.new(smart_proxy).artifacts_api.list("sha256": input[:sha256])
           duplicate_sha_artifact_href = duplicate_sha_artifact_list&.results&.first&.pulp_href
           if duplicate_sha_artifact_href
-            uploads_api.delete(input[:upload_href])
+            uploads_api.delete(input[:upload_href]) if input[:upload_href]
             output[:artifact_href] = duplicate_sha_artifact_href
             output[:pulp_tasks] = nil
           else

--- a/app/lib/actions/pulp3/repository/import_upload.rb
+++ b/app/lib/actions/pulp3/repository/import_upload.rb
@@ -4,10 +4,11 @@ module Actions
   module Pulp3
     module Repository
       class ImportUpload < Pulp3::AbstractAsyncTask
-        def plan(save_artifact_output, repository, smart_proxy)
+        def plan(save_artifact_output, repository, smart_proxy, options = {})
           plan_self(:save_artifact_output => save_artifact_output,
                     :repository_id => repository.id,
-                    :smart_proxy_id => smart_proxy.id)
+                    :smart_proxy_id => smart_proxy.id,
+                    :options => options)
         end
 
         def invoke_external_task
@@ -19,6 +20,7 @@ module Actions
 
           repo = ::Katello::Repository.find(input[:repository_id])
           repo_backend_service = repo.backend_service(smart_proxy)
+
           output[:content_unit_href] = content_unit_href
           output[:pulp_tasks] = [repo_backend_service.add_content(content_unit_href)]
         end

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -83,7 +83,6 @@ module Katello
     validate :ensure_valid_authentication_token, :if => :yum?
     validate :ensure_valid_deb_constraints, :if => :deb?
     validate :ensure_no_checksum_on_demand
-    validates :url, presence: true, if: :ostree?
     validates :checksum_type, :inclusion => {:in => CHECKSUM_TYPES}, :allow_blank => true
     validates :product_id, :presence => true
     validates :ostree_upstream_sync_policy, :inclusion => {:in => OSTREE_UPSTREAM_SYNC_POLICIES, :allow_blank => true}, :if => :ostree?

--- a/app/services/katello/pulp3/content.rb
+++ b/app/services/katello/pulp3/content.rb
@@ -9,7 +9,7 @@ module Katello
           if checksum
             content_backend_service = SmartProxy.pulp_primary.content_service(content_type)
             if repository&.generic?
-              content_list = content_backend_service.content_api(repository.repository_type, content_type).list("sha256": checksum)
+              content_list = content_backend_service.content_api(repository.repository_type, content_type).list('sha256': checksum)
             else
               content_list = content_backend_service.content_api.list("sha256": checksum)
             end

--- a/app/services/katello/pulp3/pulp_content_unit.rb
+++ b/app/services/katello/pulp3/pulp_content_unit.rb
@@ -116,24 +116,30 @@ module Katello
         content_unit_list page_opts
       end
 
+      # rubocop:disable Lint/UselessAssignment
       def self.find_duplicate_unit(repository, unit_type_id, file, checksum)
+        filter_label = 'sha256'
+        if unit_type_id == 'ostree_ref'
+          filter_label = 'checksum'
+        end
         content_backend_service = SmartProxy.pulp_primary.content_service(unit_type_id)
         duplicates_allowed = ::Katello::RepositoryTypeManager.find_content_type(unit_type_id).try(:duplicates_allowed)
         if repository.generic? && duplicates_allowed
           filename_key = ::Katello::RepositoryTypeManager.find_content_type(unit_type_id).filename_key
           duplicate_sha_path_content_list = content_backend_service.content_api(repository.repository_type, unit_type_id).list(
-            "sha256": checksum,
+            filter_label: checksum,
             filename_key => file[:filename])
         elsif repository.generic?
           duplicate_sha_path_content_list = content_backend_service.content_api(repository.repository_type, unit_type_id).list(
-            "sha256": checksum)
+            filter_label: checksum)
         else
           duplicate_sha_path_content_list = content_backend_service.content_api.list(
-            "sha256": checksum,
+            filter_label: checksum,
             "relative_path": file[:filename])
         end
         duplicate_sha_path_content_list
       end
+      # rubocop:enable Lint/UselessAssignment
     end
   end
 end

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -478,6 +478,15 @@ module Katello
         end
       end
 
+      def repository_import_content(artifact_href, options = {})
+        ostree_import = PulpOstreeClient::OstreeRepoImport.new
+        ostree_import.artifact = artifact_href
+        ostree_import.repository_name = options[:ostree_repository_name]
+        ostree_import.ref = options[:ostree_ref]
+        ostree_import.parent_commit = options[:ostree_parent_commit]
+        api.repositories_api.import_commits(repository_reference.repository_href, ostree_import)
+      end
+
       def add_content(content_unit_href, remove_all_units = false)
         content_unit_href = [content_unit_href] unless content_unit_href.is_a?(Array)
         if remove_all_units

--- a/app/services/katello/repository_type.rb
+++ b/app/services/katello/repository_type.rb
@@ -145,7 +145,7 @@ module Katello
 
     class ContentType
       attr_accessor :model_class, :priority, :pulp2_service_class, :pulp3_service_class, :index, :uploadable, :removable,
-                    :primary_content, :index_on_pulp3, :generic_browser, :content_type
+                    :primary_content, :index_on_pulp3, :generic_browser, :content_type, :repository_import_on_upload
 
       def initialize(options)
         self.model_class = options[:model_class]
@@ -159,6 +159,7 @@ module Katello
         self.removable = options[:removable] || false
         self.primary_content = options[:primary_content] || false
         self.generic_browser = options[:generic_browser]
+        self.repository_import_on_upload = options[:repository_import_on_upload]
       end
 
       def label

--- a/lib/katello/repository_types/ostree.rb
+++ b/lib/katello/repository_types/ostree.rb
@@ -26,7 +26,9 @@ Katello::RepositoryTypeManager.register('ostree') do
                        pulp3_api: PulpOstreeClient::ContentRefsApi,
                        pulp3_service_class: Katello::Pulp3::GenericContentUnit,
                        model_name: lambda { |pulp_unit| pulp_unit["name"] },
-                       model_version: lambda { |pulp_unit| pulp_unit["version"] }
+                       model_version: lambda { |pulp_unit| pulp_unit["checksum"] },
+                       uploadable: true,
+                       repository_import_on_upload: true
 
   import_attribute :ref, :content_type => 'ostree_ref',
                         :api_param => :ostree_ref,

--- a/test/actions/katello/repository/import_upload_test.rb
+++ b/test/actions/katello/repository/import_upload_test.rb
@@ -20,7 +20,8 @@ module Actions
         unit_type_id: repo.unit_type_id,
         unit_key: upload.except('id'),
         upload_id: '1',
-        unit_metadata: nil
+        unit_metadata: nil,
+        content_type: 'rpm'
       }
 
       assert_action_planed_with(action, pulp3_import_class,

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -399,7 +399,10 @@ module ::Actions::Katello::Repository
         unit_type_id: 'docker_manifest',
         unit_key: {'size' => '12333', 'checksum' => 'asf23421324', 'name' => 'test'},
         upload_id: 1,
-        unit_metadata: nil
+        unit_metadata: nil,
+        generate_metadata: true,
+        sync_capsule: true,
+        content_type: 'docker_manifest'
       }
       assert_action_planned_with(action, ::Actions::Pulp3::Orchestration::Repository::ImportUpload,
                                  docker_repository, SmartProxy.pulp_primary,
@@ -422,7 +425,10 @@ module ::Actions::Katello::Repository
         unit_type_id: 'docker_tag',
         unit_key: unit_keys[0],
         upload_id: 1,
-        unit_metadata: unit_keys[0]
+        unit_metadata: unit_keys[0],
+        generate_metadata: true,
+        sync_capsule: true,
+        content_type: 'docker_tag'
       }
       assert_action_planned_with(action, ::Actions::Pulp3::Orchestration::Repository::ImportUpload,
                                  docker_repository, SmartProxy.pulp_primary,

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,11 +10,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -22,535 +22,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:17 GMT
+      - Wed, 17 Nov 2021 12:11:58 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '568'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - '06824674edf542f1a2cbe3af45d6bcf8'
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzczMWRmY2Y3LWI3NTAtNDVmZC1iYWI2LWM5YzJjMzhjOWI1
-        OC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2VDE4OjAxOjU3Ljk4MTE4
-        MVoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvNzMxZGZjZjctYjc1MC00NWZkLWJhYjYtYzljMmMzOGM5
-        YjU4L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
-        b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzczMWRmY2Y3LWI3NTAtNDVmZC1iYWI2LWM5YzJjMzhjOWI1OC92ZXJzaW9u
-        cy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15
-        X0ZpbGVzIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNp
-        b25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwi
-        bWFuaWZlc3QiOiJQVUxQX01BTklGRVNUIn1dfQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:17 GMT
-- request:
-    method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/file/file/731dfcf7-b750-45fd-bab6-c9c2c38c9b58/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:17 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - a50235f171d64697a0199c7fbcf43d94
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRhZGNkMzFmLTVhNjEtNDI2
-        Yi1iZWZkLTEwNTZmNjdkODIyZC8ifQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:17 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:18 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '666'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - ea305e43f9cf422ebdec80f815d3d3f9
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUv
-        ZmlsZS9iZWNlNWEyMS03YWYwLTQ0YzQtODAwNC00MDJjNTM4ZjM0ZjAvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxODowMTo1Ny42NDIwODNaIiwi
-        bmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMi
-        LCJ1cmwiOiJodHRwOi8vdGVzdC90ZXN0Ly9QVUxQX01BTklGRVNUIiwiY2Ff
-        Y2VydCI6IktKTDpLREYqKERGJiooKiQmKCojJEpMS0pEKEQoKEQiLCJjbGll
-        bnRfY2VydCI6IktKTDpLREYqKERGJiooKiQmKCojJEpMS0pEKEQoKEQiLCJ0
-        bHNfdmFsaWRhdGlvbiI6ZmFsc2UsInByb3h5X3VybCI6bnVsbCwicHVscF9s
-        YWJlbHMiOnt9LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjEtMTAtMDZUMTg6
-        MDI6MDEuMDYzNDMzWiIsImRvd25sb2FkX2NvbmN1cnJlbmN5IjpudWxsLCJt
-        YXhfcmV0cmllcyI6bnVsbCwicG9saWN5IjoiaW1tZWRpYXRlIiwidG90YWxf
-        dGltZW91dCI6MzAwLjAsImNvbm5lY3RfdGltZW91dCI6bnVsbCwic29ja19j
-        b25uZWN0X3RpbWVvdXQiOm51bGwsInNvY2tfcmVhZF90aW1lb3V0IjpudWxs
-        LCJoZWFkZXJzIjpudWxsLCJyYXRlX2xpbWl0IjpudWxsfV19
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:18 GMT
-- request:
-    method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/remotes/file/file/bece5a21-7af0-44c4-8004-402c538f34f0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:18 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 97f919fdd286415cb0c1e00388e4dfe4
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZjM2IwODBkLTNkMTgtNDhm
-        NS1hMjM2LWI1MDE4MWY4MDBjMS8ifQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:18 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/4adcd31f-5a61-426b-befd-1056f67d822d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.15.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:18 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '609'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 736fe4393fad4d6c95bb78eaab4cc779
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGFkY2QzMWYtNWE2
-        MS00MjZiLWJlZmQtMTA1NmY2N2Q4MjJkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDI6MTcuNzI2NTYwWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJhNTAyMzVmMTcxZDY0Njk3YTAxOTljN2Zi
-        Y2Y0M2Q5NCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTEwLTA2VDE4OjAyOjE3Ljc3
-        NzIzMloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDI6MTcuODgw
-        MDkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wNWU2ZDdmNC1iNTY0LTRlNzMtODJlYi0xNWI1MGE1MTI0YTMvIiwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS83MzFkZmNmNy1iNzUwLTQ1
-        ZmQtYmFiNi1jOWMyYzM4YzliNTgvIl19
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:18 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/fc3b080d-3d18-48f5-a236-b50181f800c1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.15.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:18 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '604'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 20636bf38e014bf796802072466f90a1
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmMzYjA4MGQtM2Qx
-        OC00OGY1LWEyMzYtYjUwMTgxZjgwMGMxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDI6MTguMjI0Mjg1WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5N2Y5MTlmZGQyODY0MTVjYjBjMWUwMDM4
-        OGU0ZGZlNCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTEwLTA2VDE4OjAyOjE4LjI2
-        OTE5MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDI6MTguMzA3
-        OTMzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy82YjcxM2NhNS1lMWZiLTQ3OWEtODZhMy04NWVkMTFiMzkzZmIvIiwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvYmVjZTVhMjEtN2FmMC00NGM0LTgw
-        MDQtNDAyYzUzOGYzNGYwLyJdfQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:18 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:19 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '553'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - d5f7b08687e6408495727f8d74aba568
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS9lYTEyMTA3Ny04YjJjLTRlZTEtYWE1Zi1lZTgwZDM2ZTUx
-        YTIvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxODowMTo1OS40MDEy
-        MTRaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
-        eS9NeV9GaWxlcyIsImJhc2VfdXJsIjoiaHR0cHM6Ly9wdWxwMy1zYW5kYm94
-        LWNlbnRvczcuYmFsbW9yYS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVm
-        YXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9NeV9GaWxlcy8iLCJjb250ZW50
-        X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMvY2VydGd1YXJk
-        L3Joc20vMDlmMThkODItZDRhOC00MDYxLWI3NjctMTYzOGUzMDFhNTFjLyIs
-        InB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9u
-        LUNhYmluZXQtTXlfRmlsZXMiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNh
-        dGlvbiI6bnVsbH1dfQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:19 GMT
-- request:
-    method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/distributions/file/file/ea121077-8b2c-4ee1-aa5f-ee80d36e51a2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:19 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - f7ec1b0543a64bb39bb2f9643397f565
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzljMTE1Y2Y3LTg2MjYtNGNi
-        MS1iNTRkLTE4ODhmZDAxYmJiNC8ifQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:19 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:19 GMT
-      Content-Type:
-      - application/json
       Content-Length:
       - '52'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4d2338dff49d4615bf62fbb11cb171ec
+      - bf37ef4ee7ff4b1cae39088beb022958
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:19 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:58 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/9c115cf7-8626-4cb1-b54d-1888fd01bbb4/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -558,11 +63,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.15.2/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -570,53 +75,146 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:19 GMT
+      - Wed, 17 Nov 2021 12:11:58 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '558'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 05bee32830e247d0a628bccfe5fad63b
+      - 9e4f28acc34f459d9be6b5d324f5ba7f
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWMxMTVjZjctODYy
-        Ni00Y2IxLWI1NGQtMTg4OGZkMDFiYmI0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDI6MTkuMjMxNjIyWiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJmN2VjMWIwNTQzYTY0YmIzOWJiMmY5NjQz
-        Mzk3ZjU2NSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTEwLTA2VDE4OjAyOjE5LjI3
-        NDU4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDI6MTkuMzE5
-        NTA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wNWU2ZDdmNC1iNTY0LTRlNzMtODJlYi0xNWI1MGE1MTI0YTMvIiwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
-        L2Rpc3RyaWJ1dGlvbnMvIl19
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:19 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:58 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:11:58 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 29683e327c6d4ac195598932f3cb9482
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:11:58 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:11:58 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 771c1c23776e4011a07dc489510f8f33
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:11:58 GMT
 - request:
     method: post
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -630,11 +228,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -642,55 +240,53 @@ http_interactions:
       code: 201
       message: Created
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:20 GMT
+      - Wed, 17 Nov 2021 12:11:58 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '555'
-      Connection:
-      - keep-alive
       Location:
-      - "/pulp/api/v3/remotes/file/file/4f1db236-88f4-4089-8443-95ef87033a1a/"
+      - "/pulp/api/v3/remotes/file/file/3106df79-c33b-49a8-b98e-69974c358346/"
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '555'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ed3d8020e8af4254a86b24f14936abdd
+      - e9c4863230394b1cba3bd9ac32d8ae74
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        NGYxZGIyMzYtODhmNC00MDg5LTg0NDMtOTVlZjg3MDMzYTFhLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjEtMTAtMDZUMTg6MDI6MjAuMDA4NTI2WiIsIm5hbWUi
+        MzEwNmRmNzktYzMzYi00OWE4LWI5OGUtNjk5NzRjMzU4MzQ2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjEtMTEtMTdUMTI6MTE6NTguNjAyOTY1WiIsIm5hbWUi
         OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwidXJs
         IjoiaHR0cDovL3Rlc3QvdGVzdC8vUFVMUF9NQU5JRkVTVCIsImNhX2NlcnQi
         Om51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1
         ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFz
-        dF91cGRhdGVkIjoiMjAyMS0xMC0wNlQxODowMjoyMC4wMDg1NDRaIiwiZG93
+        dF91cGRhdGVkIjoiMjAyMS0xMS0xN1QxMjoxMTo1OC42MDI5ODhaIiwiZG93
         bmxvYWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJw
         b2xpY3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozMDAuMCwiY29u
         bmVjdF90aW1lb3V0IjpudWxsLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6bnVs
         bCwic29ja19yZWFkX3RpbWVvdXQiOm51bGwsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOm51bGx9
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:20 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:58 GMT
 - request:
     method: post
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/file/file/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -700,11 +296,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -712,54 +308,52 @@ http_interactions:
       code: 201
       message: Created
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:20 GMT
+      - Wed, 17 Nov 2021 12:11:58 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '516'
-      Connection:
-      - keep-alive
       Location:
-      - "/pulp/api/v3/repositories/file/file/8da64df8-4176-49d4-85a0-9df37da28f36/"
+      - "/pulp/api/v3/repositories/file/file/826ead8c-0bee-4bb5-b8a2-00fe1af3d2c4/"
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '516'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1e28489e2b7445d9998009bad4a97876
+      - ec656836ed6d4d7c8dfe8f158ac80274
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS84ZGE2NGRmOC00MTc2LTQ5ZDQtODVhMC05ZGYzN2RhMjhmMzYvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxODowMjoyMC4zODc4OTZaIiwi
+        ZmlsZS84MjZlYWQ4Yy0wYmVlLTRiYjUtYjhhMi0wMGZlMWFmM2QyYzQvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xN1QxMjoxMTo1OC43NjY1NzNaIiwi
         dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlLzhkYTY0ZGY4LTQxNzYtNDlkNC04NWEwLTlkZjM3ZGEyOGYzNi92
+        ZS9maWxlLzgyNmVhZDhjLTBiZWUtNGJiNS1iOGEyLTAwZmUxYWYzZDJjNC92
         ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30sImxhdGVzdF92ZXJzaW9uX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS84ZGE2
-        NGRmOC00MTc2LTQ5ZDQtODVhMC05ZGYzN2RhMjhmMzYvdmVyc2lvbnMvMC8i
+        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS84MjZl
+        YWQ4Yy0wYmVlLTRiYjUtYjhhMi0wMGZlMWFmM2QyYzQvdmVyc2lvbnMvMC8i
         LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
         cyIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6
         bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1hbmlm
         ZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:20 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:58 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/file/file/8da64df8-4176-49d4-85a0-9df37da28f36/versions/2/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/826ead8c-0bee-4bb5-b8a2-00fe1af3d2c4/versions/2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -767,11 +361,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -779,18 +373,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:23 GMT
+      - Wed, 17 Nov 2021 12:12:00 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '666'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -800,34 +390,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ddee1a44d1204d9292307d04260923d1
+      - 96e876443d974d06bf9cf18da2d5f604
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '248'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS84ZGE2NGRmOC00MTc2LTQ5ZDQtODVhMC05ZGYzN2RhMjhmMzYvdmVy
-        c2lvbnMvMi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2VDE4OjAyOjIy
-        LjYxNDQyOFoiLCJudW1iZXIiOjIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS84ZGE2NGRmOC00MTc2LTQ5ZDQt
-        ODVhMC05ZGYzN2RhMjhmMzYvIiwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250
+        ZmlsZS84MjZlYWQ4Yy0wYmVlLTRiYjUtYjhhMi0wMGZlMWFmM2QyYzQvdmVy
+        c2lvbnMvMi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTE3VDEyOjEyOjAw
+        LjI0MjQ5MVoiLCJudW1iZXIiOjIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkv
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS84MjZlYWQ4Yy0wYmVlLTRiYjUt
+        YjhhMi0wMGZlMWFmM2QyYzQvIiwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250
         ZW50X3N1bW1hcnkiOnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50Ijox
         LCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVw
         b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
-        ZXMvZmlsZS9maWxlLzhkYTY0ZGY4LTQxNzYtNDlkNC04NWEwLTlkZjM3ZGEy
-        OGYzNi92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsi
+        ZXMvZmlsZS9maWxlLzgyNmVhZDhjLTBiZWUtNGJiNS1iOGEyLTAwZmUxYWYz
+        ZDJjNC92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsi
         ZmlsZS5maWxlIjp7ImNvdW50IjoyLCJocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
         bnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzhkYTY0ZGY4LTQxNzYtNDlk
-        NC04NWEwLTlkZjM3ZGEyOGYzNi92ZXJzaW9ucy8yLyJ9fX19
+        aS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzgyNmVhZDhjLTBiZWUtNGJi
+        NS1iOGEyLTAwZmUxYWYzZDJjNC92ZXJzaW9ucy8yLyJ9fX19
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:23 GMT
+  recorded_at: Wed, 17 Nov 2021 12:12:00 GMT
 - request:
     method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/remotes/file/file/4f1db236-88f4-4089-8443-95ef87033a1a/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/3106df79-c33b-49a8-b98e-69974c358346/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -835,11 +427,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -847,40 +439,40 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:23 GMT
+      - Wed, 17 Nov 2021 12:12:01 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '67'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9ad31f66d17446be9aa3e2c0660eba88
+      - 2ad2ca9e63ff4b6ba920d2e8ddc06f74
       Access-Control-Expose-Headers:
       - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FiMWY5ZTViLWM0YzMtNGI0
-        Yi1hYmFiLWE2Y2NiYWMwYzhiOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M4M2IzNzY0LWMyNTAtNDQ0
+        Mi1hZDZiLTA3MDJhNTExOWE3Mi8ifQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:23 GMT
+  recorded_at: Wed, 17 Nov 2021 12:12:01 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/ab1f9e5b-c4c3-4b4b-abab-a6ccbac0c8b9/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/c83b3764-c250-4442-ad6b-0702a5119a72/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -892,7 +484,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -900,18 +492,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:23 GMT
+      - Wed, 17 Nov 2021 12:12:01 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '604'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -921,33 +509,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - caaf2557d4cd416caa96b14137b742df
+      - 63837c2b5e2249df8a5cf57f37b722f0
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '372'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWIxZjllNWItYzRj
-        My00YjRiLWFiYWItYTZjY2JhYzBjOGI5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDI6MjMuNjY4NTg3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzgzYjM3NjQtYzI1
+        MC00NDQyLWFkNmItMDcwMmE1MTE5YTcyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTdUMTI6MTI6MDEuMDkyOTI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5YWQzMWY2NmQxNzQ0NmJlOWFhM2UyYzA2
-        NjBlYmE4OCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTEwLTA2VDE4OjAyOjIzLjcx
-        NzAxMloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDI6MjMuNzY3
-        NzE5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy82YjcxM2NhNS1lMWZiLTQ3OWEtODZhMy04NWVkMTFiMzkzZmIvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyYWQyY2E5ZTYzZmY0YjZiYTkyMGQyZThk
+        ZGMwNmY3NCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE3VDEyOjEyOjAxLjE1
+        NTQ0OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTdUMTI6MTI6MDEuMjEy
+        NTgzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy80OTAwMjhmYy1lM2I4LTRhYmYtYjA4ZC05ZDc3MDcwZTg2Y2IvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvNGYxZGIyMzYtODhmNC00MDg5LTg0
-        NDMtOTVlZjg3MDMzYTFhLyJdfQ==
+        cGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvMzEwNmRmNzktYzMzYi00OWE4LWI5
+        OGUtNjk5NzRjMzU4MzQ2LyJdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:23 GMT
+  recorded_at: Wed, 17 Nov 2021 12:12:01 GMT
 - request:
     method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/file/file/8da64df8-4176-49d4-85a0-9df37da28f36/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/826ead8c-0bee-4bb5-b8a2-00fe1af3d2c4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -955,11 +545,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -967,40 +557,40 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:24 GMT
+      - Wed, 17 Nov 2021 12:12:01 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '67'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ae356b967e2f4d4b9aae53a2b681620c
+      - ddb1cdf9aac448caaca65d9c0112d90f
       Access-Control-Expose-Headers:
       - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkxZjhkMWU0LTRiODYtNGU0
-        NC1hOTY5LWViYjZhNWEyYjhhNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUwODZhODA3LWQ2ZjAtNGM4
+        YS1iNmIyLWU1ZWQzOGJkMDhhYS8ifQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:24 GMT
+  recorded_at: Wed, 17 Nov 2021 12:12:01 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/91f8d1e4-4b86-4e44-a969-ebb6a5a2b8a5/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/5086a807-d6f0-4c8a-b6b2-e5ed38bd08aa/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1012,7 +602,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1020,18 +610,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:24 GMT
+      - Wed, 17 Nov 2021 12:12:01 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '609'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1041,33 +627,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7275975968414ee49d1b95b78dd2f7b4
+      - 3d048a53f79045dd8156871abe15e6d6
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '371'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTFmOGQxZTQtNGI4
-        Ni00ZTQ0LWE5NjktZWJiNmE1YTJiOGE1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDI6MjQuMjI5NjY0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTA4NmE4MDctZDZm
+        MC00YzhhLWI2YjItZTVlZDM4YmQwOGFhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTdUMTI6MTI6MDEuNDAxNjU4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJhZTM1NmI5NjdlMmY0ZDRiOWFhZTUzYTJi
-        NjgxNjIwYyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTEwLTA2VDE4OjAyOjI0LjI3
-        NzgxOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDI6MjQuMzMx
-        MDYyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wNWU2ZDdmNC1iNTY0LTRlNzMtODJlYi0xNWI1MGE1MTI0YTMvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkZGIxY2RmOWFhYzQ0OGNhYWNhNjVkOWMw
+        MTEyZDkwZiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE3VDEyOjEyOjAxLjQ2
+        NDMyNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTdUMTI6MTI6MDEuNTQ1
+        Mzc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy80OTAwMjhmYy1lM2I4LTRhYmYtYjA4ZC05ZDc3MDcwZTg2Y2IvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS84ZGE2NGRmOC00MTc2LTQ5
-        ZDQtODVhMC05ZGYzN2RhMjhmMzYvIl19
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS84MjZlYWQ4Yy0wYmVlLTRi
+        YjUtYjhhMi0wMGZlMWFmM2QyYzQvIl19
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:24 GMT
+  recorded_at: Wed, 17 Nov 2021 12:12:01 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1075,11 +663,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.15.0/ruby
+      - OpenAPI-Generator/2.15.1/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1087,248 +675,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:24 GMT
+      - Wed, 17 Nov 2021 12:12:01 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '673'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 1738650f5dcd4e9d8e595f2884461ff6
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yNGU3MzlkNS1hMTc0LTRjMGYtODE4ZS0yMGY5Y2Q5MTlhMmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxODowMDo0OC4zMzM1MDFa
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yNGU3MzlkNS1hMTc0LTRjMGYtODE4ZS0yMGY5Y2Q5MTlhMmIv
-        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzI0ZTcz
-        OWQ1LWExNzQtNGMwZi04MThlLTIwZjljZDkxOWEyYi92ZXJzaW9ucy8yLyIs
-        Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
-        cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
-        ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
-        a2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVs
-        bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
-        cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:24 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/24e739d5-a174-4c0f-818e-20f9cd919a2b/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:25 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '3808'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 6279728dfc5248ce8150ed43a2cb3f37
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yNGU3MzlkNS1hMTc0LTRjMGYtODE4ZS0yMGY5Y2Q5MTlhMmIv
-        dmVyc2lvbnMvMi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2VDE4OjAw
-        OjU1Ljc0NDA5M1oiLCJudW1iZXIiOjIsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjRlNzM5ZDUtYTE3NC00YzBm
-        LTgxOGUtMjBmOWNkOTE5YTJiLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5hZHZpc29yeSI6eyJjb3Vu
-        dCI6NSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzI0ZTczOWQ1LWExNzQtNGMwZi04MThlLTIw
-        ZjljZDkxOWEyYi92ZXJzaW9ucy8yLyJ9LCJycG0uZGlzdHJpYnV0aW9uX3Ry
-        ZWUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vZGlzdHJpYnV0aW9uX3RyZWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRk
-        ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzI0ZTczOWQ1
-        LWExNzQtNGMwZi04MThlLTIwZjljZDkxOWEyYi92ZXJzaW9ucy8yLyJ9LCJy
-        cG0ubW9kdWxlbWQiOnsiY291bnQiOjYsImhyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vbW9kdWxlbWRzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRk
-        ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzI0ZTczOWQ1
-        LWExNzQtNGMwZi04MThlLTIwZjljZDkxOWEyYi92ZXJzaW9ucy8yLyJ9LCJy
-        cG0ucGFja2FnZSI6eyJjb3VudCI6MjAsImhyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vcGFja2FnZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRl
-        ZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjRlNzM5ZDUt
-        YTE3NC00YzBmLTgxOGUtMjBmOWNkOTE5YTJiL3ZlcnNpb25zLzIvIn0sInJw
-        bS5wYWNrYWdlZ3JvdXAiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZWdyb3Vwcy8/cmVwb3NpdG9yeV92ZXJz
-        aW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8y
-        NGU3MzlkNS1hMTc0LTRjMGYtODE4ZS0yMGY5Y2Q5MTlhMmIvdmVyc2lvbnMv
-        Mi8ifSwicnBtLnJlcG9fbWV0YWRhdGFfZmlsZSI6eyJjb3VudCI6MSwiaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9yZXBvX21ldGFkYXRhX2Zp
-        bGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzI0ZTczOWQ1LWExNzQtNGMwZi04MThlLTIw
-        ZjljZDkxOWEyYi92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnsicnBtLmFkdmlzb3J5Ijp7ImNvdW50Ijo1LCJocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvP3JlcG9zaXRvcnlfdmVy
-        c2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjRlNzM5
-        ZDUtYTE3NC00YzBmLTgxOGUtMjBmOWNkOTE5YTJiL3ZlcnNpb25zLzIvIn0s
-        InJwbS5kaXN0cmlidXRpb25fdHJlZSI6eyJjb3VudCI6MSwiaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9kaXN0cmlidXRpb25fdHJlZXMvP3Jl
-        cG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3Jw
-        bS9ycG0vMjRlNzM5ZDUtYTE3NC00YzBmLTgxOGUtMjBmOWNkOTE5YTJiL3Zl
-        cnNpb25zLzIvIn0sInJwbS5tb2R1bGVtZCI6eyJjb3VudCI6NiwiaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvP3JlcG9zaXRv
-        cnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0v
-        MjRlNzM5ZDUtYTE3NC00YzBmLTgxOGUtMjBmOWNkOTE5YTJiL3ZlcnNpb25z
-        LzIvIn0sInJwbS5wYWNrYWdlIjp7ImNvdW50IjoyMCwiaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8/cmVwb3NpdG9yeV92ZXJz
-        aW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yNGU3Mzlk
-        NS1hMTc0LTRjMGYtODE4ZS0yMGY5Y2Q5MTlhMmIvdmVyc2lvbnMvMi8ifSwi
-        cnBtLnBhY2thZ2VlbnZpcm9ubWVudCI6eyJjb3VudCI6MSwiaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlZW52aXJvbm1lbnRzLz9y
-        ZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
-        cG0vcnBtLzI0ZTczOWQ1LWExNzQtNGMwZi04MThlLTIwZjljZDkxOWEyYi92
-        ZXJzaW9ucy8yLyJ9LCJycG0ucGFja2FnZWdyb3VwIjp7ImNvdW50IjoxLCJo
-        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMv
-        P3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
-        L3JwbS9ycG0vMjRlNzM5ZDUtYTE3NC00YzBmLTgxOGUtMjBmOWNkOTE5YTJi
-        L3ZlcnNpb25zLzIvIn0sInJwbS5yZXBvX21ldGFkYXRhX2ZpbGUiOnsiY291
-        bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19t
-        ZXRhZGF0YV9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yNGU3MzlkNS1hMTc0LTRjMGYtODE4
-        ZS0yMGY5Y2Q5MTlhMmIvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yNGU3MzlkNS1h
-        MTc0LTRjMGYtODE4ZS0yMGY5Y2Q5MTlhMmIvdmVyc2lvbnMvMS8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDIxLTEwLTA2VDE4OjAwOjU1LjM5NTcwOFoiLCJudW1i
-        ZXIiOjEsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
-        L3JwbS9ycG0vMjRlNzM5ZDUtYTE3NC00YzBmLTgxOGUtMjBmOWNkOTE5YTJi
-        LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
-        ZGVkIjp7InJwbS5wYWNrYWdlZW52aXJvbm1lbnQiOnsiY291bnQiOjEsImhy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZWVudmlyb25t
-        ZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvcnBtL3JwbS8yNGU3MzlkNS1hMTc0LTRjMGYtODE4ZS0y
-        MGY5Y2Q5MTlhMmIvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9LCJwcmVz
-        ZW50Ijp7InJwbS5wYWNrYWdlZW52aXJvbm1lbnQiOnsiY291bnQiOjEsImhy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZWVudmlyb25t
-        ZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvcnBtL3JwbS8yNGU3MzlkNS1hMTc0LTRjMGYtODE4ZS0yMGY5Y2Q5
-        MTlhMmIvdmVyc2lvbnMvMS8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8yNGU3MzlkNS1hMTc0LTRjMGYt
-        ODE4ZS0yMGY5Y2Q5MTlhMmIvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQi
-        OiIyMDIxLTEwLTA2VDE4OjAwOjQ4LjMzNjgxMVoiLCJudW1iZXIiOjAsInJl
-        cG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0v
-        MjRlNzM5ZDUtYTE3NC00YzBmLTgxOGUtMjBmOWNkOTE5YTJiLyIsImJhc2Vf
-        dmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwi
-        cmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:25 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:25 GMT
-      Content-Type:
-      - application/json
       Content-Length:
       - '52'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e35b40a5dcce46fda7fbf0ddd296b585
+      - cad65200a7164748acb2397de75a96be
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:25 GMT
+  recorded_at: Wed, 17 Nov 2021 12:12:01 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1336,11 +716,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.2/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1348,53 +728,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:25 GMT
+      - Wed, 17 Nov 2021 12:12:01 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '559'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d826f2d1a8d24e358757eb763f311cad
+      - 42de3fa4dc7b498eb1c57770316c8614
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi85MDExZGVmZS02MjlkLTRmYzAtYWU0MC1jNjk4NjI5
-        YmVjMmEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxNzo0ODoyOC4w
-        MzkyODNaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvcHl0aG9uL3B5dGhvbi85MDExZGVmZS02MjlkLTRmYzAtYWU0MC1j
-        Njk4NjI5YmVjMmEvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
-        c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9w
-        eXRob24vcHl0aG9uLzkwMTFkZWZlLTYyOWQtNGZjMC1hZTQwLWM2OTg2Mjli
-        ZWMyYS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlv
-        bi1DYWJpbmV0LXB1bHAzX1B5dGhvbl8xIiwiZGVzY3JpcHRpb24iOm51bGws
-        InJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1
-        dG9wdWJsaXNoIjpmYWxzZX1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:25 GMT
+  recorded_at: Wed, 17 Nov 2021 12:12:01 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/python/python/9011defe-629d-4fc0-ae40-c698629bec2a/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1406,7 +773,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1414,49 +781,93 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:25 GMT
+      - Wed, 17 Nov 2021 12:12:01 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '382'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
-      - GET, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3a378f50438a4c3f862f930a41d8d1ef
+      - 71dac187f6ed49a2848e06647392a8c6
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi85MDExZGVmZS02MjlkLTRmYzAtYWU0MC1jNjk4NjI5
-        YmVjMmEvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2
-        VDE3OjQ4OjI4LjA0MjE3NVoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vOTAxMWRl
-        ZmUtNjI5ZC00ZmMwLWFlNDAtYzY5ODYyOWJlYzJhLyIsImJhc2VfdmVyc2lv
-        biI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3Zl
-        ZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:25 GMT
+  recorded_at: Wed, 17 Nov 2021 12:12:01 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.9.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:12:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0ab1995cca844aca8e636778aedca3bc
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:12:02 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1468,7 +879,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1476,42 +887,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:26 GMT
+      - Wed, 17 Nov 2021 12:12:02 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 26ca417d48314c47bfe05afe2a6ae657
+      - af196cbef3704523ba6e661d1eae3b85
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:26 GMT
+  recorded_at: Wed, 17 Nov 2021 12:12:02 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1519,11 +928,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.15.0/ruby
+      - OpenAPI-Generator/3.15.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1531,18 +940,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:26 GMT
+      - Wed, 17 Nov 2021 12:12:02 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '498'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1552,225 +957,65 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 86acb1f8e9d14b2b927b2b3cf457b661
+      - 05b3e4bbb1c34b318574c84c438663cb
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '459'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZGViL2FwdC8xY2VjYTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4N2Uv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxODowMToxNy4xNjIzMjVa
+        cnBtL3JwbS82N2QyN2U0OS05NjZkLTRhYmQtYjE5YS1kMzdkNDQwOTY4NzUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xNVQyMDo1MDozMi44ODMwNzla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZGViL2FwdC8xY2VjYTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4N2Uv
+        cnBtL3JwbS82N2QyN2U0OS05NjZkLTRhYmQtYjE5YS1kMzdkNDQwOTY4NzUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzFjZWNh
-        NDQzLWE0YjQtNGUwYS04ZmMwLTYyNzVjNGZkNDg3ZS92ZXJzaW9ucy8xLyIs
-        Im5hbWUiOiJkZWJpYW5fcHVscF9yYWduYXJvayIsImRlc2NyaXB0aW9uIjpu
-        dWxsLCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxs
-        fV19
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:26 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/deb/apt/1ceca443-a4b4-4e0a-8fc0-6275c4fd487e/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:26 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '3347'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - e9d7fcdecfb04920a3d7a6f46a0590b2
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZGViL2FwdC8xY2VjYTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4N2Uv
-        dmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2VDE4OjAx
-        OjE4LjM4MzczMloiLCJudW1iZXIiOjEsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMWNlY2E0NDMtYTRiNC00ZTBh
-        LThmYzAtNjI3NWM0ZmQ0ODdlLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7ImRlYi5wYWNrYWdlIjp7ImNvdW50
-        IjozLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2Vz
-        Lz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9kZWIvYXB0LzFjZWNhNDQzLWE0YjQtNGUwYS04ZmMwLTYyNzVj
-        NGZkNDg3ZS92ZXJzaW9ucy8xLyJ9LCJkZWIucGFja2FnZV9pbmRleCI6eyJj
-        b3VudCI6MiwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNr
-        YWdlX2luZGljZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMWNlY2E0NDMtYTRiNC00ZTBh
-        LThmYzAtNjI3NWM0ZmQ0ODdlL3ZlcnNpb25zLzEvIn0sImRlYi5wYWNrYWdl
-        X3JlbGVhc2VfY29tcG9uZW50Ijp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VfcmVsZWFzZV9jb21wb25lbnRz
-        Lz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9kZWIvYXB0LzFjZWNhNDQzLWE0YjQtNGUwYS04ZmMwLTYyNzVj
-        NGZkNDg3ZS92ZXJzaW9ucy8xLyJ9LCJkZWIucmVsZWFzZSI6eyJjb3VudCI6
-        MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9yZWxlYXNlcy8/
-        cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvZGViL2FwdC8xY2VjYTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRm
-        ZDQ4N2UvdmVyc2lvbnMvMS8ifSwiZGViLnJlbGVhc2VfYXJjaGl0ZWN0dXJl
-        Ijp7ImNvdW50IjoyLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGVi
-        L3JlbGVhc2VfYXJjaGl0ZWN0dXJlcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2Fk
-        ZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8xY2VjYTQ0
-        My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4N2UvdmVyc2lvbnMvMS8ifSwi
-        ZGViLnJlbGVhc2VfY29tcG9uZW50Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvZGViL3JlbGVhc2VfY29tcG9uZW50cy8/cmVw
-        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
-        ZXMvZGViL2FwdC8xY2VjYTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4
-        N2UvdmVyc2lvbnMvMS8ifSwiZGViLnJlbGVhc2VfZmlsZSI6eyJjb3VudCI6
-        MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9yZWxlYXNlX2Zp
-        bGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9kZWIvYXB0LzFjZWNhNDQzLWE0YjQtNGUwYS04ZmMwLTYy
-        NzVjNGZkNDg3ZS92ZXJzaW9ucy8xLyJ9fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnsiZGViLnBhY2thZ2UiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9kZWIvcGFja2FnZXMvP3JlcG9zaXRvcnlfdmVyc2lv
-        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMWNlY2E0NDMt
-        YTRiNC00ZTBhLThmYzAtNjI3NWM0ZmQ0ODdlL3ZlcnNpb25zLzEvIn0sImRl
-        Yi5wYWNrYWdlX2luZGV4Ijp7ImNvdW50IjoyLCJocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvZGViL3BhY2thZ2VfaW5kaWNlcy8/cmVwb3NpdG9yeV92
-        ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8xY2Vj
-        YTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4N2UvdmVyc2lvbnMvMS8i
-        fSwiZGViLnBhY2thZ2VfcmVsZWFzZV9jb21wb25lbnQiOnsiY291bnQiOjMs
-        ImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kZWIvcGFja2FnZV9yZWxl
-        YXNlX2NvbXBvbmVudHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMWNlY2E0NDMtYTRiNC00ZTBhLThm
-        YzAtNjI3NWM0ZmQ0ODdlL3ZlcnNpb25zLzEvIn0sImRlYi5yZWxlYXNlIjp7
-        ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3Jl
-        bGVhc2VzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9kZWIvYXB0LzFjZWNhNDQzLWE0YjQtNGUwYS04ZmMwLTYyNzVj
-        NGZkNDg3ZS92ZXJzaW9ucy8xLyJ9LCJkZWIucmVsZWFzZV9hcmNoaXRlY3R1
-        cmUiOnsiY291bnQiOjIsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
-        ZWIvcmVsZWFzZV9hcmNoaXRlY3R1cmVzLz9yZXBvc2l0b3J5X3ZlcnNpb249
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzFjZWNhNDQzLWE0
-        YjQtNGUwYS04ZmMwLTYyNzVjNGZkNDg3ZS92ZXJzaW9ucy8xLyJ9LCJkZWIu
-        cmVsZWFzZV9jb21wb25lbnQiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9kZWIvcmVsZWFzZV9jb21wb25lbnRzLz9yZXBvc2l0
-        b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0
-        LzFjZWNhNDQzLWE0YjQtNGUwYS04ZmMwLTYyNzVjNGZkNDg3ZS92ZXJzaW9u
-        cy8xLyJ9LCJkZWIucmVsZWFzZV9maWxlIjp7ImNvdW50IjoxLCJocmVmIjoi
-        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3JlbGVhc2VfZmlsZXMvP3JlcG9z
-        aXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
-        cHQvMWNlY2E0NDMtYTRiNC00ZTBhLThmYzAtNjI3NWM0ZmQ0ODdlL3ZlcnNp
-        b25zLzEvIn19fX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2RlYi9hcHQvMWNlY2E0NDMtYTRiNC00ZTBhLThmYzAtNjI3NWM0
-        ZmQ0ODdlL3ZlcnNpb25zLzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0w
-        NlQxODowMToxNy4xNjU0NTRaIiwibnVtYmVyIjowLCJyZXBvc2l0b3J5Ijoi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzFjZWNhNDQzLWE0
-        YjQtNGUwYS04ZmMwLTYyNzVjNGZkNDg3ZS8iLCJiYXNlX3ZlcnNpb24iOm51
-        bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9
-        LCJwcmVzZW50Ijp7fX19XX0=
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:26 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:27 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '551'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 1a8bc0531a624fad8c73ca09ebabdd47
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci8zM2EzMmFlNS1mYzNjLTRlOGQtYTE0MS0x
-        YmVjY2RjMjYzZjgvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxNzoy
-        Mjo0OS44MzM0OTRaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8zM2EzMmFlNS1mYzNj
-        LTRlOGQtYTE0MS0xYmVjY2RjMjYzZjgvdmVyc2lvbnMvIiwicHVscF9sYWJl
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzY3ZDI3
+        ZTQ5LTk2NmQtNGFiZC1iMTlhLWQzN2Q0NDA5Njg3NS92ZXJzaW9ucy8wLyIs
+        Im5hbWUiOiJ5dW0tanNoZXJpbGwtMi0yMTY3MDEiLCJkZXNjcmlwdGlvbiI6
+        bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVs
+        bCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZp
+        Y2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowLCJtZXRhZGF0
+        YV9jaGVja3N1bV90eXBlIjpudWxsLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUi
+        Om51bGwsImdwZ2NoZWNrIjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVf
+        bWV0YWRhdGEiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvcnBtL3JwbS80YzZiMTU4Zi03NDMzLTRkNDgtYjA0ZC1h
+        Yzc3ZTY4ZDkxZDEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xNVQyMDo1
+        MDoxMi4yMjM1NDFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvcnBtL3JwbS80YzZiMTU4Zi03NDMzLTRkNDgtYjA0ZC1h
+        Yzc3ZTY4ZDkxZDEvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
+        c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
+        cG0vcnBtLzRjNmIxNThmLTc0MzMtNGQ0OC1iMDRkLWFjNzdlNjhkOTFkMS92
+        ZXJzaW9ucy8wLyIsIm5hbWUiOiJ5dW0tanNoZXJpbGwtMS0yMDc1NTgiLCJk
+        ZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGws
+        InJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9z
+        aWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25z
+        IjowLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjpudWxsLCJwYWNrYWdlX2No
+        ZWNrc3VtX3R5cGUiOm51bGwsImdwZ2NoZWNrIjowLCJyZXBvX2dwZ2NoZWNr
+        IjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82MTY0MGFhMC0yZTdk
+        LTRlYjUtYTFhNy1iZTlkNWYyODU1Y2EvIiwicHVscF9jcmVhdGVkIjoiMjAy
+        MS0xMS0xMlQxMzowMzowMS43MjQxODZaIiwidmVyc2lvbnNfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82MTY0MGFhMC0yZTdk
+        LTRlYjUtYTFhNy1iZTlkNWYyODU1Y2EvdmVyc2lvbnMvIiwicHVscF9sYWJl
         bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzMzYTMyYWU1LWZjM2Mt
-        NGU4ZC1hMTQxLTFiZWNjZGMyNjNmOC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJE
-        ZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwiZGVzY3Jp
-        cHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1v
-        dGUiOm51bGx9XX0=
+        cG9zaXRvcmllcy9ycG0vcnBtLzYxNjQwYWEwLTJlN2QtNGViNS1hMWE3LWJl
+        OWQ1ZjI4NTVjYS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJ0ZXN0LTk2MzgteXVt
+        LTE3NTkzMSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJz
+        aW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2Us
+        Im1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2th
+        Z2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOm51bGws
+        InBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJl
+        cG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:27 GMT
+  recorded_at: Wed, 17 Nov 2021 12:12:02 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/container/container/33a32ae5-fc3c-4e8d-a141-1beccdc263f8/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/67d27e49-966d-4abd-b19a-d37d44096875/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1778,11 +1023,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.8.1/ruby
+      - OpenAPI-Generator/3.15.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1790,18 +1035,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:27 GMT
+      - Wed, 17 Nov 2021 12:12:02 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '394'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
@@ -1811,28 +1052,30 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1885b981f17644319420101dc9354ed5
+      - cc74bc98cc1c4d809dc02158b481c2b8
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '231'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci8zM2EzMmFlNS1mYzNjLTRlOGQtYTE0MS0x
-        YmVjY2RjMjYzZjgvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIx
-        LTEwLTA2VDE3OjIyOjQ5LjkxNTIwMloiLCJudW1iZXIiOjAsInJlcG9zaXRv
-        cnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250
-        YWluZXIvMzNhMzJhZTUtZmMzYy00ZThkLWExNDEtMWJlY2NkYzI2M2Y4LyIs
-        ImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVk
-        Ijp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        cnBtL3JwbS82N2QyN2U0OS05NjZkLTRhYmQtYjE5YS1kMzdkNDQwOTY4NzUv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTE1VDIwOjUw
+        OjMyLjg4ODMxNFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjdkMjdlNDktOTY2ZC00YWJk
+        LWIxOWEtZDM3ZDQ0MDk2ODc1LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:27 GMT
+  recorded_at: Wed, 17 Nov 2021 12:12:02 GMT
 - request:
-    method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/24e739d5-a174-4c0f-818e-20f9cd919a2b/versions/2/
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/4c6b158f-7433-4d48-b04d-ac77e68d91d1/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1844,28 +1087,24 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:27 GMT
+      - Wed, 17 Nov 2021 12:12:02 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
-      - GET, DELETE, HEAD, OPTIONS
+      - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       X-Content-Type-Options:
@@ -1873,19 +1112,30 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8b01a2b5f826489a8514e19c2f2e9f03
+      - 28fda467d2c049a298b0f2b8f8df4abe
       Access-Control-Expose-Headers:
       - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '231'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdkMGRiMTUzLTRlNGItNDQ2
-        MC1iN2QyLTUxNzVjOWZmZDk1Zi8ifQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS80YzZiMTU4Zi03NDMzLTRkNDgtYjA0ZC1hYzc3ZTY4ZDkxZDEv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTE1VDIwOjUw
+        OjEyLjIyODUyN1oiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNGM2YjE1OGYtNzQzMy00ZDQ4
+        LWIwNGQtYWM3N2U2OGQ5MWQxLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:27 GMT
+  recorded_at: Wed, 17 Nov 2021 12:12:02 GMT
 - request:
-    method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/24e739d5-a174-4c0f-818e-20f9cd919a2b/versions/1/
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/61640aa0-2e7d-4eb5-a1a7-be9d5f2855ca/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1897,28 +1147,24 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:27 GMT
+      - Wed, 17 Nov 2021 12:12:02 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
-      - GET, DELETE, HEAD, OPTIONS
+      - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       X-Content-Type-Options:
@@ -1926,72 +1172,30 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 37ea1fa91bad4634aa311a65e42a4390
+      - e88678aa536849109b73a931311f1613
       Access-Control-Expose-Headers:
       - Correlation-ID
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcxOTgwYzdkLTFjOWUtNGM3
-        Zi1hYjhhLWExOTA0ZTQwYmE2ZS8ifQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:27 GMT
-- request:
-    method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/deb/apt/1ceca443-a4b4-4e0a-8fc0-6275c4fd487e/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:28 GMT
-      Content-Type:
-      - application/json
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 3c7c81c90b8e41b9a87715129adba949
-      Access-Control-Expose-Headers:
-      - Correlation-ID
+      - '230'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM0MjMwODg4LTJiYmUtNDc0
-        Ni04NTAxLTcwZWRjZjI0MGNjYi8ifQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS82MTY0MGFhMC0yZTdkLTRlYjUtYTFhNy1iZTlkNWYyODU1Y2Ev
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTEyVDEzOjAz
+        OjAxLjczMDg3M1oiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjE2NDBhYTAtMmU3ZC00ZWI1
+        LWExYTctYmU5ZDVmMjg1NWNhLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:28 GMT
+  recorded_at: Wed, 17 Nov 2021 12:12:02 GMT
 - request:
     method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/orphans/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/orphans/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2003,7 +1207,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -2011,40 +1215,40 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:28 GMT
+      - Wed, 17 Nov 2021 12:12:02 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - DELETE, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '67'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b516729fa56f45c2bd75cc5198aa224c
+      - 05e566aed0134347a491aa2c20ae38f6
       Access-Control-Expose-Headers:
       - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q0ZTAwMzdkLTk1ZWEtNDll
-        Yi05ZjA4LTRhMDNkNDZkMjMzZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ4M2E5ODVmLWNkMTEtNGY1
+        Ni1iNTc1LWU0ZTc5NDY5OWU2ZC8ifQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:28 GMT
+  recorded_at: Wed, 17 Nov 2021 12:12:02 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/d4e0037d-95ea-49eb-9f08-4a03d46d233d/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/483a985f-cd11-4f56-b575-e4e794699e6d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2056,7 +1260,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -2064,18 +1268,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:28 GMT
+      - Wed, 17 Nov 2021 12:12:02 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '771'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -2085,23 +1285,25 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2cdfd2a420ed45a59e5c8772e40a0db6
+      - 9b6401426d524da1bb9f0858e1ba618b
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '410'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDRlMDAzN2QtOTVl
-        YS00OWViLTlmMDgtNGEwM2Q0NmQyMzNkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDI6MjguNDIxMTI5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDgzYTk4NWYtY2Qx
+        MS00ZjU2LWI1NzUtZTRlNzk0Njk5ZTZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTdUMTI6MTI6MDIuMzQyNjg4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJsb2dnaW5nX2NpZCI6ImI1MTY3MjlmYTU2ZjQ1YzJiZDc1Y2M1
-        MTk4YWEyMjRjIiwic3RhcnRlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDI6Mjgu
-        NDY0MTg5WiIsImZpbmlzaGVkX2F0IjoiMjAyMS0xMC0wNlQxODowMjoyOC40
-        OTgzNzJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzLzA1ZTZkN2Y0LWI1NjQtNGU3My04MmViLTE1YjUwYTUxMjRhMy8i
+        ZWFudXAiLCJsb2dnaW5nX2NpZCI6IjA1ZTU2NmFlZDAxMzQzNDdhNDkxYWEy
+        YzIwYWUzOGY2Iiwic3RhcnRlZF9hdCI6IjIwMjEtMTEtMTdUMTI6MTI6MDIu
+        NDI4MTYyWiIsImZpbmlzaGVkX2F0IjoiMjAyMS0xMS0xN1QxMjoxMjowMi40
+        NzQyMjdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzQ5MDAyOGZjLWUzYjgtNGFiZi1iMDhkLTlkNzcwNzBlODZjYi8i
         LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
         b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xl
         YW4gdXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVu
@@ -2112,5 +1314,5 @@ http_interactions:
         ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
         ZCI6W119
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:28 GMT
+  recorded_at: Wed, 17 Nov 2021 12:12:02 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary.yml
@@ -15030,4 +15030,687 @@ http_interactions:
         NDlkNC04NWEwLTlkZjM3ZGEyOGYzNi8iXX0=
     http_version: 
   recorded_at: Wed, 06 Oct 2021 18:02:21 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/f8900b9f-0b51-474b-a967-1a2c2068bda5/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2U5YTk5YzdjLTAwZGQtNDE2Yy04ODE1LThhNDE1NDA3ZTIw
+        YS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 18:17:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f1a3a1c9c1644895a5db6602949608aa
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdjNmU3NWM3LTlmMGUtNGQz
+        Mi04YjljLTI4NTZiN2I2OGVhMS8ifQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 18:17:55 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/7c6e75c7-9f0e-4d32-8b9c-2856b7b68ea1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 18:17:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d60b05e2ba8d4213b68efe8abc06c85f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '392'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2M2ZTc1YzctOWYw
+        ZS00ZDMyLThiOWMtMjg1NmI3YjY4ZWExLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMTg6MTc6NTQuOTY1MzQ2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJmMWEzYTFjOWMxNjQ0ODk1YTVk
+        YjY2MDI5NDk2MDhhYSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE2VDE4OjE3
+        OjU1LjAzMDU3OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTZUMTg6MTc6
+        NTUuMTU3MTY3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9iZmJlMjlhMC04YzQ2LTRkNzgtYjA2YS03ODk4OTlmYTMw
+        NzcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlL2Y4OTAwYjlmLTBiNTEtNDc0Yi1hOTY3LTFhMmMyMDY4YmRhNS92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2Y4OTAwYjlmLTBiNTEt
+        NDc0Yi1hOTY3LTFhMmMyMDY4YmRhNS8iXX0=
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 18:17:55 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/5612ab8f-54bb-4120-948f-ebb814e4f96b/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2U5YTk5YzdjLTAwZGQtNDE2Yy04ODE1LThhNDE1NDA3ZTIw
+        YS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 18:22:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 876af11367f74dad843dd0f25d91d445
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZkYzkxOTAxLWNiNGYtNGQ0
+        My04ODg2LWM4Nzg5MTJmMzQwMS8ifQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 18:22:42 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/6dc91901-cb4f-4d43-8886-c878912f3401/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 18:22:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 73cb2d9052ca4165a9a7b85ab24d105a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '392'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmRjOTE5MDEtY2I0
+        Zi00ZDQzLTg4ODYtYzg3ODkxMmYzNDAxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMTg6MjI6NDIuNjczNDY1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4NzZhZjExMzY3Zjc0ZGFkODQz
+        ZGQwZjI1ZDkxZDQ0NSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE2VDE4OjIy
+        OjQyLjczODUwM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTZUMTg6MjI6
+        NDIuODQ4NzE5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy80OTAwMjhmYy1lM2I4LTRhYmYtYjA4ZC05ZDc3MDcwZTg2
+        Y2IvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzU2MTJhYjhmLTU0YmItNDEyMC05NDhmLWViYjgxNGU0Zjk2Yi92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzU2MTJhYjhmLTU0YmIt
+        NDEyMC05NDhmLWViYjgxNGU0Zjk2Yi8iXX0=
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 18:22:42 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/eb290e60-1ce8-44fd-8c8a-9176a142d1d4/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2U5YTk5YzdjLTAwZGQtNDE2Yy04ODE1LThhNDE1NDA3ZTIw
+        YS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:09:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9be1840517a6438a9c849237219e4897
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlmMWMxNzcyLWRmZWMtNGNh
+        NC1hMzFiLTY5MmFkY2VlYjIxYy8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:09:48 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/9f1c1772-dfec-4ca4-a31b-692adceeb21c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:09:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7112758a1c914ba6a59a349050b5c1a3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '389'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWYxYzE3NzItZGZl
+        Yy00Y2E0LWEzMWItNjkyYWRjZWViMjFjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTdUMTI6MDk6NDguNjg4NTM2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5YmUxODQwNTE3YTY0MzhhOWM4
+        NDkyMzcyMTllNDg5NyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE3VDEyOjA5
+        OjQ4Ljc0ODU4NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTdUMTI6MDk6
+        NDguODU2MDUyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8zYjQxMGEzZi0yMTE5LTQ4NDgtYTIzZi1lOGQwZTI1NGRj
+        YjQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlL2ViMjkwZTYwLTFjZTgtNDRmZC04YzhhLTkxNzZhMTQyZDFkNC92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2ViMjkwZTYwLTFjZTgt
+        NDRmZC04YzhhLTkxNzZhMTQyZDFkNC8iXX0=
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:09:48 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/81d04790-e0d3-44fb-9b67-471e05b270db/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2U5YTk5YzdjLTAwZGQtNDE2Yy04ODE1LThhNDE1NDA3ZTIw
+        YS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:10:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 45635d90dda94352b6d7cb90b5bd83f4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzViOGNmNzc3LTMxMDMtNGE2
+        Ny1iNzg2LTU0MzM4NTJmYzk3Yi8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:10:44 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/5b8cf777-3103-4a67-b786-5433852fc97b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:10:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 583eefd5791949bfbc70a6310796e76a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '390'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWI4Y2Y3NzctMzEw
+        My00YTY3LWI3ODYtNTQzMzg1MmZjOTdiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTdUMTI6MTA6NDQuMDExNjQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0NTYzNWQ5MGRkYTk0MzUyYjZk
+        N2NiOTBiNWJkODNmNCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE3VDEyOjEw
+        OjQ0LjA3MzQwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTdUMTI6MTA6
+        NDQuMTgwNzExWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy83YmUxMDlhMS1hNTY5LTRkNjYtYTM1Ni05ZDlmNWE5ZDM2
+        MmEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzgxZDA0NzkwLWUwZDMtNDRmYi05YjY3LTQ3MWUwNWIyNzBkYi92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzgxZDA0NzkwLWUwZDMt
+        NDRmYi05YjY3LTQ3MWUwNWIyNzBkYi8iXX0=
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:10:44 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:11:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 46ddf7c1730840e3a48f00cbf4f7672e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '488'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
+        ZmlsZXMvZTlhOTljN2MtMDBkZC00MTZjLTg4MTUtOGE0MTU0MDdlMjBhLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjEtMTEtMTZUMTU6NTg6MjcuOTU4NzIxWiIs
+        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85M2ZiNTY5NC0w
+        OTMxLTQ0NjgtOWQ0Ni0wMzNjNDgwZmQ1ZWUvIiwicmVsYXRpdmVfcGF0aCI6
+        InRlc3RfZXJyYXR1bS5qc29uIiwibWQ1IjpudWxsLCJzaGExIjoiNjA5ODg1
+        NzE1ZmQ4ZDZhNzA3ZjE4ZmM1NTlkNjFiOGJkZWU3MTgwZSIsInNoYTIyNCI6
+        ImUyOTMxZjAzNjY1NmJhNmQwMTdiNTA2YjhmZWM1N2I4N2U1N2VlYzI3YWVh
+        ZDBkZjdhZDhlZDNjIiwic2hhMjU2IjoiZWYwYzk5ODMxMDZiODI0Zjk0Mzg1
+        MGRmOTQ0MjBlN2YxOGFkMzgxYWNjNmJkNWEyMWVhMDVkY2Y2NjBhNzc5MSIs
+        InNoYTM4NCI6ImQzYzUyOGQyMTEwZDgwNjY3NTliZWQwY2RkYzA5OTEzOTFk
+        NDc3MjdkN2JiMDAzODY0ZWE5MzYyMTNhOGVjNDRhM2RmNTJkZDFiMjdjNzg1
+        YzdlNjdiMTAzMjJlOTlmZCIsInNoYTUxMiI6ImNmYjg1MjNlODdjN2JmOTFl
+        ODIzMGY1Y2UxNjhiZTFkODUyN2FiNzY3ZjU1NzE0ZWU0NWRiY2Q1MDVmNzdl
+        ODQxYTU0MTc4MjI0ODdmZGUyMjVlNjIyZmQ0ZjljZGYzMzM4NDVkOTAxNDAw
+        Nzg2M2E5OWExOWE3ZjQ5MDJlZTI4In1dfQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:11:59 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/826ead8c-0bee-4bb5-b8a2-00fe1af3d2c4/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2U5YTk5YzdjLTAwZGQtNDE2Yy04ODE1LThhNDE1NDA3ZTIw
+        YS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:11:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c619d30524d540a6ba27f0e7a51878c7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVmMWI5NzdjLTFiY2QtNDRk
+        Yy05OTdlLWRmMjYzYTYwMzg4OC8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:11:59 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/5f1b977c-1bcd-44dc-997e-df263a603888/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:11:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 465a9eccbae44b7eadecf72656e2160b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '390'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWYxYjk3N2MtMWJj
+        ZC00NGRjLTk5N2UtZGYyNjNhNjAzODg4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTdUMTI6MTE6NTkuMTY1MjQ3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjNjE5ZDMwNTI0ZDU0MGE2YmEy
+        N2YwZTdhNTE4NzhjNyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE3VDEyOjEx
+        OjU5LjIyNzIzMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTdUMTI6MTE6
+        NTkuMzMwNDc3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy80OTAwMjhmYy1lM2I4LTRhYmYtYjA4ZC05ZDc3MDcwZTg2
+        Y2IvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzgyNmVhZDhjLTBiZWUtNGJiNS1iOGEyLTAwZmUxYWYzZDJjNC92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzgyNmVhZDhjLTBiZWUt
+        NGJiNS1iOGEyLTAwZmUxYWYzZDJjNC8iXX0=
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:11:59 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary_duplicate.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary_duplicate.yml
@@ -5843,139 +5843,6 @@ http_interactions:
   recorded_at: Wed, 06 Oct 2021 16:26:56 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.15.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 16:59:31 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '683'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 82547fcc9adb4d4fa8886f3dd15a9984
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYjUy
-        ZmY4OTAtYzNkZS00ODYzLWJlOTQtMmU2YWU3MTlmODk0LyIsInB1bHBfY3Jl
-        YXRlZCI6IjIwMjEtMTAtMDZUMTY6NTY6MTIuNTkyMzg3WiIsImZpbGUiOiJh
-        cnRpZmFjdC9lZi8wYzk5ODMxMDZiODI0Zjk0Mzg1MGRmOTQ0MjBlN2YxOGFk
-        MzgxYWNjNmJkNWEyMWVhMDVkY2Y2NjBhNzc5MSIsInNpemUiOjc0MCwibWQ1
-        IjpudWxsLCJzaGExIjpudWxsLCJzaGEyMjQiOiJlMjkzMWYwMzY2NTZiYTZk
-        MDE3YjUwNmI4ZmVjNTdiODdlNTdlZWMyN2FlYWQwZGY3YWQ4ZWQzYyIsInNo
-        YTI1NiI6ImVmMGM5OTgzMTA2YjgyNGY5NDM4NTBkZjk0NDIwZTdmMThhZDM4
-        MWFjYzZiZDVhMjFlYTA1ZGNmNjYwYTc3OTEiLCJzaGEzODQiOiJkM2M1Mjhk
-        MjExMGQ4MDY2NzU5YmVkMGNkZGMwOTkxMzkxZDQ3NzI3ZDdiYjAwMzg2NGVh
-        OTM2MjEzYThlYzQ0YTNkZjUyZGQxYjI3Yzc4NWM3ZTY3YjEwMzIyZTk5ZmQi
-        LCJzaGE1MTIiOiJjZmI4NTIzZTg3YzdiZjkxZTgyMzBmNWNlMTY4YmUxZDg1
-        MjdhYjc2N2Y1NTcxNGVlNDVkYmNkNTA1Zjc3ZTg0MWE1NDE3ODIyNDg3ZmRl
-        MjI1ZTYyMmZkNGY5Y2RmMzMzODQ1ZDkwMTQwMDc4NjNhOTlhMTlhN2Y0OTAy
-        ZWUyOCJ9XX0=
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 16:59:31 GMT
-- request:
-    method: post
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/content/file/files/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTViODdmZGQxM2JlMzZi
-        YzIyNGYyNTFlNTkxZjA5OWM0DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bTEu
-        anNvbg0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTViODdmZGQx
-        M2JlMzZiYzIyNGYyNTFlNTkxZjA5OWM0DQpDb250ZW50LURpc3Bvc2l0aW9u
-        OiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0KDQovcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzL2I1MmZmODkwLWMzZGUtNDg2My1iZTk0LTJlNmFlNzE5Zjg5
-        NC8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC01Yjg3ZmRkMTNi
-        ZTM2YmMyMjRmMjUxZTU5MWYwOTljNC0tDQo=
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-5b87fdd13be36bc224f251e591f099c4
-      User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Content-Length:
-      - '386'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 16:59:31 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - d2b0bcfab37d4c22b3cbfa5d14e111b8
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg4OThmMGQwLTVlMjUtNGEy
-        MC1hNzVlLWFiNjljYzNlZGFlMi8ifQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 16:59:31 GMT
-- request:
-    method: get
     uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/8898f0d0-5e25-4a20-a75e-ab69cc3edae2/
     body:
       encoding: US-ASCII
@@ -6360,4 +6227,706 @@ http_interactions:
         NDlkNC04NWEwLTlkZjM3ZGEyOGYzNi8iXX0=
     http_version: 
   recorded_at: Wed, 06 Oct 2021 18:02:22 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:09:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a4463432d1cc41409efaa74a1c0fc14b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '440'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOTNm
+        YjU2OTQtMDkzMS00NDY4LTlkNDYtMDMzYzQ4MGZkNWVlLyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjEtMTEtMTZUMTU6NTg6MjcuMzcyNzY0WiIsImZpbGUiOiJh
+        cnRpZmFjdC9lZi8wYzk5ODMxMDZiODI0Zjk0Mzg1MGRmOTQ0MjBlN2YxOGFk
+        MzgxYWNjNmJkNWEyMWVhMDVkY2Y2NjBhNzc5MSIsInNpemUiOjc0MCwibWQ1
+        IjpudWxsLCJzaGExIjoiNjA5ODg1NzE1ZmQ4ZDZhNzA3ZjE4ZmM1NTlkNjFi
+        OGJkZWU3MTgwZSIsInNoYTIyNCI6ImUyOTMxZjAzNjY1NmJhNmQwMTdiNTA2
+        YjhmZWM1N2I4N2U1N2VlYzI3YWVhZDBkZjdhZDhlZDNjIiwic2hhMjU2Ijoi
+        ZWYwYzk5ODMxMDZiODI0Zjk0Mzg1MGRmOTQ0MjBlN2YxOGFkMzgxYWNjNmJk
+        NWEyMWVhMDVkY2Y2NjBhNzc5MSIsInNoYTM4NCI6ImQzYzUyOGQyMTEwZDgw
+        NjY3NTliZWQwY2RkYzA5OTEzOTFkNDc3MjdkN2JiMDAzODY0ZWE5MzYyMTNh
+        OGVjNDRhM2RmNTJkZDFiMjdjNzg1YzdlNjdiMTAzMjJlOTlmZCIsInNoYTUx
+        MiI6ImNmYjg1MjNlODdjN2JmOTFlODIzMGY1Y2UxNjhiZTFkODUyN2FiNzY3
+        ZjU1NzE0ZWU0NWRiY2Q1MDVmNzdlODQxYTU0MTc4MjI0ODdmZGUyMjVlNjIy
+        ZmQ0ZjljZGYzMzM4NDVkOTAxNDAwNzg2M2E5OWExOWE3ZjQ5MDJlZTI4In1d
+        fQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:09:49 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/content/file/files/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWNmZjliMGQwNDA1NzYx
+        NWQ3Mjc4Y2YyMjkzMjEyNjFlDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bTEu
+        anNvbg0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWNmZjliMGQw
+        NDA1NzYxNWQ3Mjc4Y2YyMjkzMjEyNjFlDQpDb250ZW50LURpc3Bvc2l0aW9u
+        OiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0KDQovcHVscC9hcGkvdjMv
+        YXJ0aWZhY3RzLzkzZmI1Njk0LTA5MzEtNDQ2OC05ZDQ2LTAzM2M0ODBmZDVl
+        ZS8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC1jZmY5YjBkMDQw
+        NTc2MTVkNzI3OGNmMjI5MzIxMjYxZS0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-cff9b0d04057615d7278cf229321261e
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '386'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:09:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a97facaaee954ea3a744b9dee431647f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZjMmUxNWU0LWI5N2ItNGNi
+        ZS1iYzJiLTk1YmM4MDY3NzBkYi8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:09:49 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/6c2e15e4-b97b-4cbe-bc2b-95bc806770db/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:09:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f65f8d3dddba4b4fb43cbf190e4a7806
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '370'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmMyZTE1ZTQtYjk3
+        Yi00Y2JlLWJjMmItOTViYzgwNjc3MGRiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTdUMTI6MDk6NDkuNzE0MjUxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJhOTdmYWNhYWVlOTU0ZWEzYTc0NGI5ZGVl
+        NDMxNjQ3ZiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE3VDEyOjA5OjQ5Ljc3
+        MDQ3OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTdUMTI6MDk6NDkuODk5
+        MjIyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy80OTAwMjhmYy1lM2I4LTRhYmYtYjA4ZC05ZDc3MDcwZTg2Y2IvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvMWYwOGNk
+        M2EtZDU3Yi00MjIzLTk5NzEtN2YyMGZlMTdkOWY5LyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbXX0=
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:09:49 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/eb290e60-1ce8-44fd-8c8a-9176a142d1d4/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzFmMDhjZDNhLWQ1N2ItNDIyMy05OTcxLTdmMjBmZTE3ZDlm
+        OS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:09:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8de212f11f1e47df9eb59db4aac8bbdb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmNWZiYWQ0LWYwNDItNGU3
+        ZC1iMjM0LTZkMWQ5MzM4N2IwYi8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:09:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/7f5fbad4-f042-4e7d-b234-6d1d93387b0b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:09:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ef0669d9cc8145c59cdb457ea2f7c24c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '389'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2Y1ZmJhZDQtZjA0
+        Mi00ZTdkLWIyMzQtNmQxZDkzMzg3YjBiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTdUMTI6MDk6NTAuMDY3NTQzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI4ZGUyMTJmMTFmMWU0N2RmOWVi
+        NTlkYjRhYWM4YmJkYiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE3VDEyOjA5
+        OjUwLjEyMjg0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTdUMTI6MDk6
+        NTAuMjI3Nzc2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy80OTAwMjhmYy1lM2I4LTRhYmYtYjA4ZC05ZDc3MDcwZTg2
+        Y2IvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlL2ViMjkwZTYwLTFjZTgtNDRmZC04YzhhLTkxNzZhMTQyZDFkNC92ZXJz
+        aW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2ViMjkwZTYwLTFjZTgt
+        NDRmZC04YzhhLTkxNzZhMTQyZDFkNC8iXX0=
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:09:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum1.json
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:10:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c6713b92b11645a1acb38a5a8d20eb63
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '489'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
+        ZmlsZXMvMWYwOGNkM2EtZDU3Yi00MjIzLTk5NzEtN2YyMGZlMTdkOWY5LyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjEtMTEtMTdUMTI6MDk6NDkuODgxNzg0WiIs
+        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85M2ZiNTY5NC0w
+        OTMxLTQ0NjgtOWQ0Ni0wMzNjNDgwZmQ1ZWUvIiwicmVsYXRpdmVfcGF0aCI6
+        InRlc3RfZXJyYXR1bTEuanNvbiIsIm1kNSI6bnVsbCwic2hhMSI6IjYwOTg4
+        NTcxNWZkOGQ2YTcwN2YxOGZjNTU5ZDYxYjhiZGVlNzE4MGUiLCJzaGEyMjQi
+        OiJlMjkzMWYwMzY2NTZiYTZkMDE3YjUwNmI4ZmVjNTdiODdlNTdlZWMyN2Fl
+        YWQwZGY3YWQ4ZWQzYyIsInNoYTI1NiI6ImVmMGM5OTgzMTA2YjgyNGY5NDM4
+        NTBkZjk0NDIwZTdmMThhZDM4MWFjYzZiZDVhMjFlYTA1ZGNmNjYwYTc3OTEi
+        LCJzaGEzODQiOiJkM2M1MjhkMjExMGQ4MDY2NzU5YmVkMGNkZGMwOTkxMzkx
+        ZDQ3NzI3ZDdiYjAwMzg2NGVhOTM2MjEzYThlYzQ0YTNkZjUyZGQxYjI3Yzc4
+        NWM3ZTY3YjEwMzIyZTk5ZmQiLCJzaGE1MTIiOiJjZmI4NTIzZTg3YzdiZjkx
+        ZTgyMzBmNWNlMTY4YmUxZDg1MjdhYjc2N2Y1NTcxNGVlNDVkYmNkNTA1Zjc3
+        ZTg0MWE1NDE3ODIyNDg3ZmRlMjI1ZTYyMmZkNGY5Y2RmMzMzODQ1ZDkwMTQw
+        MDc4NjNhOTlhMTlhN2Y0OTAyZWUyOCJ9XX0=
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:10:44 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/81d04790-e0d3-44fb-9b67-471e05b270db/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzFmMDhjZDNhLWQ1N2ItNDIyMy05OTcxLTdmMjBmZTE3ZDlm
+        OS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:10:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 03023522a48e49f784af735aaf5445dc
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk1YmQxNmQzLWYwMmUtNGNl
+        OS05NWJkLWY0N2FiNDg5NTUxZi8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:10:45 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/95bd16d3-f02e-4ce9-95bd-f47ab489551f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:10:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 160e72491b3744d989136b8ee17e9605
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTViZDE2ZDMtZjAy
+        ZS00Y2U5LTk1YmQtZjQ3YWI0ODk1NTFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTdUMTI6MTA6NDUuMDI1NDI3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwMzAyMzUyMmE0OGU0OWY3ODRh
+        ZjczNWFhZjU0NDVkYyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE3VDEyOjEw
+        OjQ1LjA5MDA5MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTdUMTI6MTA6
+        NDUuMjE5MTgzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8zYjQxMGEzZi0yMTE5LTQ4NDgtYTIzZi1lOGQwZTI1NGRj
+        YjQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzgxZDA0NzkwLWUwZDMtNDRmYi05YjY3LTQ3MWUwNWIyNzBkYi92ZXJz
+        aW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzgxZDA0NzkwLWUwZDMt
+        NDRmYi05YjY3LTQ3MWUwNWIyNzBkYi8iXX0=
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:10:45 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum1.json
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:11:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8893d34ab2604b63b1f9c51eb62b1a2b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '489'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
+        ZmlsZXMvMWYwOGNkM2EtZDU3Yi00MjIzLTk5NzEtN2YyMGZlMTdkOWY5LyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjEtMTEtMTdUMTI6MDk6NDkuODgxNzg0WiIs
+        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85M2ZiNTY5NC0w
+        OTMxLTQ0NjgtOWQ0Ni0wMzNjNDgwZmQ1ZWUvIiwicmVsYXRpdmVfcGF0aCI6
+        InRlc3RfZXJyYXR1bTEuanNvbiIsIm1kNSI6bnVsbCwic2hhMSI6IjYwOTg4
+        NTcxNWZkOGQ2YTcwN2YxOGZjNTU5ZDYxYjhiZGVlNzE4MGUiLCJzaGEyMjQi
+        OiJlMjkzMWYwMzY2NTZiYTZkMDE3YjUwNmI4ZmVjNTdiODdlNTdlZWMyN2Fl
+        YWQwZGY3YWQ4ZWQzYyIsInNoYTI1NiI6ImVmMGM5OTgzMTA2YjgyNGY5NDM4
+        NTBkZjk0NDIwZTdmMThhZDM4MWFjYzZiZDVhMjFlYTA1ZGNmNjYwYTc3OTEi
+        LCJzaGEzODQiOiJkM2M1MjhkMjExMGQ4MDY2NzU5YmVkMGNkZGMwOTkxMzkx
+        ZDQ3NzI3ZDdiYjAwMzg2NGVhOTM2MjEzYThlYzQ0YTNkZjUyZGQxYjI3Yzc4
+        NWM3ZTY3YjEwMzIyZTk5ZmQiLCJzaGE1MTIiOiJjZmI4NTIzZTg3YzdiZjkx
+        ZTgyMzBmNWNlMTY4YmUxZDg1MjdhYjc2N2Y1NTcxNGVlNDVkYmNkNTA1Zjc3
+        ZTg0MWE1NDE3ODIyNDg3ZmRlMjI1ZTYyMmZkNGY5Y2RmMzMzODQ1ZDkwMTQw
+        MDc4NjNhOTlhMTlhN2Y0OTAyZWUyOCJ9XX0=
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:11:59 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/826ead8c-0bee-4bb5-b8a2-00fe1af3d2c4/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzFmMDhjZDNhLWQ1N2ItNDIyMy05OTcxLTdmMjBmZTE3ZDlm
+        OS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:12:00 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7ab00ed253494aebbe30b83cae381bb7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFlYmFhZTBlLThjYzQtNDg4
+        OS1hNThiLWEyNjQyZDM2NGNkMS8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:12:00 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/1ebaae0e-8cc4-4889-a58b-a2642d364cd1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:12:00 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f8117bfd564840b7a3373cc7ef6f176f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '387'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWViYWFlMGUtOGNj
+        NC00ODg5LWE1OGItYTI2NDJkMzY0Y2QxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTdUMTI6MTI6MDAuMTUwNzcxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3YWIwMGVkMjUzNDk0YWViYmUz
+        MGI4M2NhZTM4MWJiNyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE3VDEyOjEy
+        OjAwLjIxMDM4OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTdUMTI6MTI6
+        MDAuMzI0NjI1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy83YmUxMDlhMS1hNTY5LTRkNjYtYTM1Ni05ZDlmNWE5ZDM2
+        MmEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzgyNmVhZDhjLTBiZWUtNGJiNS1iOGEyLTAwZmUxYWYzZDJjNC92ZXJz
+        aW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzgyNmVhZDhjLTBiZWUt
+        NGJiNS1iOGEyLTAwZmUxYWYzZDJjNC8iXX0=
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:12:00 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,11 +10,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -22,42 +22,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:29 GMT
+      - Wed, 17 Nov 2021 12:11:54 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 10379996e9384882bd7b2c8df3994002
+      - f29feba6a8794da580bc340c6cba85dd
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:29 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:54 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -65,11 +63,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -77,42 +75,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:29 GMT
+      - Wed, 17 Nov 2021 12:11:54 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5d2e514be1a64e258d8d282ac9023823
+      - c4e93fdcbd4e43edb3af69360175fe76
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:29 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:54 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -120,11 +116,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -132,42 +128,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:30 GMT
+      - Wed, 17 Nov 2021 12:11:54 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0e180f36ef1a45ca96f41897dcf3b15b
+      - 0e8d8d29421643dfba1eafccb2b44fbb
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:30 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:54 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -175,11 +169,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -187,42 +181,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:30 GMT
+      - Wed, 17 Nov 2021 12:11:54 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 94e1ebe845e244de99230e2d569013c8
+      - 28ead03b0636434c8033843b3b6a9891
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:30 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:54 GMT
 - request:
     method: post
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -236,11 +228,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -248,55 +240,53 @@ http_interactions:
       code: 201
       message: Created
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:30 GMT
+      - Wed, 17 Nov 2021 12:11:54 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '555'
-      Connection:
-      - keep-alive
       Location:
-      - "/pulp/api/v3/remotes/file/file/b8c268ab-3b90-4595-bd91-f823dbb154d8/"
+      - "/pulp/api/v3/remotes/file/file/a8093a5c-0576-4cc5-9329-c1aab9b3cac0/"
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '555'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4a905bf4685440dab54a55ed16dcad9d
+      - e98c20e050004d71a9c0fedc2befec40
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        YjhjMjY4YWItM2I5MC00NTk1LWJkOTEtZjgyM2RiYjE1NGQ4LyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjEtMTAtMDZUMTg6MDI6MzAuNTQxNjM2WiIsIm5hbWUi
+        YTgwOTNhNWMtMDU3Ni00Y2M1LTkzMjktYzFhYWI5YjNjYWMwLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjEtMTEtMTdUMTI6MTE6NTQuNDk0Nzk4WiIsIm5hbWUi
         OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwidXJs
         IjoiaHR0cDovL3Rlc3QvdGVzdC8vUFVMUF9NQU5JRkVTVCIsImNhX2NlcnQi
         Om51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1
         ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFz
-        dF91cGRhdGVkIjoiMjAyMS0xMC0wNlQxODowMjozMC41NDE2NTZaIiwiZG93
+        dF91cGRhdGVkIjoiMjAyMS0xMS0xN1QxMjoxMTo1NC40OTQ4MjRaIiwiZG93
         bmxvYWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJw
         b2xpY3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozMDAuMCwiY29u
         bmVjdF90aW1lb3V0IjpudWxsLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6bnVs
         bCwic29ja19yZWFkX3RpbWVvdXQiOm51bGwsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOm51bGx9
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:30 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:54 GMT
 - request:
     method: post
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/file/file/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -306,11 +296,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -318,54 +308,52 @@ http_interactions:
       code: 201
       message: Created
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:30 GMT
+      - Wed, 17 Nov 2021 12:11:54 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '516'
-      Connection:
-      - keep-alive
       Location:
-      - "/pulp/api/v3/repositories/file/file/05fd8552-35d6-418f-8aab-3e9b3dae8d16/"
+      - "/pulp/api/v3/repositories/file/file/bae3b075-cc41-4db9-a495-929772fc0092/"
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '516'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f0cd0dad4c464a79a84cb437d9e5e54f
+      - 0e25c94a53374260bbf6b65b3c36374b
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wNWZkODU1Mi0zNWQ2LTQxOGYtOGFhYi0zZTliM2RhZThkMTYvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxODowMjozMC45MjQ1MjFaIiwi
+        ZmlsZS9iYWUzYjA3NS1jYzQxLTRkYjktYTQ5NS05Mjk3NzJmYzAwOTIvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xN1QxMjoxMTo1NC43Mzk1NDNaIiwi
         dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlLzA1ZmQ4NTUyLTM1ZDYtNDE4Zi04YWFiLTNlOWIzZGFlOGQxNi92
+        ZS9maWxlL2JhZTNiMDc1LWNjNDEtNGRiOS1hNDk1LTkyOTc3MmZjMDA5Mi92
         ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30sImxhdGVzdF92ZXJzaW9uX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wNWZk
-        ODU1Mi0zNWQ2LTQxOGYtOGFhYi0zZTliM2RhZThkMTYvdmVyc2lvbnMvMC8i
+        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9iYWUz
+        YjA3NS1jYzQxLTRkYjktYTQ5NS05Mjk3NzJmYzAwOTIvdmVyc2lvbnMvMC8i
         LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
         cyIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6
         bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1hbmlm
         ZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:30 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:54 GMT
 - request:
     method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/remotes/file/file/b8c268ab-3b90-4595-bd91-f823dbb154d8/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/a8093a5c-0576-4cc5-9329-c1aab9b3cac0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -373,11 +361,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -385,40 +373,40 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:32 GMT
+      - Wed, 17 Nov 2021 12:11:56 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '67'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 78d1dea3ee394910a5761d01ffd3a7b4
+      - 85d2a895d5d64996a7b95f71283e3591
       Access-Control-Expose-Headers:
       - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA1NWM2Mzk1LWQ5NjUtNGQ2
-        NC04MzI2LTE0NTMzYjUyM2ZmZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQwY2UzMGFkLTdlYTYtNDVi
+        YS05YmZkLTljY2FhNTAwMTc0NS8ifQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:32 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:56 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/055c6395-d965-4d64-8326-14533b523fff/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/40ce30ad-7ea6-45ba-9bfd-9ccaa5001745/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -430,7 +418,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -438,18 +426,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:32 GMT
+      - Wed, 17 Nov 2021 12:11:56 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '604'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -459,33 +443,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d9e3edc2cb244982afdbe814ce1741cd
+      - 23fa3470df8b498696867718047defdf
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '371'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDU1YzYzOTUtZDk2
-        NS00ZDY0LTgzMjYtMTQ1MzNiNTIzZmZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDI6MzIuNjY3NjAyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDBjZTMwYWQtN2Vh
+        Ni00NWJhLTliZmQtOWNjYWE1MDAxNzQ1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTdUMTI6MTE6NTYuMDg5MDcwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI3OGQxZGVhM2VlMzk0OTEwYTU3NjFkMDFm
-        ZmQzYTdiNCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTEwLTA2VDE4OjAyOjMyLjcx
-        MDk2NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDI6MzIuNzQ5
-        OTIxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy82YjcxM2NhNS1lMWZiLTQ3OWEtODZhMy04NWVkMTFiMzkzZmIvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4NWQyYTg5NWQ1ZDY0OTk2YTdiOTVmNzEy
+        ODNlMzU5MSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE3VDEyOjExOjU2LjE0
+        Nzg4NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTdUMTI6MTE6NTYuMTk5
+        NzY3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8zYjQxMGEzZi0yMTE5LTQ4NDgtYTIzZi1lOGQwZTI1NGRjYjQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvYjhjMjY4YWItM2I5MC00NTk1LWJk
-        OTEtZjgyM2RiYjE1NGQ4LyJdfQ==
+        cGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvYTgwOTNhNWMtMDU3Ni00Y2M1LTkz
+        MjktYzFhYWI5YjNjYWMwLyJdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:32 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:56 GMT
 - request:
     method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/file/file/05fd8552-35d6-418f-8aab-3e9b3dae8d16/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/bae3b075-cc41-4db9-a495-929772fc0092/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -493,11 +479,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -505,40 +491,40 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:33 GMT
+      - Wed, 17 Nov 2021 12:11:56 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '67'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ea2e3ac648ae4f26b9556039511c7c9b
+      - 4e6b0bc36fcd4ee0b2ec68a861ae32c5
       Access-Control-Expose-Headers:
       - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk4OTkxYTMzLTcxNGYtNDEz
-        MC05ZTI1LTEzNmQ3NGRlMzY3Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNmNjQ3ODBmLTY0MDMtNGRi
+        MS1hYzI0LTE3ZGNlNWEwZmMwYS8ifQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:33 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:56 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/98991a33-714f-4130-9e25-136d74de3677/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/3f64780f-6403-4db1-ac24-17dce5a0fc0a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -550,7 +536,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -558,18 +544,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:33 GMT
+      - Wed, 17 Nov 2021 12:11:56 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '609'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -579,33 +561,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 94147488ecf74198b219558940530af9
+      - 138fe8ac70c346a4b48a324269533f57
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '374'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTg5OTFhMzMtNzE0
-        Zi00MTMwLTllMjUtMTM2ZDc0ZGUzNjc3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDI6MzMuMjQxMjYyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2Y2NDc4MGYtNjQw
+        My00ZGIxLWFjMjQtMTdkY2U1YTBmYzBhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTdUMTI6MTE6NTYuMzc1NTY1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJlYTJlM2FjNjQ4YWU0ZjI2Yjk1NTYwMzk1
-        MTFjN2M5YiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTEwLTA2VDE4OjAyOjMzLjI4
-        MTc4MloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDI6MzMuMzMx
-        NjM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wNWU2ZDdmNC1iNTY0LTRlNzMtODJlYi0xNWI1MGE1MTI0YTMvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0ZTZiMGJjMzZmY2Q0ZWUwYjJlYzY4YTg2
+        MWFlMzJjNSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE3VDEyOjExOjU2LjQ0
+        NzQ0NloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTdUMTI6MTE6NTYuNTI1
+        MDQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8zYjQxMGEzZi0yMTE5LTQ4NDgtYTIzZi1lOGQwZTI1NGRjYjQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wNWZkODU1Mi0zNWQ2LTQx
-        OGYtOGFhYi0zZTliM2RhZThkMTYvIl19
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS9iYWUzYjA3NS1jYzQxLTRk
+        YjktYTQ5NS05Mjk3NzJmYzAwOTIvIl19
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:33 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:56 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -613,11 +597,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.15.0/ruby
+      - OpenAPI-Generator/2.15.1/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -625,172 +609,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:33 GMT
+      - Wed, 17 Nov 2021 12:11:56 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '673'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 4ea00194fa4e45d7903fbb386f2bde39
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yNGU3MzlkNS1hMTc0LTRjMGYtODE4ZS0yMGY5Y2Q5MTlhMmIv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxODowMDo0OC4zMzM1MDFa
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yNGU3MzlkNS1hMTc0LTRjMGYtODE4ZS0yMGY5Y2Q5MTlhMmIv
-        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzI0ZTcz
-        OWQ1LWExNzQtNGMwZi04MThlLTIwZjljZDkxOWEyYi92ZXJzaW9ucy8wLyIs
-        Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
-        cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
-        ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
-        a2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVs
-        bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
-        cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX1dfQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:33 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/24e739d5-a174-4c0f-818e-20f9cd919a2b/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:34 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '370'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - b6c195d4e3164c3fb550a2a0f77e9e04
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8yNGU3MzlkNS1hMTc0LTRjMGYtODE4ZS0yMGY5Y2Q5MTlhMmIv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2VDE4OjAw
-        OjQ4LjMzNjgxMVoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjRlNzM5ZDUtYTE3NC00YzBm
-        LTgxOGUtMjBmOWNkOTE5YTJiLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:34 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:34 GMT
-      Content-Type:
-      - application/json
       Content-Length:
       - '52'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1b848e3db6ad45c1b7b36d184eda8b25
+      - 0f230dce4649421bb3347557b35fe814
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:34 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:56 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -798,11 +650,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.2/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -810,53 +662,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:34 GMT
+      - Wed, 17 Nov 2021 12:11:56 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '559'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c8b108f5a58640b08d2a2f1acb395c40
+      - 0ac41ab4a10b46839545f2e1977e6da4
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi85MDExZGVmZS02MjlkLTRmYzAtYWU0MC1jNjk4NjI5
-        YmVjMmEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxNzo0ODoyOC4w
-        MzkyODNaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvcHl0aG9uL3B5dGhvbi85MDExZGVmZS02MjlkLTRmYzAtYWU0MC1j
-        Njk4NjI5YmVjMmEvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
-        c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9w
-        eXRob24vcHl0aG9uLzkwMTFkZWZlLTYyOWQtNGZjMC1hZTQwLWM2OTg2Mjli
-        ZWMyYS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlv
-        bi1DYWJpbmV0LXB1bHAzX1B5dGhvbl8xIiwiZGVzY3JpcHRpb24iOm51bGws
-        InJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1
-        dG9wdWJsaXNoIjpmYWxzZX1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:34 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:56 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/python/python/9011defe-629d-4fc0-ae40-c698629bec2a/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -868,7 +707,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -876,49 +715,93 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:35 GMT
+      - Wed, 17 Nov 2021 12:11:56 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '382'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
-      - GET, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c2886dc913ca414a91eb9a8d5f219808
+      - c0439b1a06c346799306687b4516515f
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi85MDExZGVmZS02MjlkLTRmYzAtYWU0MC1jNjk4NjI5
-        YmVjMmEvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2
-        VDE3OjQ4OjI4LjA0MjE3NVoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vOTAxMWRl
-        ZmUtNjI5ZC00ZmMwLWFlNDAtYzY5ODYyOWJlYzJhLyIsImJhc2VfdmVyc2lv
-        biI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3Zl
-        ZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:35 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:56 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.9.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:11:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7d306a1c6770447a899f0c0054f1ba2c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:11:56 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -930,7 +813,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -938,42 +821,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:35 GMT
+      - Wed, 17 Nov 2021 12:11:56 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1635e2ed5ed14777a46d71b9a09dc8bd
+      - 1aeae5dea2024ec7a63933e82bd91849
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:35 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:56 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -981,11 +862,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.15.0/ruby
+      - OpenAPI-Generator/3.15.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -993,18 +874,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:35 GMT
+      - Wed, 17 Nov 2021 12:11:57 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '498'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1014,31 +891,65 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b02f95d70034487491b701b3c603e444
+      - 4418ad8182b840e3b2eb61afd02aeaf1
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '459'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZGViL2FwdC8xY2VjYTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4N2Uv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxODowMToxNy4xNjIzMjVa
+        cnBtL3JwbS82N2QyN2U0OS05NjZkLTRhYmQtYjE5YS1kMzdkNDQwOTY4NzUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xNVQyMDo1MDozMi44ODMwNzla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZGViL2FwdC8xY2VjYTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4N2Uv
+        cnBtL3JwbS82N2QyN2U0OS05NjZkLTRhYmQtYjE5YS1kMzdkNDQwOTY4NzUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzFjZWNh
-        NDQzLWE0YjQtNGUwYS04ZmMwLTYyNzVjNGZkNDg3ZS92ZXJzaW9ucy8wLyIs
-        Im5hbWUiOiJkZWJpYW5fcHVscF9yYWduYXJvayIsImRlc2NyaXB0aW9uIjpu
-        dWxsLCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxs
-        fV19
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzY3ZDI3
+        ZTQ5LTk2NmQtNGFiZC1iMTlhLWQzN2Q0NDA5Njg3NS92ZXJzaW9ucy8wLyIs
+        Im5hbWUiOiJ5dW0tanNoZXJpbGwtMi0yMTY3MDEiLCJkZXNjcmlwdGlvbiI6
+        bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVs
+        bCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZp
+        Y2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowLCJtZXRhZGF0
+        YV9jaGVja3N1bV90eXBlIjpudWxsLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUi
+        Om51bGwsImdwZ2NoZWNrIjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVf
+        bWV0YWRhdGEiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvcnBtL3JwbS80YzZiMTU4Zi03NDMzLTRkNDgtYjA0ZC1h
+        Yzc3ZTY4ZDkxZDEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xNVQyMDo1
+        MDoxMi4yMjM1NDFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvcnBtL3JwbS80YzZiMTU4Zi03NDMzLTRkNDgtYjA0ZC1h
+        Yzc3ZTY4ZDkxZDEvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
+        c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
+        cG0vcnBtLzRjNmIxNThmLTc0MzMtNGQ0OC1iMDRkLWFjNzdlNjhkOTFkMS92
+        ZXJzaW9ucy8wLyIsIm5hbWUiOiJ5dW0tanNoZXJpbGwtMS0yMDc1NTgiLCJk
+        ZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGws
+        InJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9z
+        aWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25z
+        IjowLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjpudWxsLCJwYWNrYWdlX2No
+        ZWNrc3VtX3R5cGUiOm51bGwsImdwZ2NoZWNrIjowLCJyZXBvX2dwZ2NoZWNr
+        IjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82MTY0MGFhMC0yZTdk
+        LTRlYjUtYTFhNy1iZTlkNWYyODU1Y2EvIiwicHVscF9jcmVhdGVkIjoiMjAy
+        MS0xMS0xMlQxMzowMzowMS43MjQxODZaIiwidmVyc2lvbnNfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82MTY0MGFhMC0yZTdk
+        LTRlYjUtYTFhNy1iZTlkNWYyODU1Y2EvdmVyc2lvbnMvIiwicHVscF9sYWJl
+        bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzYxNjQwYWEwLTJlN2QtNGViNS1hMWE3LWJl
+        OWQ1ZjI4NTVjYS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJ0ZXN0LTk2MzgteXVt
+        LTE3NTkzMSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJz
+        aW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2Us
+        Im1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2th
+        Z2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOm51bGws
+        InBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJl
+        cG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:35 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:57 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/deb/apt/1ceca443-a4b4-4e0a-8fc0-6275c4fd487e/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/67d27e49-966d-4abd-b19a-d37d44096875/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1046,11 +957,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.15.0/ruby
+      - OpenAPI-Generator/3.15.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1058,18 +969,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:35 GMT
+      - Wed, 17 Nov 2021 12:11:57 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '370'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
@@ -1079,28 +986,30 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3b0e0e127f454a23b5a3fa6b4feeca41
+      - 3f7751db28bc4691afe8604efde58afa
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '231'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZGViL2FwdC8xY2VjYTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4N2Uv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2VDE4OjAx
-        OjE3LjE2NTQ1NFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMWNlY2E0NDMtYTRiNC00ZTBh
-        LThmYzAtNjI3NWM0ZmQ0ODdlLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        cnBtL3JwbS82N2QyN2U0OS05NjZkLTRhYmQtYjE5YS1kMzdkNDQwOTY4NzUv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTE1VDIwOjUw
+        OjMyLjg4ODMxNFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjdkMjdlNDktOTY2ZC00YWJk
+        LWIxOWEtZDM3ZDQ0MDk2ODc1LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
         dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
         bnQiOnt9fX1dfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:35 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:57 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/4c6b158f-7433-4d48-b04d-ac77e68d91d1/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1108,11 +1017,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.8.1/ruby
+      - OpenAPI-Generator/3.15.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1120,84 +1029,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:36 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '551'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - d48074a8332d4550a9d0455a23b3ed1c
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci8zM2EzMmFlNS1mYzNjLTRlOGQtYTE0MS0x
-        YmVjY2RjMjYzZjgvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxNzoy
-        Mjo0OS44MzM0OTRaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8zM2EzMmFlNS1mYzNj
-        LTRlOGQtYTE0MS0xYmVjY2RjMjYzZjgvdmVyc2lvbnMvIiwicHVscF9sYWJl
-        bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzMzYTMyYWU1LWZjM2Mt
-        NGU4ZC1hMTQxLTFiZWNjZGMyNjNmOC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJE
-        ZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwiZGVzY3Jp
-        cHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1v
-        dGUiOm51bGx9XX0=
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:36 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/container/container/33a32ae5-fc3c-4e8d-a141-1beccdc263f8/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
+      - Wed, 17 Nov 2021 12:11:57 GMT
       Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:36 GMT
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '394'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
@@ -1207,28 +1046,90 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 973135ebb50e495c84c78176111fea4f
+      - 4fc56ca1f710441a83083690446c110c
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '231'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci8zM2EzMmFlNS1mYzNjLTRlOGQtYTE0MS0x
-        YmVjY2RjMjYzZjgvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIx
-        LTEwLTA2VDE3OjIyOjQ5LjkxNTIwMloiLCJudW1iZXIiOjAsInJlcG9zaXRv
-        cnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250
-        YWluZXIvMzNhMzJhZTUtZmMzYy00ZThkLWExNDEtMWJlY2NkYzI2M2Y4LyIs
-        ImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVk
-        Ijp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        cnBtL3JwbS80YzZiMTU4Zi03NDMzLTRkNDgtYjA0ZC1hYzc3ZTY4ZDkxZDEv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTE1VDIwOjUw
+        OjEyLjIyODUyN1oiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNGM2YjE1OGYtNzQzMy00ZDQ4
+        LWIwNGQtYWM3N2U2OGQ5MWQxLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:36 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:57 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/61640aa0-2e7d-4eb5-a1a7-be9d5f2855ca/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:11:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1ced58bba21749c7856050290e5c58ac
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '230'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS82MTY0MGFhMC0yZTdkLTRlYjUtYTFhNy1iZTlkNWYyODU1Y2Ev
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTEyVDEzOjAz
+        OjAxLjczMDg3M1oiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjE2NDBhYTAtMmU3ZC00ZWI1
+        LWExYTctYmU5ZDVmMjg1NWNhLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:11:57 GMT
 - request:
     method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/orphans/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/orphans/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1240,7 +1141,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1248,40 +1149,40 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:37 GMT
+      - Wed, 17 Nov 2021 12:11:57 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - DELETE, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '67'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1a560980a0f544a9bcbd7ea45168899a
+      - 94583d4e062c405b91bdefae616ddda0
       Access-Control-Expose-Headers:
       - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVlYWQyNzgwLWZkMmItNGY0
-        MS05ZDM5LWVjYzJmYTRkNzk5NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMyODk5ZTlkLTViYjYtNGJm
+        ZC1iNWI2LTM4Mzc3Y2FkZDVjMi8ifQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:37 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:57 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/5ead2780-fd2b-4f41-9d39-ecc2fa4d7995/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/32899e9d-5bb6-4bfd-b5b6-38377cadd5c2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1293,7 +1194,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1301,18 +1202,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:37 GMT
+      - Wed, 17 Nov 2021 12:11:57 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '771'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1322,23 +1219,25 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c1d8d4d957624f01861c716f55e1a35b
+      - 43fe8468523244f697f262e436ff6c4b
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '409'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWVhZDI3ODAtZmQy
-        Yi00ZjQxLTlkMzktZWNjMmZhNGQ3OTk1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDI6MzcuMDE5OTIzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzI4OTllOWQtNWJi
+        Ni00YmZkLWI1YjYtMzgzNzdjYWRkNWMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTdUMTI6MTE6NTcuMjc1ODUwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJsb2dnaW5nX2NpZCI6IjFhNTYwOTgwYTBmNTQ0YTliY2JkN2Vh
-        NDUxNjg4OTlhIiwic3RhcnRlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDI6Mzcu
-        MTExNjAzWiIsImZpbmlzaGVkX2F0IjoiMjAyMS0xMC0wNlQxODowMjozNy4x
-        NTg2MDBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzLzZiNzEzY2E1LWUxZmItNDc5YS04NmEzLTg1ZWQxMWIzOTNmYi8i
+        ZWFudXAiLCJsb2dnaW5nX2NpZCI6Ijk0NTgzZDRlMDYyYzQwNWI5MWJkZWZh
+        ZTYxNmRkZGEwIiwic3RhcnRlZF9hdCI6IjIwMjEtMTEtMTdUMTI6MTE6NTcu
+        MzQ0MjI4WiIsImZpbmlzaGVkX2F0IjoiMjAyMS0xMS0xN1QxMjoxMTo1Ny4z
+        OTAwNzBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzQ5MDAyOGZjLWUzYjgtNGFiZi1iMDhkLTlkNzcwNzBlODZjYi8i
         LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
         b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xl
         YW4gdXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVu
@@ -1349,5 +1248,5 @@ http_interactions:
         ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
         ZCI6W119
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:37 GMT
+  recorded_at: Wed, 17 Nov 2021 12:11:57 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload_binary.yml
@@ -16509,4 +16509,564 @@ http_interactions:
         NDE4Zi04YWFiLTNlOWIzZGFlOGQxNi8iXX0=
     http_version: 
   recorded_at: Wed, 06 Oct 2021 18:02:31 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/6b0f3615-659f-479e-b96f-ef79c6f585df/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2U5YTk5YzdjLTAwZGQtNDE2Yy04ODE1LThhNDE1NDA3ZTIw
+        YS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:18:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9f8c16f9385f4f0c94f31f1b0bf37859
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I2MTNjNjhjLTY2NTktNDEy
+        Yy04ZTg1LWYzN2YxZmY5ZWM3MC8ifQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:18:49 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/b613c68c-6659-412c-8e85-f37f1ff9ec70/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:18:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7c62ff6baf894eb09cb350b3f9e0ed4e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '390'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjYxM2M2OGMtNjY1
+        OS00MTJjLThlODUtZjM3ZjFmZjllYzcwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMTY6MTg6NDkuNDM2MDYyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI5ZjhjMTZmOTM4NWY0ZjBjOTRm
+        MzFmMWIwYmYzNzg1OSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE2VDE2OjE4
+        OjQ5LjQ5NDU2MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTZUMTY6MTg6
+        NDkuNjAzNzc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy80OTAwMjhmYy1lM2I4LTRhYmYtYjA4ZC05ZDc3MDcwZTg2
+        Y2IvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzZiMGYzNjE1LTY1OWYtNDc5ZS1iOTZmLWVmNzljNmY1ODVkZi92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzZiMGYzNjE1LTY1OWYt
+        NDc5ZS1iOTZmLWVmNzljNmY1ODVkZi8iXX0=
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:18:49 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/074a0726-4bfc-4a36-ab9e-9fbccda03f81/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2U5YTk5YzdjLTAwZGQtNDE2Yy04ODE1LThhNDE1NDA3ZTIw
+        YS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:09:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c5e3b294b19c456f873cfdeaf3429336
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI1NDA0MjdlLWRlZTEtNGZl
+        NC1hN2ZkLWI2NDMxOWZkYmQwOS8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:09:44 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/2540427e-dee1-4fe4-a7fd-b64319fdbd09/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:09:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 700c3db44fe74d86a607db1367bbfdc7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjU0MDQyN2UtZGVl
+        MS00ZmU0LWE3ZmQtYjY0MzE5ZmRiZDA5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTdUMTI6MDk6NDQuNTM5MzQ5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJjNWUzYjI5NGIxOWM0NTZmODcz
+        Y2ZkZWFmMzQyOTMzNiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE3VDEyOjA5
+        OjQ0LjU5OTkyNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTdUMTI6MDk6
+        NDQuNzEzMjA4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9iZmJlMjlhMC04YzQ2LTRkNzgtYjA2YS03ODk4OTlmYTMw
+        NzcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlLzA3NGEwNzI2LTRiZmMtNGEzNi1hYjllLTlmYmNjZGEwM2Y4MS92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzA3NGEwNzI2LTRiZmMt
+        NGEzNi1hYjllLTlmYmNjZGEwM2Y4MS8iXX0=
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:09:44 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/b052c9f5-c30b-40cd-ba3a-a595dd96bb7d/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2U5YTk5YzdjLTAwZGQtNDE2Yy04ODE1LThhNDE1NDA3ZTIw
+        YS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:10:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0565bfafcae54c4b9c5b33a500d770d5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk2NDI1NmY3LTVkZjItNGZk
+        Yi04NjdmLTVkY2VhNzE4NmNmMy8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:10:49 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/964256f7-5df2-4fdb-867f-5dcea7186cf3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:10:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 35f1c6ac802d41b9b48605d0d8630dbb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '392'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTY0MjU2ZjctNWRm
+        Mi00ZmRiLTg2N2YtNWRjZWE3MTg2Y2YzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTdUMTI6MTA6NDguOTg1MTY3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIwNTY1YmZhZmNhZTU0YzRiOWM1
+        YjMzYTUwMGQ3NzBkNSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE3VDEyOjEw
+        OjQ5LjA1MTUxMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTdUMTI6MTA6
+        NDkuMTcwMTAyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9iZmJlMjlhMC04YzQ2LTRkNzgtYjA2YS03ODk4OTlmYTMw
+        NzcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlL2IwNTJjOWY1LWMzMGItNDBjZC1iYTNhLWE1OTVkZDk2YmI3ZC92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2IwNTJjOWY1LWMzMGIt
+        NDBjZC1iYTNhLWE1OTVkZDk2YmI3ZC8iXX0=
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:10:49 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:11:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 14800150ca884424a46acd3fea0ec713
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '488'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
+        ZmlsZXMvZTlhOTljN2MtMDBkZC00MTZjLTg4MTUtOGE0MTU0MDdlMjBhLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjEtMTEtMTZUMTU6NTg6MjcuOTU4NzIxWiIs
+        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85M2ZiNTY5NC0w
+        OTMxLTQ0NjgtOWQ0Ni0wMzNjNDgwZmQ1ZWUvIiwicmVsYXRpdmVfcGF0aCI6
+        InRlc3RfZXJyYXR1bS5qc29uIiwibWQ1IjpudWxsLCJzaGExIjoiNjA5ODg1
+        NzE1ZmQ4ZDZhNzA3ZjE4ZmM1NTlkNjFiOGJkZWU3MTgwZSIsInNoYTIyNCI6
+        ImUyOTMxZjAzNjY1NmJhNmQwMTdiNTA2YjhmZWM1N2I4N2U1N2VlYzI3YWVh
+        ZDBkZjdhZDhlZDNjIiwic2hhMjU2IjoiZWYwYzk5ODMxMDZiODI0Zjk0Mzg1
+        MGRmOTQ0MjBlN2YxOGFkMzgxYWNjNmJkNWEyMWVhMDVkY2Y2NjBhNzc5MSIs
+        InNoYTM4NCI6ImQzYzUyOGQyMTEwZDgwNjY3NTliZWQwY2RkYzA5OTEzOTFk
+        NDc3MjdkN2JiMDAzODY0ZWE5MzYyMTNhOGVjNDRhM2RmNTJkZDFiMjdjNzg1
+        YzdlNjdiMTAzMjJlOTlmZCIsInNoYTUxMiI6ImNmYjg1MjNlODdjN2JmOTFl
+        ODIzMGY1Y2UxNjhiZTFkODUyN2FiNzY3ZjU1NzE0ZWU0NWRiY2Q1MDVmNzdl
+        ODQxYTU0MTc4MjI0ODdmZGUyMjVlNjIyZmQ0ZjljZGYzMzM4NDVkOTAxNDAw
+        Nzg2M2E5OWExOWE3ZjQ5MDJlZTI4In1dfQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:11:55 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/bae3b075-cc41-4db9-a495-929772fc0092/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzL2U5YTk5YzdjLTAwZGQtNDE2Yy04ODE1LThhNDE1NDA3ZTIw
+        YS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:11:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2fd355a2d84f4888a1ab62e74e7687f3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQwYTYwM2YyLWMxMTEtNDgw
+        OS05ZWQzLTlmN2I3ZWQ5ZDU3My8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:11:55 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/40a603f2-c111-4809-9ed3-9f7b7ed9d573/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Nov 2021 12:11:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a8e225ba9aec4ba0abacd14444267ac3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '389'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDBhNjAzZjItYzEx
+        MS00ODA5LTllZDMtOWY3YjdlZDlkNTczLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTdUMTI6MTE6NTUuMTY5Njg5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyZmQzNTVhMmQ4NGY0ODg4YTFh
+        YjYyZTc0ZTc2ODdmMyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE3VDEyOjEx
+        OjU1LjIzMDY2NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTdUMTI6MTE6
+        NTUuMzQxMjc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy83YmUxMDlhMS1hNTY5LTRkNjYtYTM1Ni05ZDlmNWE5ZDM2
+        MmEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
+        aWxlL2JhZTNiMDc1LWNjNDEtNGRiOS1hNDk1LTkyOTc3MmZjMDA5Mi92ZXJz
+        aW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlL2JhZTNiMDc1LWNjNDEt
+        NGRiOS1hNDk1LTkyOTc3MmZjMDA5Mi8iXX0=
+    http_version: 
+  recorded_at: Wed, 17 Nov 2021 12:11:55 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -14,7 +14,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -22,42 +22,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:40 GMT
+      - Tue, 16 Nov 2021 16:14:06 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6eb04aba5a0b4f838a111b745350fff0
+      - 60fbe99184064ccda5c9e7d1e3167c78
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:40 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:06 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -69,7 +67,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -77,42 +75,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:40 GMT
+      - Tue, 16 Nov 2021 16:14:06 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bce4668953ca4752bc0bae0ec2ff1a74
+      - 6c2415b6a44146f78ec025952b235edd
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:40 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:06 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -124,7 +120,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -132,42 +128,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:40 GMT
+      - Tue, 16 Nov 2021 16:14:06 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 443d348dad264e9790e24f2daa8df079
+      - be1f4cbbb53949b08d3520bb96f91cf8
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:40 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:06 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -179,7 +173,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -187,42 +181,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:41 GMT
+      - Tue, 16 Nov 2021 16:14:07 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d82fe225958f4e82aa549092c700780d
+      - 39ba4da930694b58aea44d497c02a676
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:41 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:07 GMT
 - request:
     method: post
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -239,7 +231,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -247,54 +239,52 @@ http_interactions:
       code: 201
       message: Created
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:41 GMT
+      - Tue, 16 Nov 2021 16:14:07 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '534'
-      Connection:
-      - keep-alive
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/b7bdb27a-2c88-41a9-a4eb-e1e6c19a9764/"
+      - "/pulp/api/v3/remotes/rpm/rpm/f72e4fcf-5b5d-4542-954e-1a420500ff37/"
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '534'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c1b89956c958480ca65c46234c7395ee
+      - 407a24c8c4184f21906979b59e3fe73c
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I3
-        YmRiMjdhLTJjODgtNDFhOS1hNGViLWUxZTZjMTlhOTc2NC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIxLTEwLTA2VDE4OjAzOjQxLjUyNDE0NloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Y3
+        MmU0ZmNmLTViNWQtNDU0Mi05NTRlLTFhNDIwNTAwZmYzNy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIxLTExLTE2VDE2OjE0OjA3LjI5MDQ4MFoiLCJuYW1lIjoi
         RmVkb3JhXzE3IiwidXJsIjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0
         IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRy
         dWUsInByb3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjEtMTAtMDZUMTg6MDM6NDEuNTI0MTY5WiIsImRv
+        c3RfdXBkYXRlZCI6IjIwMjEtMTEtMTZUMTY6MTQ6MDcuMjkwNTA2WiIsImRv
         d25sb2FkX2NvbmN1cnJlbmN5IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwi
         cG9saWN5Ijoib25fZGVtYW5kIiwidG90YWxfdGltZW91dCI6MzAwLjAsImNv
         bm5lY3RfdGltZW91dCI6bnVsbCwic29ja19jb25uZWN0X3RpbWVvdXQiOm51
         bGwsInNvY2tfcmVhZF90aW1lb3V0IjpudWxsLCJoZWFkZXJzIjpudWxsLCJy
         YXRlX2xpbWl0IjpudWxsLCJzbGVzX2F1dGhfdG9rZW4iOm51bGx9
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:41 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:07 GMT
 - request:
     method: post
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -308,7 +298,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -316,45 +306,43 @@ http_interactions:
       code: 201
       message: Created
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:42 GMT
+      - Tue, 16 Nov 2021 16:14:07 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '629'
-      Connection:
-      - keep-alive
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/b145d5e0-0349-4d47-8b4b-6cb5c264b3cf/"
+      - "/pulp/api/v3/repositories/rpm/rpm/53a9ffaf-efc9-438b-8136-23a19b613be7/"
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '629'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7371c3835f984be7975c5b1e430018df
+      - acc67e8e936f4662b0578ffb217f9213
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYjE0NWQ1ZTAtMDM0OS00ZDQ3LThiNGItNmNiNWMyNjRiM2NmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjEtMTAtMDZUMTg6MDM6NDIuMDA0NDgwWiIsInZl
+        cG0vNTNhOWZmYWYtZWZjOS00MzhiLTgxMzYtMjNhMTliNjEzYmU3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjEtMTEtMTZUMTY6MTQ6MDcuNTQwMzUyWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYjE0NWQ1ZTAtMDM0OS00ZDQ3LThiNGItNmNiNWMyNjRiM2NmL3ZlcnNp
+        cG0vNTNhOWZmYWYtZWZjOS00MzhiLTgxMzYtMjNhMTliNjEzYmU3L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9iMTQ1ZDVlMC0w
-        MzQ5LTRkNDctOGI0Yi02Y2I1YzI2NGIzY2YvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81M2E5ZmZhZi1l
+        ZmM5LTQzOGItODEzNi0yM2ExOWI2MTNiZTcvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiRmVkb3JhXzE3IiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBv
         X3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpm
         YWxzZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5f
@@ -362,10 +350,10 @@ http_interactions:
         bnVsbCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6
         MCwicmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:42 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:07 GMT
 - request:
     method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/b7bdb27a-2c88-41a9-a4eb-e1e6c19a9764/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/f72e4fcf-5b5d-4542-954e-1a420500ff37/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -377,7 +365,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -385,40 +373,40 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:45 GMT
+      - Tue, 16 Nov 2021 16:14:09 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '67'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1f21c148672747f290274baa6380c248
+      - a9826d686efe4277a3b7a5fef36895a4
       Access-Control-Expose-Headers:
       - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY3Yzc2YTdkLTY5YTYtNDRi
-        MS05OTllLTZhZjU0MjA3MzFhOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FhNTdmZjI5LWYyYjEtNDQ0
+        ZS1iN2Y5LWU2MmFkM2YyOWQxOS8ifQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:45 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:09 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/67c76a7d-69a6-44b1-999e-6af5420731a9/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/aa57ff29-f2b1-444e-b7f9-e62ad3f29d19/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -430,7 +418,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -438,18 +426,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:45 GMT
+      - Tue, 16 Nov 2021 16:14:09 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '602'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -459,33 +443,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ee2235bb58454c0986b761266ae1a844
+      - 385883a6b7fe4205b6a88be0bc57e226
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '371'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjdjNzZhN2QtNjlh
-        Ni00NGIxLTk5OWUtNmFmNTQyMDczMWE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDM6NDUuMjE5MDg4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWE1N2ZmMjktZjJi
+        MS00NDRlLWI3ZjktZTYyYWQzZjI5ZDE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMTY6MTQ6MDkuNjI1MzM4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxZjIxYzE0ODY3Mjc0N2YyOTAyNzRiYWE2
-        MzgwYzI0OCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTEwLTA2VDE4OjAzOjQ1LjI3
-        MjE3MloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDM6NDUuMzE3
-        MDEyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy82YjcxM2NhNS1lMWZiLTQ3OWEtODZhMy04NWVkMTFiMzkzZmIvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhOTgyNmQ2ODZlZmU0Mjc3YTNiN2E1ZmVm
+        MzY4OTVhNCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE2VDE2OjE0OjA5LjY5
+        MDU5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTZUMTY6MTQ6MDkuNzQ0
+        Njg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy83YmUxMDlhMS1hNTY5LTRkNjYtYTM1Ni05ZDlmNWE5ZDM2MmEvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I3YmRiMjdhLTJjODgtNDFhOS1hNGVi
-        LWUxZTZjMTlhOTc2NC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Y3MmU0ZmNmLTViNWQtNDU0Mi05NTRl
+        LTFhNDIwNTAwZmYzNy8iXX0=
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:45 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:09 GMT
 - request:
     method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/b145d5e0-0349-4d47-8b4b-6cb5c264b3cf/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/53a9ffaf-efc9-438b-8136-23a19b613be7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -497,7 +483,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -505,40 +491,40 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:45 GMT
+      - Tue, 16 Nov 2021 16:14:09 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '67'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2e145257e9da4589ad6f6030439a3b0f
+      - ce9eae98bc9840c6ae1248645eda44fd
       Access-Control-Expose-Headers:
       - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc1Y2ExNWNmLTVlNWEtNGRh
-        MS1hMmE4LTAzNmNiYTc5NzNmNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAwNWQ1MDNiLTE0ZDUtNGEy
+        Ny05MGVhLWIzYjA5MGFhNzRjMC8ifQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:45 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:09 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/75ca15cf-5e5a-4da1-a2a8-036cba7973f7/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/005d503b-14d5-4a27-90ea-b3b090aa74c0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -550,7 +536,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -558,18 +544,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:46 GMT
+      - Tue, 16 Nov 2021 16:14:10 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '607'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -579,33 +561,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 74d366fc62334840a2d5990fcb73eb37
+      - 69f6a2a04a3d4de88f3ac0e70c2a7636
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '374'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzVjYTE1Y2YtNWU1
-        YS00ZGExLWEyYTgtMDM2Y2JhNzk3M2Y3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDM6NDUuODE4NDk4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDA1ZDUwM2ItMTRk
+        NS00YTI3LTkwZWEtYjNiMDkwYWE3NGMwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMTY6MTQ6MDkuOTE3NjM3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIyZTE0NTI1N2U5ZGE0NTg5YWQ2ZjYwMzA0
-        MzlhM2IwZiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTEwLTA2VDE4OjAzOjQ1Ljg2
-        OTAxNloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDM6NDUuOTI4
-        OTAyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wNWU2ZDdmNC1iNTY0LTRlNzMtODJlYi0xNWI1MGE1MTI0YTMvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjZTllYWU5OGJjOTg0MGM2YWUxMjQ4NjQ1
+        ZWRhNDRmZCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE2VDE2OjE0OjA5Ljk3
+        OTQ1M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTZUMTY6MTQ6MTAuMDU1
+        Njk5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy83YmUxMDlhMS1hNTY5LTRkNjYtYTM1Ni05ZDlmNWE5ZDM2MmEvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjE0NWQ1ZTAtMDM0OS00ZDQ3
-        LThiNGItNmNiNWMyNjRiM2NmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTNhOWZmYWYtZWZjOS00Mzhi
+        LTgxMzYtMjNhMTliNjEzYmU3LyJdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:46 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:10 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -617,7 +601,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -625,18 +609,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:46 GMT
+      - Tue, 16 Nov 2021 16:14:10 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '1305'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -646,178 +626,65 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8803fdd5e31d445d8048f52de86eaa50
+      - e118d79030764f57a8cd9e073c45f959
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jOWJkODU1OC03YjBjLTQ3ZDktODFkMC00ZTVhOWVmODdlYzAv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxODowMzoyNS43NjMzMDRa
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jOWJkODU1OC03YjBjLTQ3ZDktODFkMC00ZTVhOWVmODdlYzAv
-        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2M5YmQ4
-        NTU4LTdiMGMtNDdkOS04MWQwLTRlNWE5ZWY4N2VjMC92ZXJzaW9ucy8yLyIs
-        Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
-        cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
-        ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
-        a2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVs
-        bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
-        cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0v
-        M2Q5MjM2NmMtM2RlOC00Y2NlLWFiNzgtZTQ4MjU3MTk4ZDdhLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjEtMTAtMDZUMTg6MDM6MjIuMTIwNDU3WiIsInZlcnNp
-        b25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0v
-        M2Q5MjM2NmMtM2RlOC00Y2NlLWFiNzgtZTQ4MjU3MTk4ZDdhL3ZlcnNpb25z
-        LyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zZDkyMzY2Yy0zZGU4
-        LTRjY2UtYWI3OC1lNDgyNTcxOThkN2EvdmVyc2lvbnMvMS8iLCJuYW1lIjoi
-        Ml9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9f
-        dmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZh
-        bHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9w
-        YWNrYWdlX3ZlcnNpb25zIjowLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjpu
-        dWxsLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOm51bGwsImdwZ2NoZWNrIjow
-        LCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNlfV19
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:46 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/c9bd8558-7b0c-47d9-81d0-4e5a9ef87ec0/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:03:46 GMT
-      Content-Type:
-      - application/json
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '3436'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 77dcf06faa8b44628d59bcdd57adf5de
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      - '459'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jOWJkODU1OC03YjBjLTQ3ZDktODFkMC00ZTVhOWVmODdlYzAv
-        dmVyc2lvbnMvMi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2VDE4OjAz
-        OjM1LjI5MzkwNVoiLCJudW1iZXIiOjIsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzliZDg1NTgtN2IwYy00N2Q5
-        LTgxZDAtNGU1YTllZjg3ZWMwLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5hZHZpc29yeSI6eyJjb3Vu
-        dCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtL2M5YmQ4NTU4LTdiMGMtNDdkOS04MWQwLTRl
-        NWE5ZWY4N2VjMC92ZXJzaW9ucy8yLyJ9LCJycG0uZGlzdHJpYnV0aW9uX3Ry
-        ZWUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vZGlzdHJpYnV0aW9uX3RyZWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRk
-        ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2M5YmQ4NTU4
-        LTdiMGMtNDdkOS04MWQwLTRlNWE5ZWY4N2VjMC92ZXJzaW9ucy8yLyJ9LCJy
-        cG0ubW9kdWxlbWQiOnsiY291bnQiOjYsImhyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vbW9kdWxlbWRzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRk
-        ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2M5YmQ4NTU4
-        LTdiMGMtNDdkOS04MWQwLTRlNWE5ZWY4N2VjMC92ZXJzaW9ucy8yLyJ9LCJy
-        cG0ucGFja2FnZSI6eyJjb3VudCI6MiwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVk
-        PS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jOWJkODU1OC03
-        YjBjLTQ3ZDktODFkMC00ZTVhOWVmODdlYzAvdmVyc2lvbnMvMi8ifSwicnBt
-        LnJlcG9fbWV0YWRhdGFfZmlsZSI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxw
-        L2FwaS92My9jb250ZW50L3JwbS9yZXBvX21ldGFkYXRhX2ZpbGVzLz9yZXBv
-        c2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtL2M5YmQ4NTU4LTdiMGMtNDdkOS04MWQwLTRlNWE5ZWY4N2Vj
-        MC92ZXJzaW9ucy8yLyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsicnBt
-        LmFkdmlzb3J5Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL2Fkdmlzb3JpZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzliZDg1NTgtN2IwYy00
-        N2Q5LTgxZDAtNGU1YTllZjg3ZWMwL3ZlcnNpb25zLzIvIn0sInJwbS5kaXN0
-        cmlidXRpb25fdHJlZSI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92
-        My9jb250ZW50L3JwbS9kaXN0cmlidXRpb25fdHJlZXMvP3JlcG9zaXRvcnlf
-        dmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzli
-        ZDg1NTgtN2IwYy00N2Q5LTgxZDAtNGU1YTllZjg3ZWMwL3ZlcnNpb25zLzIv
-        In0sInJwbS5tb2R1bGVtZCI6eyJjb3VudCI6NiwiaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9tb2R1bGVtZHMvP3JlcG9zaXRvcnlfdmVyc2lv
-        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzliZDg1NTgt
-        N2IwYy00N2Q5LTgxZDAtNGU1YTllZjg3ZWMwL3ZlcnNpb25zLzIvIn0sInJw
-        bS5wYWNrYWdlIjp7ImNvdW50IjoyLCJocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
-        bnRlbnQvcnBtL3BhY2thZ2VzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAv
-        YXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2M5YmQ4NTU4LTdiMGMtNDdk
-        OS04MWQwLTRlNWE5ZWY4N2VjMC92ZXJzaW9ucy8yLyJ9LCJycG0ucGFja2Fn
-        ZWVudmlyb25tZW50Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2VlbnZpcm9ubWVudHMvP3JlcG9zaXRvcnlf
-        dmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzli
-        ZDg1NTgtN2IwYy00N2Q5LTgxZDAtNGU1YTllZjg3ZWMwL3ZlcnNpb25zLzIv
-        In0sInJwbS5yZXBvX21ldGFkYXRhX2ZpbGUiOnsiY291bnQiOjEsImhyZWYi
-        OiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxl
-        cy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
-        ZXMvcnBtL3JwbS9jOWJkODU1OC03YjBjLTQ3ZDktODFkMC00ZTVhOWVmODdl
-        YzAvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jOWJkODU1OC03YjBjLTQ3ZDktODFk
-        MC00ZTVhOWVmODdlYzAvdmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIy
-        MDIxLTEwLTA2VDE4OjAzOjM0Ljk2NDM0OVoiLCJudW1iZXIiOjEsInJlcG9z
-        aXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzli
-        ZDg1NTgtN2IwYy00N2Q5LTgxZDAtNGU1YTllZjg3ZWMwLyIsImJhc2VfdmVy
-        c2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5w
-        YWNrYWdlZW52aXJvbm1lbnQiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZWVudmlyb25tZW50cy8/cmVwb3Np
-        dG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jOWJkODU1OC03YjBjLTQ3ZDktODFkMC00ZTVhOWVmODdlYzAv
-        dmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7InJwbS5w
-        YWNrYWdlZW52aXJvbm1lbnQiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9h
-        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZWVudmlyb25tZW50cy8/cmVwb3Np
-        dG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
-        bS9jOWJkODU1OC03YjBjLTQ3ZDktODFkMC00ZTVhOWVmODdlYzAvdmVyc2lv
-        bnMvMS8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvcnBtL3JwbS9jOWJkODU1OC03YjBjLTQ3ZDktODFkMC00ZTVhOWVm
-        ODdlYzAvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2
-        VDE4OjAzOjI1Ljc2OTIxNloiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzliZDg1NTgtN2Iw
-        Yy00N2Q5LTgxZDAtNGU1YTllZjg3ZWMwLyIsImJhc2VfdmVyc2lvbiI6bnVs
-        bCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30s
-        InByZXNlbnQiOnt9fX1dfQ==
+        cnBtL3JwbS82N2QyN2U0OS05NjZkLTRhYmQtYjE5YS1kMzdkNDQwOTY4NzUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xNVQyMDo1MDozMi44ODMwNzla
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS82N2QyN2U0OS05NjZkLTRhYmQtYjE5YS1kMzdkNDQwOTY4NzUv
+        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzY3ZDI3
+        ZTQ5LTk2NmQtNGFiZC1iMTlhLWQzN2Q0NDA5Njg3NS92ZXJzaW9ucy8wLyIs
+        Im5hbWUiOiJ5dW0tanNoZXJpbGwtMi0yMTY3MDEiLCJkZXNjcmlwdGlvbiI6
+        bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVs
+        bCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZp
+        Y2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowLCJtZXRhZGF0
+        YV9jaGVja3N1bV90eXBlIjpudWxsLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUi
+        Om51bGwsImdwZ2NoZWNrIjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVf
+        bWV0YWRhdGEiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvcnBtL3JwbS80YzZiMTU4Zi03NDMzLTRkNDgtYjA0ZC1h
+        Yzc3ZTY4ZDkxZDEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xNVQyMDo1
+        MDoxMi4yMjM1NDFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvcnBtL3JwbS80YzZiMTU4Zi03NDMzLTRkNDgtYjA0ZC1h
+        Yzc3ZTY4ZDkxZDEvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
+        c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
+        cG0vcnBtLzRjNmIxNThmLTc0MzMtNGQ0OC1iMDRkLWFjNzdlNjhkOTFkMS92
+        ZXJzaW9ucy8wLyIsIm5hbWUiOiJ5dW0tanNoZXJpbGwtMS0yMDc1NTgiLCJk
+        ZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGws
+        InJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9z
+        aWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25z
+        IjowLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjpudWxsLCJwYWNrYWdlX2No
+        ZWNrc3VtX3R5cGUiOm51bGwsImdwZ2NoZWNrIjowLCJyZXBvX2dwZ2NoZWNr
+        IjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82MTY0MGFhMC0yZTdk
+        LTRlYjUtYTFhNy1iZTlkNWYyODU1Y2EvIiwicHVscF9jcmVhdGVkIjoiMjAy
+        MS0xMS0xMlQxMzowMzowMS43MjQxODZaIiwidmVyc2lvbnNfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82MTY0MGFhMC0yZTdk
+        LTRlYjUtYTFhNy1iZTlkNWYyODU1Y2EvdmVyc2lvbnMvIiwicHVscF9sYWJl
+        bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzYxNjQwYWEwLTJlN2QtNGViNS1hMWE3LWJl
+        OWQ1ZjI4NTVjYS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJ0ZXN0LTk2MzgteXVt
+        LTE3NTkzMSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJz
+        aW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2Us
+        Im1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2th
+        Z2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOm51bGws
+        InBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJl
+        cG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:46 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:10 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/3d92366c-3de8-4cce-ab78-e48257198d7a/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/67d27e49-966d-4abd-b19a-d37d44096875/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -829,7 +696,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -837,18 +704,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:47 GMT
+      - Tue, 16 Nov 2021 16:14:10 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '4069'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
@@ -858,110 +721,30 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2d1c29aa2d1748948bc908534906b7b9
+      - c8a9cc605ec64ef39bc28401a10fdbf3
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '231'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zZDkyMzY2Yy0zZGU4LTRjY2UtYWI3OC1lNDgyNTcxOThkN2Ev
-        dmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2VDE4OjAz
-        OjI3LjE4MDA5NFoiLCJudW1iZXIiOjEsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2Q5MjM2NmMtM2RlOC00Y2Nl
-        LWFiNzgtZTQ4MjU3MTk4ZDdhLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5hZHZpc29yeSI6eyJjb3Vu
-        dCI6NywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzNkOTIzNjZjLTNkZTgtNGNjZS1hYjc4LWU0
-        ODI1NzE5OGQ3YS92ZXJzaW9ucy8xLyJ9LCJycG0uZGlzdHJpYnV0aW9uX3Ry
-        ZWUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vZGlzdHJpYnV0aW9uX3RyZWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRk
-        ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzNkOTIzNjZj
-        LTNkZTgtNGNjZS1hYjc4LWU0ODI1NzE5OGQ3YS92ZXJzaW9ucy8xLyJ9LCJy
-        cG0ubW9kdWxlbWQiOnsiY291bnQiOjYsImhyZWYiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudC9ycG0vbW9kdWxlbWRzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRk
-        ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzNkOTIzNjZj
-        LTNkZTgtNGNjZS1hYjc4LWU0ODI1NzE5OGQ3YS92ZXJzaW9ucy8xLyJ9LCJy
-        cG0ubW9kdWxlbWRfZGVmYXVsdHMiOnsiY291bnQiOjMsImhyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRfZGVmYXVsdHMvP3JlcG9z
-        aXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
-        L3JwbS9ycG0vM2Q5MjM2NmMtM2RlOC00Y2NlLWFiNzgtZTQ4MjU3MTk4ZDdh
-        L3ZlcnNpb25zLzEvIn0sInJwbS5wYWNrYWdlIjp7ImNvdW50IjoyMCwiaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8/cmVwb3Np
-        dG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zZDkyMzY2Yy0zZGU4LTRjY2UtYWI3OC1lNDgyNTcxOThkN2Ev
-        dmVyc2lvbnMvMS8ifSwicnBtLnBhY2thZ2VjYXRlZ29yeSI6eyJjb3VudCI6
-        MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlY2F0
-        ZWdvcmllcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zZDkyMzY2Yy0zZGU4LTRjY2UtYWI3
-        OC1lNDgyNTcxOThkN2EvdmVyc2lvbnMvMS8ifSwicnBtLnBhY2thZ2VlbnZp
-        cm9ubWVudCI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3JwbS9wYWNrYWdlZW52aXJvbm1lbnRzLz9yZXBvc2l0b3J5X3ZlcnNp
-        b25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzNk
-        OTIzNjZjLTNkZTgtNGNjZS1hYjc4LWU0ODI1NzE5OGQ3YS92ZXJzaW9ucy8x
-        LyJ9LCJycG0ucGFja2FnZWdyb3VwIjp7ImNvdW50IjoyLCJocmVmIjoiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMvP3JlcG9zaXRv
-        cnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3Jw
-        bS9ycG0vM2Q5MjM2NmMtM2RlOC00Y2NlLWFiNzgtZTQ4MjU3MTk4ZDdhL3Zl
-        cnNpb25zLzEvIn0sInJwbS5yZXBvX21ldGFkYXRhX2ZpbGUiOnsiY291bnQi
-        OjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRh
-        ZGF0YV9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2Fw
-        aS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zZDkyMzY2Yy0zZGU4LTRjY2Ut
-        YWI3OC1lNDgyNTcxOThkN2EvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9
-        LCJwcmVzZW50Ijp7InJwbS5hZHZpc29yeSI6eyJjb3VudCI6NywiaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLz9yZXBvc2l0
-        b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzNkOTIzNjZjLTNkZTgtNGNjZS1hYjc4LWU0ODI1NzE5OGQ3YS92ZXJzaW9u
-        cy8xLyJ9LCJycG0uZGlzdHJpYnV0aW9uX3RyZWUiOnsiY291bnQiOjEsImhy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vZGlzdHJpYnV0aW9uX3Ry
-        ZWVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzNkOTIzNjZjLTNkZTgtNGNjZS1hYjc4LWU0ODI1NzE5
-        OGQ3YS92ZXJzaW9ucy8xLyJ9LCJycG0ubW9kdWxlbWQiOnsiY291bnQiOjYs
-        ImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRzLz9y
-        ZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
-        cG0vcnBtLzNkOTIzNjZjLTNkZTgtNGNjZS1hYjc4LWU0ODI1NzE5OGQ3YS92
-        ZXJzaW9ucy8xLyJ9LCJycG0ubW9kdWxlbWRfZGVmYXVsdHMiOnsiY291bnQi
-        OjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vbW9kdWxlbWRf
-        ZGVmYXVsdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL3JwbS9ycG0vM2Q5MjM2NmMtM2RlOC00Y2NlLWFiNzgtZTQ4
-        MjU3MTk4ZDdhL3ZlcnNpb25zLzEvIn0sInJwbS5wYWNrYWdlIjp7ImNvdW50
-        IjoyMCwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
-        ZXMvcnBtL3JwbS8zZDkyMzY2Yy0zZGU4LTRjY2UtYWI3OC1lNDgyNTcxOThk
-        N2EvdmVyc2lvbnMvMS8ifSwicnBtLnBhY2thZ2VjYXRlZ29yeSI6eyJjb3Vu
-        dCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        Y2F0ZWdvcmllcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvcnBtL3JwbS8zZDkyMzY2Yy0zZGU4LTRjY2UtYWI3OC1l
-        NDgyNTcxOThkN2EvdmVyc2lvbnMvMS8ifSwicnBtLnBhY2thZ2VlbnZpcm9u
-        bWVudCI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
-        L3JwbS9wYWNrYWdlZW52aXJvbm1lbnRzLz9yZXBvc2l0b3J5X3ZlcnNpb249
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzNkOTIzNjZjLTNk
-        ZTgtNGNjZS1hYjc4LWU0ODI1NzE5OGQ3YS92ZXJzaW9ucy8xLyJ9LCJycG0u
-        cGFja2FnZWdyb3VwIjp7ImNvdW50IjoyLCJocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL3BhY2thZ2Vncm91cHMvP3JlcG9zaXRvcnlfdmVyc2lv
-        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2Q5MjM2NmMt
-        M2RlOC00Y2NlLWFiNzgtZTQ4MjU3MTk4ZDdhL3ZlcnNpb25zLzEvIn0sInJw
-        bS5yZXBvX21ldGFkYXRhX2ZpbGUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9ycG0vcmVwb19tZXRhZGF0YV9maWxlcy8/cmVw
-        b3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBt
-        L3JwbS8zZDkyMzY2Yy0zZGU4LTRjY2UtYWI3OC1lNDgyNTcxOThkN2EvdmVy
-        c2lvbnMvMS8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcnBtL3JwbS8zZDkyMzY2Yy0zZGU4LTRjY2UtYWI3OC1lNDgy
-        NTcxOThkN2EvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEw
-        LTA2VDE4OjAzOjIyLjEyNDAzOFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnki
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2Q5MjM2NmMt
-        M2RlOC00Y2NlLWFiNzgtZTQ4MjU3MTk4ZDdhLyIsImJhc2VfdmVyc2lvbiI6
-        bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6
-        e30sInByZXNlbnQiOnt9fX1dfQ==
+        cnBtL3JwbS82N2QyN2U0OS05NjZkLTRhYmQtYjE5YS1kMzdkNDQwOTY4NzUv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTE1VDIwOjUw
+        OjMyLjg4ODMxNFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjdkMjdlNDktOTY2ZC00YWJk
+        LWIxOWEtZDM3ZDQ0MDk2ODc1LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:47 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:10 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/4c6b158f-7433-4d48-b04d-ac77e68d91d1/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -969,11 +752,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/3.15.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -981,20 +764,16 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:47 GMT
+      - Tue, 16 Nov 2021 16:14:10 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       X-Content-Type-Options:
@@ -1002,21 +781,143 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 076d5b9186b84892ad22a9478bc67105
+      - fe3f55e797634d2f91ecbc3bafa17317
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '231'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS80YzZiMTU4Zi03NDMzLTRkNDgtYjA0ZC1hYzc3ZTY4ZDkxZDEv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTE1VDIwOjUw
+        OjEyLjIyODUyN1oiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNGM2YjE1OGYtNzQzMy00ZDQ4
+        LWIwNGQtYWM3N2U2OGQ5MWQxLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:14:10 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/61640aa0-2e7d-4eb5-a1a7-be9d5f2855ca/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:14:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1c916247c58e41ce945a32eb8a71abd3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '230'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS82MTY0MGFhMC0yZTdkLTRlYjUtYTFhNy1iZTlkNWYyODU1Y2Ev
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTEyVDEzOjAz
+        OjAxLjczMDg3M1oiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjE2NDBhYTAtMmU3ZC00ZWI1
+        LWExYTctYmU5ZDVmMjg1NWNhLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:14:10 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.15.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:14:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 98c1406efcd8422bbfeeee3b0219151b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:47 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:10 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1024,11 +925,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.2/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1036,53 +937,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:47 GMT
+      - Tue, 16 Nov 2021 16:14:10 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '559'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3881db191e9942e0b5cd1e5dee58c378
+      - f1257df14dbe47259e65795e404725fb
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi85MDExZGVmZS02MjlkLTRmYzAtYWU0MC1jNjk4NjI5
-        YmVjMmEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxNzo0ODoyOC4w
-        MzkyODNaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvcHl0aG9uL3B5dGhvbi85MDExZGVmZS02MjlkLTRmYzAtYWU0MC1j
-        Njk4NjI5YmVjMmEvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
-        c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9w
-        eXRob24vcHl0aG9uLzkwMTFkZWZlLTYyOWQtNGZjMC1hZTQwLWM2OTg2Mjli
-        ZWMyYS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlv
-        bi1DYWJpbmV0LXB1bHAzX1B5dGhvbl8xIiwiZGVzY3JpcHRpb24iOm51bGws
-        InJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1
-        dG9wdWJsaXNoIjpmYWxzZX1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:47 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:10 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/python/python/9011defe-629d-4fc0-ae40-c698629bec2a/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1094,7 +982,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1102,49 +990,93 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:48 GMT
+      - Tue, 16 Nov 2021 16:14:10 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '382'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
-      - GET, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7de6d35d81254969b28ab09c337d3a86
+      - f468f1b5782642d0a54cbdf810646f16
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi85MDExZGVmZS02MjlkLTRmYzAtYWU0MC1jNjk4NjI5
-        YmVjMmEvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2
-        VDE3OjQ4OjI4LjA0MjE3NVoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vOTAxMWRl
-        ZmUtNjI5ZC00ZmMwLWFlNDAtYzY5ODYyOWJlYzJhLyIsImJhc2VfdmVyc2lv
-        biI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3Zl
-        ZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:48 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:10 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.9.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:14:10 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 81d9d3a6a6aa4b9b8e742e878b23cc62
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:14:10 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1156,7 +1088,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1164,456 +1096,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:48 GMT
+      - Tue, 16 Nov 2021 16:14:10 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a6c5d87bbe104482a054c81b3aad2f33
+      - 620cfc95995a4e81b3d0e65879501b3e
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:48 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:03:48 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '498'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - e53bd72085754a239b971b5d1a8ff24c
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZGViL2FwdC8xY2VjYTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4N2Uv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxODowMToxNy4xNjIzMjVa
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZGViL2FwdC8xY2VjYTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4N2Uv
-        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzFjZWNh
-        NDQzLWE0YjQtNGUwYS04ZmMwLTYyNzVjNGZkNDg3ZS92ZXJzaW9ucy8wLyIs
-        Im5hbWUiOiJkZWJpYW5fcHVscF9yYWduYXJvayIsImRlc2NyaXB0aW9uIjpu
-        dWxsLCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxs
-        fV19
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:48 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/deb/apt/1ceca443-a4b4-4e0a-8fc0-6275c4fd487e/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:03:48 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '370'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 7b4d4c710a6c4dd19f0706e30831da6a
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZGViL2FwdC8xY2VjYTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4N2Uv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2VDE4OjAx
-        OjE3LjE2NTQ1NFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMWNlY2E0NDMtYTRiNC00ZTBh
-        LThmYzAtNjI3NWM0ZmQ0ODdlLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:48 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:03:49 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '551'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 91ed68edb4954f9d88dd72b0b5c91082
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci8zM2EzMmFlNS1mYzNjLTRlOGQtYTE0MS0x
-        YmVjY2RjMjYzZjgvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxNzoy
-        Mjo0OS44MzM0OTRaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8zM2EzMmFlNS1mYzNj
-        LTRlOGQtYTE0MS0xYmVjY2RjMjYzZjgvdmVyc2lvbnMvIiwicHVscF9sYWJl
-        bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzMzYTMyYWU1LWZjM2Mt
-        NGU4ZC1hMTQxLTFiZWNjZGMyNjNmOC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJE
-        ZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwiZGVzY3Jp
-        cHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1v
-        dGUiOm51bGx9XX0=
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:49 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/container/container/33a32ae5-fc3c-4e8d-a141-1beccdc263f8/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:03:49 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '394'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - c6a1f4b09cb743e582a5cbca22739297
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci8zM2EzMmFlNS1mYzNjLTRlOGQtYTE0MS0x
-        YmVjY2RjMjYzZjgvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIx
-        LTEwLTA2VDE3OjIyOjQ5LjkxNTIwMloiLCJudW1iZXIiOjAsInJlcG9zaXRv
-        cnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250
-        YWluZXIvMzNhMzJhZTUtZmMzYy00ZThkLWExNDEtMWJlY2NkYzI2M2Y4LyIs
-        ImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVk
-        Ijp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:49 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:10 GMT
 - request:
     method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/c9bd8558-7b0c-47d9-81d0-4e5a9ef87ec0/versions/2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:03:49 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - da07fd1fd9514ca282ac3e93c758e851
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM3YTAwNjk0LWJkNTgtNDJm
-        NC1hY2QwLTUwOGE3YzQ2ZmYxNi8ifQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:49 GMT
-- request:
-    method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/c9bd8558-7b0c-47d9-81d0-4e5a9ef87ec0/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:03:49 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 186b890e53364765bff158354298a7f4
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QxMDA0YzJiLWZhYTEtNGVk
-        ZC1iNDZkLWY0NTM4MDYwNzAwYi8ifQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:49 GMT
-- request:
-    method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/3d92366c-3de8-4cce-ab78-e48257198d7a/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:03:50 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - e966811abddb449fa67fa635c13fa2f4
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JhNmJkOGJiLTM0NTYtNDA1
-        Ny1hOThhLWRkYjhmMTllZjk0MS8ifQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:50 GMT
-- request:
-    method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/orphans/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/orphans/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1625,7 +1141,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1633,40 +1149,40 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:50 GMT
+      - Tue, 16 Nov 2021 16:14:10 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - DELETE, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '67'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bd194a73171f4fc08efe5b0c184799f5
+      - d5de95850401458eb4ecfe025e372aa6
       Access-Control-Expose-Headers:
       - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM1MDMzOTJkLTNjYmUtNGE3
-        OS1iYjc2LTNjZmNmMjk2MWMwNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M4MDRhNDNiLTRhMTMtNDVi
+        YS05NWViLWRjYTFkMTU3NGE4MS8ifQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:50 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:10 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/3503392d-3cbe-4a79-bb76-3cfcf2961c04/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/c804a43b-4a13-45ba-95eb-dca1d1574a81/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1678,7 +1194,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1686,18 +1202,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:50 GMT
+      - Tue, 16 Nov 2021 16:14:10 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '771'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1707,23 +1219,25 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dcdced2e602f4e11ba6da93e5082ba18
+      - fc3471bec0644143b8f4504599ca6109
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '410'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzUwMzM5MmQtM2Ni
-        ZS00YTc5LWJiNzYtM2NmY2YyOTYxYzA0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDM6NTAuNDU2NDY1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzgwNGE0M2ItNGEx
+        My00NWJhLTk1ZWItZGNhMWQxNTc0YTgxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMTY6MTQ6MTAuNzkyMzc2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJsb2dnaW5nX2NpZCI6ImJkMTk0YTczMTcxZjRmYzA4ZWZlNWIw
-        YzE4NDc5OWY1Iiwic3RhcnRlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDM6NTAu
-        NTA0OTI3WiIsImZpbmlzaGVkX2F0IjoiMjAyMS0xMC0wNlQxODowMzo1MC41
-        Mzg5NTJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzLzA1ZTZkN2Y0LWI1NjQtNGU3My04MmViLTE1YjUwYTUxMjRhMy8i
+        ZWFudXAiLCJsb2dnaW5nX2NpZCI6ImQ1ZGU5NTg1MDQwMTQ1OGViNGVjZmUw
+        MjVlMzcyYWE2Iiwic3RhcnRlZF9hdCI6IjIwMjEtMTEtMTZUMTY6MTQ6MTAu
+        ODY2Mzk0WiIsImZpbmlzaGVkX2F0IjoiMjAyMS0xMS0xNlQxNjoxNDoxMC45
+        MTM0ODdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzNiNDEwYTNmLTIxMTktNDg0OC1hMjNmLWU4ZDBlMjU0ZGNiNC8i
         LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
         b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xl
         YW4gdXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVu
@@ -1734,5 +1248,5 @@ http_interactions:
         ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
         ZCI6W119
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:50 GMT
+  recorded_at: Tue, 16 Nov 2021 16:14:11 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload_binary.yml
@@ -16410,4 +16410,278 @@ http_interactions:
         LThiNGItNmNiNWMyNjRiM2NmLyJdfQ==
     http_version: 
   recorded_at: Wed, 06 Oct 2021 18:03:43 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/content/rpm/packages/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:14:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ebf86ee0355b4ba6bd7102568c55df6a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '1860'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9hMjQ4ZmY0Yy02M2Q3LTRkMjctOGEzZi00OWY1NmQwNDg5YWQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xMlQxMzowNzozNS45MDg5ODFa
+        IiwibWQ1IjpudWxsLCJzaGExIjoiYmRhNmFhZjY0MzMxYjAwYzkwYTcwNzhm
+        Nzg1Yzg5Y2I2YWU0YWM3YiIsInNoYTIyNCI6IjkzOGQ3YmFhMzc4NTEwMTlh
+        N2E3M2EwZWIzYTA5ZWE2ZDJkNWRhMzY3Y2I2NTg0YTBhODYxYzliIiwic2hh
+        MjU2IjoiODAxYTJhMmM3ZGQ2NGNkMzk5N2RjZGYxZTYxZTE2ZjZjZjAxZWY3
+        Y2NlOWI0ZDUyNzcxMmU1OGM0MGVjYTU1ZiIsInNoYTM4NCI6ImVhMzNkYzA1
+        NDUwNjc3ZTZiZTAzODZiYzRlZGI3NmM1YjUwOTBmMDI0NWFmOGM1OThlNjYw
+        YzA5YWE3MTE2YjcwMGYzNzRiZmQ0YmRlMzBhZDc3OGZiYzlmYmE0MjcyOSIs
+        InNoYTUxMiI6IjIxMWNiNWE4MTgyZWM3MzdmNjhjY2NkODU4Y2M5ZjM3NGQy
+        Y2M0NTM1NjljOTYwZGI0ZjZmNmNlMmJkOGMxZmQ4YTIxMzFlYzU4N2VlODAy
+        ZTljOTMxMWMyZjhhY2Y1NTU1Njk0NzE1NGM1NDhhYjM4NGJlMWZjNmJjYzVm
+        ZGQzIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2E0ODcx
+        MDcyLTFiYzktNGNjOS1iZWY5LTUxNWE4ZGUyMzAzZC8iLCJuYW1lIjoiemVi
+        cmEiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjIi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MDFhMmEyYzdkZDY0Y2QzOTk3
+        ZGNkZjFlNjFlMTZmNmNmMDFlZjdjY2U5YjRkNTI3NzEyZTU4YzQwZWNhNTVm
+        IiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgemVicmEiLCJkZXNjcmlwdGlvbiI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiB6ZWJyYSIsInVybCI6Imh0dHA6Ly90c3RyYWNob3RhLmZlZG9y
+        YXBlb3BsZS5vcmciLCJjaGFuZ2Vsb2dzIjpbXSwiZmlsZXMiOltbbnVsbCwi
+        L3RtcC8iLCJ6ZWJyYS50eHQiXV0sInJlcXVpcmVzIjpbWyJkb2xwaGluIixu
+        dWxsLG51bGwsbnVsbCxudWxsLGZhbHNlXSxbImdvcmlsbGEiLG51bGwsbnVs
+        bCxudWxsLG51bGwsZmFsc2VdLFsicGlrZSIsbnVsbCxudWxsLG51bGwsbnVs
+        bCxmYWxzZV1dLCJwcm92aWRlcyI6W1siemVicmEiLCJFUSIsIjAiLCIwLjEi
+        LCIyIixmYWxzZV1dLCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMiOltdLCJz
+        dWdnZXN0cyI6W10sImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6W10sInN1
+        cHBsZW1lbnRzIjpbXSwibG9jYXRpb25fYmFzZSI6IiIsImxvY2F0aW9uX2hy
+        ZWYiOiJ6ZWJyYS0wLjEtMi5ub2FyY2gucnBtIiwicnBtX2J1aWxkaG9zdCI6
+        InNtcWUtd3MxNSIsInJwbV9ncm91cCI6IkludGVybmV0L0FwcGxpY2F0aW9u
+        cyIsInJwbV9saWNlbnNlIjoiR1BMdjIiLCJycG1fcGFja2FnZXIiOiIiLCJy
+        cG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsInJwbV92ZW5k
+        b3IiOiIiLCJycG1faGVhZGVyX3N0YXJ0Ijo4NzIsInJwbV9oZWFkZXJfZW5k
+        IjoyMzI1LCJpc19tb2R1bGFyIjpmYWxzZSwic2l6ZV9hcmNoaXZlIjoyOTYs
+        InNpemVfaW5zdGFsbGVkIjo0Miwic2l6ZV9wYWNrYWdlIjoyNDc3LCJ0aW1l
+        X2J1aWxkIjoxMzMxODMxMzc1LCJ0aW1lX2ZpbGUiOjE0NTQxMjMzNzR9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzhjZDMxMDkzLTIzZGUtNDJkOC1hOWRhLWRlZjdhMjQxNGFjZC8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIxLTExLTAyVDIwOjA4OjE0LjI3MjQ3MloiLCJtZDUi
+        Om51bGwsInNoYTEiOiI4NTZjZjNhZmY2Zjc1ZThjNDg3NjFjOTMzYzZmYjMw
+        NzMyYzAzZjFmIiwic2hhMjI0IjoiNTZhZjgwMDRmZTcyZTRhM2JiMzljZGJk
+        MTZiY2I3MDIxYTEzMjc0MTc4OTUxZmFmNjRlMDMzOWQiLCJzaGEyNTYiOiIy
+        YmRmMWNiNzFkOWQzYTc4NWFmMjRmODZiZGIzNWJjZTlmYWUyOWZlYjg2Y2Yy
+        YzQ4YWQ1YTJiMzcyNDQxZTAwIiwic2hhMzg0IjoiMDg1OTkxNDFiNWViNWNk
+        Y2JmMTcyOGY2MGVhMWVhOWI0ZmIyNmJlNDkyZmRiNzRjOWYzZWUzYjIzYmRi
+        YzVhZDJjZDU1MzU4ZmQ5N2E1YTFkOTQ2NmU5ZjM0MjZiYjU1Iiwic2hhNTEy
+        IjoiZTUzYmI2NWI1NmFiY2M5MmMwODE5NGUxYWNlYTJhNWJjNTg2NjdmNWJk
+        MDc4NTgxYTkwYTk0NDE3ZmMzYTI0YTg4NGM5MzY1NDhmN2M5NzMyZDFjNDAy
+        YzMwZDg5YzA4YTdiYWU4YzRjYWQ4OGEyODUxMmQ2OThlMzUwNzhjOWEiLCJh
+        cnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNDQxYzcwMTQtNWQ2
+        NC00MGFiLWJlOTYtMDhjMWMwYzQzYzQwLyIsIm5hbWUiOiJjcmVhdGVyZXBv
+        X2MiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xNy4xIiwicmVsZWFzZSI6
+        IjEuZWw3IiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiMmJkZjFjYjcxZDlkM2E3
+        ODVhZjI0Zjg2YmRiMzViY2U5ZmFlMjlmZWI4NmNmMmM0OGFkNWEyYjM3MjQ0
+        MWUwMCIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJzdW1tYXJ5IjoiQ3Jl
+        YXRlcyBhIGNvbW1vbiBtZXRhZGF0YSByZXBvc2l0b3J5IiwiZGVzY3JpcHRp
+        b24iOiJDIGltcGxlbWVudGF0aW9uIG9mIENyZWF0ZXJlcG8uXG5BIHNldCBv
+        ZiB1dGlsaXRpZXMgKGNyZWF0ZXJlcG9fYywgbWVyZ2VyZXBvX2MsIG1vZGlm
+        eXJlcG9fYylcbmZvciBnZW5lcmF0aW5nIGEgY29tbW9uIG1ldGFkYXRhIHJl
+        cG9zaXRvcnkgZnJvbSBhIGRpcmVjdG9yeSBvZlxucnBtIHBhY2thZ2VzIGFu
+        ZCBtYWludGFpbmluZyBpdC4iLCJ1cmwiOiJodHRwczovL2dpdGh1Yi5jb20v
+        cnBtLXNvZnR3YXJlLW1hbmFnZW1lbnQvY3JlYXRlcmVwb19jIiwiY2hhbmdl
+        bG9ncyI6W1siRXZnZW5pIEdvbG92IC0gMC4xNS4xMC0xIiwxNTg4NTkzNjAw
+        LCItIHVwZGF0ZSB0byB1cHN0cmVhbSAwLjE1LjEwIl0sWyJFdmdlbmkgR29s
+        b3YgLSAwLjE2LjEtMSIsMTYwMTU1MzYwMCwiLSBSZWxlYXNlIGNyZWF0ZXJl
+        cG9fYyAwLjE2LjEiXSxbIkp1c3RpbiBTaGVycmlsbCA8anNoZXJyaWxAcmVk
+        aGF0LmNvbT4gMC4xNi4yLTEiLDE2MDUwOTYwMDAsIiogdXBkYXRlIHRvIDAu
+        MTYuMiJdLFsiSnVzdGluIFNoZXJyaWxsIDxqc2hlcnJpbEByZWRoYXQuY29t
+        PiAwLjE3LjAtMSIsMTYxMzY0OTYwMCwiLSB1cGRhdGUgdG8gMC4xNy4wIl0s
+        WyJFdmdlbmkgR29sb3YgLSAwLjE3LjEtMSIsMTYxNDc3MjgwMCwiLSBSZWxl
+        YXNlIGNyZWF0ZXJlcG9fYyAwLjE3LjEiXV0sImZpbGVzIjpbWyIiLCIiLCJj
+        cmVhdGVyZXBvX2MtMC4xNy4xLnRhci5neiJdLFsiIiwiIiwiY3JlYXRlcmVw
+        b19jLnNwZWMiXV0sInJlcXVpcmVzIjpbWyJjbWFrZSIsbnVsbCxudWxsLG51
+        bGwsbnVsbCxmYWxzZV0sWyJnY2MiLG51bGwsbnVsbCxudWxsLG51bGwsZmFs
+        c2VdLFsiYnppcDItZGV2ZWwiLG51bGwsbnVsbCxudWxsLG51bGwsZmFsc2Vd
+        LFsiZG94eWdlbiIsbnVsbCxudWxsLG51bGwsbnVsbCxmYWxzZV0sWyJmaWxl
+        LWRldmVsIixudWxsLG51bGwsbnVsbCxudWxsLGZhbHNlXSxbImdsaWIyLWRl
+        dmVsIiwiR0UiLCIwIiwiMi4yMi4wIixudWxsLGZhbHNlXSxbImxpYmN1cmwt
+        ZGV2ZWwiLG51bGwsbnVsbCxudWxsLG51bGwsZmFsc2VdLFsibGlieG1sMi1k
+        ZXZlbCIsbnVsbCxudWxsLG51bGwsbnVsbCxmYWxzZV0sWyJvcGVuc3NsLWRl
+        dmVsIixudWxsLG51bGwsbnVsbCxudWxsLGZhbHNlXSxbInJwbS1kZXZlbCIs
+        IkdFIiwiMCIsIjQuOC4wIiwiMjgiLGZhbHNlXSxbInNxbGl0ZS1kZXZlbCIs
+        bnVsbCxudWxsLG51bGwsbnVsbCxmYWxzZV0sWyJ4ei1kZXZlbCIsbnVsbCxu
+        dWxsLG51bGwsbnVsbCxmYWxzZV0sWyJ6bGliLWRldmVsIixudWxsLG51bGws
+        bnVsbCxudWxsLGZhbHNlXSxbImJhc2gtY29tcGxldGlvbiIsbnVsbCxudWxs
+        LG51bGwsbnVsbCxmYWxzZV0sWyJweXRob24zLWRldmVsIixudWxsLG51bGws
+        bnVsbCxudWxsLGZhbHNlXV0sInByb3ZpZGVzIjpbXSwiY29uZmxpY3RzIjpb
+        XSwib2Jzb2xldGVzIjpbXSwic3VnZ2VzdHMiOltdLCJlbmhhbmNlcyI6W10s
+        InJlY29tbWVuZHMiOltdLCJzdXBwbGVtZW50cyI6W10sImxvY2F0aW9uX2Jh
+        c2UiOiIiLCJsb2NhdGlvbl9ocmVmIjoiY3JlYXRlcmVwb19jLTAuMTcuMS0x
+        LmVsNy5zcmMucnBtIiwicnBtX2J1aWxkaG9zdCI6Imtvamkua2F0ZWxsby5v
+        cmciLCJycG1fZ3JvdXAiOiJVbnNwZWNpZmllZCIsInJwbV9saWNlbnNlIjoi
+        R1BMdjIrIiwicnBtX3BhY2thZ2VyIjoiS29qaSIsInJwbV9zb3VyY2VycG0i
+        OiIiLCJycG1fdmVuZG9yIjoiS29qaSIsInJwbV9oZWFkZXJfc3RhcnQiOjE0
+        ODgsInJwbV9oZWFkZXJfZW5kIjozNjY0LCJpc19tb2R1bGFyIjpmYWxzZSwi
+        c2l6ZV9hcmNoaXZlIjo1OTk4NzIsInNpemVfaW5zdGFsbGVkIjo1OTk0Nzgs
+        InNpemVfcGFja2FnZSI6NjAwNDgyLCJ0aW1lX2J1aWxkIjoxNjE0NzY4OTU4
+        LCJ0aW1lX2ZpbGUiOjE2MzU4ODM2OTR9XX0=
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:14:07 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/53a9ffaf-efc9-438b-8136-23a19b613be7/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYTI0OGZmNGMtNjNkNy00ZDI3LThhM2YtNDlmNTZkMDQ4
+        OWFkLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:14:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2dfc1f36ff8d469987ac9ac7040e168c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc0OGFlYmMzLWVjNjYtNGIx
+        YS1iNTkxLWVkYzU1YzdhMDE1My8ifQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:14:08 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/748aebc3-ec66-4b1a-b591-edc55c7a0153/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:14:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 410e293a8ba8454d91db3fcc05e6a362
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '390'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzQ4YWViYzMtZWM2
+        Ni00YjFhLWI1OTEtZWRjNTVjN2EwMTUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMTY6MTQ6MDcuOTc3NDk2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyZGZjMWYzNmZmOGQ0Njk5ODdh
+        YzlhYzcwNDBlMTY4YyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE2VDE2OjE0
+        OjA4LjAzODEwMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTZUMTY6MTQ6
+        MDguMjMwNjM2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy80OTAwMjhmYy1lM2I4LTRhYmYtYjA4ZC05ZDc3MDcwZTg2
+        Y2IvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS81M2E5ZmZhZi1lZmM5LTQzOGItODEzNi0yM2ExOWI2MTNiZTcvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTNhOWZmYWYtZWZjOS00Mzhi
+        LTgxMzYtMjNhMTliNjEzYmU3LyJdfQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:14:08 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload_binary_duplicate.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload_binary_duplicate.yml
@@ -4321,4 +4321,276 @@ http_interactions:
         OS00ZDQ3LThiNGItNmNiNWMyNjRiM2NmLyJdfQ==
     http_version: 
   recorded_at: Wed, 06 Oct 2021 18:03:44 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/content/rpm/packages/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:14:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 23f96855f68348ebbd4715cd4db3cfcb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '1860'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9hMjQ4ZmY0Yy02M2Q3LTRkMjctOGEzZi00OWY1NmQwNDg5YWQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xMlQxMzowNzozNS45MDg5ODFa
+        IiwibWQ1IjpudWxsLCJzaGExIjoiYmRhNmFhZjY0MzMxYjAwYzkwYTcwNzhm
+        Nzg1Yzg5Y2I2YWU0YWM3YiIsInNoYTIyNCI6IjkzOGQ3YmFhMzc4NTEwMTlh
+        N2E3M2EwZWIzYTA5ZWE2ZDJkNWRhMzY3Y2I2NTg0YTBhODYxYzliIiwic2hh
+        MjU2IjoiODAxYTJhMmM3ZGQ2NGNkMzk5N2RjZGYxZTYxZTE2ZjZjZjAxZWY3
+        Y2NlOWI0ZDUyNzcxMmU1OGM0MGVjYTU1ZiIsInNoYTM4NCI6ImVhMzNkYzA1
+        NDUwNjc3ZTZiZTAzODZiYzRlZGI3NmM1YjUwOTBmMDI0NWFmOGM1OThlNjYw
+        YzA5YWE3MTE2YjcwMGYzNzRiZmQ0YmRlMzBhZDc3OGZiYzlmYmE0MjcyOSIs
+        InNoYTUxMiI6IjIxMWNiNWE4MTgyZWM3MzdmNjhjY2NkODU4Y2M5ZjM3NGQy
+        Y2M0NTM1NjljOTYwZGI0ZjZmNmNlMmJkOGMxZmQ4YTIxMzFlYzU4N2VlODAy
+        ZTljOTMxMWMyZjhhY2Y1NTU1Njk0NzE1NGM1NDhhYjM4NGJlMWZjNmJjYzVm
+        ZGQzIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2E0ODcx
+        MDcyLTFiYzktNGNjOS1iZWY5LTUxNWE4ZGUyMzAzZC8iLCJuYW1lIjoiemVi
+        cmEiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjIi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MDFhMmEyYzdkZDY0Y2QzOTk3
+        ZGNkZjFlNjFlMTZmNmNmMDFlZjdjY2U5YjRkNTI3NzEyZTU4YzQwZWNhNTVm
+        IiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgemVicmEiLCJkZXNjcmlwdGlvbiI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiB6ZWJyYSIsInVybCI6Imh0dHA6Ly90c3RyYWNob3RhLmZlZG9y
+        YXBlb3BsZS5vcmciLCJjaGFuZ2Vsb2dzIjpbXSwiZmlsZXMiOltbbnVsbCwi
+        L3RtcC8iLCJ6ZWJyYS50eHQiXV0sInJlcXVpcmVzIjpbWyJkb2xwaGluIixu
+        dWxsLG51bGwsbnVsbCxudWxsLGZhbHNlXSxbImdvcmlsbGEiLG51bGwsbnVs
+        bCxudWxsLG51bGwsZmFsc2VdLFsicGlrZSIsbnVsbCxudWxsLG51bGwsbnVs
+        bCxmYWxzZV1dLCJwcm92aWRlcyI6W1siemVicmEiLCJFUSIsIjAiLCIwLjEi
+        LCIyIixmYWxzZV1dLCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMiOltdLCJz
+        dWdnZXN0cyI6W10sImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6W10sInN1
+        cHBsZW1lbnRzIjpbXSwibG9jYXRpb25fYmFzZSI6IiIsImxvY2F0aW9uX2hy
+        ZWYiOiJ6ZWJyYS0wLjEtMi5ub2FyY2gucnBtIiwicnBtX2J1aWxkaG9zdCI6
+        InNtcWUtd3MxNSIsInJwbV9ncm91cCI6IkludGVybmV0L0FwcGxpY2F0aW9u
+        cyIsInJwbV9saWNlbnNlIjoiR1BMdjIiLCJycG1fcGFja2FnZXIiOiIiLCJy
+        cG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsInJwbV92ZW5k
+        b3IiOiIiLCJycG1faGVhZGVyX3N0YXJ0Ijo4NzIsInJwbV9oZWFkZXJfZW5k
+        IjoyMzI1LCJpc19tb2R1bGFyIjpmYWxzZSwic2l6ZV9hcmNoaXZlIjoyOTYs
+        InNpemVfaW5zdGFsbGVkIjo0Miwic2l6ZV9wYWNrYWdlIjoyNDc3LCJ0aW1l
+        X2J1aWxkIjoxMzMxODMxMzc1LCJ0aW1lX2ZpbGUiOjE0NTQxMjMzNzR9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzhjZDMxMDkzLTIzZGUtNDJkOC1hOWRhLWRlZjdhMjQxNGFjZC8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIxLTExLTAyVDIwOjA4OjE0LjI3MjQ3MloiLCJtZDUi
+        Om51bGwsInNoYTEiOiI4NTZjZjNhZmY2Zjc1ZThjNDg3NjFjOTMzYzZmYjMw
+        NzMyYzAzZjFmIiwic2hhMjI0IjoiNTZhZjgwMDRmZTcyZTRhM2JiMzljZGJk
+        MTZiY2I3MDIxYTEzMjc0MTc4OTUxZmFmNjRlMDMzOWQiLCJzaGEyNTYiOiIy
+        YmRmMWNiNzFkOWQzYTc4NWFmMjRmODZiZGIzNWJjZTlmYWUyOWZlYjg2Y2Yy
+        YzQ4YWQ1YTJiMzcyNDQxZTAwIiwic2hhMzg0IjoiMDg1OTkxNDFiNWViNWNk
+        Y2JmMTcyOGY2MGVhMWVhOWI0ZmIyNmJlNDkyZmRiNzRjOWYzZWUzYjIzYmRi
+        YzVhZDJjZDU1MzU4ZmQ5N2E1YTFkOTQ2NmU5ZjM0MjZiYjU1Iiwic2hhNTEy
+        IjoiZTUzYmI2NWI1NmFiY2M5MmMwODE5NGUxYWNlYTJhNWJjNTg2NjdmNWJk
+        MDc4NTgxYTkwYTk0NDE3ZmMzYTI0YTg4NGM5MzY1NDhmN2M5NzMyZDFjNDAy
+        YzMwZDg5YzA4YTdiYWU4YzRjYWQ4OGEyODUxMmQ2OThlMzUwNzhjOWEiLCJh
+        cnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNDQxYzcwMTQtNWQ2
+        NC00MGFiLWJlOTYtMDhjMWMwYzQzYzQwLyIsIm5hbWUiOiJjcmVhdGVyZXBv
+        X2MiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xNy4xIiwicmVsZWFzZSI6
+        IjEuZWw3IiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiMmJkZjFjYjcxZDlkM2E3
+        ODVhZjI0Zjg2YmRiMzViY2U5ZmFlMjlmZWI4NmNmMmM0OGFkNWEyYjM3MjQ0
+        MWUwMCIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJzdW1tYXJ5IjoiQ3Jl
+        YXRlcyBhIGNvbW1vbiBtZXRhZGF0YSByZXBvc2l0b3J5IiwiZGVzY3JpcHRp
+        b24iOiJDIGltcGxlbWVudGF0aW9uIG9mIENyZWF0ZXJlcG8uXG5BIHNldCBv
+        ZiB1dGlsaXRpZXMgKGNyZWF0ZXJlcG9fYywgbWVyZ2VyZXBvX2MsIG1vZGlm
+        eXJlcG9fYylcbmZvciBnZW5lcmF0aW5nIGEgY29tbW9uIG1ldGFkYXRhIHJl
+        cG9zaXRvcnkgZnJvbSBhIGRpcmVjdG9yeSBvZlxucnBtIHBhY2thZ2VzIGFu
+        ZCBtYWludGFpbmluZyBpdC4iLCJ1cmwiOiJodHRwczovL2dpdGh1Yi5jb20v
+        cnBtLXNvZnR3YXJlLW1hbmFnZW1lbnQvY3JlYXRlcmVwb19jIiwiY2hhbmdl
+        bG9ncyI6W1siRXZnZW5pIEdvbG92IC0gMC4xNS4xMC0xIiwxNTg4NTkzNjAw
+        LCItIHVwZGF0ZSB0byB1cHN0cmVhbSAwLjE1LjEwIl0sWyJFdmdlbmkgR29s
+        b3YgLSAwLjE2LjEtMSIsMTYwMTU1MzYwMCwiLSBSZWxlYXNlIGNyZWF0ZXJl
+        cG9fYyAwLjE2LjEiXSxbIkp1c3RpbiBTaGVycmlsbCA8anNoZXJyaWxAcmVk
+        aGF0LmNvbT4gMC4xNi4yLTEiLDE2MDUwOTYwMDAsIiogdXBkYXRlIHRvIDAu
+        MTYuMiJdLFsiSnVzdGluIFNoZXJyaWxsIDxqc2hlcnJpbEByZWRoYXQuY29t
+        PiAwLjE3LjAtMSIsMTYxMzY0OTYwMCwiLSB1cGRhdGUgdG8gMC4xNy4wIl0s
+        WyJFdmdlbmkgR29sb3YgLSAwLjE3LjEtMSIsMTYxNDc3MjgwMCwiLSBSZWxl
+        YXNlIGNyZWF0ZXJlcG9fYyAwLjE3LjEiXV0sImZpbGVzIjpbWyIiLCIiLCJj
+        cmVhdGVyZXBvX2MtMC4xNy4xLnRhci5neiJdLFsiIiwiIiwiY3JlYXRlcmVw
+        b19jLnNwZWMiXV0sInJlcXVpcmVzIjpbWyJjbWFrZSIsbnVsbCxudWxsLG51
+        bGwsbnVsbCxmYWxzZV0sWyJnY2MiLG51bGwsbnVsbCxudWxsLG51bGwsZmFs
+        c2VdLFsiYnppcDItZGV2ZWwiLG51bGwsbnVsbCxudWxsLG51bGwsZmFsc2Vd
+        LFsiZG94eWdlbiIsbnVsbCxudWxsLG51bGwsbnVsbCxmYWxzZV0sWyJmaWxl
+        LWRldmVsIixudWxsLG51bGwsbnVsbCxudWxsLGZhbHNlXSxbImdsaWIyLWRl
+        dmVsIiwiR0UiLCIwIiwiMi4yMi4wIixudWxsLGZhbHNlXSxbImxpYmN1cmwt
+        ZGV2ZWwiLG51bGwsbnVsbCxudWxsLG51bGwsZmFsc2VdLFsibGlieG1sMi1k
+        ZXZlbCIsbnVsbCxudWxsLG51bGwsbnVsbCxmYWxzZV0sWyJvcGVuc3NsLWRl
+        dmVsIixudWxsLG51bGwsbnVsbCxudWxsLGZhbHNlXSxbInJwbS1kZXZlbCIs
+        IkdFIiwiMCIsIjQuOC4wIiwiMjgiLGZhbHNlXSxbInNxbGl0ZS1kZXZlbCIs
+        bnVsbCxudWxsLG51bGwsbnVsbCxmYWxzZV0sWyJ4ei1kZXZlbCIsbnVsbCxu
+        dWxsLG51bGwsbnVsbCxmYWxzZV0sWyJ6bGliLWRldmVsIixudWxsLG51bGws
+        bnVsbCxudWxsLGZhbHNlXSxbImJhc2gtY29tcGxldGlvbiIsbnVsbCxudWxs
+        LG51bGwsbnVsbCxmYWxzZV0sWyJweXRob24zLWRldmVsIixudWxsLG51bGws
+        bnVsbCxudWxsLGZhbHNlXV0sInByb3ZpZGVzIjpbXSwiY29uZmxpY3RzIjpb
+        XSwib2Jzb2xldGVzIjpbXSwic3VnZ2VzdHMiOltdLCJlbmhhbmNlcyI6W10s
+        InJlY29tbWVuZHMiOltdLCJzdXBwbGVtZW50cyI6W10sImxvY2F0aW9uX2Jh
+        c2UiOiIiLCJsb2NhdGlvbl9ocmVmIjoiY3JlYXRlcmVwb19jLTAuMTcuMS0x
+        LmVsNy5zcmMucnBtIiwicnBtX2J1aWxkaG9zdCI6Imtvamkua2F0ZWxsby5v
+        cmciLCJycG1fZ3JvdXAiOiJVbnNwZWNpZmllZCIsInJwbV9saWNlbnNlIjoi
+        R1BMdjIrIiwicnBtX3BhY2thZ2VyIjoiS29qaSIsInJwbV9zb3VyY2VycG0i
+        OiIiLCJycG1fdmVuZG9yIjoiS29qaSIsInJwbV9oZWFkZXJfc3RhcnQiOjE0
+        ODgsInJwbV9oZWFkZXJfZW5kIjozNjY0LCJpc19tb2R1bGFyIjpmYWxzZSwi
+        c2l6ZV9hcmNoaXZlIjo1OTk4NzIsInNpemVfaW5zdGFsbGVkIjo1OTk0Nzgs
+        InNpemVfcGFja2FnZSI6NjAwNDgyLCJ0aW1lX2J1aWxkIjoxNjE0NzY4OTU4
+        LCJ0aW1lX2ZpbGUiOjE2MzU4ODM2OTR9XX0=
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:14:08 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/53a9ffaf-efc9-438b-8136-23a19b613be7/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYTI0OGZmNGMtNjNkNy00ZDI3LThhM2YtNDlmNTZkMDQ4
+        OWFkLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:14:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7b26a4f294514ef0afdfff5e46bed2ac
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UzZmEzYTdiLTJmMWQtNGI3
+        Mi1hY2FmLWQ3NDUxN2ZmM2EzNi8ifQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:14:08 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/e3fa3a7b-2f1d-4b72-acaf-d74517ff3a36/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:14:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - bb9d37088547431ea7c69e6d79739cba
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '380'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTNmYTNhN2ItMmYx
+        ZC00YjcyLWFjYWYtZDc0NTE3ZmYzYTM2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMTY6MTQ6MDguOTU1MTE4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3YjI2YTRmMjk0NTE0ZWYwYWZk
+        ZmZmNWU0NmJlZDJhYyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE2VDE2OjE0
+        OjA5LjAxODMxOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTZUMTY6MTQ6
+        MDkuMjEwNjQ4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9iZmJlMjlhMC04YzQ2LTRkNzgtYjA2YS03ODk4OTlmYTMw
+        NzcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNTNhOWZmYWYtZWZj
+        OS00MzhiLTgxMzYtMjNhMTliNjEzYmU3LyJdfQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:14:09 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -14,7 +14,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -22,42 +22,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:51 GMT
+      - Tue, 16 Nov 2021 20:05:23 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3450ba83c40941cebe9858e8d54674fd
+      - ce587771bb2d4f2fa28774083f434c95
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:51 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:23 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -69,7 +67,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -77,42 +75,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:52 GMT
+      - Tue, 16 Nov 2021 20:05:23 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4aa1f93b79d74c549ed764a3d0e6543f
+      - d8dbedac7c7a4a14a8eeee9d6385d2ce
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:52 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:23 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -124,7 +120,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -132,42 +128,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:52 GMT
+      - Tue, 16 Nov 2021 20:05:23 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 95c0b480ff964ed48b0c563606e9cf2c
+      - b2d18f6b062a4688a70f6ab6b6285d3c
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:52 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:23 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -179,7 +173,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -187,42 +181,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:52 GMT
+      - Tue, 16 Nov 2021 20:05:23 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5161c91f1f834960a85ddd65420a416b
+      - a3940e7982554a6c8288fb0ff4d8c8db
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:52 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:23 GMT
 - request:
     method: post
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -239,7 +231,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -247,54 +239,52 @@ http_interactions:
       code: 201
       message: Created
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:52 GMT
+      - Tue, 16 Nov 2021 20:05:23 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '534'
-      Connection:
-      - keep-alive
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/b9696161-f678-4572-9fb3-efcad88b37c1/"
+      - "/pulp/api/v3/remotes/rpm/rpm/f90baf74-5b3c-4757-aaf5-84c7dfb407a6/"
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '534'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e65a9db11611473084d9fe0dbf0dc3e5
+      - 91b6b4db51e04f5697e0f72fe7ea1fad
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I5
-        Njk2MTYxLWY2NzgtNDU3Mi05ZmIzLWVmY2FkODhiMzdjMS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIxLTEwLTA2VDE4OjAzOjUyLjkyMDcwOVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Y5
+        MGJhZjc0LTViM2MtNDc1Ny1hYWY1LTg0YzdkZmI0MDdhNi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIxLTExLTE2VDIwOjA1OjIzLjkyNDM5NVoiLCJuYW1lIjoi
         RmVkb3JhXzE3IiwidXJsIjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0
         IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRy
         dWUsInByb3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjEtMTAtMDZUMTg6MDM6NTIuOTIwNzI3WiIsImRv
+        c3RfdXBkYXRlZCI6IjIwMjEtMTEtMTZUMjA6MDU6MjMuOTI0NDIwWiIsImRv
         d25sb2FkX2NvbmN1cnJlbmN5IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwi
         cG9saWN5Ijoib25fZGVtYW5kIiwidG90YWxfdGltZW91dCI6MzAwLjAsImNv
         bm5lY3RfdGltZW91dCI6bnVsbCwic29ja19jb25uZWN0X3RpbWVvdXQiOm51
         bGwsInNvY2tfcmVhZF90aW1lb3V0IjpudWxsLCJoZWFkZXJzIjpudWxsLCJy
         YXRlX2xpbWl0IjpudWxsLCJzbGVzX2F1dGhfdG9rZW4iOm51bGx9
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:52 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:23 GMT
 - request:
     method: post
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -308,7 +298,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -316,45 +306,43 @@ http_interactions:
       code: 201
       message: Created
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:53 GMT
+      - Tue, 16 Nov 2021 20:05:24 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '629'
-      Connection:
-      - keep-alive
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/437df93e-95f9-40bf-821d-170ff0c532b1/"
+      - "/pulp/api/v3/repositories/rpm/rpm/99eb4f81-513e-4327-8799-d20961ede8f9/"
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '629'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 91b162e421b746378e0e2c0a44cf27c8
+      - a7324784eaf9434781125b2464c51c6a
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNDM3ZGY5M2UtOTVmOS00MGJmLTgyMWQtMTcwZmYwYzUzMmIxLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjEtMTAtMDZUMTg6MDM6NTMuMjYzNjA1WiIsInZl
+        cG0vOTllYjRmODEtNTEzZS00MzI3LTg3OTktZDIwOTYxZWRlOGY5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjEtMTEtMTZUMjA6MDU6MjQuMTY0NDIzWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNDM3ZGY5M2UtOTVmOS00MGJmLTgyMWQtMTcwZmYwYzUzMmIxL3ZlcnNp
+        cG0vOTllYjRmODEtNTEzZS00MzI3LTg3OTktZDIwOTYxZWRlOGY5L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS80MzdkZjkzZS05
-        NWY5LTQwYmYtODIxZC0xNzBmZjBjNTMyYjEvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS85OWViNGY4MS01
+        MTNlLTQzMjctODc5OS1kMjA5NjFlZGU4ZjkvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiRmVkb3JhXzE3IiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBv
         X3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpm
         YWxzZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5f
@@ -362,10 +350,10 @@ http_interactions:
         bnVsbCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6
         MCwicmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:53 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:24 GMT
 - request:
     method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/b9696161-f678-4572-9fb3-efcad88b37c1/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/f90baf74-5b3c-4757-aaf5-84c7dfb407a6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -377,7 +365,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -385,40 +373,40 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:55 GMT
+      - Tue, 16 Nov 2021 20:05:25 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '67'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0a1da6d9301841139a0dcfbe700373ce
+      - bed8f4c676a047a0b94baab313da0656
       Access-Control-Expose-Headers:
       - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI4M2U3OWEzLWU5ODctNDNl
-        Ny1hMTY3LWJiMzMxYzQ3OWRiNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VkYTYwZDliLTZlN2QtNGQ4
+        Yy1iZjU4LTQ1NTg2YzBhNDM3ZS8ifQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:55 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:25 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/283e79a3-e987-43e7-a167-bb331c479db5/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/eda60d9b-6e7d-4d8c-bf58-45586c0a437e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -430,7 +418,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -438,18 +426,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:55 GMT
+      - Tue, 16 Nov 2021 20:05:25 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '602'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -459,33 +443,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7183d7ecb8da440bbfe198a0e6691a77
+      - 327f2fddeed4482f93f8142da750b697
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '371'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjgzZTc5YTMtZTk4
-        Ny00M2U3LWExNjctYmIzMzFjNDc5ZGI1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDM6NTUuMDcwMjU2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWRhNjBkOWItNmU3
+        ZC00ZDhjLWJmNTgtNDU1ODZjMGE0MzdlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMjA6MDU6MjUuNDYwODU0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIwYTFkYTZkOTMwMTg0MTEzOWEwZGNmYmU3
-        MDAzNzNjZSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTEwLTA2VDE4OjAzOjU1LjEx
-        MzQ3NloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDM6NTUuMTUy
-        OTQ2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wNWU2ZDdmNC1iNTY0LTRlNzMtODJlYi0xNWI1MGE1MTI0YTMvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiZWQ4ZjRjNjc2YTA0N2EwYjk0YmFhYjMx
+        M2RhMDY1NiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE2VDIwOjA1OjI1LjUy
+        MzkyOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTZUMjA6MDU6MjUuNTcz
+        Mjk4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy80OTAwMjhmYy1lM2I4LTRhYmYtYjA4ZC05ZDc3MDcwZTg2Y2IvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2I5Njk2MTYxLWY2NzgtNDU3Mi05ZmIz
-        LWVmY2FkODhiMzdjMS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Y5MGJhZjc0LTViM2MtNDc1Ny1hYWY1
+        LTg0YzdkZmI0MDdhNi8iXX0=
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:55 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:25 GMT
 - request:
     method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/437df93e-95f9-40bf-821d-170ff0c532b1/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/99eb4f81-513e-4327-8799-d20961ede8f9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -497,7 +483,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -505,40 +491,40 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:55 GMT
+      - Tue, 16 Nov 2021 20:05:25 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '67'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bf3b6d3611bf4b04980d001026c5a7c0
+      - 106887310bfa418d9202291d7794506a
       Access-Control-Expose-Headers:
       - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAyMTQyODYxLTA0ZTctNDIx
-        ZC1iMzJmLTU1MmVlYWQ4OTFmYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFiNmFmOWEwLTY3YmEtNGZj
+        Yy04OTM1LWQzYzg4NjhkZWU0OS8ifQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:55 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:25 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/02142861-04e7-421d-b32f-552eead891fc/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/1b6af9a0-67ba-4fcc-8935-d3c8868dee49/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -550,7 +536,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -558,18 +544,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:55 GMT
+      - Tue, 16 Nov 2021 20:05:25 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '607'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -579,33 +561,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 54c173b335604282aebc5c56b75b3cff
+      - 8fb4b81759174d8f8094777013fa4453
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '374'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDIxNDI4NjEtMDRl
-        Ny00MjFkLWIzMmYtNTUyZWVhZDg5MWZjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDM6NTUuNjM0NjQ2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWI2YWY5YTAtNjdi
+        YS00ZmNjLTg5MzUtZDNjODg2OGRlZTQ5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMjA6MDU6MjUuNzM3NTg5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJiZjNiNmQzNjExYmY0YjA0OTgwZDAwMTAy
-        NmM1YTdjMCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTEwLTA2VDE4OjAzOjU1LjY4
-        NjAxOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDM6NTUuNzQ1
-        NTY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wNWU2ZDdmNC1iNTY0LTRlNzMtODJlYi0xNWI1MGE1MTI0YTMvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIxMDY4ODczMTBiZmE0MThkOTIwMjI5MWQ3
+        Nzk0NTA2YSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE2VDIwOjA1OjI1Ljc5
+        MjQ3MloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTZUMjA6MDU6MjUuODY0
+        NTQzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy83YmUxMDlhMS1hNTY5LTRkNjYtYTM1Ni05ZDlmNWE5ZDM2MmEvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNDM3ZGY5M2UtOTVmOS00MGJm
-        LTgyMWQtMTcwZmYwYzUzMmIxLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTllYjRmODEtNTEzZS00MzI3
+        LTg3OTktZDIwOTYxZWRlOGY5LyJdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:55 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:25 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -617,7 +601,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -625,18 +609,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:56 GMT
+      - Tue, 16 Nov 2021 20:05:26 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '1305'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -646,48 +626,65 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 23446bd644634d97b924a286a7c70c75
+      - 8557e8b0f2be4a06acdefaec835276dd
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '459'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jOWJkODU1OC03YjBjLTQ3ZDktODFkMC00ZTVhOWVmODdlYzAv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxODowMzoyNS43NjMzMDRa
+        cnBtL3JwbS82N2QyN2U0OS05NjZkLTRhYmQtYjE5YS1kMzdkNDQwOTY4NzUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xNVQyMDo1MDozMi44ODMwNzla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jOWJkODU1OC03YjBjLTQ3ZDktODFkMC00ZTVhOWVmODdlYzAv
+        cnBtL3JwbS82N2QyN2U0OS05NjZkLTRhYmQtYjE5YS1kMzdkNDQwOTY4NzUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2M5YmQ4
-        NTU4LTdiMGMtNDdkOS04MWQwLTRlNWE5ZWY4N2VjMC92ZXJzaW9ucy8wLyIs
-        Im5hbWUiOiIyIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
-        cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
-        ZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFj
-        a2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVs
-        bCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwi
-        cmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0v
-        M2Q5MjM2NmMtM2RlOC00Y2NlLWFiNzgtZTQ4MjU3MTk4ZDdhLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjEtMTAtMDZUMTg6MDM6MjIuMTIwNDU3WiIsInZlcnNp
-        b25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0v
-        M2Q5MjM2NmMtM2RlOC00Y2NlLWFiNzgtZTQ4MjU3MTk4ZDdhL3ZlcnNpb25z
-        LyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zZDkyMzY2Yy0zZGU4
-        LTRjY2UtYWI3OC1lNDgyNTcxOThkN2EvdmVyc2lvbnMvMC8iLCJuYW1lIjoi
-        Ml9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9f
-        dmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZh
-        bHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9w
-        YWNrYWdlX3ZlcnNpb25zIjowLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjpu
-        dWxsLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOm51bGwsImdwZ2NoZWNrIjow
-        LCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNlfV19
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzY3ZDI3
+        ZTQ5LTk2NmQtNGFiZC1iMTlhLWQzN2Q0NDA5Njg3NS92ZXJzaW9ucy8wLyIs
+        Im5hbWUiOiJ5dW0tanNoZXJpbGwtMi0yMTY3MDEiLCJkZXNjcmlwdGlvbiI6
+        bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVs
+        bCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZp
+        Y2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowLCJtZXRhZGF0
+        YV9jaGVja3N1bV90eXBlIjpudWxsLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUi
+        Om51bGwsImdwZ2NoZWNrIjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVf
+        bWV0YWRhdGEiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvcnBtL3JwbS80YzZiMTU4Zi03NDMzLTRkNDgtYjA0ZC1h
+        Yzc3ZTY4ZDkxZDEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xNVQyMDo1
+        MDoxMi4yMjM1NDFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvcnBtL3JwbS80YzZiMTU4Zi03NDMzLTRkNDgtYjA0ZC1h
+        Yzc3ZTY4ZDkxZDEvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
+        c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
+        cG0vcnBtLzRjNmIxNThmLTc0MzMtNGQ0OC1iMDRkLWFjNzdlNjhkOTFkMS92
+        ZXJzaW9ucy8wLyIsIm5hbWUiOiJ5dW0tanNoZXJpbGwtMS0yMDc1NTgiLCJk
+        ZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGws
+        InJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9z
+        aWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25z
+        IjowLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjpudWxsLCJwYWNrYWdlX2No
+        ZWNrc3VtX3R5cGUiOm51bGwsImdwZ2NoZWNrIjowLCJyZXBvX2dwZ2NoZWNr
+        IjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82MTY0MGFhMC0yZTdk
+        LTRlYjUtYTFhNy1iZTlkNWYyODU1Y2EvIiwicHVscF9jcmVhdGVkIjoiMjAy
+        MS0xMS0xMlQxMzowMzowMS43MjQxODZaIiwidmVyc2lvbnNfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82MTY0MGFhMC0yZTdk
+        LTRlYjUtYTFhNy1iZTlkNWYyODU1Y2EvdmVyc2lvbnMvIiwicHVscF9sYWJl
+        bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzYxNjQwYWEwLTJlN2QtNGViNS1hMWE3LWJl
+        OWQ1ZjI4NTVjYS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJ0ZXN0LTk2MzgteXVt
+        LTE3NTkzMSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJz
+        aW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2Us
+        Im1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2th
+        Z2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOm51bGws
+        InBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJl
+        cG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:56 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:26 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/c9bd8558-7b0c-47d9-81d0-4e5a9ef87ec0/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/67d27e49-966d-4abd-b19a-d37d44096875/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -699,7 +696,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -707,18 +704,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:56 GMT
+      - Tue, 16 Nov 2021 20:05:26 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '370'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
@@ -728,28 +721,30 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e2af0d192a2d493c9814c0e69edfc6b6
+      - 83e3cd95a5f344a29a331e0102b3fd54
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '231'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jOWJkODU1OC03YjBjLTQ3ZDktODFkMC00ZTVhOWVmODdlYzAv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2VDE4OjAz
-        OjI1Ljc2OTIxNloiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzliZDg1NTgtN2IwYy00N2Q5
-        LTgxZDAtNGU1YTllZjg3ZWMwLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        cnBtL3JwbS82N2QyN2U0OS05NjZkLTRhYmQtYjE5YS1kMzdkNDQwOTY4NzUv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTE1VDIwOjUw
+        OjMyLjg4ODMxNFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjdkMjdlNDktOTY2ZC00YWJk
+        LWIxOWEtZDM3ZDQ0MDk2ODc1LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
         dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
         bnQiOnt9fX1dfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:56 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:26 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/3d92366c-3de8-4cce-ab78-e48257198d7a/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/4c6b158f-7433-4d48-b04d-ac77e68d91d1/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -761,7 +756,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -769,18 +764,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:56 GMT
+      - Tue, 16 Nov 2021 20:05:26 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '370'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
@@ -790,28 +781,30 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a4dbf985bd0b49fbbc366c780c194e38
+      - 1b445224973d45aabadd6fbcc92ae315
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '231'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8zZDkyMzY2Yy0zZGU4LTRjY2UtYWI3OC1lNDgyNTcxOThkN2Ev
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2VDE4OjAz
-        OjIyLjEyNDAzOFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2Q5MjM2NmMtM2RlOC00Y2Nl
-        LWFiNzgtZTQ4MjU3MTk4ZDdhLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        cnBtL3JwbS80YzZiMTU4Zi03NDMzLTRkNDgtYjA0ZC1hYzc3ZTY4ZDkxZDEv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTE1VDIwOjUw
+        OjEyLjIyODUyN1oiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNGM2YjE1OGYtNzQzMy00ZDQ4
+        LWIwNGQtYWM3N2U2OGQ5MWQxLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
         dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
         bnQiOnt9fX1dfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:56 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:26 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/61640aa0-2e7d-4eb5-a1a7-be9d5f2855ca/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -819,11 +812,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/3.15.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -831,42 +824,100 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:57 GMT
+      - Tue, 16 Nov 2021 20:05:26 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 928186fe365145818d1a9e33a7d7e2c0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '230'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS82MTY0MGFhMC0yZTdkLTRlYjUtYTFhNy1iZTlkNWYyODU1Y2Ev
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTEyVDEzOjAz
+        OjAxLjczMDg3M1oiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjE2NDBhYTAtMmU3ZC00ZWI1
+        LWExYTctYmU5ZDVmMjg1NWNhLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 20:05:26 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.15.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 20:05:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
       Content-Length:
       - '52'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 83c57737cab4405bbef05863b01cf6bf
+      - d2e0dfc3c2c84258aff6e2cb57930cdf
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:57 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:26 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -874,11 +925,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.2/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -886,53 +937,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:57 GMT
+      - Tue, 16 Nov 2021 20:05:26 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '559'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 52dbb4cfa24c4e01a69ab05ddec0a752
+      - d35db324ae0f48f8b2d8772944a6ff56
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi85MDExZGVmZS02MjlkLTRmYzAtYWU0MC1jNjk4NjI5
-        YmVjMmEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxNzo0ODoyOC4w
-        MzkyODNaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvcHl0aG9uL3B5dGhvbi85MDExZGVmZS02MjlkLTRmYzAtYWU0MC1j
-        Njk4NjI5YmVjMmEvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
-        c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9w
-        eXRob24vcHl0aG9uLzkwMTFkZWZlLTYyOWQtNGZjMC1hZTQwLWM2OTg2Mjli
-        ZWMyYS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlv
-        bi1DYWJpbmV0LXB1bHAzX1B5dGhvbl8xIiwiZGVzY3JpcHRpb24iOm51bGws
-        InJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1
-        dG9wdWJsaXNoIjpmYWxzZX1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:57 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:26 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/python/python/9011defe-629d-4fc0-ae40-c698629bec2a/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -944,7 +982,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -952,49 +990,93 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:57 GMT
+      - Tue, 16 Nov 2021 20:05:26 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '382'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
-      - GET, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b3bd8eb440164bdd87c137e2cc8cc2b0
+      - 6267b2c9be8349cfb7581c80332cc8dd
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi85MDExZGVmZS02MjlkLTRmYzAtYWU0MC1jNjk4NjI5
-        YmVjMmEvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2
-        VDE3OjQ4OjI4LjA0MjE3NVoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vOTAxMWRl
-        ZmUtNjI5ZC00ZmMwLWFlNDAtYzY5ODYyOWJlYzJhLyIsImJhc2VfdmVyc2lv
-        biI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3Zl
-        ZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:57 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:26 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.9.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 20:05:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e5877cd5285344598644cbd516b2a367
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 20:05:26 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1006,7 +1088,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1014,297 +1096,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:57 GMT
+      - Tue, 16 Nov 2021 20:05:26 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 65e6edef3a9649b0908c8663085dd26e
+      - 69ad73416d414f8982953e1fdbaee461
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:57 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:03:58 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '498'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 2790c167305b4cb49673e13b07b436d1
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZGViL2FwdC8xY2VjYTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4N2Uv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxODowMToxNy4xNjIzMjVa
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZGViL2FwdC8xY2VjYTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4N2Uv
-        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzFjZWNh
-        NDQzLWE0YjQtNGUwYS04ZmMwLTYyNzVjNGZkNDg3ZS92ZXJzaW9ucy8wLyIs
-        Im5hbWUiOiJkZWJpYW5fcHVscF9yYWduYXJvayIsImRlc2NyaXB0aW9uIjpu
-        dWxsLCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxs
-        fV19
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:58 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/deb/apt/1ceca443-a4b4-4e0a-8fc0-6275c4fd487e/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:03:58 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '370'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 13d142a8192b4c5f835c2635ea8f35c8
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZGViL2FwdC8xY2VjYTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4N2Uv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2VDE4OjAx
-        OjE3LjE2NTQ1NFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMWNlY2E0NDMtYTRiNC00ZTBh
-        LThmYzAtNjI3NWM0ZmQ0ODdlLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:58 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:03:58 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '551'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 040476cd6e354a7983b33c394f55e10e
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci8zM2EzMmFlNS1mYzNjLTRlOGQtYTE0MS0x
-        YmVjY2RjMjYzZjgvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxNzoy
-        Mjo0OS44MzM0OTRaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8zM2EzMmFlNS1mYzNj
-        LTRlOGQtYTE0MS0xYmVjY2RjMjYzZjgvdmVyc2lvbnMvIiwicHVscF9sYWJl
-        bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzMzYTMyYWU1LWZjM2Mt
-        NGU4ZC1hMTQxLTFiZWNjZGMyNjNmOC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJE
-        ZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwiZGVzY3Jp
-        cHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1v
-        dGUiOm51bGx9XX0=
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:58 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/container/container/33a32ae5-fc3c-4e8d-a141-1beccdc263f8/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:03:58 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '394'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 7f76207d77274473ae06c17f989301de
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci8zM2EzMmFlNS1mYzNjLTRlOGQtYTE0MS0x
-        YmVjY2RjMjYzZjgvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIx
-        LTEwLTA2VDE3OjIyOjQ5LjkxNTIwMloiLCJudW1iZXIiOjAsInJlcG9zaXRv
-        cnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250
-        YWluZXIvMzNhMzJhZTUtZmMzYy00ZThkLWExNDEtMWJlY2NkYzI2M2Y4LyIs
-        ImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVk
-        Ijp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:58 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:26 GMT
 - request:
     method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/orphans/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/orphans/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1316,7 +1141,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1324,40 +1149,40 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:59 GMT
+      - Tue, 16 Nov 2021 20:05:26 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - DELETE, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '67'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ec4442b66b794600bf2a03aa9d8c9a1e
+      - 5def6910f2b04b4a8cf8056dd0d69cc6
       Access-Control-Expose-Headers:
       - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E1MWI2NGM0LWQ0ZmEtNDll
-        Ny04Njc5LTI2ZGFhNGFiNDc3My8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhhY2ZkMjc0LWM3MmYtNGJk
+        NC1hZmJjLWZmY2ZhZGFhODYzMi8ifQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:59 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:26 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/a51b64c4-d4fa-49e7-8679-26daa4ab4773/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/8acfd274-c72f-4bd4-afbc-ffcfadaa8632/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1369,7 +1194,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1377,18 +1202,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:03:59 GMT
+      - Tue, 16 Nov 2021 20:05:26 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '771'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1398,23 +1219,25 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 31b67e95a85c4589a08ac81db3ea60a6
+      - 4e0c0ddc2e394d4ea440655581263516
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '410'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTUxYjY0YzQtZDRm
-        YS00OWU3LTg2NzktMjZkYWE0YWI0NzczLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDM6NTkuMTIyMjcwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGFjZmQyNzQtYzcy
+        Zi00YmQ0LWFmYmMtZmZjZmFkYWE4NjMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMjA6MDU6MjYuNjYxMzY3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJsb2dnaW5nX2NpZCI6ImVjNDQ0MmI2NmI3OTQ2MDBiZjJhMDNh
-        YTlkOGM5YTFlIiwic3RhcnRlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDM6NTku
-        MTc0NzE0WiIsImZpbmlzaGVkX2F0IjoiMjAyMS0xMC0wNlQxODowMzo1OS4y
-        MDk3NzNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzLzZiNzEzY2E1LWUxZmItNDc5YS04NmEzLTg1ZWQxMWIzOTNmYi8i
+        ZWFudXAiLCJsb2dnaW5nX2NpZCI6IjVkZWY2OTEwZjJiMDRiNGE4Y2Y4MDU2
+        ZGQwZDY5Y2M2Iiwic3RhcnRlZF9hdCI6IjIwMjEtMTEtMTZUMjA6MDU6MjYu
+        NzIxMDI5WiIsImZpbmlzaGVkX2F0IjoiMjAyMS0xMS0xNlQyMDowNToyNi43
+        Njg0NTBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzQ5MDAyOGZjLWUzYjgtNGFiZi1iMDhkLTlkNzcwNzBlODZjYi8i
         LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
         b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xl
         YW4gdXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVu
@@ -1425,5 +1248,5 @@ http_interactions:
         ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
         ZCI6W119
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:03:59 GMT
+  recorded_at: Tue, 16 Nov 2021 20:05:26 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/upload_binary.yml
@@ -17363,4 +17363,278 @@ http_interactions:
         LTgyMWQtMTcwZmYwYzUzMmIxLyJdfQ==
     http_version: 
   recorded_at: Wed, 06 Oct 2021 18:03:54 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/content/rpm/packages/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 20:05:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6d4188b8fa204d8b86e3471a04388806
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '1860'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy9hMjQ4ZmY0Yy02M2Q3LTRkMjctOGEzZi00OWY1NmQwNDg5YWQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xMlQxMzowNzozNS45MDg5ODFa
+        IiwibWQ1IjpudWxsLCJzaGExIjoiYmRhNmFhZjY0MzMxYjAwYzkwYTcwNzhm
+        Nzg1Yzg5Y2I2YWU0YWM3YiIsInNoYTIyNCI6IjkzOGQ3YmFhMzc4NTEwMTlh
+        N2E3M2EwZWIzYTA5ZWE2ZDJkNWRhMzY3Y2I2NTg0YTBhODYxYzliIiwic2hh
+        MjU2IjoiODAxYTJhMmM3ZGQ2NGNkMzk5N2RjZGYxZTYxZTE2ZjZjZjAxZWY3
+        Y2NlOWI0ZDUyNzcxMmU1OGM0MGVjYTU1ZiIsInNoYTM4NCI6ImVhMzNkYzA1
+        NDUwNjc3ZTZiZTAzODZiYzRlZGI3NmM1YjUwOTBmMDI0NWFmOGM1OThlNjYw
+        YzA5YWE3MTE2YjcwMGYzNzRiZmQ0YmRlMzBhZDc3OGZiYzlmYmE0MjcyOSIs
+        InNoYTUxMiI6IjIxMWNiNWE4MTgyZWM3MzdmNjhjY2NkODU4Y2M5ZjM3NGQy
+        Y2M0NTM1NjljOTYwZGI0ZjZmNmNlMmJkOGMxZmQ4YTIxMzFlYzU4N2VlODAy
+        ZTljOTMxMWMyZjhhY2Y1NTU1Njk0NzE1NGM1NDhhYjM4NGJlMWZjNmJjYzVm
+        ZGQzIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2E0ODcx
+        MDcyLTFiYzktNGNjOS1iZWY5LTUxNWE4ZGUyMzAzZC8iLCJuYW1lIjoiemVi
+        cmEiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xIiwicmVsZWFzZSI6IjIi
+        LCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MDFhMmEyYzdkZDY0Y2QzOTk3
+        ZGNkZjFlNjFlMTZmNmNmMDFlZjdjY2U5YjRkNTI3NzEyZTU4YzQwZWNhNTVm
+        IiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiIsInN1bW1hcnkiOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgemVicmEiLCJkZXNjcmlwdGlvbiI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiB6ZWJyYSIsInVybCI6Imh0dHA6Ly90c3RyYWNob3RhLmZlZG9y
+        YXBlb3BsZS5vcmciLCJjaGFuZ2Vsb2dzIjpbXSwiZmlsZXMiOltbbnVsbCwi
+        L3RtcC8iLCJ6ZWJyYS50eHQiXV0sInJlcXVpcmVzIjpbWyJkb2xwaGluIixu
+        dWxsLG51bGwsbnVsbCxudWxsLGZhbHNlXSxbImdvcmlsbGEiLG51bGwsbnVs
+        bCxudWxsLG51bGwsZmFsc2VdLFsicGlrZSIsbnVsbCxudWxsLG51bGwsbnVs
+        bCxmYWxzZV1dLCJwcm92aWRlcyI6W1siemVicmEiLCJFUSIsIjAiLCIwLjEi
+        LCIyIixmYWxzZV1dLCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMiOltdLCJz
+        dWdnZXN0cyI6W10sImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6W10sInN1
+        cHBsZW1lbnRzIjpbXSwibG9jYXRpb25fYmFzZSI6IiIsImxvY2F0aW9uX2hy
+        ZWYiOiJ6ZWJyYS0wLjEtMi5ub2FyY2gucnBtIiwicnBtX2J1aWxkaG9zdCI6
+        InNtcWUtd3MxNSIsInJwbV9ncm91cCI6IkludGVybmV0L0FwcGxpY2F0aW9u
+        cyIsInJwbV9saWNlbnNlIjoiR1BMdjIiLCJycG1fcGFja2FnZXIiOiIiLCJy
+        cG1fc291cmNlcnBtIjoiemVicmEtMC4xLTIuc3JjLnJwbSIsInJwbV92ZW5k
+        b3IiOiIiLCJycG1faGVhZGVyX3N0YXJ0Ijo4NzIsInJwbV9oZWFkZXJfZW5k
+        IjoyMzI1LCJpc19tb2R1bGFyIjpmYWxzZSwic2l6ZV9hcmNoaXZlIjoyOTYs
+        InNpemVfaW5zdGFsbGVkIjo0Miwic2l6ZV9wYWNrYWdlIjoyNDc3LCJ0aW1l
+        X2J1aWxkIjoxMzMxODMxMzc1LCJ0aW1lX2ZpbGUiOjE0NTQxMjMzNzR9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        LzhjZDMxMDkzLTIzZGUtNDJkOC1hOWRhLWRlZjdhMjQxNGFjZC8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIxLTExLTAyVDIwOjA4OjE0LjI3MjQ3MloiLCJtZDUi
+        Om51bGwsInNoYTEiOiI4NTZjZjNhZmY2Zjc1ZThjNDg3NjFjOTMzYzZmYjMw
+        NzMyYzAzZjFmIiwic2hhMjI0IjoiNTZhZjgwMDRmZTcyZTRhM2JiMzljZGJk
+        MTZiY2I3MDIxYTEzMjc0MTc4OTUxZmFmNjRlMDMzOWQiLCJzaGEyNTYiOiIy
+        YmRmMWNiNzFkOWQzYTc4NWFmMjRmODZiZGIzNWJjZTlmYWUyOWZlYjg2Y2Yy
+        YzQ4YWQ1YTJiMzcyNDQxZTAwIiwic2hhMzg0IjoiMDg1OTkxNDFiNWViNWNk
+        Y2JmMTcyOGY2MGVhMWVhOWI0ZmIyNmJlNDkyZmRiNzRjOWYzZWUzYjIzYmRi
+        YzVhZDJjZDU1MzU4ZmQ5N2E1YTFkOTQ2NmU5ZjM0MjZiYjU1Iiwic2hhNTEy
+        IjoiZTUzYmI2NWI1NmFiY2M5MmMwODE5NGUxYWNlYTJhNWJjNTg2NjdmNWJk
+        MDc4NTgxYTkwYTk0NDE3ZmMzYTI0YTg4NGM5MzY1NDhmN2M5NzMyZDFjNDAy
+        YzMwZDg5YzA4YTdiYWU4YzRjYWQ4OGEyODUxMmQ2OThlMzUwNzhjOWEiLCJh
+        cnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNDQxYzcwMTQtNWQ2
+        NC00MGFiLWJlOTYtMDhjMWMwYzQzYzQwLyIsIm5hbWUiOiJjcmVhdGVyZXBv
+        X2MiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4xNy4xIiwicmVsZWFzZSI6
+        IjEuZWw3IiwiYXJjaCI6InNyYyIsInBrZ0lkIjoiMmJkZjFjYjcxZDlkM2E3
+        ODVhZjI0Zjg2YmRiMzViY2U5ZmFlMjlmZWI4NmNmMmM0OGFkNWEyYjM3MjQ0
+        MWUwMCIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJzdW1tYXJ5IjoiQ3Jl
+        YXRlcyBhIGNvbW1vbiBtZXRhZGF0YSByZXBvc2l0b3J5IiwiZGVzY3JpcHRp
+        b24iOiJDIGltcGxlbWVudGF0aW9uIG9mIENyZWF0ZXJlcG8uXG5BIHNldCBv
+        ZiB1dGlsaXRpZXMgKGNyZWF0ZXJlcG9fYywgbWVyZ2VyZXBvX2MsIG1vZGlm
+        eXJlcG9fYylcbmZvciBnZW5lcmF0aW5nIGEgY29tbW9uIG1ldGFkYXRhIHJl
+        cG9zaXRvcnkgZnJvbSBhIGRpcmVjdG9yeSBvZlxucnBtIHBhY2thZ2VzIGFu
+        ZCBtYWludGFpbmluZyBpdC4iLCJ1cmwiOiJodHRwczovL2dpdGh1Yi5jb20v
+        cnBtLXNvZnR3YXJlLW1hbmFnZW1lbnQvY3JlYXRlcmVwb19jIiwiY2hhbmdl
+        bG9ncyI6W1siRXZnZW5pIEdvbG92IC0gMC4xNS4xMC0xIiwxNTg4NTkzNjAw
+        LCItIHVwZGF0ZSB0byB1cHN0cmVhbSAwLjE1LjEwIl0sWyJFdmdlbmkgR29s
+        b3YgLSAwLjE2LjEtMSIsMTYwMTU1MzYwMCwiLSBSZWxlYXNlIGNyZWF0ZXJl
+        cG9fYyAwLjE2LjEiXSxbIkp1c3RpbiBTaGVycmlsbCA8anNoZXJyaWxAcmVk
+        aGF0LmNvbT4gMC4xNi4yLTEiLDE2MDUwOTYwMDAsIiogdXBkYXRlIHRvIDAu
+        MTYuMiJdLFsiSnVzdGluIFNoZXJyaWxsIDxqc2hlcnJpbEByZWRoYXQuY29t
+        PiAwLjE3LjAtMSIsMTYxMzY0OTYwMCwiLSB1cGRhdGUgdG8gMC4xNy4wIl0s
+        WyJFdmdlbmkgR29sb3YgLSAwLjE3LjEtMSIsMTYxNDc3MjgwMCwiLSBSZWxl
+        YXNlIGNyZWF0ZXJlcG9fYyAwLjE3LjEiXV0sImZpbGVzIjpbWyIiLCIiLCJj
+        cmVhdGVyZXBvX2MtMC4xNy4xLnRhci5neiJdLFsiIiwiIiwiY3JlYXRlcmVw
+        b19jLnNwZWMiXV0sInJlcXVpcmVzIjpbWyJjbWFrZSIsbnVsbCxudWxsLG51
+        bGwsbnVsbCxmYWxzZV0sWyJnY2MiLG51bGwsbnVsbCxudWxsLG51bGwsZmFs
+        c2VdLFsiYnppcDItZGV2ZWwiLG51bGwsbnVsbCxudWxsLG51bGwsZmFsc2Vd
+        LFsiZG94eWdlbiIsbnVsbCxudWxsLG51bGwsbnVsbCxmYWxzZV0sWyJmaWxl
+        LWRldmVsIixudWxsLG51bGwsbnVsbCxudWxsLGZhbHNlXSxbImdsaWIyLWRl
+        dmVsIiwiR0UiLCIwIiwiMi4yMi4wIixudWxsLGZhbHNlXSxbImxpYmN1cmwt
+        ZGV2ZWwiLG51bGwsbnVsbCxudWxsLG51bGwsZmFsc2VdLFsibGlieG1sMi1k
+        ZXZlbCIsbnVsbCxudWxsLG51bGwsbnVsbCxmYWxzZV0sWyJvcGVuc3NsLWRl
+        dmVsIixudWxsLG51bGwsbnVsbCxudWxsLGZhbHNlXSxbInJwbS1kZXZlbCIs
+        IkdFIiwiMCIsIjQuOC4wIiwiMjgiLGZhbHNlXSxbInNxbGl0ZS1kZXZlbCIs
+        bnVsbCxudWxsLG51bGwsbnVsbCxmYWxzZV0sWyJ4ei1kZXZlbCIsbnVsbCxu
+        dWxsLG51bGwsbnVsbCxmYWxzZV0sWyJ6bGliLWRldmVsIixudWxsLG51bGws
+        bnVsbCxudWxsLGZhbHNlXSxbImJhc2gtY29tcGxldGlvbiIsbnVsbCxudWxs
+        LG51bGwsbnVsbCxmYWxzZV0sWyJweXRob24zLWRldmVsIixudWxsLG51bGws
+        bnVsbCxudWxsLGZhbHNlXV0sInByb3ZpZGVzIjpbXSwiY29uZmxpY3RzIjpb
+        XSwib2Jzb2xldGVzIjpbXSwic3VnZ2VzdHMiOltdLCJlbmhhbmNlcyI6W10s
+        InJlY29tbWVuZHMiOltdLCJzdXBwbGVtZW50cyI6W10sImxvY2F0aW9uX2Jh
+        c2UiOiIiLCJsb2NhdGlvbl9ocmVmIjoiY3JlYXRlcmVwb19jLTAuMTcuMS0x
+        LmVsNy5zcmMucnBtIiwicnBtX2J1aWxkaG9zdCI6Imtvamkua2F0ZWxsby5v
+        cmciLCJycG1fZ3JvdXAiOiJVbnNwZWNpZmllZCIsInJwbV9saWNlbnNlIjoi
+        R1BMdjIrIiwicnBtX3BhY2thZ2VyIjoiS29qaSIsInJwbV9zb3VyY2VycG0i
+        OiIiLCJycG1fdmVuZG9yIjoiS29qaSIsInJwbV9oZWFkZXJfc3RhcnQiOjE0
+        ODgsInJwbV9oZWFkZXJfZW5kIjozNjY0LCJpc19tb2R1bGFyIjpmYWxzZSwi
+        c2l6ZV9hcmNoaXZlIjo1OTk4NzIsInNpemVfaW5zdGFsbGVkIjo1OTk0Nzgs
+        InNpemVfcGFja2FnZSI6NjAwNDgyLCJ0aW1lX2J1aWxkIjoxNjE0NzY4OTU4
+        LCJ0aW1lX2ZpbGUiOjE2MzU4ODM2OTR9XX0=
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 20:05:24 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/99eb4f81-513e-4327-8799-d20961ede8f9/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYTI0OGZmNGMtNjNkNy00ZDI3LThhM2YtNDlmNTZkMDQ4
+        OWFkLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 20:05:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 217da7e793334f5d98aea3c7fe04a243
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JhNDg4MTQxLWQzMzUtNGRl
+        Ny05YWRlLTExYTBiZWE5NzY5Mi8ifQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 20:05:24 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/ba488141-d335-4de7-9ade-11a0bea97692/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 20:05:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8ce85b9076a74ac1b3e066f0e4c767f5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '387'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmE0ODgxNDEtZDMz
+        NS00ZGU3LTlhZGUtMTFhMGJlYTk3NjkyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMjA6MDU6MjQuNTc4MzUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyMTdkYTdlNzkzMzM0ZjVkOThh
+        ZWEzYzdmZTA0YTI0MyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE2VDIwOjA1
+        OjI0LjYzMzQ4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTZUMjA6MDU6
+        MjQuODE4Nzc5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy80OTAwMjhmYy1lM2I4LTRhYmYtYjA4ZC05ZDc3MDcwZTg2
+        Y2IvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS85OWViNGY4MS01MTNlLTQzMjctODc5OS1kMjA5NjFlZGU4ZjkvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOTllYjRmODEtNTEzZS00MzI3
+        LTg3OTktZDIwOTYxZWRlOGY5LyJdfQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 20:05:24 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/srpm_upload/upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/srpm_upload/upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -14,7 +14,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -22,42 +22,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:42 GMT
+      - Tue, 16 Nov 2021 16:11:01 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4e2f8d702e3c4d71a9bd2a7e24ea4852
+      - 344c59515162459aafae65e751bbc46b
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:42 GMT
+  recorded_at: Tue, 16 Nov 2021 16:11:01 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -69,7 +67,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -77,42 +75,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:42 GMT
+      - Tue, 16 Nov 2021 16:11:01 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d53bbfa53add4802aead56fb0287eec6
+      - 4ad4b485d78e49d6b8186094ab0683d4
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:42 GMT
+  recorded_at: Tue, 16 Nov 2021 16:11:01 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -124,7 +120,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -132,42 +128,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:43 GMT
+      - Tue, 16 Nov 2021 16:11:02 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 352b565d0cab4c20be6f77d069feb84e
+      - 3a02681a06d341bea387e9af9a6812b6
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:43 GMT
+  recorded_at: Tue, 16 Nov 2021 16:11:02 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -179,7 +173,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -187,42 +181,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:43 GMT
+      - Tue, 16 Nov 2021 16:11:02 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 212f15ef2e254fb88da4f9223bab2400
+      - 9c367067e89646eb86eaa8808038ec8e
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:43 GMT
+  recorded_at: Tue, 16 Nov 2021 16:11:02 GMT
 - request:
     method: post
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -239,7 +231,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -247,54 +239,52 @@ http_interactions:
       code: 201
       message: Created
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:43 GMT
+      - Tue, 16 Nov 2021 16:11:02 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '534'
-      Connection:
-      - keep-alive
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/dccee868-5c4c-4765-9d86-95594545d3cb/"
+      - "/pulp/api/v3/remotes/rpm/rpm/48276b0a-d9c4-46e9-a3dc-ba059296ae5c/"
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '534'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6076d5f3624a4cf8bcc02e4b0ddfbafe
+      - 998f5ad823ed491fb457d4a4f288bdfe
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Rj
-        Y2VlODY4LTVjNGMtNDc2NS05ZDg2LTk1NTk0NTQ1ZDNjYi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIxLTEwLTA2VDE4OjAyOjQzLjYzMjA3NloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQ4
+        Mjc2YjBhLWQ5YzQtNDZlOS1hM2RjLWJhMDU5Mjk2YWU1Yy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIxLTExLTE2VDE2OjExOjAyLjQxMDM1MloiLCJuYW1lIjoi
         RmVkb3JhXzE3IiwidXJsIjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0
         IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRy
         dWUsInByb3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjEtMTAtMDZUMTg6MDI6NDMuNjMyMDkzWiIsImRv
+        c3RfdXBkYXRlZCI6IjIwMjEtMTEtMTZUMTY6MTE6MDIuNDEwMzc4WiIsImRv
         d25sb2FkX2NvbmN1cnJlbmN5IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwi
         cG9saWN5Ijoib25fZGVtYW5kIiwidG90YWxfdGltZW91dCI6MzAwLjAsImNv
         bm5lY3RfdGltZW91dCI6bnVsbCwic29ja19jb25uZWN0X3RpbWVvdXQiOm51
         bGwsInNvY2tfcmVhZF90aW1lb3V0IjpudWxsLCJoZWFkZXJzIjpudWxsLCJy
         YXRlX2xpbWl0IjpudWxsLCJzbGVzX2F1dGhfdG9rZW4iOm51bGx9
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:43 GMT
+  recorded_at: Tue, 16 Nov 2021 16:11:02 GMT
 - request:
     method: post
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -308,7 +298,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -316,45 +306,43 @@ http_interactions:
       code: 201
       message: Created
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:43 GMT
+      - Tue, 16 Nov 2021 16:11:02 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '629'
-      Connection:
-      - keep-alive
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/5e9b6e2e-0163-4f26-b006-8cda3dc838ad/"
+      - "/pulp/api/v3/repositories/rpm/rpm/e322c6c9-6d28-41f1-8e49-ea4a4930f28a/"
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '629'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6f450492fc274e47a57431ee6cae8abb
+      - 93412a17c6164b39aa3d16aa18c01299
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNWU5YjZlMmUtMDE2My00ZjI2LWIwMDYtOGNkYTNkYzgzOGFkLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjEtMTAtMDZUMTg6MDI6NDMuOTY3NzQwWiIsInZl
+        cG0vZTMyMmM2YzktNmQyOC00MWYxLThlNDktZWE0YTQ5MzBmMjhhLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjEtMTEtMTZUMTY6MTE6MDIuODMyODcxWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vNWU5YjZlMmUtMDE2My00ZjI2LWIwMDYtOGNkYTNkYzgzOGFkL3ZlcnNp
+        cG0vZTMyMmM2YzktNmQyOC00MWYxLThlNDktZWE0YTQ5MzBmMjhhL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81ZTliNmUyZS0w
-        MTYzLTRmMjYtYjAwNi04Y2RhM2RjODM4YWQvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9lMzIyYzZjOS02
+        ZDI4LTQxZjEtOGU0OS1lYTRhNDkzMGYyOGEvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiRmVkb3JhXzE3IiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBv
         X3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpm
         YWxzZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5f
@@ -362,10 +350,10 @@ http_interactions:
         bnVsbCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6
         MCwicmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:43 GMT
+  recorded_at: Tue, 16 Nov 2021 16:11:02 GMT
 - request:
     method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/remotes/rpm/rpm/dccee868-5c4c-4765-9d86-95594545d3cb/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/48276b0a-d9c4-46e9-a3dc-ba059296ae5c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -377,7 +365,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -385,40 +373,40 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:45 GMT
+      - Tue, 16 Nov 2021 16:11:04 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '67'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 17af2ed08c8a4016901ac93458b86061
+      - f610bba958dd44ceb99e7099ad167225
       Access-Control-Expose-Headers:
       - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBiY2ExOTVhLTEwYmYtNGJk
-        My1hNjczLTU2M2QzMWJhZmQ5MS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M1NDAwYWNmLWQ3NzQtNDZk
+        ZC1hNGU1LWMwZGJkZGE5ZTQ4MS8ifQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:45 GMT
+  recorded_at: Tue, 16 Nov 2021 16:11:04 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/0bca195a-10bf-4bd3-a673-563d31bafd91/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/c5400acf-d774-46dd-a4e5-c0dbdda9e481/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -430,7 +418,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -438,18 +426,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:45 GMT
+      - Tue, 16 Nov 2021 16:11:04 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '602'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -459,33 +443,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - adaeaf6ad9fb4f5994d37d822941d0e8
+      - 02ea578f0adb427a8f71ae83bc69f0e5
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '371'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGJjYTE5NWEtMTBi
-        Zi00YmQzLWE2NzMtNTYzZDMxYmFmZDkxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDI6NDUuNjc0NDEwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzU0MDBhY2YtZDc3
+        NC00NmRkLWE0ZTUtYzBkYmRkYTllNDgxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMTY6MTE6MDQuMjczNjkzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIxN2FmMmVkMDhjOGE0MDE2OTAxYWM5MzQ1
-        OGI4NjA2MSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTEwLTA2VDE4OjAyOjQ1Ljcy
-        MDU0N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDI6NDUuNzYx
-        MTgzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wNWU2ZDdmNC1iNTY0LTRlNzMtODJlYi0xNWI1MGE1MTI0YTMvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJmNjEwYmJhOTU4ZGQ0NGNlYjk5ZTcwOTlh
+        ZDE2NzIyNSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE2VDE2OjExOjA0LjM0
+        NDA0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTZUMTY6MTE6MDQuNDEx
+        MDI1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy80OTAwMjhmYy1lM2I4LTRhYmYtYjA4ZC05ZDc3MDcwZTg2Y2IvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2RjY2VlODY4LTVjNGMtNDc2NS05ZDg2
-        LTk1NTk0NTQ1ZDNjYi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQ4Mjc2YjBhLWQ5YzQtNDZlOS1hM2Rj
+        LWJhMDU5Mjk2YWU1Yy8iXX0=
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:45 GMT
+  recorded_at: Tue, 16 Nov 2021 16:11:04 GMT
 - request:
     method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/5e9b6e2e-0163-4f26-b006-8cda3dc838ad/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/e322c6c9-6d28-41f1-8e49-ea4a4930f28a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -497,7 +483,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -505,40 +491,40 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:46 GMT
+      - Tue, 16 Nov 2021 16:11:04 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '67'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c179cebe0421405087e43c198c9fb543
+      - 4099773f742245b7b8d3a7524d54a2ab
       Access-Control-Expose-Headers:
       - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk4NGE4ZjEyLWRjZTItNDU2
-        YS1hZGE0LTNhODUwNmE4NGFmZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg0MGFjYjEwLTMwODEtNGI0
+        Ny1hYzQyLWEyYjE4YWVhMjk0My8ifQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:46 GMT
+  recorded_at: Tue, 16 Nov 2021 16:11:04 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/984a8f12-dce2-456a-ada4-3a8506a84aff/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/840acb10-3081-4b47-ac42-a2b18aea2943/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -550,7 +536,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -558,18 +544,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:46 GMT
+      - Tue, 16 Nov 2021 16:11:04 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '607'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -579,33 +561,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bef2a55ddfe64fdf98c95f03144eee4e
+      - c40a2f4abc4e40dd88c87c6df07b9505
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '373'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTg0YThmMTItZGNl
-        Mi00NTZhLWFkYTQtM2E4NTA2YTg0YWZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDI6NDYuMjgyMjQ0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODQwYWNiMTAtMzA4
+        MS00YjQ3LWFjNDItYTJiMThhZWEyOTQzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMTY6MTE6MDQuNjA5OTg1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJjMTc5Y2ViZTA0MjE0MDUwODdlNDNjMTk4
-        YzlmYjU0MyIsInN0YXJ0ZWRfYXQiOiIyMDIxLTEwLTA2VDE4OjAyOjQ2LjM0
-        MDk1NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDI6NDYuMzk2
-        MDY2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wNWU2ZDdmNC1iNTY0LTRlNzMtODJlYi0xNWI1MGE1MTI0YTMvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0MDk5NzczZjc0MjI0NWI3YjhkM2E3NTI0
+        ZDU0YTJhYiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE2VDE2OjExOjA0LjY3
+        NTgwN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTZUMTY6MTE6MDQuNzU0
+        NTYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9iZmJlMjlhMC04YzQ2LTRkNzgtYjA2YS03ODk4OTlmYTMwNzcvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNWU5YjZlMmUtMDE2My00ZjI2
-        LWIwMDYtOGNkYTNkYzgzOGFkLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTMyMmM2YzktNmQyOC00MWYx
+        LThlNDktZWE0YTQ5MzBmMjhhLyJdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:46 GMT
+  recorded_at: Tue, 16 Nov 2021 16:11:04 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -617,7 +601,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -625,18 +609,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:47 GMT
+      - Tue, 16 Nov 2021 16:11:05 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -646,142 +626,65 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 38783c99c16f482e9168f3245942495d
+      - f1dc3926666e4f8d8b7f0a38bbba6a4c
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:47 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:47 GMT
-      Content-Type:
-      - application/json
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 7ac5c54409dc4e7daf59a23b539501f0
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      - '459'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:47 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.5.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:47 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '559'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - d7eba206b5104436952a2d9d2b9b7b1e
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi85MDExZGVmZS02MjlkLTRmYzAtYWU0MC1jNjk4NjI5
-        YmVjMmEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxNzo0ODoyOC4w
-        MzkyODNaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvcHl0aG9uL3B5dGhvbi85MDExZGVmZS02MjlkLTRmYzAtYWU0MC1j
-        Njk4NjI5YmVjMmEvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
-        c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9w
-        eXRob24vcHl0aG9uLzkwMTFkZWZlLTYyOWQtNGZjMC1hZTQwLWM2OTg2Mjli
-        ZWMyYS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlv
-        bi1DYWJpbmV0LXB1bHAzX1B5dGhvbl8xIiwiZGVzY3JpcHRpb24iOm51bGws
-        InJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1
-        dG9wdWJsaXNoIjpmYWxzZX1dfQ==
+        cnBtL3JwbS82N2QyN2U0OS05NjZkLTRhYmQtYjE5YS1kMzdkNDQwOTY4NzUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xNVQyMDo1MDozMi44ODMwNzla
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS82N2QyN2U0OS05NjZkLTRhYmQtYjE5YS1kMzdkNDQwOTY4NzUv
+        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzY3ZDI3
+        ZTQ5LTk2NmQtNGFiZC1iMTlhLWQzN2Q0NDA5Njg3NS92ZXJzaW9ucy8xLyIs
+        Im5hbWUiOiJ5dW0tanNoZXJpbGwtMi0yMTY3MDEiLCJkZXNjcmlwdGlvbiI6
+        bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVs
+        bCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZp
+        Y2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowLCJtZXRhZGF0
+        YV9jaGVja3N1bV90eXBlIjpudWxsLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUi
+        Om51bGwsImdwZ2NoZWNrIjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVf
+        bWV0YWRhdGEiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvcnBtL3JwbS80YzZiMTU4Zi03NDMzLTRkNDgtYjA0ZC1h
+        Yzc3ZTY4ZDkxZDEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xNVQyMDo1
+        MDoxMi4yMjM1NDFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvcnBtL3JwbS80YzZiMTU4Zi03NDMzLTRkNDgtYjA0ZC1h
+        Yzc3ZTY4ZDkxZDEvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
+        c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
+        cG0vcnBtLzRjNmIxNThmLTc0MzMtNGQ0OC1iMDRkLWFjNzdlNjhkOTFkMS92
+        ZXJzaW9ucy8xLyIsIm5hbWUiOiJ5dW0tanNoZXJpbGwtMS0yMDc1NTgiLCJk
+        ZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGws
+        InJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9z
+        aWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25z
+        IjowLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjpudWxsLCJwYWNrYWdlX2No
+        ZWNrc3VtX3R5cGUiOm51bGwsImdwZ2NoZWNrIjowLCJyZXBvX2dwZ2NoZWNr
+        IjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNlfSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82MTY0MGFhMC0yZTdk
+        LTRlYjUtYTFhNy1iZTlkNWYyODU1Y2EvIiwicHVscF9jcmVhdGVkIjoiMjAy
+        MS0xMS0xMlQxMzowMzowMS43MjQxODZaIiwidmVyc2lvbnNfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82MTY0MGFhMC0yZTdk
+        LTRlYjUtYTFhNy1iZTlkNWYyODU1Y2EvdmVyc2lvbnMvIiwicHVscF9sYWJl
+        bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzYxNjQwYWEwLTJlN2QtNGViNS1hMWE3LWJl
+        OWQ1ZjI4NTVjYS92ZXJzaW9ucy8xLyIsIm5hbWUiOiJ0ZXN0LTk2MzgteXVt
+        LTE3NTkzMSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJz
+        aW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2Us
+        Im1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2th
+        Z2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOm51bGws
+        InBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJl
+        cG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:47 GMT
+  recorded_at: Tue, 16 Nov 2021 16:11:05 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/python/python/9011defe-629d-4fc0-ae40-c698629bec2a/versions/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/67d27e49-966d-4abd-b19a-d37d44096875/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -789,11 +692,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.2/ruby
+      - OpenAPI-Generator/3.15.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -801,18 +704,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:47 GMT
+      - Tue, 16 Nov 2021 16:11:05 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '382'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
@@ -822,28 +721,414 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9319a897d8d94b25bd456b8050c07821
+      - ddbc777815f748388bfd2c864daf318a
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '303'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS82N2QyN2U0OS05NjZkLTRhYmQtYjE5YS1kMzdkNDQwOTY4NzUv
+        dmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTE1VDIwOjUx
+        OjQ1LjE5Mzc1MVoiLCJudW1iZXIiOjEsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjdkMjdlNDktOTY2ZC00YWJk
+        LWIxOWEtZDM3ZDQ0MDk2ODc1LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5wYWNrYWdlIjp7ImNvdW50
+        IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        Lz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzY3ZDI3ZTQ5LTk2NmQtNGFiZC1iMTlhLWQzN2Q0
+        NDA5Njg3NS92ZXJzaW9ucy8xLyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQi
+        OnsicnBtLnBhY2thZ2UiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0v
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjdkMjdlNDktOTY2
+        ZC00YWJkLWIxOWEtZDM3ZDQ0MDk2ODc1L3ZlcnNpb25zLzEvIn19fX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0v
+        NjdkMjdlNDktOTY2ZC00YWJkLWIxOWEtZDM3ZDQ0MDk2ODc1L3ZlcnNpb25z
+        LzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xNVQyMDo1MDozMi44ODgz
+        MTRaIiwibnVtYmVyIjowLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzY3ZDI3ZTQ5LTk2NmQtNGFiZC1iMTlhLWQz
+        N2Q0NDA5Njg3NS8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3Vt
+        bWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7fX19
+        XX0=
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:11:05 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/4c6b158f-7433-4d48-b04d-ac77e68d91d1/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:11:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9fc6668d1899404885d7595c7b51f5f6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '304'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS80YzZiMTU4Zi03NDMzLTRkNDgtYjA0ZC1hYzc3ZTY4ZDkxZDEv
+        dmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTE1VDIwOjUx
+        OjI5LjQyNzU3NFoiLCJudW1iZXIiOjEsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNGM2YjE1OGYtNzQzMy00ZDQ4
+        LWIwNGQtYWM3N2U2OGQ5MWQxLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5wYWNrYWdlIjp7ImNvdW50
+        IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        Lz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9ycG0vcnBtLzRjNmIxNThmLTc0MzMtNGQ0OC1iMDRkLWFjNzdl
+        NjhkOTFkMS92ZXJzaW9ucy8xLyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQi
+        OnsicnBtLnBhY2thZ2UiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9ycG0vcGFja2FnZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0v
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNGM2YjE1OGYtNzQz
+        My00ZDQ4LWIwNGQtYWM3N2U2OGQ5MWQxL3ZlcnNpb25zLzEvIn19fX0seyJw
+        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0v
+        NGM2YjE1OGYtNzQzMy00ZDQ4LWIwNGQtYWM3N2U2OGQ5MWQxL3ZlcnNpb25z
+        LzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xNVQyMDo1MDoxMi4yMjg1
+        MjdaIiwibnVtYmVyIjowLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzRjNmIxNThmLTc0MzMtNGQ0OC1iMDRkLWFj
+        NzdlNjhkOTFkMS8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3Vt
+        bWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7fX19
+        XX0=
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:11:05 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/61640aa0-2e7d-4eb5-a1a7-be9d5f2855ca/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:11:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4ae38e1868fd446fb6053d383f1ce767
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '327'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS82MTY0MGFhMC0yZTdkLTRlYjUtYTFhNy1iZTlkNWYyODU1Y2Ev
+        dmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTEyVDEzOjA3
+        OjM0LjA3MDE5M1oiLCJudW1iZXIiOjEsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjE2NDBhYTAtMmU3ZC00ZWI1
+        LWExYTctYmU5ZDVmMjg1NWNhLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5hZHZpc29yeSI6eyJjb3Vu
+        dCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
+        aWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzYxNjQwYWEwLTJlN2QtNGViNS1hMWE3LWJl
+        OWQ1ZjI4NTVjYS92ZXJzaW9ucy8xLyJ9LCJycG0ucGFja2FnZSI6eyJjb3Vu
+        dCI6MzIsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVw
+        b3NpdG9yaWVzL3JwbS9ycG0vNjE2NDBhYTAtMmU3ZC00ZWI1LWExYTctYmU5
+        ZDVmMjg1NWNhL3ZlcnNpb25zLzEvIn19LCJyZW1vdmVkIjp7fSwicHJlc2Vu
+        dCI6eyJycG0uYWR2aXNvcnkiOnsiY291bnQiOjQsImhyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vYWR2aXNvcmllcy8/cmVwb3NpdG9yeV92ZXJz
+        aW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82MTY0MGFh
+        MC0yZTdkLTRlYjUtYTFhNy1iZTlkNWYyODU1Y2EvdmVyc2lvbnMvMS8ifSwi
+        cnBtLnBhY2thZ2UiOnsiY291bnQiOjMyLCJocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzYxNjQwYWEwLTJlN2Qt
+        NGViNS1hMWE3LWJlOWQ1ZjI4NTVjYS92ZXJzaW9ucy8xLyJ9fX19LHsicHVs
+        cF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzYx
+        NjQwYWEwLTJlN2QtNGViNS1hMWE3LWJlOWQ1ZjI4NTVjYS92ZXJzaW9ucy8w
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMTEtMTJUMTM6MDM6MDEuNzMwODcz
+        WiIsIm51bWJlciI6MCwicmVwb3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvcnBtL3JwbS82MTY0MGFhMC0yZTdkLTRlYjUtYTFhNy1iZTlk
+        NWYyODU1Y2EvIiwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1h
+        cnkiOnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6e319fV19
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:11:05 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.15.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:11:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8d21210068ec4c1799bcb2c823a47ce2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi85MDExZGVmZS02MjlkLTRmYzAtYWU0MC1jNjk4NjI5
-        YmVjMmEvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2
-        VDE3OjQ4OjI4LjA0MjE3NVoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vOTAxMWRl
-        ZmUtNjI5ZC00ZmMwLWFlNDAtYzY5ODYyOWJlYzJhLyIsImJhc2VfdmVyc2lv
-        biI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3Zl
-        ZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:47 GMT
+  recorded_at: Tue, 16 Nov 2021 16:11:05 GMT
 - request:
     method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:11:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9179e0d8c4894f179b26af74aa3b9e83
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:11:05 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.5.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:11:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f766164fe76d461a920c5dd6fbbc4b67
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:11:05 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.9.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:11:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - da303d211f8d4332a765006bcfc47445
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:11:05 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -855,7 +1140,7 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -863,297 +1148,40 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:48 GMT
+      - Tue, 16 Nov 2021 16:11:05 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '52'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8cb1f30a0e4543c5b72c9e124ef119d7
+      - ab3c49e58d854ea2bf682ac3b24431d1
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:48 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:48 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '498'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 2feed5b06bd84207abd36681dfd901bf
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZGViL2FwdC8xY2VjYTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4N2Uv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxODowMToxNy4xNjIzMjVa
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZGViL2FwdC8xY2VjYTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4N2Uv
-        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzFjZWNh
-        NDQzLWE0YjQtNGUwYS04ZmMwLTYyNzVjNGZkNDg3ZS92ZXJzaW9ucy8wLyIs
-        Im5hbWUiOiJkZWJpYW5fcHVscF9yYWduYXJvayIsImRlc2NyaXB0aW9uIjpu
-        dWxsLCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxs
-        fV19
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:48 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/deb/apt/1ceca443-a4b4-4e0a-8fc0-6275c4fd487e/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:48 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '370'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 8164e046271a4c2789ea65c9c94bd9a4
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZGViL2FwdC8xY2VjYTQ0My1hNGI0LTRlMGEtOGZjMC02Mjc1YzRmZDQ4N2Uv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEwLTA2VDE4OjAx
-        OjE3LjE2NTQ1NFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMWNlY2E0NDMtYTRiNC00ZTBh
-        LThmYzAtNjI3NWM0ZmQ0ODdlLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
-        bnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:48 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:48 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '551'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 711da9f8f3444497b2fc0edba10ea5db
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci8zM2EzMmFlNS1mYzNjLTRlOGQtYTE0MS0x
-        YmVjY2RjMjYzZjgvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMC0wNlQxNzoy
-        Mjo0OS44MzM0OTRaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci8zM2EzMmFlNS1mYzNj
-        LTRlOGQtYTE0MS0xYmVjY2RjMjYzZjgvdmVyc2lvbnMvIiwicHVscF9sYWJl
-        bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzMzYTMyYWU1LWZjM2Mt
-        NGU4ZC1hMTQxLTFiZWNjZGMyNjNmOC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJE
-        ZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtZGV2IiwiZGVzY3Jp
-        cHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1v
-        dGUiOm51bGx9XX0=
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:48 GMT
-- request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/repositories/container/container/33a32ae5-fc3c-4e8d-a141-1beccdc263f8/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.20.1
-      Date:
-      - Wed, 06 Oct 2021 18:02:49 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '394'
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 78bd14fdc38943a9ac4331f4950a8596
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        Y29udGFpbmVyL2NvbnRhaW5lci8zM2EzMmFlNS1mYzNjLTRlOGQtYTE0MS0x
-        YmVjY2RjMjYzZjgvdmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIx
-        LTEwLTA2VDE3OjIyOjQ5LjkxNTIwMloiLCJudW1iZXIiOjAsInJlcG9zaXRv
-        cnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250
-        YWluZXIvMzNhMzJhZTUtZmMzYy00ZThkLWExNDEtMWJlY2NkYzI2M2Y4LyIs
-        ImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVk
-        Ijp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-    http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:49 GMT
+  recorded_at: Tue, 16 Nov 2021 16:11:05 GMT
 - request:
     method: delete
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/orphans/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/67d27e49-966d-4abd-b19a-d37d44096875/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1161,11 +1189,11 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.15.2/ruby
+      - OpenAPI-Generator/3.15.0/ruby
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1173,40 +1201,146 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:49 GMT
+      - Tue, 16 Nov 2021 16:11:05 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '67'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie
       Allow:
-      - DELETE, OPTIONS
+      - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '67'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 81d25e2f4ffb40358c9249f2c738472b
+      - 13fcc193e71945aaab2d0cce590f3f4b
       Access-Control-Expose-Headers:
       - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE4OTM2NWQwLWIyMjYtNDY5
-        NS04MGZlLTE4NTUwN2I3MjlhMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YwM2NjMjQ4LTU4NGItNDIz
+        OS05YThhLWQxYTMzM2I0N2QxZi8ifQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:49 GMT
+  recorded_at: Tue, 16 Nov 2021 16:11:05 GMT
 - request:
-    method: get
-    uri: https://pulp3-sandbox-centos7.balmora.example.com/pulp/api/v3/tasks/189365d0-b226-4695-80fe-185507b729a3/
+    method: delete
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/4c6b158f-7433-4d48-b04d-ac77e68d91d1/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:11:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6b15f6a4ab174c74be82742e4eba00d0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q2MTI4MzkzLTVhMzgtNGU2
+        Ny05YzdmLWIxMjkzMWY2NWFiNy8ifQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:11:05 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/61640aa0-2e7d-4eb5-a1a7-be9d5f2855ca/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:11:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b12f737700754bcea2d1f46b32ff442a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY3NmRjNWFkLTUzNzEtNDEy
+        Ny1iZGI5LTAxMDA4YmQ1YTI2Yi8ifQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:11:05 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/orphans/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1218,7 +1352,60 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:11:06 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - DELETE, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 54067f5c762147089e7b8e2d36a6aab8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgzOWRkZGI4LTYxMDktNGQ3
+        NC1hNDhhLWY5MGQ2ZjlhNzk5Ni8ifQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:11:06 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/839dddb8-6109-4d74-a48a-f90d6f9a7996/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -1226,18 +1413,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.20.1
       Date:
-      - Wed, 06 Oct 2021 18:02:49 GMT
+      - Tue, 16 Nov 2021 16:11:07 GMT
+      Server:
+      - gunicorn
       Content-Type:
       - application/json
-      Content-Length:
-      - '771'
-      Connection:
-      - keep-alive
       Vary:
-      - Accept, Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1247,32 +1430,34 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ddf51133a2a74c0295f0d6b5c3f5f4a0
+      - 3315b13a95cb46e2b85360a7fa779632
       Access-Control-Expose-Headers:
       - Correlation-ID
-      Strict-Transport-Security:
-      - max-age=15768000
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '420'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTg5MzY1ZDAtYjIy
-        Ni00Njk1LTgwZmUtMTg1NTA3YjcyOWEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTAtMDZUMTg6MDI6NDkuNTMyMDU3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODM5ZGRkYjgtNjEw
+        OS00ZDc0LWE0OGEtZjkwZDZmOWE3OTk2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMTY6MTE6MDYuMDIxMTYwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJsb2dnaW5nX2NpZCI6IjgxZDI1ZTJmNGZmYjQwMzU4YzkyNDlm
-        MmM3Mzg0NzJiIiwic3RhcnRlZF9hdCI6IjIwMjEtMTAtMDZUMTg6MDI6NDku
-        NTk5MjIwWiIsImZpbmlzaGVkX2F0IjoiMjAyMS0xMC0wNlQxODowMjo0OS42
-        Mzk3MjdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzLzA1ZTZkN2Y0LWI1NjQtNGU3My04MmViLTE1YjUwYTUxMjRhMy8i
+        ZWFudXAiLCJsb2dnaW5nX2NpZCI6IjU0MDY3ZjVjNzYyMTQ3MDg5ZTdiOGUy
+        ZDM2YTZhYWI4Iiwic3RhcnRlZF9hdCI6IjIwMjEtMTEtMTZUMTY6MTE6MDYu
+        MTU3ODQ3WiIsImZpbmlzaGVkX2F0IjoiMjAyMS0xMS0xNlQxNjoxMTowNy4w
+        MDc5NzBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzQ5MDAyOGZjLWUzYjgtNGFiZi1iMDhkLTlkNzcwNzBlODZjYi8i
         LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
         b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xl
         YW4gdXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVu
-        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1
-        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQ2xlYW4gdXAgb3JwaGFuIEFydGlm
-        YWN0cyIsImNvZGUiOiJjbGVhbi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21w
-        bGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNy
-        ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
-        ZCI6W119
+        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQ3LCJkb25lIjo0Nywi
+        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQXJ0
+        aWZhY3RzIiwiY29kZSI6ImNsZWFuLXVwLmNvbnRlbnQiLCJzdGF0ZSI6ImNv
+        bXBsZXRlZCIsInRvdGFsIjo1MiwiZG9uZSI6NTIsInN1ZmZpeCI6bnVsbH1d
+        LCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jlc291cmNlc19y
+        ZWNvcmQiOltdfQ==
     http_version: 
-  recorded_at: Wed, 06 Oct 2021 18:02:49 GMT
+  recorded_at: Tue, 16 Nov 2021 16:11:07 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/srpm_upload/upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/srpm_upload/upload_binary.yml
@@ -9756,4 +9756,1615 @@ http_interactions:
         LWIwMDYtOGNkYTNkYzgzOGFkLyJdfQ==
     http_version: 
   recorded_at: Wed, 06 Oct 2021 18:02:45 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/79e15ee5-9350-46fe-b42f-bc6d173ca12b/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYTI0OGZmNGMtNjNkNy00ZDI3LThhM2YtNDlmNTZkMDQ4
+        OWFkLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:02:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1bfdf09dbcb44947bf694beaa504232e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFlYzgwZjdlLTAwNTItNGFj
+        Mi1iOGE3LTU3OGY4N2U4MTFiYy8ifQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:02:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/1ec80f7e-0052-4ac2-b8a7-578f87e811bc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:02:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5176c49ba0fc4bed98039a67567dcb91
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '391'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWVjODBmN2UtMDA1
+        Mi00YWMyLWI4YTctNTc4Zjg3ZTgxMWJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMTY6MDI6MjkuODIwMTQ5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIxYmZkZjA5ZGJjYjQ0OTQ3YmY2
+        OTRiZWFhNTA0MjMyZSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE2VDE2OjAy
+        OjI5Ljg4NzE1N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTZUMTY6MDI6
+        MzAuMDk0ODAzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy83YTZkNjUzMy1mNGRlLTQ1YmYtYTc4Zi1lMjk2MzJhZjEz
+        YjgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS83OWUxNWVlNS05MzUwLTQ2ZmUtYjQyZi1iYzZkMTczY2ExMmIvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzllMTVlZTUtOTM1MC00NmZl
+        LWI0MmYtYmM2ZDE3M2NhMTJiLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:02:30 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/109816b8-506c-4e8a-95b1-a124ae97f717/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYTI0OGZmNGMtNjNkNy00ZDI3LThhM2YtNDlmNTZkMDQ4
+        OWFkLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:04:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 24ed33353b9b4e59b7d5764d3e44258e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU2N2Y3NDhlLWM0MWQtNDFk
+        Yi1iMmNlLTZiOTYwY2VkMDNmYy8ifQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:04:35 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/567f748e-c41d-41db-b2ce-6b960ced03fc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:04:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f760934edd4944fa9797fa496d5734ad
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '387'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTY3Zjc0OGUtYzQx
+        ZC00MWRiLWIyY2UtNmI5NjBjZWQwM2ZjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMTY6MDQ6MzUuNDQ1ODczWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyNGVkMzMzNTNiOWI0ZTU5Yjdk
+        NTc2NGQzZTQ0MjU4ZSIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE2VDE2OjA0
+        OjM1LjUxNjQxMloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTZUMTY6MDQ6
+        MzUuNzIwMjAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9hZmU5YmU1Yy0wM2JlLTRiODMtOTg5Yy02YTRiODRlYmNj
+        NmEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS8xMDk4MTZiOC01MDZjLTRlOGEtOTViMS1hMTI0YWU5N2Y3MTcvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTA5ODE2YjgtNTA2Yy00ZThh
+        LTk1YjEtYTEyNGFlOTdmNzE3LyJdfQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:04:35 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/content/rpm/packages/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:11:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c06ad04513bd4e3ba840056baa1bbb1a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '13496'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MzMsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
+        cGFja2FnZXMvYTI0OGZmNGMtNjNkNy00ZDI3LThhM2YtNDlmNTZkMDQ4OWFk
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMTEtMTJUMTM6MDc6MzUuOTA4OTgx
+        WiIsIm1kNSI6bnVsbCwic2hhMSI6ImJkYTZhYWY2NDMzMWIwMGM5MGE3MDc4
+        Zjc4NWM4OWNiNmFlNGFjN2IiLCJzaGEyMjQiOiI5MzhkN2JhYTM3ODUxMDE5
+        YTdhNzNhMGViM2EwOWVhNmQyZDVkYTM2N2NiNjU4NGEwYTg2MWM5YiIsInNo
+        YTI1NiI6IjgwMWEyYTJjN2RkNjRjZDM5OTdkY2RmMWU2MWUxNmY2Y2YwMWVm
+        N2NjZTliNGQ1Mjc3MTJlNThjNDBlY2E1NWYiLCJzaGEzODQiOiJlYTMzZGMw
+        NTQ1MDY3N2U2YmUwMzg2YmM0ZWRiNzZjNWI1MDkwZjAyNDVhZjhjNTk4ZTY2
+        MGMwOWFhNzExNmI3MDBmMzc0YmZkNGJkZTMwYWQ3NzhmYmM5ZmJhNDI3Mjki
+        LCJzaGE1MTIiOiIyMTFjYjVhODE4MmVjNzM3ZjY4Y2NjZDg1OGNjOWYzNzRk
+        MmNjNDUzNTY5Yzk2MGRiNGY2ZjZjZTJiZDhjMWZkOGEyMTMxZWM1ODdlZTgw
+        MmU5YzkzMTFjMmY4YWNmNTU1NTY5NDcxNTRjNTQ4YWIzODRiZTFmYzZiY2M1
+        ZmRkMyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9hNDg3
+        MTA3Mi0xYmM5LTRjYzktYmVmOS01MTVhOGRlMjMwM2QvIiwibmFtZSI6Inpl
+        YnJhIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIy
+        IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODAxYTJhMmM3ZGQ2NGNkMzk5
+        N2RjZGYxZTYxZTE2ZjZjZjAxZWY3Y2NlOWI0ZDUyNzcxMmU1OGM0MGVjYTU1
+        ZiIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJzdW1tYXJ5IjoiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHplYnJhIiwiZGVzY3JpcHRpb24iOiJBIGR1bW15IHBh
+        Y2thZ2Ugb2YgemVicmEiLCJ1cmwiOiJodHRwOi8vdHN0cmFjaG90YS5mZWRv
+        cmFwZW9wbGUub3JnIiwiY2hhbmdlbG9ncyI6W10sImZpbGVzIjpbW251bGws
+        Ii90bXAvIiwiemVicmEudHh0Il1dLCJyZXF1aXJlcyI6W1siZG9scGhpbiIs
+        bnVsbCxudWxsLG51bGwsbnVsbCxmYWxzZV0sWyJnb3JpbGxhIixudWxsLG51
+        bGwsbnVsbCxudWxsLGZhbHNlXSxbInBpa2UiLG51bGwsbnVsbCxudWxsLG51
+        bGwsZmFsc2VdXSwicHJvdmlkZXMiOltbInplYnJhIiwiRVEiLCIwIiwiMC4x
+        IiwiMiIsZmFsc2VdXSwiY29uZmxpY3RzIjpbXSwib2Jzb2xldGVzIjpbXSwi
+        c3VnZ2VzdHMiOltdLCJlbmhhbmNlcyI6W10sInJlY29tbWVuZHMiOltdLCJz
+        dXBwbGVtZW50cyI6W10sImxvY2F0aW9uX2Jhc2UiOiIiLCJsb2NhdGlvbl9o
+        cmVmIjoiemVicmEtMC4xLTIubm9hcmNoLnJwbSIsInJwbV9idWlsZGhvc3Qi
+        OiJzbXFlLXdzMTUiLCJycG1fZ3JvdXAiOiJJbnRlcm5ldC9BcHBsaWNhdGlv
+        bnMiLCJycG1fbGljZW5zZSI6IkdQTHYyIiwicnBtX3BhY2thZ2VyIjoiIiwi
+        cnBtX3NvdXJjZXJwbSI6InplYnJhLTAuMS0yLnNyYy5ycG0iLCJycG1fdmVu
+        ZG9yIjoiIiwicnBtX2hlYWRlcl9zdGFydCI6ODcyLCJycG1faGVhZGVyX2Vu
+        ZCI6MjMyNSwiaXNfbW9kdWxhciI6ZmFsc2UsInNpemVfYXJjaGl2ZSI6Mjk2
+        LCJzaXplX2luc3RhbGxlZCI6NDIsInNpemVfcGFja2FnZSI6MjQ3NywidGlt
+        ZV9idWlsZCI6MTMzMTgzMTM3NSwidGltZV9maWxlIjoxNDU0MTIzMzc0fSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy9jMzYxNDVjZi1lMjIwLTQzYTYtYTI4Mi0yYTdmMzdjMTMyODAvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMS0xMS0xMlQxMzowNzozNS45MDUzMDBaIiwibWQ1
+        IjpudWxsLCJzaGExIjoiMWM1MTlkZTYzNjUyNGNhZjFlNTRlYTdjYzVhMTYy
+        ZTYwYjY1ZjhlZiIsInNoYTIyNCI6IjAxOGQ2NGNmOWIyNmYwYTdkYzFjMjUw
+        ZDhjMDk5YWYzZjFiYjkwMWIwMTZhMzQ5Zjk3YWMwMjNmIiwic2hhMjU2Ijoi
+        M2IzNDIzNGFmYzhiODkzMWQ2MjdmODQ2NmYwZTRmZDM1MjE0NWEyNTEyNjgx
+        ZWMyOWRiMGEwNTFhMGM5ZDg5MyIsInNoYTM4NCI6ImMxYzVlZWZjMzU2ZWNk
+        ZTAyMThiZGQyZThiZjIwYzc0NmYxYzRlMmVmMjI0MzJhNTgyYzcxYmJmZDQy
+        NDA1ZTFkYWU0MjI4Yjg4MjJlODExODA0Y2QwOGExMzViZDk0OCIsInNoYTUx
+        MiI6ImFlOWFkODA3NzliZTIzY2NmZDhhNWZhMzg0YzBkOGRhM2NhZDA5MmEx
+        MjNjMGNiM2I2ZWI3MmIxNWI0OTQwZmIzNDFiOTBhZjY1ZTdjZmU5OGFkY2Vl
+        YjNjYTRmN2UxNmQ5ZGUyYWM3MjQ5ZTlhOTIwYWE5MWE0MWVlNWVlZjJhIiwi
+        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzQ2OTQyZmFjLWI2
+        OWMtNDdhZC1hYTlmLTIwMWM1YTZiNTAxOS8iLCJuYW1lIjoid2hhbGUiLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiIzYjM0MjM0YWZjOGI4OTMxZDYyN2Y4NDY2
+        ZjBlNGZkMzUyMTQ1YTI1MTI2ODFlYzI5ZGIwYTA1MWEwYzlkODkzIiwiY2hl
+        Y2tzdW1fdHlwZSI6InNoYTI1NiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
+        Z2Ugb2Ygd2hhbGUiLCJkZXNjcmlwdGlvbiI6IkEgZHVtbXkgcGFja2FnZSBv
+        ZiB3aGFsZSIsInVybCI6Imh0dHA6Ly90c3RyYWNob3RhLmZlZG9yYXBlb3Bs
+        ZS5vcmciLCJjaGFuZ2Vsb2dzIjpbXSwiZmlsZXMiOltbbnVsbCwiL3RtcC8i
+        LCJ3aGFsZS50eHQiXV0sInJlcXVpcmVzIjpbWyJzaGFyayIsbnVsbCxudWxs
+        LG51bGwsbnVsbCxmYWxzZV0sWyJzdG9yayIsbnVsbCxudWxsLG51bGwsbnVs
+        bCxmYWxzZV1dLCJwcm92aWRlcyI6W1sid2hhbGUiLCJFUSIsIjAiLCIwLjIi
+        LCIxIixmYWxzZV1dLCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMiOltdLCJz
+        dWdnZXN0cyI6W10sImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6W10sInN1
+        cHBsZW1lbnRzIjpbXSwibG9jYXRpb25fYmFzZSI6IiIsImxvY2F0aW9uX2hy
+        ZWYiOiJ3aGFsZS0wLjItMS5ub2FyY2gucnBtIiwicnBtX2J1aWxkaG9zdCI6
+        InNtcWUtd3MxNSIsInJwbV9ncm91cCI6IkludGVybmV0L0FwcGxpY2F0aW9u
+        cyIsInJwbV9saWNlbnNlIjoiR1BMdjIiLCJycG1fcGFja2FnZXIiOiIiLCJy
+        cG1fc291cmNlcnBtIjoid2hhbGUtMC4yLTEuc3JjLnJwbSIsInJwbV92ZW5k
+        b3IiOiIiLCJycG1faGVhZGVyX3N0YXJ0Ijo4NzIsInJwbV9oZWFkZXJfZW5k
+        IjoyMzA5LCJpc19tb2R1bGFyIjpmYWxzZSwic2l6ZV9hcmNoaXZlIjoyOTYs
+        InNpemVfaW5zdGFsbGVkIjo0Miwic2l6ZV9wYWNrYWdlIjoyNDYxLCJ0aW1l
+        X2J1aWxkIjoxMzMxODMxMzY4LCJ0aW1lX2ZpbGUiOjE0NTQxMjMzNzR9LHsi
+        cHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
+        L2NmY2ExMGYyLThmYzMtNDE4OC05YzY2LTYzNzI1MmY3MmJhOC8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIxLTExLTEyVDEzOjA3OjM1LjkwMzQ1NVoiLCJtZDUi
+        Om51bGwsInNoYTEiOiI1Yzc1YTI0MjNkYmQ1YjIwN2I2NTQ0N2JjYjM4NmMz
+        MzYzYzBmNDdlIiwic2hhMjI0IjoiODEwNGE3NmJmMThiOWJjMGY4MDFjNjIy
+        NzJkMzU3YjgyMmUzYmYzNTc0ODVkYzMzYWNjMGRkY2QiLCJzaGEyNTYiOiJk
+        NjE5MjVhZThmNTFmZWNjYzJmMWJjYzJlY2Q2YTgzZGNjOTVjM2U4YzUzOTJm
+        NDNhYTQ3NzVjMjQ2YTVlZGYyIiwic2hhMzg0IjoiZjhlY2Q3NjY5OTU0NTk3
+        YzFjNzhkYWE2YTc2NTc5ZDIwN2RmYjgwMzA2OGEwMTI4NjM3NWZiMWJjNjNm
+        OGYwMjA0NzkxMThiMmNiNDZlNjlmNjg2NjhkNjZkNzFhMjViIiwic2hhNTEy
+        IjoiNjIzZjczODIyNGUyZDA5OTRiZjMyYjRhOTljNTRiNzNmZDU5ODBmNmY0
+        OTI5ZTgwNGVjNjQ1MDAzZTYxYzFkZjgxZTFiNTQ2OTM2NTg4ZTQzN2ZmODky
+        Yjc3MzdmNTIyMjQ5ODRkMjU0YTlkMjBlNjM1Mjk5ZjIyYzA1OWYwNTUiLCJh
+        cnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYWUyMjQ2ZDYtOTRj
+        OS00YzJkLThlYzctMGYxYzRhMGE5MDQxLyIsIm5hbWUiOiJ3b2xmIiwiZXBv
+        Y2giOiIwIiwidmVyc2lvbiI6IjkuNCIsInJlbGVhc2UiOiIyIiwiYXJjaCI6
+        Im5vYXJjaCIsInBrZ0lkIjoiZDYxOTI1YWU4ZjUxZmVjY2MyZjFiY2MyZWNk
+        NmE4M2RjYzk1YzNlOGM1MzkyZjQzYWE0Nzc1YzI0NmE1ZWRmMiIsImNoZWNr
+        c3VtX3R5cGUiOiJzaGEyNTYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdl
+        IG9mIHdvbGYiLCJkZXNjcmlwdGlvbiI6IkEgZHVtbXkgcGFja2FnZSBvZiB3
+        b2xmIiwidXJsIjoiaHR0cDovL3RzdHJhY2hvdGEuZmVkb3JhcGVvcGxlLm9y
+        ZyIsImNoYW5nZWxvZ3MiOltdLCJmaWxlcyI6W1tudWxsLCIvdG1wLyIsIndv
+        bGYudHh0Il1dLCJyZXF1aXJlcyI6W10sInByb3ZpZGVzIjpbWyJ3b2xmIiwi
+        RVEiLCIwIiwiOS40IiwiMiIsZmFsc2VdXSwiY29uZmxpY3RzIjpbXSwib2Jz
+        b2xldGVzIjpbXSwic3VnZ2VzdHMiOltdLCJlbmhhbmNlcyI6W10sInJlY29t
+        bWVuZHMiOltdLCJzdXBwbGVtZW50cyI6W10sImxvY2F0aW9uX2Jhc2UiOiIi
+        LCJsb2NhdGlvbl9ocmVmIjoid29sZi05LjQtMi5ub2FyY2gucnBtIiwicnBt
+        X2J1aWxkaG9zdCI6InNtcWUtd3MxNSIsInJwbV9ncm91cCI6IkludGVybmV0
+        L0FwcGxpY2F0aW9ucyIsInJwbV9saWNlbnNlIjoiR1BMdjIiLCJycG1fcGFj
+        a2FnZXIiOiIiLCJycG1fc291cmNlcnBtIjoid29sZi05LjQtMi5zcmMucnBt
+        IiwicnBtX3ZlbmRvciI6IiIsInJwbV9oZWFkZXJfc3RhcnQiOjg3MiwicnBt
+        X2hlYWRlcl9lbmQiOjIyODksImlzX21vZHVsYXIiOmZhbHNlLCJzaXplX2Fy
+        Y2hpdmUiOjI5Niwic2l6ZV9pbnN0YWxsZWQiOjQyLCJzaXplX3BhY2thZ2Ui
+        OjI0MzksInRpbWVfYnVpbGQiOjEzMzE4MzEzNjIsInRpbWVfZmlsZSI6MTQ1
+        NDEyMzM3NH0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNThiMDRlZDUtNzU1My00ZDk5LTk2ODctZTVhZjg5NWZh
+        ZmRiLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMTEtMTJUMTM6MDc6MzUuOTAx
+        NTAyWiIsIm1kNSI6bnVsbCwic2hhMSI6IjhkZWEyYjY0ZmM1MjA2MmQ3OWQ1
+        Zjk2YmE2NDE1YmZmYWU0ZDIxNTMiLCJzaGEyMjQiOiJkZTUzMTNkOTE1ZjQw
+        M2E4NGY4NWQzOGIyZjQ4YzU2ODkwZTg1YzkwYjYwYWQ4YjhiNGIyZWE3YyIs
+        InNoYTI1NiI6ImU4MzdhNjM1Y2M5OWY5NjdhNzBmMzRiMjY4YmFhNTJlMGY0
+        MTJjMTUwMmUwOGU5MjRmZjViMDlmMWY5NTczZjIiLCJzaGEzODQiOiIyNDgz
+        ZjY3OGQ3NTRiMzExY2QyOTRlNDdjZjlhMTU1OGI5ZTQ2NGE0ZjYxYmIzYjU2
+        OTBjNGFiZDM3YmQxNTEzOGFmZTU1ZDYxYjdlNzQ1MmU2MWY2OTExNzM1YTg3
+        OWYiLCJzaGE1MTIiOiI5OGFkOWQ5OGVhNWNkOGE4ZTdlODM0MGQyODM0ZWMz
+        NTE3ODFlOTk5MzRhNWNmMDIxZjE4ZGY0N2E0NjZmMTA4YjQ1OWVmYmQxMWI0
+        MTUyMGE4OTc1OGJlNDY4OGQ3OTI3ZTVhYmU2NDcwY2FmZWY2OWEwMjAyNjA2
+        OTkzZWJlMiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9l
+        NWEzZTRiOS00MWE5LTQzY2UtOGMwYi0zMWQ3N2Y1YjViODAvIiwibmFtZSI6
+        IndhbHJ1cyIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI1LjIxIiwicmVsZWFz
+        ZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJlODM3YTYzNWNjOTlm
+        OTY3YTcwZjM0YjI2OGJhYTUyZTBmNDEyYzE1MDJlMDhlOTI0ZmY1YjA5ZjFm
+        OTU3M2YyIiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiIsInN1bW1hcnkiOiJB
+        IGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwiZGVzY3JpcHRpb24iOiJBIGR1
+        bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwidXJsIjoiaHR0cDovL3RzdHJhY2hv
+        dGEuZmVkb3JhcGVvcGxlLm9yZyIsImNoYW5nZWxvZ3MiOltdLCJmaWxlcyI6
+        W1tudWxsLCIvdG1wLyIsIndhbHJ1cy50eHQiXV0sInJlcXVpcmVzIjpbXSwi
+        cHJvdmlkZXMiOltbIndhbHJ1cyIsIkVRIiwiMCIsIjUuMjEiLCIxIixmYWxz
+        ZV1dLCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMiOltdLCJzdWdnZXN0cyI6
+        W10sImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6W10sInN1cHBsZW1lbnRz
+        IjpbXSwibG9jYXRpb25fYmFzZSI6IiIsImxvY2F0aW9uX2hyZWYiOiJ3YWxy
+        dXMtNS4yMS0xLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0Ijoic21xZS13
+        czE1IiwicnBtX2dyb3VwIjoiSW50ZXJuZXQvQXBwbGljYXRpb25zIiwicnBt
+        X2xpY2Vuc2UiOiJHUEx2MiIsInJwbV9wYWNrYWdlciI6IiIsInJwbV9zb3Vy
+        Y2VycG0iOiJ3YWxydXMtNS4yMS0xLnNyYy5ycG0iLCJycG1fdmVuZG9yIjoi
+        IiwicnBtX2hlYWRlcl9zdGFydCI6ODcyLCJycG1faGVhZGVyX2VuZCI6MjI5
+        MywiaXNfbW9kdWxhciI6ZmFsc2UsInNpemVfYXJjaGl2ZSI6Mjk2LCJzaXpl
+        X2luc3RhbGxlZCI6NDIsInNpemVfcGFja2FnZSI6MjQ0NSwidGltZV9idWls
+        ZCI6MTMzMTgzMTM2OCwidGltZV9maWxlIjoxNDU0MTIzMzc0fSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy82YzE3
+        NTY0NS1jMzMyLTQyNWUtODhiZC00MzcwZGVkYjA3ZGUvIiwicHVscF9jcmVh
+        dGVkIjoiMjAyMS0xMS0xMlQxMzowNzozNS44OTk2NjdaIiwibWQ1IjpudWxs
+        LCJzaGExIjoiNzY1MDFmYjhlOTA4MWRiYTVlOTcwM2U5YjczNTJjYWRiZDM2
+        YjgyZSIsInNoYTIyNCI6IjVmZDlkNWNkZGMxZjk0ZmRhMGViOTc4MjkxODMz
+        OGRkY2M3ZDkxMzJjOTNjZGFjMGJiNmUzZDBiIiwic2hhMjU2IjoiZDkwZjBl
+        MGQ4MDU2ODZkNTlhNjdmZDZlZjNlZGJmOGE5ZTRiM2NiYzk5MDhiODc4NjUy
+        YTFiOTk4YTFmMDRhOCIsInNoYTM4NCI6ImY3NjJhYmNkNTk3YzIxYmNjMzAw
+        NzdmMjFmZTVlN2RlZmEyZWY4YTFiNWU4ODMxNjEzMGViMzY2NWNmZTY0M2Nm
+        NTg2ODM4YWI5Y2ZjY2NlOGEzYjk0MGE3YjUxYWEzNSIsInNoYTUxMiI6ImUw
+        NTU4ODQyNzFmZDFmNDU4MmQxZGRmNjUxYWE2NDk3N2FiYTlmNzdlOTRmYTk2
+        ZjZlYWVhNGM5Zjk5ZWJjYTZkZDg0NmNlNjIyMTc2ZDA0ZWJjNzgwYTMyNzIz
+        NDcyZjJiMTI4NTY1YjA3ZmU0NzkzM2UyMjVmZGM1Yzk1ZjYwIiwiYXJ0aWZh
+        Y3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzI2YjY0MDM3LTY5MGMtNGM3
+        Yy1iN2RjLWU3NWI1YjgwYzM2Ny8iLCJuYW1lIjoid2FscnVzIiwiZXBvY2gi
+        OiIwIiwidmVyc2lvbiI6IjAuNzEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
+        b2FyY2giLCJwa2dJZCI6ImQ5MGYwZTBkODA1Njg2ZDU5YTY3ZmQ2ZWYzZWRi
+        ZjhhOWU0YjNjYmM5OTA4Yjg3ODY1MmExYjk5OGExZjA0YTgiLCJjaGVja3N1
+        bV90eXBlIjoic2hhMjU2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
+        ZiB3YWxydXMiLCJkZXNjcmlwdGlvbiI6IkEgZHVtbXkgcGFja2FnZSBvZiB3
+        YWxydXMiLCJ1cmwiOiJodHRwOi8vdHN0cmFjaG90YS5mZWRvcmFwZW9wbGUu
+        b3JnIiwiY2hhbmdlbG9ncyI6W10sImZpbGVzIjpbW251bGwsIi90bXAvIiwi
+        d2FscnVzLnR4dCJdXSwicmVxdWlyZXMiOltbIndoYWxlIixudWxsLG51bGws
+        bnVsbCxudWxsLGZhbHNlXV0sInByb3ZpZGVzIjpbWyJ3YWxydXMiLCJFUSIs
+        IjAiLCIwLjcxIiwiMSIsZmFsc2VdXSwiY29uZmxpY3RzIjpbXSwib2Jzb2xl
+        dGVzIjpbXSwic3VnZ2VzdHMiOltdLCJlbmhhbmNlcyI6W10sInJlY29tbWVu
+        ZHMiOltdLCJzdXBwbGVtZW50cyI6W10sImxvY2F0aW9uX2Jhc2UiOiIiLCJs
+        b2NhdGlvbl9ocmVmIjoid2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwicnBt
+        X2J1aWxkaG9zdCI6InNtcWUtd3MxNSIsInJwbV9ncm91cCI6IkludGVybmV0
+        L0FwcGxpY2F0aW9ucyIsInJwbV9saWNlbnNlIjoiR1BMdjIiLCJycG1fcGFj
+        a2FnZXIiOiIiLCJycG1fc291cmNlcnBtIjoid2FscnVzLTAuNzEtMS5zcmMu
+        cnBtIiwicnBtX3ZlbmRvciI6IiIsInJwbV9oZWFkZXJfc3RhcnQiOjg3Miwi
+        cnBtX2hlYWRlcl9lbmQiOjIzMDUsImlzX21vZHVsYXIiOmZhbHNlLCJzaXpl
+        X2FyY2hpdmUiOjMzNiwic2l6ZV9pbnN0YWxsZWQiOjg0LCJzaXplX3BhY2th
+        Z2UiOjI0NjAsInRpbWVfYnVpbGQiOjEzMzE4MzEzNjksInRpbWVfZmlsZSI6
+        MTQ1NDEyMzM3NH0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvY2FiMTU0MmUtMjExYi00NTI3LThjMmQtMmY1NzNl
+        MGI1OGJlLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMTEtMTJUMTM6MDc6MzUu
+        ODk3NzQ3WiIsIm1kNSI6bnVsbCwic2hhMSI6IjViOTExNzBjZjdjZWFkNjYx
+        NDI3ZTlmMTdjYWQ5NThjZmQ4ODk0MzAiLCJzaGEyMjQiOiIyMDg5N2JmYTFi
+        MjJlNDU0ZDk5YjM2ZjcxMDQ3YTRlMDFlOTBmOGFhZDkwNTg0NWQxYjBkZjIw
+        MyIsInNoYTI1NiI6IjI0MDM0M2MxMjljYmU1YjYyZTI5MjM1YmQxYzM4YWE4
+        OWFlYjYyNjcxZWI3Njc4ZmUxY2FkZTc2MjU1MzQ1MTciLCJzaGEzODQiOiJj
+        Njk5NTdhYTZhMzBlM2Q5M2M4ODQwNmEyNTVjMmE3ZDJjYTcxZDIyZWRkYzg0
+        NTJhZWFhZTg4ZDg1M2I3NTAzMTY0N2IxNjBjNmNkNGJjNjQzNjBkOTA4YWNl
+        NDBiNTciLCJzaGE1MTIiOiJjNGZhZjI0MTJlYjljZDA5ZmQ1NmY1ZGY0NzRl
+        NjE0NzBlOTg4ZTUyMzYzMjQwNzQ3NzE0OTY2OTRlMTI5ODk4ZThkNDQzZmE2
+        MjY2Y2IwNjY2ODk3NWI2YjlkOTM0YTA5ZWFiM2ViNjk3MDdhMDRiZWQ4MzE2
+        NTk2ZTEyZDVmYSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
+        cy8xN2Y2NzdlOC1mNDIwLTQ2NjktOGEwMy1kZWIzYWFmZGU5MTYvIiwibmFt
+        ZSI6InRpZ2VyIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjEuMCIsInJlbGVh
+        c2UiOiI0IiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMjQwMzQzYzEyOWNi
+        ZTViNjJlMjkyMzViZDFjMzhhYTg5YWViNjI2NzFlYjc2NzhmZTFjYWRlNzYy
+        NTUzNDUxNyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIHRpZ2VyIiwiZGVzY3JpcHRpb24iOiJBIGR1
+        bW15IHBhY2thZ2Ugb2YgdGlnZXIiLCJ1cmwiOiJodHRwOi8vdHN0cmFjaG90
+        YS5mZWRvcmFwZW9wbGUub3JnIiwiY2hhbmdlbG9ncyI6W10sImZpbGVzIjpb
+        W251bGwsIi90bXAvIiwidGlnZXIudHh0Il1dLCJyZXF1aXJlcyI6W10sInBy
+        b3ZpZGVzIjpbWyJ0aWdlciIsIkVRIiwiMCIsIjEuMCIsIjQiLGZhbHNlXV0s
+        ImNvbmZsaWN0cyI6W10sIm9ic29sZXRlcyI6W10sInN1Z2dlc3RzIjpbXSwi
+        ZW5oYW5jZXMiOltdLCJyZWNvbW1lbmRzIjpbXSwic3VwcGxlbWVudHMiOltd
+        LCJsb2NhdGlvbl9iYXNlIjoiIiwibG9jYXRpb25faHJlZiI6InRpZ2VyLTEu
+        MC00Lm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0Ijoic21xZS13czE1Iiwi
+        cnBtX2dyb3VwIjoiSW50ZXJuZXQvQXBwbGljYXRpb25zIiwicnBtX2xpY2Vu
+        c2UiOiJHUEx2MiIsInJwbV9wYWNrYWdlciI6IiIsInJwbV9zb3VyY2VycG0i
+        OiJ0aWdlci0xLjAtNC5zcmMucnBtIiwicnBtX3ZlbmRvciI6IiIsInJwbV9o
+        ZWFkZXJfc3RhcnQiOjg3MiwicnBtX2hlYWRlcl9lbmQiOjIyODksImlzX21v
+        ZHVsYXIiOmZhbHNlLCJzaXplX2FyY2hpdmUiOjI5Niwic2l6ZV9pbnN0YWxs
+        ZWQiOjQyLCJzaXplX3BhY2thZ2UiOjI0NDEsInRpbWVfYnVpbGQiOjEzMzE4
+        MzEzNjcsInRpbWVfZmlsZSI6MTQ1NDEyMzM3NH0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZmI5Y2RiN2EtNGFk
+        Mi00N2RjLWJhNDUtMjc4NzBhYWI2MzJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTJUMTM6MDc6MzUuODk1NTg2WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        ImUzMjJjNDlhMTg0YzdlMWQxMDg1ODVhMTQ3ZGFkM2IyZTE4ZDU2ZTMiLCJz
+        aGEyMjQiOiIxYTFhZGE5NjcwOTIzNDI5ZTU4ZjY3ZmU1Njc2M2IyOTQ2OGZh
+        NDZhNzc1ZWVlMjhiZGFjZjgzZSIsInNoYTI1NiI6IjQ2YTJhOGYyNzU0Njdi
+        MTYyMTFlNzJiZWU3YTUxYTAzYTA2Nzg2MTBiNDE5ODY1OWMxZGI0NjRmNWVl
+        NDZlMGQiLCJzaGEzODQiOiI0MDVjNGE4MGQ5NjA3NjdhZGQ4OTk1MWE3NzAx
+        YWRmM2EyZGUzNzE2Yjc2MTk1Zjg5MWQxZjUyODA0ZmY4ZmQ5NjJiMzI4ZDNk
+        ODY2MWRjMmZjODQ3MmZmZDU1ZTdhMmEiLCJzaGE1MTIiOiI0ZDMwNWJhOTJi
+        ZDRlMTUwYmQwOTg5NzMwOTRlMDdmMDMyNjQxN2RiYjRjZjY2OWUzOWQxN2Ey
+        Y2M4MTU0NDdhZDZkNWM0MWI5NmVmZjA4NGZhZWYwZmE4NjNmMGQ2ZDIwYWMy
+        MmZmYTA4ZDU1ZTJkY2FkODVkN2Q1YWVhMzY5MSIsImFydGlmYWN0IjoiL3B1
+        bHAvYXBpL3YzL2FydGlmYWN0cy81ZTNkNzFkZi0wZDE4LTQ5NDUtYTRlNC05
+        ZTJjMzI4ZTczMzYvIiwibmFtZSI6InNxdWlycmVsIiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjAuMSIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
+        InBrZ0lkIjoiNDZhMmE4ZjI3NTQ2N2IxNjIxMWU3MmJlZTdhNTFhMDNhMDY3
+        ODYxMGI0MTk4NjU5YzFkYjQ2NGY1ZWU0NmUwZCIsImNoZWNrc3VtX3R5cGUi
+        OiJzaGEyNTYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWly
+        cmVsIiwiZGVzY3JpcHRpb24iOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJy
+        ZWwiLCJ1cmwiOiJodHRwOi8vdHN0cmFjaG90YS5mZWRvcmFwZW9wbGUub3Jn
+        IiwiY2hhbmdlbG9ncyI6W10sImZpbGVzIjpbW251bGwsIi90bXAvIiwic3F1
+        aXJyZWwudHh0Il1dLCJyZXF1aXJlcyI6W1siY2FtZWwiLG51bGwsbnVsbCxu
+        dWxsLG51bGwsZmFsc2VdLFsiZm94IixudWxsLG51bGwsbnVsbCxudWxsLGZh
+        bHNlXV0sInByb3ZpZGVzIjpbWyJzcXVpcnJlbCIsIkVRIiwiMCIsIjAuMSIs
+        IjEiLGZhbHNlXV0sImNvbmZsaWN0cyI6W10sIm9ic29sZXRlcyI6W10sInN1
+        Z2dlc3RzIjpbXSwiZW5oYW5jZXMiOltdLCJyZWNvbW1lbmRzIjpbXSwic3Vw
+        cGxlbWVudHMiOltdLCJsb2NhdGlvbl9iYXNlIjoiIiwibG9jYXRpb25faHJl
+        ZiI6InNxdWlycmVsLTAuMS0xLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0
+        Ijoic21xZS13czE1IiwicnBtX2dyb3VwIjoiSW50ZXJuZXQvQXBwbGljYXRp
+        b25zIiwicnBtX2xpY2Vuc2UiOiJHUEx2MiIsInJwbV9wYWNrYWdlciI6IiIs
+        InJwbV9zb3VyY2VycG0iOiJzcXVpcnJlbC0wLjEtMS5zcmMucnBtIiwicnBt
+        X3ZlbmRvciI6IiIsInJwbV9oZWFkZXJfc3RhcnQiOjg3MiwicnBtX2hlYWRl
+        cl9lbmQiOjIzMzMsImlzX21vZHVsYXIiOmZhbHNlLCJzaXplX2FyY2hpdmUi
+        OjMwMCwic2l6ZV9pbnN0YWxsZWQiOjQyLCJzaXplX3BhY2thZ2UiOjI0ODgs
+        InRpbWVfYnVpbGQiOjEzMzE4MzEzNjAsInRpbWVfZmlsZSI6MTQ1NDEyMzM3
+        NH0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFj
+        a2FnZXMvZDdlNWNlNWYtYjU4Yy00MzU2LWI1NzAtMTJmNWY2ZDIxMzRiLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjEtMTEtMTJUMTM6MDc6MzUuODkzMjA2WiIs
+        Im1kNSI6bnVsbCwic2hhMSI6ImJlZWFkNWRiMDIwYzkyOWVmZjUzM2U5Yjg2
+        ZjJmNWYwYTVlOTk1YjciLCJzaGEyMjQiOiJlNjFiNjFmYzRkMzFiMGY2Mzhh
+        NzAxZDlkZjc0NTY1YjI0MzgyZDI2Yjg5OGQyZDEyZTNkOTY1ZSIsInNoYTI1
+        NiI6IjgzMDE0NWRlNzQ1NTA4MTU4NjUwMTRjM2M4ZDQ3YmM2NTU2MGZjNjhj
+        MTljZTA4NWNlMTUyM2M5NGEyMzEwNjQiLCJzaGEzODQiOiIyYTZkMTM1MTQy
+        NDNhYzEyY2U4OGVkZjk1MmZmMzkyMTc3MWNiM2E1MmYwZDIxYTFjMTVkNGIy
+        YWNmMzEyNTA1ODBiZmZjMzU1MDI5YjhmZTk0OWE0YTgzMzM4MjhmODkiLCJz
+        aGE1MTIiOiJkMWM3MjM5MWNjMzZjNTgxM2QxZTJlMGUzYTRlYTY4MTI0ODhk
+        N2JjYTFhMTIxOTU5NjI1ZWViZjEzODcyYTEyYTAyZTA2YmY2NDMwZTRiZWYy
+        NDQxNzE5OWRjNDdkN2IyMTA4ZGIyZjA1ZmI4MmYxZjMxNDk1MTM3NWVlZWVm
+        OSIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8yYjE1NTI3
+        Ny0wOWNiLTQ5YzYtOGE4NC0xODk2MzQ5MmQ2ZTkvIiwibmFtZSI6InN0b3Jr
+        IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMTIiLCJyZWxlYXNlIjoiMiIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjgzMDE0NWRlNzQ1NTA4MTU4NjUw
+        MTRjM2M4ZDQ3YmM2NTU2MGZjNjhjMTljZTA4NWNlMTUyM2M5NGEyMzEwNjQi
+        LCJjaGVja3N1bV90eXBlIjoic2hhMjU2Iiwic3VtbWFyeSI6IkEgZHVtbXkg
+        cGFja2FnZSBvZiBzdG9yayIsImRlc2NyaXB0aW9uIjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIHN0b3JrIiwidXJsIjoiaHR0cDovL3RzdHJhY2hvdGEuZmVkb3Jh
+        cGVvcGxlLm9yZyIsImNoYW5nZWxvZ3MiOltdLCJmaWxlcyI6W1tudWxsLCIv
+        dG1wLyIsInN0b3JrLnR4dCJdXSwicmVxdWlyZXMiOltdLCJwcm92aWRlcyI6
+        W1sic3RvcmsiLCJFUSIsIjAiLCIwLjEyIiwiMiIsZmFsc2VdXSwiY29uZmxp
+        Y3RzIjpbXSwib2Jzb2xldGVzIjpbXSwic3VnZ2VzdHMiOltdLCJlbmhhbmNl
+        cyI6W10sInJlY29tbWVuZHMiOltdLCJzdXBwbGVtZW50cyI6W10sImxvY2F0
+        aW9uX2Jhc2UiOiIiLCJsb2NhdGlvbl9ocmVmIjoic3RvcmstMC4xMi0yLm5v
+        YXJjaC5ycG0iLCJycG1fYnVpbGRob3N0Ijoic21xZS13czE1IiwicnBtX2dy
+        b3VwIjoiSW50ZXJuZXQvQXBwbGljYXRpb25zIiwicnBtX2xpY2Vuc2UiOiJH
+        UEx2MiIsInJwbV9wYWNrYWdlciI6IiIsInJwbV9zb3VyY2VycG0iOiJzdG9y
+        ay0wLjEyLTIuc3JjLnJwbSIsInJwbV92ZW5kb3IiOiIiLCJycG1faGVhZGVy
+        X3N0YXJ0Ijo4NzIsInJwbV9oZWFkZXJfZW5kIjoyMjkzLCJpc19tb2R1bGFy
+        IjpmYWxzZSwic2l6ZV9hcmNoaXZlIjoyOTYsInNpemVfaW5zdGFsbGVkIjo0
+        Miwic2l6ZV9wYWNrYWdlIjoyNDQ1LCJ0aW1lX2J1aWxkIjoxMzMxODMxMzcy
+        LCJ0aW1lX2ZpbGUiOjE0NTQxMjMzNzR9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzgwOGI1Y2NjLTY3NWYtNGRl
+        Zi04ODdiLTk3ZDM0ZGU2MGJlZi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEx
+        LTEyVDEzOjA3OjM1Ljg5MTI4NVoiLCJtZDUiOm51bGwsInNoYTEiOiI3YTUy
+        MzFlNTlmOGUxYmYzZjlkY2Y4ZTU5MDJlYjkxY2FhZDFhNDM2Iiwic2hhMjI0
+        IjoiYzMwOTlmOTYzMWQ5M2QwZWE3NTE4NmJkZTg1YmQ1MTg2ZGU2ZmU1Y2Vj
+        MjM2OTU0ZTQzZTQ0ZTAiLCJzaGEyNTYiOiJhZWE5MWQ3M2Q4ZGYyMTUwMmZl
+        Y2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJhMjczMDkzOWQ1N2ZjODQyNjAyZTE0
+        Iiwic2hhMzg0IjoiMTk4ZmI0MDAxZjA3MDJjMDdlZTQyZDBjYmYxMWIxYTAy
+        ZDZjODlkZDE1ZGZmNGQ4NWFlMzA1NDUyNTIwNzRlZWM5YmJlNDY2MTE3M2I5
+        MWZiNjAzNGMzNzgzZDc1MDNlIiwic2hhNTEyIjoiNTI4M2QwOGIzNWJkYjNl
+        YzRmZmU5MzdlM2QwNmVkZGQ5ODJmNjczOWU3ODEwODBhMzZhMTY3YzYzMDgw
+        ODE5YjZmMjVlNjFkZmVjNjUwMmJjYmY2OThmOThiOTUyYzVmMzZhZjFhODk0
+        NmE4MzY0OTgwMmVhZDQ4YTBjMDBhYzIiLCJhcnRpZmFjdCI6Ii9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvZDI2MGMwZWUtZTA4OS00MTMzLWI4MGUtOTdlYzJi
+        OTYzYzMxLyIsIm5hbWUiOiJ0cm91dCIsImVwb2NoIjoiMCIsInZlcnNpb24i
+        OiIwLjEyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiJhZWE5MWQ3M2Q4ZGYyMTUwMmZlY2JjMWJiZjY0ZTdjZmRkNjE3NTFhMWJh
+        MjczMDkzOWQ1N2ZjODQyNjAyZTE0IiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1
+        NiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgdHJvdXQiLCJkZXNj
+        cmlwdGlvbiI6IkEgZHVtbXkgcGFja2FnZSBvZiB0cm91dCIsInVybCI6Imh0
+        dHA6Ly90c3RyYWNob3RhLmZlZG9yYXBlb3BsZS5vcmciLCJjaGFuZ2Vsb2dz
+        IjpbXSwiZmlsZXMiOltbbnVsbCwiL3RtcC8iLCJ0cm91dC50eHQiXV0sInJl
+        cXVpcmVzIjpbWyJjYXQiLG51bGwsbnVsbCxudWxsLG51bGwsZmFsc2VdLFsi
+        aG9yc2UiLG51bGwsbnVsbCxudWxsLG51bGwsZmFsc2VdXSwicHJvdmlkZXMi
+        OltbInRyb3V0IiwiRVEiLCIwIiwiMC4xMiIsIjEiLGZhbHNlXV0sImNvbmZs
+        aWN0cyI6W10sIm9ic29sZXRlcyI6W10sInN1Z2dlc3RzIjpbXSwiZW5oYW5j
+        ZXMiOltdLCJyZWNvbW1lbmRzIjpbXSwic3VwcGxlbWVudHMiOltdLCJsb2Nh
+        dGlvbl9iYXNlIjoiIiwibG9jYXRpb25faHJlZiI6InRyb3V0LTAuMTItMS5u
+        b2FyY2gucnBtIiwicnBtX2J1aWxkaG9zdCI6InNtcWUtd3MxNSIsInJwbV9n
+        cm91cCI6IkludGVybmV0L0FwcGxpY2F0aW9ucyIsInJwbV9saWNlbnNlIjoi
+        R1BMdjIiLCJycG1fcGFja2FnZXIiOiIiLCJycG1fc291cmNlcnBtIjoidHJv
+        dXQtMC4xMi0xLnNyYy5ycG0iLCJycG1fdmVuZG9yIjoiIiwicnBtX2hlYWRl
+        cl9zdGFydCI6ODcyLCJycG1faGVhZGVyX2VuZCI6MjMxMywiaXNfbW9kdWxh
+        ciI6ZmFsc2UsInNpemVfYXJjaGl2ZSI6Mjk2LCJzaXplX2luc3RhbGxlZCI6
+        NDIsInNpemVfcGFja2FnZSI6MjQ2NSwidGltZV9idWlsZCI6MTMzMTgzMTM3
+        MSwidGltZV9maWxlIjoxNDU0MTIzMzc0fSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy9jZTRkNjgyZS00M2Y5LTRi
+        MDAtYTI2ZS03NjdjMmQ2MjBkZGUvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0x
+        MS0xMlQxMzowNzozNS44ODkwODhaIiwibWQ1IjpudWxsLCJzaGExIjoiMjg2
+        OTU3NWIwNmE1ZDY3YmY3MTY0NWI1OTM5YTc3ZmY3YWY0OTFiYyIsInNoYTIy
+        NCI6IjU4OTc4ZDQwZWQ5ZDJmOTViZDc3ZDAzODI1M2UyNGJmN2JjZDQxZDg4
+        M2Q5NjU0YzVmNTRlMjkwIiwic2hhMjU2IjoiOTUxZTBlYWNmM2U2ZTYxMDJi
+        MTBhY2IyZTY4OTI0M2I1ODY2ZWMyYzc3MjBlNzgzNzQ5ZGJkMzJmNGE2OWFi
+        MyIsInNoYTM4NCI6IjRiOTM0MDVlNjI3M2U0NWViN2M2YzYxNGRlZDg2OWY3
+        MjFhN2NlZWFhOGU5MmRkZDFmYmE1MmFhYWNlYzM4Nzk1MWUwNDI2YTQ5Njdi
+        OGZiNmM0Nzg3YmVjYjRkMTg3MiIsInNoYTUxMiI6IjRiYWQ2NWNjNjJkYzc5
+        ZjYyN2NkNmZmY2JlODc2Y2UxMmIxOTdiNTZlM2JmYzI0MjhmZWI0MWIzY2Iw
+        MGI5ODQ2ZjJkMDkzYzlkZWI0MDNhYjY3M2JhNWY2YTJmMGE0ZjhmYTliMjQ5
+        MTUzYmVkYmIxNGUxYWVmMTYzMTVhZjNhIiwiYXJ0aWZhY3QiOiIvcHVscC9h
+        cGkvdjMvYXJ0aWZhY3RzL2IxY2NkNTI5LTU0MTMtNDllZS04ZTQ0LTExOTE1
+        YTQxZjVlMS8iLCJuYW1lIjoic2hhcmsiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMC4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQi
+        OiI5NTFlMGVhY2YzZTZlNjEwMmIxMGFjYjJlNjg5MjQzYjU4NjZlYzJjNzcy
+        MGU3ODM3NDlkYmQzMmY0YTY5YWIzIiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1
+        NiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Ygc2hhcmsiLCJkZXNj
+        cmlwdGlvbiI6IkEgZHVtbXkgcGFja2FnZSBvZiBzaGFyayIsInVybCI6Imh0
+        dHA6Ly90c3RyYWNob3RhLmZlZG9yYXBlb3BsZS5vcmciLCJjaGFuZ2Vsb2dz
+        IjpbXSwiZmlsZXMiOltbbnVsbCwiL3RtcC8iLCJzaGFyay50eHQiXV0sInJl
+        cXVpcmVzIjpbXSwicHJvdmlkZXMiOltbInNoYXJrIiwiRVEiLCIwIiwiMC4x
+        IiwiMSIsZmFsc2VdXSwiY29uZmxpY3RzIjpbXSwib2Jzb2xldGVzIjpbXSwi
+        c3VnZ2VzdHMiOltdLCJlbmhhbmNlcyI6W10sInJlY29tbWVuZHMiOltdLCJz
+        dXBwbGVtZW50cyI6W10sImxvY2F0aW9uX2Jhc2UiOiIiLCJsb2NhdGlvbl9o
+        cmVmIjoic2hhcmstMC4xLTEubm9hcmNoLnJwbSIsInJwbV9idWlsZGhvc3Qi
+        OiJzbXFlLXdzMTUiLCJycG1fZ3JvdXAiOiJJbnRlcm5ldC9BcHBsaWNhdGlv
+        bnMiLCJycG1fbGljZW5zZSI6IkdQTHYyIiwicnBtX3BhY2thZ2VyIjoiIiwi
+        cnBtX3NvdXJjZXJwbSI6InNoYXJrLTAuMS0xLnNyYy5ycG0iLCJycG1fdmVu
+        ZG9yIjoiIiwicnBtX2hlYWRlcl9zdGFydCI6ODcyLCJycG1faGVhZGVyX2Vu
+        ZCI6MjI4OSwiaXNfbW9kdWxhciI6ZmFsc2UsInNpemVfYXJjaGl2ZSI6Mjk2
+        LCJzaXplX2luc3RhbGxlZCI6NDIsInNpemVfcGFja2FnZSI6MjQ0MSwidGlt
+        ZV9idWlsZCI6MTMzMTgzMTM2OSwidGltZV9maWxlIjoxNDU0MTIzMzc0fSx7
+        InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
+        cy8wOGIzYjFhMC0xMTg2LTQ4YWItODEyMi0yYzRlZTY1MjBlZDQvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMS0xMS0xMlQxMzowNzozNS44ODYyMjlaIiwibWQ1
+        IjpudWxsLCJzaGExIjoiOWZkYzU0Y2ZlNDA2MmNiODZjNDhlMWRhZWNhMzI5
+        NGNiMGY0NjMzNCIsInNoYTIyNCI6IjM0MWE3YTBmZGNjNWI0Y2I3Nzg3NWZh
+        YjVhMDc3ZWRkMTRiMzcyZjllNzgyZTUyZWJhOWI1MzVkIiwic2hhMjU2Ijoi
+        ZDE4YzY4MDczZWNlMDczZGMzZWNlNzJiN2ZhMjAxMWMxODA1OTllOTY5OGU0
+        NTYyNDNjNGZhZjlhOGI5MTI0YSIsInNoYTM4NCI6IjNmM2MyZjhlMjAxNzcx
+        NmU5ZmI1OTUxYmJlYmJmZDQ0OWU4ZTcxMGQyODFkNzNlZWJiYzlmMzAwOWU5
+        NGY0Yjc1MTI0ODRlYWFhYjM3NTc1OWI2OGU1YzA2MjZkY2NiNyIsInNoYTUx
+        MiI6IjZhNjdmMDZjNjI2NzNkMDlhMDgwNGUyYzk5NGU4MTU5YjJkMjY1ODM5
+        YzIzMGEzNjhhZmE0ODA2NjQ5ZGRlZjJiZmEyNWNlZmM4ZmIxNDJmYzJjYThm
+        M2Y4Y2Y0OTg3MTE4MmM2NWJiZjE4ZjhmN2ViY2RkZjRhYjdmZDYyMjZiIiwi
+        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2U2NDVhMjJiLThk
+        NjYtNDhhMC1hNWJhLWJhMWExYTdhNDFhNi8iLCJuYW1lIjoicGlrZSIsImVw
+        b2NoIjoiMCIsInZlcnNpb24iOiIyLjIiLCJyZWxlYXNlIjoiMSIsImFyY2gi
+        OiJub2FyY2giLCJwa2dJZCI6ImQxOGM2ODA3M2VjZTA3M2RjM2VjZTcyYjdm
+        YTIwMTFjMTgwNTk5ZTk2OThlNDU2MjQzYzRmYWY5YThiOTEyNGEiLCJjaGVj
+        a3N1bV90eXBlIjoic2hhMjU2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2Fn
+        ZSBvZiBwaWtlIiwiZGVzY3JpcHRpb24iOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        cGlrZSIsInVybCI6Imh0dHA6Ly90c3RyYWNob3RhLmZlZG9yYXBlb3BsZS5v
+        cmciLCJjaGFuZ2Vsb2dzIjpbXSwiZmlsZXMiOltbbnVsbCwiL3RtcC8iLCJw
+        aWtlLnR4dCJdXSwicmVxdWlyZXMiOltbImNyb3ciLG51bGwsbnVsbCxudWxs
+        LG51bGwsZmFsc2VdLFsiZWxlcGhhbnQiLG51bGwsbnVsbCxudWxsLG51bGws
+        ZmFsc2VdXSwicHJvdmlkZXMiOltbInBpa2UiLCJFUSIsIjAiLCIyLjIiLCIx
+        IixmYWxzZV1dLCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMiOltdLCJzdWdn
+        ZXN0cyI6W10sImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6W10sInN1cHBs
+        ZW1lbnRzIjpbXSwibG9jYXRpb25fYmFzZSI6IiIsImxvY2F0aW9uX2hyZWYi
+        OiJwaWtlLTIuMi0xLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0Ijoic21x
+        ZS13czE1IiwicnBtX2dyb3VwIjoiSW50ZXJuZXQvQXBwbGljYXRpb25zIiwi
+        cnBtX2xpY2Vuc2UiOiJHUEx2MiIsInJwbV9wYWNrYWdlciI6IiIsInJwbV9z
+        b3VyY2VycG0iOiJwaWtlLTIuMi0xLnNyYy5ycG0iLCJycG1fdmVuZG9yIjoi
+        IiwicnBtX2hlYWRlcl9zdGFydCI6ODcyLCJycG1faGVhZGVyX2VuZCI6MjMx
+        MywiaXNfbW9kdWxhciI6ZmFsc2UsInNpemVfYXJjaGl2ZSI6Mjk2LCJzaXpl
+        X2luc3RhbGxlZCI6NDIsInNpemVfcGFja2FnZSI6MjQ2MiwidGltZV9idWls
+        ZCI6MTMzMTgzMTM3MSwidGltZV9maWxlIjoxNDU0MTIzMzczfSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85OTAz
+        MTc5MS01ZjlhLTQwYWMtYThiNC01NjJlZTU4NzU3YTEvIiwicHVscF9jcmVh
+        dGVkIjoiMjAyMS0xMS0xMlQxMzowNzozNS44ODQ0MjZaIiwibWQ1IjpudWxs
+        LCJzaGExIjoiN2Q3NTZmYjgwOGUxMWRkYjI5MzVkNmNhM2FmZjJmNjkyZTlh
+        NDVlYiIsInNoYTIyNCI6IjNmYmM5OTFlNGQ0MDQ0NTdjMmU3ODJhZDg3OTgy
+        NWQ1MzU2ODBlNmI4YjhhNGIzODljMWY4MDkzIiwic2hhMjU2IjoiOTQxNmNi
+        ZTllOGMxODNmNDQwZWQ1OTBkNjZkNTZkNDcxZDUyOWE0Y2Y2NzkzMGNlYThi
+        ZDcwNTZkZjVjYTkxYyIsInNoYTM4NCI6IjMwMWE4MDBiNmQ1OGNiOWRmYmM2
+        MzM2OTExMTI1OTA4MWMxZDBiZGIyNjMzMWI2NWNiZmNjNWRlMmExNGY2OWFi
+        Y2NiMTdhY2U3M2UxODYyYjU5NWVlMDBiZDIzNTc5YiIsInNoYTUxMiI6Ijlm
+        MzQ0MTZiYmI5ZTdhMDBjNjhkMWMwYzY0OWUxY2QyYjM2ZDhmZmI0NWE2MTIy
+        Y2FlYjNlNzVhZjJjNWVmNDQ1NjQzNmQ1OGZkODEyODc2NDQ3ZDdiYTIxMmQ3
+        NTUwMmMwMjUzYTYzYzIwODliZGJlNzFhYWY2MWJiNGNlYjllIiwiYXJ0aWZh
+        Y3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzQ4MTQyYjA2LTVmN2QtNDNm
+        NS1iZTI4LWJkYzBiYTZiZjJmMy8iLCJuYW1lIjoia2FuZ2Fyb28iLCJlcG9j
+        aCI6IjAiLCJ2ZXJzaW9uIjoiMC4yIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoi
+        bm9hcmNoIiwicGtnSWQiOiI5NDE2Y2JlOWU4YzE4M2Y0NDBlZDU5MGQ2NmQ1
+        NmQ0NzFkNTI5YTRjZjY3OTMwY2VhOGJkNzA1NmRmNWNhOTFjIiwiY2hlY2tz
+        dW1fdHlwZSI6InNoYTI1NiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ug
+        b2Yga2FuZ2Fyb28iLCJkZXNjcmlwdGlvbiI6IkEgZHVtbXkgcGFja2FnZSBv
+        ZiBrYW5nYXJvbyIsInVybCI6Imh0dHA6Ly90c3RyYWNob3RhLmZlZG9yYXBl
+        b3BsZS5vcmciLCJjaGFuZ2Vsb2dzIjpbXSwiZmlsZXMiOltbbnVsbCwiL3Rt
+        cC8iLCJrYW5nYXJvby50eHQiXV0sInJlcXVpcmVzIjpbXSwicHJvdmlkZXMi
+        OltbImthbmdhcm9vIiwiRVEiLCIwIiwiMC4yIiwiMSIsZmFsc2VdXSwiY29u
+        ZmxpY3RzIjpbXSwib2Jzb2xldGVzIjpbXSwic3VnZ2VzdHMiOltdLCJlbmhh
+        bmNlcyI6W10sInJlY29tbWVuZHMiOltdLCJzdXBwbGVtZW50cyI6W10sImxv
+        Y2F0aW9uX2Jhc2UiOiIiLCJsb2NhdGlvbl9ocmVmIjoia2FuZ2Fyb28tMC4y
+        LTEubm9hcmNoLnJwbSIsInJwbV9idWlsZGhvc3QiOiJzbXFlLXdzMTUiLCJy
+        cG1fZ3JvdXAiOiJJbnRlcm5ldC9BcHBsaWNhdGlvbnMiLCJycG1fbGljZW5z
+        ZSI6IkdQTHYyIiwicnBtX3BhY2thZ2VyIjoiIiwicnBtX3NvdXJjZXJwbSI6
+        Imthbmdhcm9vLTAuMi0xLnNyYy5ycG0iLCJycG1fdmVuZG9yIjoiIiwicnBt
+        X2hlYWRlcl9zdGFydCI6ODcyLCJycG1faGVhZGVyX2VuZCI6MjMxMywiaXNf
+        bW9kdWxhciI6ZmFsc2UsInNpemVfYXJjaGl2ZSI6MzAwLCJzaXplX2luc3Rh
+        bGxlZCI6NDIsInNpemVfcGFja2FnZSI6MjQ2NywidGltZV9idWlsZCI6MTMz
+        MTgzMTM3NiwidGltZV9maWxlIjoxNDU0MTIzMzczfSx7InB1bHBfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8zOWUxNWExMC03
+        NzdhLTQ3OWEtYjAxNy1mOGI0MzMxYmEzZWIvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0xMS0xMlQxMzowNzozNS44ODI1ODhaIiwibWQ1IjpudWxsLCJzaGEx
+        IjoiNzQ3ZGVmNjY5MTYyZGRmNTQ0ZDNhYjcxZTljNmU5Mzk2MzZlN2M0OCIs
+        InNoYTIyNCI6ImM4MmZkOWY2NjNmYmM4NWE5ODdlNGI2NWVkN2I5ZjBhODZm
+        OGFjNTQwZTE0NTM2NzQ0Nzk1MDZlIiwic2hhMjU2IjoiZjQyMDA2NDNiMDg0
+        NWZkYzU1ZWUwMDJjOTJjMDQwNGE5ZjNhMmE0OWY1OTZjNzhiNDBhYjU2NzQ5
+        ZGUyMjZjZSIsInNoYTM4NCI6ImY3NGY3NjdhYjhiNjJjZjJhM2NlYjQ4Nzdi
+        NzcxMGZjNjFmN2FkZTliZjliMGMyMWQwMzVlZDA1ZGFmZmVmODM3YzU2NmE2
+        NTU5ZWMyMDBhMzc5NjM0YWExOGFiZjBiNyIsInNoYTUxMiI6ImYzZmQyZTUw
+        NTJiMTc5MzI4NDIzNzk0ZjNiZGE1NzlkZDJkMmFiZDRhYjYwZTlkZGIwNDdk
+        OGIyZmIwZjQ5NjJmYzZlNzliM2NlZDgwZGJmMThiZmRlZWE0ZWFiNjhkOGMx
+        ZGZhNzlhZjU4MWY3MWRhZmY5YjUzMmQ5YzVhYTUwIiwiYXJ0aWZhY3QiOiIv
+        cHVscC9hcGkvdjMvYXJ0aWZhY3RzL2RjNTE3MGZhLTQ0OGMtNDkzMi1hZWZl
+        LTFmOTcyNjI2YjhlZS8iLCJuYW1lIjoibW91c2UiLCJlcG9jaCI6IjAiLCJ2
+        ZXJzaW9uIjoiMC4xLjEyIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNo
+        IiwicGtnSWQiOiJmNDIwMDY0M2IwODQ1ZmRjNTVlZTAwMmM5MmMwNDA0YTlm
+        M2EyYTQ5ZjU5NmM3OGI0MGFiNTY3NDlkZTIyNmNlIiwiY2hlY2tzdW1fdHlw
+        ZSI6InNoYTI1NiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgbW91
+        c2UiLCJkZXNjcmlwdGlvbiI6IkEgZHVtbXkgcGFja2FnZSBvZiBtb3VzZSIs
+        InVybCI6Imh0dHA6Ly90c3RyYWNob3RhLmZlZG9yYXBlb3BsZS5vcmciLCJj
+        aGFuZ2Vsb2dzIjpbXSwiZmlsZXMiOltbbnVsbCwiL3RtcC8iLCJtb3VzZS50
+        eHQiXV0sInJlcXVpcmVzIjpbWyJkb2xwaGluIixudWxsLG51bGwsbnVsbCxu
+        dWxsLGZhbHNlXSxbInplYnJhIixudWxsLG51bGwsbnVsbCxudWxsLGZhbHNl
+        XV0sInByb3ZpZGVzIjpbWyJtb3VzZSIsIkVRIiwiMCIsIjAuMS4xMiIsIjEi
+        LGZhbHNlXV0sImNvbmZsaWN0cyI6W10sIm9ic29sZXRlcyI6W10sInN1Z2dl
+        c3RzIjpbXSwiZW5oYW5jZXMiOltdLCJyZWNvbW1lbmRzIjpbXSwic3VwcGxl
+        bWVudHMiOltdLCJsb2NhdGlvbl9iYXNlIjoiIiwibG9jYXRpb25faHJlZiI6
+        Im1vdXNlLTAuMS4xMi0xLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0Ijoi
+        c21xZS13czE1IiwicnBtX2dyb3VwIjoiSW50ZXJuZXQvQXBwbGljYXRpb25z
+        IiwicnBtX2xpY2Vuc2UiOiJHUEx2MiIsInJwbV9wYWNrYWdlciI6IiIsInJw
+        bV9zb3VyY2VycG0iOiJtb3VzZS0wLjEuMTItMS5zcmMucnBtIiwicnBtX3Zl
+        bmRvciI6IiIsInJwbV9oZWFkZXJfc3RhcnQiOjg3MiwicnBtX2hlYWRlcl9l
+        bmQiOjIzMjUsImlzX21vZHVsYXIiOmZhbHNlLCJzaXplX2FyY2hpdmUiOjI5
+        Niwic2l6ZV9pbnN0YWxsZWQiOjQyLCJzaXplX3BhY2thZ2UiOjI0NzYsInRp
+        bWVfYnVpbGQiOjEzMzE4MzEzNzYsInRpbWVfZmlsZSI6MTQ1NDEyMzM3M30s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMjRiODdjOTYtYjRhNy00YWRkLWFiOWQtYTExNmIzZTNlYTEzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjEtMTEtMTJUMTM6MDc6MzUuODgwNjIwWiIsIm1k
+        NSI6bnVsbCwic2hhMSI6IjFhNjkwZjUzZjMzZDBjOTM3OGI3MjNjYWNhYjE5
+        NTRkODBmOGFjN2YiLCJzaGEyMjQiOiJmNzE3NjVlMjVmNWZiN2U3YzM2Nzhi
+        NDRlMjVlYmNmZDA4MzRiNmJiNmVjYTEwMWYzMjdkOTI5NyIsInNoYTI1NiI6
+        IjJjNWRmNmI1MWRmMTY3ZWIwMTI0NmRjZTMwNDk2NjhjYmU2ODgwMzNiOWFi
+        ZmYyNDQ2NGIwZTA1Y2RlYjIwYWMiLCJzaGEzODQiOiI1ZmQxMzE5MzBlMTZi
+        YjkxZDE5NTI2ODg0ZDBiYTgzMzNkNDU5ZTFhZjNiZWQ4MjczYmMxNDk1YzZh
+        YjI0OTQ1MWQ5NDQ2ZTAzZjIyMGI2MGMyZjUzZGM3ODllZWM2NmUiLCJzaGE1
+        MTIiOiI0MzViMDM2NjQ2ZGY1M2I2NmJkOGM1NGRkN2RlZDBhZDFhNmI4YzI5
+        OTJjYTc1MjFkYTJhZWNiZTE2ZjM4M2JhMzVhODNlNzMzNjg4ZWEwZjVmZDM1
+        YmRiZDQwNjBlOTIzY2UxMWM1ZjU4Yjk0OWI1Y2VkZGE4YWE3Mjk5MzcyZSIs
+        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9mOWE2MjFjOC02
+        NmU1LTRiYTktOGFiMy02YWM4NTQ5NzVjZGIvIiwibmFtZSI6Imxpb24iLCJl
+        cG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC40IiwicmVsZWFzZSI6IjEiLCJhcmNo
+        Ijoibm9hcmNoIiwicGtnSWQiOiIyYzVkZjZiNTFkZjE2N2ViMDEyNDZkY2Uz
+        MDQ5NjY4Y2JlNjg4MDMzYjlhYmZmMjQ0NjRiMGUwNWNkZWIyMGFjIiwiY2hl
+        Y2tzdW1fdHlwZSI6InNoYTI1NiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2th
+        Z2Ugb2YgbGlvbiIsImRlc2NyaXB0aW9uIjoiQSBkdW1teSBwYWNrYWdlIG9m
+        IGxpb24iLCJ1cmwiOiJodHRwOi8vdHN0cmFjaG90YS5mZWRvcmFwZW9wbGUu
+        b3JnIiwiY2hhbmdlbG9ncyI6W10sImZpbGVzIjpbW251bGwsIi90bXAvIiwi
+        bGlvbi50eHQiXV0sInJlcXVpcmVzIjpbWyJ3b2xmIixudWxsLG51bGwsbnVs
+        bCxudWxsLGZhbHNlXV0sInByb3ZpZGVzIjpbWyJsaW9uIiwiRVEiLCIwIiwi
+        MC40IiwiMSIsZmFsc2VdXSwiY29uZmxpY3RzIjpbXSwib2Jzb2xldGVzIjpb
+        XSwic3VnZ2VzdHMiOltdLCJlbmhhbmNlcyI6W10sInJlY29tbWVuZHMiOltd
+        LCJzdXBwbGVtZW50cyI6W10sImxvY2F0aW9uX2Jhc2UiOiIiLCJsb2NhdGlv
+        bl9ocmVmIjoibGlvbi0wLjQtMS5ub2FyY2gucnBtIiwicnBtX2J1aWxkaG9z
+        dCI6InNtcWUtd3MxNSIsInJwbV9ncm91cCI6IkludGVybmV0L0FwcGxpY2F0
+        aW9ucyIsInJwbV9saWNlbnNlIjoiR1BMdjIiLCJycG1fcGFja2FnZXIiOiIi
+        LCJycG1fc291cmNlcnBtIjoibGlvbi0wLjQtMS5zcmMucnBtIiwicnBtX3Zl
+        bmRvciI6IiIsInJwbV9oZWFkZXJfc3RhcnQiOjg3MiwicnBtX2hlYWRlcl9l
+        bmQiOjIyOTcsImlzX21vZHVsYXIiOmZhbHNlLCJzaXplX2FyY2hpdmUiOjI5
+        Niwic2l6ZV9pbnN0YWxsZWQiOjQyLCJzaXplX3BhY2thZ2UiOjI0NDYsInRp
+        bWVfYnVpbGQiOjEzMzE4MzEzNjYsInRpbWVfZmlsZSI6MTQ1NDEyMzM3M30s
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvMjY3MDkzMDMtNGIyNy00OTliLTllZDItNmM2ZmFhMWUyZTU1LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjEtMTEtMTJUMTM6MDc6MzUuODc3NTM2WiIsIm1k
+        NSI6bnVsbCwic2hhMSI6ImZiNWY0OGY2MzI5YTE0OTRkZGMyZDk3MTY3ZDky
+        MGEwOGQxNDU3YzQiLCJzaGEyMjQiOiJmNzExYWNjMzgwNWYzN2VkODFiN2E5
+        OWRlNmE3YjA5NGU1MWI2YjI0MjNjZTg4NmJlZDRhY2UwZSIsInNoYTI1NiI6
+        IjNlZWNlNWQ4YzZjZTAzYmQzMTJkNzAzNGRhMDViNjdiMWYxYWM3YmQ1ZTAw
+        YWU3N2I0ZTVmZGYwYzRjN2YzNjMiLCJzaGEzODQiOiIzY2JiM2QwOWRhMWZi
+        MjFjNzIwODVlNTJhMTZhMDY2NmMwM2U5YmMxMjBhMWVmYzczOTNjMDVjOGZh
+        YWEzNGJlODUwYjNiOTJjODU3ZmJjZjQ0MTI1ZDhjZGNiYTMxZmUiLCJzaGE1
+        MTIiOiI0OWM4YWM3N2Q5OWJiNTQwMWMxZTc5NDA3OWI3NzdiYTYwNGNmYjM0
+        NThkNTVhNmMyZTdkOTJlYjMzMDllNTA2NTZiZWI3ZDgxOTI2MjNmMjE2NmRi
+        NmYxNmRlMDMzODU1YWU5YTlkNzEzZGQ5ZjlmOGY4YTZlY2Q5MDBjNDAyNCIs
+        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9mYTIzMTdlNC05
+        MzQxLTQ0OGEtYTczNy0xN2MyYjRhNTU4NWUvIiwibmFtZSI6ImdpcmFmZmUi
+        LCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC42NyIsInJlbGVhc2UiOiIyIiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiM2VlY2U1ZDhjNmNlMDNiZDMxMmQ3
+        MDM0ZGEwNWI2N2IxZjFhYzdiZDVlMDBhZTc3YjRlNWZkZjBjNGM3ZjM2MyIs
+        ImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
+        YWNrYWdlIG9mIGdpcmFmZmUiLCJkZXNjcmlwdGlvbiI6IkEgZHVtbXkgcGFj
+        a2FnZSBvZiBnaXJhZmZlIiwidXJsIjoiaHR0cDovL3RzdHJhY2hvdGEuZmVk
+        b3JhcGVvcGxlLm9yZyIsImNoYW5nZWxvZ3MiOltdLCJmaWxlcyI6W1tudWxs
+        LCIvdG1wLyIsImdpcmFmZmUudHh0Il1dLCJyZXF1aXJlcyI6W10sInByb3Zp
+        ZGVzIjpbWyJnaXJhZmZlIiwiRVEiLCIwIiwiMC42NyIsIjIiLGZhbHNlXV0s
+        ImNvbmZsaWN0cyI6W10sIm9ic29sZXRlcyI6W10sInN1Z2dlc3RzIjpbXSwi
+        ZW5oYW5jZXMiOltdLCJyZWNvbW1lbmRzIjpbXSwic3VwcGxlbWVudHMiOltd
+        LCJsb2NhdGlvbl9iYXNlIjoiIiwibG9jYXRpb25faHJlZiI6ImdpcmFmZmUt
+        MC42Ny0yLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0Ijoic21xZS13czE1
+        IiwicnBtX2dyb3VwIjoiSW50ZXJuZXQvQXBwbGljYXRpb25zIiwicnBtX2xp
+        Y2Vuc2UiOiJHUEx2MiIsInJwbV9wYWNrYWdlciI6IiIsInJwbV9zb3VyY2Vy
+        cG0iOiJnaXJhZmZlLTAuNjctMi5zcmMucnBtIiwicnBtX3ZlbmRvciI6IiIs
+        InJwbV9oZWFkZXJfc3RhcnQiOjg3MiwicnBtX2hlYWRlcl9lbmQiOjIzMDEs
+        ImlzX21vZHVsYXIiOmZhbHNlLCJzaXplX2FyY2hpdmUiOjI5Niwic2l6ZV9p
+        bnN0YWxsZWQiOjQyLCJzaXplX3BhY2thZ2UiOjI0NTEsInRpbWVfYnVpbGQi
+        OjEzMzE4MzEzNjYsInRpbWVfZmlsZSI6MTQ1NDEyMzM3M30seyJwdWxwX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMGQ3OTc0
+        NDgtNzgxNy00ZmMwLWEzZWUtYjVhMWNkMDE5MWEyLyIsInB1bHBfY3JlYXRl
+        ZCI6IjIwMjEtMTEtMTJUMTM6MDc6MzUuODc1MDEzWiIsIm1kNSI6bnVsbCwi
+        c2hhMSI6IjMxNjgyYzExNDQ2YjBhZjRmNzdhMjk4YzM1YWRlNTU2ZWE4OGQ4
+        NjciLCJzaGEyMjQiOiIzMWMxMGY5MTg3OTI4ZGRlZGVlYzNmYTQ2N2NmNzM2
+        NjY2MzUyN2NiZjIzODNhMDNhNzRiNmUyYyIsInNoYTI1NiI6IjU3ZDMxNGNj
+        NmY1MzIyNDg0Y2RjZDMzZjQxNzMzNzRkZTk1YzUzMDM0ZGU1YjExNjhiOTI5
+        MWNhMGFkMDZkZWMiLCJzaGEzODQiOiIyYTRiYmJmOGM4OGEzZTE5MTA2MDlk
+        NmVkNDUxYTgzNjYzNDk3NzJjM2YxYzYzZjc0MmQ2MmViZTQ2NWU5ODE2Y2Zl
+        Y2UyOWE2Mzc2YTgxZDk0NWViMmI3MjgwOTFiNzkiLCJzaGE1MTIiOiJhYjQ5
+        YTQzMTAzOTMxMzFmZjE1ZGJmMGEwNTkzZmE1MGQ2NTkxZWVmZmI5MjIwMGRl
+        ZjUyYmMxZWIwYzc0MWU1NTI1Y2VkZjBjZGQxMjQ3ZmIzNTcyZmZlYTY5Njk2
+        YTk5ZGZjMjgyMTk0YjgyMWI1MWJlMDg2MTA2YWJkZTY0OCIsImFydGlmYWN0
+        IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84ZWU5ODYzMC0xNmViLTQ3MDIt
+        OGU5My03ODRkZWEwYzBhNmIvIiwibmFtZSI6InBlbmd1aW4iLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC45LjEiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJu
+        b2FyY2giLCJwa2dJZCI6IjU3ZDMxNGNjNmY1MzIyNDg0Y2RjZDMzZjQxNzMz
+        NzRkZTk1YzUzMDM0ZGU1YjExNjhiOTI5MWNhMGFkMDZkZWMiLCJjaGVja3N1
+        bV90eXBlIjoic2hhMjU2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBv
+        ZiBwZW5ndWluIiwiZGVzY3JpcHRpb24iOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        cGVuZ3VpbiIsInVybCI6Imh0dHA6Ly90c3RyYWNob3RhLmZlZG9yYXBlb3Bs
+        ZS5vcmciLCJjaGFuZ2Vsb2dzIjpbXSwiZmlsZXMiOltbbnVsbCwiL3RtcC8i
+        LCJwZW5ndWluLnR4dCJdXSwicmVxdWlyZXMiOltbImRvbHBoaW4iLG51bGws
+        bnVsbCxudWxsLG51bGwsZmFsc2VdXSwicHJvdmlkZXMiOltbInBlbmd1aW4i
+        LCJFUSIsIjAiLCIwLjkuMSIsIjEiLGZhbHNlXV0sImNvbmZsaWN0cyI6W10s
+        Im9ic29sZXRlcyI6W10sInN1Z2dlc3RzIjpbXSwiZW5oYW5jZXMiOltdLCJy
+        ZWNvbW1lbmRzIjpbXSwic3VwcGxlbWVudHMiOltdLCJsb2NhdGlvbl9iYXNl
+        IjoiIiwibG9jYXRpb25faHJlZiI6InBlbmd1aW4tMC45LjEtMS5ub2FyY2gu
+        cnBtIiwicnBtX2J1aWxkaG9zdCI6InNtcWUtd3MxNSIsInJwbV9ncm91cCI6
+        IkludGVybmV0L0FwcGxpY2F0aW9ucyIsInJwbV9saWNlbnNlIjoiR1BMdjIi
+        LCJycG1fcGFja2FnZXIiOiIiLCJycG1fc291cmNlcnBtIjoicGVuZ3Vpbi0w
+        LjkuMS0xLnNyYy5ycG0iLCJycG1fdmVuZG9yIjoiIiwicnBtX2hlYWRlcl9z
+        dGFydCI6ODcyLCJycG1faGVhZGVyX2VuZCI6MjMxMywiaXNfbW9kdWxhciI6
+        ZmFsc2UsInNpemVfYXJjaGl2ZSI6Mjk2LCJzaXplX2luc3RhbGxlZCI6NDIs
+        InNpemVfcGFja2FnZSI6MjQ2NCwidGltZV9idWlsZCI6MTMzMTgzMTM3Mywi
+        dGltZV9maWxlIjoxNDU0MTIzMzczfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L3JwbS9wYWNrYWdlcy84M2U4NGEzZi0yY2Q3LTRlMDQt
+        OGIzMC02OTA5YTYxN2U0MDAvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0x
+        MlQxMzowNzozNS44NzI5OThaIiwibWQ1IjpudWxsLCJzaGExIjoiYWJjNTAz
+        YmI0OTU1NmNhOWNkOWY1NDI5ZjVjMjI4NDczNmViZDViNiIsInNoYTIyNCI6
+        ImZkYmY2YmIxOWQ4MjZkYWIxOTIyNTU2NmY1MTliMGI4ZjYyODdlM2RlYmVi
+        MzU4MDZlOGQyMzIwIiwic2hhMjU2IjoiNjJlNDNhNzYzMTc3YTQ5ZjZhYmIz
+        NzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2MzMTliMThmNDE5YmNmOGYyOWQ2OCIs
+        InNoYTM4NCI6IjAzNDFjMWM2Zjc5ZTIwNzcxNTk5MTk1MDgwNGM0M2NmMjA0
+        YTY1ODU5ZGZjYzQxODBmMTAyOThmMTA5NWQ3ZmFkZTgzMmMwNWVmNTczYjc2
+        NzhmMjdlYjVlODc2NTM5ZiIsInNoYTUxMiI6ImY4MDUyN2E0MTAwZGZlNGY5
+        YTFlOTI2NmI3ODM2Y2MxZTkzYmJlZmEzYzdlNTE5ZjgwOGYzNzMxNjM0YmJi
+        YzdkNDgzY2M1YWVhNzcwMmY2NmEwY2ZlYjQ3NjExOWY1Yjc1NzBkZDI4NTZj
+        MGRiYWNjOWExOGVmOTM1YTZmOTEyIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkv
+        djMvYXJ0aWZhY3RzLzhiMDRmYjIxLWI3NDItNGZiMy05NDAyLWM2Y2Q2YzFk
+        MWM4My8iLCJuYW1lIjoiaG9yc2UiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoi
+        MC4yMiIsInJlbGVhc2UiOiIyIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
+        NjJlNDNhNzYzMTc3YTQ5ZjZhYmIzNzgzMzIxYjY2MzM1NzZiYTI1MzY0Y2Mz
+        MTliMThmNDE5YmNmOGYyOWQ2OCIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGhvcnNlIiwiZGVzY3Jp
+        cHRpb24iOiJBIGR1bW15IHBhY2thZ2Ugb2YgaG9yc2UiLCJ1cmwiOiJodHRw
+        Oi8vdHN0cmFjaG90YS5mZWRvcmFwZW9wbGUub3JnIiwiY2hhbmdlbG9ncyI6
+        W10sImZpbGVzIjpbW251bGwsIi90bXAvIiwiaG9yc2UudHh0Il1dLCJyZXF1
+        aXJlcyI6W1sibW91c2UiLG51bGwsbnVsbCxudWxsLG51bGwsZmFsc2VdLFsi
+        cGVuZ3VpbiIsbnVsbCxudWxsLG51bGwsbnVsbCxmYWxzZV1dLCJwcm92aWRl
+        cyI6W1siaG9yc2UiLCJFUSIsIjAiLCIwLjIyIiwiMiIsZmFsc2VdXSwiY29u
+        ZmxpY3RzIjpbXSwib2Jzb2xldGVzIjpbXSwic3VnZ2VzdHMiOltdLCJlbmhh
+        bmNlcyI6W10sInJlY29tbWVuZHMiOltdLCJzdXBwbGVtZW50cyI6W10sImxv
+        Y2F0aW9uX2Jhc2UiOiIiLCJsb2NhdGlvbl9ocmVmIjoiaG9yc2UtMC4yMi0y
+        Lm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0Ijoic21xZS13czE1IiwicnBt
+        X2dyb3VwIjoiSW50ZXJuZXQvQXBwbGljYXRpb25zIiwicnBtX2xpY2Vuc2Ui
+        OiJHUEx2MiIsInJwbV9wYWNrYWdlciI6IiIsInJwbV9zb3VyY2VycG0iOiJo
+        b3JzZS0wLjIyLTIuc3JjLnJwbSIsInJwbV92ZW5kb3IiOiIiLCJycG1faGVh
+        ZGVyX3N0YXJ0Ijo4NzIsInJwbV9oZWFkZXJfZW5kIjoyMzE3LCJpc19tb2R1
+        bGFyIjpmYWxzZSwic2l6ZV9hcmNoaXZlIjoyOTYsInNpemVfaW5zdGFsbGVk
+        Ijo0Miwic2l6ZV9wYWNrYWdlIjoyNDY5LCJ0aW1lX2J1aWxkIjoxMzMxODMx
+        Mzc2LCJ0aW1lX2ZpbGUiOjE0NTQxMjMzNzN9LHsicHVscF9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzMwMjEyOTMzLTMyNzIt
+        NGY0NC1hOGNmLWViYjVjZTZjNmQyNy8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIx
+        LTExLTEyVDEzOjA3OjM1Ljg3MTA4NFoiLCJtZDUiOm51bGwsInNoYTEiOiIy
+        MDNmOTA0ZTE3ZGNhZTRmNjcwYzA0MzExMTlhODc2ZmMzOTNmMDhkIiwic2hh
+        MjI0IjoiYWYxN2Q0MTYzODRiMjJkMzVkNGE3ZDM1OWQ4ZTc3YTM0YTQxNTI5
+        ODU5ODFjNGZhZGQxMWFkMDMiLCJzaGEyNTYiOiJmZmQ1MTFiZTMyYWRiZjkx
+        ZmEwYjNmNTRmMjNjZDFjMDJhZGQ1MDU3ODM0NGZmOGRlNDRjZWE0ZjRhYjVh
+        YTM3Iiwic2hhMzg0IjoiN2IxZjExMjdjMWRjNDY5NDI2NWRjMTNlZGUyMGNm
+        YTBkNTNkZmQ5ODFkYzQwZDcyOWRlODRhYWI2NTYxZDI5ZWVhM2RlZDZiZTg3
+        OGQ2NTAyMzM0OGExNjA0ODkxZTU5Iiwic2hhNTEyIjoiOTk4YWVhMTNjYmZj
+        ODJhMzY4MWE4YzMwODAzMzY1OWUxODdkOTA5MGNiMGQwZWUxNjQ3YWU3YTlm
+        ZTBiZjViNDRlNmI4MzllZmVjYWJmYjM0MmRhYmIyNmE0YTZhZjUzMWI0ZmZh
+        NzQ2NGYzZTBjY2E5ZTU1MTRjOTg1ZjUzZDEiLCJhcnRpZmFjdCI6Ii9wdWxw
+        L2FwaS92My9hcnRpZmFjdHMvOGJlOTdkYjQtYmE0Zi00OWM0LThjOWMtNWIw
+        NGJiOTgyNDU2LyIsIm5hbWUiOiJnb3JpbGxhIiwiZXBvY2giOiIwIiwidmVy
+        c2lvbiI6IjAuNjIiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJw
+        a2dJZCI6ImZmZDUxMWJlMzJhZGJmOTFmYTBiM2Y1NGYyM2NkMWMwMmFkZDUw
+        NTc4MzQ0ZmY4ZGU0NGNlYTRmNGFiNWFhMzciLCJjaGVja3N1bV90eXBlIjoi
+        c2hhMjU2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBnb3JpbGxh
+        IiwiZGVzY3JpcHRpb24iOiJBIGR1bW15IHBhY2thZ2Ugb2YgZ29yaWxsYSIs
+        InVybCI6Imh0dHA6Ly90c3RyYWNob3RhLmZlZG9yYXBlb3BsZS5vcmciLCJj
+        aGFuZ2Vsb2dzIjpbXSwiZmlsZXMiOltbbnVsbCwiL3RtcC8iLCJnb3JpbGxh
+        LnR4dCJdXSwicmVxdWlyZXMiOltdLCJwcm92aWRlcyI6W1siZ29yaWxsYSIs
+        IkVRIiwiMCIsIjAuNjIiLCIxIixmYWxzZV1dLCJjb25mbGljdHMiOltdLCJv
+        YnNvbGV0ZXMiOltdLCJzdWdnZXN0cyI6W10sImVuaGFuY2VzIjpbXSwicmVj
+        b21tZW5kcyI6W10sInN1cHBsZW1lbnRzIjpbXSwibG9jYXRpb25fYmFzZSI6
+        IiIsImxvY2F0aW9uX2hyZWYiOiJnb3JpbGxhLTAuNjItMS5ub2FyY2gucnBt
+        IiwicnBtX2J1aWxkaG9zdCI6InNtcWUtd3MxNSIsInJwbV9ncm91cCI6Iklu
+        dGVybmV0L0FwcGxpY2F0aW9ucyIsInJwbV9saWNlbnNlIjoiR1BMdjIiLCJy
+        cG1fcGFja2FnZXIiOiIiLCJycG1fc291cmNlcnBtIjoiZ29yaWxsYS0wLjYy
+        LTEuc3JjLnJwbSIsInJwbV92ZW5kb3IiOiIiLCJycG1faGVhZGVyX3N0YXJ0
+        Ijo4NzIsInJwbV9oZWFkZXJfZW5kIjoyMzAxLCJpc19tb2R1bGFyIjpmYWxz
+        ZSwic2l6ZV9hcmNoaXZlIjoyOTYsInNpemVfaW5zdGFsbGVkIjo0Miwic2l6
+        ZV9wYWNrYWdlIjoyNDUyLCJ0aW1lX2J1aWxkIjoxMzMxODMxMzY0LCJ0aW1l
+        X2ZpbGUiOjE0NTQxMjMzNzN9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvcnBtL3BhY2thZ2VzLzY2OTI5NTlhLTFmMzUtNDZiZC1hZWQ1
+        LWE3OWM2NTQ3OTBjYi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTEyVDEz
+        OjA3OjM1Ljg2OTMxMloiLCJtZDUiOm51bGwsInNoYTEiOiIwMTMxNGJkMjQ2
+        ZTQ3OTcwMzZhNDg3ZDc0ZWUyMDk4MjNhYjA2YzQzIiwic2hhMjI0IjoiOGUy
+        MjNlNjM0ODBlNDVkOTNhNDg5YTZmMmU2MGU0YWM3OWM1ZGNiZjhmMWQ2NTVh
+        MDlhOTViZDIiLCJzaGEyNTYiOiIxNTU0MTlkODYyNTEyNDkyMzNmOWQ4MDE2
+        ZjYwMTJlMTM4ZWYzYTNmNWM2NzljODY4NWRlODQ0NjBlMzJlM2UzIiwic2hh
+        Mzg0IjoiNGY4OWZiNWFjMmUyOWUzMmM4ZDM5NGU1ZmMzYjI3ZDZhNDFlZDQx
+        NjU3YjBlMDJiNTBhMjUwOTc5NmUxYWEzMjkyM2MwNTBkYzRiYTAwNTcxNjcz
+        NTA5ZjhiZjRjYzNhIiwic2hhNTEyIjoiZWZkYTY4OTkzNDRjNDBmMGVlZGU4
+        MzAzYjg3MDgwNDEzMGRlNTU4YTc3YmE1ZDliNjRhYTc2YWU4OTI1MTYxM2I0
+        ZDZkOGRkMzBmMGMyZmY4NWZiNWI5ZDJiNzg0ZmY0MDM2MjA5Mjk2NzE4MDY1
+        NjAxMDUwNjM5NzhiOTk1OTEiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9h
+        cnRpZmFjdHMvMTI4MjFhYjktOTVkNC00ZGU4LTk1NmEtNGFjNzZhY2JiOWJi
+        LyIsIm5hbWUiOiJmcm9nIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIs
+        InJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiMTU1NDE5
+        ZDg2MjUxMjQ5MjMzZjlkODAxNmY2MDEyZTEzOGVmM2EzZjVjNjc5Yzg2ODVk
+        ZTg0NDYwZTMyZTNlMyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJzdW1t
+        YXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGZyb2ciLCJkZXNjcmlwdGlvbiI6
+        IkEgZHVtbXkgcGFja2FnZSBvZiBmcm9nIiwidXJsIjoiaHR0cDovL3RzdHJh
+        Y2hvdGEuZmVkb3JhcGVvcGxlLm9yZyIsImNoYW5nZWxvZ3MiOltdLCJmaWxl
+        cyI6W1tudWxsLCIvdG1wLyIsImZyb2cudHh0Il1dLCJyZXF1aXJlcyI6W10s
+        InByb3ZpZGVzIjpbWyJmcm9nIiwiRVEiLCIwIiwiMC4xIiwiMSIsZmFsc2Vd
+        XSwiY29uZmxpY3RzIjpbXSwib2Jzb2xldGVzIjpbXSwic3VnZ2VzdHMiOltd
+        LCJlbmhhbmNlcyI6W10sInJlY29tbWVuZHMiOltdLCJzdXBwbGVtZW50cyI6
+        W10sImxvY2F0aW9uX2Jhc2UiOiIiLCJsb2NhdGlvbl9ocmVmIjoiZnJvZy0w
+        LjEtMS5ub2FyY2gucnBtIiwicnBtX2J1aWxkaG9zdCI6InNtcWUtd3MxNSIs
+        InJwbV9ncm91cCI6IkludGVybmV0L0FwcGxpY2F0aW9ucyIsInJwbV9saWNl
+        bnNlIjoiR1BMdjIiLCJycG1fcGFja2FnZXIiOiIiLCJycG1fc291cmNlcnBt
+        IjoiZnJvZy0wLjEtMS5zcmMucnBtIiwicnBtX3ZlbmRvciI6IiIsInJwbV9o
+        ZWFkZXJfc3RhcnQiOjg3MiwicnBtX2hlYWRlcl9lbmQiOjIyODksImlzX21v
+        ZHVsYXIiOmZhbHNlLCJzaXplX2FyY2hpdmUiOjI5Niwic2l6ZV9pbnN0YWxs
+        ZWQiOjQyLCJzaXplX3BhY2thZ2UiOjI0MzksInRpbWVfYnVpbGQiOjEzMzE4
+        MzEzNzcsInRpbWVfZmlsZSI6MTQ1NDEyMzM3M30seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvNjJkMzIxZTktZmY0
+        MS00OGNjLWJjMzgtMjkwNGRmYWExMTliLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTJUMTM6MDc6MzUuODY3NTI1WiIsIm1kNSI6bnVsbCwic2hhMSI6
+        ImIzOTdjZGQ0ZjZhMDIxNWUyZjBhY2Q5OGZlNTQ3OGM5OTU1YjQyNjAiLCJz
+        aGEyMjQiOiIxZDIzZjc0MmJjYTdjN2YzYmY5ZWJkN2M5Yzk1MzJmNzdkZTUz
+        YTQ5MTcwODAyMDFjOTI2YTcxMCIsInNoYTI1NiI6IjM4NzZkOGQ0ZmUwODY0
+        YzRhMmU1M2M5ZjQ4ZGE4N2QwN2M4NzA3Mzk2ZmEzOTNjZTFiNWU3ZDAxOGFm
+        M2UzNzYiLCJzaGEzODQiOiI1Y2Y1Yzk1ZTUyYzE2NzdmMjhmMjRlNDZjYzkw
+        YjU3ZTFhMTNjMDgzMTk5ZmVjZmNkNzlmODUwOTM2ODcwMzhmMTBjZTU1M2E1
+        NWQzZTE3NmI5MmRmNjBlOWE2M2YzYmQiLCJzaGE1MTIiOiIwMzFhNmI4MDc4
+        YjgwYzQ4MWE4MmVkY2Q2OGNjODZiOGJkMzE1MjU0NjNiODZlZTM1MjQ3MDY2
+        NGE0NWE2Zjk4YzY1NjAxOTBmMjI1MTZjNjA4NTM1MTUyNmQwMGM3OWZkZGZl
+        Y2ZhNzNhNGViNzExMmE4ZmVmZWUyMjljNjAwOCIsImFydGlmYWN0IjoiL3B1
+        bHAvYXBpL3YzL2FydGlmYWN0cy81NzQzN2ZlZC00YzhjLTQ5MGMtYWMwMi04
+        OGIxZmY0MjU0NWYvIiwibmFtZSI6ImVsZXBoYW50IiwiZXBvY2giOiIwIiwi
+        dmVyc2lvbiI6IjguMyIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIs
+        InBrZ0lkIjoiMzg3NmQ4ZDRmZTA4NjRjNGEyZTUzYzlmNDhkYTg3ZDA3Yzg3
+        MDczOTZmYTM5M2NlMWI1ZTdkMDE4YWYzZTM3NiIsImNoZWNrc3VtX3R5cGUi
+        OiJzaGEyNTYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBo
+        YW50IiwiZGVzY3JpcHRpb24iOiJBIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhh
+        bnQiLCJ1cmwiOiJodHRwOi8vdHN0cmFjaG90YS5mZWRvcmFwZW9wbGUub3Jn
+        IiwiY2hhbmdlbG9ncyI6W10sImZpbGVzIjpbW251bGwsIi90bXAvIiwiZWxl
+        cGhhbnQudHh0Il1dLCJyZXF1aXJlcyI6W1sia2FuZ2Fyb28iLG51bGwsbnVs
+        bCxudWxsLG51bGwsZmFsc2VdXSwicHJvdmlkZXMiOltbImVsZXBoYW50Iiwi
+        RVEiLCIwIiwiOC4zIiwiMSIsZmFsc2VdXSwiY29uZmxpY3RzIjpbXSwib2Jz
+        b2xldGVzIjpbXSwic3VnZ2VzdHMiOltdLCJlbmhhbmNlcyI6W10sInJlY29t
+        bWVuZHMiOltdLCJzdXBwbGVtZW50cyI6W10sImxvY2F0aW9uX2Jhc2UiOiIi
+        LCJsb2NhdGlvbl9ocmVmIjoiZWxlcGhhbnQtOC4zLTEubm9hcmNoLnJwbSIs
+        InJwbV9idWlsZGhvc3QiOiJzbXFlLXdzMTUiLCJycG1fZ3JvdXAiOiJJbnRl
+        cm5ldC9BcHBsaWNhdGlvbnMiLCJycG1fbGljZW5zZSI6IkdQTHYyIiwicnBt
+        X3BhY2thZ2VyIjoiIiwicnBtX3NvdXJjZXJwbSI6ImVsZXBoYW50LTguMy0x
+        LnNyYy5ycG0iLCJycG1fdmVuZG9yIjoiIiwicnBtX2hlYWRlcl9zdGFydCI6
+        ODcyLCJycG1faGVhZGVyX2VuZCI6MjMyNSwiaXNfbW9kdWxhciI6ZmFsc2Us
+        InNpemVfYXJjaGl2ZSI6MzAwLCJzaXplX2luc3RhbGxlZCI6NDIsInNpemVf
+        cGFja2FnZSI6MjQ3NywidGltZV9idWlsZCI6MTMzMTgzMTM2NCwidGltZV9m
+        aWxlIjoxNDU0MTIzMzczfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy9kZTFmNTNiNS1kN2QzLTQ4NTgtODQ5ZS1j
+        M2RkODA1MjFjYjEvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xMlQxMzow
+        NzozNS44NjU2MjNaIiwibWQ1IjpudWxsLCJzaGExIjoiMGNjMmRkMjUyZTdm
+        NzVkYzdiNjExYmY0NmYwMGYxOGIzMWY1NDhlMyIsInNoYTIyNCI6ImNlMDlk
+        ZGM0YWQ5MWZmMmQ3OTNjNmI0NTNmYTE3OWY0NzM4OTg4OTA5NzJmZDVhYzRm
+        ODIzYzJkIiwic2hhMjU2IjoiNzA4OTQ1Yjg5YWNhNTRjNWVkOWFmYjhlMmJi
+        MTQxZmQ1NjQ1OWFjOThiMTg0N2JlNDY0N2ZhMTgyNTQ3MWNjZCIsInNoYTM4
+        NCI6IjNmMjIwYTlhZTllMzRhYWE1Yjc2ZTY1NDU4MmNjNTBlMDFhYTBjOThl
+        OTYxNWVkNjZiOTljMzljM2IyMGQwYjc0MzU0ZDNhNjZkOGI5YzhiZGVhMzFj
+        MTRkOWQ0MWFmZiIsInNoYTUxMiI6IjE3OThlY2EzZTQ1NzY5MTZhNTQzZGUx
+        OTA4Yjc0YmNjMThjZmZiZmU5OThkZTIzOGRiOGRiZjJhNDBlZjhkMjc5YzI0
+        M2NiZDEyYjE4NzMzMjdjYTMyZGFjM2YyNzhhYjJkZWY2YWMxMmE2NjhhYTMw
+        NTNkZDA4MjU2OWZmMzViIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0
+        aWZhY3RzL2ZkZGI4ZTc0LTQ0NTYtNDFkYy05N2JlLWI2NzBhZGQ5NTE3Ni8i
+        LCJuYW1lIjoiZG9scGhpbiIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIzLjEw
+        LjIzMiIsInJlbGVhc2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoi
+        NzA4OTQ1Yjg5YWNhNTRjNWVkOWFmYjhlMmJiMTQxZmQ1NjQ1OWFjOThiMTg0
+        N2JlNDY0N2ZhMTgyNTQ3MWNjZCIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYi
+        LCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNrYWdlIG9mIGRvbHBoaW4iLCJkZXNj
+        cmlwdGlvbiI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2xwaGluIiwidXJsIjoi
+        aHR0cDovL3RzdHJhY2hvdGEuZmVkb3JhcGVvcGxlLm9yZyIsImNoYW5nZWxv
+        Z3MiOltdLCJmaWxlcyI6W1tudWxsLCIvdG1wLyIsImRvbHBoaW4udHh0Il1d
+        LCJyZXF1aXJlcyI6W1siYmVhciIsbnVsbCxudWxsLG51bGwsbnVsbCxmYWxz
+        ZV0sWyJsaW9uIixudWxsLG51bGwsbnVsbCxudWxsLGZhbHNlXSxbInRpZ2Vy
+        IixudWxsLG51bGwsbnVsbCxudWxsLGZhbHNlXV0sInByb3ZpZGVzIjpbWyJk
+        b2xwaGluIiwiRVEiLCIwIiwiMy4xMC4yMzIiLCIxIixmYWxzZV1dLCJjb25m
+        bGljdHMiOltdLCJvYnNvbGV0ZXMiOltdLCJzdWdnZXN0cyI6W10sImVuaGFu
+        Y2VzIjpbXSwicmVjb21tZW5kcyI6W10sInN1cHBsZW1lbnRzIjpbXSwibG9j
+        YXRpb25fYmFzZSI6IiIsImxvY2F0aW9uX2hyZWYiOiJkb2xwaGluLTMuMTAu
+        MjMyLTEubm9hcmNoLnJwbSIsInJwbV9idWlsZGhvc3QiOiJzbXFlLXdzMTUi
+        LCJycG1fZ3JvdXAiOiJJbnRlcm5ldC9BcHBsaWNhdGlvbnMiLCJycG1fbGlj
+        ZW5zZSI6IkdQTHYyIiwicnBtX3BhY2thZ2VyIjoiIiwicnBtX3NvdXJjZXJw
+        bSI6ImRvbHBoaW4tMy4xMC4yMzItMS5zcmMucnBtIiwicnBtX3ZlbmRvciI6
+        IiIsInJwbV9oZWFkZXJfc3RhcnQiOjg3MiwicnBtX2hlYWRlcl9lbmQiOjIz
+        NDUsImlzX21vZHVsYXIiOmZhbHNlLCJzaXplX2FyY2hpdmUiOjI5Niwic2l6
+        ZV9pbnN0YWxsZWQiOjQyLCJzaXplX3BhY2thZ2UiOjI0OTUsInRpbWVfYnVp
+        bGQiOjEzMzE4MzEzNzAsInRpbWVfZmlsZSI6MTQ1NDEyMzM3M30seyJwdWxw
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvMTg0
+        NzA5NTktMDU2MC00ZmJmLWFkMTEtYWI0ZDI3YmNkYjg2LyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjEtMTEtMTJUMTM6MDc6MzUuODYzNjAxWiIsIm1kNSI6bnVs
+        bCwic2hhMSI6ImM3MjAzMWJjYTY0ZjkzOGJjODQxYjEwZjdjYTRjODY3ZDQ5
+        MTc3NmQiLCJzaGEyMjQiOiI2MzAyMmI2ZWUwOTdmYTE5MzUzNWEzNDQ3ZjUw
+        YTYzZmFjZTZjZjkzOGNmOWIwYTUyZDg3NGM1MCIsInNoYTI1NiI6IjQ4ZGJh
+        ZmI1M2RiY2MxNTY0YmY5YzBkNGI1NTMxMDM5YWMwYTE5MDJiNmNmZTIyNWE3
+        MDJmZjA5NDVjYWE1YmIiLCJzaGEzODQiOiI2NTEwMjg1ODRiZDFiMTQ3Y2My
+        NjM4YjJjNDI4M2ZjMjdkNzljZDUxOTQ1NjZhZDYzNDkwOWUzNmY4MWIwOGRk
+        YjIxNzEwMGY0M2UxODcwNGVkY2ViMjY0YjUwNDM1MTQiLCJzaGE1MTIiOiI3
+        YWVlMmRiNDNkZjQxMTFiYjkyZDc2Y2Y2MGE1MWJhNTMyZWQyZjA5YmM1ZDhk
+        MTczYjk3Y2JhZjc4ZWY2NTMyZDI5NDA4YWYwMTA0YzBkM2UxZmU2M2UyMzdh
+        YTE1Yjg2MWZiMzAwMmU2MmVjNDM4NWMyMjU3ZGQxNTkxYmRlNSIsImFydGlm
+        YWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8yOTZhNjAxNC01ZjllLTQz
+        NTMtYjU5OC02OWEzODM0NWQ3MDMvIiwibmFtZSI6ImR1Y2siLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMC42IiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
+        cmNoIiwicGtnSWQiOiI0OGRiYWZiNTNkYmNjMTU2NGJmOWMwZDRiNTUzMTAz
+        OWFjMGExOTAyYjZjZmUyMjVhNzAyZmYwOTQ1Y2FhNWJiIiwiY2hlY2tzdW1f
+        dHlwZSI6InNoYTI1NiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        ZHVjayIsImRlc2NyaXB0aW9uIjoiQSBkdW1teSBwYWNrYWdlIG9mIGR1Y2si
+        LCJ1cmwiOiJodHRwOi8vdHN0cmFjaG90YS5mZWRvcmFwZW9wbGUub3JnIiwi
+        Y2hhbmdlbG9ncyI6W10sImZpbGVzIjpbW251bGwsIi90bXAvIiwiZHVjay50
+        eHQiXV0sInJlcXVpcmVzIjpbWyJjb2NrYXRlZWwiLG51bGwsbnVsbCxudWxs
+        LG51bGwsZmFsc2VdLFsibGlvbiIsbnVsbCxudWxsLG51bGwsbnVsbCxmYWxz
+        ZV1dLCJwcm92aWRlcyI6W1siZHVjayIsIkVRIiwiMCIsIjAuNiIsIjEiLGZh
+        bHNlXV0sImNvbmZsaWN0cyI6W10sIm9ic29sZXRlcyI6W10sInN1Z2dlc3Rz
+        IjpbXSwiZW5oYW5jZXMiOltdLCJyZWNvbW1lbmRzIjpbXSwic3VwcGxlbWVu
+        dHMiOltdLCJsb2NhdGlvbl9iYXNlIjoiIiwibG9jYXRpb25faHJlZiI6ImR1
+        Y2stMC42LTEubm9hcmNoLnJwbSIsInJwbV9idWlsZGhvc3QiOiJzbXFlLXdz
+        MTUiLCJycG1fZ3JvdXAiOiJJbnRlcm5ldC9BcHBsaWNhdGlvbnMiLCJycG1f
+        bGljZW5zZSI6IkdQTHYyIiwicnBtX3BhY2thZ2VyIjoiIiwicnBtX3NvdXJj
+        ZXJwbSI6ImR1Y2stMC42LTEuc3JjLnJwbSIsInJwbV92ZW5kb3IiOiIiLCJy
+        cG1faGVhZGVyX3N0YXJ0Ijo4NzIsInJwbV9oZWFkZXJfZW5kIjoyMzEzLCJp
+        c19tb2R1bGFyIjpmYWxzZSwic2l6ZV9hcmNoaXZlIjoyOTYsInNpemVfaW5z
+        dGFsbGVkIjo0Miwic2l6ZV9wYWNrYWdlIjoyNDYzLCJ0aW1lX2J1aWxkIjox
+        MzMxODMxMzczLCJ0aW1lX2ZpbGUiOjE0NTQxMjMzNzN9LHsicHVscF9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzllMjMzZmIy
+        LWY2N2YtNGI1NC1hNTdmLWQyNzBkOWFlZmUyYy8iLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDIxLTExLTEyVDEzOjA3OjM1Ljg2MTQ2NFoiLCJtZDUiOm51bGwsInNo
+        YTEiOiJkZjY1YTYyZmIxYTU4Y2Y1ZTM4OGI2NThjMGQ3YTUyNjU5YjNlOTJi
+        Iiwic2hhMjI0IjoiZGM0ZmFjZGViMTMxNTA5NGMzOWFkYzk4YzIzMWU2ZDk5
+        YjAzOTBlNzA2NGE4OThkOGZiOWNlYmIiLCJzaGEyNTYiOiI5ZGU1MjQ4Njhl
+        NjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgxZTEwZmFiNjFlNjY0MjBmMDJk
+        MDBhYzU5MjY3Iiwic2hhMzg0IjoiMjcxNTQzYjkxMTA1MDkwZDJhOTk2ZWEx
+        NmZhNGQ4MDMwNTUzNzFlNDZjYTExMGY2ZjIxNGNjNjVmY2Q3ZDIxMWJiMmMx
+        ZTZhNWE0ODE5YjJhMTlhNjc4M2EzNmNhOWQ0Iiwic2hhNTEyIjoiNmJhMGE2
+        YWU1OGRkMTc3ZDk1OWZlMDZmOTFiNDZlZWU3ZDVjNzRkOGVlYzExYTU1Yjc4
+        NDg5ZWUyYzg4NjkxNTM2MmYyYzJlNGVjNzQ5YWJkM2UzMjgwMDFhMjc0ODE5
+        MWU0MGIyMmFjODczMjJhNWVmMjJhZWExNDYwZTA4OTkiLCJhcnRpZmFjdCI6
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvM2Y1OTdmMDQtZDIyZS00Mjk0LThi
+        Y2UtNjI5ZmRkMmE4MWM4LyIsIm5hbWUiOiJmb3giLCJlcG9jaCI6IjAiLCJ2
+        ZXJzaW9uIjoiMS4xIiwicmVsZWFzZSI6IjIiLCJhcmNoIjoibm9hcmNoIiwi
+        cGtnSWQiOiI5ZGU1MjQ4NjhlNjRiM2RhYzRjNGY5NTAwNDU2OTA1NjgxZjgx
+        ZTEwZmFiNjFlNjY0MjBmMDJkMDBhYzU5MjY3IiwiY2hlY2tzdW1fdHlwZSI6
+        InNoYTI1NiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgZm94Iiwi
+        ZGVzY3JpcHRpb24iOiJBIGR1bW15IHBhY2thZ2Ugb2YgZm94IiwidXJsIjoi
+        aHR0cDovL3RzdHJhY2hvdGEuZmVkb3JhcGVvcGxlLm9yZyIsImNoYW5nZWxv
+        Z3MiOltdLCJmaWxlcyI6W1tudWxsLCIvdG1wLyIsImZveC50eHQiXV0sInJl
+        cXVpcmVzIjpbXSwicHJvdmlkZXMiOltbImZveCIsIkVRIiwiMCIsIjEuMSIs
+        IjIiLGZhbHNlXV0sImNvbmZsaWN0cyI6W10sIm9ic29sZXRlcyI6W10sInN1
+        Z2dlc3RzIjpbXSwiZW5oYW5jZXMiOltdLCJyZWNvbW1lbmRzIjpbXSwic3Vw
+        cGxlbWVudHMiOltdLCJsb2NhdGlvbl9iYXNlIjoiIiwibG9jYXRpb25faHJl
+        ZiI6ImZveC0xLjEtMi5ub2FyY2gucnBtIiwicnBtX2J1aWxkaG9zdCI6InNt
+        cWUtd3MxNSIsInJwbV9ncm91cCI6IkludGVybmV0L0FwcGxpY2F0aW9ucyIs
+        InJwbV9saWNlbnNlIjoiR1BMdjIiLCJycG1fcGFja2FnZXIiOiIiLCJycG1f
+        c291cmNlcnBtIjoiZm94LTEuMS0yLnNyYy5ycG0iLCJycG1fdmVuZG9yIjoi
+        IiwicnBtX2hlYWRlcl9zdGFydCI6ODcyLCJycG1faGVhZGVyX2VuZCI6MjI3
+        MywiaXNfbW9kdWxhciI6ZmFsc2UsInNpemVfYXJjaGl2ZSI6MjkyLCJzaXpl
+        X2luc3RhbGxlZCI6NDIsInNpemVfcGFja2FnZSI6MjQxNywidGltZV9idWls
+        ZCI6MTMzMTgzMTM2MCwidGltZV9maWxlIjoxNDU0MTIzMzczfSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy85YzVh
+        NGI1My01YWE4LTRmOGEtYTExYy02ZTZkMzAwZTk5ZDMvIiwicHVscF9jcmVh
+        dGVkIjoiMjAyMS0xMS0xMlQxMzowNzozNS44NTk1NzFaIiwibWQ1IjpudWxs
+        LCJzaGExIjoiMDRmNzJhNmIxNmZiNDVkNmRlNzg1ZDcyOGQ3ODk2OTk1NmU1
+        N2FlYiIsInNoYTIyNCI6ImU5ZWQ0NjBiZDQ1OGRhZjQ1Y2I4ZDU5MDVkYzFi
+        OTkyMDIzOTE4OTM2NTdlMDMzYzNmMzdhOWI4Iiwic2hhMjU2IjoiZWVlZDQ0
+        ZTg2MmM2Y2NiNTA1MjNlNGJhYTY5MDA1MTlmY2ZkN2NjODhmMjhhYTBiYTA1
+        NGE3OTVkODY1NzIwMSIsInNoYTM4NCI6ImQ0MzFmYWEyMzUwNWRmMGMzZTRj
+        NzViNGEzNTU0MDRhYjBhYjBjZWZmNzJhMDllOGQ5ZDA0ODZlMDQzN2MzNjU4
+        Yzc0NDg0NDYwZWJiMTAxYzk0OTAzMDIxNjZhNGMzZiIsInNoYTUxMiI6ImUx
+        ZTEyMGRiY2RmNmJiNmFiYjQyMTk2YWEyNTMxMGRlMmQxNDA5YmFhMTMyNzVh
+        ZGI3ZThiZjQ0ZWFjMGQyOTAxZDdkMzU4ODI5NzdhZGI2ZTQzMjQ4MDAwMzAx
+        ZjQwYTg4MGYxNDcxMzI4MGY5ZmYwOGY2YTAyMjY5ZDk1MjkzIiwiYXJ0aWZh
+        Y3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzFmNzRlNmZkLTBlYWMtNDdk
+        My04NzE0LTJmMjAzMTZjMDgzMC8iLCJuYW1lIjoiZG9nIiwiZXBvY2giOiIw
+        IiwidmVyc2lvbiI6IjQuMjMiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2Fy
+        Y2giLCJwa2dJZCI6ImVlZWQ0NGU4NjJjNmNjYjUwNTIzZTRiYWE2OTAwNTE5
+        ZmNmZDdjYzg4ZjI4YWEwYmEwNTRhNzk1ZDg2NTcyMDEiLCJjaGVja3N1bV90
+        eXBlIjoic2hhMjU2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBk
+        b2ciLCJkZXNjcmlwdGlvbiI6IkEgZHVtbXkgcGFja2FnZSBvZiBkb2ciLCJ1
+        cmwiOiJodHRwOi8vdHN0cmFjaG90YS5mZWRvcmFwZW9wbGUub3JnIiwiY2hh
+        bmdlbG9ncyI6W10sImZpbGVzIjpbW251bGwsIi90bXAvIiwiZG9nLnR4dCJd
+        XSwicmVxdWlyZXMiOltdLCJwcm92aWRlcyI6W1siZG9nIiwiRVEiLCIwIiwi
+        NC4yMyIsIjEiLGZhbHNlXV0sImNvbmZsaWN0cyI6W10sIm9ic29sZXRlcyI6
+        W10sInN1Z2dlc3RzIjpbXSwiZW5oYW5jZXMiOltdLCJyZWNvbW1lbmRzIjpb
+        XSwic3VwcGxlbWVudHMiOltdLCJsb2NhdGlvbl9iYXNlIjoiIiwibG9jYXRp
+        b25faHJlZiI6ImRvZy00LjIzLTEubm9hcmNoLnJwbSIsInJwbV9idWlsZGhv
+        c3QiOiJzbXFlLXdzMTUiLCJycG1fZ3JvdXAiOiJJbnRlcm5ldC9BcHBsaWNh
+        dGlvbnMiLCJycG1fbGljZW5zZSI6IkdQTHYyIiwicnBtX3BhY2thZ2VyIjoi
+        IiwicnBtX3NvdXJjZXJwbSI6ImRvZy00LjIzLTEuc3JjLnJwbSIsInJwbV92
+        ZW5kb3IiOiIiLCJycG1faGVhZGVyX3N0YXJ0Ijo4NzIsInJwbV9oZWFkZXJf
+        ZW5kIjoyMjc3LCJpc19tb2R1bGFyIjpmYWxzZSwic2l6ZV9hcmNoaXZlIjoy
+        OTIsInNpemVfaW5zdGFsbGVkIjo0Miwic2l6ZV9wYWNrYWdlIjoyNDIzLCJ0
+        aW1lX2J1aWxkIjoxMzMxODMxMzYxLCJ0aW1lX2ZpbGUiOjE0NTQxMjMzNzN9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2th
+        Z2VzL2Y0MGQ5OGQyLWZlYTQtNGZmNi05NWYxLTY1OGU5YzRlYjc0Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIxLTExLTEyVDEzOjA3OjM1Ljg1NzcyNVoiLCJt
+        ZDUiOm51bGwsInNoYTEiOiJjNzU3MmVjNzRkOTdhOWYxYjEyOTFkMWM5ZDE2
+        MWJiNGMxYzM3YmZkIiwic2hhMjI0IjoiMjkyM2VhNjMwZGNlMzU5ZGMwZDhj
+        MzE5Mzk0YzBhMDIzMmI5ODBhZGQ2ZDE1MjM3YWQyNzg1NTciLCJzaGEyNTYi
+        OiJlZThkYTA5ZTMwNzU5NDM3OGMxMzk1NWE5N2NhNzg2ZTY4NjdjMmIyNDFh
+        ODU5ZGYxZDliMDJmMTM0ZjA2NDUxIiwic2hhMzg0IjoiNjlmNGQ1NDliNjdk
+        ZGJjN2JiNjE5NWZlZjNiNTgxNGI0YmY2OGU3MWZlZGJjZmE4ZGY0ZjZiNTY2
+        ZDNhM2NkMzZhZWQ3MWRkYjE5Y2UwMGE0MDU3NzJhNzExYWEyNmJiIiwic2hh
+        NTEyIjoiMTRkYjI2OTFlMzM5YWI2ZmUxODYwMzQ3OGY3MzE0ZGE1Y2ZhNjZk
+        ZmU2ZTJkMDk0NTE5OGM2MjZlMzJhZGYyZTk2NThjYjAyOTgzOTMyYzk5Mjdm
+        ZTJkOTQxYTVmYTgxMzYzMWNhMDUzZjQxY2Y1MWZlNDg4OTVhMmE3OWZjOTUi
+        LCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOGEyYThkYWUt
+        NWIxNC00NjEzLWFiMWMtMzQ2Y2NiN2NiNDYxLyIsIm5hbWUiOiJjcm93Iiwi
+        ZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuOCIsInJlbGVhc2UiOiIxIiwiYXJj
+        aCI6Im5vYXJjaCIsInBrZ0lkIjoiZWU4ZGEwOWUzMDc1OTQzNzhjMTM5NTVh
+        OTdjYTc4NmU2ODY3YzJiMjQxYTg1OWRmMWQ5YjAyZjEzNGYwNjQ1MSIsImNo
+        ZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJzdW1tYXJ5IjoiQSBkdW1teSBwYWNr
+        YWdlIG9mIGNyb3ciLCJkZXNjcmlwdGlvbiI6IkEgZHVtbXkgcGFja2FnZSBv
+        ZiBjcm93IiwidXJsIjoiaHR0cDovL3RzdHJhY2hvdGEuZmVkb3JhcGVvcGxl
+        Lm9yZyIsImNoYW5nZWxvZ3MiOltdLCJmaWxlcyI6W1tudWxsLCIvdG1wLyIs
+        ImNyb3cudHh0Il1dLCJyZXF1aXJlcyI6W10sInByb3ZpZGVzIjpbWyJjcm93
+        IiwiRVEiLCIwIiwiMC44IiwiMSIsZmFsc2VdXSwiY29uZmxpY3RzIjpbXSwi
+        b2Jzb2xldGVzIjpbXSwic3VnZ2VzdHMiOltdLCJlbmhhbmNlcyI6W10sInJl
+        Y29tbWVuZHMiOltdLCJzdXBwbGVtZW50cyI6W10sImxvY2F0aW9uX2Jhc2Ui
+        OiIiLCJsb2NhdGlvbl9ocmVmIjoiY3Jvdy0wLjgtMS5ub2FyY2gucnBtIiwi
+        cnBtX2J1aWxkaG9zdCI6InNtcWUtd3MxNSIsInJwbV9ncm91cCI6IkludGVy
+        bmV0L0FwcGxpY2F0aW9ucyIsInJwbV9saWNlbnNlIjoiR1BMdjIiLCJycG1f
+        cGFja2FnZXIiOiIiLCJycG1fc291cmNlcnBtIjoiY3Jvdy0wLjgtMS5zcmMu
+        cnBtIiwicnBtX3ZlbmRvciI6IiIsInJwbV9oZWFkZXJfc3RhcnQiOjg3Miwi
+        cnBtX2hlYWRlcl9lbmQiOjIyODksImlzX21vZHVsYXIiOmZhbHNlLCJzaXpl
+        X2FyY2hpdmUiOjI5Niwic2l6ZV9pbnN0YWxsZWQiOjQyLCJzaXplX3BhY2th
+        Z2UiOjI0MzksInRpbWVfYnVpbGQiOjEzMzE4MzEzNzIsInRpbWVfZmlsZSI6
+        MTQ1NDEyMzM3M30seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9ycG0vcGFja2FnZXMvMTJkZGNhNzAtMzRjOS00YjNkLWE2ODktNzNkODYx
+        OGJlNDQ5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMTEtMTJUMTM6MDc6MzUu
+        ODU1NzQ4WiIsIm1kNSI6bnVsbCwic2hhMSI6ImQ1NmNiOWE2ZGRiYTdiODhm
+        ODkwYzJjYWQ0YzcwNTZmOGQ0NDgzNWYiLCJzaGEyMjQiOiI0YWM1MDU3ZGE0
+        OTM1NjM3YmM0YTljNzMxZmIxZjBjNmQyODI5ZjIwZjFiZTAxMzliMjk1M2Uw
+        MCIsInNoYTI1NiI6IjgyZTQ5N2NhM2U3YWZmYjU2ODIzNjJiNTA1MzdhZjI5
+        MGQwYTIwMmU0YWQwMGI2ZWY2MjM1N2EyY2M5ODE5YmEiLCJzaGEzODQiOiIz
+        OGY0MzJmMWYzYmM0OWZjZmJmZTEyNzAxNjBiZWMxYTc5N2MyZjU4YjYwYTE1
+        YjdiMzE3YTkyMDhkZTNiYzdlNTIzYTdmMGY2YjY4NTJmYWQxZDhhNzkwMTY0
+        MTY5ZmYiLCJzaGE1MTIiOiI2MWIzZDE3OTNkNWJkZTMwODhiYzQ5MjgwYjFj
+        ZmYxMGUwZGJkZmNiY2Q5YzllYmMzODI2OTNhZGRkOTljNGRiNWY5YzFhOTEx
+        MzcxNzYxMDlkNTBhYjdlMTM5NmY5MzdlM2IxZmVlY2E3ZjE4MTRhNjZlZWYw
+        NDQ4ZTYyYzhmMyIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
+        cy8xZWQzZTI1OS02NWY4LTQ1ZWYtYWFmYS05M2ZlNmZkZjFiODYvIiwibmFt
+        ZSI6ImNhbWVsIiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMSIsInJlbGVh
+        c2UiOiIxIiwiYXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODJlNDk3Y2EzZTdh
+        ZmZiNTY4MjM2MmI1MDUzN2FmMjkwZDBhMjAyZTRhZDAwYjZlZjYyMzU3YTJj
+        Yzk4MTliYSIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJzdW1tYXJ5Ijoi
+        QSBkdW1teSBwYWNrYWdlIG9mIGNhbWVsIiwiZGVzY3JpcHRpb24iOiJBIGR1
+        bW15IHBhY2thZ2Ugb2YgY2FtZWwiLCJ1cmwiOiJodHRwOi8vdHN0cmFjaG90
+        YS5mZWRvcmFwZW9wbGUub3JnIiwiY2hhbmdlbG9ncyI6W10sImZpbGVzIjpb
+        W251bGwsIi90bXAvIiwiY2FtZWwudHh0Il1dLCJyZXF1aXJlcyI6W10sInBy
+        b3ZpZGVzIjpbWyJjYW1lbCIsIkVRIiwiMCIsIjAuMSIsIjEiLGZhbHNlXV0s
+        ImNvbmZsaWN0cyI6W10sIm9ic29sZXRlcyI6W10sInN1Z2dlc3RzIjpbXSwi
+        ZW5oYW5jZXMiOltdLCJyZWNvbW1lbmRzIjpbXSwic3VwcGxlbWVudHMiOltd
+        LCJsb2NhdGlvbl9iYXNlIjoiIiwibG9jYXRpb25faHJlZiI6ImNhbWVsLTAu
+        MS0xLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0Ijoic21xZS13czE1Iiwi
+        cnBtX2dyb3VwIjoiSW50ZXJuZXQvQXBwbGljYXRpb25zIiwicnBtX2xpY2Vu
+        c2UiOiJHUEx2MiIsInJwbV9wYWNrYWdlciI6IiIsInJwbV9zb3VyY2VycG0i
+        OiJjYW1lbC0wLjEtMS5zcmMucnBtIiwicnBtX3ZlbmRvciI6IiIsInJwbV9o
+        ZWFkZXJfc3RhcnQiOjg3MiwicnBtX2hlYWRlcl9lbmQiOjIyODksImlzX21v
+        ZHVsYXIiOmZhbHNlLCJzaXplX2FyY2hpdmUiOjI5Niwic2l6ZV9pbnN0YWxs
+        ZWQiOjQyLCJzaXplX3BhY2thZ2UiOjI0MzksInRpbWVfYnVpbGQiOjEzMzE4
+        MzEzNjAsInRpbWVfZmlsZSI6MTQ1NDEyMzM3M30seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvZjgxNzYzZTYtOGM1
+        YS00YmI5LWFlZGUtYThhZGJkOGQ0N2U4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTJUMTM6MDc6MzUuODUzODMzWiIsIm1kNSI6bnVsbCwic2hhMSI6
+        ImFhMTdlMGYzMzQ2ZDE3M2IzOGE5YmRmYjVlNGY1OTlhNjRhZmEwNjEiLCJz
+        aGEyMjQiOiI2ZTIxMjg5MzliZDMwN2IwNDljNDk4ZjBkMmEzOWY3NWUxNDc4
+        YTUwNTE0N2E4ZGRhMGM5MTI2YiIsInNoYTI1NiI6IjQzZTc3YWRiN2Y1MWI1
+        NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJmMzU5ODJhYjVhZTJiMjk3ODQ4
+        NjIzOWYiLCJzaGEzODQiOiIwN2ViMmQ2OThlZWMyNjgzOThiYzQ2YmRlNDM0
+        NzJjOGEzZGFmOTgyNThmODYyNzIwYWVmYzBmZTQ0NzU2OWI3NTNmYmYwYzVk
+        NDMxYjg4MDhlN2ZjYmJiZmE1OTc3NmMiLCJzaGE1MTIiOiJiZDk1ZWFjM2Vm
+        ZWY3NGQ3NTZlYTc0NWE2OTRjYThkYTI2NzIwNjExNmI5ZTM3ODdjODM3YjE2
+        OTczNDNkOTI4N2M3ZjM2ZTE5ZGM1MGJmYWQ4ZWRmOTk1MjExYjU1YzNkMDE0
+        M2I2NzM3YmEwMmYyZWJkOWI5NjQ1NDA3YWIwOSIsImFydGlmYWN0IjoiL3B1
+        bHAvYXBpL3YzL2FydGlmYWN0cy9iMGIzOTNmOS01ODE2LTQ2M2YtOWQ0MC1j
+        NWM1YjI4MTFkNWUvIiwibmFtZSI6ImNhdCIsImVwb2NoIjoiMCIsInZlcnNp
+        b24iOiIxLjAiLCJyZWxlYXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJ
+        ZCI6IjQzZTc3YWRiN2Y1MWI1NTQyYjgxMzAyNGE4ZWUzZTQ3NzE3NWMxNDJm
+        MzU5ODJhYjVhZTJiMjk3ODQ4NjIzOWYiLCJjaGVja3N1bV90eXBlIjoic2hh
+        MjU2Iiwic3VtbWFyeSI6IkEgZHVtbXkgcGFja2FnZSBvZiBjYXQiLCJkZXNj
+        cmlwdGlvbiI6IkEgZHVtbXkgcGFja2FnZSBvZiBjYXQiLCJ1cmwiOiJodHRw
+        Oi8vdHN0cmFjaG90YS5mZWRvcmFwZW9wbGUub3JnIiwiY2hhbmdlbG9ncyI6
+        W10sImZpbGVzIjpbW251bGwsIi90bXAvIiwiY2F0LnR4dCJdXSwicmVxdWly
+        ZXMiOltdLCJwcm92aWRlcyI6W1siY2F0IiwiRVEiLCIwIiwiMS4wIiwiMSIs
+        ZmFsc2VdXSwiY29uZmxpY3RzIjpbXSwib2Jzb2xldGVzIjpbXSwic3VnZ2Vz
+        dHMiOltdLCJlbmhhbmNlcyI6W10sInJlY29tbWVuZHMiOltdLCJzdXBwbGVt
+        ZW50cyI6W10sImxvY2F0aW9uX2Jhc2UiOiIiLCJsb2NhdGlvbl9ocmVmIjoi
+        Y2F0LTEuMC0xLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0Ijoic21xZS13
+        czE1IiwicnBtX2dyb3VwIjoiSW50ZXJuZXQvQXBwbGljYXRpb25zIiwicnBt
+        X2xpY2Vuc2UiOiJHUEx2MiIsInJwbV9wYWNrYWdlciI6IiIsInJwbV9zb3Vy
+        Y2VycG0iOiJjYXQtMS4wLTEuc3JjLnJwbSIsInJwbV92ZW5kb3IiOiIiLCJy
+        cG1faGVhZGVyX3N0YXJ0Ijo4NzIsInJwbV9oZWFkZXJfZW5kIjoyMjczLCJp
+        c19tb2R1bGFyIjpmYWxzZSwic2l6ZV9hcmNoaXZlIjoyOTIsInNpemVfaW5z
+        dGFsbGVkIjo0Miwic2l6ZV9wYWNrYWdlIjoyNDIwLCJ0aW1lX2J1aWxkIjox
+        MzMxODMxMzYyLCJ0aW1lX2ZpbGUiOjE0NTQxMjMzNzN9LHsicHVscF9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzkyMTE4YWYy
+        LThlZWYtNDI3ZS04YTFmLWU5Njk2ZjY0ZTU3My8iLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDIxLTExLTEyVDEzOjA3OjM1Ljg1MTg5OFoiLCJtZDUiOm51bGwsInNo
+        YTEiOiI5MGEwNGRlMDY3NTRhMmMzZjE2ZWYyNTE3NWY2NWMyYTM1ZGY5MWQw
+        Iiwic2hhMjI0IjoiMGZjNTBiNTFkYjZhZDVjYWU5N2ExYTM1N2FlYjE4Yzg0
+        NjM5NzNhMjM0NmE0NTU4NDcxYjY0Y2UiLCJzaGEyNTYiOiI5YjNkMjJkMDUx
+        ODc4MTBkODUyMWQ5OWNhMjQ4MzIzMmU3ZGE4MDA4NzY5MWU1YzFmOGZhMTA2
+        YTI1MTE4YmRmIiwic2hhMzg0IjoiYWFlNDBmOTM3NGFiOTUzOTNjMjJhNTIx
+        ZTBkNDRhZGU4MGIwZGYxOGJmNTgyNjNjZTEwYzRhZmVhNDI5ODk3N2VmMmVm
+        YTQxODFiMTk2MTNhZjIzODRiOWE2YWI5ZDdhIiwic2hhNTEyIjoiNzlmMTU0
+        ZDlmZGI3MjZlOTUzNzk1OGYxOWY1YTg0NTg5ODk0NWY1M2EyNmFmYTM5NGYw
+        YzE3ZjI4N2JkZDc1MWNhZmIwMGYxMzM3YzQ2NGRkYmI5NTZkZDEzYTExZWVh
+        NTdhMTJjMmIxYTExMGU5NmJhNTUwM2MxMDgxMTQxNGIiLCJhcnRpZmFjdCI6
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZDdlZmI2ZjEtYzc4Ny00ZGY5LThj
+        NGMtNGIxMTAzZTUxODVjLyIsIm5hbWUiOiJjb2NrYXRlZWwiLCJlcG9jaCI6
+        IjAiLCJ2ZXJzaW9uIjoiMy4xIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9h
+        cmNoIiwicGtnSWQiOiI5YjNkMjJkMDUxODc4MTBkODUyMWQ5OWNhMjQ4MzIz
+        MmU3ZGE4MDA4NzY5MWU1YzFmOGZhMTA2YTI1MTE4YmRmIiwiY2hlY2tzdW1f
+        dHlwZSI6InNoYTI1NiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Y29ja2F0ZWVsIiwiZGVzY3JpcHRpb24iOiJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Y29ja2F0ZWVsIiwidXJsIjoiaHR0cDovL3RzdHJhY2hvdGEuZmVkb3JhcGVv
+        cGxlLm9yZyIsImNoYW5nZWxvZ3MiOltdLCJmaWxlcyI6W1tudWxsLCIvdG1w
+        LyIsImNvY2thdGVlbC50eHQiXV0sInJlcXVpcmVzIjpbWyJ3b2xmIixudWxs
+        LG51bGwsbnVsbCxudWxsLGZhbHNlXV0sInByb3ZpZGVzIjpbWyJjb2NrYXRl
+        ZWwiLCJFUSIsIjAiLCIzLjEiLCIxIixmYWxzZV1dLCJjb25mbGljdHMiOltd
+        LCJvYnNvbGV0ZXMiOltdLCJzdWdnZXN0cyI6W10sImVuaGFuY2VzIjpbXSwi
+        cmVjb21tZW5kcyI6W10sInN1cHBsZW1lbnRzIjpbXSwibG9jYXRpb25fYmFz
+        ZSI6IiIsImxvY2F0aW9uX2hyZWYiOiJjb2NrYXRlZWwtMy4xLTEubm9hcmNo
+        LnJwbSIsInJwbV9idWlsZGhvc3QiOiJzbXFlLXdzMTUiLCJycG1fZ3JvdXAi
+        OiJJbnRlcm5ldC9BcHBsaWNhdGlvbnMiLCJycG1fbGljZW5zZSI6IkdQTHYy
+        IiwicnBtX3BhY2thZ2VyIjoiIiwicnBtX3NvdXJjZXJwbSI6ImNvY2thdGVl
+        bC0zLjEtMS5zcmMucnBtIiwicnBtX3ZlbmRvciI6IiIsInJwbV9oZWFkZXJf
+        c3RhcnQiOjg3MiwicnBtX2hlYWRlcl9lbmQiOjIzMjEsImlzX21vZHVsYXIi
+        OmZhbHNlLCJzaXplX2FyY2hpdmUiOjMwMCwic2l6ZV9pbnN0YWxsZWQiOjQy
+        LCJzaXplX3BhY2thZ2UiOjI0NzYsInRpbWVfYnVpbGQiOjEzMzE4MzEzNzQs
+        InRpbWVfZmlsZSI6MTQ1NDEyMzM3M30seyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvM2YxZDQ0YmMtYTExMy00NDJi
+        LWIxZjgtMjBkZmI3NzJmZjZmLyIsInB1bHBfY3JlYXRlZCI6IjIwMjEtMTEt
+        MTJUMTM6MDc6MzUuODQ5OTkzWiIsIm1kNSI6bnVsbCwic2hhMSI6IjRlODBj
+        MWNhOTdjZTYwY2VkZjM3OGRhMDhiNzQ4M2I3ZWNkOWMyYzAiLCJzaGEyMjQi
+        OiIwM2E1NDI1ZDdmZjdlOWNiODc1MDIzNGVjYzRhOTNlNzFjNzQ5MjNlYzgy
+        ZDg0MTQyNTQxZmMxYiIsInNoYTI1NiI6IjIxODlhYzRiZjA1OWY5OGE4ZDQ4
+        MTM2ZWI3MmI0NjQxNWYzYWEyNjMwMjY0NDNlYmQ4ODc5ZDQxNWVhY2FmNDIi
+        LCJzaGEzODQiOiIzMTBiMDU5MDliMjIwYjg3NjAzZDBmN2U4ZmJiYThmMzFm
+        Nzk3ODNlYzA2ODY0ZWY0ODcwOTU2MTc4YjkxMzVjZjM3MTI0NTI1ZTJjOWFj
+        YmNkMzQ3YmEwYWQ2YzJhZDgiLCJzaGE1MTIiOiI2Nzg3YjQzNDU4MWVmZjVh
+        OTI1NjMwOTk0MjllYmIxMmEyMzYxMzgyYTFmNDBmNjdiOTc3NmRkZTg2ZjZl
+        MDBiZjFjNWQ3MDM3YjA5N2YxOGViZmI1YjkxZDRjYTQ5ZTUyNDNkYTBlNzkw
+        Zjg3MmM5NjM4ZTQ1N2RiNGJhNGE1MyIsImFydGlmYWN0IjoiL3B1bHAvYXBp
+        L3YzL2FydGlmYWN0cy82OTRkMTE0NC1iODY2LTQ2ZDQtOTg4NS03MmUzNzFl
+        NzNiNjgvIiwibmFtZSI6ImNoZWV0YWgiLCJlcG9jaCI6IjAiLCJ2ZXJzaW9u
+        IjoiMS4yNS4zIiwicmVsZWFzZSI6IjUiLCJhcmNoIjoibm9hcmNoIiwicGtn
+        SWQiOiIyMTg5YWM0YmYwNTlmOThhOGQ0ODEzNmViNzJiNDY0MTVmM2FhMjYz
+        MDI2NDQzZWJkODg3OWQ0MTVlYWNhZjQyIiwiY2hlY2tzdW1fdHlwZSI6InNo
+        YTI1NiIsInN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIs
+        ImRlc2NyaXB0aW9uIjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCJ1
+        cmwiOiJodHRwOi8vdHN0cmFjaG90YS5mZWRvcmFwZW9wbGUub3JnIiwiY2hh
+        bmdlbG9ncyI6W10sImZpbGVzIjpbW251bGwsIi90bXAvIiwiY2hlZXRhaC50
+        eHQiXV0sInJlcXVpcmVzIjpbWyJ0cm91dCIsbnVsbCxudWxsLG51bGwsbnVs
+        bCxmYWxzZV1dLCJwcm92aWRlcyI6W1siY2hlZXRhaCIsIkVRIiwiMCIsIjEu
+        MjUuMyIsIjUiLGZhbHNlXV0sImNvbmZsaWN0cyI6W10sIm9ic29sZXRlcyI6
+        W10sInN1Z2dlc3RzIjpbXSwiZW5oYW5jZXMiOltdLCJyZWNvbW1lbmRzIjpb
+        XSwic3VwcGxlbWVudHMiOltdLCJsb2NhdGlvbl9iYXNlIjoiIiwibG9jYXRp
+        b25faHJlZiI6ImNoZWV0YWgtMS4yNS4zLTUubm9hcmNoLnJwbSIsInJwbV9i
+        dWlsZGhvc3QiOiJzbXFlLXdzMTUiLCJycG1fZ3JvdXAiOiJJbnRlcm5ldC9B
+        cHBsaWNhdGlvbnMiLCJycG1fbGljZW5zZSI6IkdQTHYyIiwicnBtX3BhY2th
+        Z2VyIjoiIiwicnBtX3NvdXJjZXJwbSI6ImNoZWV0YWgtMS4yNS4zLTUuc3Jj
+        LnJwbSIsInJwbV92ZW5kb3IiOiIiLCJycG1faGVhZGVyX3N0YXJ0Ijo4NzIs
+        InJwbV9oZWFkZXJfZW5kIjoyMzIxLCJpc19tb2R1bGFyIjpmYWxzZSwic2l6
+        ZV9hcmNoaXZlIjoyOTYsInNpemVfaW5zdGFsbGVkIjo0Miwic2l6ZV9wYWNr
+        YWdlIjoyNDcyLCJ0aW1lX2J1aWxkIjoxMzMxODMxMzY3LCJ0aW1lX2ZpbGUi
+        OjE0NTQxMjMzNzN9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvcnBtL3BhY2thZ2VzL2JkMzVhYmUxLWUwMTUtNDY0Mi1iZGY3LWIxMWE0
+        YjRjOGMyYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTEyVDEzOjA3OjM1
+        Ljg0ODA4N1oiLCJtZDUiOm51bGwsInNoYTEiOiI3MTRjN2U1NTM4MmJkZTY2
+        OWQ2OWJiOThkMjk5ZTk2OTI3NDg5ODUwIiwic2hhMjI0IjoiODg0MGIzYmZh
+        YmI1MDcwODIyYWQyM2RjMzRmNzI4YzA5MjMwMjMzYjFjYzJiYWNhMDYzMWE4
+        MjMiLCJzaGEyNTYiOiJiMzgxMDIyYzRmYTYzY2FhYTg0MDc3OGE5YzM5ODY0
+        Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1ZTlkYWZmIiwic2hhMzg0Ijoi
+        NmJmNjVmMWRjNTBjMjY1OGFjNTY2MjYxYTAwMmY1MjFlZGVkYzZiYmU0OWNl
+        YmNiMjA3NjM5ZjczN2IxYTAxMWVjZDU0YTA4YzQ2OTc4NGE2OTM4MzAzZWVj
+        NDE3M2RjIiwic2hhNTEyIjoiY2U0MzY1NGQ2ZjcwZmY2MDU2ZmY1ZmMzMzc1
+        YTUxYTZlMDFlODZlNDY1OTdhY2UwMDNjNTA5MWY4NGU2NThlNWJjNTYzNzc2
+        MGRjMTg1MWVhYWY2NWE4ODk0MDQxZjkwNDQ3Y2M1ZDI5Mzc4YTQ5YWIwNmQ3
+        ZGU0M2M5ODVlOGMiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFj
+        dHMvNjUxZjc0NTItYjc1Yy00MzNhLTg4MjEtNThmMDdjNDg3YjU4LyIsIm5h
+        bWUiOiJjb3ciLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMi4yIiwicmVsZWFz
+        ZSI6IjMiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiJiMzgxMDIyYzRmYTYz
+        Y2FhYTg0MDc3OGE5YzM5ODY0Zjg1YTM3MjI1M2M5NDE1NTU5NWJmMDIzYWY1
+        ZTlkYWZmIiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiIsInN1bW1hcnkiOiJB
+        IGR1bW15IHBhY2thZ2Ugb2YgY293IiwiZGVzY3JpcHRpb24iOiJBIGR1bW15
+        IHBhY2thZ2Ugb2YgY293IiwidXJsIjoiaHR0cDovL3RzdHJhY2hvdGEuZmVk
+        b3JhcGVvcGxlLm9yZyIsImNoYW5nZWxvZ3MiOltdLCJmaWxlcyI6W1tudWxs
+        LCIvdG1wLyIsImNvdy50eHQiXV0sInJlcXVpcmVzIjpbXSwicHJvdmlkZXMi
+        OltbImNvdyIsIkVRIiwiMCIsIjIuMiIsIjMiLGZhbHNlXV0sImNvbmZsaWN0
+        cyI6W10sIm9ic29sZXRlcyI6W10sInN1Z2dlc3RzIjpbXSwiZW5oYW5jZXMi
+        OltdLCJyZWNvbW1lbmRzIjpbXSwic3VwcGxlbWVudHMiOltdLCJsb2NhdGlv
+        bl9iYXNlIjoiIiwibG9jYXRpb25faHJlZiI6ImNvdy0yLjItMy5ub2FyY2gu
+        cnBtIiwicnBtX2J1aWxkaG9zdCI6InNtcWUtd3MxNSIsInJwbV9ncm91cCI6
+        IkludGVybmV0L0FwcGxpY2F0aW9ucyIsInJwbV9saWNlbnNlIjoiR1BMdjIi
+        LCJycG1fcGFja2FnZXIiOiIiLCJycG1fc291cmNlcnBtIjoiY293LTIuMi0z
+        LnNyYy5ycG0iLCJycG1fdmVuZG9yIjoiIiwicnBtX2hlYWRlcl9zdGFydCI6
+        ODcyLCJycG1faGVhZGVyX2VuZCI6MjI3MywiaXNfbW9kdWxhciI6ZmFsc2Us
+        InNpemVfYXJjaGl2ZSI6MjkyLCJzaXplX2luc3RhbGxlZCI6NDIsInNpemVf
+        cGFja2FnZSI6MjQyMCwidGltZV9idWlsZCI6MTMzMTgzMTM2MywidGltZV9m
+        aWxlIjoxNDU0MTIzMzczfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L3JwbS9wYWNrYWdlcy85Y2Y5Y2YzYi0zMzEwLTRlZTQtOWI0ZC00
+        NmFlYmNkMjA1NTAvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xMlQxMzow
+        NzozNS44NDU4OTdaIiwibWQ1IjpudWxsLCJzaGExIjoiN2FmZGEzODRjMTM1
+        ZGM1MmI3NGNlOWM1NjZiZjEwZWY3NDI2MjEzMyIsInNoYTIyNCI6ImZiMjM5
+        YjBjYWJlOTAzMDFlNzUzMzYzNjE3OGQ4YzU5MTBhOGJiODQyMmViZjQ5OTRk
+        YmQzOTNmIiwic2hhMjU2IjoiNWFhOGIwZWIxMGE5NzRhMDI2MzlmZmVhN2Mx
+        MGQ3ZGFiOTNmODJjNGQwOGMzMmIwMGI1Njc3ZTYzOGZkNGRhNiIsInNoYTM4
+        NCI6ImZhYTE4NWEwODY2YTkyOTUwM2VkMDdjYjE3NTlkZDczMjJkZjE4MjJl
+        NzRkMTE5NmY5OGU1MmIwMjNhYTU5ZmQ5MGU3YWY5YmE4MTQ1NDk4ZGQ5NmY4
+        MmU2YmY4YTI3YSIsInNoYTUxMiI6IjZmM2VkZjVmZjg2OTQ3ZjczNGUwMDI2
+        OGVhMTNlZDZjODNhYWQ0ZThlNjBlYjYyN2E2YzM4MjYzNWJhMTE3ODY3OGE3
+        MDQ2YTE4ZDRhMmY2MGRlOGJhM2NjZWU3NGIwZWQwNWNhYTAxOTMwMDkyMjhk
+        OTY4OTNlMDRjNjMzODUwIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0
+        aWZhY3RzLzk2YmZmMjk3LWNhYWItNDMyZC1iNTYwLTRlYmJkMWYyMTEwOS8i
+        LCJuYW1lIjoiY2hpbXBhbnplZSIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIw
+        LjIxIiwicmVsZWFzZSI6IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI1
+        YWE4YjBlYjEwYTk3NGEwMjYzOWZmZWE3YzEwZDdkYWI5M2Y4MmM0ZDA4YzMy
+        YjAwYjU2NzdlNjM4ZmQ0ZGE2IiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiIs
+        InN1bW1hcnkiOiJBIGR1bW15IHBhY2thZ2Ugb2YgY2hpbXBhbnplZSIsImRl
+        c2NyaXB0aW9uIjoiQSBkdW1teSBwYWNrYWdlIG9mIGNoaW1wYW56ZWUiLCJ1
+        cmwiOiJodHRwOi8vdHN0cmFjaG90YS5mZWRvcmFwZW9wbGUub3JnIiwiY2hh
+        bmdlbG9ncyI6W10sImZpbGVzIjpbW251bGwsIi90bXAvIiwiY2hpbXBhbnpl
+        ZS50eHQiXV0sInJlcXVpcmVzIjpbWyJzcXVpcnJlbCIsbnVsbCxudWxsLG51
+        bGwsbnVsbCxmYWxzZV0sWyJ3YWxydXMiLG51bGwsbnVsbCxudWxsLG51bGws
+        ZmFsc2VdXSwicHJvdmlkZXMiOltbImNoaW1wYW56ZWUiLCJFUSIsIjAiLCIw
+        LjIxIiwiMSIsZmFsc2VdXSwiY29uZmxpY3RzIjpbXSwib2Jzb2xldGVzIjpb
+        XSwic3VnZ2VzdHMiOltdLCJlbmhhbmNlcyI6W10sInJlY29tbWVuZHMiOltd
+        LCJzdXBwbGVtZW50cyI6W10sImxvY2F0aW9uX2Jhc2UiOiIiLCJsb2NhdGlv
+        bl9ocmVmIjoiY2hpbXBhbnplZS0wLjIxLTEubm9hcmNoLnJwbSIsInJwbV9i
+        dWlsZGhvc3QiOiJzbXFlLXdzMTUiLCJycG1fZ3JvdXAiOiJJbnRlcm5ldC9B
+        cHBsaWNhdGlvbnMiLCJycG1fbGljZW5zZSI6IkdQTHYyIiwicnBtX3BhY2th
+        Z2VyIjoiIiwicnBtX3NvdXJjZXJwbSI6ImNoaW1wYW56ZWUtMC4yMS0xLnNy
+        Yy5ycG0iLCJycG1fdmVuZG9yIjoiIiwicnBtX2hlYWRlcl9zdGFydCI6ODcy
+        LCJycG1faGVhZGVyX2VuZCI6MjM0MSwiaXNfbW9kdWxhciI6ZmFsc2UsInNp
+        emVfYXJjaGl2ZSI6MzAwLCJzaXplX2luc3RhbGxlZCI6NDIsInNpemVfcGFj
+        a2FnZSI6MjQ5NywidGltZV9idWlsZCI6MTMzMTgzMTM2MywidGltZV9maWxl
+        IjoxNDU0MTIzMzczfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L3JwbS9wYWNrYWdlcy80OTg5YWY0Yy1lODc3LTQyNDktOGNlMC0yNWVl
+        YjY5M2QyYTMvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xMlQxMzowNzoz
+        NS44MzQwNDZaIiwibWQ1IjpudWxsLCJzaGExIjoiN2NjODg5NGQ4NDY5NmJm
+        YWMzMjhhMGY3MTA0ZGFlYzdjYmIwZjVjNCIsInNoYTIyNCI6ImE1OWY4NzFh
+        OTBmM2RkODI3YzdjZTM1NmMxOTlmN2MwMmRkZGVhMmU4NTllNmU0MzczNjA5
+        YjM2Iiwic2hhMjU2IjoiN2E4MzFmOWY5MGJmNGQyMTAyNzU3MmNiNTAzZDIw
+        YjcwMmRlOGU4Nzg1YjAyYzAzOTc0NDVjMmU0ODFkODFiMyIsInNoYTM4NCI6
+        IjAyNjI4MzNkNzc1MGE2OTg4MzQ4NjlhZjkzZTgyNTgyZTM5YTA5YzNmMzJj
+        YzExMDBkZmUzYWYwMTA4NTJmMzVkZThhNDM2MGE4NDgzZDZhYjgwZDQwZjE1
+        ZTM2NDRiZiIsInNoYTUxMiI6ImIwYTk3MzA5ZTBhMjkyNTdlODdmYmE0YzZj
+        NjViNTRmYjRjNmFlMzk1NDlmOTI3OWI4YTBjNGZkMzAyNzc1M2M4N2Y4MmY5
+        NzdjY2JiODdmOTdjNWUyNmU4Y2I3ODhkMGQ3MzY1OTc5OWU0YTAxNzc4OTk1
+        YjVjYWUwYTJkNDMyIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
+        Y3RzL2QzZDc5NzVlLWZlNjctNGQ3Yy1iZGRmLTk3MDM5MjhmYmJjMS8iLCJu
+        YW1lIjoiYmVhciIsImVwb2NoIjoiMCIsInZlcnNpb24iOiI0LjEiLCJyZWxl
+        YXNlIjoiMSIsImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjdhODMxZjlmOTBi
+        ZjRkMjEwMjc1NzJjYjUwM2QyMGI3MDJkZThlODc4NWIwMmMwMzk3NDQ1YzJl
+        NDgxZDgxYjMiLCJjaGVja3N1bV90eXBlIjoic2hhMjU2Iiwic3VtbWFyeSI6
+        IkEgZHVtbXkgcGFja2FnZSBvZiBiZWFyIiwiZGVzY3JpcHRpb24iOiJBIGR1
+        bW15IHBhY2thZ2Ugb2YgYmVhciIsInVybCI6Imh0dHA6Ly90c3RyYWNob3Rh
+        LmZlZG9yYXBlb3BsZS5vcmciLCJjaGFuZ2Vsb2dzIjpbXSwiZmlsZXMiOltb
+        bnVsbCwiL3RtcC8iLCJiZWFyLnR4dCJdXSwicmVxdWlyZXMiOltdLCJwcm92
+        aWRlcyI6W1siYmVhciIsIkVRIiwiMCIsIjQuMSIsIjEiLGZhbHNlXV0sImNv
+        bmZsaWN0cyI6W10sIm9ic29sZXRlcyI6W10sInN1Z2dlc3RzIjpbXSwiZW5o
+        YW5jZXMiOltdLCJyZWNvbW1lbmRzIjpbXSwic3VwcGxlbWVudHMiOltdLCJs
+        b2NhdGlvbl9iYXNlIjoiIiwibG9jYXRpb25faHJlZiI6ImJlYXItNC4xLTEu
+        bm9hcmNoLnJwbSIsInJwbV9idWlsZGhvc3QiOiJzbXFlLXdzMTUiLCJycG1f
+        Z3JvdXAiOiJJbnRlcm5ldC9BcHBsaWNhdGlvbnMiLCJycG1fbGljZW5zZSI6
+        IkdQTHYyIiwicnBtX3BhY2thZ2VyIjoiIiwicnBtX3NvdXJjZXJwbSI6ImJl
+        YXItNC4xLTEuc3JjLnJwbSIsInJwbV92ZW5kb3IiOiIiLCJycG1faGVhZGVy
+        X3N0YXJ0Ijo4NzIsInJwbV9oZWFkZXJfZW5kIjoyMjg5LCJpc19tb2R1bGFy
+        IjpmYWxzZSwic2l6ZV9hcmNoaXZlIjoyOTYsInNpemVfaW5zdGFsbGVkIjo0
+        Miwic2l6ZV9wYWNrYWdlIjoyNDM4LCJ0aW1lX2J1aWxkIjoxMzMxODMxMzc0
+        LCJ0aW1lX2ZpbGUiOjE0NTQxMjMzNzN9LHsicHVscF9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2VzLzhjZDMxMDkzLTIzZGUtNDJk
+        OC1hOWRhLWRlZjdhMjQxNGFjZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTEx
+        LTAyVDIwOjA4OjE0LjI3MjQ3MloiLCJtZDUiOm51bGwsInNoYTEiOiI4NTZj
+        ZjNhZmY2Zjc1ZThjNDg3NjFjOTMzYzZmYjMwNzMyYzAzZjFmIiwic2hhMjI0
+        IjoiNTZhZjgwMDRmZTcyZTRhM2JiMzljZGJkMTZiY2I3MDIxYTEzMjc0MTc4
+        OTUxZmFmNjRlMDMzOWQiLCJzaGEyNTYiOiIyYmRmMWNiNzFkOWQzYTc4NWFm
+        MjRmODZiZGIzNWJjZTlmYWUyOWZlYjg2Y2YyYzQ4YWQ1YTJiMzcyNDQxZTAw
+        Iiwic2hhMzg0IjoiMDg1OTkxNDFiNWViNWNkY2JmMTcyOGY2MGVhMWVhOWI0
+        ZmIyNmJlNDkyZmRiNzRjOWYzZWUzYjIzYmRiYzVhZDJjZDU1MzU4ZmQ5N2E1
+        YTFkOTQ2NmU5ZjM0MjZiYjU1Iiwic2hhNTEyIjoiZTUzYmI2NWI1NmFiY2M5
+        MmMwODE5NGUxYWNlYTJhNWJjNTg2NjdmNWJkMDc4NTgxYTkwYTk0NDE3ZmMz
+        YTI0YTg4NGM5MzY1NDhmN2M5NzMyZDFjNDAyYzMwZDg5YzA4YTdiYWU4YzRj
+        YWQ4OGEyODUxMmQ2OThlMzUwNzhjOWEiLCJhcnRpZmFjdCI6Ii9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvNDQxYzcwMTQtNWQ2NC00MGFiLWJlOTYtMDhjMWMw
+        YzQzYzQwLyIsIm5hbWUiOiJjcmVhdGVyZXBvX2MiLCJlcG9jaCI6IjAiLCJ2
+        ZXJzaW9uIjoiMC4xNy4xIiwicmVsZWFzZSI6IjEuZWw3IiwiYXJjaCI6InNy
+        YyIsInBrZ0lkIjoiMmJkZjFjYjcxZDlkM2E3ODVhZjI0Zjg2YmRiMzViY2U5
+        ZmFlMjlmZWI4NmNmMmM0OGFkNWEyYjM3MjQ0MWUwMCIsImNoZWNrc3VtX3R5
+        cGUiOiJzaGEyNTYiLCJzdW1tYXJ5IjoiQ3JlYXRlcyBhIGNvbW1vbiBtZXRh
+        ZGF0YSByZXBvc2l0b3J5IiwiZGVzY3JpcHRpb24iOiJDIGltcGxlbWVudGF0
+        aW9uIG9mIENyZWF0ZXJlcG8uXG5BIHNldCBvZiB1dGlsaXRpZXMgKGNyZWF0
+        ZXJlcG9fYywgbWVyZ2VyZXBvX2MsIG1vZGlmeXJlcG9fYylcbmZvciBnZW5l
+        cmF0aW5nIGEgY29tbW9uIG1ldGFkYXRhIHJlcG9zaXRvcnkgZnJvbSBhIGRp
+        cmVjdG9yeSBvZlxucnBtIHBhY2thZ2VzIGFuZCBtYWludGFpbmluZyBpdC4i
+        LCJ1cmwiOiJodHRwczovL2dpdGh1Yi5jb20vcnBtLXNvZnR3YXJlLW1hbmFn
+        ZW1lbnQvY3JlYXRlcmVwb19jIiwiY2hhbmdlbG9ncyI6W1siRXZnZW5pIEdv
+        bG92IC0gMC4xNS4xMC0xIiwxNTg4NTkzNjAwLCItIHVwZGF0ZSB0byB1cHN0
+        cmVhbSAwLjE1LjEwIl0sWyJFdmdlbmkgR29sb3YgLSAwLjE2LjEtMSIsMTYw
+        MTU1MzYwMCwiLSBSZWxlYXNlIGNyZWF0ZXJlcG9fYyAwLjE2LjEiXSxbIkp1
+        c3RpbiBTaGVycmlsbCA8anNoZXJyaWxAcmVkaGF0LmNvbT4gMC4xNi4yLTEi
+        LDE2MDUwOTYwMDAsIiogdXBkYXRlIHRvIDAuMTYuMiJdLFsiSnVzdGluIFNo
+        ZXJyaWxsIDxqc2hlcnJpbEByZWRoYXQuY29tPiAwLjE3LjAtMSIsMTYxMzY0
+        OTYwMCwiLSB1cGRhdGUgdG8gMC4xNy4wIl0sWyJFdmdlbmkgR29sb3YgLSAw
+        LjE3LjEtMSIsMTYxNDc3MjgwMCwiLSBSZWxlYXNlIGNyZWF0ZXJlcG9fYyAw
+        LjE3LjEiXV0sImZpbGVzIjpbWyIiLCIiLCJjcmVhdGVyZXBvX2MtMC4xNy4x
+        LnRhci5neiJdLFsiIiwiIiwiY3JlYXRlcmVwb19jLnNwZWMiXV0sInJlcXVp
+        cmVzIjpbWyJjbWFrZSIsbnVsbCxudWxsLG51bGwsbnVsbCxmYWxzZV0sWyJn
+        Y2MiLG51bGwsbnVsbCxudWxsLG51bGwsZmFsc2VdLFsiYnppcDItZGV2ZWwi
+        LG51bGwsbnVsbCxudWxsLG51bGwsZmFsc2VdLFsiZG94eWdlbiIsbnVsbCxu
+        dWxsLG51bGwsbnVsbCxmYWxzZV0sWyJmaWxlLWRldmVsIixudWxsLG51bGws
+        bnVsbCxudWxsLGZhbHNlXSxbImdsaWIyLWRldmVsIiwiR0UiLCIwIiwiMi4y
+        Mi4wIixudWxsLGZhbHNlXSxbImxpYmN1cmwtZGV2ZWwiLG51bGwsbnVsbCxu
+        dWxsLG51bGwsZmFsc2VdLFsibGlieG1sMi1kZXZlbCIsbnVsbCxudWxsLG51
+        bGwsbnVsbCxmYWxzZV0sWyJvcGVuc3NsLWRldmVsIixudWxsLG51bGwsbnVs
+        bCxudWxsLGZhbHNlXSxbInJwbS1kZXZlbCIsIkdFIiwiMCIsIjQuOC4wIiwi
+        MjgiLGZhbHNlXSxbInNxbGl0ZS1kZXZlbCIsbnVsbCxudWxsLG51bGwsbnVs
+        bCxmYWxzZV0sWyJ4ei1kZXZlbCIsbnVsbCxudWxsLG51bGwsbnVsbCxmYWxz
+        ZV0sWyJ6bGliLWRldmVsIixudWxsLG51bGwsbnVsbCxudWxsLGZhbHNlXSxb
+        ImJhc2gtY29tcGxldGlvbiIsbnVsbCxudWxsLG51bGwsbnVsbCxmYWxzZV0s
+        WyJweXRob24zLWRldmVsIixudWxsLG51bGwsbnVsbCxudWxsLGZhbHNlXV0s
+        InByb3ZpZGVzIjpbXSwiY29uZmxpY3RzIjpbXSwib2Jzb2xldGVzIjpbXSwi
+        c3VnZ2VzdHMiOltdLCJlbmhhbmNlcyI6W10sInJlY29tbWVuZHMiOltdLCJz
+        dXBwbGVtZW50cyI6W10sImxvY2F0aW9uX2Jhc2UiOiIiLCJsb2NhdGlvbl9o
+        cmVmIjoiY3JlYXRlcmVwb19jLTAuMTcuMS0xLmVsNy5zcmMucnBtIiwicnBt
+        X2J1aWxkaG9zdCI6Imtvamkua2F0ZWxsby5vcmciLCJycG1fZ3JvdXAiOiJV
+        bnNwZWNpZmllZCIsInJwbV9saWNlbnNlIjoiR1BMdjIrIiwicnBtX3BhY2th
+        Z2VyIjoiS29qaSIsInJwbV9zb3VyY2VycG0iOiIiLCJycG1fdmVuZG9yIjoi
+        S29qaSIsInJwbV9oZWFkZXJfc3RhcnQiOjE0ODgsInJwbV9oZWFkZXJfZW5k
+        IjozNjY0LCJpc19tb2R1bGFyIjpmYWxzZSwic2l6ZV9hcmNoaXZlIjo1OTk4
+        NzIsInNpemVfaW5zdGFsbGVkIjo1OTk0NzgsInNpemVfcGFja2FnZSI6NjAw
+        NDgyLCJ0aW1lX2J1aWxkIjoxNjE0NzY4OTU4LCJ0aW1lX2ZpbGUiOjE2MzU4
+        ODM2OTR9XX0=
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:11:03 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/e322c6c9-6d28-41f1-8e49-ea4a4930f28a/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvYTI0OGZmNGMtNjNkNy00ZDI3LThhM2YtNDlmNTZkMDQ4
+        OWFkLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:11:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 552e83645b124e96818fea528ef3fb32
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM3NGI1YzE0LTUyNjMtNDI1
+        My04ZTU1LTkyNjJmZmE3MzZhOS8ifQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:11:03 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/374b5c14-5263-4253-8e55-9262ffa736a9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.15.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Nov 2021 16:11:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 75e9328ee29e4623bebfab1a64bf0535
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos7-katello-devel-stable.example.com
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzc0YjVjMTQtNTI2
+        My00MjUzLThlNTUtOTI2MmZmYTczNmE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMTY6MTE6MDMuMzMxODk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1NTJlODM2NDViMTI0ZTk2ODE4
+        ZmVhNTI4ZWYzZmIzMiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE2VDE2OjEx
+        OjAzLjQyODY2MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTZUMTY6MTE6
+        MDMuNjQ2MDI0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy83YmUxMDlhMS1hNTY5LTRkNjYtYTM1Ni05ZDlmNWE5ZDM2
+        MmEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS9lMzIyYzZjOS02ZDI4LTQxZjEtOGU0OS1lYTRhNDkzMGYyOGEvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTMyMmM2YzktNmQyOC00MWYx
+        LThlNDktZWE0YTQ5MzBmMjhhLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 16 Nov 2021 16:11:03 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/content/chunk_upload.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/content/chunk_upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel8.markarth.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Nov 2021 14:31:35 GMT
+      - Tue, 16 Nov 2021 15:58:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -41,21 +41,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f47c30080ced4087ac53ebb375a2a720
+      - 7fc4465fc3db4312baa10dfacd7de6f8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel8.markarth.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:35 GMT
+  recorded_at: Tue, 16 Nov 2021 15:58:25 GMT
 - request:
     method: get
-    uri: https://devel8.markarth.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -76,7 +76,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Nov 2021 14:31:35 GMT
+      - Tue, 16 Nov 2021 15:58:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -94,21 +94,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 528a3ad3eab149e1bf495671be55584b
+      - 94857b8f832e43279ac5f22c50005e7f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel8.markarth.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:35 GMT
+  recorded_at: Tue, 16 Nov 2021 15:58:25 GMT
 - request:
     method: get
-    uri: https://devel8.markarth.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -116,7 +116,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -129,7 +129,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Nov 2021 14:31:35 GMT
+      - Tue, 16 Nov 2021 15:58:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -147,21 +147,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e5c3486f80db418f9c49e71ae529355f
+      - ccf13f1de9304ed29a8690220d74670d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel8.markarth.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:35 GMT
+  recorded_at: Tue, 16 Nov 2021 15:58:25 GMT
 - request:
     method: get
-    uri: https://devel8.markarth.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -169,7 +169,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -182,7 +182,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Nov 2021 14:31:35 GMT
+      - Tue, 16 Nov 2021 15:58:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -200,21 +200,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0bd5f7b2ebc04ef2ac4c2e909140fa30
+      - 42a94de9121e41c7936660ea4eb0e82c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel8.markarth.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:35 GMT
+  recorded_at: Tue, 16 Nov 2021 15:58:25 GMT
 - request:
     method: post
-    uri: https://devel8.markarth.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -228,7 +228,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -241,13 +241,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 03 Nov 2021 14:31:35 GMT
+      - Tue, 16 Nov 2021 15:58:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/893cb501-2f59-4476-a970-fa63278df318/"
+      - "/pulp/api/v3/remotes/file/file/1b60ced2-0886-447d-a835-09fef9622eb0/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -261,32 +261,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7382b60452ad429da17662efc4f271c3
+      - 0cb00cc6757d4a06b522af740d9d200f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel8.markarth.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        ODkzY2I1MDEtMmY1OS00NDc2LWE5NzAtZmE2MzI3OGRmMzE4LyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjEtMTEtMDNUMTQ6MzE6MzUuNTg1ODQ5WiIsIm5hbWUi
+        MWI2MGNlZDItMDg4Ni00NDdkLWE4MzUtMDlmZWY5NjIyZWIwLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjEtMTEtMTZUMTU6NTg6MjUuNjQ5ODMwWiIsIm5hbWUi
         OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwidXJs
         IjoiaHR0cDovL3Rlc3QvdGVzdC8vUFVMUF9NQU5JRkVTVCIsImNhX2NlcnQi
         Om51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1
         ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1bHBfbGFz
-        dF91cGRhdGVkIjoiMjAyMS0xMS0wM1QxNDozMTozNS41ODU4NzFaIiwiZG93
+        dF91cGRhdGVkIjoiMjAyMS0xMS0xNlQxNTo1ODoyNS42NDk4NTRaIiwiZG93
         bmxvYWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpudWxsLCJw
         b2xpY3kiOiJpbW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozMDAuMCwiY29u
         bmVjdF90aW1lb3V0IjpudWxsLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6bnVs
         bCwic29ja19yZWFkX3RpbWVvdXQiOm51bGwsImhlYWRlcnMiOm51bGwsInJh
         dGVfbGltaXQiOm51bGx9
     http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:35 GMT
+  recorded_at: Tue, 16 Nov 2021 15:58:25 GMT
 - request:
     method: post
-    uri: https://devel8.markarth.example.com/pulp/api/v3/repositories/file/file/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -296,7 +296,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -309,13 +309,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 03 Nov 2021 14:31:35 GMT
+      - Tue, 16 Nov 2021 15:58:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/653884b1-c2e0-4b34-a159-7c979103aee9/"
+      - "/pulp/api/v3/repositories/file/file/7d366602-e4d7-4280-8fd6-727059657363/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -329,31 +329,31 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a151e864348448439ea1072940436df2
+      - fde38b4870ec41209510935b2dcf631a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel8.markarth.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS82NTM4ODRiMS1jMmUwLTRiMzQtYTE1OS03Yzk3OTEwM2FlZTkvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyMS0xMS0wM1QxNDozMTozNS43OTk4NTBaIiwi
+        ZmlsZS83ZDM2NjYwMi1lNGQ3LTQyODAtOGZkNi03MjcwNTk2NTczNjMvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyMS0xMS0xNlQxNTo1ODoyNS44OTQ3MzlaIiwi
         dmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlLzY1Mzg4NGIxLWMyZTAtNGIzNC1hMTU5LTdjOTc5MTAzYWVlOS92
+        ZS9maWxlLzdkMzY2NjAyLWU0ZDctNDI4MC04ZmQ2LTcyNzA1OTY1NzM2My92
         ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30sImxhdGVzdF92ZXJzaW9uX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS82NTM4
-        ODRiMS1jMmUwLTRiMzQtYTE1OS03Yzk3OTEwM2FlZTkvdmVyc2lvbnMvMC8i
+        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS83ZDM2
+        NjYwMi1lNGQ3LTQyODAtOGZkNi03MjcwNTk2NTczNjMvdmVyc2lvbnMvMC8i
         LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
         cyIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6
         bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1hbmlm
         ZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
     http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:35 GMT
+  recorded_at: Tue, 16 Nov 2021 15:58:25 GMT
 - request:
     method: get
-    uri: https://devel8.markarth.example.com/pulp/api/v3/content/file/files/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/content/file/files/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -361,7 +361,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -374,7 +374,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Nov 2021 14:31:36 GMT
+      - Tue, 16 Nov 2021 15:58:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -392,21 +392,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5d05b7392fb249a292079e5b7d5b5f3e
+      - cd0904635d384e4095b004e234716d8e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel8.markarth.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:36 GMT
+  recorded_at: Tue, 16 Nov 2021 15:58:26 GMT
 - request:
     method: post
-    uri: https://devel8.markarth.example.com/pulp/api/v3/uploads/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/uploads/
     body:
       encoding: UTF-8
       base64_string: 'eyJzaXplIjo3NDB9
@@ -429,13 +429,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 03 Nov 2021 14:31:36 GMT
+      - Tue, 16 Nov 2021 15:58:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/uploads/e98d8f1e-07bf-4d47-93b0-33c5ecddd2cb/"
+      - "/pulp/api/v3/uploads/08583e83-4209-49e8-9952-4cae4f84e281/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -449,22 +449,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 841d179e73c64fa0b69736a8039eef5d
+      - a803e5616a024857ad865f7fa4336b43
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel8.markarth.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9lOThkOGYxZS0w
-        N2JmLTRkNDctOTNiMC0zM2M1ZWNkZGQyY2IvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyMS0xMS0wM1QxNDozMTozNi4xMDkyMjdaIiwic2l6ZSI6NzQwfQ==
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wODU4M2U4My00
+        MjA5LTQ5ZTgtOTk1Mi00Y2FlNGY4NGUyODEvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMS0xMS0xNlQxNTo1ODoyNi4xNDgzNjVaIiwic2l6ZSI6NzQwfQ==
     http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:36 GMT
+  recorded_at: Tue, 16 Nov 2021 15:58:26 GMT
 - request:
     method: get
-    uri: https://devel8.markarth.example.com/pulp/api/v3/content/file/files/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/file/file/653884b1-c2e0-4b34-a159-7c979103aee9/versions/1/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/content/file/files/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/file/file/7d366602-e4d7-4280-8fd6-727059657363/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -472,7 +472,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -485,7 +485,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Nov 2021 14:31:46 GMT
+      - Tue, 16 Nov 2021 15:58:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -501,22 +501,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3e078b2ce6f44c2db5de263a323ec5bf
+      - f3da9c42f34347c3a1943e708c5392c2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel8.markarth.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '489'
+      - '488'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
-        ZmlsZXMvMTI5YTYzNzgtNWNhYy00NWRkLWFhMWItMTcwMDEwODE4YzNjLyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjEtMTEtMDNUMTQ6MzE6MzcuNzg0Mjk1WiIs
-        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy81ZWMwYmZiMy1m
-        YmRiLTRjZGYtOGNjNS1hMjkxM2QyYTlhOTMvIiwicmVsYXRpdmVfcGF0aCI6
+        ZmlsZXMvZTlhOTljN2MtMDBkZC00MTZjLTg4MTUtOGE0MTU0MDdlMjBhLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjEtMTEtMTZUMTU6NTg6MjcuOTU4NzIxWiIs
+        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85M2ZiNTY5NC0w
+        OTMxLTQ0NjgtOWQ0Ni0wMzNjNDgwZmQ1ZWUvIiwicmVsYXRpdmVfcGF0aCI6
         InRlc3RfZXJyYXR1bS5qc29uIiwibWQ1IjpudWxsLCJzaGExIjoiNjA5ODg1
         NzE1ZmQ4ZDZhNzA3ZjE4ZmM1NTlkNjFiOGJkZWU3MTgwZSIsInNoYTIyNCI6
         ImUyOTMxZjAzNjY1NmJhNmQwMTdiNTA2YjhmZWM1N2I4N2U1N2VlYzI3YWVh
@@ -529,10 +529,10 @@ http_interactions:
         ODQxYTU0MTc4MjI0ODdmZGUyMjVlNjIyZmQ0ZjljZGYzMzM4NDVkOTAxNDAw
         Nzg2M2E5OWExOWE3ZjQ5MDJlZTI4In1dfQ==
     http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:46 GMT
+  recorded_at: Tue, 16 Nov 2021 15:58:38 GMT
 - request:
     method: delete
-    uri: https://devel8.markarth.example.com/pulp/api/v3/remotes/file/file/893cb501-2f59-4476-a970-fa63278df318/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/1b60ced2-0886-447d-a835-09fef9622eb0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -540,7 +540,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -553,7 +553,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 03 Nov 2021 14:31:46 GMT
+      - Tue, 16 Nov 2021 15:58:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -571,21 +571,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0ff1258d46124f51b8537a45bedec0cb
+      - 0de5bbaa19cc41ccbd98e97e12b9a85b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel8.markarth.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FlNDhkOTljLTY4NTctNDBi
-        OC1hM2ZkLTg3ZTVhNmE4YjZhOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZiZjM5ZWI0LTEyNGYtNGFh
+        YS04YTQ2LThlYWEwZDM2YjExZC8ifQ==
     http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:46 GMT
+  recorded_at: Tue, 16 Nov 2021 15:58:39 GMT
 - request:
     method: get
-    uri: https://devel8.markarth.example.com/pulp/api/v3/tasks/ae48d99c-6857-40b8-a3fd-87e5a6a8b6a8/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/fbf39eb4-124f-4aaa-8a46-8eaa0d36b11d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -606,7 +606,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Nov 2021 14:31:46 GMT
+      - Tue, 16 Nov 2021 15:58:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -622,35 +622,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 00ac3b90e96442a49e87a05b77ea215b
+      - 25a3015e48e04742a9e4c2c5cda7dac0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel8.markarth.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '373'
+      - '372'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWU0OGQ5OWMtNjg1
-        Ny00MGI4LWEzZmQtODdlNWE2YThiNmE4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTEtMDNUMTQ6MzE6NDYuNzY3MTgwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmJmMzllYjQtMTI0
+        Zi00YWFhLThhNDYtOGVhYTBkMzZiMTFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMTU6NTg6MzkuMDMyOTE0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIwZmYxMjU4ZDQ2MTI0ZjUxYjg1MzdhNDVi
-        ZWRlYzBjYiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTAzVDE0OjMxOjQ2Ljgx
-        OTkzMloiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMDNUMTQ6MzE6NDYuODY4
-        MTUyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iMGUwODY0NC02YzM3LTQ0ZDEtOGI4OC1jYTlkZGEyYTc5YTIvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwZGU1YmJhYTE5Y2M0MWNjYmQ5OGU5N2Ux
+        MmI5YTg1YiIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE2VDE1OjU4OjM5LjEw
+        ODQ2NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTZUMTU6NTg6MzkuMTYz
+        MTU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy83YTZkNjUzMy1mNGRlLTQ1YmYtYTc4Zi1lMjk2MzJhZjEzYjgvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvODkzY2I1MDEtMmY1OS00NDc2LWE5
-        NzAtZmE2MzI3OGRmMzE4LyJdfQ==
+        cGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvMWI2MGNlZDItMDg4Ni00NDdkLWE4
+        MzUtMDlmZWY5NjIyZWIwLyJdfQ==
     http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:46 GMT
+  recorded_at: Tue, 16 Nov 2021 15:58:39 GMT
 - request:
     method: delete
-    uri: https://devel8.markarth.example.com/pulp/api/v3/distributions/file/file/9aa12ed6-2094-4e23-b142-b7f2c90212ee/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/4f47ada6-98f0-4b1a-955b-ef13a22dd12a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -658,7 +658,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -671,7 +671,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 03 Nov 2021 14:31:47 GMT
+      - Tue, 16 Nov 2021 15:58:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -689,21 +689,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 637f271f158548cb90bf1d7e06e28c77
+      - 758ebfba34f342678e765dabda3ff4d5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel8.markarth.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg5NGE2ZjdkLWVlMTItNDky
-        My05MWI5LTg2MWIyOTI3NmVlZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UzZDY5MWZhLTNlYjctNDlk
+        Ny04ODk4LTBlMzRjZjM3MjJmMS8ifQ==
     http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:47 GMT
+  recorded_at: Tue, 16 Nov 2021 15:58:39 GMT
 - request:
     method: delete
-    uri: https://devel8.markarth.example.com/pulp/api/v3/repositories/file/file/653884b1-c2e0-4b34-a159-7c979103aee9/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/7d366602-e4d7-4280-8fd6-727059657363/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -711,7 +711,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -724,7 +724,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 03 Nov 2021 14:31:47 GMT
+      - Tue, 16 Nov 2021 15:58:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -742,21 +742,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ea975c6a3dc74963b39dd21363969684
+      - 3f5b7eee31174d65a4e4208b80f9cd00
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel8.markarth.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U1YjdhNTk3LWRmNGYtNDM4
-        Ny05ZmMyLThiODcyYmYyZDkyOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYxOWI1NDgwLTc5ZDEtNGIx
+        NC1iNjAyLWRiOTgwNWFlYzM2ZS8ifQ==
     http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:47 GMT
+  recorded_at: Tue, 16 Nov 2021 15:58:39 GMT
 - request:
     method: get
-    uri: https://devel8.markarth.example.com/pulp/api/v3/tasks/e5b7a597-df4f-4387-9fc2-8b872bf2d928/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/619b5480-79d1-4b14-b602-db9805aec36e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -777,7 +777,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Nov 2021 14:31:47 GMT
+      - Tue, 16 Nov 2021 15:58:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -793,88 +793,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 29d17b3cd28b48a4adb12ef3af4c4904
+      - c6cd2e1e30fb4011b1f8ff4ee0c1d174
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel8.markarth.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
       Content-Length:
-      - '375'
+      - '374'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTViN2E1OTctZGY0
-        Zi00Mzg3LTlmYzItOGI4NzJiZjJkOTI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTEtMDNUMTQ6MzE6NDcuMDg1MTExWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjE5YjU0ODAtNzlk
+        MS00YjE0LWI2MDItZGI5ODA1YWVjMzZlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjEtMTEtMTZUMTU6NTg6MzkuNDYwNjQyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJlYTk3NWM2YTNkYzc0OTYzYjM5ZGQyMTM2
-        Mzk2OTY4NCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTAzVDE0OjMxOjQ3LjE1
-        MjgxM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMDNUMTQ6MzE6NDcuMjYz
-        Njg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iMGUwODY0NC02YzM3LTQ0ZDEtOGI4OC1jYTlkZGEyYTc5YTIvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIzZjViN2VlZTMxMTc0ZDY1YTRlNDIwOGI4
+        MGY5Y2QwMCIsInN0YXJ0ZWRfYXQiOiIyMDIxLTExLTE2VDE1OjU4OjM5LjUy
+        NTA5NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjEtMTEtMTZUMTU6NTg6MzkuNjY1
+        NDkxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9hNWQ0MGI3YS1kYzgzLTQ3N2EtOTg3Yy0zOTM3NjgzYzgwYzcvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS82NTM4ODRiMS1jMmUwLTRi
-        MzQtYTE1OS03Yzk3OTEwM2FlZTkvIl19
+        cGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS83ZDM2NjYwMi1lNGQ3LTQy
+        ODAtOGZkNi03MjcwNTk2NTczNjMvIl19
     http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:47 GMT
+  recorded_at: Tue, 16 Nov 2021 15:58:39 GMT
 - request:
     method: get
-    uri: https://devel8.markarth.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/0.10.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Nov 2021 14:31:47 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 0b6755098a374dd593d8e098a02cf54a
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel8.markarth.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:47 GMT
-- request:
-    method: get
-    uri: https://devel8.markarth.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -895,7 +842,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Nov 2021 14:31:47 GMT
+      - Tue, 16 Nov 2021 15:58:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -913,21 +860,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f697891b2d20497993c639b2edcfac84
+      - 9e2bc124017941659ceaf6aa68f5d29b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel8.markarth.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:47 GMT
+  recorded_at: Tue, 16 Nov 2021 15:58:40 GMT
 - request:
     method: get
-    uri: https://devel8.markarth.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -935,7 +882,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.8.1/ruby
+      - OpenAPI-Generator/1.10.0/ruby
       Accept:
       - application/json
       Authorization:
@@ -948,7 +895,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 03 Nov 2021 14:31:47 GMT
+      - Tue, 16 Nov 2021 15:58:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -966,74 +913,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d14242c492254b73a92b6231ecd19974
+      - 1418530c83424c0d91bdc374f3f626e9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel8.markarth.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:47 GMT
+  recorded_at: Tue, 16 Nov 2021 15:58:40 GMT
 - request:
     method: get
-    uri: https://devel8.markarth.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/1.9.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Nov 2021 14:31:47 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - f2bff4d8842b4aaa95b42cf782df914e
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel8.markarth.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:47 GMT
-- request:
-    method: get
-    uri: https://devel8.markarth.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1050,497 +944,36 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: Not Found
     headers:
       Date:
-      - Wed, 03 Nov 2021 14:31:47 GMT
+      - Tue, 16 Nov 2021 15:58:40 GMT
       Server:
       - gunicorn
       Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
+      - text/html; charset=UTF-8
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '179'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7bbb5aac39154636b6741afb74e68890
+      - 2f13cca349164fb882ddf6ed628fc445
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 devel8.markarth.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        CjwhZG9jdHlwZSBodG1sPgo8aHRtbCBsYW5nPSJlbiI+CjxoZWFkPgogIDx0
+        aXRsZT5Ob3QgRm91bmQ8L3RpdGxlPgo8L2hlYWQ+Cjxib2R5PgogIDxoMT5O
+        b3QgRm91bmQ8L2gxPjxwPlRoZSByZXF1ZXN0ZWQgcmVzb3VyY2Ugd2FzIG5v
+        dCBmb3VuZCBvbiB0aGlzIHNlcnZlci48L3A+CjwvYm9keT4KPC9odG1sPgo=
     http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:47 GMT
-- request:
-    method: get
-    uri: https://devel8.markarth.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Nov 2021 14:31:47 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - e2ac94df3b2e47b8881860bef7706105
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel8.markarth.example.com
-      Content-Length:
-      - '379'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82ODI5ZDYyMC1mZjkyLTQ3NTEtYTFhMC03MjRjMGY1MTJiN2Mv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0wMlQyMDowMTowNy40NDU3MDNa
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82ODI5ZDYyMC1mZjkyLTQ3NTEtYTFhMC03MjRjMGY1MTJiN2Mv
-        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzY4Mjlk
-        NjIwLWZmOTItNDc1MS1hMWEwLTcyNGMwZjUxMmI3Yy92ZXJzaW9ucy8xLyIs
-        Im5hbWUiOiJ0ZXN0Mi0yOTcyMyIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
-        aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
-        bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
-        cmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3Vt
-        X3R5cGUiOm51bGwsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3Bn
-        Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
-        ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtL2ViZGJjMzAwLWRiYTctNGQ2My05OWQ1LTE1NWQ1ZTEzMzFk
-        ZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTAyVDIwOjAwOjA2LjcyMTM5
-        MloiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtL2ViZGJjMzAwLWRiYTctNGQ2My05OWQ1LTE1NWQ1ZTEzMzFk
-        ZS92ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30sImxhdGVzdF92ZXJzaW9u
-        X2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWJk
-        YmMzMDAtZGJhNy00ZDYzLTk5ZDUtMTU1ZDVlMTMzMWRlL3ZlcnNpb25zLzEv
-        IiwibmFtZSI6InRlc3QtMTMyMTUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0
-        YWluX3JlcG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1
-        Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGws
-        InJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowLCJtZXRhZGF0YV9jaGVja3N1
-        bV90eXBlIjpudWxsLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOm51bGwsImdw
-        Z2NoZWNrIjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEi
-        OmZhbHNlfV19
-    http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:47 GMT
-- request:
-    method: get
-    uri: https://devel8.markarth.example.com/pulp/api/v3/repositories/rpm/rpm/6829d620-ff92-4751-a1a0-724c0f512b7c/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Nov 2021 14:31:47 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 5ce59f3a639e47a1af176d9127259174
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel8.markarth.example.com
-      Content-Length:
-      - '303'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS82ODI5ZDYyMC1mZjkyLTQ3NTEtYTFhMC03MjRjMGY1MTJiN2Mv
-        dmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTAyVDIwOjAx
-        OjE4Ljk1ODc3OFoiLCJudW1iZXIiOjEsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjgyOWQ2MjAtZmY5Mi00NzUx
-        LWExYTAtNzI0YzBmNTEyYjdjLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5wYWNrYWdlIjp7ImNvdW50
-        IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzY4MjlkNjIwLWZmOTItNDc1MS1hMWEwLTcyNGMw
-        ZjUxMmI3Yy92ZXJzaW9ucy8xLyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQi
-        OnsicnBtLnBhY2thZ2UiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0v
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjgyOWQ2MjAtZmY5
-        Mi00NzUxLWExYTAtNzI0YzBmNTEyYjdjL3ZlcnNpb25zLzEvIn19fX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0v
-        NjgyOWQ2MjAtZmY5Mi00NzUxLWExYTAtNzI0YzBmNTEyYjdjL3ZlcnNpb25z
-        LzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0wMlQyMDowMTowNy40NDky
-        NjJaIiwibnVtYmVyIjowLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzY4MjlkNjIwLWZmOTItNDc1MS1hMWEwLTcy
-        NGMwZjUxMmI3Yy8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3Vt
-        bWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7fX19
-        XX0=
-    http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:47 GMT
-- request:
-    method: get
-    uri: https://devel8.markarth.example.com/pulp/api/v3/repositories/rpm/rpm/ebdbc300-dba7-4d63-99d5-155d5e1331de/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Nov 2021 14:31:47 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 184509afc7ac42b5b4b8945f572f3c5b
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel8.markarth.example.com
-      Content-Length:
-      - '303'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9lYmRiYzMwMC1kYmE3LTRkNjMtOTlkNS0xNTVkNWUxMzMxZGUv
-        dmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIxLTExLTAyVDIwOjAw
-        OjM4LjYzNzQzMloiLCJudW1iZXIiOjEsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWJkYmMzMDAtZGJhNy00ZDYz
-        LTk5ZDUtMTU1ZDVlMTMzMWRlLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5wYWNrYWdlIjp7ImNvdW50
-        IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL3BhY2thZ2Vz
-        Lz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2ViZGJjMzAwLWRiYTctNGQ2My05OWQ1LTE1NWQ1
-        ZTEzMzFkZS92ZXJzaW9ucy8xLyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQi
-        OnsicnBtLnBhY2thZ2UiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkv
-        djMvY29udGVudC9ycG0vcGFja2FnZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0v
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZWJkYmMzMDAtZGJh
-        Ny00ZDYzLTk5ZDUtMTU1ZDVlMTMzMWRlL3ZlcnNpb25zLzEvIn19fX0seyJw
-        dWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0v
-        ZWJkYmMzMDAtZGJhNy00ZDYzLTk5ZDUtMTU1ZDVlMTMzMWRlL3ZlcnNpb25z
-        LzAvIiwicHVscF9jcmVhdGVkIjoiMjAyMS0xMS0wMlQyMDowMDowNi43MjY4
-        NThaIiwibnVtYmVyIjowLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtL2ViZGJjMzAwLWRiYTctNGQ2My05OWQ1LTE1
-        NWQ1ZTEzMzFkZS8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3Vt
-        bWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7fX19
-        XX0=
-    http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:47 GMT
-- request:
-    method: delete
-    uri: https://devel8.markarth.example.com/pulp/api/v3/repositories/rpm/rpm/6829d620-ff92-4751-a1a0-724c0f512b7c/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 03 Nov 2021 14:31:47 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - f55017d091bb49d2b7cde6f13a069aba
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel8.markarth.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBkYWE2NTA4LTkyMTEtNGNh
-        OS05YWJkLWVjY2VhYWM2MjE4Yi8ifQ==
-    http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:47 GMT
-- request:
-    method: delete
-    uri: https://devel8.markarth.example.com/pulp/api/v3/repositories/rpm/rpm/ebdbc300-dba7-4d63-99d5-155d5e1331de/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.15.0/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 03 Nov 2021 14:31:48 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 4c9b0f5dcdcc4b4ba2336cfd5dba75c0
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel8.markarth.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU5ODUxMjFiLWMxOGItNDMw
-        Yy1hNzhhLTk2YmU0MTI3ZGFiMi8ifQ==
-    http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:48 GMT
-- request:
-    method: delete
-    uri: https://devel8.markarth.example.com/pulp/api/v3/orphans/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.15.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 03 Nov 2021 14:31:48 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - DELETE, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 9fb64f3f7bc242b4b22118dcec78d96e
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel8.markarth.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMzOTQ5ZTU3LWIyYWEtNDg5
-        Yi1iNTc1LWM4YWJhNDI5OWEzMC8ifQ==
-    http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:48 GMT
-- request:
-    method: get
-    uri: https://devel8.markarth.example.com/pulp/api/v3/tasks/33949e57-b2aa-489b-b575-c8aba4299a30/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.15.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Nov 2021 14:31:48 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 0fc17f2c9da941e0ba5508769f13823d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 devel8.markarth.example.com
-      Content-Length:
-      - '411'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzM5NDllNTctYjJh
-        YS00ODliLWI1NzUtYzhhYmE0Mjk5YTMwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjEtMTEtMDNUMTQ6MzE6NDguMDkwOTA1WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJsb2dnaW5nX2NpZCI6IjlmYjY0ZjNmN2JjMjQyYjRiMjIxMThk
-        Y2VjNzhkOTZlIiwic3RhcnRlZF9hdCI6IjIwMjEtMTEtMDNUMTQ6MzE6NDgu
-        MTUwNjk0WiIsImZpbmlzaGVkX2F0IjoiMjAyMS0xMS0wM1QxNDozMTo0OC4x
-        OTQ1MDdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzL2IwZTA4NjQ0LTZjMzctNDRkMS04Yjg4LWNhOWRkYTJhNzlhMi8i
-        LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
-        b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xl
-        YW4gdXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVu
-        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1
-        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQ2xlYW4gdXAgb3JwaGFuIEFydGlm
-        YWN0cyIsImNvZGUiOiJjbGVhbi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21w
-        bGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNy
-        ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
-        ZCI6W119
-    http_version: 
-  recorded_at: Wed, 03 Nov 2021 14:31:48 GMT
+  recorded_at: Tue, 16 Nov 2021 15:58:40 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
This PR introduces change to allow for CLI uploads of OSTree content (primarily `commit_ref` content units) via the CLI/API.

To test, you will need to create a file based OSTree archive:

1. wget --no-parent -r https://fixtures.pulpproject.org/ostree/small/
2. tar --exclude="index.html" -cvf "fixtures_small_repo.tar" -C fixtures.pulpproject.org/ostree "small"

Using hammer:
```
hammer repository upload-content --id <repostory_id> --content-type ostree_ref --path <path to fixtures_small_repo.tar file> --ostree-repository-name small
```
After the import process completes, hammer will report the file was uploaded. Check for 2 things in Katello - 1. that the upload task completed (which includes both the upload and import actions), and 2. that the new content is present in the repository. The "small" repo will have 2 commit refs present with labels "stable" and "rawhide". 

There are additional options that can be passed to the content import process for ostree content (commit refs): `ref`, `repository_name`, and `parent_commit`. Repository name is *required*, although the default is typically "repo", so that can be used in most other examples.

Some more things to check:
If you omit the repository name (that is, the name _inside_ the uploaded ostree archive), the upload should fail:
```
[vagrant@centos7-hammer-devel ~]$ hammer repository upload-content --path ~/projects/2efad613-fb5e-4485-b67c-10f8ebed27e8-commit.tar  --id 1
Could not upload the content:
  OSTree commit ref uploads require a repository name.
```

Another note for testing: hammer ostree uploads may take enough time to "fail" with sync timeout errors, however the actual upload task may complete successfully. Check the upload task in the Katello task monitoring to be sure.
