### PR TITLE
Fixes #31436 - Clean duplicate table rows & re-enable disabled Rubocops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -157,13 +157,13 @@ Performance/RegexpMatch:
   Enabled: false
 
 Minitest/GlobalExpectations:
-  Enabled: false
+  Enabled: true
 
 Performance/CollectionLiteralInLoop:
-  Enabled: false
+  Enabled: true
 
 Rails/RedundantForeignKey:
-  Enabled: false
+  Enabled: true
 
 Rails/UniqueValidationWithoutIndex:
-  Enabled: false
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -157,7 +157,7 @@ Performance/RegexpMatch:
   Enabled: false
 
 Minitest/GlobalExpectations:
-  Enabled: true
+  Enabled: false
 
 Performance/CollectionLiteralInLoop:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -157,7 +157,7 @@ Performance/RegexpMatch:
   Enabled: false
 
 Minitest/GlobalExpectations:
-  Enabled: false
+  Enabled: true
 
 Performance/CollectionLiteralInLoop:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -160,7 +160,7 @@ Minitest/GlobalExpectations:
   Enabled: true
 
 Performance/CollectionLiteralInLoop:
-  Enabled: true
+  Enabled: false
 
 Rails/RedundantForeignKey:
   Enabled: true

--- a/app/lib/katello/util/deduplication_migrator.rb
+++ b/app/lib/katello/util/deduplication_migrator.rb
@@ -1,0 +1,105 @@
+module Katello
+  module Util
+    class DeduplicationMigrator # used in db/migrate/20211201154845_add_unique_indexes.rb
+      include ActionView::Helpers::TextHelper
+
+      def models_to_clean
+        [
+          {
+            :model => ::Katello::CapsuleLifecycleEnvironment,
+            :fields => [:lifecycle_environment_id, :capsule_id]
+          },
+          {
+            :model => ::Katello::ContentViewErratumFilterRule,
+            :fields => [:errata_id, :content_view_filter_id]
+          },
+          {
+            :model => ::Katello::ContentViewModuleStreamFilterRule,
+            :fields => [:module_stream_id, :content_view_filter_id]
+          },
+          {
+            :model => ::Katello::ContentViewPackageGroupFilterRule,
+            :fields => [:uuid, :content_view_filter_id]
+          },
+          {
+            :model =>
+            ::Katello::ContentViewRepository,
+            :fields => [:content_view_id, :repository_id]
+          }
+        ]
+      end
+
+      def models_to_rename
+        [
+          {
+            :model => ::Katello::ContentView,
+            :fields => [:name, :organization_id]
+          }
+        ]
+      end
+
+      # example ---- (IDs 1/7 and 6/8 are duplicates ) ::Katello::CapsuleLifecycleEnvironment.all
+      # => [#<Katello::CapsuleLifecycleEnvironment:0x0000000017e11060 id: 1, capsule_id: 1, lifecycle_environment_id: 1>,
+      # #<Katello::CapsuleLifecycleEnvironment:0x0000000017e10f98 id: 2, capsule_id: 1, lifecycle_environment_id: 2>,
+      # #<Katello::CapsuleLifecycleEnvironment:0x0000000017e10ed0 id: 3, capsule_id: 1, lifecycle_environment_id: 3>,
+      # ...
+      # #<Katello::CapsuleLifecycleEnvironment:0x0000000017e10c78 id: 6, capsule_id: 1, lifecycle_environment_id: 6>,
+      # #<Katello::CapsuleLifecycleEnvironment:0x0000000017e10bb0 id: 7, capsule_id: 1, lifecycle_environment_id: 1>,
+      # #<Katello::CapsuleLifecycleEnvironment:0x0000000017e10ac0 id: 8, capsule_id: 1, lifecycle_environment_id: 6>]
+      def execute!
+        models_to_clean.each do |model_to_clean|
+          rows_deleted = 0
+          model = model_to_clean[:model]
+          cleaning_queries(model_to_clean).each { |query| rows_deleted += clean_duplicates(query, model) }
+          if rows_deleted > 0
+            Rails.logger.info("Deleted #{pluralize(rows_deleted, 'duplicate table row')} from #{model.table_name}")
+          end
+        end
+        Rails.logger.info("Finished cleaning duplicate table rows")
+
+        models_to_rename.each do |model_to_rename|
+          rows_renamed = 0
+          model = model_to_rename[:model]
+          cleaning_queries(model_to_rename).each { |query| rows_renamed += rename_duplicates(query, model) }
+          if rows_renamed > 0
+            Rails.logger.info("Renamed #{pluralize(rows_renamed, 'duplicate table row')} from #{model.table_name}")
+          end
+        end
+        Rails.logger.info("Finished renaming duplicate table rows")
+      end
+
+      def cleaning_queries(model_to_clean)
+        model = model_to_clean[:model]
+        fields = model_to_clean[:fields]
+        dup_query = model.group(fields).having("count(*) > 1")
+        duplicate_entries = dup_query.count.try(:keys) #  [[1, 1], [6, 1]] - the set of duplicate combinations
+        return [] if duplicate_entries.blank?
+        min_ids = dup_query.pluck('min(id)') # [1, 6] - the ids of the duplicate entries with the lowest id, in the same order as duplicate_entries
+        duplicate_entries.map.with_index do |entry, idx|
+          # [{:lifecycle_environment_id=>1, :capsule_id=>1, :min_id=>1},
+          # {:lifecycle_environment_id=>6, :capsule_id=>1, :min_id=>6}]
+          Hash[fields.zip(entry)].merge({ min_id: min_ids[idx] })
+        end
+      end
+
+      def clean_duplicates(query, model)
+        min_id = query.delete(:min_id)
+        model.where(query).where.not(id: min_id).delete_all # returns quantity deleted
+      end
+
+      def rename_duplicates(query, model)
+        min_id = query.delete(:min_id)
+        counter = 0
+        model.where(query).where.not(id: min_id).each do |duplicate|
+          counter += 1
+          old_name = duplicate.name
+          new_name = "#{duplicate.name}_#{duplicate.id}"
+          duplicate.name = new_name
+          duplicate.save(validate: false) # skip validation since migrations should never fail
+          Rails.logger.info("Content view #{old_name} (id #{duplicate.id}) renamed to #{new_name}")
+        end
+        counter
+      end
+    end
+  end
+end

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -30,7 +30,7 @@ module Katello
              :inverse_of => :composite_content_view, :foreign_key => :composite_content_view_id, autosave: true
 
     has_many :component_composites, :class_name => "Katello::ContentViewComponent",
-             :dependent => :destroy, :inverse_of => :content_view, :foreign_key => :content_view_id
+             :dependent => :destroy, :inverse_of => :content_view
 
     has_many :content_view_repositories, :class_name => 'Katello::ContentViewRepository',
              :dependent => :destroy, :inverse_of => :content_view
@@ -41,16 +41,16 @@ module Katello
 
     has_many :activation_keys, :class_name => "Katello::ActivationKey", :dependent => :restrict_with_exception
 
-    has_many :content_facets, :class_name => "Katello::Host::ContentFacet", :foreign_key => :content_view_id,
+    has_many :content_facets, :class_name => "Katello::Host::ContentFacet",
                           :inverse_of => :content_view, :dependent => :restrict_with_exception
     has_many :hosts,      :class_name => "::Host::Managed", :through => :content_facets,
                           :inverse_of => :content_view
-    has_many :hostgroup_content_facets, :class_name => "Katello::Hostgroup::ContentFacet", :foreign_key => :content_view_id,
+    has_many :hostgroup_content_facets, :class_name => "Katello::Hostgroup::ContentFacet",
                           :inverse_of => :content_view, :dependent => :nullify
     has_many :hostgroups, :class_name => "::Hostgroup", :through => :hostgroup_content_facets,
                           :inverse_of => :content_view
 
-    has_many :repository_references, :class_name => 'Katello::Pulp3::RepositoryReference', :foreign_key => :content_view_id,
+    has_many :repository_references, :class_name => 'Katello::Pulp3::RepositoryReference',
              :dependent => :destroy, :inverse_of => :content_view
 
     validates_lengths_from_database :except => [:label]

--- a/app/models/katello/content_view_filter.rb
+++ b/app/models/katello/content_view_filter.rb
@@ -15,7 +15,7 @@ module Katello
                :class_name => "Katello::ContentView",
                :inverse_of => :filters
 
-    has_many :repository_content_view_filters, :class_name => "Katello::RepositoryContentViewFilter", :dependent => :delete_all, :inverse_of => :filter, :foreign_key => :content_view_filter_id
+    has_many :repository_content_view_filters, :class_name => "Katello::RepositoryContentViewFilter", :dependent => :delete_all, :inverse_of => :filter
     has_many :repositories, :through => :repository_content_view_filters, :class_name => "Katello::Repository"
 
     validates_lengths_from_database

--- a/app/models/katello/content_view_history.rb
+++ b/app/models/katello/content_view_history.rb
@@ -8,7 +8,7 @@ module Katello
 
     belongs_to :triggered_by, :class_name => "Katello::ContentViewVersion", :inverse_of => :triggered_histories
 
-    belongs_to :task, :class_name => "ForemanTasks::Task::DynflowTask", :foreign_key => :task_id
+    belongs_to :task, :class_name => "ForemanTasks::Task::DynflowTask"
 
     IN_PROGRESS = 'in progress'.freeze
     FAILED = 'failed'.freeze

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -24,9 +24,9 @@ module Katello
              :inverse_of => :triggered_by, :foreign_key => :triggered_by_id
 
     has_many :export_histories, :class_name => "::Katello::ContentViewVersionExportHistory", :dependent => :destroy,
-             :inverse_of => :content_view_version, :foreign_key => :content_view_version_id
+             :inverse_of => :content_view_version
     has_many :import_histories, :class_name => "::Katello::ContentViewVersionImportHistory", :dependent => :destroy,
-             :inverse_of => :content_view_version, :foreign_key => :content_view_version_id
+             :inverse_of => :content_view_version
     has_many :repositories, :class_name => "::Katello::Repository", :dependent => :destroy
     has_one :task_status, :class_name => "Katello::TaskStatus", :as => :task_owner, :dependent => :destroy
 

--- a/app/models/katello/content_view_version_export_history.rb
+++ b/app/models/katello/content_view_version_export_history.rb
@@ -9,7 +9,7 @@ module Katello
     INCREMENTAL = "incremental".freeze
     EXPORT_TYPES = [COMPLETE, INCREMENTAL].freeze
 
-    belongs_to :content_view_version, :class_name => "::Katello::ContentViewVersion", :inverse_of => :export_histories, foreign_key: 'content_view_version_id'
+    belongs_to :content_view_version, :class_name => "::Katello::ContentViewVersion", :inverse_of => :export_histories
     validates_lengths_from_database
 
     validates :content_view_version_id, :presence => true

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -9,10 +9,10 @@ module Katello
       HOST_TOOLS_TRACER_PACKAGE_NAME = 'katello-host-tools-tracer'.freeze
       SUBSCRIPTION_MANAGER_PACKAGE_NAME = 'subscription-manager'.freeze
 
-      belongs_to :kickstart_repository, :class_name => "::Katello::Repository", :foreign_key => :kickstart_repository_id, :inverse_of => :kickstart_content_facets
+      belongs_to :kickstart_repository, :class_name => "::Katello::Repository", :inverse_of => :kickstart_content_facets
       belongs_to :content_view, :inverse_of => :content_facets, :class_name => "Katello::ContentView"
       belongs_to :lifecycle_environment, :inverse_of => :content_facets, :class_name => "Katello::KTEnvironment"
-      belongs_to :content_source, :class_name => "::SmartProxy", :foreign_key => :content_source_id, :inverse_of => :content_facets
+      belongs_to :content_source, :class_name => "::SmartProxy", :inverse_of => :content_facets
 
       has_many :content_facet_errata, :class_name => "Katello::ContentFacetErratum", :dependent => :delete_all, :inverse_of => :content_facet
       has_many :applicable_errata, :through => :content_facet_errata, :class_name => "Katello::Erratum", :source => :erratum

--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -7,7 +7,7 @@ module Katello
       include DirtyAssociations
 
       belongs_to :user, :inverse_of => :subscription_facets, :class_name => "::User"
-      belongs_to :hypervisor_host, :class_name => "::Host::Managed", :foreign_key => "hypervisor_host_id"
+      belongs_to :hypervisor_host, :class_name => "::Host::Managed"
 
       has_many :subscription_facet_activation_keys, :class_name => "Katello::SubscriptionFacetActivationKey", :dependent => :destroy, :inverse_of => :subscription_facet
       has_many :activation_keys, :through => :subscription_facet_activation_keys, :class_name => "Katello::ActivationKey"

--- a/app/models/katello/hostgroup/content_facet.rb
+++ b/app/models/katello/hostgroup/content_facet.rb
@@ -5,10 +5,10 @@ module Katello
       self.table_name = 'katello_hostgroup_content_facets'
       include Facets::HostgroupFacet
 
-      belongs_to :kickstart_repository, :class_name => "::Katello::Repository", :foreign_key => :kickstart_repository_id, :inverse_of => :kickstart_hostgroup_content_facets
+      belongs_to :kickstart_repository, :class_name => "::Katello::Repository", :inverse_of => :kickstart_hostgroup_content_facets
       belongs_to :content_view, :inverse_of => :hostgroup_content_facets, :class_name => "Katello::ContentView"
       belongs_to :lifecycle_environment, :inverse_of => :hostgroup_content_facets, :class_name => "Katello::KTEnvironment"
-      belongs_to :content_source, :class_name => "::SmartProxy", :foreign_key => :content_source_id, :inverse_of => :hostgroup_content_facets
+      belongs_to :content_source, :class_name => "::SmartProxy", :inverse_of => :hostgroup_content_facets
 
       validates_with Katello::Validators::ContentViewEnvironmentValidator
       validates_with Katello::Validators::HostgroupKickstartRepositoryValidator

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -15,7 +15,7 @@ module Katello
     belongs_to :provider, :inverse_of => :products, :class_name => 'Katello::Provider'
     belongs_to :sync_plan, :inverse_of => :products, :class_name => 'Katello::SyncPlan'
     belongs_to :gpg_key, :inverse_of => :products, :class_name => "Katello::ContentCredential"
-    has_many :product_contents, :foreign_key => 'product_id', :class_name => "Katello::ProductContent", :dependent => :destroy
+    has_many :product_contents, :class_name => "Katello::ProductContent", :dependent => :destroy
     has_many :contents, :through => :product_contents
     has_many :displayable_product_contents, -> { displayable }, :foreign_key => 'product_id', :class_name => "Katello::ProductContent", :dependent => :destroy
     belongs_to :ssl_ca_cert, :class_name => "Katello::ContentCredential", :inverse_of => :ssl_ca_products

--- a/app/models/katello/product_content.rb
+++ b/app/models/katello/product_content.rb
@@ -1,7 +1,7 @@
 module Katello
   class ProductContent < Katello::Model
-    belongs_to :product, :class_name => 'Katello::Product', :foreign_key => 'product_id', :inverse_of => :product_contents
-    belongs_to :content, :class_name => 'Katello::Content', :foreign_key => 'content_id', :inverse_of => :product_contents
+    belongs_to :product, :class_name => 'Katello::Product', :inverse_of => :product_contents
+    belongs_to :content, :class_name => 'Katello::Content', :inverse_of => :product_contents
 
     default_scope { includes(:content) }
 

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -37,7 +37,7 @@ module Katello
 
     belongs_to :root, :inverse_of => :repositories, :class_name => "Katello::RootRepository"
     belongs_to :environment, :inverse_of => :repositories, :class_name => "Katello::KTEnvironment"
-    belongs_to :library_instance, :class_name => "Katello::Repository", :inverse_of => :library_instances_inverse, :foreign_key => :library_instance_id
+    belongs_to :library_instance, :class_name => "Katello::Repository", :inverse_of => :library_instances_inverse
     has_many :library_instances_inverse,
              :class_name  => 'Katello::Repository',
              :dependent   => :restrict_with_exception,
@@ -105,7 +105,7 @@ module Katello
     has_many :filters, :through => :repository_content_view_filters
 
     belongs_to :content_view_version, :inverse_of => :repositories, :class_name => "Katello::ContentViewVersion"
-    has_many :distribution_references, :class_name => 'Katello::Pulp3::DistributionReference', :foreign_key => :repository_id,
+    has_many :distribution_references, :class_name => 'Katello::Pulp3::DistributionReference',
              :dependent => :destroy, :inverse_of => :repository
 
     has_many :smart_proxy_sync_histories, :class_name => "::Katello::SmartProxySyncHistory", :inverse_of => :repository, :dependent => :delete_all

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -49,7 +49,7 @@ module Katello
     has_many :repositories, :class_name => "Katello::Repository", :foreign_key => :root_id,
                           :inverse_of => :root, :dependent => :destroy
 
-    has_many :repository_references, :class_name => 'Katello::Pulp3::RepositoryReference', :foreign_key => :root_repository_id,
+    has_many :repository_references, :class_name => 'Katello::Pulp3::RepositoryReference',
              :dependent => :destroy, :inverse_of => :root_repository
 
     validates_lengths_from_database :except => [:label]

--- a/db/migrate/20150930183738_migrate_content_hosts.rb
+++ b/db/migrate/20150930183738_migrate_content_hosts.rb
@@ -38,7 +38,7 @@ class MigrateContentHosts < ActiveRecord::Migration[4.2]
     self.table_name = "katello_content_views"
 
     has_many :systems, :class_name => "MigrateContentHosts::System", :dependent => :restrict_with_exception
-    has_many :content_facets, :class_name => "MigrateContentHosts::ContentFacet", :foreign_key => :content_view_id,
+    has_many :content_facets, :class_name => "MigrateContentHosts::ContentFacet",
              :inverse_of => :content_view, :dependent => :restrict_with_exception
   end
 

--- a/db/migrate/20180612164926_add_content_org_id.rb
+++ b/db/migrate/20180612164926_add_content_org_id.rb
@@ -7,8 +7,8 @@ class AddContentOrgId < ActiveRecord::Migration[5.1]
 
   class FakeProductContent < Katello::Model
     self.table_name = 'katello_product_contents'
-    belongs_to :product, :class_name => 'Katello::Product', :foreign_key => 'product_id', :inverse_of => :product_contents
-    belongs_to :content, :class_name => 'FakeContent', :foreign_key => 'content_id', :inverse_of => :product_contents
+    belongs_to :product, :class_name => 'Katello::Product', :inverse_of => :product_contents
+    belongs_to :content, :class_name => 'FakeContent', :inverse_of => :product_contents
   end
 
   class FakeProduct < Katello::Model

--- a/db/migrate/20211201154845_add_unique_indexes.rb
+++ b/db/migrate/20211201154845_add_unique_indexes.rb
@@ -1,0 +1,114 @@
+class AddUniqueIndexes < ActiveRecord::Migration[6.0]
+  include ActionView::Helpers::TextHelper
+  def up
+    clean_unindexed_tables
+    add_index :katello_capsule_lifecycle_environments, [:capsule_id, :lifecycle_environment_id], unique: true, name: 'katello_capsule_lifecycle_environments_unique_index'
+    add_index :katello_content_view_erratum_filter_rules, [:errata_id, :content_view_filter_id], unique: true, name: 'katello_content_view_erratum_filter_rules_unique_index'
+    add_index :katello_content_view_module_stream_filter_rules, [:module_stream_id, :content_view_filter_id], unique: true, name: 'katello_content_view_module_stream_filter_rules_unique_index'
+    add_index :katello_content_view_package_group_filter_rules, [:uuid, :content_view_filter_id], unique: true, name: 'katello_content_view_package_group_filter_rules_unique_index'
+    add_index :katello_content_view_repositories, [:content_view_id, :repository_id], unique: true, name: 'katello_content_view_repositories_unique_index'
+    add_index :katello_content_views, [:name, :organization_id], unique: true, name: 'katello_content_views_name_unique_index'
+  end
+
+  def down
+    remove_index :katello_capsule_lifecycle_environments, name: 'katello_capsule_lifecycle_environments_unique_index'
+    remove_index :katello_content_view_erratum_filter_rules, name: 'katello_content_view_erratum_filter_rules_unique_index'
+    remove_index :katello_content_view_module_stream_filter_rules, name: 'katello_content_view_module_stream_filter_rules_unique_index'
+    remove_index :katello_content_view_package_group_filter_rules, name: 'katello_content_view_package_group_filter_rules_unique_index'
+    remove_index :katello_content_view_repositories, name: 'katello_content_view_repositories_unique_index'
+    remove_index :katello_content_views, name: 'katello_content_views_name_unique_index'
+  end
+
+  def clean_unindexed_tables
+    models_to_clean = [
+      {
+        :model => ::Katello::CapsuleLifecycleEnvironment,
+        :fields => [:lifecycle_environment_id, :capsule_id]
+      },
+      {
+        :model => ::Katello::ContentViewErratumFilterRule,
+        :fields => [:errata_id, :content_view_filter_id]
+      },
+      {
+        :model => ::Katello::ContentViewModuleStreamFilterRule,
+        :fields => [:module_stream_id, :content_view_filter_id]
+      },
+      {
+        :model => ::Katello::ContentViewPackageGroupFilterRule,
+        :fields => [:uuid, :content_view_filter_id]
+      },
+      {
+        :model =>
+        ::Katello::ContentViewRepository,
+        :fields => [:content_view_id, :repository_id]
+      }
+    ]
+    # example ---- (IDs 1/7 and 6/8 are duplicates ) ::Katello::CapsuleLifecycleEnvironment.all
+    # => [#<Katello::CapsuleLifecycleEnvironment:0x0000000017e11060 id: 1, capsule_id: 1, lifecycle_environment_id: 1>,
+    # #<Katello::CapsuleLifecycleEnvironment:0x0000000017e10f98 id: 2, capsule_id: 1, lifecycle_environment_id: 2>,
+    # #<Katello::CapsuleLifecycleEnvironment:0x0000000017e10ed0 id: 3, capsule_id: 1, lifecycle_environment_id: 3>,
+    # ...
+    # #<Katello::CapsuleLifecycleEnvironment:0x0000000017e10c78 id: 6, capsule_id: 1, lifecycle_environment_id: 6>,
+    # #<Katello::CapsuleLifecycleEnvironment:0x0000000017e10bb0 id: 7, capsule_id: 1, lifecycle_environment_id: 1>,
+    # #<Katello::CapsuleLifecycleEnvironment:0x0000000017e10ac0 id: 8, capsule_id: 1, lifecycle_environment_id: 6>]
+
+    models_to_clean.each do |model_to_clean|
+      rows_deleted = 0
+      model = model_to_clean[:model]
+      cleaning_queries(model_to_clean).each { |query| rows_deleted += clean_duplicates(query, model) }
+      if rows_deleted > 0
+        Rails.logger.info("Deleted #{pluralize(rows_deleted, 'duplicate table row')} from #{model.table_name}")
+      end
+    end
+    Rails.logger.info("Finished cleaning duplicate table rows")
+
+    models_to_rename = [
+      {
+        :model => ::Katello::ContentView,
+        :fields => [:name, :organization_id]
+      }
+    ]
+    models_to_rename.each do |model_to_rename|
+      rows_renamed = 0
+      model = model_to_rename[:model]
+      cleaning_queries(model_to_rename).each { |query| rows_renamed += rename_duplicates(query, model) }
+      if rows_renamed > 0
+        Rails.logger.info("Renamed #{pluralize(rows_renamed, 'duplicate table row')} from #{model.table_name}")
+      end
+    end
+    Rails.logger.info("Finished renaming duplicate table rows")
+  end
+
+  def cleaning_queries(model_to_clean)
+    model = model_to_clean[:model]
+    fields = model_to_clean[:fields]
+    dup_query = model.group(fields).having("count(*) > 1")
+    duplicate_entries = dup_query.count.keys #  [[1, 1], [6, 1]] - the set of duplicate combinations
+    return [] if duplicate_entries.blank?
+    min_ids = dup_query&.pluck('min(id)') # [1, 6] - the ids of the duplicate entries with the lowest id, in the same order as duplicate_entries
+    duplicate_entries.map.with_index do |entry, idx|
+      # [{:lifecycle_environment_id=>1, :capsule_id=>1, :min_id=>1},
+      # {:lifecycle_environment_id=>6, :capsule_id=>1, :min_id=>6}]
+      Hash[fields.zip(entry)].merge({ min_id: min_ids[idx] })
+    end
+  end
+
+  def clean_duplicates(query, model)
+    min_id = query.delete(:min_id)
+    model.where(query).where.not(id: min_id).delete_all # returns quantity deleted
+  end
+
+  def rename_duplicates(query, model)
+    min_id = query.delete(:min_id)
+    counter = 0
+    model.where(query).where.not(id: min_id).each do |duplicate|
+      counter += 1
+      old_name = duplicate.name
+      new_name = "#{duplicate.name}_#{duplicate.id}"
+      duplicate.name = new_name
+      duplicate.save(validate: false) # skip validation since migrations should never fail
+      Rails.logger.info("Content view #{old_name} (id #{duplicate.id}) renamed to #{new_name}")
+    end
+    counter
+  end
+end

--- a/db/migrate/20211201154845_add_unique_indexes.rb
+++ b/db/migrate/20211201154845_add_unique_indexes.rb
@@ -1,7 +1,6 @@
 class AddUniqueIndexes < ActiveRecord::Migration[6.0]
