### PR TITLE
Fixes #33940 - Fix Errata installion on host collections

### DIFF
--- a/app/models/katello/concerns/pulp_database_unit.rb
+++ b/app/models/katello/concerns/pulp_database_unit.rb
@@ -95,8 +95,8 @@ module Katello
 
         if hosts
           hosts = ::Host.where(id: hosts) if hosts.is_a?(Array)
-          facet_repos = facet_repos.merge(hosts).reorder(nil)
-          facet_content_units = facet_content_units.merge(hosts).reorder(nil)
+          facet_repos = facet_repos.where(hosts: { id: hosts }).reorder(nil)
+          facet_content_units = facet_content_units.where(hosts: { id: hosts }).reorder(nil)
         end
 
         self.joins(repository_association_units).

--- a/test/support/auth_support.rb
+++ b/test/support/auth_support.rb
@@ -46,8 +46,11 @@ module Katello
     # {:name => :view_lifecycle_environments, :search => 'name=Dev'} OR
     # [{:name => :view_lifecycle_environments, :search => 'name=Dev'}, ..] OR
     # :view_lifecycle_environments
-    def setup_user_with_permissions(permissions, user)
+    def setup_user_with_permissions(permissions, user, organizations: [], locations: [])
       as_admin do
+        user.update!(organizations: organizations) unless organizations.blank?
+        user.update!(locations: locations) unless locations.blank?
+
         actual_permissions = if permissions.is_a?(Hash)
                                [permissions]
                              elsif permissions.is_a?(Array)
@@ -68,9 +71,9 @@ module Katello
       end
     end
 
-    def setup_current_user_with_permissions(permissions)
+    def setup_current_user_with_permissions(permissions, organizations: [], locations: [])
       fail("setup_current_user_with_permissions called with current user not set") unless User.current
-      setup_user_with_permissions(permissions, User.current)
+      setup_user_with_permissions(permissions, User.current, organizations: organizations, locations: locations)
     end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Correction to a couple of queries on the errata installation page.

In short this behavior has been fixed

```ruby
> User.current = User.find_by(name: 'myUser')
> Katello::ContentFacetErratum.joins(:content_facet => :host).merge(::Host::Managed.authorized(:view_hosts)).to_sql
ActiveRecord::ConfigurationError: Can't join 'Katello::ContentFacetErratum' to association named 'hostgroup'; perhaps you misspelled it?
from /home/vagrant/foreman/.vendor/ruby/2.7.0/gems/activerecord-6.0.3.7/lib/active_record/associations/join_dependency.rb:201:in `find_reflection'
```
by changing the last query to 
```ruby
> Katello::ContentFacetErratum.joins(:content_facet => :host).where(hosts: {id:  Host::Managed.authorized(:view_hosts)}).count
=> 38
```

#### What are the testing steps for this pull request?
1. Register a host and ensure it has some installable updates available.

2. Associate the host with a hostgroup named "Test" and host_collection name "Patch"

3. Create a custom role with following permissions and filters.
```
----|-------------------------|------------------|------------|-----------|---------|---------------------------------------------------------------------------------
ID  | RESOURCE TYPE           | SEARCH           | UNLIMITED? | OVERRIDE? | ROLE    | PERMISSIONS                                                                     
----|-------------------------|------------------|------------|-----------|---------|---------------------------------------------------------------------------------
350 | Host                    | hostgroup = Test | no         | no        | ospatch | view_hosts, edit_hosts                                                          
351 | Katello::HostCollection | none             | no         | no        | ospatch | view_host_collections, create_host_collections, edit_host_collections, destro...
354 | Organization            | none             | no         | no        | ospatch | view_organizations                                                              
357 | Hostgroup               | name = Test      | no         | no        | ospatch | view_hostgroups, destroy_hostgroups                                             
----|-------------------------|------------------|------------|-----------|---------|---------------------------------------------------------------------------------
```


4. Create a user called "Patch-Admin" and add the role "ospatch" to that user.

5. Login to satellite as "Patch-Admin" user and access Host --> Host Collections --> Patch --> Click on "Errata Installation"


Actual results before this commit
- In GUI --> "There are no Errata associated with this Content Host to display." with an error in the development  log along the lines of  
```
2021-06-11T00:14:26 [E|app|39d0c057] ActiveRecord::ConfigurationError: Can't join 'Katello::ContentFacetRepository' to association named 'hostgroup'; perhaps you misspelled it?
```


After this commit

- It should show the available errata's to install.