### PR TITLE
Fixes #33858 - Truncate long env names

### DIFF
--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard.js
@@ -43,7 +43,7 @@ const HostContentViewDetails = ({
                 <Flex>
                   <FlexItem spacer={{ default: 'spacerNone' }}><ContentViewIcon composite={contentView.composite} /></FlexItem>
                   <FlexItem><a href={`/content_views/${contentView.id}`}>{`${contentView.name}`}</a> </FlexItem>
-                  <FlexItem><Label color="purple" href={`/lifecycle_environments/${lifecycleEnvironment.id}`}>{`${lifecycleEnvironment.name}`}</Label></FlexItem>
+                  <FlexItem><Label isTruncated color="purple" href={`/lifecycle_environments/${lifecycleEnvironment.id}`}>{`${lifecycleEnvironment.name}`}</Label></FlexItem>
                 </Flex>
               </DescriptionListDescription>
             </DescriptionListGroup>

--- a/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReview.js
+++ b/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReview.js
@@ -34,7 +34,7 @@ const CVDeletionReview = () => {
         </Flex>
         <Flex>
           {cvEnvironments?.map(({ name, id }) =>
-            <FlexItem key={name}><Label color="purple" href={`/lifecycle_environments/${id}`}>{name}</Label></FlexItem>)}
+            <FlexItem key={name}><Label isTruncated color="purple" href={`/lifecycle_environments/${id}`}>{name}</Label></FlexItem>)}
         </Flex>
       </>}
       {affectedHosts &&
@@ -43,7 +43,7 @@ const CVDeletionReview = () => {
         <Flex>
           <FlexItem><ExclamationTriangleIcon /></FlexItem>
           <FlexItem><p>{__(`${pluralize(hostResponse.length, 'host')} will be moved to content view ${selectedCVNameForHosts} in `)}</p></FlexItem>
-          <FlexItem><Label color="purple" href={`/lifecycle_environments/${selectedEnvForHost[0].id}`}>{selectedEnvForHost[0].name}</Label></FlexItem>
+          <FlexItem><Label isTruncated color="purple" href={`/lifecycle_environments/${selectedEnvForHost[0].id}`}>{selectedEnvForHost[0].name}</Label></FlexItem>
         </Flex>
       </>}
       {affectedActivationKeys &&
@@ -52,7 +52,7 @@ const CVDeletionReview = () => {
         <Flex>
           <FlexItem><ExclamationTriangleIcon /></FlexItem>
           <FlexItem><p>{__(`${pluralize(akResponse.length, 'activation key')} will be moved to content view ${selectedCVNameForAK} in `)}</p></FlexItem>
-          <FlexItem><Label color="purple" href={`/lifecycle_environments/${selectedEnvForAK[0].id}`}>{selectedEnvForAK[0].name}</Label></FlexItem>
+          <FlexItem><Label isTruncated color="purple" href={`/lifecycle_environments/${selectedEnvForAK[0].id}`}>{selectedEnvForAK[0].name}</Label></FlexItem>
         </Flex>
       </>}
     </>

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentEnvironments.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentEnvironments.js
@@ -6,7 +6,7 @@ const ComponentEnvironments = ({ environments }) => {
   const envList = environments.map(env =>
     (
       <FlexItem key={env.id} style={{ marginTop: '0.25em', marginBottom: '0.25em' }}>
-        <Label color="purple" href={`/lifecycle_environments/${env.id}`}>{`${env.name}`}</Label>
+        <Label color="purple" href={`/lifecycle_environments/${env.id}`} isTruncated>{`${env.name}`}</Label>
       </FlexItem>
     ));
   return (

--- a/webpack/scenes/ContentViews/Details/Histories/ContentViewHistories.js
+++ b/webpack/scenes/ContentViews/Details/Histories/ContentViewHistories.js
@@ -49,9 +49,9 @@ const ContentViewHistories = ({ cvId }) => {
     const taskType = task ? task.label : taskTypes[action];
 
     if (taskType === taskTypes.removal) {
-      return <>{__('Deleted from ')} <Label key="1" color="blue" href={`/lifecycle_environments/${environment?.id}`}>{`${environment?.name ?? __('all environments')}`}</Label>{}</>;
+      return <>{__('Deleted from ')} <Label isTruncated key="1" color="blue" href={`/lifecycle_environments/${environment?.id}`}>{`${environment?.name ?? __('all environments')}`}</Label>{}</>;
     } else if (action === 'promotion' || taskType === taskTypes.promotion) {
-      return <>{__('Promoted to ')}<Label key="2" color="blue" href={`/lifecycle_environments/${environment?.id}`}>{`${environment?.name}`}</Label>{}</>;
+      return <>{__('Promoted to ')}<Label isTruncated key="2" color="blue" href={`/lifecycle_environments/${environment?.id}`}>{`${environment?.name}`}</Label>{}</>;
     } else if (taskType === taskTypes.publish) {
       return __('Published new version');
     } else if (taskType === taskTypes.export) {

--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionEnvironments.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionEnvironments.js
@@ -15,7 +15,7 @@ const ContentViewVersionEnvironments = ({ environments }) => {
     <React.Fragment key={env.id}>
       <Flex>
         <FlexItem>
-          <Label color="purple" href={`/lifecycle_environments/${env.id}`}>{`${env.name}`}</Label>
+          <Label isTruncated color="purple" href={`/lifecycle_environments/${env.id}`}>{env.name}</Label>
         </FlexItem>
         <FlexItem>
           <InactiveText text={` ${env.publish_date} ago`} /><br />

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVVersionRemoveReview.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVVersionRemoveReview.js
@@ -39,7 +39,7 @@ const CVVersionRemoveReview = () => {
           </Flex>
           <Flex>
             {selectedEnv?.map(({ name, id }) =>
-              <FlexItem key={name}><Label color="purple" href={`/lifecycle_environments/${id}`}>{name}</Label></FlexItem>)}
+              <FlexItem key={name}><Label isTruncated color="purple" href={`/lifecycle_environments/${id}`}>{name}</Label></FlexItem>)}
           </Flex>
         </>}
       {affectedHosts &&
@@ -48,7 +48,7 @@ const CVVersionRemoveReview = () => {
           <Flex>
             <FlexItem><ExclamationTriangleIcon /></FlexItem>
             <FlexItem><p>{__(`${pluralize(hostResponse.length, 'host')} will be moved to content view ${selectedCVNameForHosts} in `)}</p></FlexItem>
-            <FlexItem><Label color="purple" href={`/lifecycle_environments/${selectedEnvForHost[0].id}`}>{selectedEnvForHost[0].name}</Label></FlexItem>
+            <FlexItem><Label isTruncated color="purple" href={`/lifecycle_environments/${selectedEnvForHost[0].id}`}>{selectedEnvForHost[0].name}</Label></FlexItem>
           </Flex>
         </>}
       {affectedActivationKeys &&
@@ -57,7 +57,7 @@ const CVVersionRemoveReview = () => {
         <Flex>
           <FlexItem><ExclamationTriangleIcon /></FlexItem>
           <FlexItem><p>{__(`${pluralize(akResponse.length, 'activation key')} will be moved to content view ${selectedCVNameForAK} in `)}</p></FlexItem>
-          <FlexItem><Label color="purple" href={`/lifecycle_environments/${selectedEnvForAK[0].id}`}>{selectedEnvForAK[0].name}</Label></FlexItem>
+          <FlexItem><Label isTruncated color="purple" href={`/lifecycle_environments/${selectedEnvForAK[0].id}`}>{selectedEnvForAK[0].name}</Label></FlexItem>
         </Flex>
       </>}
     </>

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
@@ -45,7 +45,7 @@ const ContentViewVersionDetailsHeader = ({
       </TextContent>
       <Flex>
         {environments?.map(({ name, id }) =>
-          <FlexItem key={name}><Label color="purple" href={`/lifecycle_environments/${id}`}>{name}</Label></FlexItem>)}
+          <FlexItem key={name}><Label isTruncated color="purple" href={`/lifecycle_environments/${id}`}>{name}</Label></FlexItem>)}
       </Flex>
     </GridItem>
   </>

--- a/webpack/scenes/ContentViews/components/EnvironmentLabels.js
+++ b/webpack/scenes/ContentViews/components/EnvironmentLabels.js
@@ -10,15 +10,16 @@ const EnvironmentLabels = (environments) => {
         <React.Fragment key={env.id} style={{ marginBottom: '5px' }}>
           <Label
             color="purple"
-          >{`${env.name}`}
+            isTruncated
+          >{env.name}
           </Label>
         </React.Fragment>
       ));
     default:
       return (
         <React.Fragment>
-          <Label color="purple">
-            {`${name}`}
+          <Label color="purple" isTruncated>
+            {name}
           </Label>
         </React.Fragment>
       );


### PR DESCRIPTION
### What are the changes introduced in this pull request?
For really really long environment names, the labels in the new UI should be truncated.
### What is the thinking behind these changes?

### What are the testing steps for this pull request?
Create an env with a really really really long name.
Publish and promote CV to that env. The versions page, CV index page, publish/promote pages etc should have the env name truncated..