### PR TITLE
Fixes #33952 - do not audit internal columns

### DIFF
--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -55,6 +55,10 @@ module Katello
         # so that it will execute after :dependent => :destroy
         before_destroy :destroy_taxable_taxonomies
 
+        def self.non_audited_columns
+          super | [:created_in_katello]
+        end
+
         def default_content_view
           ContentView.default.where(:organization_id => self.id).first
         end

--- a/app/services/katello/organization_creator.rb
+++ b/app/services/katello/organization_creator.rb
@@ -28,6 +28,7 @@ module Katello
     def seed!
       ActiveRecord::Base.transaction do
         @organization.setup_label_from_name
+        @organization.created_in_katello = true
 
         # existing validation errors are not resolvable here, so don't validatate
         @organization.save(validate: false)
@@ -47,8 +48,6 @@ module Katello
         seed!
 
         create_backend_objects!
-
-        @organization.created_in_katello = true
 
         begin
           @organization.save!


### PR DESCRIPTION
Disable auditing of Katello internal column.

Found as https://github.com/Katello/katello/pull/9270#issuecomment-972763008

#### What are the changes introduced in this pull request?
Stop auditing internal column `created_in_katello`

#### What are the testing steps for this pull request?
Create org