### PR TITLE
Fixes #34000 - update deprecated registry name

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -332,7 +332,7 @@ Foreman::Plugin.register :katello do
 
   register_info_provider Katello::Host::InfoProvider
 
-  medium_providers.register(Katello::ManagedContentMediumProvider)
+  medium_providers_registry.register(Katello::ManagedContentMediumProvider)
 
   Katello::PermissionCreator.new(self).define
   add_all_permissions_to_default_roles


### PR DESCRIPTION
`medium_providers` was renamed to `medium_providers_registry`.

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
