### PR TITLE
Fixes #33988 - remove old ostree code from repository manange content ui

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-manage-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-manage-content.controller.js
@@ -13,7 +13,6 @@
  * @requires DockerManifest
  * @requires DockerManifestList
  * @requires DockerTag
- * @requires OstreeBranch
  * @requires File
  * @requires Deb
  * @requires ModuleStream
@@ -25,8 +24,8 @@
  *   Provides the functionality for the repository details pane.
  */
 angular.module('Bastion.repositories').controller('RepositoryManageContentController',
-    ['$scope', '$state', 'translate', 'Notification', 'Nutupane', 'Repository', 'Package', 'PackageGroup', 'DockerManifest', 'DockerManifestList', 'DockerTag', 'OstreeBranch', 'File', 'Deb', 'ModuleStream', 'AnsibleCollection', 'GenericContent', 'RepositoryTypesService',
-    function ($scope, $state, translate, Notification, Nutupane, Repository, Package, PackageGroup, DockerManifest, DockerManifestList, DockerTag, OstreeBranch, File, Deb, ModuleStream, AnsibleCollection, GenericContent, RepositoryTypesService) {
+    ['$scope', '$state', 'translate', 'Notification', 'Nutupane', 'Repository', 'Package', 'PackageGroup', 'DockerManifest', 'DockerManifestList', 'DockerTag', 'File', 'Deb', 'ModuleStream', 'AnsibleCollection', 'GenericContent', 'RepositoryTypesService',
+    function ($scope, $state, translate, Notification, Nutupane, Repository, Package, PackageGroup, DockerManifest, DockerManifestList, DockerTag, File, Deb, ModuleStream, AnsibleCollection, GenericContent, RepositoryTypesService) {
         var contentTypes, nutupaneParams;
 
         function success(response, selected) {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
There was an error at urls like `/products/1/repositories/36/content/packages` because ostree branch code wasn't removed from this UI.
#### What are the testing steps for this pull request?
1. Sync an rpm repo
2. Go the repositories page and click the rpm packages count to get to the content management page
3. Observe there is no error