### PR TITLE
Fixes #33944 - Restart all traces via UI

### DIFF
--- a/app/controllers/katello/api/v2/host_tracer_controller.rb
+++ b/app/controllers/katello/api/v2/host_tracer_controller.rb
@@ -35,6 +35,10 @@ module Katello
       @host.host_traces
     end
 
+    def total_selectable(query)
+      query.where(:id => @host.host_traces.selectable).count
+    end
+
     private
 
     def find_host

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -383,9 +383,8 @@ module Katello
         @traces_status_label ||= get_status(::Katello::TraceStatus).to_label(options)
       end
 
-      def traces_helpers(ids = nil)
-        traces = host_traces
-        traces = host_traces.where(id: ids) if ids.present?
+      def traces_helpers(search:)
+        traces = host_traces.selectable.search_for(search)
         ::Katello::HostTracer.helpers_for(traces)
       end
 

--- a/app/models/katello/host_tracer.rb
+++ b/app/models/katello/host_tracer.rb
@@ -10,6 +10,7 @@ module Katello
     validates :application, :length => {:maximum => 255}, :presence => true
     validates :app_type, :length => {:maximum => 255}, :presence => true
 
+    scoped_search :on => :id, :only_explicit => true
     scoped_search :on => :application, :complete_value => true
     scoped_search :on => :app_type, :complete_value => true
     scoped_search :on => :helper, :complete_value => true

--- a/app/models/katello/host_tracer.rb
+++ b/app/models/katello/host_tracer.rb
@@ -5,6 +5,7 @@ module Katello
     belongs_to :host, :inverse_of => :host_traces, :class_name => '::Host::Managed'
 
     scope :reboot_required, -> { where(app_type: 'static') }
+    scope :selectable, -> { where.not(app_type: 'session') }
 
     validates :application, :length => {:maximum => 255}, :presence => true
     validates :app_type, :length => {:maximum => 255}, :presence => true

--- a/app/views/foreman/job_templates/resolve_traces.erb
+++ b/app/views/foreman/job_templates/resolve_traces.erb
@@ -6,15 +6,14 @@ description_format: 'Resolve Traces'
 feature: katello_host_tracer_resolve
 provider_type: SSH
 template_inputs:
-- name: ids
-  description: A comma-separated list of trace IDs to resolve
+- name: Traces search query
+  description: Search query to provide traces to resolve
   input_type: user
   required: true
 %>
 
 <%
-ids = input(:ids).split(',').map { |split| split.strip.to_i }
-commands = @host.traces_helpers(ids)
+commands = @host.traces_helpers(search: input('Traces search query'))
 reboot = commands.delete('reboot')
 -%>
 <% if reboot -%>

--- a/app/views/foreman/job_templates/resolve_traces.erb
+++ b/app/views/foreman/job_templates/resolve_traces.erb
@@ -9,7 +9,7 @@ template_inputs:
 - name: Traces search query
   description: Search query to provide traces to resolve
   input_type: user
-  required: true
+  required: false
 %>
 
 <%

--- a/app/views/foreman/job_templates/resolve_traces_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/resolve_traces_-_katello_ansible_default.erb
@@ -5,18 +5,16 @@ model: JobTemplate
 job_category: Katello via Ansible
 description_format: Resolve Traces
 template_inputs:
-- name: ids
-  description: A comma-separated list of trace IDs to resolve
+- name: Traces search query
+  description: Search query to provide traces to resolve
   input_type: user
   required: true
-  advanced: false
 provider_type: Ansible
 kind: job_template
 %>
 
 <%
