### PR TITLE
Fixes #34087 - Revert "Fixes #31173 - no deb repo in sub-man"

### DIFF
--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -396,11 +396,7 @@ module Katello
 
     def format_arches
       if content_type == ::Katello::Repository::DEB_TYPE
-        # FIXME: This should be set to self.deb_architectures but it needs to have the
-        # subscription-manager PR https://github.com/candlepin/subscription-manager/pull/2213
-        # merged. Otherwise subscription-manager returns _NO_ debian repository as described in
-        # https://community.theforeman.org/t/katello-3-16-1-1-el7-subscription-manager-doesnt-create-rhsm-repos-for-ubuntu/20928/38
-        nil
+        self.deb_architectures
       else
         self.arch == "noarch" ? nil : self.arch
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This reverts commit ed89bc5cfb4e9ffec082be68a1c40d8efd25bbca.

Instead of transmitting the corresponding debian architecture to the host, a default value has been sent. From now on, the _actual_ architecture must be sent to enable debian architecture support.

#### Considerations taken when implementing this change?

The mentioned commit reverted changes due to a delayed implementation of features in `subscription-manager`. Since the changes have been [merged](https://github.com/candlepin/subscription-manager/pull/2213) by now, this commit can be "un-reverted" to enable the debian architecture functionality.
