### PR TITLE
Fixes #33893 - fix smart proxy sync with blank url

### DIFF
--- a/app/lib/actions/katello/capsule_content/refresh_repos.rb
+++ b/app/lib/actions/katello/capsule_content/refresh_repos.rb
@@ -40,7 +40,7 @@ module Actions
             pulp_repo = repo.backend_service(smart_proxy)
             if !current_repos_on_capsule_ids.include?(repo.id)
               pulp_repo.create_mirror_entities
-            elsif pulp_repo.mirror_needs_updates?
+            else
               tasks += pulp_repo.refresh_mirror_entities
             end
           end

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -183,10 +183,6 @@ module Katello
         RepositoryMirror.new(self).refresh_entities
       end
 
-      def mirror_needs_updates?
-        RepositoryMirror.new(self).needs_updates?
-      end
-
       def refresh_if_needed
         tasks = []
         tasks << update_remote #always update remote

--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -79,7 +79,7 @@ module Katello
       end
 
       def publication_href
-        api.publications_api.list(:repository_version => version_href).results.first.pulp_href
+        api.publications_api.list(:repository_version => version_href).results.first&.pulp_href
       end
 
       def create_version(options = {})

--- a/test/actions/pulp/repository/refresh_repos_test.rb
+++ b/test/actions/pulp/repository/refresh_repos_test.rb
@@ -41,7 +41,6 @@ module ::Actions::Pulp::Repository
         planned_action = create_and_plan_action action_class, @smart_proxy, repository: repo
         # repo already exist in capsule
         ::Katello::Pulp::SmartProxyRepository.any_instance.expects(:current_repositories).returns([repo])
-        pulp_repo.expects(:mirror_needs_updates?).returns(true)
         pulp_repo.expects(:refresh_mirror_entities).once.returns([])
         run_action planned_action
       end
@@ -74,7 +73,6 @@ module ::Actions::Pulp::Repository
         planned_action = create_and_plan_action action_class, @smart_proxy, repository: repo
         # repo already exist in capsule
         ::Katello::Pulp3::SmartProxyRepository.any_instance.expects(:current_repositories).returns([repo])
-        pulp_repo.expects(:mirror_needs_updates?).returns(true)
         pulp_repo.expects(:refresh_mirror_entities).once.returns([])
         run_action planned_action
       end


### PR DESCRIPTION
### What are the changes introduced in this pull request?
We stopped checking remotes to see if they need updates due to the issue around that check. (Thinks like password and certs are not provided by pulp so will always show as needing updates).  It seems the code for smart proxy syncing was comparing the remote config on the SP to the one that was supposed to be on the main pulp server.  This was incorrect, and would have always been returning true!  Except it seems that this completely errors if the repository has no url

### What is the thinking behind these changes?
Skip the remote comparison like we do for regular repo syncs

### What are the testing steps for this pull request?
1) create some yum repository in Library without a url set
2) try to sync it to a smart proxy (either associating the SP to library or promoting to an LCE)
