### PR TITLE
Fixes #33859 - Remove Greedy DepSolving from UI

### DIFF
--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -13,7 +13,6 @@ class Setting::Content < Setting
     download_policies = proc { hashify_parameters(::Katello::RootRepository::DOWNLOAD_POLICIES) }
 
     proxy_download_policies = proc { hashify_parameters(::SmartProxy::DOWNLOAD_POLICIES) }
-    dependency_solving_options = proc { hashify_parameters(['conservative', 'greedy']) }
     cdn_ssl_versions = proc { hashify_parameters(Katello::Resources::CDN::SUPPORTED_SSL_VERSIONS) }
     http_proxy_select = [{
       name: _("HTTP Proxies"),
@@ -125,12 +124,6 @@ class Setting::Content < Setting
       self.set('content_view_solve_dependencies',
                N_('The default dependency solving value for new Content Views.'),
                false, N_('Content View Dependency Solving Default')),
-      self.set('dependency_solving_algorithm',
-               N_("How the logic of solving dependencies in a Content View is managed. Conservative will only add " \
-               "packages to solve the dependencies if the package needed doesn't exist. Greedy will pull in the " \
-               "latest package to solve a dependency even if it already does exist in the repository."),
-               'conservative', N_('Content View Dependency Solving Algorithm'), nil,
-               :collection => dependency_solving_options),
       self.set('host_dmi_uuid_duplicates',
                N_("If hosts fail to register because of duplicate DMI UUIDs " \
                   "add their comma-separated values here. Subsequent registrations will generate a unique DMI UUID for the affected hosts."),

--- a/db/migrate/20211129200124_remove_dependency_solving_algorithm_setting.rb
+++ b/db/migrate/20211129200124_remove_dependency_solving_algorithm_setting.rb
@@ -1,0 +1,5 @@
+class RemoveDependencySolvingAlgorithmSetting < ActiveRecord::Migration[6.0]
+  def change
+    Setting.where(:name => 'dependency_solving_algorithm', :category => 'Setting::Content').delete_all
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Removing UI option to choose greedy as the dependency solving option in Administer > Settings > Content >  Content View Dependency Solving Algorithm. It also drops `dependency_solving_algorithm` from Setting, which was used to store 'greedy' or 'conservative'

#### What are the testing steps for this pull request?
1. Migrate
2. Go to Administer > Settings > Content
3. greedy should no longer be an option for Content View Dependency Solving Algorithm
4. `Setting.all.find { |s| s.name === "dependency_solving_algorithm" }` in the console should return nil.