### PR TITLE
Fixes #33576 - Add upgrade rake task to change repo url auth

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -234,6 +234,10 @@ module Katello
         fail HttpErrors::UnprocessableEntity, msg
       end
 
+      if !repo_params[:url].nil? && URI(repo_params[:url]).userinfo
+        fail "Do not include the username/password in the URL. Use the username/password settings instead."
+      end
+
       gpg_key = get_content_credential(repo_params, CONTENT_CREDENTIAL_GPG_KEY_TYPE)
       ssl_ca_cert = get_content_credential(repo_params, CONTENT_CREDENTIAL_SSL_CA_CERT_TYPE)
       ssl_client_cert = get_content_credential(repo_params, CONTENT_CREDENTIAL_SSL_CLIENT_CERT_TYPE)
@@ -324,6 +328,9 @@ module Katello
     param_group :repo
     def update
       repo_params = repository_params
+      if !repo_params[:url].nil? && URI(repo_params[:url]).userinfo
+        fail "Do not include the username/password in the URL. Use the username/password settings instead."
+      end
 
       if @repository.generic?
         generic_remote_options = generic_remote_options_hash(repo_params)

--- a/lib/katello/tasks/upgrades/4.3/fix_url_auth.rake
+++ b/lib/katello/tasks/upgrades/4.3/fix_url_auth.rake
@@ -1,0 +1,25 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '4.3' do
+      desc "change urls with username and password in the url to use basic auth parameters in pulp3"
+      task :fix_url_auth => ["environment"] do
+        User.current = User.anonymous_admin
+
+        Katello::Repository.all.each do |repo|
+          upstream_url = repo.root.url
+          uri = URI(repo.root.url)
+          if uri.userinfo
+            user, password = uri.userinfo.split(':')
+            upstream_url.slice!(uri.userinfo + "@")
+            repo_params = {
+              upstream_username: user,
+              upstream_password: password,
+              url: upstream_url
+            }
+            ForemanTasks.sync_task(Actions::Katello::Repository::Update, repo.root, repo_params)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This adds a rake task that checks all the existing repositories for URLs that include username/password like `https://user:pass@example.com`, then replaces said URL with `https://example.com` and assigns the username and password fields to `upstream_username` and `upstream_password` in the repository.

It also adds an error check to repository create and update, so that the user cannot include username and password in the URL.
#### Considerations taken when implementing this change?
The task performs the Update action which should make sure that everything that needs to get updated is, including in pulp.
#### What are the testing steps for this pull request?
1. Try creating and updating a repository and put the username/password in the URL. Notice you'll get an error.
2. Remove the error check and create a repository with the username/password in the URL.
3. Run the rake task and verify that the repository has been updated correctly in katello and pulp.