### PR TITLE
Fixes #34003 - Add repo_type to pulp3_migration

### DIFF
--- a/app/lib/actions/pulp3/content_migration.rb
+++ b/app/lib/actions/pulp3/content_migration.rb
@@ -5,13 +5,15 @@ module Actions
 
       def plan(smart_proxy, options)
         sequence do
-          action = plan_self(smart_proxy_id: smart_proxy.id)
+          action = plan_self(smart_proxy_id: smart_proxy.id, repository_types: options[:repository_types])
           plan_action(Actions::Pulp3::ImportMigration, options.merge(:dependency => action.output))
         end
       end
 
       def invoke_external_task
-        migration_service = ::Katello::Pulp3::Migration.new(smart_proxy)
+        options = {}
+        options[:repository_types] = input['repository_types'] unless input['repository_types'].nil?
+        migration_service = ::Katello::Pulp3::Migration.new(smart_proxy, options)
         migration_service.create_and_run_migrations
       end
 

--- a/lib/katello/tasks/pulp3_migration.rake
+++ b/lib/katello/tasks/pulp3_migration.rake
@@ -16,10 +16,16 @@ namespace :katello do
       reimport_all = ::Foreman::Cast.to_bool(ENV['reimport_all'])
       wait = ::Foreman::Cast.to_bool(ENV['wait'] || 'true')
       preserve_output = ::Foreman::Cast.to_bool(ENV['preserve_output'])
+      repository_types = ENV['repository_types']&.split(',')&.map(&:strip)
 
       User.current = User.anonymous_api_admin
       Katello::Pulp3::MigrationSwitchover.new(SmartProxy.pulp_primary).remove_orphaned_content
-      task = ForemanTasks.async_task(Actions::Pulp3::ContentMigration, SmartProxy.pulp_primary, reimport_all: reimport_all)
+      task = ForemanTasks.async_task(
+        Actions::Pulp3::ContentMigration,
+        SmartProxy.pulp_primary,
+        reimport_all: reimport_all,
+        repository_types: repository_types
+      )
 
       if wait
         clear_count = nil


### PR DESCRIPTION
Usage:
```
repository_types='rpm,deb' foreman-rake katello:pulp3_migration
```