### PR TITLE
Fixes #34037 - Pluralized hosts messge on traces reboot

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-traces-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-traces-modal.html
@@ -23,7 +23,7 @@
           <div data-block="modal-body">
             <span translate>Are you sure you want to restart the services on the selected content hosts?</span>
             <span ng-show="rebootRequired()">
-              <strong translate>Resolving the selected Traces will reboot this host.</strong>
+              <strong translate>Resolving the selected Traces will reboot the selected content hosts.</strong>
             </span>
           </div>
           <span data-block="modal-confirm-button">


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Host traces reboot message has been appropriately pluralized when working with bulk hosts.