### PR TITLE
Job template - Configure subman to new content source

### DIFF
--- a/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
@@ -28,7 +28,7 @@ module Katello
       end
 
       def context_urls
-        super.merge(rhsm_url: rhsm_url, pulp_content_url: pulp_content_url)
+        super.merge(rhsm_url: smart_proxy.rhsm_url, pulp_content_url: smart_proxy.pulp_content_url)
       end
 
       private
@@ -42,14 +42,6 @@ module Katello
 
           proxy
         end
-      end
-
-      def rhsm_url
-        URI(smart_proxy.rhsm_url)
-      end
-
-      def pulp_content_url
-        smart_proxy.setting(SmartProxy::PULP3_FEATURE, 'content_app_url')
       end
     end
   end

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -446,13 +446,21 @@ module Katello
       def rhsm_url
         # Since Foreman 3.1 this setting is set
         if (rhsm_url = setting(SmartProxy::PULP3_FEATURE, 'rhsm_url'))
-          rhsm_url
+          URI(rhsm_url)
         # Compatibility fall back
         elsif pulp_primary?
-          "https://#{URI.parse(url).host}/rhsm"
+          URI("https://#{URI.parse(url).host}/rhsm")
         elsif pulp_mirror?
-          "https://#{URI.parse(url).host}:8443/rhsm"
+          URI("https://#{URI.parse(url).host}:8443/rhsm")
         end
+      end
+
+      def pulp_content_url
+        URI(setting(SmartProxy::PULP3_FEATURE, 'content_app_url'))
+      end
+
+      class ::SmartProxy::Jail < ::Safemode::Jail
+        allow :rhsm_url, :pulp_content_url
       end
     end
   end

--- a/app/views/foreman/job_templates/change_content_source.erb
+++ b/app/views/foreman/job_templates/change_content_source.erb
@@ -1,0 +1,42 @@
+<%#
+kind: job_template
+name: Change content source
+job_category: Katello
+model: JobTemplate
+provider_type: SSH
+description_format: Configure subscription manager to new content source
+feature: katello_change_content_source
+%>
+#!/bin/sh
+<%
+    content_source = @host.content_source
+-%>
+
+<% if content_source -%>
+SSL_CA_CERT=$(mktemp)
+cat << EOF > $SSL_CA_CERT
+<%= foreman_server_ca_cert %>
+EOF
+
+KATELLO_SERVER_CA_CERT=/etc/rhsm/ca/katello-server-ca.pem
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+# Prepare SSL certificate
+mkdir -p /etc/rhsm/ca
+cp -f $SSL_CA_CERT $KATELLO_SERVER_CA_CERT
+chmod 644 $KATELLO_SERVER_CA_CERT
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+
+subscription-manager config \
+  --server.hostname="<%= content_source.rhsm_url.host %>" \
+  --server.port="<%= content_source.rhsm_url.port %>" \
+  --server.prefix="<%= content_source.rhsm_url.path %>" \
+  --rhsm.repo_ca_cert="$KATELLO_SERVER_CA_CERT" \
+  --rhsm.baseurl="<%= content_source.pulp_content_url %>"
+
+<% else -%>
+echo "Host [<%= @host.name %>] doesn't have assigned content source!"
+exit 1
+<% end -%>

--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -64,12 +64,12 @@ module Katello
     end
 
     def test_rhsm_url_pulp_primary
-      assert_includes @proxy.rhsm_url, "/rhsm"
-      assert_not_includes @proxy.rhsm_url, ":8443"
+      assert_includes @proxy.rhsm_url.to_s, "/rhsm"
+      assert_not_includes @proxy.rhsm_url.to_s, ":8443"
     end
 
     def test_rhsm_url_pulp_mirror
-      assert_includes @proxy_mirror.rhsm_url, ":8443/rhsm"
+      assert_includes @proxy_mirror.rhsm_url.to_s, ":8443/rhsm"
     end
 
     def test_sync_container_gateway


### PR DESCRIPTION
### What are the changes introduced in this pull request?
New REX job template for configuring `subscription-manager` to new content source

### What is the thinking behind these changes?
Partial replacement for Bootstrap.py `--new-capsule` feature

### What are the testing steps for this pull request?
Run the job and check that subman's configuration have been changed.