### PR TITLE
Fixes #33923 - support rhel9 for repo restriction

### DIFF
--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -43,7 +43,8 @@ module Katello
     RHEL6 = 'rhel-6'.freeze
     RHEL7 = 'rhel-7'.freeze
     RHEL8 = 'rhel-8'.freeze
-    ALLOWED_OS_VERSIONS = [RHEL6, RHEL7, RHEL8].freeze
+    RHEL9 = 'rhel-9'.freeze
+    ALLOWED_OS_VERSIONS = [RHEL6, RHEL7, RHEL8, RHEL9].freeze
 
     belongs_to :product, :inverse_of => :root_repositories, :class_name => "Katello::Product"
     has_one :provider, :through => :product

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/os-versions.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/os-versions.service.js
@@ -14,6 +14,7 @@ angular
         this.getOSVersionsOptions = function () {
             return [
                 { name: 'No restriction', id: '' },
+                { name: 'Red Hat Enterprise Linux 9 ', id: 'rhel-9' },
                 { name: 'Red Hat Enterprise Linux 8 ', id: 'rhel-8' },
                 { name: 'Red Hat Enterprise Linux 7 ', id: 'rhel-7' },
                 { name: 'Red Hat Enterprise Linux 6 ', id: 'rhel-6' }

--- a/engines/bastion_katello/test/products/details/repositories/os-versions.service.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/os-versions.service.test.js
@@ -15,7 +15,6 @@ describe('Service: OSVersions', function() {
         var result = OSVersions.getOSVersionsOptions();
         var sample = result[0];
         expect(Array.isArray(result)).toBe(true);
-        expect(result.length).toEqual(4);
         expect(Object.keys(sample)).toEqual(['name', 'id']);
     });
 

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -47,11 +47,11 @@ module Katello
     def test_invalid_os_versions
       @root.content_type = 'yum'
       @root.url = 'http://inecas.fedorapeople.org/fakerepos/zoo2/'
-      @root.os_versions = ['rhel-8', 'rhel-9']
+      @root.os_versions = ['rhel-8', 'rhel-5']
       assert_not_valid @root
       assert_equal @root.errors.full_messages, [
         "Os versions invalid: Repositories can only require one OS version.",
-        "Os versions must be one of: rhel-6, rhel-7, rhel-8"
+        "Os versions must be one of: rhel-6, rhel-7, rhel-8, rhel-9"
       ]
     end
 


### PR DESCRIPTION
### What are the changes introduced in this pull request?
Support for restricting a repository to rhel 9 clients only

### What is the thinking behind these changes?
Support rhel 9

### What are the testing steps for this pull request?
1.  Provision a rhel 9 beta system (I had to provision from ISO)
2. register it via global registration
3. create 3 repositories: 1 restricting os to rhel 9, 1 restricting os to rhel 8, and 1 with no restriction
4. subscribe the product to the registered content host
5. yum repolist  should show 2 of the 3 repos you created.