### PR TITLE
Fixes #33175 - change 'publish via http' to 'unprotected' in UI

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -262,7 +262,7 @@
       <dd translate>Yes</dd>
 
       <span ng-hide="repository.content_type === 'docker' || repository.content_type === 'ansible_collection'">
-        <dt translate>Publish via HTTP</dt>
+        <dt translate>Unprotected</dt>
         <dd bst-edit-checkbox="repository.unprotected"
             formatter="booleanToYesNo"
             on-save="save(repository)"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -332,8 +332,11 @@
       <div class="checkbox" ng-hide="repository.content_type === 'docker' || repository.content_type === 'ansible_collection'">
         <label>
           <input id="unprotected" name="unprotected" ng-model="repository.unprotected" type="checkbox"/>
-          <span translate>Publish via HTTP</span>
+          <span translate>Unprotected</span>
         </label>
+        <p class="help-block" translate>
+          Do not require a subscription entitlement certificate for accessing this repository.
+        </p>
       </div>
 
       <div bst-form-group label="{{ 'GPG Key' | translate }}" ng-show="repository.content_type === 'yum' || repository.content_type === 'deb'">


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Publish via HTTP should be renamed Unprotected
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Create a new repo.
You should see a checkbox labeled Unprotected.
Save.
On the details page, field Unprotected should be present.