### PR TITLE
Fixes #33912 - content is not destroyed with force deleted repo

### DIFF
--- a/app/lib/actions/katello/repository/destroy.rb
+++ b/app/lib/actions/katello/repository/destroy.rb
@@ -37,7 +37,7 @@ module Actions
               handle_redhat_content(repository) unless skip_environment_update
             else
               if destroy_content && !skip_environment_update
-                handle_custom_content(repository)
+                handle_custom_content(repository, remove_from_content_view_versions)
               end
             end
           end
@@ -57,9 +57,9 @@ module Actions
           end
         end
 
-        def handle_custom_content(repository)
+        def handle_custom_content(repository, remove_from_content_view_versions)
           #if this is the last instance of a custom repo, destroy the content
-          if repository.root.repositories.where.not(id: repository.id).empty?
+          if remove_from_content_view_versions || repository.root.repositories.where.not(id: repository.id).empty?
             plan_action(::Actions::Katello::Product::ContentDestroy, repository.root)
           end
         end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -154,7 +154,7 @@ module ::Actions::Katello::Repository
 
       assert_action_planned_with action, ::Actions::BulkAction, ::Actions::Katello::Repository::Destroy, in_use_repository.library_instances_inverse
 
-      refute_action_planned action, ::Actions::Katello::Product::ContentDestroy
+      assert_action_planned_with action, ::Actions::Katello::Product::ContentDestroy, in_use_repository.root
     end
 
     it 'plans when custom and no clones' do


### PR DESCRIPTION
### What are the changes introduced in this pull request?

`::Katello::Content` entries were not being deleted due to the check for repositories tied to a root before destroying.  This PR further utilizes the `remove_from_content_view_versions` flag to force the content deletion as well.

### What is the thinking behind these changes?

Since the force delete option should remove all traces of the repo, it should be safe to delete the content before the `library_instances_inverse` repositories are all destroyed.

### What are the testing steps for this pull request?

1) Create some repo and publish it in a CVV.
2) Create a content host registered to the new CVV.
3) Force destroy the new repo.
4) Run `subscription-manager refresh` on the host.
5) Check that the host no longer sees the deleted repo in `/etc/yum.repos.d/redhat.repo`.