### PR TITLE
Fixes #34104 - Add Errata overview card

### DIFF
--- a/webpack/components/Errata/index.js
+++ b/webpack/components/Errata/index.js
@@ -5,8 +5,65 @@ import {
   BugIcon,
   SecurityIcon,
   EnhancementIcon,
+  SquareIcon,
 } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
+import { urlBuilder } from 'foremanReact/common/urlHelpers';
+
+export const ErrataMapper = ({ data, id }) => data.map(({ x: type, y: count }) => <ErrataSummary count={count} type={type} key={`${count} ${type}`} id={id} />);
+
+export const ErrataSummary = ({ type, count, id }) => {
+  let ErrataIcon;
+  let label;
+  let name;
+  let url;
+  let color;
+  switch (type) {
+    case 'security':
+      label = __('Security');
+      ErrataIcon = SecurityIcon;
+      name = 'security advisories';
+      color = '#0066cc';
+      url = <a href={urlBuilder(`content_hosts/${id}/errata`, '')}> {count} {name} </a>;
+      break;
+    case 'recommended':
+    case 'bugfix':
+      label = __('Bugfix');
+      ErrataIcon = BugIcon;
+      name = 'bug fixes';
+      color = '#8bc1f7';
+      url = <a href={urlBuilder(`content_hosts/${id}/errata`, '')}> {count} {name} </a>;
+      break;
+    case 'enhancement':
+    case 'optional':
+      label = __('Enhancement');
+      ErrataIcon = EnhancementIcon;
+      name = 'enhancements';
+      color = '#002f5d';
+      url = <a href={urlBuilder(`content_hosts/${id}/errata`, '')}> {count} {name} </a>;
+      break;
+    default:
+  }
+  if (!ErrataIcon) return null;
+
+  return (
+    <span style={{ whiteSpace: 'nowrap' }}>
+      <TableText wrapModifier="nowrap">
+        <SquareIcon size="sm" color={color} />
+        <span style={{ marginLeft: '8px' }}>
+          <ErrataIcon title={label} />
+          {url}
+        </span>
+      </TableText>
+    </span>
+  );
+};
+
+ErrataSummary.propTypes = {
+  type: PropTypes.string.isRequired,
+  count: PropTypes.number.isRequired,
+  id: PropTypes.number.isRequired,
+};
 
 export const ErrataType = ({ type }) => {
   let ErrataIcon;
@@ -29,6 +86,7 @@ export const ErrataType = ({ type }) => {
     default:
   }
   if (!ErrataIcon) return null;
+
 
   return (
     <TableText wrapModifier="nowrap">

--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardBody,
+  Flex,
+  FlexItem,
+  GridItem,
+} from '@patternfly/react-core';
+import { urlBuilder } from 'foremanReact/common/urlHelpers';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { propsToCamelCase } from 'foremanReact/common/helpers';
+import PropTypes from 'prop-types';
+import { ChartPie } from '@patternfly/react-charts';
+import { ErrataMapper } from '../../../../components/Errata';
+
+function HostInstallableErrata({
+  id, errataCounts,
+}) {
+  const errataTotal = errataCounts.total;
+  const errataSecurity = errataCounts.security;
+  const errataBug = errataCounts.bugfix;
+  const errataEnhance = errataCounts.enhancement;
+  const chartData = [{
+    w: 'security advisories', x: 'security', y: errataSecurity, z: errataTotal,
+  }, {
+    w: 'bug fixes', x: 'bugfix', y: errataBug, z: errataTotal,
+  }, {
+    w: 'enhancements', x: 'enhancement', y: errataEnhance, z: errataTotal,
+  }];
+  return (
+    <GridItem rowSpan={2} md={3} lg={4}>
+      <Card isHoverable>
+        <CardHeader>
+          <CardTitle>{__('Installable Errata')}</CardTitle>
+        </CardHeader>
+        <CardBody>
+          <Flex direction="column">
+            <FlexItem>
+              <a href={urlBuilder(`content_hosts/${id}/errata`, '')}>
+                {errataTotal} errata
+              </a>
+            </FlexItem>
+            <Flex flexWrap={{ xl: 'nowrap' }} direction="row" alignItems={{ default: 'alignItemsCenter' }}>
+              <div className="piechart-overflow" style={{ overflow: 'visible', minWidth: '140px', maxHeight: '155px' }}>
+                <div className="erratachart" style={{ minWidth: '300px', minHeight: '300px' }}>
+                  <ChartPie
+                    ariaDesc="errataChart"
+                    data={chartData}
+                    constrainToVisibleArea
+                    labels={({ datum }) => `${datum.y} ${datum.w}`}
+                    padding={{
+                      bottom: 20,
+                      left: 20,
+                      right: 140,
+                      top: 20,
+                    }}
+                    width={250}
+                    height={130}
+                  />
+                </div>
+              </div>
+              <div className="erratalegend">
+                <FlexItem>
+                  <ErrataMapper data={chartData} id={id} />
+                </FlexItem>
+              </div>
+            </Flex>
+          </Flex>
+        </CardBody>
+      </Card>
+    </GridItem>
+  );
+}
+
+const ErrataOverviewCard = ({ hostDetails }) => {
+  if (hostDetails.content_facet_attributes) {
+    const { id: hostId } = hostDetails;
+    return (<HostInstallableErrata
+      {...propsToCamelCase(hostDetails.content_facet_attributes)}
+      id={hostId}
+    />);
+  }
+  return null;
+};
+
+HostInstallableErrata.propTypes = {
+  id: PropTypes.number.isRequired,
+  errataCounts: PropTypes.shape({
+    bugfix: PropTypes.number,
+    enhancement: PropTypes.number,
+    security: PropTypes.number,
+    total: PropTypes.number,
+  }).isRequired,
+};
+
+ErrataOverviewCard.propTypes = {
+  hostDetails: PropTypes.shape({
+    content_facet_attributes: PropTypes.shape({}),
+    id: PropTypes.number,
+  }),
+};
+
+ErrataOverviewCard.defaultProps = {
+  hostDetails: {},
+};
+
+export default ErrataOverviewCard;

--- a/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render } from 'react-testing-lib-wrapper';
+import ErrataOverviewCard from '../ErrataOverviewCard';
+import nock from '../../../../../test-utils/nockWrapper';
+
+describe('Without errata', () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test('does not show piechart when there are 0 errata', () => {
+    const hostDetails = {
+      id: 2,
+      content_facet_attributes: {
+        errata_counts: {
+          bugfix: 0,
+          enhancement: 0,
+          security: 0,
+          total: 0,
+        },
+      },
+    };
+    /* eslint-disable max-len */
+    const { queryByLabelText, getByText } = render(<ErrataOverviewCard hostDetails={hostDetails} />);
+    /* eslint-enable max-len */
+    expect(queryByLabelText('errataChart')).not.toBeInTheDocument();
+    expect(getByText('0 errata')).toBeInTheDocument();
+  });
+});
+
+describe('With errata', () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test('show piechart when there are errata', () => {
+    const hostDetails = {
+      id: 2,
+      content_facet_attributes: {
+        errata_counts: {
+          bugfix: 10,
+          enhancement: 20,
+          security: 30,
+          total: 60,
+        },
+      },
+    };
+    const { getByText, container } = render(<ErrataOverviewCard hostDetails={hostDetails} />);
+    expect(container.getElementsByClassName('erratachart')).toHaveLength(1);
+    expect(container.getElementsByClassName('erratalegend')).toHaveLength(1);
+    expect(getByText('60 errata')).toBeInTheDocument();
+    expect(getByText('30 security advisories')).toBeInTheDocument();
+    expect(getByText('10 bug fixes')).toBeInTheDocument();
+    expect(getByText('20 enhancements')).toBeInTheDocument();
+  });
+});

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -7,6 +7,7 @@ import SystemStatuses from './components/extensions/about';
 import RegistrationCommands from './components/extensions/RegistrationCommands';
 import ContentTab from './components/extensions/HostDetails/Tabs/ContentTab';
 import ContentViewDetailsCard from './components/extensions/HostDetails/Cards/ContentViewDetailsCard';
+import ErrataOverviewCard from './components/extensions/HostDetails/Cards/ErrataOverviewCard';
 
 // import SubscriptionTab from './components/extensions/HostDetails/Tabs/SubscriptionTab';
 import RepositorySetsTab from './components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab';
@@ -29,4 +30,6 @@ addGlobalFill(
   'details-cards',
   'Content View Details',
   <ContentViewDetailsCard key="content-view-details" />,
+  2000,
 );
+addGlobalFill('details-cards', 'Installable errata', <ErrataOverviewCard key="errata-overview" />, 1900);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

With the new host details work being done and the errata work finished up, the next step is to add an errrata card to the host overview page.

#### Considerations taken when implementing this change?

Nothing major, we are returning our own custom legend that was made with the `ErrataSummary` function inside `Errata/index.js` We are using Piechart from Patternfly.

#### What are the testing steps for this pull request?

* Register a host either el7/el8
* Attach a custom sub for a product/repo that has errata
* Install some packages so there is applicable errata
* Enable the new host ui in the experimental settings
* goto hosts, new details page, look at the errata overview card.