-  include ActionView::Helpers::TextHelper
   def up
-    clean_unindexed_tables
+    ::Katello::Util::DeduplicationMigrator.new.execute!
     add_index :katello_capsule_lifecycle_environments, [:capsule_id, :lifecycle_environment_id], unique: true, name: 'katello_capsule_lifecycle_environments_unique_index'
     add_index :katello_content_view_erratum_filter_rules, [:errata_id, :content_view_filter_id], unique: true, name: 'katello_content_view_erratum_filter_rules_unique_index'
     add_index :katello_content_view_module_stream_filter_rules, [:module_stream_id, :content_view_filter_id], unique: true, name: 'katello_content_view_module_stream_filter_rules_unique_index'
@@ -17,98 +16,5 @@ class AddUniqueIndexes < ActiveRecord::Migration[6.0]
     remove_index :katello_content_view_package_group_filter_rules, name: 'katello_content_view_package_group_filter_rules_unique_index'
     remove_index :katello_content_view_repositories, name: 'katello_content_view_repositories_unique_index'
     remove_index :katello_content_views, name: 'katello_content_views_name_unique_index'
-  end
-
-  def clean_unindexed_tables
-    models_to_clean = [
-      {
-        :model => ::Katello::CapsuleLifecycleEnvironment,
-        :fields => [:lifecycle_environment_id, :capsule_id]
-      },
-      {
-        :model => ::Katello::ContentViewErratumFilterRule,
-        :fields => [:errata_id, :content_view_filter_id]
-      },
-      {
-        :model => ::Katello::ContentViewModuleStreamFilterRule,
-        :fields => [:module_stream_id, :content_view_filter_id]
-      },
-      {
-        :model => ::Katello::ContentViewPackageGroupFilterRule,
-        :fields => [:uuid, :content_view_filter_id]
-      },
-      {
-        :model =>
-        ::Katello::ContentViewRepository,
-        :fields => [:content_view_id, :repository_id]
-      }
-    ]
-    # example ---- (IDs 1/7 and 6/8 are duplicates ) ::Katello::CapsuleLifecycleEnvironment.all
-    # => [#<Katello::CapsuleLifecycleEnvironment:0x0000000017e11060 id: 1, capsule_id: 1, lifecycle_environment_id: 1>,
-    # #<Katello::CapsuleLifecycleEnvironment:0x0000000017e10f98 id: 2, capsule_id: 1, lifecycle_environment_id: 2>,
-    # #<Katello::CapsuleLifecycleEnvironment:0x0000000017e10ed0 id: 3, capsule_id: 1, lifecycle_environment_id: 3>,
-    # ...
-    # #<Katello::CapsuleLifecycleEnvironment:0x0000000017e10c78 id: 6, capsule_id: 1, lifecycle_environment_id: 6>,
-    # #<Katello::CapsuleLifecycleEnvironment:0x0000000017e10bb0 id: 7, capsule_id: 1, lifecycle_environment_id: 1>,
-    # #<Katello::CapsuleLifecycleEnvironment:0x0000000017e10ac0 id: 8, capsule_id: 1, lifecycle_environment_id: 6>]
-
-    models_to_clean.each do |model_to_clean|
-      rows_deleted = 0
-      model = model_to_clean[:model]
-      cleaning_queries(model_to_clean).each { |query| rows_deleted += clean_duplicates(query, model) }
-      if rows_deleted > 0
-        Rails.logger.info("Deleted #{pluralize(rows_deleted, 'duplicate table row')} from #{model.table_name}")
-      end
-    end
-    Rails.logger.info("Finished cleaning duplicate table rows")
-
-    models_to_rename = [
-      {
-        :model => ::Katello::ContentView,
-        :fields => [:name, :organization_id]
-      }
-    ]
-    models_to_rename.each do |model_to_rename|
-      rows_renamed = 0
-      model = model_to_rename[:model]
-      cleaning_queries(model_to_rename).each { |query| rows_renamed += rename_duplicates(query, model) }
-      if rows_renamed > 0
-        Rails.logger.info("Renamed #{pluralize(rows_renamed, 'duplicate table row')} from #{model.table_name}")
-      end
-    end
-    Rails.logger.info("Finished renaming duplicate table rows")
-  end
-
-  def cleaning_queries(model_to_clean)
-    model = model_to_clean[:model]
-    fields = model_to_clean[:fields]
-    dup_query = model.group(fields).having("count(*) > 1")
-    duplicate_entries = dup_query.count.keys #  [[1, 1], [6, 1]] - the set of duplicate combinations
-    return [] if duplicate_entries.blank?
-    min_ids = dup_query&.pluck('min(id)') # [1, 6] - the ids of the duplicate entries with the lowest id, in the same order as duplicate_entries
-    duplicate_entries.map.with_index do |entry, idx|
-      # [{:lifecycle_environment_id=>1, :capsule_id=>1, :min_id=>1},
-      # {:lifecycle_environment_id=>6, :capsule_id=>1, :min_id=>6}]
-      Hash[fields.zip(entry)].merge({ min_id: min_ids[idx] })
-    end
-  end
-
-  def clean_duplicates(query, model)
-    min_id = query.delete(:min_id)
-    model.where(query).where.not(id: min_id).delete_all # returns quantity deleted
-  end
-
-  def rename_duplicates(query, model)
-    min_id = query.delete(:min_id)
-    counter = 0
-    model.where(query).where.not(id: min_id).each do |duplicate|
-      counter += 1
-      old_name = duplicate.name
-      new_name = "#{duplicate.name}_#{duplicate.id}"
-      duplicate.name = new_name
-      duplicate.save(validate: false) # skip validation since migrations should never fail
-      Rails.logger.info("Content view #{old_name} (id #{duplicate.id}) renamed to #{new_name}")
-    end
-    counter
   end
 end

--- a/test/actions/katello/activation_key_test.rb
+++ b/test/actions/katello/activation_key_test.rb
@@ -34,7 +34,7 @@ module ::Actions::Katello::ActivationKey
 
     it 'raises error when validation fails' do
       activation_key.name = nil
-      _ { proc { plan_action action, activation_key } }.must_raise(ActiveRecord::RecordInvalid)
+      proc { plan_action action, activation_key }.must_raise(ActiveRecord::RecordInvalid)
     end
   end
 

--- a/test/actions/katello/activation_key_test.rb
+++ b/test/actions/katello/activation_key_test.rb
@@ -34,7 +34,7 @@ module ::Actions::Katello::ActivationKey
 
     it 'raises error when validation fails' do
       activation_key.name = nil
-      proc { plan_action action, activation_key }.must_raise(ActiveRecord::RecordInvalid)
+      assert_raises(ActiveRecord::RecordInvalid) { plan_action action, activation_key }
     end
   end
 

--- a/test/actions/katello/activation_key_test.rb
+++ b/test/actions/katello/activation_key_test.rb
@@ -34,7 +34,7 @@ module ::Actions::Katello::ActivationKey
 
     it 'raises error when validation fails' do
       activation_key.name = nil
-      proc { plan_action action, activation_key }.must_raise(ActiveRecord::RecordInvalid)
+      _ { proc { plan_action action, activation_key } }.must_raise(ActiveRecord::RecordInvalid)
     end
   end
 

--- a/test/actions/katello/activation_key_test.rb
+++ b/test/actions/katello/activation_key_test.rb
@@ -29,7 +29,7 @@ module ::Actions::Katello::ActivationKey
 
       plan_action action, activation_key, service_level: 'Self-support'
 
-      assert_action_planed_with(action, ::Actions::Candlepin::ActivationKey::Create, candlepin_input)
+      assert_action_planned_with(action, ::Actions::Candlepin::ActivationKey::Create, candlepin_input)
     end
 
     it 'raises error when validation fails' do
@@ -85,7 +85,7 @@ module ::Actions::Katello::ActivationKey
       action.expects(:plan_self)
       action.expects(:action_subject).with(activation_key)
       plan_action(action, activation_key)
-      assert_action_planed_with(action, ::Actions::Candlepin::ActivationKey::Destroy, cp_id: activation_key.cp_id)
+      assert_action_planned_with(action, ::Actions::Candlepin::ActivationKey::Destroy, cp_id: activation_key.cp_id)
     end
   end
 end

--- a/test/actions/katello/check_matching_content_test.rb
+++ b/test/actions/katello/check_matching_content_test.rb
@@ -28,7 +28,7 @@ module ::Actions::Katello
 
       plan_action(action, new_repo, [repo])
 
-      assert_action_planed_with(action, Actions::Katello::Repository::CheckMatchingContent, :source_repo_id => repo.id, :target_repo_id => new_repo.id)
+      assert_action_planned_with(action, Actions::Katello::Repository::CheckMatchingContent, :source_repo_id => repo.id, :target_repo_id => new_repo.id)
     end
 
     def test_does_not_plan_check_matching_content_without_target_repo_environment

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -341,7 +341,7 @@ module ::Actions::Katello::ContentView
 
     it 'raises error when validation fails' do
       ::Actions::Katello::ContentView::Update.any_instance.expects(:action_subject).with(content_view)
-      proc { create_and_plan_action action_class, content_view, :name => '' }.must_raise(ActiveRecord::RecordInvalid)
+      assert_raises(ActiveRecord::RecordInvalid) { create_and_plan_action action_class, content_view, :name => '' }
     end
   end
 

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -341,7 +341,7 @@ module ::Actions::Katello::ContentView
 
     it 'raises error when validation fails' do
       ::Actions::Katello::ContentView::Update.any_instance.expects(:action_subject).with(content_view)
-      proc { create_and_plan_action action_class, content_view, :name => '' }.must_raise(ActiveRecord::RecordInvalid)
+      _ { proc { create_and_plan_action action_class, content_view, :name => '' } }.must_raise(ActiveRecord::RecordInvalid)
     end
   end
 

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -192,7 +192,7 @@ module ::Actions::Katello::ContentView
 
       action.expects(:action_subject).with(content_view)
       plan_action(action, content_view, environment)
-      assert_action_planed_with(action, ::Actions::Katello::ContentViewEnvironment::Destroy, cve)
+      assert_action_planned_with(action, ::Actions::Katello::ContentViewEnvironment::Destroy, cve)
     end
   end
 
@@ -219,7 +219,7 @@ module ::Actions::Katello::ContentView
 
       action.expects(:action_subject).with(version.content_view)
       plan_action(action, version)
-      assert_action_planed_with(action, ::Actions::Katello::ContentViewVersion::Destroy, version)
+      assert_action_planned_with(action, ::Actions::Katello::ContentViewVersion::Destroy, version)
     end
   end
 
@@ -274,7 +274,7 @@ module ::Actions::Katello::ContentView
       action.expects(:action_subject).with(content_view)
       plan_action(action, content_view, options)
 
-      assert_action_planed_with(action, ::Actions::Katello::ContentViewEnvironment::Destroy, cv_env, :skip_repo_destroy => false, :organization_destroy => false)
+      assert_action_planned_with(action, ::Actions::Katello::ContentViewEnvironment::Destroy, cv_env, :skip_repo_destroy => false, :organization_destroy => false)
     end
 
     it 'plans for removing a version and an environment' do
@@ -289,8 +289,8 @@ module ::Actions::Katello::ContentView
       action.expects(:action_subject).with(content_view)
 
       plan_action(action, content_view, options)
-      assert_action_planed_with(action, ::Actions::Katello::ContentViewEnvironment::Destroy, cv_env, :skip_repo_destroy => false, :organization_destroy => false)
-      assert_action_planed_with(action, ::Actions::Katello::ContentViewVersion::Destroy, version, :skip_environment_check => true, :skip_destroy_env_content => true)
+      assert_action_planned_with(action, ::Actions::Katello::ContentViewEnvironment::Destroy, cv_env, :skip_repo_destroy => false, :organization_destroy => false)
+      assert_action_planned_with(action, ::Actions::Katello::ContentViewVersion::Destroy, version, :skip_environment_check => true, :skip_destroy_env_content => true)
     end
 
     it 'plans deleting all CV env and versions and removing repository references with destroy_content_view param' do
@@ -307,12 +307,12 @@ module ::Actions::Katello::ContentView
 
       plan_action(action, content_view, options)
       content_view.content_view_environments.each do |cvenv|
-        assert_action_planed_with(action, ::Actions::Katello::ContentViewEnvironment::Destroy, cvenv, :skip_repo_destroy => false, :organization_destroy => false)
+        assert_action_planned_with(action, ::Actions::Katello::ContentViewEnvironment::Destroy, cvenv, :skip_repo_destroy => false, :organization_destroy => false)
       end
       content_view.versions.each do |cv_version|
-        assert_action_planed_with(action, ::Actions::Katello::ContentViewVersion::Destroy, cv_version, :skip_environment_check => true, :skip_destroy_env_content => true)
+        assert_action_planned_with(action, ::Actions::Katello::ContentViewVersion::Destroy, cv_version, :skip_environment_check => true, :skip_destroy_env_content => true)
       end
-      assert_action_planed_with(action, ::Actions::Pulp3::ContentView::DeleteRepositoryReferences, content_view, smart_proxy_service_1.smart_proxy)
+      assert_action_planned_with(action, ::Actions::Pulp3::ContentView::DeleteRepositoryReferences, content_view, smart_proxy_service_1.smart_proxy)
     end
 
     context 'organization destroy' do
@@ -363,7 +363,7 @@ module ::Actions::Katello::ContentView
       action.expects(:action_subject).with(view.reload)
       action.expects(:plan_self)
       plan_action(action, view)
-      assert_action_planed_with(action, ::Actions::Katello::ContentViewVersion::Destroy, version, {})
+      assert_action_planned_with(action, ::Actions::Katello::ContentViewVersion::Destroy, version, {})
     end
   end
 
@@ -418,7 +418,7 @@ module ::Actions::Katello::ContentView
 
       plan_action(action, [{:content_view_version => content_view.version(library), :environments => [library]}], [],
                   {:errata_ids => ["FOO"]}, true, [], "BadDescription")
