### PR TITLE
Fixes #33921 - CV counter shows In progress when count is 0

### DIFF
--- a/webpack/scenes/ContentViews/components/ContentViewsCounter.js
+++ b/webpack/scenes/ContentViews/components/ContentViewsCounter.js
@@ -18,7 +18,7 @@ const ContentViewsCounter = () => {
         <b>
           <Flex>
             <FlexItem spacer={{ default: 'spacerXs' }}>
-              <ContentViewIcon composite={false} description={__('Component content views')} count={component || <InProgressIcon />} />
+              <ContentViewIcon composite={false} description={__('Component content views')} count={(component || component === 0) ? component : <InProgressIcon />} />
             </FlexItem>
             <FlexItem>
               <Tooltip
@@ -37,7 +37,7 @@ const ContentViewsCounter = () => {
         <b>
           <Flex>
             <FlexItem spacer={{ default: 'spacerXs' }}>
-              <ContentViewIcon composite description={__('Composite content views')} count={composite || <InProgressIcon />} />
+              <ContentViewIcon composite description={__('Composite content views')} count={(composite || composite === 0) ? composite : <InProgressIcon />} />
             </FlexItem>
             <FlexItem>
               <Tooltip


### PR DESCRIPTION
### What are the changes introduced in this pull request?
Show 0 in CV counter when there are 0 component/composite CVs on the CV index page.
### What is the thinking behind these changes?

### What are the testing steps for this pull request?
Have a setup with 0 composite content views.
The counter should say 0 composite views instead of In progress icon.
