### PR TITLE
Fixes #34059 - disable validation when seeding existing org

### DIFF
--- a/app/services/katello/organization_creator.rb
+++ b/app/services/katello/organization_creator.rb
@@ -16,7 +16,7 @@ module Katello
       User.as_anonymous_admin do
         Organization.not_created_in_katello.each do |org|
           creator = self.new(org)
-          creator.create!
+          creator.create!(raise_validation_errors: false)
         end
       end
     end
@@ -42,7 +42,7 @@ module Katello
       end
     end
 
-    def create!
+    def create!(raise_validation_errors: true)
       ActiveRecord::Base.transaction do
         seed!
 
@@ -50,8 +50,11 @@ module Katello
 
         @organization.created_in_katello = true
 
-        # existing validation errors are not resolvable here, so don't validatate
-        @organization.save(validate: false)
+        begin
+          @organization.save!
+        rescue => e
+          raise e if raise_validation_errors
+        end
       end
     end
 

--- a/app/services/katello/organization_creator.rb
+++ b/app/services/katello/organization_creator.rb
@@ -28,7 +28,9 @@ module Katello
     def seed!
       ActiveRecord::Base.transaction do
         @organization.setup_label_from_name
-        @organization.save!
+
+        # existing validation errors are not resolvable here, so don't validatate
+        @organization.save(validate: false)
 
         create_library_environment
         create_library_view
@@ -47,7 +49,9 @@ module Katello
         create_backend_objects!
 
         @organization.created_in_katello = true
-        @organization.save!
+
+        # existing validation errors are not resolvable here, so don't validatate
+        @organization.save(validate: false)
       end
     end
 

--- a/test/controllers/api/v2/organizations_controller_test.rb
+++ b/test/controllers/api/v2/organizations_controller_test.rb
@@ -71,8 +71,11 @@ module Katello
     end
 
     def test_create_duplicate_name
+      stub_organization_creator
+
       post(:create, params: { :organization => {"name" => @organization.name} })
       assert_response :unprocessable_entity
+      assert_match(/Name has already been taken/, response.body)
     end
 
     def test_controller_path


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Disables validation when seeding organizations

#### Considerations taken when implementing this change?

Disabling validation should be safe because any existing validation errors are not resolvable at this point in execution (db seed)

#### What are the testing steps for this pull request?

I haven't been through these steps, but they should get you started. The goal is to create an org that is not "created in katello" and will hit this code path when seeding, and also has host mismatches which is defined as an org having a host in a location that the org itself does not belong to.

- create a host in some organization
- assign that host to a location
- ensure the host's org is not in that location
- the above steps may need to be done via rails console to disable validations
- use the rails console to set created_in_katello on the org to false
- running db:seed should fail with an error "ActiveRecord::RecordInvalid: Validation failed: Environments expecting environments used by hosts or inherited (check mismatches report)."
- Checking out this PR and seeding again should succeed (check that the org now has created_in_katello=true)
