### PR TITLE
Fixes #33978 - Show content views when deleting environment

### DIFF
--- a/app/views/katello/api/v2/environments/show.json.rabl
+++ b/app/views/katello/api/v2/environments/show.json.rabl
@@ -46,4 +46,13 @@ node :permissions do |env|
   }
 end
 
+node :content_views do |env|
+  env.content_views.non_default.map do |cv|
+    {
+      :name => cv.name,
+      :id => cv.id
+    }
+  end
+end
+
 extends 'katello/api/v2/common/timestamps'

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment.html
@@ -7,11 +7,36 @@
 
   <div data-block="item-actions">
     <button ng-show="!environment.library"
-            ng-click="remove(environment)"
+            ng-click="openModal()"
             type="button"
             class="btn btn-default">
       <span translate>Remove Environment</span>
     </button>
+    <div bst-modal="remove(environment)" model="environment">
+      <div data-block="modal-header" translate>Remove environment {{ environment.name }}?</div>
+      <div data-block="modal-body">
+        <div ng-show="environment.content_views.length" style="margin-bottom: 1em">
+          <span translate>Environment will also be removed from the following published content views!</span>
+          <table class="table table-striped table-bordered" style="margin-top: 1em">
+              <thead>
+                  <tr>
+                      <th translate>Content View</th>
+                  </tr>
+              </thead>
+              <tbody>
+                <tr ng-repeat="cv in environment.content_views">
+                  <td class="align-center">
+                      <a href="/content_views/{{cv['id']}}" target="_blank">
+                          {{cv['name']}}
+                      </a>
+                  </td>
+                </tr>
+              </tbody>
+          </table>
+        </div>
+        <span translate>Are you sure you want to remove environment {{ environment.name }}?</span>
+      </div>
+    </div>
   </div>
 
   <nav data-block="navigation">


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
1. Adds a confirmation modal on environment delete.
2. Shows content views tied to environment if any.

#### Considerations taken when implementing this change?
Inform users there are content views tied to environment for confirmation before delete. 
Users are still allowed to delete env and the content view is removed from the environment. However, user is not allowed to delete env tied to a content host. That validation is still in place.
#### What are the testing steps for this pull request?
Create a CV
Publish and promote it to an env.
Go to env and delete.
You should see a modal like below:
![Screenshot from 2021-11-23 07-03-40](https://user-images.githubusercontent.com/21146741/143021007-8f0e0979-c5ba-464d-a365-144715ea9cfa.png)

