### PR TITLE
fixes #34075 - Update facts related calls

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -178,7 +178,7 @@ module Katello
       end
 
       def rhsm_fact_values
-        self.fact_values.joins(:fact_name).where("#{::FactName.table_name}.type = '#{Katello::RhsmFactName}'")
+        self.fact_values.joins(:fact_name).where("#{::FactName.table_name}.type = '#{FactNames::Rhsm}'")
       end
 
       def self.available_locks

--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -212,7 +212,7 @@ module Katello
 
       def self.update_facts(host, rhsm_facts)
         return if host.build? || rhsm_facts.nil?
-        rhsm_facts[:_type] = RhsmFactName::FACT_TYPE
+        rhsm_facts[:_type] = FactNames::Rhsm::FACT_TYPE
         rhsm_facts[:_timestamp] = Time.now.to_s
         if ignore_os?(host.operatingsystem, rhsm_facts)
           rhsm_facts[:ignore_os] = true

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -28,7 +28,7 @@ module Katello
     def test_rhsm_fact_values
       assert_empty @foreman_host.rhsm_fact_values
 
-      fv = FactValue.create!(value: 'something', host: @foreman_host, fact_name: RhsmFactName.create(name: 'some-fact'))
+      fv = FactValue.create!(value: 'something', host: @foreman_host, fact_name: FactNames::Rhsm.create(name: 'some-fact'))
 
       assert_equal [fv], @foreman_host.rhsm_fact_values
     end

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -281,7 +281,7 @@ module Katello
       end
 
       def test_unregister_host_rhsm_facts
-        FactValue.create!(value: 'something', host: @host, fact_name: RhsmFactName.create(name: 'some-fact'))
+        FactValue.create!(value: 'something', host: @host, fact_name: FactNames::Rhsm.create(name: 'some-fact'))
 
         ::Katello::RegistrationManager.unregister_host(@host, unregistering: true)
 


### PR DESCRIPTION
There is effort to refactor fact parsers in core. That means also organizing a fact names. Katello doesn't reflect that. This PR solves that.

This PR solves the failing tests at https://github.com/theforeman/foreman/pull/8917

So I think that this PR will have failed test until the related PR on in core will be merged.