-      assert_action_planed_with(action, ::Actions::Katello::ContentViewVersion::IncrementalUpdate, content_view.version(library), [library],
+      assert_action_planned_with(action, ::Actions::Katello::ContentViewVersion::IncrementalUpdate, content_view.version(library), [library],
                                 :content => {:errata_ids => ["FOO"]}, :resolve_dependencies => true, :description => "BadDescription")
     end
 
@@ -432,9 +432,9 @@ module ::Actions::Katello::ContentView
 
       plan_action(action, [{:content_view_version => component, :environments => []}], [{:content_view_version => composite_version, :environments => [library]}],
                   {:errata_ids => ["FOO"]}, true, [], "BadDescription")
-      assert_action_planed_with(action, ::Actions::Katello::ContentViewVersion::IncrementalUpdate, component, [],
+      assert_action_planned_with(action, ::Actions::Katello::ContentViewVersion::IncrementalUpdate, component, [],
                                 :content => {:errata_ids => ["FOO"]}, :resolve_dependencies => true, :description => "BadDescription")
-      assert_action_planed_with(action, ::Actions::Katello::ContentViewVersion::IncrementalUpdate, composite_version, [library],
+      assert_action_planned_with(action, ::Actions::Katello::ContentViewVersion::IncrementalUpdate, composite_version, [library],
                                 :new_components => [new_version],
                                 :description => "BadDescription")
     end

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -341,7 +341,7 @@ module ::Actions::Katello::ContentView
 
     it 'raises error when validation fails' do
       ::Actions::Katello::ContentView::Update.any_instance.expects(:action_subject).with(content_view)
-      _ { proc { create_and_plan_action action_class, content_view, :name => '' } }.must_raise(ActiveRecord::RecordInvalid)
+      proc { create_and_plan_action action_class, content_view, :name => '' }.must_raise(ActiveRecord::RecordInvalid)
     end
   end
 

--- a/test/actions/katello/content_view_version/create_repos_test.rb
+++ b/test/actions/katello/content_view_version/create_repos_test.rb
@@ -24,7 +24,7 @@ module Katello::Host
         repositories = [[library_repo]]
         library_repo.expects(:build_clone).with(content_view: @version.content_view, version: @version).returns(new_repo)
         plan_action(action, @version, repositories)
-        assert_action_planed_with(action, ::Actions::Katello::Repository::Create, new_repo, clone: true)
+        assert_action_planned_with(action, ::Actions::Katello::Repository::Create, new_repo, clone: true)
         mapping = {}
         mapping[[library_repo]] = new_repo
         assert_equal mapping, action.repository_mapping

--- a/test/actions/katello/content_view_version/destroy_test.rb
+++ b/test/actions/katello/content_view_version/destroy_test.rb
@@ -20,7 +20,7 @@ module Katello::Host
         plan_action(action, @version, options)
 
         @version.repositories.each do |repo|
-          assert_action_planed_with(action, Actions::Katello::Repository::Destroy, repo, options)
+          assert_action_planned_with(action, Actions::Katello::Repository::Destroy, repo, options)
         end
       end
     end

--- a/test/actions/katello/content_view_version/republish_repositories_test.rb
+++ b/test/actions/katello/content_view_version/republish_repositories_test.rb
@@ -20,7 +20,7 @@ module Katello::Host
 
         plan_action(action, @version)
 
-        assert_action_planed_with(action, ::Actions::Katello::Repository::BulkMetadataGenerate, @version.repositories)
+        assert_action_planned_with(action, ::Actions::Katello::Repository::BulkMetadataGenerate, @version.repositories)
       end
     end
   end

--- a/test/actions/katello/content_view_version_test.rb
+++ b/test/actions/katello/content_view_version_test.rb
@@ -45,8 +45,8 @@ module ::Actions::Katello::ContentViewVersion
       action.expects(:action_subject).with(content_view_version.content_view)
       plan_action(action, content_view_version, [library], :content => {:package_ids => [@rpm.id]})
 
-      assert_action_planed_with(action, ::Actions::Katello::Repository::MetadataGenerate, new_repo)
-      assert_action_planed_with(action, ::Actions::Katello::Repository::IndexContent, id: new_repo.id)
+      assert_action_planned_with(action, ::Actions::Katello::Repository::MetadataGenerate, new_repo)
+      assert_action_planned_with(action, ::Actions::Katello::Repository::IndexContent, id: new_repo.id)
     end
 
     describe 'pulp3' do
@@ -87,12 +87,12 @@ module ::Actions::Katello::ContentViewVersion
 
         pulp3_repo_map = {}
         pulp3_repo_map[[library_repo.id]] = { :dest_repo => new_repo.id, :base_version => 1 }
-        assert_action_planed_with(action, ::Actions::Pulp3::Repository::MultiCopyUnits,
+        assert_action_planned_with(action, ::Actions::Pulp3::Repository::MultiCopyUnits,
                                   pulp3_repo_map,
                                   { :errata => [], :rpms => [old_rpm.id] },
                                   :dependency_solving => false)
-        assert_action_planed_with(action, ::Actions::Katello::Repository::MetadataGenerate, new_repo)
-        assert_action_planed_with(action, ::Actions::Katello::Repository::IndexContent, id: new_repo.id)
+        assert_action_planned_with(action, ::Actions::Katello::Repository::MetadataGenerate, new_repo)
+        assert_action_planned_with(action, ::Actions::Katello::Repository::IndexContent, id: new_repo.id)
       end
 
       it 'respects dep solving true' do
@@ -101,7 +101,7 @@ module ::Actions::Katello::ContentViewVersion
 
         pulp3_repo_map = {}
         pulp3_repo_map[[library_repo.id]] = { :dest_repo => new_repo.id, :base_version => 1 }
-        assert_action_planed_with(action, ::Actions::Pulp3::Repository::MultiCopyUnits,
+        assert_action_planned_with(action, ::Actions::Pulp3::Repository::MultiCopyUnits,
                                   pulp3_repo_map,
                                   { :errata => [], :rpms => [old_rpm.id] },
                                   :dependency_solving => true)

--- a/test/actions/katello/environment_test.rb
+++ b/test/actions/katello/environment_test.rb
@@ -28,7 +28,7 @@ module ::Actions::Katello::Environment
       environment.expects(:content_view_environments).returns([cve])
       environment.expects(:deletable?).returns(true)
       plan_action(action, environment)
-      assert_action_planed_with(action, ::Actions::Katello::ContentView::Remove, content_view, :content_view_environments => [cve], :skip_repo_destroy => false, :organization_destroy => false)
+      assert_action_planned_with(action, ::Actions::Katello::ContentView::Remove, content_view, :content_view_environments => [cve], :skip_repo_destroy => false, :organization_destroy => false)
     end
   end
 end

--- a/test/actions/katello/host/attach_subscriptions_test.rb
+++ b/test/actions/katello/host/attach_subscriptions_test.rb
@@ -27,9 +27,9 @@ module Katello::Host
 
         plan_action action, @host, pools_with_quantities
 
-        assert_action_planed_with action, Actions::Candlepin::Consumer::AttachSubscription, :uuid => @host.subscription_facet.uuid,
+        assert_action_planned_with action, Actions::Candlepin::Consumer::AttachSubscription, :uuid => @host.subscription_facet.uuid,
                                   :quantity => 1, :pool_uuid => @pool.cp_id
-        assert_action_planed_with action, Actions::Candlepin::Consumer::AttachSubscription, :uuid => @host.subscription_facet.uuid,
+        assert_action_planned_with action, Actions::Candlepin::Consumer::AttachSubscription, :uuid => @host.subscription_facet.uuid,
                                           :quantity => 2, :pool_uuid => @pool.cp_id
       end
 

--- a/test/actions/katello/host/auto_attach_subscription_test.rb
+++ b/test/actions/katello/host/auto_attach_subscription_test.rb
@@ -20,7 +20,7 @@ module Katello::Host
 
         plan_action action, @host
 
-        assert_action_planed_with action, Actions::Candlepin::Consumer::AutoAttachSubscriptions, :uuid => @host.subscription_facet.uuid
+        assert_action_planned_with action, Actions::Candlepin::Consumer::AutoAttachSubscriptions, :uuid => @host.subscription_facet.uuid
       end
     end
   end

--- a/test/actions/katello/host/hypervisors_test.rb
+++ b/test/actions/katello/host/hypervisors_test.rb
@@ -24,7 +24,7 @@ module Katello::Host
 
         plan_action(action, @hypervisor_params)
         assert_action_planed_with(action, ::Actions::Katello::Host::HypervisorsUpdate) do |results, *_|
-          results.must_equal(:hypervisors => [{:uuid => 1, :name => 'foo', :organization_label => 'org-label'}])
+          _(results).must_equal(:hypervisors => [{:uuid => 1, :name => 'foo', :organization_label => 'org-label'}])
         end
       end
 

--- a/test/actions/katello/host/hypervisors_test.rb
+++ b/test/actions/katello/host/hypervisors_test.rb
@@ -24,7 +24,7 @@ module Katello::Host
 
         plan_action(action, @hypervisor_params)
         assert_action_planed_with(action, ::Actions::Katello::Host::HypervisorsUpdate) do |results, *_|
-          _(results).must_equal(:hypervisors => [{:uuid => 1, :name => 'foo', :organization_label => 'org-label'}])
+          results.must_equal(:hypervisors => [{:uuid => 1, :name => 'foo', :organization_label => 'org-label'}])
         end
       end
 

--- a/test/actions/katello/host/hypervisors_test.rb
+++ b/test/actions/katello/host/hypervisors_test.rb
@@ -24,7 +24,7 @@ module Katello::Host
 
         plan_action(action, @hypervisor_params)
         assert_action_planed_with(action, ::Actions::Katello::Host::HypervisorsUpdate) do |results, *_|
-          results.must_equal(:hypervisors => [{:uuid => 1, :name => 'foo', :organization_label => 'org-label'}])
+          assert_equal results, { :hypervisors => [{:uuid => 1, :name => 'foo', :organization_label => 'org-label'}] }
         end
       end
 
@@ -40,7 +40,7 @@ module Katello::Host
                     {:uuid => 2, :name => 'foo2', :organization_label => 'org-label'},
                     {:uuid => 3, :name => 'foo3', :organization_label => 'org-label'}]
         assert_equal expected, action.class.parse_hypervisors(json)
-        assert_equal [], action.class.parse_hypervisors({})
+        assert_empty action.class.parse_hypervisors({})
       end
     end
   end

--- a/test/actions/katello/host/hypervisors_test.rb
+++ b/test/actions/katello/host/hypervisors_test.rb
@@ -23,7 +23,7 @@ module Katello::Host
         ::Katello::Resources::Candlepin::Consumer.expects(:register_hypervisors).with(@hypervisor_params).returns(@hypervisor_response)
 
         plan_action(action, @hypervisor_params)
-        assert_action_planed_with(action, ::Actions::Katello::Host::HypervisorsUpdate) do |results, *_|
+        assert_action_planned_with(action, ::Actions::Katello::Host::HypervisorsUpdate) do |results, *_|
           assert_equal results, { :hypervisors => [{:uuid => 1, :name => 'foo', :organization_label => 'org-label'}] }
         end
       end

--- a/test/actions/katello/host/remove_subscriptions_test.rb
+++ b/test/actions/katello/host/remove_subscriptions_test.rb
@@ -27,9 +27,9 @@ module Katello::Host
 
         plan_action action, @host, pools_with_quantities
 
-        assert_action_planed_with action, Actions::Candlepin::Consumer::RemoveSubscription, :uuid => @host.subscription_facet.uuid,
+        assert_action_planned_with action, Actions::Candlepin::Consumer::RemoveSubscription, :uuid => @host.subscription_facet.uuid,
                                           :entitlement_id => 3, :pool_id => 'foo'
-        assert_action_planed_with action, Actions::Candlepin::Consumer::RemoveSubscription, :uuid => @host.subscription_facet.uuid,
+        assert_action_planned_with action, Actions::Candlepin::Consumer::RemoveSubscription, :uuid => @host.subscription_facet.uuid,
                                           :entitlement_id => 4, :pool_id => 'bar'
       end
     end

--- a/test/actions/katello/host/upload_profiles_test.rb
+++ b/test/actions/katello/host/upload_profiles_test.rb
@@ -68,7 +68,7 @@ module Katello::Host
         ::Host.expects(:find_by).returns(@host).at_least_once
         @host.expects(:import_package_profile).with do |packages|
           expected_packages = rpm_profiles.map { |prof| ::Katello::Pulp::SimplePackage.new(prof) }
-          _(packages.map(&:nvra)).must_equal(expected_packages.map(&:nvra))
+          packages.map(&:nvra).must_equal(expected_packages.map(&:nvra))
         end
         @host.expects(:import_enabled_repositories).with(enabled_repos)
 

--- a/test/actions/katello/host/upload_profiles_test.rb
+++ b/test/actions/katello/host/upload_profiles_test.rb
@@ -68,7 +68,7 @@ module Katello::Host
         ::Host.expects(:find_by).returns(@host).at_least_once
         @host.expects(:import_package_profile).with do |packages|
           expected_packages = rpm_profiles.map { |prof| ::Katello::Pulp::SimplePackage.new(prof) }
-          packages.map(&:nvra).must_equal(expected_packages.map(&:nvra))
+          _(packages.map(&:nvra)).must_equal(expected_packages.map(&:nvra))
         end
         @host.expects(:import_enabled_repositories).with(enabled_repos)
 

--- a/test/actions/katello/host/upload_profiles_test.rb
+++ b/test/actions/katello/host/upload_profiles_test.rb
@@ -68,7 +68,7 @@ module Katello::Host
         ::Host.expects(:find_by).returns(@host).at_least_once
         @host.expects(:import_package_profile).with do |packages|
           expected_packages = rpm_profiles.map { |prof| ::Katello::Pulp::SimplePackage.new(prof) }
-          packages.map(&:nvra).must_equal(expected_packages.map(&:nvra))
+          assert_equal packages.map(&:nvra), expected_packages.map(&:nvra)
         end
         @host.expects(:import_enabled_repositories).with(enabled_repos)
 

--- a/test/actions/katello/product_test.rb
+++ b/test/actions/katello/product_test.rb
@@ -38,10 +38,10 @@ module ::Actions::Katello::Product
           action = create_action action_class
           action.stubs(:action_subject).with(@repository)
           plan_action action, @repository.root
-          assert_action_planed_with action, candlepin_remove_class, product_id: @product.cp_id,
+          assert_action_planned_with action, candlepin_remove_class, product_id: @product.cp_id,
                                                                     owner: @product.organization.label,
                                                                     content_id: @repository.content_id
-          assert_action_planed_with action, candlepin_destroy_class, content_id: @repository.content_id,
+          assert_action_planned_with action, candlepin_destroy_class, content_id: @repository.content_id,
                                                                      owner: @product.organization.label
         end
 
@@ -51,10 +51,10 @@ module ::Actions::Katello::Product
           action = create_action action_class
           action.stubs(:action_subject).with(@repository)
           plan_action action, @repository.root
-          assert_action_planed_with action, candlepin_remove_class, product_id: @product.cp_id,
+          assert_action_planned_with action, candlepin_remove_class, product_id: @product.cp_id,
                                                                     owner: @product.organization.label,
                                                                     content_id: @repository.content_id
-          assert_action_planed_with action, candlepin_destroy_class, content_id: @repository.content_id,
+          assert_action_planned_with action, candlepin_destroy_class, content_id: @repository.content_id,
                                                                      owner: @product.organization.label
         end
 
@@ -94,7 +94,7 @@ module ::Actions::Katello::Product
 
       plan_action(action, product, product.organization)
 
-      assert_action_planed_with(action,
+      assert_action_planned_with(action,
                                 ::Actions::Candlepin::Product::Create,
                                 :id => '3',
                                 :name => product.name,
@@ -117,13 +117,13 @@ module ::Actions::Katello::Product
       action.expects(:action_subject).with(product)
       product.expects(:reload)
       plan_action action, product, :gpg_key_id => key.id, :name => "Animal Product"
-      assert_action_planed_with(action, ::Actions::Katello::Product::RepositoriesGpgReset, product)
+      assert_action_planned_with(action, ::Actions::Katello::Product::RepositoriesGpgReset, product)
 
-      assert_action_planed_with(action, ::Actions::Candlepin::Product::Update, owner: product.organization.label, name: product.name, id: product.cp_id)
+      assert_action_planned_with(action, ::Actions::Candlepin::Product::Update, owner: product.organization.label, name: product.name, id: product.cp_id)
 
       assert(product.subscriptions.length > 0)
       product.subscriptions.each do |subscription|
-        assert_action_planed_with(action, ::Actions::Katello::Subscription::Update, subscription, name: product.name)
+        assert_action_planned_with(action, ::Actions::Katello::Subscription::Update, subscription, name: product.name)
       end
     end
 
@@ -201,21 +201,21 @@ module ::Actions::Katello::Product
 
       plan_action(action, product)
 
-      assert_action_planed_with(action, candlepin_destroy_class, cp_id: product.cp_id, owner: product.organization.label)
-      assert_action_planed_with(action, ::Actions::Katello::Product::ContentDestroy) do |root|
+      assert_action_planned_with(action, candlepin_destroy_class, cp_id: product.cp_id, owner: product.organization.label)
+      assert_action_planned_with(action, ::Actions::Katello::Product::ContentDestroy) do |root|
         root.first.repositories.where.not(id: root.first.repositories.first.id).empty?
         !root.first.repositories.first.redhat?
       end
-      assert_action_planed_with(action, ::Actions::Katello::Repository::Destroy) do |repo|
+      assert_action_planned_with(action, ::Actions::Katello::Repository::Destroy) do |repo|
         default_view_repos.include?(repo.first.id)
       end
 
-      assert_action_planed_with(action,
+      assert_action_planned_with(action,
                                 candlepin_delete_pools_class,
                                 cp_id: product.cp_id,
                                 organization_label: product.organization.label)
 
-      assert_action_planed_with(action, candlepin_delete_subscriptions_class,
+      assert_action_planned_with(action, candlepin_delete_subscriptions_class,
                                 cp_id: product.cp_id, organization_label: product.organization.label)
     end
 

--- a/test/actions/katello/product_test.rb
+++ b/test/actions/katello/product_test.rb
@@ -86,7 +86,7 @@ module ::Actions::Katello::Product
 
     it 'plans' do
       action.stubs(:action_subject).with do |subject, _params|
-        subject.must_equal(product)
+        _(subject).must_equal(product)
       end
       product.expects(:save!).returns([])
       product.organization.label = 'somelabel'
@@ -129,7 +129,7 @@ module ::Actions::Katello::Product
 
     it 'raises error when validation fails' do
       ::Actions::Katello::Product::Update.any_instance.expects(:action_subject).with(product)
-      proc { create_and_plan_action action_class, product, :name => '' }.must_raise(ActiveRecord::RecordInvalid)
+      _ { proc { create_and_plan_action action_class, product, :name => '' } }.must_raise(ActiveRecord::RecordInvalid)
     end
   end
 
@@ -191,7 +191,7 @@ module ::Actions::Katello::Product
 
     it 'plans' do
       action.stubs(:action_subject).with do |subject, _params|
-        subject.must_equal(product)
+        _(subject).must_equal(product)
       end
       product.expects(:published_content_view_versions).returns([])
       product.expects(:product_contents).returns([])

--- a/test/actions/katello/product_test.rb
+++ b/test/actions/katello/product_test.rb
@@ -86,7 +86,7 @@ module ::Actions::Katello::Product
 
     it 'plans' do
       action.stubs(:action_subject).with do |subject, _params|
-        subject.must_equal(product)
+        assert_equal subject, product
       end
       product.expects(:save!).returns([])
       product.organization.label = 'somelabel'
@@ -129,7 +129,7 @@ module ::Actions::Katello::Product
 
     it 'raises error when validation fails' do
       ::Actions::Katello::Product::Update.any_instance.expects(:action_subject).with(product)
-      proc { create_and_plan_action action_class, product, :name => '' }.must_raise(ActiveRecord::RecordInvalid)
+      assert_raises(ActiveRecord::RecordInvalid) { create_and_plan_action action_class, product, :name => '' }
     end
   end
 
@@ -191,7 +191,7 @@ module ::Actions::Katello::Product
 
     it 'plans' do
       action.stubs(:action_subject).with do |subject, _params|
-        subject.must_equal(product)
+        assert_equal subject, product
       end
       product.expects(:published_content_view_versions).returns([])
       product.expects(:product_contents).returns([])

--- a/test/actions/katello/product_test.rb
+++ b/test/actions/katello/product_test.rb
@@ -86,7 +86,7 @@ module ::Actions::Katello::Product
 
     it 'plans' do
       action.stubs(:action_subject).with do |subject, _params|
-        _(subject).must_equal(product)
+        subject.must_equal(product)
       end
       product.expects(:save!).returns([])
       product.organization.label = 'somelabel'
@@ -129,7 +129,7 @@ module ::Actions::Katello::Product
 
     it 'raises error when validation fails' do
       ::Actions::Katello::Product::Update.any_instance.expects(:action_subject).with(product)
-      _ { proc { create_and_plan_action action_class, product, :name => '' } }.must_raise(ActiveRecord::RecordInvalid)
+      proc { create_and_plan_action action_class, product, :name => '' }.must_raise(ActiveRecord::RecordInvalid)
     end
   end
 
@@ -191,7 +191,7 @@ module ::Actions::Katello::Product
 
     it 'plans' do
       action.stubs(:action_subject).with do |subject, _params|
-        _(subject).must_equal(product)
+        subject.must_equal(product)
       end
       product.expects(:published_content_view_versions).returns([])
       product.expects(:product_contents).returns([])

--- a/test/actions/katello/pulp_selector_test.rb
+++ b/test/actions/katello/pulp_selector_test.rb
@@ -39,7 +39,7 @@ module ::Actions::Katello
 
       plan_action(action, [Pulp2TestAction, Pulp3TestAction], repo, smart_proxy)
 
-      assert_action_planed_with(action, Pulp2TestAction, repo, smart_proxy)
+      assert_action_planned_with(action, Pulp2TestAction, repo, smart_proxy)
     end
 
     def test_plans_pulp3
@@ -48,7 +48,7 @@ module ::Actions::Katello
 
       plan_action(action, [Pulp2TestAction, Pulp3TestAction], repo, smart_proxy)
 
-      assert_action_planed_with(action, Pulp3TestAction, repo, smart_proxy)
+      assert_action_planned_with(action, Pulp3TestAction, repo, smart_proxy)
     end
 
     def test_plans_not_found

--- a/test/actions/katello/repository/bulk_metadata_generate_test.rb
+++ b/test/actions/katello/repository/bulk_metadata_generate_test.rb
@@ -18,8 +18,8 @@ module Actions
 
       plan_action(action, query, :force => true)
 
-      assert_action_planed_with(action, bulk_action, metadata_gen, query.archived, :force => true)
-      assert_action_planed_with(action, bulk_action, metadata_gen, query.in_published_environments, :force => true)
+      assert_action_planned_with(action, bulk_action, metadata_gen, query.archived, :force => true)
+      assert_action_planned_with(action, bulk_action, metadata_gen, query.in_published_environments, :force => true)
     end
   end
 end

--- a/test/actions/katello/repository/clone_to_version_test.rb
+++ b/test/actions/katello/repository/clone_to_version_test.rb
@@ -40,7 +40,7 @@ module Actions
 
       plan_action(action, [yum_repo], version, cloned_repo, options)
 
-      assert_action_planed_with(action, Actions::Katello::Repository::CloneContents, [yum_repo], cloned_repo,
+      assert_action_planned_with(action, Actions::Katello::Repository::CloneContents, [yum_repo], cloned_repo,
                                 :purge_empty_contents => true, :filters => [], :rpm_filenames => nil,
                                 :copy_contents => true, :metadata_generate => true,
                                 :solve_dependencies => false)
@@ -56,7 +56,7 @@ module Actions
 
       plan_action(action, [yum_repo], version_solve_deps, cloned_repo, {})
 
-      assert_action_planed_with(action, Actions::Katello::Repository::CloneContents, [yum_repo], cloned_repo,
+      assert_action_planned_with(action, Actions::Katello::Repository::CloneContents, [yum_repo], cloned_repo,
                                 :purge_empty_contents => true, :filters => [], :rpm_filenames => nil,
                                 :copy_contents => true, :metadata_generate => true,
                                 :solve_dependencies => true)
@@ -71,7 +71,7 @@ module Actions
 
       plan_action(action, [yum_repo], version, cloned_repo, options)
 
-      assert_action_planed_with(action, Actions::Katello::Repository::CloneContents, [yum_repo], cloned_repo,
+      assert_action_planned_with(action, Actions::Katello::Repository::CloneContents, [yum_repo], cloned_repo,
                                 :purge_empty_contents => true, :filters => [], :rpm_filenames => nil,
                                 :copy_contents => true, :metadata_generate => true,
                                 :solve_dependencies => false)
@@ -86,7 +86,7 @@ module Actions
 
       plan_action(action, [docker_repo], version, cloned_repo, options)
 
-      assert_action_planed_with(action, Actions::Katello::Repository::CloneContents, [docker_repo], cloned_repo,
+      assert_action_planned_with(action, Actions::Katello::Repository::CloneContents, [docker_repo], cloned_repo,
                                 :purge_empty_contents => true, :filters => [], :rpm_filenames => nil,
                                 :copy_contents => true, :metadata_generate => true,
                                 :solve_dependencies => false)
@@ -100,7 +100,7 @@ module Actions
 
       plan_action(action, [file_repo], version, cloned_repo, options)
 
-      assert_action_planed_with(action, Actions::Katello::Repository::CloneContents, [file_repo], cloned_repo,
+      assert_action_planned_with(action, Actions::Katello::Repository::CloneContents, [file_repo], cloned_repo,
                                 :purge_empty_contents => true, :filters => [], :rpm_filenames => nil, :copy_contents => true,
                                 :metadata_generate => true, :solve_dependencies => false)
     end

--- a/test/actions/katello/repository/import_upload_test.rb
+++ b/test/actions/katello/repository/import_upload_test.rb
@@ -24,7 +24,7 @@ module Actions
         content_type: 'rpm'
       }
 
-      assert_action_planed_with(action, pulp3_import_class,
+      assert_action_planned_with(action, pulp3_import_class,
                                 repo, SmartProxy.pulp_primary,
                                 import_upload_args)
     end

--- a/test/actions/katello/repository/metadata_generate_test.rb
+++ b/test/actions/katello/repository/metadata_generate_test.rb
@@ -22,7 +22,7 @@ module Actions
       action = create_action(action_class)
       plan_action(action, yum_repo)
 
-      assert_action_planed_with(action, pulp_metadata_generate_class, yum_repo, SmartProxy.pulp_primary,
+      assert_action_planned_with(action, pulp_metadata_generate_class, yum_repo, SmartProxy.pulp_primary,
             action_options)
     end
 
@@ -33,7 +33,7 @@ module Actions
       action = create_action(action_class)
       plan_action(action, yum_repo)
 
-      assert_action_planed_with(action, pulp_metadata_generate_class, yum_repo, SmartProxy.pulp_primary,
+      assert_action_planned_with(action, pulp_metadata_generate_class, yum_repo, SmartProxy.pulp_primary,
                                 action_options)
     ensure
       Location.current = old_location
@@ -46,7 +46,7 @@ module Actions
       yum_action_options = action_options.clone
       yum_action_options[:source_repository] = yum_repo2
 
-      assert_action_planed_with(action, pulp_metadata_generate_class, yum_repo, SmartProxy.pulp_primary,
+      assert_action_planned_with(action, pulp_metadata_generate_class, yum_repo, SmartProxy.pulp_primary,
             yum_action_options)
     end
 
@@ -56,7 +56,7 @@ module Actions
 
       yum_action_options = action_options.clone
       yum_action_options[:matching_content] = true
-      assert_action_planed_with(action, pulp_metadata_generate_class, yum_repo, SmartProxy.pulp_primary,
+      assert_action_planned_with(action, pulp_metadata_generate_class, yum_repo, SmartProxy.pulp_primary,
                                 yum_action_options)
     end
 
@@ -67,7 +67,7 @@ module Actions
 
       yum_action_options = action_options.clone
       yum_action_options[:matching_content] = not_falsey
-      assert_action_planed_with(action, pulp_metadata_generate_class, yum_repo, SmartProxy.pulp_primary,
+      assert_action_planned_with(action, pulp_metadata_generate_class, yum_repo, SmartProxy.pulp_primary,
                                 yum_action_options)
     end
   end

--- a/test/actions/katello/repository/update_metadata_sync_test.rb
+++ b/test/actions/katello/repository/update_metadata_sync_test.rb
@@ -23,8 +23,8 @@ module Actions
       plan_action(action, repo)
 
       # primary capsule sync should get ignored
-      assert_action_planed_with(action, capsule_sync_class, mirror, repository_id: repo.id)
-      assert_action_planed_with(action, metadata_generate_class, repo)
+      assert_action_planned_with(action, capsule_sync_class, mirror, repository_id: repo.id)
+      assert_action_planned_with(action, metadata_generate_class, repo)
     end
   end
 end

--- a/test/actions/katello/repository/update_redhat_repository_test.rb
+++ b/test/actions/katello/repository/update_redhat_repository_test.rb
@@ -27,7 +27,7 @@ module Actions
       assert_equal expected_upstream_url, repo.root.url
       assert_equal expected_relative_path, repo.relative_path
 
-      assert_action_planed_with(action, refresh_class, repo)
+      assert_action_planned_with(action, refresh_class, repo)
     end
   end
 end

--- a/test/actions/katello/repository_set_test.rb
+++ b/test/actions/katello/repository_set_test.rb
@@ -56,10 +56,9 @@ module ::Actions::Katello::RepositorySet
 
     it 'fails when repository already enabled' do
       repository_already_enabled!
-      failed = lambda do
+      assert_raises(::Katello::Errors::ConflictException) do
         plan_action(action, product, content, substitutions)
       end
-      failed.must_raise(::Katello::Errors::ConflictException)
     end
   end
 
@@ -77,10 +76,9 @@ module ::Actions::Katello::RepositorySet
     end
 
     it 'fails when repository not enabled' do
-      failed = lambda do
+      assert_raises(::Katello::Errors::NotFound) do
         plan_action(action, product, content, substitutions)
       end
-      failed.must_raise(::Katello::Errors::NotFound)
     end
   end
 
@@ -97,8 +95,8 @@ module ::Actions::Katello::RepositorySet
     it 'plans' do
       plan_action action, product, content.cp_content_id
       assert_run_phase action do
-        action.input[:product_id].must_equal product.id
-        action.input[:content_id].must_equal content.cp_content_id
+        assert_equal action.input[:product_id], product.id
+        assert_equal action.input[:content_id], content.cp_content_id
       end
     end
 
@@ -124,7 +122,7 @@ module ::Actions::Katello::RepositorySet
     it 'considers the repo being enabled when the repository object is present' do
       repository_already_enabled!
       action = simulate_run
-      action.output[:results].first[:enabled].must_equal true
+      assert_equal action.output[:results].first[:enabled], true
     end
 
     def simulate_run

--- a/test/actions/katello/repository_set_test.rb
+++ b/test/actions/katello/repository_set_test.rb
@@ -59,7 +59,7 @@ module ::Actions::Katello::RepositorySet
       failed = lambda do
         plan_action(action, product, content, substitutions)
       end
-      failed.must_raise(::Katello::Errors::ConflictException)
+      _ { failed }.must_raise(::Katello::Errors::ConflictException)
     end
   end
 
@@ -80,7 +80,7 @@ module ::Actions::Katello::RepositorySet
       failed = lambda do
         plan_action(action, product, content, substitutions)
       end
-      failed.must_raise(::Katello::Errors::NotFound)
+      _ { failed }.must_raise(::Katello::Errors::NotFound)
     end
   end
 
@@ -97,8 +97,8 @@ module ::Actions::Katello::RepositorySet
     it 'plans' do
       plan_action action, product, content.cp_content_id
       assert_run_phase action do
-        action.input[:product_id].must_equal product.id
-        action.input[:content_id].must_equal content.cp_content_id
+        _(action.input[:product_id]).must_equal product.id
+        _(action.input[:content_id]).must_equal content.cp_content_id
       end
     end
 
@@ -124,7 +124,7 @@ module ::Actions::Katello::RepositorySet
     it 'considers the repo being enabled when the repository object is present' do
       repository_already_enabled!
       action = simulate_run
-      action.output[:results].first[:enabled].must_equal true
+      _(action.output[:results].first[:enabled]).must_equal true
     end
 
     def simulate_run

--- a/test/actions/katello/repository_set_test.rb
+++ b/test/actions/katello/repository_set_test.rb
@@ -59,7 +59,7 @@ module ::Actions::Katello::RepositorySet
       failed = lambda do
         plan_action(action, product, content, substitutions)
       end
-      _ { failed }.must_raise(::Katello::Errors::ConflictException)
+      failed.must_raise(::Katello::Errors::ConflictException)
     end
   end
 
@@ -80,7 +80,7 @@ module ::Actions::Katello::RepositorySet
       failed = lambda do
         plan_action(action, product, content, substitutions)
       end
-      _ { failed }.must_raise(::Katello::Errors::NotFound)
+      failed.must_raise(::Katello::Errors::NotFound)
     end
   end
 
@@ -97,8 +97,8 @@ module ::Actions::Katello::RepositorySet
     it 'plans' do
       plan_action action, product, content.cp_content_id
       assert_run_phase action do
-        _(action.input[:product_id]).must_equal product.id
-        _(action.input[:content_id]).must_equal content.cp_content_id
+        action.input[:product_id].must_equal product.id
+        action.input[:content_id].must_equal content.cp_content_id
       end
     end
 
@@ -124,7 +124,7 @@ module ::Actions::Katello::RepositorySet
     it 'considers the repo being enabled when the repository object is present' do
       repository_already_enabled!
       action = simulate_run
-      _(action.output[:results].first[:enabled]).must_equal true
+      action.output[:results].first[:enabled].must_equal true
     end
 
     def simulate_run

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -543,7 +543,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          pulp_action.run_progress.must_be_within_delta 0.6256
+          assert_in_delta pulp_action.run_progress, 0.6256
         end
       end
 
@@ -578,7 +578,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          pulp3_action.run_progress.must_be_within_delta 1
+          assert_in_delta pulp3_action.run_progress, 1
         end
       end
 
@@ -593,7 +593,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          pulp3_action.run_progress.must_be_within_delta 1
+          assert_in_delta pulp3_action.run_progress, 1
         end
       end
 
@@ -610,7 +610,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          pulp3_action.run_progress.must_be_within_delta 1
+          assert_in_delta pulp3_action.run_progress, 1
         end
       end
 
@@ -628,7 +628,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          pulp3_action.run_progress.must_be_within_delta 1
+          assert_in_delta pulp3_action.run_progress, 1
         end
       end
 
@@ -644,7 +644,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          pulp3_action.run_progress.must_be_within_delta 0.50
+          assert_in_delta pulp3_action.run_progress, 0.50
         end
       end
 
@@ -658,7 +658,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          pulp3_action.run_progress.must_be_within_delta 0.5
+          assert_in_delta pulp3_action.run_progress, 0.5
         end
       end
     end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -543,7 +543,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          pulp_action.run_progress.must_be_within_delta 0.6256
+          _(pulp_action.run_progress).must_be_within_delta 0.6256
         end
       end
 
@@ -578,7 +578,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          pulp3_action.run_progress.must_be_within_delta 1
+          _(pulp3_action.run_progress).must_be_within_delta 1
         end
       end
 
@@ -593,7 +593,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          pulp3_action.run_progress.must_be_within_delta 1
+          _(pulp3_action.run_progress).must_be_within_delta 1
         end
       end
 
@@ -610,7 +610,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          pulp3_action.run_progress.must_be_within_delta 1
+          _(pulp3_action.run_progress).must_be_within_delta 1
         end
       end
 
@@ -628,7 +628,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          pulp3_action.run_progress.must_be_within_delta 1
+          _(pulp3_action.run_progress).must_be_within_delta 1
         end
       end
 
@@ -644,7 +644,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          pulp3_action.run_progress.must_be_within_delta 0.50
+          _(pulp3_action.run_progress).must_be_within_delta 0.50
         end
       end
 
@@ -658,7 +658,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          pulp3_action.run_progress.must_be_within_delta 0.5
+          _(pulp3_action.run_progress).must_be_within_delta 0.5
         end
       end
     end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -62,7 +62,7 @@ module ::Actions::Katello::Repository
 
     it 'plans' do
       plan_action action, repository
-      assert_action_planed_with action, candlepin_action_class, view_env_cp_id: "1", content_id: "69"
+      assert_action_planned_with action, candlepin_action_class, view_env_cp_id: "1", content_id: "69"
     end
 
     it 'no clone flag means generate metadata in run phase' do
@@ -131,7 +131,7 @@ module ::Actions::Katello::Repository
 
       action.expects(:plan_self)
       plan_action action, in_use_repository
-      assert_action_planed_with action, pulp3_action_class,
+      assert_action_planned_with action, pulp3_action_class,
         in_use_repository, proxy
 
       refute_action_planned action, ::Actions::BulkAction
@@ -163,7 +163,7 @@ module ::Actions::Katello::Repository
       action.expects(:plan_self)
       plan_action action, unpublished_repository
 
-      assert_action_planed_with action, ::Actions::Katello::Product::ContentDestroy, unpublished_repository.root
+      assert_action_planned_with action, ::Actions::Katello::Product::ContentDestroy, unpublished_repository.root
     end
 
     it 'does not plan content destroy when custom and 1 clone with planned destroy' do
@@ -216,7 +216,7 @@ module ::Actions::Katello::Repository
       action.expects(:action_subject).with(custom_repository)
       plan_action action, custom_repository, to_remove
 
-      assert_action_planed_with action, ::Actions::Pulp3::Orchestration::Repository::RemoveUnits,
+      assert_action_planned_with action, ::Actions::Pulp3::Orchestration::Repository::RemoveUnits,
         custom_repository, proxy,
         contents: uuids, content_unit_type: "rpm"
     end
@@ -251,7 +251,7 @@ module ::Actions::Katello::Repository
       action.expects(:action_subject).with(docker_repo)
       plan_action action, docker_repo, docker_repo.docker_manifests
 
-      assert_action_planed_with action,
+      assert_action_planned_with action,
        Actions::Pulp3::Orchestration::Repository::RemoveUnits,
        docker_repo, proxy,
        contents: docker_repo.docker_manifests.pluck(:id), content_unit_type: "docker_manifest"
@@ -266,7 +266,7 @@ module ::Actions::Katello::Repository
       file = File.join(::Katello::Engine.root, "test", "fixtures", "files", "squirrel-0.3-0.8.noarch.rpm")
       action.expects(:action_subject).with(custom_repository)
       plan_action action, custom_repository, [{:path => file, :filename => 'squirrel-0.3-0.8.noarch.rpm'}]
-      assert_action_planed_with action,
+      assert_action_planned_with action,
                                 ::Actions::Katello::Applicability::Repository::Regenerate,
                                 :repo_ids => [custom_repository.id]
     end
@@ -276,7 +276,7 @@ module ::Actions::Katello::Repository
       file = File.join(::Katello::Engine.root, "test", "fixtures", "files", "squirrel-0.3-0.8.noarch.rpm")
       action.expects(:action_subject).with(custom_repository)
       plan_action action, custom_repository, [{:path => file, :filename => 'squirrel-0.3-0.8.noarch.rpm'}]
-      assert_action_planed_with action,
+      assert_action_planned_with action,
                                 ::Actions::Katello::Applicability::Repository::Regenerate,
                                 :repo_ids => [custom_repository.id]
     end
@@ -302,16 +302,16 @@ module ::Actions::Katello::Repository
       end
 
       plan_action action, repository_pulp3, proxy, {:path => file, :filename => 'puppet_module.tar.gz'}, 'file'
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::UploadFile,
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::UploadFile,
                                 repository_pulp3, proxy, file)
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::SaveArtifact,
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::SaveArtifact,
                                 {:path => file, :filename => 'puppet_module.tar.gz'},
                                 repository_pulp3, proxy,
                                 [{href: "demo_task/href"}],
                                 "file")
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::ImportUpload,
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::ImportUpload,
                                 {pulp_tasks: [{href: "demo_task/artifact_href"}]}, repository_pulp3, proxy)
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::SaveVersion,
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::SaveVersion,
                                 repository_pulp3,
                                 tasks: [{href: "demo_task/version_href"}])
     end
@@ -325,9 +325,9 @@ module ::Actions::Katello::Repository
       end
 
       plan_action action, repository_pulp3, proxy, {:path => file, :filename => 'puppet_module.tar.gz'}, 'file'
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::ImportUpload,
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::ImportUpload,
                                 {content_unit_href: "demo_content/href"}, repository_pulp3, proxy)
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::SaveVersion,
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::SaveVersion,
                                 repository_pulp3,
                                 tasks: [{href: "demo_task/version_href"}])
     end
@@ -352,16 +352,16 @@ module ::Actions::Katello::Repository
       end
 
       plan_action action, repository_python_pulp3, proxy, {:path => file, :filename => 'shelf_reader-0.1-py2-none-any.whl'}, 'python_package'
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::UploadFile,
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::UploadFile,
                                 repository_python_pulp3, proxy, file)
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::SaveArtifact,
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::SaveArtifact,
                                 {:path => file, :filename => 'shelf_reader-0.1-py2-none-any.whl'},
                                 repository_python_pulp3, proxy,
                                 [{href: "demo_task/href"}],
                                 "python_package")
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::ImportUpload,
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::ImportUpload,
                                 {pulp_tasks: [{href: "demo_task/artifact_href"}]}, repository_python_pulp3, proxy)
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::SaveVersion,
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::SaveVersion,
                                 repository_python_pulp3,
                                 tasks: [{href: "demo_task/version_href"}])
     end
@@ -375,9 +375,9 @@ module ::Actions::Katello::Repository
       end
 
       plan_action action, repository_python_pulp3, proxy, {:path => file, :filename => 'shelf_reader-0.1-py2-none-any.whl'}, 'python_package'
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::ImportUpload,
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::ImportUpload,
                                 {content_unit_href: "demo_content/href"}, repository_python_pulp3, proxy)
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::SaveVersion,
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::SaveVersion,
                                 repository_python_pulp3,
                                 tasks: [{href: "demo_task/version_href"}])
     end
@@ -465,14 +465,14 @@ module ::Actions::Katello::Repository
       action.stubs(:action_subject).with(repository)
       plan_action action, repository, :validate_contents => true
 
-      assert_action_planed_with(action, ::Actions::Katello::Repository::VerifyChecksum, repository)
+      assert_action_planned_with(action, ::Actions::Katello::Repository::VerifyChecksum, repository)
     end
 
     it 'plans pulp3 orchestration actions with file repo' do
       action = create_action pulp3_action_class
       action.stubs(:action_subject).with(repository_pulp3)
       plan_action action, repository_pulp3, proxy, {}
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::Sync, repository_pulp3, proxy, {})
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::Sync, repository_pulp3, proxy, {})
       assert_action_planed action, ::Actions::Pulp3::Repository::SaveVersion
       assert_action_planed action, ::Actions::Pulp3::Orchestration::Repository::GenerateMetadata
     end
@@ -481,15 +481,15 @@ module ::Actions::Katello::Repository
       action = create_action pulp3_metadata_generate_action_class
       action.stubs(:action_subject).with(repository_pulp3)
       plan_action action, repository_pulp3, proxy, :contents_changed => true
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::CreatePublication, repository_pulp3, proxy, :contents_changed => true)
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::RefreshDistribution, repository_pulp3, proxy, :contents_changed => true)
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::CreatePublication, repository_pulp3, proxy, :contents_changed => true)
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::RefreshDistribution, repository_pulp3, proxy, :contents_changed => true)
     end
 
     it 'plans pulp3 orchestration actions with apt repo' do
       action = create_action pulp3_action_class
       action.stubs(:action_subject).with(repository_apt_pulp3)
       plan_action action, repository_apt_pulp3, proxy, {}
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::Sync, repository_apt_pulp3, proxy, {})
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::Sync, repository_apt_pulp3, proxy, {})
       assert_action_planed action, ::Actions::Pulp3::Repository::SaveVersion
       assert_action_planed action, ::Actions::Pulp3::Orchestration::Repository::GenerateMetadata
     end
