### PR TITLE
Fixes #33959 - correct incorrect client_certificate setting

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -186,7 +186,7 @@ module Katello
       end
 
       def pulp3_ssl_configuration(config)
-        legacy_pulp_cert = !self.setting(PULP3_FEATURE, 'client_authentication')&.include?('client_certificates')
+        legacy_pulp_cert = !self.setting(PULP3_FEATURE, 'client_authentication')&.include?('client_certificate')
 
         if Faraday.default_adapter == :excon
           config.ssl_client_cert = ::Cert::Certs.ssl_client_cert_filename(use_admin_as_cn_cert: legacy_pulp_cert)


### PR DESCRIPTION
for pulp communication

#### What are the changes introduced in this pull request?
fixing a typo in which setting to look for.  here's the setting that gets set: https://github.com/theforeman/puppet-foreman_proxy/blob/4775f3f3adb26892beac0e5ea75d88abb3c75be8/manifests/plugin/pulp.pp#L32
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
testing any pulp actions should be fine