### PR TITLE
Fixes #33838 - Make Generic Content Units Controller Apipie Compatible

### DIFF
--- a/app/controllers/katello/api/v2/generic_content_units_controller.rb
+++ b/app/controllers/katello/api/v2/generic_content_units_controller.rb
@@ -1,10 +1,15 @@
 module Katello
   class Api::V2::GenericContentUnitsController < Api::V2::ApiController
+    resource_description do
+      name 'Content Units'
+      param :content_type, String, desc: N_("Possible values: #{Katello::RepositoryTypeManager.generic_content_types.join(", ")}"), required: true
+    end
+    apipie_concern_subst(:a_resource => N_("a content unit"), :resource_id => "content_units")
+
     Katello::RepositoryTypeManager.generic_content_types(false).each do |type|
-      apipie_concern_subst(:a_resource => N_(type), :resource_id => type.pluralize)
-      resource_description do
-        name type.pluralize.titleize
-      end
+      api :GET, "/#{type.pluralize}", N_("List %s" % type.pluralize)
+      api :GET, "/#{type.pluralize}/:id", N_("Show %s" % type.gsub(/_/, ' '))
+      api :GET, "/repositories/:repository_id/#{type.pluralize}/:id", N_("Show %s" % type.gsub(/_/, ' '))
     end
 
     include Katello::Concerns::Api::V2::RepositoryContentController
@@ -14,6 +19,7 @@ module Katello
     end
 
     def resource_class
+      fail "Required param content_type is missing" unless params[:content_type]
       ::Katello::GenericContentUnit.where(content_type: params[:content_type].singularize)
     end
 

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -286,6 +286,7 @@ Katello::Engine.routes.draw do
             end
           end
         end
+        api_resources :content_units, :only => [:index, :show], :controller => 'generic_content_units'
 
         match "/ping" => "katello_ping#index", :via => :get
         match "/status" => "katello_ping#server_status", :via => :get
@@ -408,6 +409,7 @@ Katello::Engine.routes.draw do
           Katello::RepositoryTypeManager.generic_content_types(false).each do |type|
             api_resources type.pluralize.to_sym, :only => [:index, :show], :controller => 'generic_content_units', :content_type => type
           end
+          api_resources :content_units, :only => [:index, :show], :controller => 'generic_content_units'
 
           api_resources :content_uploads, :controller => :content_uploads, :only => [:create, :destroy, :update]
 

--- a/test/controllers/api/v2/generic_content_units_controller_test.rb
+++ b/test/controllers/api/v2/generic_content_units_controller_test.rb
@@ -14,6 +14,13 @@ module Katello
       setup_product_permissions
     end
 
+    def test_content_units_required_param
+      get :index, :params => {}
+
+      assert_response :error
+      assert_match "Required param content_type is missing", @response.body
+    end
+
     def test_python_package_index
       get :index, :params => { content_type: "python_package" }
 


### PR DESCRIPTION
### What are the changes introduced in this pull request?
- This adds the `katello/api/v2/content_units` (and other similar) route(s). 
- This route has a required `content_type` parameter to select which content type to return. 
- It also changes the apidoc such that the routes for `content_units`, `python_packages` and `ostree_refs` are all under the "Content Units" subheading.
### What is the thinking behind these changes?
Apipie was previously overwriting the GenericContentUnitController's resource with whichever route was defined last. This changes the controller so that the route is "content_units", with a param to specify the content type. The main motivation for this is to make viewing generic content units possible with hammer.

The `katello/api/v2/python_packages`, `katello/api/v2/ostree_refs`, and other related routes are still valid.
### What are the testing steps for this pull request?
1. Sync a python and/or ostree repository.
2. Check these endpoints (and ostree_refs):
   - `katello/api/v2/python_packages/`
   - `katello/api/v2/python_packages/:id`
   - `katello/api/v2/repositories/:repository_id/python_packages`
   - `katello/api/v2/repositories/:repository_id/python_packages/:id`
3. Replace "python_packages" with "content_units" and pass the param `content_type=python_packages`. The results should be the same.
4. Check the Apidoc and see if the routes under "Content Units" are displaying properly.