### PR TITLE
Fixes #34071 - Fix redux toast action failures on katello

### DIFF
--- a/app/views/katello/layouts/react.html.erb
+++ b/app/views/katello/layouts/react.html.erb
@@ -7,7 +7,6 @@
 <% end %>
 
 <% content_for(:content) do %>
-    <%= notifications %>
     <div id="organization-id" data-id="<%= Organization.current.id if Organization.current %>" ></div>
     <div id="user-id" data-id="<%= User.current.id if User.current %>" ></div>
     <div id="reactRoot">

--- a/engines/bastion/app/views/bastion/layouts/application.html.erb
+++ b/engines/bastion/app/views/bastion/layouts/application.html.erb
@@ -1,6 +1,5 @@
 
 <% content_for(:content) do %>
-  <%= notifications %>
   <div id="content" class="article maincontent bastion" data-no-turbolink="true">
     <section class="container-fluid">
         <div ui-view></div>

--- a/webpack/__mocks__/foremanReact/components/ToastsList/index.js
+++ b/webpack/__mocks__/foremanReact/components/ToastsList/index.js
@@ -1,7 +1,8 @@
 export const addToast = toast => ({
-  type: 'TOASTS_ADD',
+  type: 'toasts/addToast',
   payload: {
-    message: toast,
+    key: 'addToast',
+    toast,
   },
 });
 

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
@@ -1,5 +1,5 @@
 import { API_OPERATIONS, APIActions, get, put, post } from 'foremanReact/redux/API';
-import { addToast } from 'foremanReact/redux/actions/toasts';
+import { addToast } from 'foremanReact/components/ToastsList';
 import { translate as __ } from 'foremanReact/common/I18n';
 import {
   RPM_PACKAGES_CONTENT,

--- a/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsActions.test.js.snap
+++ b/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsActions.test.js.snap
@@ -43,7 +43,8 @@ Array [
   },
   Object {
     "payload": Object {
-      "message": Object {
+      "key": "addToast",
+      "toast": Object {
         "link": Object {
           "children": "Go to task page",
           "href": "/foreman_tasks/tasks/eb1b6271-8a69-4d98-84fc-bea06ddcc166/",
@@ -53,7 +54,7 @@ Array [
         "type": "pending",
       },
     },
-    "type": "TOASTS_ADD",
+    "type": "toasts/addToast",
   },
   Object {
     "type": "SUBSCRIPTIONS_RESET_TASKS",

--- a/webpack/scenes/Tasks/TaskActions.js
+++ b/webpack/scenes/Tasks/TaskActions.js
@@ -1,4 +1,4 @@
-import { addToast } from 'foremanReact/redux/actions/toasts';
+import { addToast } from 'foremanReact/components/ToastsList';
 import { propsToSnakeCase } from 'foremanReact/common/helpers';
 import { get } from 'foremanReact/redux/API';
 import { stopInterval, withInterval } from 'foremanReact/redux/middlewares/IntervalMiddleware';

--- a/webpack/scenes/Tasks/__tests__/__snapshots__/TaskActions.test.js.snap
+++ b/webpack/scenes/Tasks/__tests__/__snapshots__/TaskActions.test.js.snap
@@ -44,7 +44,8 @@ Array [
   Array [
     Object {
       "payload": Object {
-        "message": Object {
+        "key": "addToast",
+        "toast": Object {
           "link": Object {
             "children": "Go to task page",
             "href": "/foreman_tasks/tasks/eb1b6271-8a69-4d98-84fc-bea06ddcc166/",
@@ -54,7 +55,7 @@ Array [
           "type": "pending",
         },
       },
-      "type": "TOASTS_ADD",
+      "type": "toasts/addToast",
     },
   ],
 ]

--- a/webpack/services/api/testHelpers.js
+++ b/webpack/services/api/testHelpers.js
@@ -12,13 +12,15 @@ export const failureAction = (type, message = 'Request failed with status code 4
 export const toastErrorAction = (message = 'Request failed with status code 422') => (
   {
     payload: {
-      message: {
+      key: 'addToast',
+      toast: {
+        key: 'toastError_0',
         message,
         sticky: true,
-        type: 'error',
+        type: 'danger',
       },
     },
-    type: 'TOASTS_ADD',
+    type: 'toasts/addToast',
   }
 );
 

--- a/webpack/utils/helpers.js
+++ b/webpack/utils/helpers.js
@@ -1,4 +1,4 @@
-import { addToast } from 'foremanReact/redux/actions/toasts';
+import { addToast } from 'foremanReact/components/ToastsList';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { head } from 'lodash';
 import { SUBSCRIPTIONS_QUANTITIES_FAILURE } from '../scenes/Subscriptions/SubscriptionConstants';
@@ -77,10 +77,11 @@ export const apiResponse = (actionType, result, additionalData = {}) => (dispatc
 };
 
 export const sendErrorNotifications = messages => (dispatch) => {
-  messages.forEach((msg) => {
+  messages.forEach((msg, item) => {
     const message = typeof msg === 'string' ? msg : `${msg.message}: ${msg.details}`;
     dispatch(addToast({
-      type: 'error',
+      type: 'danger',
+      key: `toastError_${item}`,
       message,
       sticky: true,
     }));


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
- See associated closed pull request [here](https://github.com/Katello/katello/pull/9828)

#### What are the testing steps for this pull request?

- At present, you must add the following line to your `bundler.d> katello.local.rb` file:
`gem 'foreman-tasks', :git => 'https://github.com/theforeman/foreman-tasks.git'` 
The foreman folks will likely need to update foreman-tasks to the latest version in a separate ticket. 

- bundle install

- In the new CV UI create a contentView with a name that already exists to cause an error to appear. 
- Ensure the toast fires successfully, and no console.errors regarding toasts are shown.
