### PR TITLE
Fixes #33966 - Capsule sync task failed to refresh repos

### DIFF
--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -38,8 +38,8 @@ module Katello
       def needs_updates?
         remote = fetch_remote
         return true if remote.blank?
-        options = repo_service.compute_remote_options
-        options.keys.any? { |key| remote.send(key) != options[key] }
+        options = compute_remote_options
+        options.keys.any? { |key| strip(remote.send(key)) != strip(options[key]) }
       end
 
       def remote_href
@@ -205,6 +205,16 @@ module Katello
       def create_distribution(path)
         distribution_data = api.distribution_class.new(distribution_options(path))
         repo_service.distributions_api.create(distribution_data)
+      end
+
+      private
+
+      def strip(value)
+        if value.respond_to?(:strip)
+          value.strip
+        else
+          value
+        end
       end
     end
   end


### PR DESCRIPTION
This patch fixed the following 2 issues:
- Repositories in Capsule always get refreshed even their remotes
are not changed.
- Failed to refresh a repository in Capsule if its root.url is
empty, such as custom repository without feed url.
