### PR TITLE
Fixes #33899 - Use Smart Proxy exposed rhsm_url setting

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -443,7 +443,11 @@ module Katello
       end
 
       def rhsm_url
-        if pulp_primary?
+        # Since Foreman 3.1 this setting is set
+        if (rhsm_url = setting(SmartProxy::PULP3_FEATURE, 'rhsm_url'))
+          rhsm_url
+        # Compatibility fall back
+        elsif pulp_primary?
           "https://#{URI.parse(url).host}/rhsm"
         elsif pulp_mirror?
           "https://#{URI.parse(url).host}:8443/rhsm"


### PR DESCRIPTION
### What are the changes introduced in this pull request?

The smart_proxy_pulp plugin can expose a setting `rhsm_url` and Katello should prefer this over logic that tries to derive it.

### What is the thinking behind these changes?

Foreman Installer 3.1+ sets the rhsm_url setting in smart_proxy_pulp. This should be used if available. Compatibility with older proxies is still required.

This allows the installer to migrate the port to 443. Multi homing also becomes a possibility.

### What are the testing steps for this pull request?

Install a Smart Proxy with a non-standard URL (don't forget to refresh features) and observe rhsm_url (used in the registration template) is reflected.