### PR TITLE
Fixes #34070 - fix container registry with azure plugin

### DIFF
--- a/app/lib/katello/resources/registry.rb
+++ b/app/lib/katello/resources/registry.rb
@@ -32,7 +32,7 @@ module Katello
             self.prefix = "/pulpcore_registry/"
             self.site = "#{uri.scheme}://#{uri.host}:#{uri.port}"
             self.ca_cert_file = Setting[:ssl_ca_file]
-            pulp_primary.pulp3_ssl_configuration(self)
+            pulp_primary.pulp3_ssl_configuration(self, :net_http)
 
             self
           end

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -185,17 +185,17 @@ module Katello
         end
       end
 
-      def pulp3_ssl_configuration(config)
+      def pulp3_ssl_configuration(config, connection_adapter = Faraday.default_adapter)
         legacy_pulp_cert = !self.setting(PULP3_FEATURE, 'client_authentication')&.include?('client_certificate')
 
-        if Faraday.default_adapter == :excon
+        if connection_adapter == :excon
           config.ssl_client_cert = ::Cert::Certs.ssl_client_cert_filename(use_admin_as_cn_cert: legacy_pulp_cert)
           config.ssl_client_key = ::Cert::Certs.ssl_client_key_filename(use_admin_as_cn_cert: legacy_pulp_cert)
-        elsif Faraday.default_adapter == :net_http
+        elsif connection_adapter == :net_http
           config.ssl_client_cert = ::Cert::Certs.ssl_client_cert(use_admin_as_cn_cert: legacy_pulp_cert)
           config.ssl_client_key = ::Cert::Certs.ssl_client_key(use_admin_as_cn_cert: legacy_pulp_cert)
         else
-          fail "Unexpected faraday default_adapter #{Faraday.default_adapter}!  Cannot continue, this is likely a bug."
+          fail "Unexpected connection_adapter #{Faraday.default_adapter}!  Cannot continue, this is likely a bug."
         end
       end
 


### PR DESCRIPTION
a previous fix switched to using filenames for certs
if the Faraday default adapter was set to :excon,
however this broke the container registry proxy, as its
using rest_client, but is still using this same piece of code

#### What are the changes introduced in this pull request?
Allows you to specify what net library you're using when calling the ssl configuration 
method, so you can still use net_http

#### What are the testing steps for this pull request?
1. on a dev environment or production environment
2. install the foreman_azure_rm gem 
3. create a docker repository, sync it
4. using podman, 'podman login hostname'
5. podman search hostname/
6. podman pull IMAGE