### PR TITLE
Fixes #31523 - Autocomplete with inclusion_type on filters

### DIFF
--- a/app/models/katello/content_view_filter.rb
+++ b/app/models/katello/content_view_filter.rb
@@ -35,7 +35,7 @@ module Katello
                                       Erratum::CONTENT_TYPE.to_sym => "Katello::ContentViewErratumFilter",
                                       DOCKER.to_sym => "Katello::ContentViewDockerFilter",
                                       MODULE_STREAM.to_sym => "Katello::ContentViewModuleStreamFilter"}
-    scoped_search :on => :inclusion, :rename => :inclusion_type, :complete_value => {:include => true, :exclude => :false}
+    scoped_search :on => :inclusion, :rename => :inclusion_type, :complete_value => {include: "true", exclude: "false"}
 
     def self.yum(include_module_streams = true)
       types = [::Katello::ContentViewPackageGroupFilter.name,


### PR DESCRIPTION
### What are the changes introduced in this pull request?
On the filters tab for CVs, permit autocomplete serach on inclusion_type
### What is the thinking behind these changes?

### What are the testing steps for this pull request?
Go to Content View > some CV > Filters
Try autocomplete search and select inclusion_type. 
An error is thrown immediately.
With this PR, we shouldn't see the error.