### PR TITLE
Fixes #33876 - Fix content view card styles

### DIFF
--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard.js
@@ -33,8 +33,12 @@ const HostContentViewDetails = ({
         </CardHeader>
         <CardBody>
           <Flex direction={{ default: 'column' }}>
-            <Flex direction={{ default: 'row', sm: 'row' }} flexWrap={{ default: 'nowrap' }}>
-              <ContentViewIcon composite={contentView.composite} />
+            <Flex
+              direction={{ default: 'row', sm: 'row' }}
+              flexWrap={{ default: 'nowrap' }}
+              alignItems={{ default: 'alignItemsCenter', sm: 'alignItemsCenter' }}
+            >
+              <ContentViewIcon composite={contentView.composite} style={{ marginRight: '2px' }} />
               <h3>{__('Content view')}</h3>
             </Flex>
             <Flex direction={{ default: 'row', sm: 'row' }} flexWrap={{ default: 'wrap' }}>

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard.js
@@ -1,9 +1,5 @@
 import React from 'react';
 import {
-  DescriptionList,
-  DescriptionListTerm,
-  DescriptionListGroup,
-  DescriptionListDescription,
   Card,
   CardHeader,
   CardTitle,
@@ -30,36 +26,30 @@ const HostContentViewDetails = ({
   }
 
   return (
-    <GridItem rowSpan={2} md={6} lg={3}>
+    <GridItem rowSpan={2} md={6} lg={4}>
       <Card isHoverable>
         <CardHeader>
-          <CardTitle>{__('Content View Details')}</CardTitle>
+          <CardTitle>{__('Content view details')}</CardTitle>
         </CardHeader>
         <CardBody>
-          <DescriptionList isHorizontal isAutoColumnWidths>
-            <DescriptionListGroup>
-              <DescriptionListTerm>{__('Content View')}</DescriptionListTerm>
-              <DescriptionListDescription>
-                <Flex>
-                  <FlexItem spacer={{ default: 'spacerNone' }}><ContentViewIcon composite={contentView.composite} /></FlexItem>
-                  <FlexItem><a href={`/content_views/${contentView.id}`}>{`${contentView.name}`}</a> </FlexItem>
-                  <FlexItem><Label isTruncated color="purple" href={`/lifecycle_environments/${lifecycleEnvironment.id}`}>{`${lifecycleEnvironment.name}`}</Label></FlexItem>
-                </Flex>
-              </DescriptionListDescription>
-            </DescriptionListGroup>
-            <DescriptionListGroup>
-              <DescriptionListTerm>{__('Version in use')}</DescriptionListTerm>
-              <DescriptionListDescription>
-                <Flex>
-                  <FlexItem>
-                    <a href={urlBuilder(`content_views/${contentView.id}/versions/${contentViewVersionId}`, '')}>
-                      {versionLabel}
-                    </a>
-                  </FlexItem>
-                </Flex>
-              </DescriptionListDescription>
-            </DescriptionListGroup>
-          </DescriptionList>
+          <Flex direction={{ default: 'column' }}>
+            <Flex direction={{ default: 'row', sm: 'row' }} flexWrap={{ default: 'nowrap' }}>
+              <ContentViewIcon composite={contentView.composite} />
+              <h3>{__('Content view')}</h3>
+            </Flex>
+            <Flex direction={{ default: 'row', sm: 'row' }} flexWrap={{ default: 'wrap' }}>
+              <a style={{ fontSize: '14px' }} href={`/content_views/${contentView.id}`}>{`${contentView.name}`}</a>
+              <Label isTruncated color="purple" href={`/lifecycle_environments/${lifecycleEnvironment.id}`}>{`${lifecycleEnvironment.name}`}</Label>
+            </Flex>
+          </Flex>
+          <Flex direction={{ default: 'column' }}>
+            <FlexItem>
+              <h3>{__('Version in use')}</h3>
+              <a style={{ fontSize: '14px' }} href={urlBuilder(`content_views/${contentView.id}/versions/${contentViewVersionId}`, '')}>
+                {versionLabel}
+              </a>
+            </FlexItem>
+          </Flex>
         </CardBody>
       </Card>
     </GridItem>

--- a/webpack/scenes/ContentViews/components/ContentViewIcon.js
+++ b/webpack/scenes/ContentViews/components/ContentViewIcon.js
@@ -4,13 +4,15 @@ import PropTypes from 'prop-types';
 import { EnterpriseIcon, RegistryIcon } from '@patternfly/react-icons';
 import './contentViewIcon.scss';
 
-const ContentViewIcon = ({ composite, count, description }) => {
+const ContentViewIcon = ({
+  composite, count, description, style,
+}) => {
   const props = {
     title: composite ? __('Composite') : __('Component'),
     className: composite ? 'svg-icon-composite' : 'svg-icon-component',
   };
   return (
-    <div aria-label="content_view_icon" className="svg-centered-container">
+    <div aria-label="content_view_icon" className="svg-centered-container" style={style}>
       {count && <span className="composite-component-count">{count}</span>}
       {composite ? <RegistryIcon size="md" {...props} /> : <EnterpriseIcon size="sm" {...props} />}
       <span>{description}</span>
@@ -22,12 +24,14 @@ ContentViewIcon.propTypes = {
   composite: PropTypes.bool,
   count: PropTypes.node,
   description: PropTypes.node,
+  style: PropTypes.shape({}),
 };
 
 ContentViewIcon.defaultProps = {
   composite: false,
   count: null,
   description: null,
+  style: {},
 };
 
 export default ContentViewIcon;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Change CV card layout to a single column so that longer CV names have more room and look okay
* Bump font size down to 14px for CV name and version link
* Increase card width from 3 to 4 for `lg`-sized screens (units are twelfths of the overall grid, so the card now takes up a third of the width on lg-size screens)
* Fix capitalization

![cv_card](https://user-images.githubusercontent.com/22042343/142644751-0e53157a-3373-40a0-aef9-ff35b28dda7a.png)
See the Redmine issue [#33876](https://projects.theforeman.org/issues/33876) for the before pic

#### Considerations taken when implementing this change?

I removed the Patternfly `<DescriptionList>` components because they weren't adding any benefits.  They don't even create `<dt>`, `<dl>` or `<dd>` elements; they were just spans with classes.

I put some flex containers in to guarantee that
* Content view icon and "Content view" text are always on the same line
* The above and the actual CV name are always on a different line
* The "Version in use" label and the actual version name are always on a different line

however, the line with the CV name and the environment can still wrap if it needs to.

#### What are the testing steps for this pull request?

* Look at the CV card for a host in Default Organization View
* Test with several different screen widths
* Reload the page after changing screen width (unfortunately, some of our styles result from JS and not CSS)
