### PR TITLE
Fixes #33951 - Don't show RH Repos page in disconnected mode

### DIFF
--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -33,6 +33,10 @@ module Katello
     param_group :search, Api::V2::ApiController
     add_scoped_search_description_for(Katello::ProductContent)
     def index
+      if Setting['content_disconnected']
+        respond_for_index(:collection => { :error => _("Repositories are not available for enablement while in disconnected mode.") }, :status => :forbidden)
+        return
+      end
       collection = scoped_search(index_relation, :name, :asc, :resource_class => Katello::ProductContent)
       collection[:results] = ProductContentFinder.wrap_with_overrides(
           product_contents: collection[:results],

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -17,13 +17,14 @@ Foreman::Plugin.register :katello do
          :turbolinks => false
 
     menu :top_menu,
-         :redhat_provider,
-         :caption => N_('Red Hat Repositories'),
-         :url => '/redhat_repositories',
-         :url_hash => {:controller => 'katello/api/v2/repository_sets',
-                       :action => 'index'},
-         :engine => Katello::Engine,
-         :turbolinks => false
+        :redhat_provider,
+        :caption => N_('Red Hat Repositories'),
+        :url => '/redhat_repositories',
+        :url_hash => {:controller => 'katello/api/v2/repository_sets',
+                      :action => 'index'},
+        :engine => Katello::Engine,
+        :turbolinks => false,
+        :if => lambda { !::Setting['content_disconnected'] }
 
     menu :top_menu,
          :products,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

- [x] Don't show the Red Hat Repositories page in the nav when in disconnected mode
- [x] Update repository sets api to not provide available repository sets if disconnected

#### Considerations taken when implementing this change?

Since one does not have access to available repositories we can't really enable anything via this page.

I added a 403 response to `/repository_sets` with the explanatory error.  I chose 403 Forbidden because [the spec](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) says this means "The server understood the request, but is refusing to fulfill it." I think that fits pretty well.

* Are there other endpoints I should also block, besides index?
* I decided not to change any wording etc. on the RH Repositories page, because it won't be displayed anyway

#### What are the testing steps for this pull request?

1. Settings > Content > Disconnected mode > Yes
2. Upon page refresh, verify that Red Hat Repositories is not listed in the navigation
3. Verify API error when trying to list repository sets (you can still go to /redhat_repositories manually to try it)
4. Turn the setting back to No and refresh the page; RH Repos should reappear in the nav
