### PR TITLE
Make jest timeout configurable

### DIFF
--- a/webpack/global_test_setup.js
+++ b/webpack/global_test_setup.js
@@ -8,7 +8,7 @@ global.console.error = (error, stack) => {
 };
 
 // Increase jest timeout as some tests using multiple http mocks can time out on CI systems.
-jest.setTimeout(300000);
+jest.setTimeout(process.env.JEST_TIMEOUT || 15000);
 
 afterAll(() => {
   jest.resetModules();


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Reverts the 300sec jest timeout back to 10 seconds in dev, but preserves the 300sec timeout for our github actions

#### Considerations taken when implementing this change?

Make development less painful when writing react tests with nock requests

#### What are the testing steps for this pull request?

- break a react test by changing something like the expected request body
- with this pr checked out, notice the test fails in ~10 seconds
- run the test again, prepending your command with JEST_TIMEOUT=300000 and notice it now takes 300 secs to time out
