### PR TITLE
don't configure minitest-reporters, Foreman does already

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -71,7 +71,6 @@ Gem::Specification.new do |gem|
   # Testing
   gem.add_development_dependency "factory_bot_rails", "~> 4.5"
   gem.add_development_dependency "minitest-tags"
-  gem.add_development_dependency "minitest-reporters"
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "vcr", "< 4.0.0"
   gem.add_development_dependency "webmock"

--- a/lib/katello/tasks/jenkins.rake
+++ b/lib/katello/tasks/jenkins.rake
@@ -2,8 +2,6 @@ require File.expand_path("../engine", File.dirname(__FILE__))
 
 begin
   namespace :jenkins do
-    ENV['USE_MEAN_TIME_REPORTER'] = '1' unless ENV['USE_MEAN_TIME_REPORTER'] == '0'
-
     task :katello do
       Rake::Task['jenkins:setup:minitest'].invoke
       Rake::Task['rake:test:katello'].invoke

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -7,12 +7,6 @@ require "webmock/minitest"
 require 'mocha/minitest'
 require 'set'
 require 'robottelo/reporter/attributes'
-require 'minitest/reporters'
-
-if ENV['USE_MEAN_TIME_REPORTER'] == '1'
-  Minitest::Reporters.use!(Minitest::Reporters::MeanTimeReporter.new(previous_runs_filename: Rails.root.join('tmp', 'katello_minitest_reporters_previous_run'),
-                                                                     report_filename: Rails.root.join('tmp', 'katello_minitest_reporters_report')))
-end
 
 SimpleCov.formatters = [
   SimpleCov::Formatter::RcovFormatter,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Dropping the use of `Minitest::Reporters` in Katello tests, as these are now centrally managed in Foreman.

In https://github.com/theforeman/foreman/pull/8960 we're switching
Foreman to use minitest-reporters and also enable the MeantimeReporter,
so the special setup in Katello isn't needed anymore.

Especially, calling Minitest::Reporters.use! twice breaks things.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Ensure test output still contains MeantimeReporter output.