@@ -498,8 +498,8 @@ module ::Actions::Katello::Repository
       action = create_action pulp3_metadata_generate_action_class
       action.stubs(:action_subject).with(repository_apt_pulp3)
       plan_action action, repository_apt_pulp3, proxy, :contents_changed => true
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::CreatePublication, repository_apt_pulp3, proxy, :contents_changed => true)
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::RefreshDistribution, repository_apt_pulp3, proxy, :contents_changed => true)
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::CreatePublication, repository_apt_pulp3, proxy, :contents_changed => true)
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::RefreshDistribution, repository_apt_pulp3, proxy, :contents_changed => true)
     end
 
     it 'plans pulp3 ansible collection metadata generate without publication ' do
@@ -507,7 +507,7 @@ module ::Actions::Katello::Repository
       action.stubs(:action_subject).with(repository_ansible_collection_pulp3)
       plan_action action, repository_ansible_collection_pulp3, proxy, :contents_changed => true
       refute_action_planed action, ::Actions::Pulp3::Repository::CreatePublication
-      assert_action_planed_with(action, ::Actions::Pulp3::Repository::RefreshDistribution, repository_ansible_collection_pulp3, proxy, :contents_changed => true)
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::RefreshDistribution, repository_ansible_collection_pulp3, proxy, :contents_changed => true)
     end
 
     describe 'progress' do

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -543,7 +543,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          _(pulp_action.run_progress).must_be_within_delta 0.6256
+          pulp_action.run_progress.must_be_within_delta 0.6256
         end
       end
 
@@ -578,7 +578,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          _(pulp3_action.run_progress).must_be_within_delta 1
+          pulp3_action.run_progress.must_be_within_delta 1
         end
       end
 
@@ -593,7 +593,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          _(pulp3_action.run_progress).must_be_within_delta 1
+          pulp3_action.run_progress.must_be_within_delta 1
         end
       end
 
@@ -610,7 +610,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          _(pulp3_action.run_progress).must_be_within_delta 1
+          pulp3_action.run_progress.must_be_within_delta 1
         end
       end
 
@@ -628,7 +628,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          _(pulp3_action.run_progress).must_be_within_delta 1
+          pulp3_action.run_progress.must_be_within_delta 1
         end
       end
 
@@ -644,7 +644,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          _(pulp3_action.run_progress).must_be_within_delta 0.50
+          pulp3_action.run_progress.must_be_within_delta 0.50
         end
       end
 
@@ -658,7 +658,7 @@ module ::Actions::Katello::Repository
         end
 
         specify do
-          _(pulp3_action.run_progress).must_be_within_delta 0.5
+          pulp3_action.run_progress.must_be_within_delta 0.5
         end
       end
     end

--- a/test/actions/katello/sync_plan/run_test.rb
+++ b/test/actions/katello/sync_plan/run_test.rb
@@ -27,7 +27,7 @@ describe ::Actions::Katello::SyncPlan::Run do
     plan_action(action, @sync_plan)
     syncable_products = @sync_plan.products.syncable
     syncable_repositories = ::Katello::RootRepository.where(:product_id => syncable_products).has_url
-    assert_action_planed_with(action, ::Actions::BulkAction, ::Actions::Katello::Repository::Sync, syncable_repositories.map(&:library_instance),
+    assert_action_planned_with(action, ::Actions::BulkAction, ::Actions::Katello::Repository::Sync, syncable_repositories.map(&:library_instance),
                               generate_applicability: false)
   end
 

--- a/test/actions/katello/upstream_subscriptions/bind_entitlements_test.rb
+++ b/test/actions/katello/upstream_subscriptions/bind_entitlements_test.rb
@@ -26,13 +26,13 @@ describe ::Actions::Katello::UpstreamSubscriptions::BindEntitlements do
   end
 
   it 'raises an error when given no pools' do
-    error = proc { plan_action(@action, []) }.must_raise RuntimeError
+    error = assert_raises(RuntimeError) { plan_action(@action, []) }
     assert_match(/No pools were provided/, error.message)
   end
 
   it 'raises an error when organization is set' do
     set_organization(nil)
-    error = proc { plan_action(@action, [{}]) }.must_raise RuntimeError
+    error = assert_raises(RuntimeError) { plan_action(@action, [{}]) }
     assert_match(/Current organization is not set/, error.message)
   end
 end

--- a/test/actions/katello/upstream_subscriptions/bind_entitlements_test.rb
+++ b/test/actions/katello/upstream_subscriptions/bind_entitlements_test.rb
@@ -26,13 +26,13 @@ describe ::Actions::Katello::UpstreamSubscriptions::BindEntitlements do
   end
 
   it 'raises an error when given no pools' do
-    error = proc { plan_action(@action, []) }.must_raise RuntimeError
+    error = _ { proc { plan_action(@action, []) } }.must_raise RuntimeError
     assert_match(/No pools were provided/, error.message)
   end
 
   it 'raises an error when organization is set' do
     set_organization(nil)
-    error = proc { plan_action(@action, [{}]) }.must_raise RuntimeError
+    error = _ { proc { plan_action(@action, [{}]) } }.must_raise RuntimeError
     assert_match(/Current organization is not set/, error.message)
   end
 end

--- a/test/actions/katello/upstream_subscriptions/bind_entitlements_test.rb
+++ b/test/actions/katello/upstream_subscriptions/bind_entitlements_test.rb
@@ -26,13 +26,13 @@ describe ::Actions::Katello::UpstreamSubscriptions::BindEntitlements do
   end
 
   it 'raises an error when given no pools' do
-    error = _ { proc { plan_action(@action, []) } }.must_raise RuntimeError
+    error = proc { plan_action(@action, []) }.must_raise RuntimeError
     assert_match(/No pools were provided/, error.message)
   end
 
   it 'raises an error when organization is set' do
     set_organization(nil)
-    error = _ { proc { plan_action(@action, [{}]) } }.must_raise RuntimeError
+    error = proc { plan_action(@action, [{}]) }.must_raise RuntimeError
     assert_match(/Current organization is not set/, error.message)
   end
 end

--- a/test/actions/katello/upstream_subscriptions/remove_entitlements_test.rb
+++ b/test/actions/katello/upstream_subscriptions/remove_entitlements_test.rb
@@ -38,7 +38,7 @@ describe ::Actions::Katello::UpstreamSubscriptions::RemoveEntitlements do
     ::Katello::Pool.expects(:find).with(pool1.id).returns(pool1)
     ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:get).returns(true)
 
-    error = _ { proc { plan_action(@action, [pool1.id]) } }.must_raise RuntimeError
+    error = proc { plan_action(@action, [pool1.id]) }.must_raise RuntimeError
     assert_match(/upstream/, error.message)
   end
 
@@ -46,19 +46,19 @@ describe ::Actions::Katello::UpstreamSubscriptions::RemoveEntitlements do
     pool1 = katello_pools(:pool_one)
     ::Katello::HttpResource.expects(:get).raises(::Katello::Errors::UpstreamConsumerGone)
 
-    _ { proc { plan_action(@action, [pool1.id]) } }.must_raise ::Katello::Errors::UpstreamConsumerGone
+    proc { plan_action(@action, [pool1.id]) }.must_raise ::Katello::Errors::UpstreamConsumerGone
   end
 
   it 'raises an error when given no pool ids' do
     ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:get).returns(true)
-    error = _ { proc { plan_action(@action, []) } }.must_raise RuntimeError
+    error = proc { plan_action(@action, []) }.must_raise RuntimeError
     assert_match(/provided/, error.message)
   end
 
   it 'raises an error when no organization is set' do
     ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:get).returns(true)
     set_organization(nil)
-    error = _ { proc { plan_action(@action, [:foo]) } }.must_raise RuntimeError
+    error = proc { plan_action(@action, [:foo]) }.must_raise RuntimeError
     assert_match(/is not set/, error.message)
   end
 end

--- a/test/actions/katello/upstream_subscriptions/remove_entitlements_test.rb
+++ b/test/actions/katello/upstream_subscriptions/remove_entitlements_test.rb
@@ -38,7 +38,7 @@ describe ::Actions::Katello::UpstreamSubscriptions::RemoveEntitlements do
     ::Katello::Pool.expects(:find).with(pool1.id).returns(pool1)
     ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:get).returns(true)
 
-    error = proc { plan_action(@action, [pool1.id]) }.must_raise RuntimeError
+    error = _ { proc { plan_action(@action, [pool1.id]) } }.must_raise RuntimeError
     assert_match(/upstream/, error.message)
   end
 
@@ -46,19 +46,19 @@ describe ::Actions::Katello::UpstreamSubscriptions::RemoveEntitlements do
     pool1 = katello_pools(:pool_one)
     ::Katello::HttpResource.expects(:get).raises(::Katello::Errors::UpstreamConsumerGone)
 
-    proc { plan_action(@action, [pool1.id]) }.must_raise ::Katello::Errors::UpstreamConsumerGone
+    _ { proc { plan_action(@action, [pool1.id]) } }.must_raise ::Katello::Errors::UpstreamConsumerGone
   end
 
   it 'raises an error when given no pool ids' do
     ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:get).returns(true)
-    error = proc { plan_action(@action, []) }.must_raise RuntimeError
+    error = _ { proc { plan_action(@action, []) } }.must_raise RuntimeError
     assert_match(/provided/, error.message)
   end
 
   it 'raises an error when no organization is set' do
     ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:get).returns(true)
     set_organization(nil)
-    error = proc { plan_action(@action, [:foo]) }.must_raise RuntimeError
+    error = _ { proc { plan_action(@action, [:foo]) } }.must_raise RuntimeError
     assert_match(/is not set/, error.message)
   end
 end

--- a/test/actions/katello/upstream_subscriptions/remove_entitlements_test.rb
+++ b/test/actions/katello/upstream_subscriptions/remove_entitlements_test.rb
@@ -38,7 +38,7 @@ describe ::Actions::Katello::UpstreamSubscriptions::RemoveEntitlements do
     ::Katello::Pool.expects(:find).with(pool1.id).returns(pool1)
     ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:get).returns(true)
 
-    error = proc { plan_action(@action, [pool1.id]) }.must_raise RuntimeError
+    error = assert_raises(RuntimeError) { plan_action(@action, [pool1.id]) }
     assert_match(/upstream/, error.message)
   end
 
@@ -46,19 +46,19 @@ describe ::Actions::Katello::UpstreamSubscriptions::RemoveEntitlements do
     pool1 = katello_pools(:pool_one)
     ::Katello::HttpResource.expects(:get).raises(::Katello::Errors::UpstreamConsumerGone)
 
-    proc { plan_action(@action, [pool1.id]) }.must_raise ::Katello::Errors::UpstreamConsumerGone
+    assert_raises(::Katello::Errors::UpstreamConsumerGone) { plan_action(@action, [pool1.id]) }
   end
 
   it 'raises an error when given no pool ids' do
     ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:get).returns(true)
-    error = proc { plan_action(@action, []) }.must_raise RuntimeError
+    error = assert_raises(RuntimeError) { plan_action(@action, []) }
     assert_match(/provided/, error.message)
   end
 
   it 'raises an error when no organization is set' do
     ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:get).returns(true)
     set_organization(nil)
-    error = proc { plan_action(@action, [:foo]) }.must_raise RuntimeError
+    error = assert_raises(RuntimeError) { plan_action(@action, [:foo]) }
     assert_match(/is not set/, error.message)
   end
 end

--- a/test/actions/katello/upstream_subscriptions/update_entitlements_test.rb
+++ b/test/actions/katello/upstream_subscriptions/update_entitlements_test.rb
@@ -26,7 +26,7 @@ describe ::Actions::Katello::UpstreamSubscriptions::UpdateEntitlements do
   end
 
   it 'raises an error when given no pools' do
-    error = proc { plan_action(@action, []) }.must_raise RuntimeError
+    error = assert_raises(RuntimeError) { plan_action(@action, []) }
     assert_match(/provided/, error.message)
   end
 
@@ -35,13 +35,13 @@ describe ::Actions::Katello::UpstreamSubscriptions::UpdateEntitlements do
     pool1.expects(:upstream_entitlement_id).returns(nil)
     ::Katello::Pool.expects(:find).with(pool1.id).returns(pool1)
 
-    error = proc { plan_action(@action, [{id: pool1.id, quantity: 1}]) }.must_raise RuntimeError
+    error = assert_raises(RuntimeError) { plan_action(@action, [{id: pool1.id, quantity: 1}]) }
     assert_match(/upstream/, error.message)
   end
 
   it 'raises an error when no organization is set' do
     set_organization(nil)
-    error = proc { plan_action(@action, [:foo]) }.must_raise RuntimeError
+    error = assert_raises(RuntimeError) { plan_action(@action, [:foo]) }
     assert_match(/is not set/, error.message)
   end
 end

--- a/test/actions/katello/upstream_subscriptions/update_entitlements_test.rb
+++ b/test/actions/katello/upstream_subscriptions/update_entitlements_test.rb
@@ -26,7 +26,7 @@ describe ::Actions::Katello::UpstreamSubscriptions::UpdateEntitlements do
   end
 
   it 'raises an error when given no pools' do
-    error = proc { plan_action(@action, []) }.must_raise RuntimeError
+    error = _ { proc { plan_action(@action, []) } }.must_raise RuntimeError
     assert_match(/provided/, error.message)
   end
 
@@ -35,13 +35,13 @@ describe ::Actions::Katello::UpstreamSubscriptions::UpdateEntitlements do
     pool1.expects(:upstream_entitlement_id).returns(nil)
     ::Katello::Pool.expects(:find).with(pool1.id).returns(pool1)
 
-    error = proc { plan_action(@action, [{id: pool1.id, quantity: 1}]) }.must_raise RuntimeError
+    error = _ { proc { plan_action(@action, [{id: pool1.id, quantity: 1}]) } }.must_raise RuntimeError
     assert_match(/upstream/, error.message)
   end
 
   it 'raises an error when no organization is set' do
     set_organization(nil)
-    error = proc { plan_action(@action, [:foo]) }.must_raise RuntimeError
+    error = _ { proc { plan_action(@action, [:foo]) } }.must_raise RuntimeError
     assert_match(/is not set/, error.message)
   end
 end

--- a/test/actions/katello/upstream_subscriptions/update_entitlements_test.rb
+++ b/test/actions/katello/upstream_subscriptions/update_entitlements_test.rb
@@ -26,7 +26,7 @@ describe ::Actions::Katello::UpstreamSubscriptions::UpdateEntitlements do
   end
 
   it 'raises an error when given no pools' do
-    error = _ { proc { plan_action(@action, []) } }.must_raise RuntimeError
+    error = proc { plan_action(@action, []) }.must_raise RuntimeError
     assert_match(/provided/, error.message)
   end
 
@@ -35,13 +35,13 @@ describe ::Actions::Katello::UpstreamSubscriptions::UpdateEntitlements do
     pool1.expects(:upstream_entitlement_id).returns(nil)
     ::Katello::Pool.expects(:find).with(pool1.id).returns(pool1)
 
-    error = _ { proc { plan_action(@action, [{id: pool1.id, quantity: 1}]) } }.must_raise RuntimeError
+    error = proc { plan_action(@action, [{id: pool1.id, quantity: 1}]) }.must_raise RuntimeError
     assert_match(/upstream/, error.message)
   end
 
   it 'raises an error when no organization is set' do
     set_organization(nil)
-    error = _ { proc { plan_action(@action, [:foo]) } }.must_raise RuntimeError
+    error = proc { plan_action(@action, [:foo]) }.must_raise RuntimeError
     assert_match(/is not set/, error.message)
   end
 end

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -379,8 +379,8 @@ module Katello
       @activation_key.expects(:content_overrides).at_least_once.returns(content_overrides)
 
       ::Katello::Resources::Candlepin::ActivationKey.expects(:update_content_overrides).with do |id, hash|
-        _(id).wont_equal(@activation_key.cp_id)
-        _(hash).must_equal(content_overrides.map(&:to_entitlement_hash))
+        id.wont_equal(@activation_key.cp_id)
+        hash.must_equal(content_overrides.map(&:to_entitlement_hash))
       end
 
       post :copy, params: { :id => @activation_key.id, :organization_id => @organization.id, :new_name => "NewAK" }

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -379,8 +379,8 @@ module Katello
       @activation_key.expects(:content_overrides).at_least_once.returns(content_overrides)
 
       ::Katello::Resources::Candlepin::ActivationKey.expects(:update_content_overrides).with do |id, hash|
-        id.wont_equal(@activation_key.cp_id)
-        hash.must_equal(content_overrides.map(&:to_entitlement_hash))
+        _(id).wont_equal(@activation_key.cp_id)
+        _(hash).must_equal(content_overrides.map(&:to_entitlement_hash))
       end
 
       post :copy, params: { :id => @activation_key.id, :organization_id => @organization.id, :new_name => "NewAK" }

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -379,8 +379,8 @@ module Katello
       @activation_key.expects(:content_overrides).at_least_once.returns(content_overrides)
 
       ::Katello::Resources::Candlepin::ActivationKey.expects(:update_content_overrides).with do |id, hash|
-        id.wont_equal(@activation_key.cp_id)
-        hash.must_equal(content_overrides.map(&:to_entitlement_hash))
+        assert_not_equal id, @activation_key.cp_id
+        assert_equal hash, content_overrides.map(&:to_entitlement_hash)
       end
 
       post :copy, params: { :id => @activation_key.id, :organization_id => @organization.id, :new_name => "NewAK" }

