### PR TITLE
Fixes #33860 - Show 404 when cv is not found for versions API

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -163,6 +163,9 @@ module Katello
 
     def find_optional_readable_content_view
       @view = ContentView.readable.find_by(:id => params[:content_view_id])
+      if params[:content_view_id] && !@view
+        fail HttpErrors::NotFound, _("Couldn't find content view with id: '%s'") % params[:content_view_id]
+      end
     end
 
     def find_publishable_content_view


### PR DESCRIPTION
### What are the changes introduced in this pull request?
Throw 404 when content view is not found for versions API
### What is the thinking behind these changes?

### What are the testing steps for this pull request?
Go to:
katello/api/v2/content_view_versions?content_view_id=NaN&per_page=20&page=1