### PR TITLE
Fixes #33685 - null generic remote options not updated correctly

### DIFF
--- a/app/services/katello/pulp3/repository/generic.rb
+++ b/app/services/katello/pulp3/repository/generic.rb
@@ -24,7 +24,7 @@ module Katello
         def remote_options
           generic_remote_options = JSON.parse(root.generic_remote_options)
           if generic_remote_options.any?
-            common_remote_options.merge(generic_remote_options.select { |_, v| !v.nil? }).symbolize_keys
+            common_remote_options.merge(generic_remote_options).symbolize_keys
           else
             common_remote_options
           end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
@@ -109,8 +109,8 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
 
                 if ($scope.genericRemoteOptions && $scope.genericRemoteOptions !== []) {
                     $scope.genericRemoteOptions.forEach(function(option) {
-                       if (option.type === "Array" && option.value) {
-                           repository[option.name] = option.value.split(option.delimiter);
+                       if (option.type === "Array") {
+                           repository[option.name] = option.value ? option.value.split(option.delimiter) : [];
                        } else {
                            repository[option.name] = option.value;
                        }


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Entering a blank remote option for python repositories in the repository update/details UI will now successfully clear the param in pulp. Presumably, this bug could occur for any content type using the generic framework.
#### Considerations taken when implementing this change?
This revealed two issues:
1. Params with array types need to be assigned `[]` instead of `null` when entered as blank in the repository details UI, otherwise pulp returns an error.
2. Previously, any generic remote options being updated with `null` were not actually being updated, because they were being filtered out: https://github.com/Katello/katello/blob/master/app/services/katello/pulp3/repository/generic.rb#L27

I can't remember why nil options were being filtered out, but I don't see any reason.
#### What are the testing steps for this pull request?
1. Create a python repo with `https://pypi.org` as the remote url (or anything, you don't need to sync to test this). Also test without creating with the remote url and instead update it later.
2. Go to the details page and add a value to the excludes/includes/package_types option
    - update the remote url so that the remote refreshes
    - Check that this value is updated in the pulp database. Get href with: `Katello::Repository.find(id).remote_href`
3. Remove the value and check that is has been cleared successfully (in this case, empty list).
4. Check anything else you can think of related to null values and python remote options.