--- a/test/controllers/api/v2/capsule_content_controller_test.rb
+++ b/test/controllers/api/v2/capsule_content_controller_test.rb
@@ -78,7 +78,7 @@ module Katello
     def test_sync
       assert_async_task ::Actions::Katello::CapsuleContent::Sync do |capsule, options|
         assert_equal proxy_with_pulp.id, capsule.id
-        options[:environment_id].must_equal environment.id
+        _(options[:environment_id]).must_equal environment.id
       end
 
       post :sync, params: { :id => proxy_with_pulp.id, :environment_id => environment.id }
@@ -88,7 +88,7 @@ module Katello
     def test_sync_with_repo
       assert_async_task ::Actions::Katello::CapsuleContent::Sync do |capsule, options|
         assert_equal proxy_with_pulp.id, capsule.id
-        options[:repository_id].must_equal @repository.id
+        _(options[:repository_id]).must_equal @repository.id
       end
 
       post :sync, params: { :id => proxy_with_pulp.id, :repository_id => @repository.id }
@@ -98,7 +98,7 @@ module Katello
     def test_sync_with_cv
       assert_async_task ::Actions::Katello::CapsuleContent::Sync do |capsule, options|
         assert_equal proxy_with_pulp.id, capsule.id
-        options[:content_view_id].must_equal @library_dev_view.id
+        _(options[:content_view_id]).must_equal @library_dev_view.id
       end
 
       post :sync, params: { :id => proxy_with_pulp.id, :content_view_id => @library_dev_view.id }

--- a/test/controllers/api/v2/capsule_content_controller_test.rb
+++ b/test/controllers/api/v2/capsule_content_controller_test.rb
@@ -78,7 +78,7 @@ module Katello
     def test_sync
       assert_async_task ::Actions::Katello::CapsuleContent::Sync do |capsule, options|
         assert_equal proxy_with_pulp.id, capsule.id
-        options[:environment_id].must_equal environment.id
+        assert_equal options[:environment_id], environment.id
       end
 
       post :sync, params: { :id => proxy_with_pulp.id, :environment_id => environment.id }
@@ -88,7 +88,7 @@ module Katello
     def test_sync_with_repo
       assert_async_task ::Actions::Katello::CapsuleContent::Sync do |capsule, options|
         assert_equal proxy_with_pulp.id, capsule.id
-        options[:repository_id].must_equal @repository.id
+        assert_equal options[:repository_id], @repository.id
       end
 
       post :sync, params: { :id => proxy_with_pulp.id, :repository_id => @repository.id }
@@ -98,7 +98,7 @@ module Katello
     def test_sync_with_cv
       assert_async_task ::Actions::Katello::CapsuleContent::Sync do |capsule, options|
         assert_equal proxy_with_pulp.id, capsule.id
-        options[:content_view_id].must_equal @library_dev_view.id
+        assert_equal options[:content_view_id], @library_dev_view.id
       end
 
       post :sync, params: { :id => proxy_with_pulp.id, :content_view_id => @library_dev_view.id }

--- a/test/controllers/api/v2/capsule_content_controller_test.rb
+++ b/test/controllers/api/v2/capsule_content_controller_test.rb
@@ -78,7 +78,7 @@ module Katello
     def test_sync
       assert_async_task ::Actions::Katello::CapsuleContent::Sync do |capsule, options|
         assert_equal proxy_with_pulp.id, capsule.id
-        _(options[:environment_id]).must_equal environment.id
+        options[:environment_id].must_equal environment.id
       end
 
       post :sync, params: { :id => proxy_with_pulp.id, :environment_id => environment.id }
@@ -88,7 +88,7 @@ module Katello
     def test_sync_with_repo
       assert_async_task ::Actions::Katello::CapsuleContent::Sync do |capsule, options|
         assert_equal proxy_with_pulp.id, capsule.id
-        _(options[:repository_id]).must_equal @repository.id
+        options[:repository_id].must_equal @repository.id
       end
 
       post :sync, params: { :id => proxy_with_pulp.id, :repository_id => @repository.id }
@@ -98,7 +98,7 @@ module Katello
     def test_sync_with_cv
       assert_async_task ::Actions::Katello::CapsuleContent::Sync do |capsule, options|
         assert_equal proxy_with_pulp.id, capsule.id
-        _(options[:content_view_id]).must_equal @library_dev_view.id
+        options[:content_view_id].must_equal @library_dev_view.id
       end
 
       post :sync, params: { :id => proxy_with_pulp.id, :content_view_id => @library_dev_view.id }

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -98,11 +98,11 @@ module Katello
       target_view = ContentView.find(katello_content_views(:library_dev_view).id)
 
       assert_async_task ::Actions::Katello::ContentView::Publish do |view, description, params|
-        view.must_equal target_view
+        assert_equal view, target_view
         assert_nil description
         assert_nil params[:force_metadata_generate]
-        params[:major].must_equal 4
-        params[:minor].must_equal 1
+        assert_equal params[:major], 4
+        assert_equal params[:minor], 1
       end
 
       post :publish, params: { :id => target_view.id, :major => 4, :minor => 1 }
@@ -112,10 +112,10 @@ module Katello
       target_view = ContentView.find(katello_content_views(:library_dev_view).id)
 
       assert_async_task ::Actions::Katello::ContentView::Publish do |view, description, params|
-        view.must_equal target_view
+        assert_equal view, target_view
         assert_nil description
         assert_nil params[:force_metadata_generate]
-        params[:environment_ids].must_equal [2]
+        assert_equal params[:environment_ids], [2]
       end
 
       post :publish, params: { :id => target_view.id, :environment_ids => [2] }
@@ -208,11 +208,11 @@ module Katello
       assert_sync_task(::Actions::Katello::ContentView::Update) do |_content_view, content_view_params|
         params.each do |key, value|
           if key == :label || key == :composite
-            content_view_params.key?(key).must_equal false
+            assert_equal content_view_params.key?(key), false
             assert_nil content_view_params[key]
           else
-            content_view_params.key?(key).must_equal true
-            content_view_params[key].must_equal value
+            assert_equal content_view_params.key?(key), true
+            assert_equal content_view_params[key], value
           end
         end
       end
@@ -228,8 +228,8 @@ module Katello
 
       params = { :repository_ids => [repository.id] }
       assert_sync_task(::Actions::Katello::ContentView::Update) do |_content_view, content_view_params|
-        content_view_params.key?(:repository_ids).must_equal true
-        content_view_params[:repository_ids].must_equal params[:repository_ids]
+        assert_equal content_view_params.key?(:repository_ids), true
+        assert_equal content_view_params[:repository_ids], params[:repository_ids]
       end
       put :update, params: { :id => @library_dev_staging_view.id, :content_view => params }
 
@@ -243,8 +243,8 @@ module Katello
 
       params = { :repository_ids => [repository.id.to_s] }
       assert_sync_task(::Actions::Katello::ContentView::Update) do |_content_view, content_view_params|
-        content_view_params.key?(:repository_ids).must_equal true
-        content_view_params[:repository_ids].must_equal params[:repository_ids]
+        assert_equal content_view_params.key?(:repository_ids), true
+        assert_equal content_view_params[:repository_ids], params[:repository_ids]
       end
       put :update, params: { :id => @library_dev_staging_view.id, :content_view => params }
 
@@ -259,9 +259,9 @@ module Katello
 
       params = { :component_ids => [version.id] }
       assert_sync_task(::Actions::Katello::ContentView::Update) do |_content_view, content_view_params|
-        content_view_params.key?(:component_ids).must_equal true
-        content_view_params[:component_ids].must_equal params[:component_ids]
-        content_view_params[:repository_ids].must_be_nil
+        assert_equal content_view_params.key?(:component_ids), true
+        assert_equal content_view_params[:component_ids], params[:component_ids]
+        assert_nil content_view_params[:repository_ids]
       end
       put :update, params: { :id => composite.id, :content_view => params }
 

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -98,11 +98,11 @@ module Katello
       target_view = ContentView.find(katello_content_views(:library_dev_view).id)
 
       assert_async_task ::Actions::Katello::ContentView::Publish do |view, description, params|
-        _(view).must_equal target_view
+        view.must_equal target_view
         assert_nil description
         assert_nil params[:force_metadata_generate]
-        _(params[:major]).must_equal 4
-        _(params[:minor]).must_equal 1
+        params[:major].must_equal 4
+        params[:minor].must_equal 1
       end
 
       post :publish, params: { :id => target_view.id, :major => 4, :minor => 1 }
@@ -112,10 +112,10 @@ module Katello
       target_view = ContentView.find(katello_content_views(:library_dev_view).id)
 
       assert_async_task ::Actions::Katello::ContentView::Publish do |view, description, params|
-        _(view).must_equal target_view
+        view.must_equal target_view
         assert_nil description
         assert_nil params[:force_metadata_generate]
-        _(params[:environment_ids]).must_equal [2]
+        params[:environment_ids].must_equal [2]
       end
 
       post :publish, params: { :id => target_view.id, :environment_ids => [2] }
@@ -208,11 +208,11 @@ module Katello
       assert_sync_task(::Actions::Katello::ContentView::Update) do |_content_view, content_view_params|
         params.each do |key, value|
           if key == :label || key == :composite
-            _(content_view_params.key?(key)).must_equal false
+            content_view_params.key?(key).must_equal false
             assert_nil content_view_params[key]
           else
-            _(content_view_params.key?(key)).must_equal true
-            _(content_view_params[key]).must_equal value
+            content_view_params.key?(key).must_equal true
+            content_view_params[key].must_equal value
           end
         end
       end
@@ -228,8 +228,8 @@ module Katello
 
       params = { :repository_ids => [repository.id] }
       assert_sync_task(::Actions::Katello::ContentView::Update) do |_content_view, content_view_params|
-        _(content_view_params.key?(:repository_ids)).must_equal true
-        _(content_view_params[:repository_ids]).must_equal params[:repository_ids]
+        content_view_params.key?(:repository_ids).must_equal true
+        content_view_params[:repository_ids].must_equal params[:repository_ids]
       end
       put :update, params: { :id => @library_dev_staging_view.id, :content_view => params }
 
@@ -243,8 +243,8 @@ module Katello
 
       params = { :repository_ids => [repository.id.to_s] }
       assert_sync_task(::Actions::Katello::ContentView::Update) do |_content_view, content_view_params|
-        _(content_view_params.key?(:repository_ids)).must_equal true
-        _(content_view_params[:repository_ids]).must_equal params[:repository_ids]
+        content_view_params.key?(:repository_ids).must_equal true
+        content_view_params[:repository_ids].must_equal params[:repository_ids]
       end
       put :update, params: { :id => @library_dev_staging_view.id, :content_view => params }
 
@@ -259,9 +259,9 @@ module Katello
 
       params = { :component_ids => [version.id] }
       assert_sync_task(::Actions::Katello::ContentView::Update) do |_content_view, content_view_params|
-        _(content_view_params.key?(:component_ids)).must_equal true
-        _(content_view_params[:component_ids]).must_equal params[:component_ids]
-        _(content_view_params[:repository_ids]).must_be_nil
+        content_view_params.key?(:component_ids).must_equal true
+        content_view_params[:component_ids].must_equal params[:component_ids]
+        content_view_params[:repository_ids].must_be_nil
       end
       put :update, params: { :id => composite.id, :content_view => params }
 

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -98,11 +98,11 @@ module Katello
       target_view = ContentView.find(katello_content_views(:library_dev_view).id)
 
       assert_async_task ::Actions::Katello::ContentView::Publish do |view, description, params|
-        view.must_equal target_view
+        _(view).must_equal target_view
         assert_nil description
         assert_nil params[:force_metadata_generate]
-        params[:major].must_equal 4
-        params[:minor].must_equal 1
+        _(params[:major]).must_equal 4
+        _(params[:minor]).must_equal 1
       end
 
       post :publish, params: { :id => target_view.id, :major => 4, :minor => 1 }
@@ -112,10 +112,10 @@ module Katello
       target_view = ContentView.find(katello_content_views(:library_dev_view).id)
 
       assert_async_task ::Actions::Katello::ContentView::Publish do |view, description, params|
-        view.must_equal target_view
+        _(view).must_equal target_view
         assert_nil description
         assert_nil params[:force_metadata_generate]
-        params[:environment_ids].must_equal [2]
+        _(params[:environment_ids]).must_equal [2]
       end
 
       post :publish, params: { :id => target_view.id, :environment_ids => [2] }
@@ -208,11 +208,11 @@ module Katello
       assert_sync_task(::Actions::Katello::ContentView::Update) do |_content_view, content_view_params|
         params.each do |key, value|
           if key == :label || key == :composite
-            content_view_params.key?(key).must_equal false
+            _(content_view_params.key?(key)).must_equal false
             assert_nil content_view_params[key]
           else
-            content_view_params.key?(key).must_equal true
-            content_view_params[key].must_equal value
+            _(content_view_params.key?(key)).must_equal true
+            _(content_view_params[key]).must_equal value
           end
         end
       end
@@ -228,8 +228,8 @@ module Katello
 
       params = { :repository_ids => [repository.id] }
       assert_sync_task(::Actions::Katello::ContentView::Update) do |_content_view, content_view_params|
-        content_view_params.key?(:repository_ids).must_equal true
-        content_view_params[:repository_ids].must_equal params[:repository_ids]
+        _(content_view_params.key?(:repository_ids)).must_equal true
+        _(content_view_params[:repository_ids]).must_equal params[:repository_ids]
       end
       put :update, params: { :id => @library_dev_staging_view.id, :content_view => params }
 
@@ -243,8 +243,8 @@ module Katello
 
       params = { :repository_ids => [repository.id.to_s] }
       assert_sync_task(::Actions::Katello::ContentView::Update) do |_content_view, content_view_params|
-        content_view_params.key?(:repository_ids).must_equal true
-        content_view_params[:repository_ids].must_equal params[:repository_ids]
+        _(content_view_params.key?(:repository_ids)).must_equal true
+        _(content_view_params[:repository_ids]).must_equal params[:repository_ids]
       end
       put :update, params: { :id => @library_dev_staging_view.id, :content_view => params }
 
@@ -259,9 +259,9 @@ module Katello
 
       params = { :component_ids => [version.id] }
       assert_sync_task(::Actions::Katello::ContentView::Update) do |_content_view, content_view_params|
-        content_view_params.key?(:component_ids).must_equal true
-        content_view_params[:component_ids].must_equal params[:component_ids]
-        content_view_params[:repository_ids].must_be_nil
+        _(content_view_params.key?(:component_ids)).must_equal true
+        _(content_view_params[:component_ids]).must_equal params[:component_ids]
+        _(content_view_params[:repository_ids]).must_be_nil
       end
       put :update, params: { :id => composite.id, :content_view => params }
 

--- a/test/controllers/api/v2/organizations_controller_test.rb
+++ b/test/controllers/api/v2/organizations_controller_test.rb
@@ -119,8 +119,8 @@ module Katello
       url = "http://www.redhat.com"
 
       assert_sync_task(::Actions::Katello::CdnConfiguration::Update) do |organization, params|
-        organization.id.must_equal @organization.id
-        params[:url].must_equal url
+        _(organization.id).must_equal @organization.id
+        _(params[:url]).must_equal url
       end
 
       put(:cdn_configuration, params: { :id => @organization.id, :url => url })

--- a/test/controllers/api/v2/organizations_controller_test.rb
+++ b/test/controllers/api/v2/organizations_controller_test.rb
@@ -119,8 +119,8 @@ module Katello
       url = "http://www.redhat.com"
 
       assert_sync_task(::Actions::Katello::CdnConfiguration::Update) do |organization, params|
-        organization.id.must_equal @organization.id
-        params[:url].must_equal url
+        assert_equal organization.id, @organization.id
+        assert_equal params[:url], url
       end
 
       put(:cdn_configuration, params: { :id => @organization.id, :url => url })

--- a/test/controllers/api/v2/organizations_controller_test.rb
+++ b/test/controllers/api/v2/organizations_controller_test.rb
@@ -119,8 +119,8 @@ module Katello
       url = "http://www.redhat.com"
 
       assert_sync_task(::Actions::Katello::CdnConfiguration::Update) do |organization, params|
-        _(organization.id).must_equal @organization.id
-        _(params[:url]).must_equal url
+        organization.id.must_equal @organization.id
+        params[:url].must_equal url
       end
 
       put(:cdn_configuration, params: { :id => @organization.id, :url => url })

--- a/test/controllers/api/v2/package_groups_controller_test.rb
+++ b/test/controllers/api/v2/package_groups_controller_test.rb
@@ -147,19 +147,19 @@ module Katello
     def test_create_and_delete
       parameters = { :repository_id => @repo.id, :name => 'My_Group', :description => "My Group", :mandatory_package_names => ["katello-agent"]}
       assert_sync_task(::Actions::Katello::Repository::UploadPackageGroup) do |repository, params|
-        repository.must_equal @repo
-        params[:name].must_equal parameters[:name]
-        params[:description].must_equal parameters[:description]
-        params[:mandatory_package_names].must_equal parameters[:mandatory_package_names]
-        params[:user_visible].must_equal true
+        assert_equal repository, @repo
+        assert_equal params[:name], parameters[:name]
+        assert_equal params[:description], parameters[:description]
+        assert_equal params[:mandatory_package_names], parameters[:mandatory_package_names]
+        assert_equal params[:user_visible], true
       end
 
       post(:create, params: parameters)
       assert_response :success
 
       assert_sync_task(::Actions::Katello::Repository::DestroyPackageGroup) do |repository, pkg_group_id|
-        repository.must_equal @repo
-        pkg_group_id.must_equal "My_Group"
+        assert_equal repository, @repo
+        assert_equal pkg_group_id, "My_Group"
       end
       delete(:destroy, params: { :name => "My_Group", :repository_id => @repo.id })
       assert_response :success

--- a/test/controllers/api/v2/package_groups_controller_test.rb
+++ b/test/controllers/api/v2/package_groups_controller_test.rb
@@ -147,19 +147,19 @@ module Katello
     def test_create_and_delete
       parameters = { :repository_id => @repo.id, :name => 'My_Group', :description => "My Group", :mandatory_package_names => ["katello-agent"]}
       assert_sync_task(::Actions::Katello::Repository::UploadPackageGroup) do |repository, params|
-        repository.must_equal @repo
-        params[:name].must_equal parameters[:name]
-        params[:description].must_equal parameters[:description]
-        params[:mandatory_package_names].must_equal parameters[:mandatory_package_names]
-        params[:user_visible].must_equal true
+        _(repository).must_equal @repo
+        _(params[:name]).must_equal parameters[:name]
+        _(params[:description]).must_equal parameters[:description]
+        _(params[:mandatory_package_names]).must_equal parameters[:mandatory_package_names]
+        _(params[:user_visible]).must_equal true
       end
 
       post(:create, params: parameters)
       assert_response :success
 
       assert_sync_task(::Actions::Katello::Repository::DestroyPackageGroup) do |repository, pkg_group_id|
-        repository.must_equal @repo
-        pkg_group_id.must_equal "My_Group"
+        _(repository).must_equal @repo
+        _(pkg_group_id).must_equal "My_Group"
       end
       delete(:destroy, params: { :name => "My_Group", :repository_id => @repo.id })
       assert_response :success

--- a/test/controllers/api/v2/package_groups_controller_test.rb
+++ b/test/controllers/api/v2/package_groups_controller_test.rb
@@ -147,19 +147,19 @@ module Katello
     def test_create_and_delete
       parameters = { :repository_id => @repo.id, :name => 'My_Group', :description => "My Group", :mandatory_package_names => ["katello-agent"]}
       assert_sync_task(::Actions::Katello::Repository::UploadPackageGroup) do |repository, params|
-        _(repository).must_equal @repo
-        _(params[:name]).must_equal parameters[:name]
-        _(params[:description]).must_equal parameters[:description]
-        _(params[:mandatory_package_names]).must_equal parameters[:mandatory_package_names]
-        _(params[:user_visible]).must_equal true
+        repository.must_equal @repo
+        params[:name].must_equal parameters[:name]
+        params[:description].must_equal parameters[:description]
+        params[:mandatory_package_names].must_equal parameters[:mandatory_package_names]
+        params[:user_visible].must_equal true
       end
 
       post(:create, params: parameters)
       assert_response :success
 
       assert_sync_task(::Actions::Katello::Repository::DestroyPackageGroup) do |repository, pkg_group_id|
-        _(repository).must_equal @repo
-        _(pkg_group_id).must_equal "My_Group"
+        repository.must_equal @repo
+        pkg_group_id.must_equal "My_Group"
       end
       delete(:destroy, params: { :name => "My_Group", :repository_id => @repo.id })
       assert_response :success

--- a/test/controllers/api/v2/products_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/products_bulk_actions_controller_test.rb
@@ -58,7 +58,7 @@ module Katello
                                         where(product: @products.syncable)).count
 
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
-        action_class.must_equal ::Actions::Katello::Repository::Sync
+        assert_equal action_class, ::Actions::Katello::Repository::Sync
         assert_equal expected_repo_size, repos.size
       end
 
@@ -70,7 +70,7 @@ module Katello
     def test_sync_with_skip_metadata_check
       create_docker_repo
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
-        action_class.must_equal ::Actions::Katello::Repository::Sync
+        assert_equal action_class, ::Actions::Katello::Repository::Sync
         refute_empty repos
         assert repos.all? { |repo| repo.yum? }
       end
@@ -86,7 +86,7 @@ module Katello
                          :content_view_version => @organization.default_content_view.versions.first, :download_policy => 'on_demand')
 
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
-        action_class.must_equal ::Actions::Katello::Repository::Sync
+        assert_equal action_class, ::Actions::Katello::Repository::Sync
         refute_empty repos
         assert repos.all? { |repo| repo.yum? } && repos.all? { |repo| repo.download_policy != ::Katello::RootRepository::DOWNLOAD_ON_DEMAND }
       end
@@ -113,7 +113,7 @@ module Katello
 
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
         refute_empty repos
-        action_class.must_equal ::Actions::Katello::Repository::VerifyChecksum
+        assert_equal action_class, ::Actions::Katello::Repository::VerifyChecksum
       end
 
       put :verify_checksum_products, params: { :ids => @products.collect(&:id), :organization_id => @organization.id }

--- a/test/controllers/api/v2/products_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/products_bulk_actions_controller_test.rb
@@ -58,7 +58,7 @@ module Katello
                                         where(product: @products.syncable)).count
 
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
-        _(action_class).must_equal ::Actions::Katello::Repository::Sync
+        action_class.must_equal ::Actions::Katello::Repository::Sync
         assert_equal expected_repo_size, repos.size
       end
 
@@ -70,7 +70,7 @@ module Katello
     def test_sync_with_skip_metadata_check
       create_docker_repo
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
-        _(action_class).must_equal ::Actions::Katello::Repository::Sync
+        action_class.must_equal ::Actions::Katello::Repository::Sync
         refute_empty repos
         assert repos.all? { |repo| repo.yum? }
       end
@@ -86,7 +86,7 @@ module Katello
                          :content_view_version => @organization.default_content_view.versions.first, :download_policy => 'on_demand')
 
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
-        _(action_class).must_equal ::Actions::Katello::Repository::Sync
+        action_class.must_equal ::Actions::Katello::Repository::Sync
         refute_empty repos
         assert repos.all? { |repo| repo.yum? } && repos.all? { |repo| repo.download_policy != ::Katello::RootRepository::DOWNLOAD_ON_DEMAND }
       end
@@ -113,7 +113,7 @@ module Katello
 
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
         refute_empty repos
-        _(action_class).must_equal ::Actions::Katello::Repository::VerifyChecksum
+        action_class.must_equal ::Actions::Katello::Repository::VerifyChecksum
       end
 
       put :verify_checksum_products, params: { :ids => @products.collect(&:id), :organization_id => @organization.id }

--- a/test/controllers/api/v2/products_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/products_bulk_actions_controller_test.rb
@@ -58,7 +58,7 @@ module Katello
                                         where(product: @products.syncable)).count
 
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
-        action_class.must_equal ::Actions::Katello::Repository::Sync
+        _(action_class).must_equal ::Actions::Katello::Repository::Sync
         assert_equal expected_repo_size, repos.size
       end
 
@@ -70,7 +70,7 @@ module Katello
     def test_sync_with_skip_metadata_check
       create_docker_repo
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
-        action_class.must_equal ::Actions::Katello::Repository::Sync
+        _(action_class).must_equal ::Actions::Katello::Repository::Sync
         refute_empty repos
         assert repos.all? { |repo| repo.yum? }
       end
@@ -86,7 +86,7 @@ module Katello
                          :content_view_version => @organization.default_content_view.versions.first, :download_policy => 'on_demand')
 
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
-        action_class.must_equal ::Actions::Katello::Repository::Sync
+        _(action_class).must_equal ::Actions::Katello::Repository::Sync
         refute_empty repos
         assert repos.all? { |repo| repo.yum? } && repos.all? { |repo| repo.download_policy != ::Katello::RootRepository::DOWNLOAD_ON_DEMAND }
       end
@@ -113,7 +113,7 @@ module Katello
 
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
         refute_empty repos
-        action_class.must_equal ::Actions::Katello::Repository::VerifyChecksum
+        _(action_class).must_equal ::Actions::Katello::Repository::VerifyChecksum
       end
 
       put :verify_checksum_products, params: { :ids => @products.collect(&:id), :organization_id => @organization.id }