-ids = input(:ids).split(',').map { |split| split.strip.to_i }
-commands = @host.traces_helpers(ids)
+commands = @host.traces_helpers(search: input('Traces search query'))
 reboot = commands.delete('reboot')
 -%>
 <%= render_template(

--- a/webpack/components/SelectAllCheckbox/index.js
+++ b/webpack/components/SelectAllCheckbox/index.js
@@ -71,13 +71,13 @@ const SelectAllCheckbox = ({
     <DropdownItem key="select-none" component="button" isDisabled={selectedCount === 0} onClick={handleSelectNone} >
       {`${__('Select none')} (0)`}
     </DropdownItem>,
-    <DropdownItem key="select-page" component="button" isDisabled={areAllRowsOnPageSelected} onClick={handleSelectPage}>
+    <DropdownItem key="select-page" component="button" isDisabled={pageRowCount === 0 || areAllRowsOnPageSelected} onClick={handleSelectPage}>
       {`${__('Select page')} (${pageRowCount})`}
     </DropdownItem>,
   ];
   if (canSelectAll) {
     selectAllDropdownItems.push((
-      <DropdownItem key="select-all" id="all" component="button" isDisabled={areAllRowsSelected} onClick={handleSelectAll}>
+      <DropdownItem key="select-all" id="all" component="button" isDisabled={totalCount === 0 || areAllRowsSelected} onClick={handleSelectAll}>
         {`${__('Select all')} (${totalCount})`}
       </DropdownItem>));
   }

--- a/webpack/components/extensions/HostDetails/Tabs/HostTracesConstants.js
+++ b/webpack/components/extensions/HostDetails/Tabs/HostTracesConstants.js
@@ -1,2 +1,3 @@
 export const HOST_TRACES_KEY = 'HOST_TRACES';
 export const KATELLO_TRACER_PACKAGE = 'katello-host-tools-tracer';
+export const TRACES_SEARCH_QUERY = 'Traces search query';

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
@@ -4,6 +4,7 @@ import { foremanApi } from '../../../../services/api';
 import { getResponseErrorMsgs } from '../../../../utils/helpers';
 import { renderTaskStartedToast } from '../../../../scenes/Tasks/helpers';
 import { ERRATA_SEARCH_QUERY } from '../HostErrata/HostErrataConstants';
+import { TRACES_SEARCH_QUERY } from './HostTracesConstants';
 
 const errorToast = (error) => {
   const message = getResponseErrorMsgs(error.response);
@@ -25,10 +26,10 @@ const katelloPackageInstallParams = ({ hostname, packageName }) =>
     feature: REX_FEATURES.KATELLO_PACKAGE_INSTALL,
   });
 
-const katelloTracerResolveParams = ({ hostname, ids }) =>
+const katelloTracerResolveParams = ({ hostname, search }) =>
   baseParams({
     hostname,
-    inputs: { ids },
+    inputs: { [TRACES_SEARCH_QUERY]: search },
     feature: REX_FEATURES.KATELLO_HOST_TRACER_RESOLVE,
   });
 
@@ -52,11 +53,11 @@ export const installPackage = ({ hostname, packageName }) => post({
   errorToast: error => errorToast(error),
 });
 
-export const resolveTraces = ({ hostname, ids }) => post({
+export const resolveTraces = ({ hostname, search }) => post({
   type: API_OPERATIONS.POST,
   key: REX_JOB_INVOCATIONS_KEY,
   url: foremanApi.getApiUrl('/job_invocations'),
-  params: katelloTracerResolveParams({ hostname, ids }),
+  params: katelloTracerResolveParams({ hostname, search }),
   handleSuccess: response => renderTaskStartedToast({
     humanized: { action: `Resolve traces on ${hostname}` },
     id: response?.data?.dynflow_task?.id,

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
@@ -210,12 +210,12 @@ describe('With tracer installed', () => {
       traceCheckbox = checkboxToTheLeftOf(traceNameNode);
     });
     const selectAllCheckbox = getByLabelText('Select all');
-    selectAllCheckbox.click();
+    fireEvent.click(selectAllCheckbox);
     expect(traceCheckbox.checked).toEqual(true);
-    getByLabelText('Select row 0').click(); // de select
-    getByLabelText('Select row 2').click(); // de select
+    fireEvent.click(getByLabelText('Select row 0')); // de select
+    fireEvent.click(getByLabelText('Select row 2')); // de select
 
-    getByText('Restart app').click();
+    fireEvent.click(getByText('Restart app'));
 
     assertNockRequest(autocompleteScope);
     assertNockRequest(resolveTracesScope);
@@ -275,7 +275,7 @@ describe('With tracer installed', () => {
       traceActionMenu = actionMenuToTheRightOf(traceNameNode);
       expect(traceActionMenu).toHaveAttribute('aria-label', 'Actions');
     });
-    traceActionMenu.click();
+    fireEvent.click(traceActionMenu);
 
     let viaCustomizedRexAction;
     await patientlyWaitFor(() => {
@@ -311,7 +311,7 @@ describe('With tracer installed', () => {
     expect(traceCheckbox.checked).toEqual(true);
 
     const actionMenu = getByLabelText('bulk_actions');
-    actionMenu.click();
+    fireEvent.click(actionMenu);
     const viaCustomizedRexAction = queryByText('Restart via customized remote execution');
 
     expect(viaCustomizedRexAction).toBeInTheDocument();

--- a/webpack/components/extensions/HostDetails/Tabs/customizedRexUrlHelpers.js
+++ b/webpack/components/extensions/HostDetails/Tabs/customizedRexUrlHelpers.js
@@ -1,33 +1,34 @@
 import { REX_FEATURES } from './RemoteExecutionConstants';
-import { KATELLO_TRACER_PACKAGE } from './HostTracesConstants';
+import { KATELLO_TRACER_PACKAGE, TRACES_SEARCH_QUERY } from './HostTracesConstants';
 import { ERRATA_SEARCH_QUERY } from '../HostErrata/HostErrataConstants';
 
-export const katelloPackageInstallUrl = ({ hostname }) => {
-  const urlQuery = encodeURI([
-    `feature=${REX_FEATURES.KATELLO_PACKAGE_INSTALL}`,
-    `inputs[package]=${KATELLO_TRACER_PACKAGE}`,
-    `host_ids=name ^ (${hostname})`,
-  ].join('&'));
-  return `/job_invocations/new?${urlQuery}`;
-};
-
-export const resolveTraceUrl = ({ hostname, ids }) => {
-  const urlQuery = encodeURI([
-    `feature=${REX_FEATURES.KATELLO_HOST_TRACER_RESOLVE}`,
-    `inputs[ids]=${ids.join(',')}`,
-    `host_ids=name ^ (${hostname})`,
-  ].join('&'));
-  return `/job_invocations/new?${urlQuery}`;
-};
-
-export const errataInstallUrl = ({
-  hostname, search,
+export const createJob = ({
+  hostname, feature, inputs,
 }) => {
+  const inputParams = Object.keys(inputs).map(key => `inputs[${key}]=${inputs[key]}`);
   const params = [
-    `feature=${REX_FEATURES.KATELLO_HOST_ERRATA_INSTALL}`,
+    `feature=${feature}`,
     `host_ids=name ^ (${hostname})`,
-    `inputs[${ERRATA_SEARCH_QUERY}]=${search}`,
+    ...inputParams,
   ];
   const urlQuery = encodeURI(params.join('&'));
   return `/job_invocations/new?${urlQuery}`;
 };
+
+export const katelloPackageInstallUrl = ({ hostname }) => createJob({
+  hostname,
+  feature: REX_FEATURES.KATELLO_PACKAGE_INSTALL,
+  inputs: { package: KATELLO_TRACER_PACKAGE },
+});
+
+export const resolveTraceUrl = ({ hostname, search }) => createJob({
+  hostname,
+  feature: REX_FEATURES.KATELLO_HOST_TRACER_RESOLVE,
+  inputs: { [TRACES_SEARCH_QUERY]: search },
+});
+
+export const errataInstallUrl = ({ hostname, search }) => createJob({
+  hostname,
+  feature: REX_FEATURES.KATELLO_HOST_ERRATA_INSTALL,
+  inputs: { [ERRATA_SEARCH_QUERY]: search },
+});


### PR DESCRIPTION
### What are the changes introduced in this pull request?
On the new host traces page
- Added support for selecting all traces and restart them together.

### What are the testing steps for this pull request?

##### On the dev env #####
-  Go to Hosts -> Job Templates
-  Unlock the `Resolve Traces - Katello SSH Default` template using the Actions Dropdown
-  Delete the `Resolve Traces - Katello SSH Default` template 
-  Run this from the rails console
```ruby
    JobTemplate.without_auditing do
      template_files = Dir[File.join("#{Katello::Engine.root}/app/views/foreman/job_templates/**/*.erb")]
      template_files.reject! { |file| file.end_with?('_ansible_default.erb') } unless Katello.with_ansible?
      template_files.each do |template|
        sync = !Rails.env.test? && Setting[:remote_execution_beclosync_templates]
        # import! was renamed to import_raw! around 1.3.1
        if JobTemplate.respond_to?('import_raw!')
          template = JobTemplate.import_raw!(File.read(template), :default => true, :lock => true, :update => sync)
        else
          template = JobTemplate.import!(File.read(template), :default => true, :lock => true, :update => sync)
        end

        template.organizations << Organization.unscoped.all if template&.organizations&.empty?
        template.locations << Location.unscoped.all if template&.locations&.empty?
      end
    end
```

- This should update the resolve traces erb template. 
- In the UI Go to Hosts -> Job Templates
- Click on `Resolve Traces - Katello SSH Default` template
- Click on the `Inputs` tab. You should see 1 input with name `Traces search query`

##### Set up the host ##### 

These steps will give you both `Applicable` and `Installable` errata on the host. 

1. Register a centos 7 host
2. Using the rails console run snippet below (make sure `host_id` is correct)
```ruby
100.times { |count| ::Katello::HostTracer.create!(application: "foo-#{count}", helper: "systemctl restart foo-#{count}", 
                          app_type: ["session", "static", "daemon"][count % 3], host_id: Host.last.id)}
```
3. This should create 100 fake traces available for the system
4. Go to Hosts -> New Host Details -> Traces tab

Notice the new select all menu items listing 66/100 items that are restartable. 

![selectall-Traces](https://user-images.githubusercontent.com/1069779/142351750-5ce9121e-fa04-4d9b-b495-4b02dd89c9eb.png)

- Click on `Select All`
- Deselect couple of rows
![02-selectall-Traces](https://user-images.githubusercontent.com/1069779/142351748-f763aa8e-df8a-4f88-9214-b1c558dc253d.png)

- From the Bulk Actions kebab (to the left of `Restart App`) choose `Restart via customized remote execution`
- Notice the new template populated with the `Trace search query` parameter
![03-template-Traces](https://user-images.githubusercontent.com/1069779/142351747-82817776-1ebe-4ce9-bd4a-0f44105b8621.png)

- Play with the bulk restart operations make sure they restart correctly


### Guidelines for Code Review ###

#### Backend Changes #####
- Added a `selectable` scope to HostTracer to list the selectable items. 
- Updated HostTracerController to include the correct `selectable` query
- Updated the `resolve_traces.erb` template. Added `Traces search query` input to handle bulk  operations.
- Updated the `traces_helpers` method in host managed extensions to aid with the new template.


#### Front End Changes ####
- In *TracesTab* mainly added functionality for restart operations. 
- Added unit tests