### PR TITLE
Fixes #33936 - Delete Pools with null subscription_id before adding not-null constraint

### DIFF
--- a/db/migrate/20210331180353_katello_pool_organization_id_not_nullable.rb
+++ b/db/migrate/20210331180353_katello_pool_organization_id_not_nullable.rb
@@ -1,6 +1,8 @@
 class KatelloPoolOrganizationIdNotNullable < ActiveRecord::Migration[6.0]
   def up
     ::Katello::Pool.where(organization_id: nil).destroy_all
+    ::Katello::Pool.where(subscription_id: nil).destroy_all
+
     change_column :katello_pools, :organization_id, :integer, null: false
     change_column :katello_pools, :subscription_id, :integer, null: false
 


### PR DESCRIPTION
### What are the changes introduced in this pull request?

Corrects a DB migration to delete Pools having a null subscription ID (this is safe - they are effectively orphaned) **before** running the rest of the migration that says "subscription ID can't be nil"

### What is the thinking behind these changes?

Failed DB migrations == Bad
Working DB migrations == Good

### What are the testing steps for this pull request?

Hmm, I recommend simply evaluating that the code change will meet the requirements I've described here otherwise I'm open to ideas as testing the entire upgrade process seems a bit extreme for this :)

Notice that the migration already handled this case for null organization_id but missed subscription ID. Oops!