--- a/test/controllers/api/v2/products_controller_test.rb
+++ b/test/controllers/api/v2/products_controller_test.rb
@@ -88,9 +88,9 @@ module Katello
         :label => 'product_label'
       }
       Api::V2::ProductsController.any_instance.expects(:sync_task).with do |action_class, prod, org|
-        action_class.must_equal ::Actions::Katello::Product::Create
-        prod.must_be_kind_of(Product)
-        org.must_equal @organization
+        _(action_class).must_equal ::Actions::Katello::Product::Create
+        _(prod).must_be_kind_of(Product)
+        _(org).must_equal @organization
         prod.organization = @organization
         prod.provider = @provider
         assert_equal product_params[:name], prod.name
@@ -154,12 +154,12 @@ module Katello
       params = { :name => 'New Name', :description => 'Product Description', :label => 'product_label' }
       assert_sync_task(::Actions::Katello::Product::Update) do |product, product_params|
         assert_equal @product.id, product.id
-        product_params.key?(:name).must_equal true
-        product_params[:name].must_equal params[:name]
-        product_params.key?(:description).must_equal true
-        product_params[:description].must_equal params[:description]
-        product_params.key?(:label).must_equal true
-        product_params[:label].must_equal params[:label]
+        _(product_params.key?(:name)).must_equal true
+        _(product_params[:name]).must_equal params[:name]
+        _(product_params.key?(:description)).must_equal true
+        _(product_params[:description]).must_equal params[:description]
+        _(product_params.key?(:label)).must_equal true
+        _(product_params[:label]).must_equal params[:label]
       end
       put :update, params: { :id => @product.id, :product => params }
 
@@ -221,7 +221,7 @@ module Katello
 
     def test_sync
       assert_async_task(::Actions::BulkAction) do |action_class, _repos|
-        action_class.must_equal ::Actions::Katello::Repository::Sync
+        _(action_class).must_equal ::Actions::Katello::Repository::Sync
       end
       post :sync, params: { :id => @product.id }
       assert_response :success

--- a/test/controllers/api/v2/products_controller_test.rb
+++ b/test/controllers/api/v2/products_controller_test.rb
@@ -88,9 +88,9 @@ module Katello
         :label => 'product_label'
       }
       Api::V2::ProductsController.any_instance.expects(:sync_task).with do |action_class, prod, org|
-        action_class.must_equal ::Actions::Katello::Product::Create
-        prod.must_be_kind_of(Product)
-        org.must_equal @organization
+        assert_equal action_class, ::Actions::Katello::Product::Create
+        assert_instance_of Product, prod
+        assert_equal org, @organization
         prod.organization = @organization
         prod.provider = @provider
         assert_equal product_params[:name], prod.name
@@ -154,12 +154,12 @@ module Katello
       params = { :name => 'New Name', :description => 'Product Description', :label => 'product_label' }
       assert_sync_task(::Actions::Katello::Product::Update) do |product, product_params|
         assert_equal @product.id, product.id
-        product_params.key?(:name).must_equal true
-        product_params[:name].must_equal params[:name]
-        product_params.key?(:description).must_equal true
-        product_params[:description].must_equal params[:description]
-        product_params.key?(:label).must_equal true
-        product_params[:label].must_equal params[:label]
+        assert_equal product_params.key?(:name), true
+        assert_equal product_params[:name], params[:name]
+        assert_equal product_params.key?(:description), true
+        assert_equal product_params[:description], params[:description]
+        assert_equal product_params.key?(:label), true
+        assert_equal product_params[:label], params[:label]
       end
       put :update, params: { :id => @product.id, :product => params }
 
@@ -221,7 +221,7 @@ module Katello
 
     def test_sync
       assert_async_task(::Actions::BulkAction) do |action_class, _repos|
-        action_class.must_equal ::Actions::Katello::Repository::Sync
+        assert_equal action_class, ::Actions::Katello::Repository::Sync
       end
       post :sync, params: { :id => @product.id }
       assert_response :success

--- a/test/controllers/api/v2/products_controller_test.rb
+++ b/test/controllers/api/v2/products_controller_test.rb
@@ -88,9 +88,9 @@ module Katello
         :label => 'product_label'
       }
       Api::V2::ProductsController.any_instance.expects(:sync_task).with do |action_class, prod, org|
-        _(action_class).must_equal ::Actions::Katello::Product::Create
-        _(prod).must_be_kind_of(Product)
-        _(org).must_equal @organization
+        action_class.must_equal ::Actions::Katello::Product::Create
+        prod.must_be_kind_of(Product)
+        org.must_equal @organization
         prod.organization = @organization
         prod.provider = @provider
         assert_equal product_params[:name], prod.name
@@ -154,12 +154,12 @@ module Katello
       params = { :name => 'New Name', :description => 'Product Description', :label => 'product_label' }
       assert_sync_task(::Actions::Katello::Product::Update) do |product, product_params|
         assert_equal @product.id, product.id
-        _(product_params.key?(:name)).must_equal true
-        _(product_params[:name]).must_equal params[:name]
-        _(product_params.key?(:description)).must_equal true
-        _(product_params[:description]).must_equal params[:description]
-        _(product_params.key?(:label)).must_equal true
-        _(product_params[:label]).must_equal params[:label]
+        product_params.key?(:name).must_equal true
+        product_params[:name].must_equal params[:name]
+        product_params.key?(:description).must_equal true
+        product_params[:description].must_equal params[:description]
+        product_params.key?(:label).must_equal true
+        product_params[:label].must_equal params[:label]
       end
       put :update, params: { :id => @product.id, :product => params }
 
@@ -221,7 +221,7 @@ module Katello
 
     def test_sync
       assert_async_task(::Actions::BulkAction) do |action_class, _repos|
-        _(action_class).must_equal ::Actions::Katello::Repository::Sync
+        action_class.must_equal ::Actions::Katello::Repository::Sync
       end
       post :sync, params: { :id => @product.id }
       assert_response :success

--- a/test/controllers/api/v2/repositories_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/repositories_bulk_actions_controller_test.rb
@@ -28,7 +28,7 @@ module Katello
 
     def test_destroy_repositories
       assert_async_task(::Actions::BulkAction) do |action_class|
-        action_class.must_equal ::Actions::Katello::Repository::Destroy
+        assert_equal action_class, ::Actions::Katello::Repository::Destroy
       end
 
       put :destroy_repositories, params: { :ids => @repositories.collect(&:id), :organization_id => @organization.id }
@@ -47,7 +47,7 @@ module Katello
 
     def test_sync
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
-        action_class.must_equal ::Actions::Katello::Repository::Sync
+        assert_equal action_class, ::Actions::Katello::Repository::Sync
         assert_equal @repositories.map(&:id).sort, repos.map(&:id).sort
       end
 
@@ -60,8 +60,8 @@ module Katello
       repo_with_feed = katello_repositories(:fedora_17_x86_64)
       repo_with_no_feed = katello_repositories(:feedless_fedora_17_x86_64)
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
-        action_class.must_equal ::Actions::Katello::Repository::Sync
-        repos.map(&:id).must_equal [repo_with_feed.id]
+        assert_equal action_class, ::Actions::Katello::Repository::Sync
+        assert_equal repos.map(&:id), [repo_with_feed.id]
       end
 
       post :sync_repositories, params: { :ids => [repo_with_feed, repo_with_no_feed].collect(&:id), :organization_id => @organization.id }

--- a/test/controllers/api/v2/repositories_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/repositories_bulk_actions_controller_test.rb
@@ -28,7 +28,7 @@ module Katello
 
     def test_destroy_repositories
       assert_async_task(::Actions::BulkAction) do |action_class|
-        action_class.must_equal ::Actions::Katello::Repository::Destroy
+        _(action_class).must_equal ::Actions::Katello::Repository::Destroy
       end
 
       put :destroy_repositories, params: { :ids => @repositories.collect(&:id), :organization_id => @organization.id }
@@ -47,7 +47,7 @@ module Katello
 
     def test_sync
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
-        action_class.must_equal ::Actions::Katello::Repository::Sync
+        _(action_class).must_equal ::Actions::Katello::Repository::Sync
         assert_equal @repositories.map(&:id).sort, repos.map(&:id).sort
       end
 
@@ -60,8 +60,8 @@ module Katello
       repo_with_feed = katello_repositories(:fedora_17_x86_64)
       repo_with_no_feed = katello_repositories(:feedless_fedora_17_x86_64)
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
-        action_class.must_equal ::Actions::Katello::Repository::Sync
-        repos.map(&:id).must_equal [repo_with_feed.id]
+        _(action_class).must_equal ::Actions::Katello::Repository::Sync
+        _(repos.map(&:id)).must_equal [repo_with_feed.id]
       end
 
       post :sync_repositories, params: { :ids => [repo_with_feed, repo_with_no_feed].collect(&:id), :organization_id => @organization.id }

--- a/test/controllers/api/v2/repositories_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/repositories_bulk_actions_controller_test.rb
@@ -28,7 +28,7 @@ module Katello
 
     def test_destroy_repositories
       assert_async_task(::Actions::BulkAction) do |action_class|
-        _(action_class).must_equal ::Actions::Katello::Repository::Destroy
+        action_class.must_equal ::Actions::Katello::Repository::Destroy
       end
 
       put :destroy_repositories, params: { :ids => @repositories.collect(&:id), :organization_id => @organization.id }
@@ -47,7 +47,7 @@ module Katello
 
     def test_sync
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
-        _(action_class).must_equal ::Actions::Katello::Repository::Sync
+        action_class.must_equal ::Actions::Katello::Repository::Sync
         assert_equal @repositories.map(&:id).sort, repos.map(&:id).sort
       end
 
@@ -60,8 +60,8 @@ module Katello
       repo_with_feed = katello_repositories(:fedora_17_x86_64)
       repo_with_no_feed = katello_repositories(:feedless_fedora_17_x86_64)
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
-        _(action_class).must_equal ::Actions::Katello::Repository::Sync
-        _(repos.map(&:id)).must_equal [repo_with_feed.id]
+        action_class.must_equal ::Actions::Katello::Repository::Sync
+        repos.map(&:id).must_equal [repo_with_feed.id]
       end
 
       post :sync_repositories, params: { :ids => [repo_with_feed, repo_with_no_feed].collect(&:id), :organization_id => @organization.id }

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -537,7 +537,7 @@ module Katello
     def test_update_with_gpg_key
       key = ContentCredential.find(katello_gpg_keys('fedora_gpg_key').id)
       assert_sync_task(::Actions::Katello::Repository::Update) do |root, attributes|
-        _(root).must_equal @repository.root
+        root.must_equal @repository.root
         expected = { 'gpg_key_id' => key.id.to_s }
         assert_equal expected, attributes.to_hash
       end
@@ -549,7 +549,7 @@ module Katello
     def test_update_with_cert
       cert = ContentCredential.find(katello_gpg_keys('fedora_cert').id)
       assert_sync_task(::Actions::Katello::Repository::Update) do |root, attributes|
-        _(root).must_equal root
+        root.must_equal root
         expected = { 'ssl_ca_cert_id' => cert.id.to_s }
         assert_equal expected, attributes.to_hash
       end
@@ -561,14 +561,14 @@ module Katello
     def test_update_with_description
       repo = katello_repositories(:busybox)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        _(attributes[:description]).must_equal "katello rules"
+        attributes[:description].must_equal "katello rules"
       end
       put :update, params: { :id => repo.id, :description => "katello rules" }
     end
 
     def test_update_with_auth_token
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        _(attributes[:upstream_authentication_token]).must_equal "foo"
+        attributes[:upstream_authentication_token].must_equal "foo"
       end
       put :update, params: { :id => @repository.id, :upstream_authentication_token => "foo" }
     end
@@ -585,7 +585,7 @@ module Katello
     def test_update_with_upstream_name
       repo = katello_repositories(:busybox)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        _(attributes[:docker_upstream_name]).must_equal "helloworld"
+        attributes[:docker_upstream_name].must_equal "helloworld"
       end
       put :update, params: { :id => repo.id, :docker_upstream_name => "helloworld" }
     end
@@ -593,7 +593,7 @@ module Katello
     def test_update_with_http_proxy_policy
       repo = katello_repositories(:busybox)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        _(attributes[:http_proxy_policy]).must_equal RootRepository::GLOBAL_DEFAULT_HTTP_PROXY
+        attributes[:http_proxy_policy].must_equal RootRepository::GLOBAL_DEFAULT_HTTP_PROXY
       end
       put :update, params: { :id => repo.id, :http_proxy_policy => RootRepository::GLOBAL_DEFAULT_HTTP_PROXY }
     end
@@ -602,7 +602,7 @@ module Katello
       repo = katello_repositories(:busybox)
       proxy = FactoryBot.create(:http_proxy)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        _(attributes[:http_proxy_id]).must_equal proxy.id
+        attributes[:http_proxy_id].must_equal proxy.id
       end
       put :update, params: { :id => repo.id, :http_proxy_id => proxy.id }
     end
@@ -620,7 +620,7 @@ module Katello
       ignorable_content = ["rpm", "srpm"]
       repo = katello_repositories(:fedora_17_unpublished)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        _(attributes[:ignorable_content]).must_equal ignorable_content
+        attributes[:ignorable_content].must_equal ignorable_content
       end
       put :update, params: { :id => repo.id, :ignorable_content => ignorable_content }
     end
@@ -629,7 +629,7 @@ module Katello
       retain_package_versions_count = 2
       repo = katello_repositories(:fedora_17_unpublished)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        _(attributes[:retain_package_versions_count]).must_equal retain_package_versions_count
+        attributes[:retain_package_versions_count].must_equal retain_package_versions_count
       end
       put :update, params: { :id => repo.id, :retain_package_versions_count => retain_package_versions_count }
     end
@@ -637,7 +637,7 @@ module Katello
     def test_update_with_whitelist_tags
       whitelist = ["latest", "1.23"]
       assert_sync_task(::Actions::Katello::Repository::Update) do |root, attributes|
-        _(root).must_equal @docker_repo.root
+        root.must_equal @docker_repo.root
         expected = {'docker_tags_whitelist' => whitelist}
         assert_equal expected, attributes.to_hash
       end
@@ -648,7 +648,7 @@ module Katello
 
     def test_update_non_docker_repo_with_whitelist_tags
       assert_sync_task(::Actions::Katello::Repository::Update) do |root, attributes|
-        _(root).must_equal @repository.root
+        root.must_equal @repository.root
         expected = { 'name' => 'new name' }
         assert_equal expected, attributes.to_hash
       end
@@ -663,7 +663,7 @@ module Katello
       stub_editable_product_find(@product)
       @product.expects(:add_repo).returns(@docker_repo.root)
       assert_sync_task(::Actions::Katello::Repository::CreateRoot, @docker_repo.root) do |root|
-        _(root).must_equal @docker_repo.root
+        root.must_equal @docker_repo.root
         assert_equal whitelist, root.docker_tags_whitelist
       end
       post :create, params: { :name => 'busybox', :product_id => @product.id, :content_type => 'docker', :docker_upstream_name => "busybox", :docker_tags_whitelist => whitelist }
@@ -676,7 +676,7 @@ module Katello
       stub_editable_product_find(@product)
       @product.expects(:add_repo).returns(@docker_repo.root)
       assert_sync_task(::Actions::Katello::Repository::CreateRoot, @docker_repo.root) do |root|
-        _(root).must_equal @docker_repo.root
+        root.must_equal @docker_repo.root
         assert_equal [], root.docker_tags_whitelist
       end
       post :create, params: { :name => 'busybox', :product_id => @product.id, :content_type => 'docker', :docker_upstream_name => "busybox" }
@@ -769,7 +769,7 @@ module Katello
     def test_sync_with_url_override
       assert_async_task ::Actions::Katello::Repository::Sync do |repo, options|
         assert_equal @repository.id, repo.id
-        _(options[:source_url]).must_equal('file:///tmp/')
+        options[:source_url].must_equal('file:///tmp/')
       end
       post :sync, params: { :id => @repository.id, :source_url => 'file:///tmp/' }
       assert_response :success
@@ -778,8 +778,8 @@ module Katello
     def test_sync_with_incremental_flag
       assert_async_task ::Actions::Katello::Repository::Sync do |repo, options|
         assert_equal @repository.id, repo.id
-        _(options[:source_url]).must_equal('file:///tmp/')
-        _(options[:incremental]).must_equal true
+        options[:source_url].must_equal('file:///tmp/')
+        options[:incremental].must_equal true
       end
       post :sync, params: { :id => @repository.id, :source_url => 'file:///tmp/', :incremental => true }
       assert_response :success

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -537,7 +537,7 @@ module Katello
     def test_update_with_gpg_key
       key = ContentCredential.find(katello_gpg_keys('fedora_gpg_key').id)
       assert_sync_task(::Actions::Katello::Repository::Update) do |root, attributes|
-        root.must_equal @repository.root
+        assert_equal root, @repository.root
         expected = { 'gpg_key_id' => key.id.to_s }
         assert_equal expected, attributes.to_hash
       end
@@ -549,7 +549,7 @@ module Katello
     def test_update_with_cert
       cert = ContentCredential.find(katello_gpg_keys('fedora_cert').id)
       assert_sync_task(::Actions::Katello::Repository::Update) do |root, attributes|
-        root.must_equal root
+        assert_equal root, @repository.root
         expected = { 'ssl_ca_cert_id' => cert.id.to_s }
         assert_equal expected, attributes.to_hash
       end
@@ -561,14 +561,14 @@ module Katello
     def test_update_with_description
       repo = katello_repositories(:busybox)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        attributes[:description].must_equal "katello rules"
+        assert_equal attributes[:description], "katello rules"
       end
       put :update, params: { :id => repo.id, :description => "katello rules" }
     end
 
     def test_update_with_auth_token
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        attributes[:upstream_authentication_token].must_equal "foo"
+        assert_equal attributes[:upstream_authentication_token], "foo"
       end
       put :update, params: { :id => @repository.id, :upstream_authentication_token => "foo" }
     end
@@ -585,7 +585,7 @@ module Katello
     def test_update_with_upstream_name
       repo = katello_repositories(:busybox)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        attributes[:docker_upstream_name].must_equal "helloworld"
+        assert_equal attributes[:docker_upstream_name], "helloworld"
       end
       put :update, params: { :id => repo.id, :docker_upstream_name => "helloworld" }
     end
@@ -593,7 +593,7 @@ module Katello
     def test_update_with_http_proxy_policy
       repo = katello_repositories(:busybox)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        attributes[:http_proxy_policy].must_equal RootRepository::GLOBAL_DEFAULT_HTTP_PROXY
+        assert_equal attributes[:http_proxy_policy], RootRepository::GLOBAL_DEFAULT_HTTP_PROXY
       end
       put :update, params: { :id => repo.id, :http_proxy_policy => RootRepository::GLOBAL_DEFAULT_HTTP_PROXY }
     end
@@ -602,7 +602,7 @@ module Katello
       repo = katello_repositories(:busybox)
       proxy = FactoryBot.create(:http_proxy)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        attributes[:http_proxy_id].must_equal proxy.id
+        assert_equal attributes[:http_proxy_id], proxy.id
       end
       put :update, params: { :id => repo.id, :http_proxy_id => proxy.id }
     end
@@ -620,7 +620,7 @@ module Katello
       ignorable_content = ["rpm", "srpm"]
       repo = katello_repositories(:fedora_17_unpublished)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        attributes[:ignorable_content].must_equal ignorable_content
+        assert_equal attributes[:ignorable_content], ignorable_content
       end
       put :update, params: { :id => repo.id, :ignorable_content => ignorable_content }
     end
@@ -629,7 +629,7 @@ module Katello
       retain_package_versions_count = 2
       repo = katello_repositories(:fedora_17_unpublished)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        attributes[:retain_package_versions_count].must_equal retain_package_versions_count
+        assert_equal attributes[:retain_package_versions_count], retain_package_versions_count
       end
       put :update, params: { :id => repo.id, :retain_package_versions_count => retain_package_versions_count }
     end
@@ -637,7 +637,7 @@ module Katello
     def test_update_with_whitelist_tags
       whitelist = ["latest", "1.23"]
       assert_sync_task(::Actions::Katello::Repository::Update) do |root, attributes|
-        root.must_equal @docker_repo.root
+        assert_equal root, @docker_repo.root
         expected = {'docker_tags_whitelist' => whitelist}
         assert_equal expected, attributes.to_hash
       end
@@ -648,7 +648,7 @@ module Katello
 
     def test_update_non_docker_repo_with_whitelist_tags
       assert_sync_task(::Actions::Katello::Repository::Update) do |root, attributes|
-        root.must_equal @repository.root
+        assert_equal root, @repository.root
         expected = { 'name' => 'new name' }
         assert_equal expected, attributes.to_hash
       end
@@ -663,7 +663,7 @@ module Katello
       stub_editable_product_find(@product)
       @product.expects(:add_repo).returns(@docker_repo.root)
       assert_sync_task(::Actions::Katello::Repository::CreateRoot, @docker_repo.root) do |root|
-        root.must_equal @docker_repo.root
+        assert_equal root, @docker_repo.root
         assert_equal whitelist, root.docker_tags_whitelist
       end
       post :create, params: { :name => 'busybox', :product_id => @product.id, :content_type => 'docker', :docker_upstream_name => "busybox", :docker_tags_whitelist => whitelist }
@@ -676,8 +676,8 @@ module Katello
       stub_editable_product_find(@product)
       @product.expects(:add_repo).returns(@docker_repo.root)
       assert_sync_task(::Actions::Katello::Repository::CreateRoot, @docker_repo.root) do |root|
-        root.must_equal @docker_repo.root
-        assert_equal [], root.docker_tags_whitelist
+        assert_equal root, @docker_repo.root
+        assert_empty root.docker_tags_whitelist
       end
       post :create, params: { :name => 'busybox', :product_id => @product.id, :content_type => 'docker', :docker_upstream_name => "busybox" }
       assert_response :success
@@ -769,7 +769,7 @@ module Katello
     def test_sync_with_url_override
       assert_async_task ::Actions::Katello::Repository::Sync do |repo, options|
         assert_equal @repository.id, repo.id
-        options[:source_url].must_equal('file:///tmp/')
+        assert_equal options[:source_url], 'file:///tmp/'
       end
       post :sync, params: { :id => @repository.id, :source_url => 'file:///tmp/' }
       assert_response :success
@@ -778,8 +778,8 @@ module Katello
     def test_sync_with_incremental_flag
       assert_async_task ::Actions::Katello::Repository::Sync do |repo, options|
         assert_equal @repository.id, repo.id
-        options[:source_url].must_equal('file:///tmp/')
-        options[:incremental].must_equal true
+        assert_equal options[:source_url], 'file:///tmp/'
+        assert_equal options[:incremental], true
       end
       post :sync, params: { :id => @repository.id, :source_url => 'file:///tmp/', :incremental => true }
       assert_response :success

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -537,7 +537,7 @@ module Katello
     def test_update_with_gpg_key
       key = ContentCredential.find(katello_gpg_keys('fedora_gpg_key').id)
       assert_sync_task(::Actions::Katello::Repository::Update) do |root, attributes|
-        root.must_equal @repository.root
+        _(root).must_equal @repository.root
         expected = { 'gpg_key_id' => key.id.to_s }
         assert_equal expected, attributes.to_hash
       end
@@ -549,7 +549,7 @@ module Katello
     def test_update_with_cert
       cert = ContentCredential.find(katello_gpg_keys('fedora_cert').id)
       assert_sync_task(::Actions::Katello::Repository::Update) do |root, attributes|
-        root.must_equal root
+        _(root).must_equal root
         expected = { 'ssl_ca_cert_id' => cert.id.to_s }
         assert_equal expected, attributes.to_hash
       end
@@ -561,14 +561,14 @@ module Katello
     def test_update_with_description
       repo = katello_repositories(:busybox)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        attributes[:description].must_equal "katello rules"
+        _(attributes[:description]).must_equal "katello rules"
       end
       put :update, params: { :id => repo.id, :description => "katello rules" }
     end
 
     def test_update_with_auth_token
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        attributes[:upstream_authentication_token].must_equal "foo"
+        _(attributes[:upstream_authentication_token]).must_equal "foo"
       end
       put :update, params: { :id => @repository.id, :upstream_authentication_token => "foo" }
     end
@@ -585,7 +585,7 @@ module Katello
     def test_update_with_upstream_name
       repo = katello_repositories(:busybox)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        attributes[:docker_upstream_name].must_equal "helloworld"
+        _(attributes[:docker_upstream_name]).must_equal "helloworld"
       end
       put :update, params: { :id => repo.id, :docker_upstream_name => "helloworld" }
     end
@@ -593,7 +593,7 @@ module Katello
     def test_update_with_http_proxy_policy
       repo = katello_repositories(:busybox)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        attributes[:http_proxy_policy].must_equal RootRepository::GLOBAL_DEFAULT_HTTP_PROXY
+        _(attributes[:http_proxy_policy]).must_equal RootRepository::GLOBAL_DEFAULT_HTTP_PROXY
       end
       put :update, params: { :id => repo.id, :http_proxy_policy => RootRepository::GLOBAL_DEFAULT_HTTP_PROXY }
     end
