### PR TITLE
Fixes #33933 - Ansible Collections should link to sub-tab

### DIFF
--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionContent.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionContent.js
@@ -26,7 +26,8 @@ const ContentViewVersionContent = ({ cvId, versionId, cvVersion }) => {
     const countLabel = `${type.names.singularLabel}_count`;
     genericContentTypes[countLabel.replace(/([-_]\w)/g, g => g[1].toUpperCase())] = [cvVersion[countLabel], type.names.pluralLowercase];
   });
-
+  // Ansible Collections has a tab in version details so it's handled separately below.
+  delete genericContentTypes.ansibleCollectionCount;
   const genericContentCountsStyle = { whiteSpace: 'pre-line' };
 
   return (


### PR DESCRIPTION
### What are the changes introduced in this pull request?

Ansible collection repos in CV should be linked to version details sub-tab.

### What is the thinking behind these changes?

### What are the testing steps for this pull request?
Create an ansible collection repo.
Add it to CV and publish.
In the versions list, the content cell should have a link from collection count to sub tab.