@@ -602,7 +602,7 @@ module Katello
       repo = katello_repositories(:busybox)
       proxy = FactoryBot.create(:http_proxy)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        attributes[:http_proxy_id].must_equal proxy.id
+        _(attributes[:http_proxy_id]).must_equal proxy.id
       end
       put :update, params: { :id => repo.id, :http_proxy_id => proxy.id }
     end
@@ -620,7 +620,7 @@ module Katello
       ignorable_content = ["rpm", "srpm"]
       repo = katello_repositories(:fedora_17_unpublished)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        attributes[:ignorable_content].must_equal ignorable_content
+        _(attributes[:ignorable_content]).must_equal ignorable_content
       end
       put :update, params: { :id => repo.id, :ignorable_content => ignorable_content }
     end
@@ -629,7 +629,7 @@ module Katello
       retain_package_versions_count = 2
       repo = katello_repositories(:fedora_17_unpublished)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
-        attributes[:retain_package_versions_count].must_equal retain_package_versions_count
+        _(attributes[:retain_package_versions_count]).must_equal retain_package_versions_count
       end
       put :update, params: { :id => repo.id, :retain_package_versions_count => retain_package_versions_count }
     end
@@ -637,7 +637,7 @@ module Katello
     def test_update_with_whitelist_tags
       whitelist = ["latest", "1.23"]
       assert_sync_task(::Actions::Katello::Repository::Update) do |root, attributes|
-        root.must_equal @docker_repo.root
+        _(root).must_equal @docker_repo.root
         expected = {'docker_tags_whitelist' => whitelist}
         assert_equal expected, attributes.to_hash
       end
@@ -648,7 +648,7 @@ module Katello
 
     def test_update_non_docker_repo_with_whitelist_tags
       assert_sync_task(::Actions::Katello::Repository::Update) do |root, attributes|
-        root.must_equal @repository.root
+        _(root).must_equal @repository.root
         expected = { 'name' => 'new name' }
         assert_equal expected, attributes.to_hash
       end
@@ -663,7 +663,7 @@ module Katello
       stub_editable_product_find(@product)
       @product.expects(:add_repo).returns(@docker_repo.root)
       assert_sync_task(::Actions::Katello::Repository::CreateRoot, @docker_repo.root) do |root|
-        root.must_equal @docker_repo.root
+        _(root).must_equal @docker_repo.root
         assert_equal whitelist, root.docker_tags_whitelist
       end
       post :create, params: { :name => 'busybox', :product_id => @product.id, :content_type => 'docker', :docker_upstream_name => "busybox", :docker_tags_whitelist => whitelist }
@@ -676,7 +676,7 @@ module Katello
       stub_editable_product_find(@product)
       @product.expects(:add_repo).returns(@docker_repo.root)
       assert_sync_task(::Actions::Katello::Repository::CreateRoot, @docker_repo.root) do |root|
-        root.must_equal @docker_repo.root
+        _(root).must_equal @docker_repo.root
         assert_equal [], root.docker_tags_whitelist
       end
       post :create, params: { :name => 'busybox', :product_id => @product.id, :content_type => 'docker', :docker_upstream_name => "busybox" }
@@ -769,7 +769,7 @@ module Katello
     def test_sync_with_url_override
       assert_async_task ::Actions::Katello::Repository::Sync do |repo, options|
         assert_equal @repository.id, repo.id
-        options[:source_url].must_equal('file:///tmp/')
+        _(options[:source_url]).must_equal('file:///tmp/')
       end
       post :sync, params: { :id => @repository.id, :source_url => 'file:///tmp/' }
       assert_response :success
@@ -778,8 +778,8 @@ module Katello
     def test_sync_with_incremental_flag
       assert_async_task ::Actions::Katello::Repository::Sync do |repo, options|
         assert_equal @repository.id, repo.id
-        options[:source_url].must_equal('file:///tmp/')
-        options[:incremental].must_equal true
+        _(options[:source_url]).must_equal('file:///tmp/')
+        _(options[:incremental]).must_equal true
       end
       post :sync, params: { :id => @repository.id, :source_url => 'file:///tmp/', :incremental => true }
       assert_response :success

--- a/test/controllers/api/v2/repository_sets_controller_test.rb
+++ b/test/controllers/api/v2/repository_sets_controller_test.rb
@@ -184,8 +184,8 @@ module Katello
 
     def test_available_repositories
       task = assert_sync_task ::Actions::Katello::RepositorySet::ScanCdn do |product, content_id|
-        _(product).must_equal @product
-        _(content_id).must_equal @content_id
+        product.must_equal @product
+        content_id.must_equal @content_id
       end
       task.expects(:output).at_least_once.returns(results: [])
 
@@ -198,8 +198,8 @@ module Katello
       # not exposing the bug
       @content.reload.product_contents.first.update(:id => Katello::ProductContent.maximum(:id) + 1000)
       task = assert_sync_task ::Actions::Katello::RepositorySet::ScanCdn do |product, content_id|
-        _(product).must_equal @product
-        _(content_id).must_equal @content_id
+        product.must_equal @product
+        content_id.must_equal @content_id
       end
       task.expects(:output).at_least_once.returns(results: [])
 
@@ -285,9 +285,9 @@ module Katello
 
     def test_repository_enable
       assert_sync_task ::Actions::Katello::RepositorySet::EnableRepository do |product, content, substitutions|
-        _(product).must_equal @product
+        product.must_equal @product
         assert_equal @content_id, content.cp_content_id
-        _(substitutions).must_equal('basearch' => 'x86_64', 'releasever' => '6Server')
+        substitutions.must_equal('basearch' => 'x86_64', 'releasever' => '6Server')
       end
 
       put :enable, params: { product_id: @product.id, id: @content_id, basearch: 'x86_64', releasever: '6Server' }
@@ -296,9 +296,9 @@ module Katello
 
     def test_repository_enable_docker
       assert_sync_task ::Actions::Katello::RepositorySet::EnableRepository do |product, content, substitutions|
-        _(product).must_equal @product
+        product.must_equal @product
         assert_equal @content_id, content.cp_content_id
-        _(substitutions).must_be_empty
+        substitutions.must_be_empty
       end
 
       put :enable, params: { product_id: @product.id, id: @content_id }
@@ -316,9 +316,9 @@ module Katello
 
     def test_repository_disable
       assert_sync_task ::Actions::Katello::RepositorySet::DisableRepository do |product, content, substitutions|
-        _(product).must_equal @product
+        product.must_equal @product
         assert_equal @content_id, content.cp_content_id
-        _(substitutions).must_equal('basearch' => 'x86_64', 'releasever' => '6Server')
+        substitutions.must_equal('basearch' => 'x86_64', 'releasever' => '6Server')
       end
 
       put :disable, params: { product_id: @product.id, id: @content_id, basearch: 'x86_64', releasever: '6Server' }
@@ -327,9 +327,9 @@ module Katello
 
     def test_repository_disable_docker
       assert_sync_task ::Actions::Katello::RepositorySet::DisableRepository do |product, content, substitutions|
-        _(product).must_equal @product
+        product.must_equal @product
         assert_equal @content_id, content.cp_content_id
-        _(substitutions).must_be_empty
+        substitutions.must_be_empty
       end
 
       put :disable, params: { product_id: @product.id, id: @content_id }

--- a/test/controllers/api/v2/repository_sets_controller_test.rb
+++ b/test/controllers/api/v2/repository_sets_controller_test.rb
@@ -184,8 +184,8 @@ module Katello
 
     def test_available_repositories
       task = assert_sync_task ::Actions::Katello::RepositorySet::ScanCdn do |product, content_id|
-        product.must_equal @product
-        content_id.must_equal @content_id
+        assert_equal product, @product
+        assert_equal content_id, @content_id
       end
       task.expects(:output).at_least_once.returns(results: [])
 
@@ -198,8 +198,8 @@ module Katello
       # not exposing the bug
       @content.reload.product_contents.first.update(:id => Katello::ProductContent.maximum(:id) + 1000)
       task = assert_sync_task ::Actions::Katello::RepositorySet::ScanCdn do |product, content_id|
-        product.must_equal @product
-        content_id.must_equal @content_id
+        assert_equal product, @product
+        assert_equal content_id, @content_id
       end
       task.expects(:output).at_least_once.returns(results: [])
 
@@ -285,9 +285,9 @@ module Katello
 
     def test_repository_enable
       assert_sync_task ::Actions::Katello::RepositorySet::EnableRepository do |product, content, substitutions|
-        product.must_equal @product
+        assert_equal product, @product
         assert_equal @content_id, content.cp_content_id
-        substitutions.must_equal('basearch' => 'x86_64', 'releasever' => '6Server')
+        assert_equal substitutions, { 'basearch' => 'x86_64', 'releasever' => '6Server' }
       end
 
       put :enable, params: { product_id: @product.id, id: @content_id, basearch: 'x86_64', releasever: '6Server' }
@@ -296,9 +296,9 @@ module Katello
 
     def test_repository_enable_docker
       assert_sync_task ::Actions::Katello::RepositorySet::EnableRepository do |product, content, substitutions|
-        product.must_equal @product
+        assert_equal product, @product
         assert_equal @content_id, content.cp_content_id
-        substitutions.must_be_empty
+        assert_empty substitutions
       end
 
       put :enable, params: { product_id: @product.id, id: @content_id }
@@ -316,9 +316,9 @@ module Katello
 
     def test_repository_disable
       assert_sync_task ::Actions::Katello::RepositorySet::DisableRepository do |product, content, substitutions|
-        product.must_equal @product
+        assert_equal product, @product
         assert_equal @content_id, content.cp_content_id
-        substitutions.must_equal('basearch' => 'x86_64', 'releasever' => '6Server')
+        assert_equal substitutions, { 'basearch' => 'x86_64', 'releasever' => '6Server' }
       end
 
       put :disable, params: { product_id: @product.id, id: @content_id, basearch: 'x86_64', releasever: '6Server' }
@@ -327,9 +327,9 @@ module Katello
 
     def test_repository_disable_docker
       assert_sync_task ::Actions::Katello::RepositorySet::DisableRepository do |product, content, substitutions|
-        product.must_equal @product
+        assert_equal product, @product
         assert_equal @content_id, content.cp_content_id
-        substitutions.must_be_empty
+        assert_empty substitutions
       end
 
       put :disable, params: { product_id: @product.id, id: @content_id }

--- a/test/controllers/api/v2/repository_sets_controller_test.rb
+++ b/test/controllers/api/v2/repository_sets_controller_test.rb
@@ -184,8 +184,8 @@ module Katello
 
     def test_available_repositories
       task = assert_sync_task ::Actions::Katello::RepositorySet::ScanCdn do |product, content_id|
-        product.must_equal @product
-        content_id.must_equal @content_id
+        _(product).must_equal @product
+        _(content_id).must_equal @content_id
       end
       task.expects(:output).at_least_once.returns(results: [])
 
@@ -198,8 +198,8 @@ module Katello
       # not exposing the bug
       @content.reload.product_contents.first.update(:id => Katello::ProductContent.maximum(:id) + 1000)
       task = assert_sync_task ::Actions::Katello::RepositorySet::ScanCdn do |product, content_id|
-        product.must_equal @product
-        content_id.must_equal @content_id
+        _(product).must_equal @product
+        _(content_id).must_equal @content_id
       end
       task.expects(:output).at_least_once.returns(results: [])
 
@@ -285,9 +285,9 @@ module Katello
 
     def test_repository_enable
       assert_sync_task ::Actions::Katello::RepositorySet::EnableRepository do |product, content, substitutions|
-        product.must_equal @product
+        _(product).must_equal @product
         assert_equal @content_id, content.cp_content_id
-        substitutions.must_equal('basearch' => 'x86_64', 'releasever' => '6Server')
+        _(substitutions).must_equal('basearch' => 'x86_64', 'releasever' => '6Server')
       end
 
       put :enable, params: { product_id: @product.id, id: @content_id, basearch: 'x86_64', releasever: '6Server' }
@@ -296,9 +296,9 @@ module Katello
 
     def test_repository_enable_docker
       assert_sync_task ::Actions::Katello::RepositorySet::EnableRepository do |product, content, substitutions|
-        product.must_equal @product
+        _(product).must_equal @product
         assert_equal @content_id, content.cp_content_id
-        substitutions.must_be_empty
+        _(substitutions).must_be_empty
       end
 
       put :enable, params: { product_id: @product.id, id: @content_id }
@@ -316,9 +316,9 @@ module Katello
 
     def test_repository_disable
       assert_sync_task ::Actions::Katello::RepositorySet::DisableRepository do |product, content, substitutions|
-        product.must_equal @product
+        _(product).must_equal @product
         assert_equal @content_id, content.cp_content_id
-        substitutions.must_equal('basearch' => 'x86_64', 'releasever' => '6Server')
+        _(substitutions).must_equal('basearch' => 'x86_64', 'releasever' => '6Server')
       end
 
       put :disable, params: { product_id: @product.id, id: @content_id, basearch: 'x86_64', releasever: '6Server' }
@@ -327,9 +327,9 @@ module Katello
 
     def test_repository_disable_docker
       assert_sync_task ::Actions::Katello::RepositorySet::DisableRepository do |product, content, substitutions|
-        product.must_equal @product
+        _(product).must_equal @product
         assert_equal @content_id, content.cp_content_id
-        substitutions.must_be_empty
+        _(substitutions).must_be_empty
       end
 
       put :disable, params: { product_id: @product.id, id: @content_id }

--- a/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
@@ -70,7 +70,7 @@ module Katello
     def test_destroy
       params = { pool_ids: %w(1 2 3), organization_id: @organization.id }
       assert_async_task ::Actions::Katello::UpstreamSubscriptions::RemoveEntitlements do |entitlement_ids|
-        entitlement_ids.must_equal %w(1 2 3)
+        _(entitlement_ids).must_equal %w(1 2 3)
       end
 
       delete :destroy, params: params
@@ -115,7 +115,7 @@ module Katello
       pools = [{"id" => "12345", "quantity" => 5}]
 
       assert_async_task ::Actions::Katello::UpstreamSubscriptions::UpdateEntitlements do |poolz|
-        poolz.must_equal pools
+        _(poolz).must_equal pools
       end
 
       put :update, params: { organization_id: @organization.id, pools: pools }

--- a/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
@@ -70,7 +70,7 @@ module Katello
     def test_destroy
       params = { pool_ids: %w(1 2 3), organization_id: @organization.id }
       assert_async_task ::Actions::Katello::UpstreamSubscriptions::RemoveEntitlements do |entitlement_ids|
-        entitlement_ids.must_equal %w(1 2 3)
+        assert_equal entitlement_ids, %w(1 2 3)
       end
 
       delete :destroy, params: params
@@ -115,7 +115,7 @@ module Katello
       pools = [{"id" => "12345", "quantity" => 5}]
 
       assert_async_task ::Actions::Katello::UpstreamSubscriptions::UpdateEntitlements do |poolz|
-        poolz.must_equal pools
+        assert_equal poolz, pools
       end
 
       put :update, params: { organization_id: @organization.id, pools: pools }

--- a/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
@@ -70,7 +70,7 @@ module Katello
     def test_destroy
       params = { pool_ids: %w(1 2 3), organization_id: @organization.id }
       assert_async_task ::Actions::Katello::UpstreamSubscriptions::RemoveEntitlements do |entitlement_ids|
-        _(entitlement_ids).must_equal %w(1 2 3)
+        entitlement_ids.must_equal %w(1 2 3)
       end
 
       delete :destroy, params: params
@@ -115,7 +115,7 @@ module Katello
       pools = [{"id" => "12345", "quantity" => 5}]
 
       assert_async_task ::Actions::Katello::UpstreamSubscriptions::UpdateEntitlements do |poolz|
-        _(poolz).must_equal pools
+        poolz.must_equal pools
       end
 
       put :update, params: { organization_id: @organization.id, pools: pools }

--- a/test/helpers/hosts_and_hostgroups_helper_test.rb
+++ b/test/helpers/hosts_and_hostgroups_helper_test.rb
@@ -92,7 +92,7 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
     ret = [{:name => "boo" }]
     ::Operatingsystem.expects(:find).with(@os.id).returns(@os).at_least_once
     @os.expects(:kickstart_repos).returns(ret).with do |host|
-      host.must_be_kind_of(::Host::Managed)
+      _(host).must_be_kind_of(::Host::Managed)
       assert_equal @os, host.os
       assert_equal @env, host.content_facet.lifecycle_environment
       assert_equal @cv, host.content_facet.content_view
@@ -112,7 +112,7 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
     ret = [{:name => "boo" }]
 
     @os.expects(:kickstart_repos).returns(ret).with do |param_host|
-      param_host.must_be_kind_of(::Host::Managed)
+      _(param_host).must_be_kind_of(::Host::Managed)
       assert_equal @os, param_host.os
       assert_equal @env, param_host.content_facet.lifecycle_environment
       assert_equal @cv, param_host.content_facet.content_view
@@ -148,7 +148,7 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
     ret = [{:name => "boo" }]
 
     @os.expects(:kickstart_repos).returns(ret).with do |param_host|
-      param_host.must_be_kind_of(::Host::Managed)
+      _(param_host).must_be_kind_of(::Host::Managed)
       assert_equal @os, param_host.os
       assert_equal @env, param_host.content_facet.lifecycle_environment
       assert_equal @cv, param_host.content_facet.content_view
@@ -174,7 +174,7 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
     ret = [{:name => "boo" }]
 
     @os.expects(:kickstart_repos).returns(ret).with do |param_host|
-      param_host.must_be_kind_of(::Host::Managed)
+      _(param_host).must_be_kind_of(::Host::Managed)
       assert_equal @os, param_host.os
       assert_equal @env, param_host.content_facet.lifecycle_environment
       assert_equal @cv, param_host.content_facet.content_view

--- a/test/helpers/hosts_and_hostgroups_helper_test.rb
+++ b/test/helpers/hosts_and_hostgroups_helper_test.rb
@@ -92,7 +92,7 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
     ret = [{:name => "boo" }]
     ::Operatingsystem.expects(:find).with(@os.id).returns(@os).at_least_once
     @os.expects(:kickstart_repos).returns(ret).with do |host|
-      host.must_be_kind_of(::Host::Managed)
+      assert_instance_of(::Host::Managed, host)
       assert_equal @os, host.os
       assert_equal @env, host.content_facet.lifecycle_environment
       assert_equal @cv, host.content_facet.content_view
@@ -112,7 +112,7 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
     ret = [{:name => "boo" }]
 
     @os.expects(:kickstart_repos).returns(ret).with do |param_host|
-      param_host.must_be_kind_of(::Host::Managed)
+      assert_instance_of ::Host::Managed, param_host
       assert_equal @os, param_host.os
       assert_equal @env, param_host.content_facet.lifecycle_environment
       assert_equal @cv, param_host.content_facet.content_view
@@ -148,7 +148,7 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
     ret = [{:name => "boo" }]
 
     @os.expects(:kickstart_repos).returns(ret).with do |param_host|
-      param_host.must_be_kind_of(::Host::Managed)
+      assert_instance_of ::Host::Managed, param_host
       assert_equal @os, param_host.os
       assert_equal @env, param_host.content_facet.lifecycle_environment
       assert_equal @cv, param_host.content_facet.content_view
@@ -174,7 +174,7 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
     ret = [{:name => "boo" }]
 
     @os.expects(:kickstart_repos).returns(ret).with do |param_host|
-      param_host.must_be_kind_of(::Host::Managed)
+      assert_instance_of ::Host::Managed, param_host
       assert_equal @os, param_host.os
       assert_equal @env, param_host.content_facet.lifecycle_environment
       assert_equal @cv, param_host.content_facet.content_view

--- a/test/helpers/hosts_and_hostgroups_helper_test.rb
+++ b/test/helpers/hosts_and_hostgroups_helper_test.rb
@@ -92,7 +92,7 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
     ret = [{:name => "boo" }]
     ::Operatingsystem.expects(:find).with(@os.id).returns(@os).at_least_once
     @os.expects(:kickstart_repos).returns(ret).with do |host|
-      _(host).must_be_kind_of(::Host::Managed)
+      host.must_be_kind_of(::Host::Managed)
       assert_equal @os, host.os
       assert_equal @env, host.content_facet.lifecycle_environment
       assert_equal @cv, host.content_facet.content_view
@@ -112,7 +112,7 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
     ret = [{:name => "boo" }]
 
     @os.expects(:kickstart_repos).returns(ret).with do |param_host|
-      _(param_host).must_be_kind_of(::Host::Managed)
+      param_host.must_be_kind_of(::Host::Managed)
       assert_equal @os, param_host.os
       assert_equal @env, param_host.content_facet.lifecycle_environment
       assert_equal @cv, param_host.content_facet.content_view
@@ -148,7 +148,7 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
     ret = [{:name => "boo" }]
 
     @os.expects(:kickstart_repos).returns(ret).with do |param_host|
-      _(param_host).must_be_kind_of(::Host::Managed)
+      param_host.must_be_kind_of(::Host::Managed)
       assert_equal @os, param_host.os
       assert_equal @env, param_host.content_facet.lifecycle_environment
       assert_equal @cv, param_host.content_facet.content_view
@@ -174,7 +174,7 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
     ret = [{:name => "boo" }]
 
     @os.expects(:kickstart_repos).returns(ret).with do |param_host|
-      _(param_host).must_be_kind_of(::Host::Managed)
+      param_host.must_be_kind_of(::Host::Managed)
       assert_equal @os, param_host.os
       assert_equal @env, param_host.content_facet.lifecycle_environment
       assert_equal @cv, param_host.content_facet.content_view

--- a/test/lib/util/deduplication_migrator_test.rb
+++ b/test/lib/util/deduplication_migrator_test.rb
@@ -1,0 +1,98 @@
+require 'katello_test_helper'
+
+module Katello
+  module Util
+    class DeduplicationMigratorTest < ActiveSupport::TestCase
+      let(:migrator) do
+        Katello::Util::DeduplicationMigrator.new
+      end
+
+      let(:model) do
+        {
+          :model => ::Katello::CapsuleLifecycleEnvironment,
+          :fields => [:lifecycle_environment_id, :capsule_id]
+        }
+      end
+
+      let(:content_view) do
+        {
+          :model => ::Katello::ContentView,
+          :fields => [:name, :organization_id]
+        }
+      end
+
+      let(:duplicate_content_view) do
+        FactoryBot.build(:katello_content_view, :organization_id => 1, :name => 'My CV', id: 499)
+      end
+
+      def test_cleaning_queries
+        mock_relation = model[:model].none
+        model[:model]
+          .expects(:group).with(model[:fields])
+          .returns(mock_relation)
+        ActiveRecord::Relation.any_instance
+          .expects(:having).with("count(*) > 1")
+          .returns(mock_relation)
+        ActiveRecord::Relation.any_instance
+          .expects(:count)
+          .returns({
+                     [1, 1] => 2,
+                     [6, 1] => 2
+                   })
+        mock_relation
+          .expects(:pluck).with('min(id)')
+          .returns([1, 6])
+        result = migrator.cleaning_queries(model)
+        expected = [
+          {:lifecycle_environment_id => 1, :capsule_id => 1, :min_id => 1},
+          {:lifecycle_environment_id => 6, :capsule_id => 1, :min_id => 6}
+        ]
+        assert_equal result, expected
+      end
+
+      def test_clean_duplicates
+        model_class = model[:model]
+        mock_relation = model_class.none
+        query = {:lifecycle_environment_id => 6, :capsule_id => 1, :min_id => 6}
+        model_class.expects(:where).with(query).returns(mock_relation)
+        mock_relation.expects(:where).returns(mock_relation)
+        mock_relation.expects(:not).with(id: 6).returns(mock_relation)
+        mock_relation.expects(:delete_all).returns 2
+
+        result = migrator.clean_duplicates(query, model_class)
+        assert_equal result, 2
+      end
+
+      def test_rename_duplicates
+        model_class = content_view[:model]
+        mock_relation = model_class.none
+        query = {:name => 'My CV', :organization_id => 1, :min_id => 7}
+        dup_cv = duplicate_content_view
+        model_class.expects(:where).with(query).returns(mock_relation)
+        mock_relation.expects(:where).returns(mock_relation)
+        mock_relation.expects(:not).with(id: 7).returns([dup_cv])
+        mock_relation.expects(:delete_all).never
+
+        dup_cv.expects(:name).twice.returns('My CV')
+        dup_cv.expects(:name=).with("My CV_#{dup_cv.id}")
+        dup_cv.expects(:save).with(:validate => false)
+
+        result = migrator.rename_duplicates(query, model_class)
+        assert_equal result, 1
+      end
+
+      def test_execute
+        migrator.expects(:cleaning_queries).at_least(5).returns(
+        [
+          {:lifecycle_environment_id => 1, :capsule_id => 1, :min_id => 1},
+          {:lifecycle_environment_id => 6, :capsule_id => 1, :min_id => 6}
+        ])
+        migrator.expects(:clean_duplicates).at_least(5).returns(5)
+        migrator.expects(:rename_duplicates).at_least_once.returns(1)
+
+        result = migrator.execute!
+        assert_equal result, true
+      end
+    end
+  end
+end

--- a/test/lib/util/package_clause_generator_test.rb
+++ b/test/lib/util/package_clause_generator_test.rb
@@ -68,10 +68,11 @@ module Katello
     end
 
     def deep_sort(obj)
-      if obj.is_a?(Array)
+      case obj
+      when Array
         to_ret = obj.map { |value| deep_sort(value) }
         to_ret[0].is_a?(Hash) ? to_ret : to_ret.sort
-      elsif obj.is_a?(Hash)
+      when Hash
         obj.inject({}) do |hash, (key, value)|
           hash[key] = deep_sort(value)
           hash
@@ -187,7 +188,7 @@ module Katello
       clause_gen = setup_whitelist_filter(rules) do |gen|
         gen.expects(:package_clauses_for_errata).once.
                     returns(returned_packages).with do |clauses|
-                      clauses.map(&:to_sql).must_equal(expected_errata_clauses.map(&:to_sql))
+                      assert_equal clauses.map(&:to_sql), expected_errata_clauses.map(&:to_sql)
                     end
       end
       assert_equal prepend_modular(returned_packages), clause_gen.copy_clause
@@ -196,7 +197,7 @@ module Katello
       clause_gen = setup_blacklist_filter(rules) do |gen|
         gen.expects(:package_clauses_for_errata).once.
                     returns(returned_packages).with do |clauses|
-                      clauses.map(&:to_sql).must_equal(expected_errata_clauses.map(&:to_sql))
+                      assert_equal clauses.map(&:to_sql), expected_errata_clauses.map(&:to_sql)
                     end
       end
       expected = {"$and" => [INCLUDE_ALL_PACKAGES, {"$nor" => [returned_packages]}]}

--- a/test/lib/util/package_clause_generator_test.rb
+++ b/test/lib/util/package_clause_generator_test.rb
@@ -187,7 +187,7 @@ module Katello
       clause_gen = setup_whitelist_filter(rules) do |gen|
         gen.expects(:package_clauses_for_errata).once.
                     returns(returned_packages).with do |clauses|
-                      clauses.map(&:to_sql).must_equal(expected_errata_clauses.map(&:to_sql))
+                      _(clauses.map(&:to_sql)).must_equal(expected_errata_clauses.map(&:to_sql))
                     end
       end
       assert_equal prepend_modular(returned_packages), clause_gen.copy_clause
@@ -196,7 +196,7 @@ module Katello
       clause_gen = setup_blacklist_filter(rules) do |gen|
         gen.expects(:package_clauses_for_errata).once.
                     returns(returned_packages).with do |clauses|
-                      clauses.map(&:to_sql).must_equal(expected_errata_clauses.map(&:to_sql))
+                      _(clauses.map(&:to_sql)).must_equal(expected_errata_clauses.map(&:to_sql))
                     end
       end
       expected = {"$and" => [INCLUDE_ALL_PACKAGES, {"$nor" => [returned_packages]}]}

--- a/test/lib/util/package_clause_generator_test.rb
+++ b/test/lib/util/package_clause_generator_test.rb
@@ -187,7 +187,7 @@ module Katello
       clause_gen = setup_whitelist_filter(rules) do |gen|
         gen.expects(:package_clauses_for_errata).once.
                     returns(returned_packages).with do |clauses|
-                      _(clauses.map(&:to_sql)).must_equal(expected_errata_clauses.map(&:to_sql))
+                      clauses.map(&:to_sql).must_equal(expected_errata_clauses.map(&:to_sql))
                     end
       end
       assert_equal prepend_modular(returned_packages), clause_gen.copy_clause
@@ -196,7 +196,7 @@ module Katello
       clause_gen = setup_blacklist_filter(rules) do |gen|
         gen.expects(:package_clauses_for_errata).once.
                     returns(returned_packages).with do |clauses|
-                      _(clauses.map(&:to_sql)).must_equal(expected_errata_clauses.map(&:to_sql))
+                      clauses.map(&:to_sql).must_equal(expected_errata_clauses.map(&:to_sql))
                     end
       end
       expected = {"$and" => [INCLUDE_ALL_PACKAGES, {"$nor" => [returned_packages]}]}

--- a/test/models/content_credential_test.rb
+++ b/test/models/content_credential_test.rb
@@ -17,7 +17,7 @@ module Katello
 
       it "should be successful with valid parameters" do
         content_credential = ContentCredential.new(:name => "Gpg Key 1", :content => @test_gpg_content, :organization => @organization)
-        _(content_credential).must_be :valid?
+        content_credential.must_be :valid?
       end
 
       it 'should be destroyable' do
@@ -25,25 +25,25 @@ module Katello
         product = katello_products(:fedora)
         product.gpg_key = content_credential
         product.save!
-        _(content_credential.destroy).wont_equal(false)
+        content_credential.destroy.wont_equal(false)
       end
 
       it "should be unsuccessful without content" do
         content_credential = ContentCredential.new(:name => "Gpg Key 1", :organization => @organization)
-        _(content_credential).wont_be :valid?
+        content_credential.wont_be :valid?
       end
 
       it "should be unsuccessful without a name" do
         content_credential = ContentCredential.new(:content => @test_gpg_content, :organization => @organization)
-        _(content_credential).wont_be :valid?
+        content_credential.wont_be :valid?
       end
 
       it "should be unsuccessful without proper gpg key" do
         content_credential = ContentCredential.new(:name => "Gpg Key 1", :content => "foo-bar-baz", :organization => @organization)
         if SETTINGS[:katello][:gpg_strict_validation]
-          _(content_credential).wont_be :valid?
+          content_credential.wont_be :valid?
         else
-          _(content_credential).must_be :valid?
+          content_credential.must_be :valid?
         end
       end
 
@@ -51,7 +51,7 @@ module Katello
         content = "\x81\xA4user\x83\xA3age\x18\xA4name\xA4ivan\xA5float\xCB@\x93J=p\xA3\xD7\n"
         content.force_encoding(::Encoding::ASCII_8BIT)
         content_credential = ContentCredential.new(:name => "Gpg Key 1", :content => content, :organization => @organization)
-        _(content_credential).wont_be :valid?
+        content_credential.wont_be :valid?
       end
     end
   end

--- a/test/models/content_credential_test.rb
+++ b/test/models/content_credential_test.rb
@@ -30,18 +30,18 @@ module Katello
 
       it "should be unsuccessful without content" do
         content_credential = ContentCredential.new(:name => "Gpg Key 1", :organization => @organization)
-        assert_not content_credential.valid?
+        refute content_credential.valid?
       end
 
       it "should be unsuccessful without a name" do
         content_credential = ContentCredential.new(:content => @test_gpg_content, :organization => @organization)
-        assert_not content_credential.valid?
+        refute content_credential.valid?
       end
 
       it "should be unsuccessful without proper gpg key" do
         content_credential = ContentCredential.new(:name => "Gpg Key 1", :content => "foo-bar-baz", :organization => @organization)
         if SETTINGS[:katello][:gpg_strict_validation]
-          assert_not content_credential.valid?
+          refute content_credential.valid?
         else
           assert content_credential.valid?
         end
@@ -51,7 +51,7 @@ module Katello
         content = "\x81\xA4user\x83\xA3age\x18\xA4name\xA4ivan\xA5float\xCB@\x93J=p\xA3\xD7\n"
         content.force_encoding(::Encoding::ASCII_8BIT)
         content_credential = ContentCredential.new(:name => "Gpg Key 1", :content => content, :organization => @organization)
-        assert_not content_credential.valid?
+        refute content_credential.valid?
       end
     end
   end

--- a/test/models/content_credential_test.rb
+++ b/test/models/content_credential_test.rb
@@ -17,7 +17,7 @@ module Katello
 
       it "should be successful with valid parameters" do
         content_credential = ContentCredential.new(:name => "Gpg Key 1", :content => @test_gpg_content, :organization => @organization)
-        content_credential.must_be :valid?
+        assert content_credential.valid?
       end
 
       it 'should be destroyable' do
@@ -25,25 +25,25 @@ module Katello
         product = katello_products(:fedora)
         product.gpg_key = content_credential
         product.save!
-        content_credential.destroy.wont_equal(false)
+        assert_not_equal content_credential.destroy, false
       end
 
       it "should be unsuccessful without content" do
         content_credential = ContentCredential.new(:name => "Gpg Key 1", :organization => @organization)
-        content_credential.wont_be :valid?
+        assert_not content_credential.valid?
       end
 
       it "should be unsuccessful without a name" do
         content_credential = ContentCredential.new(:content => @test_gpg_content, :organization => @organization)
-        content_credential.wont_be :valid?
+        assert_not content_credential.valid?
       end
 
       it "should be unsuccessful without proper gpg key" do
         content_credential = ContentCredential.new(:name => "Gpg Key 1", :content => "foo-bar-baz", :organization => @organization)
         if SETTINGS[:katello][:gpg_strict_validation]
-          content_credential.wont_be :valid?
+          assert_not content_credential.valid?
         else
-          content_credential.must_be :valid?
+          assert content_credential.valid?
         end
       end
 
@@ -51,7 +51,7 @@ module Katello
         content = "\x81\xA4user\x83\xA3age\x18\xA4name\xA4ivan\xA5float\xCB@\x93J=p\xA3\xD7\n"
         content.force_encoding(::Encoding::ASCII_8BIT)
         content_credential = ContentCredential.new(:name => "Gpg Key 1", :content => content, :organization => @organization)
-        content_credential.wont_be :valid?
+        assert_not content_credential.valid?
       end
     end
   end

--- a/test/models/content_credential_test.rb
+++ b/test/models/content_credential_test.rb
@@ -17,7 +17,7 @@ module Katello
 
       it "should be successful with valid parameters" do
         content_credential = ContentCredential.new(:name => "Gpg Key 1", :content => @test_gpg_content, :organization => @organization)
-        content_credential.must_be :valid?
+        _(content_credential).must_be :valid?
       end
 
       it 'should be destroyable' do
@@ -25,25 +25,25 @@ module Katello
         product = katello_products(:fedora)
         product.gpg_key = content_credential
         product.save!
-        content_credential.destroy.wont_equal(false)
+        _(content_credential.destroy).wont_equal(false)
       end
 
       it "should be unsuccessful without content" do
         content_credential = ContentCredential.new(:name => "Gpg Key 1", :organization => @organization)
-        content_credential.wont_be :valid?
+        _(content_credential).wont_be :valid?
       end
 
       it "should be unsuccessful without a name" do
         content_credential = ContentCredential.new(:content => @test_gpg_content, :organization => @organization)
-        content_credential.wont_be :valid?
+        _(content_credential).wont_be :valid?
       end
 
       it "should be unsuccessful without proper gpg key" do
         content_credential = ContentCredential.new(:name => "Gpg Key 1", :content => "foo-bar-baz", :organization => @organization)
         if SETTINGS[:katello][:gpg_strict_validation]
-          content_credential.wont_be :valid?
+          _(content_credential).wont_be :valid?
         else
-          content_credential.must_be :valid?
+          _(content_credential).must_be :valid?
         end
       end
 
@@ -51,7 +51,7 @@ module Katello
         content = "\x81\xA4user\x83\xA3age\x18\xA4name\xA4ivan\xA5float\xCB@\x93J=p\xA3\xD7\n"
         content.force_encoding(::Encoding::ASCII_8BIT)
         content_credential = ContentCredential.new(:name => "Gpg Key 1", :content => content, :organization => @organization)
-        content_credential.wont_be :valid?
+        _(content_credential).wont_be :valid?
       end
     end
   end

--- a/test/models/sync_plan_test.rb
+++ b/test/models/sync_plan_test.rb
@@ -302,7 +302,7 @@ module Katello
     def test_update
       @plan.save!
       p = SyncPlan.find_by_name('Norman Rockwell')
-      _(p).wont_be_nil
+      p.wont_be_nil
       new_name = p.name + "N"
       p = SyncPlan.update(p.id, :name => new_name)
       assert_equal new_name, p.name
@@ -315,7 +315,7 @@ module Katello
       pid = p.id
       p.destroy
 
-      _ { lambda { SyncPlan.find(pid) } }.must_raise(ActiveRecord::RecordNotFound)
+      lambda { SyncPlan.find(pid) }.must_raise(ActiveRecord::RecordNotFound)
     end
 
     def test_product_enabled

--- a/test/models/sync_plan_test.rb
+++ b/test/models/sync_plan_test.rb
@@ -302,7 +302,7 @@ module Katello
     def test_update
       @plan.save!
       p = SyncPlan.find_by_name('Norman Rockwell')
-      p.wont_be_nil
+      _(p).wont_be_nil
       new_name = p.name + "N"
       p = SyncPlan.update(p.id, :name => new_name)
       assert_equal new_name, p.name
@@ -315,7 +315,7 @@ module Katello
       pid = p.id
       p.destroy
 
-      lambda { SyncPlan.find(pid) }.must_raise(ActiveRecord::RecordNotFound)
+      _ { lambda { SyncPlan.find(pid) } }.must_raise(ActiveRecord::RecordNotFound)
     end
 
     def test_product_enabled

--- a/test/models/sync_plan_test.rb
+++ b/test/models/sync_plan_test.rb
@@ -302,8 +302,8 @@ module Katello
     def test_update
       @plan.save!
       p = SyncPlan.find_by_name('Norman Rockwell')
-      p.wont_be_nil
-      new_name = p.name + "N"
+      refute_nil p
+      new_name = "#{p.name}N"
       p = SyncPlan.update(p.id, :name => new_name)
       assert_equal new_name, p.name
     end
@@ -315,7 +315,7 @@ module Katello
       pid = p.id
       p.destroy
 
-      lambda { SyncPlan.find(pid) }.must_raise(ActiveRecord::RecordNotFound)
+      assert_raises(ActiveRecord::RecordNotFound) { SyncPlan.find(pid) }
     end
 
     def test_product_enabled

--- a/test/services/katello/candlepin/pool_service_test.rb
+++ b/test/services/katello/candlepin/pool_service_test.rb
@@ -23,7 +23,7 @@ module Katello
       def test_local_to_upstream_ids_no_upstream
         Katello::Pool.any_instance.expects(:upstream_pool_id).returns(nil)
 
-        error = proc { Katello::Candlepin::PoolService.local_to_upstream_ids([@pool_one.id]) }.must_raise RuntimeError
+        error = _ { proc { Katello::Candlepin::PoolService.local_to_upstream_ids([@pool_one.id]) } }.must_raise RuntimeError
         assert_match(/No upstream pool ID/, error.message)
       end
 

--- a/test/services/katello/candlepin/pool_service_test.rb
+++ b/test/services/katello/candlepin/pool_service_test.rb
@@ -23,7 +23,7 @@ module Katello
       def test_local_to_upstream_ids_no_upstream
         Katello::Pool.any_instance.expects(:upstream_pool_id).returns(nil)
 
-        error = _ { proc { Katello::Candlepin::PoolService.local_to_upstream_ids([@pool_one.id]) } }.must_raise RuntimeError
+        error = proc { Katello::Candlepin::PoolService.local_to_upstream_ids([@pool_one.id]) }.must_raise RuntimeError
         assert_match(/No upstream pool ID/, error.message)
       end
 

--- a/test/services/katello/candlepin/pool_service_test.rb
+++ b/test/services/katello/candlepin/pool_service_test.rb
@@ -23,7 +23,7 @@ module Katello
       def test_local_to_upstream_ids_no_upstream
         Katello::Pool.any_instance.expects(:upstream_pool_id).returns(nil)
 
-        error = assert_raises RuntimeError { Katello::Candlepin::PoolService.local_to_upstream_ids([@pool_one.id]) }
+        error = assert_raises(RuntimeError) { Katello::Candlepin::PoolService.local_to_upstream_ids([@pool_one.id]) }
         assert_match(/No upstream pool ID/, error.message)
       end
 

--- a/test/services/katello/candlepin/pool_service_test.rb
+++ b/test/services/katello/candlepin/pool_service_test.rb
@@ -23,7 +23,7 @@ module Katello
       def test_local_to_upstream_ids_no_upstream
         Katello::Pool.any_instance.expects(:upstream_pool_id).returns(nil)
 
-        error = proc { Katello::Candlepin::PoolService.local_to_upstream_ids([@pool_one.id]) }.must_raise RuntimeError
+        assert_raises RuntimeError { Katello::Candlepin::PoolService.local_to_upstream_ids([@pool_one.id]) }
         assert_match(/No upstream pool ID/, error.message)
       end
 

--- a/test/services/katello/candlepin/pool_service_test.rb
+++ b/test/services/katello/candlepin/pool_service_test.rb
@@ -23,7 +23,7 @@ module Katello
       def test_local_to_upstream_ids_no_upstream
         Katello::Pool.any_instance.expects(:upstream_pool_id).returns(nil)
 
-        assert_raises RuntimeError { Katello::Candlepin::PoolService.local_to_upstream_ids([@pool_one.id]) }
+        error = assert_raises RuntimeError { Katello::Candlepin::PoolService.local_to_upstream_ids([@pool_one.id]) }
         assert_match(/No upstream pool ID/, error.message)
       end
 

--- a/test/services/katello/pulp3/repository/python/python_test.rb
+++ b/test/services/katello/pulp3/repository/python/python_test.rb
@@ -56,8 +56,8 @@ module Katello
 
             assert_equal unit.content_type, "python_package"
             assert_includes unit.filename, "shelf_reader"
-            assert_not unit.pulp_id.nil? and unit.version.nil?
-            assert unit.additional_metadata['package_type'] and unit.additional_metadata['sha256']
+            refute unit.pulp_id.nil? && unit.version.nil?
+            assert unit.additional_metadata['package_type'] && unit.additional_metadata['sha256']
 
             assert_equal post_unit_count, 2
             assert_equal post_unit_repository_count, 2

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -321,7 +321,7 @@ module Katello
           ::Katello::RegistrationManager.unregister_host(@host, :unregistering => true)
         end
 
-        failed.must_raise(Exception)
+        _ { failed }.must_raise(Exception)
       end
 
       def test_registration_dead_candlepin
@@ -336,7 +336,7 @@ module Katello
           ::Katello::RegistrationManager.register_host(new_host, rhsm_params, @content_view_environment)
         end
 
-        failed.must_raise(Exception)
+        _ { failed }.must_raise(Exception)
       end
 
       # this case can only happen if candlepin/pulp dies after the host is unregistered, but before it's re-registered.
@@ -358,7 +358,7 @@ module Katello
           ::Katello::RegistrationManager.register_host(@host, rhsm_params, @content_view_environment)
         end
 
-        failed.must_raise(Exception)
+        _ { failed }.must_raise(Exception)
       end
     end
   end

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -321,7 +321,7 @@ module Katello
           ::Katello::RegistrationManager.unregister_host(@host, :unregistering => true)
         end
 
-        _ { failed }.must_raise(Exception)
+        failed.must_raise(Exception)
       end
 
       def test_registration_dead_candlepin
@@ -336,7 +336,7 @@ module Katello
           ::Katello::RegistrationManager.register_host(new_host, rhsm_params, @content_view_environment)
         end
 
-        _ { failed }.must_raise(Exception)
+        failed.must_raise(Exception)
       end
 
       # this case can only happen if candlepin/pulp dies after the host is unregistered, but before it's re-registered.
@@ -358,7 +358,7 @@ module Katello
           ::Katello::RegistrationManager.register_host(@host, rhsm_params, @content_view_environment)
         end
 
-        _ { failed }.must_raise(Exception)
+        failed.must_raise(Exception)
       end
     end
   end

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -317,11 +317,9 @@ module Katello
 
         ::Katello::Resources::Candlepin::Consumer.expects(:destroy).raises(Exception)
 
-        failed = lambda do
+        assert_raises(Exception) do
           ::Katello::RegistrationManager.unregister_host(@host, :unregistering => true)
         end
-
-        failed.must_raise(Exception)
       end
 
       def test_registration_dead_candlepin
@@ -332,11 +330,9 @@ module Katello
         new_host.organization.stubs(:simple_content_access?).returns(false)
         ::Katello::Resources::Candlepin::Consumer.expects(:create).with(@content_view_environment.cp_id, rhsm_params, []).raises("uhoh!")
 
-        failed = lambda do
+        assert_raises(Exception) do
           ::Katello::RegistrationManager.register_host(new_host, rhsm_params, @content_view_environment)
         end
-
-        failed.must_raise(Exception)
       end
 
       # this case can only happen if candlepin/pulp dies after the host is unregistered, but before it's re-registered.
@@ -354,11 +350,9 @@ module Katello
 
         ::Organization.any_instance.stubs(:simple_content_access?).returns(false)
 
-        failed = lambda do
+        assert_raises(Exception) do
           ::Katello::RegistrationManager.register_host(@host, rhsm_params, @content_view_environment)
         end
-
-        failed.must_raise(Exception)
       end
     end
   end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Re-enable the following Rubocop cops (lint rules) that were disabled previously:

[_Minitest/GlobalExpectations_](https://docs.rubocop.org/rubocop-minitest/0.10/cops_minitest.html#minitestglobalexpectations)
[_Rails/RedundantForeignKey_](https://docs.rubocop.org/rubocop-rails/2.7/cops_rails.html#railsredundantforeignkey)
[_Rails/UniqueValidationWithoutIndex_](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsuniquevalidationwithoutindex)

#### Considerations taken when implementing this change?

I am proposing that the fourth rule, [_Performance/CollectionLiteralInLoop_](https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancecollectionliteralinloop), remain disabled.  Feels like an unnecessary optimization.

The _Rails/UniqueValidationWithoutIndex_ cop requires a unique index to be present in the database any time there is a `uniqueness` Active Record validation.  This means that before we can add the unique indexes, we must first check the database for duplicate records and deal with them.

The offenses detected were
```
Offenses:
 
app/models/katello/capsule_lifecycle_environment.rb:6:5: C: Rails/UniqueValidationWithoutIndex: Uniqueness validation should be with a unique index.
    validates :lifecycle_environment_id, ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/katello/content_view.rb:59:5: C: Rails/UniqueValidationWithoutIndex: Uniqueness validation should be with a unique index.
    validates :name, :presence => true, :uniqueness => {:scope => :organization_id}
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/katello/content_view_erratum_filter_rule.rb:18:5: C: Rails/UniqueValidationWithoutIndex: Uniqueness validation should be with a unique index.
    validates :errata_id, :uniqueness => { :scope => :content_view_filter_id }, :allow_blank => true
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/katello/content_view_module_stream_filter_rule.rb:9:5: C: Rails/UniqueValidationWithoutIndex: Uniqueness validation should be with a unique index.
    validates :module_stream_id, :presence => true, :uniqueness => { :scope => :content_view_filter_id }
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/katello/content_view_package_group_filter_rule.rb:10:5: C: Rails/UniqueValidationWithoutIndex: Uniqueness validation should be with a unique index.
    validates :uuid, :presence => true, :uniqueness => { :scope => :content_view_filter_id }
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/katello/content_view_repository.rb:20:5: C: Rails/UniqueValidationWithoutIndex: Uniqueness validation should be with a unique index.
    validates :repository_id, :uniqueness => {:scope => :content_view_id, :message => N_("already belongs to the content view") }
 
```

Most of these are join tables, so addressing the duplicates is pretty straightforward.  However, for content views, we shouldn't really delete anything. So we went with a renaming approach instead.

#### What are the testing steps for this pull request?

### Rails/UniqueValidationWithoutIndex

You can use this code in the Rails console to make duplicate records:
```rb
def make_dups
  ::Katello::ContentViewRepository.all.each do |cv_repo|
    rand(0..2).times do
      ::Katello::ContentViewRepository.new(:content_view_id => cv_repo.content_view_id,
                                             :repository_id => cv_repo.repository_id).save(:validate => false)
    end
  end
  ::Katello::CapsuleLifecycleEnvironment.all.each do |capsule_lifecycle_environment|
    rand(0..2).times do
    ::Katello::CapsuleLifecycleEnvironment.new(:lifecycle_environment_id => capsule_lifecycle_environment.lifecycle_environment_id,
                                                :capsule_id => capsule_lifecycle_environment.capsule_id).save(:validate => false)
    end 
  end
  ::Katello::ContentView.all.each do |content_view|
    dup = content_view.dup
    dup.label = "dup_label_#{SecureRandom.uuid}".first(127)
    dup.save(:validate => false)
  end
  # repeat for other models as desired
  true
end
```

You can use
```rb
Katello::ContentView.all.map { | cv| [cv.id, cv.name, cv.organization_id] }
```
(change the model name and fields as necessary) to view the current state of the db.

Check out the PR and use the following two commands to move between migrations
```
bundle exec rails db:migrate:up VERSION=20211201154845
bundle exec rails db:migrate:down VERSION=20211201154845
```

Verify that

1. you cannot run `make_dups` if the database is migrated (In this case, an error like this is expected: `ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "katello_content_view_repositories_unique_index"
DETAIL:  Key (content_view_id, repository_id)=(2, 4) already exists.`)
2. both `up` and `down` migrations complete with no errors, no matter what is in the database
3. Upon running the migration, `Katello::ContentViews` are renamed, and all other duplicates are deleted

### All other enabled cops
For all other enabled cops, it is enough just to run Rubocop and verify that it passes.

* Run Rubocop from the Foreman directory, not Katello: 
```
bundle exec rubocop ../katello
```
* If you get unexpected failures of Rails/UniqueValidationWithoutIndex, run
```
bundle exec rails db:schema:dump
```
This is because Rails/UniqueValidationWithoutIndex requires the `schema.rb` file to be present and up to date.