### PR TITLE
Fixes #34060 -  Content View Version Task polling bug

### DIFF
--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
@@ -9,6 +9,7 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { selectIntervals } from 'foremanReact/redux/middlewares/IntervalMiddleware/IntervalSelectors.js';
 
+import { useSet } from '../../../../components/Table/TableHooks';
 import TableWrapper from '../../../../components/Table/TableWrapper';
 import InactiveText from '../../components/InactiveText';
 import ContentViewVersionEnvironments from './ContentViewVersionEnvironments';
@@ -23,7 +24,7 @@ import {
 import getEnvironmentPaths from '../../components/EnvironmentPaths/EnvironmentPathActions';
 import ContentViewVersionPromote from '../Promote/ContentViewVersionPromote';
 import TaskPresenter from '../../components/TaskPresenter/TaskPresenter';
-import { startPollingTask } from '../../../Tasks/TaskActions';
+import { startPollingTask, stopPollingTask } from '../../../Tasks/TaskActions';
 import RemoveCVVersionWizard from './Delete/RemoveCVVersionWizard';
 import { hasPermission } from '../../helpers';
 import { pollTaskKey } from '../../../Tasks/helpers';
@@ -48,6 +49,7 @@ const ContentViewVersions = ({ cvId, details }) => {
   const [deleteVersion, setDeleteVersion] = useState(false);
   const [currentStep, setCurrentStep] = useState(1);
   const { permissions } = details;
+  const pendingTaskSet = useSet([]);
   const intervals = useSelector(state => selectIntervals(state));
 
   const columnHeaders = [
@@ -65,6 +67,16 @@ const ContentViewVersions = ({ cvId, details }) => {
     },
     [dispatch],
   );
+
+  useEffect(() => { // eslint-disable-line arrow-body-style
+    return () => {
+      if (pendingTaskSet.size) {
+        pendingTaskSet.forEach(id =>
+          dispatch(stopPollingTask(id)));
+        pendingTaskSet.clear();
+      }
+    };
+  }, [pendingTaskSet, dispatch]);
 
   const buildCells = useCallback((cvVersion) => {
     const {
@@ -94,8 +106,18 @@ const ContentViewVersions = ({ cvId, details }) => {
     } = cvVersion;
     const { task } = activeHistory[0];
     const { result } = task || {};
+
     if (result !== 'error' && !pollIntervals[pollTaskKey(task.id)]) {
-      dispatch(startPollingTask(task.id, task));
+      pendingTaskSet.add(task.id);
+      dispatch(startPollingTask(
+        task.id, task,
+        ({ data: { pending } = {} }) => {
+          if (!pending) {
+            dispatch(stopPollingTask(task.id));
+            pendingTaskSet.delete(task.id);
+          }
+        },
+      ));
     }
 
     return [
@@ -111,7 +133,7 @@ const ContentViewVersions = ({ cvId, details }) => {
       { title: '' },
       { title: description ? <TableText wrapModifier="truncate">{description}</TableText> : <InactiveText text={__('No description')} /> },
     ];
-  }, [dispatch]);
+  }, [dispatch, pendingTaskSet]);
 
   useDeepCompareEffect(() => {
     const buildRows = () => {

--- a/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsActions.test.js.snap
+++ b/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsActions.test.js.snap
@@ -85,6 +85,7 @@ Array [
   Object {
     "interval": 5000,
     "payload": Object {
+      "handleSuccess": undefined,
       "key": "SUBSCRIPTIONS_POLL_TASK",
       "url": "/foreman_tasks/api/tasks/eb1b6271-8a69-4d98-84fc-bea06ddcc166",
     },

--- a/webpack/scenes/Tasks/TaskActions.js
+++ b/webpack/scenes/Tasks/TaskActions.js
@@ -31,12 +31,13 @@ export const startPollingTasks = (key, taskSearchParams = {}) =>
 
 export const stopPollingTasks = key => stopInterval(bulkSearchKey(key));
 
-const getTask = (key, task) => get({
+const getTask = (key, task, handleSuccess) => get({
   key,
   url: `${foremanTasksApi.baseApiPath}/tasks/${task.id}`,
+  handleSuccess,
 });
 
-export const startPollingTask = (key, task) =>
-  withInterval(getTask(pollTaskKey(key), task));
+export const startPollingTask = (key, task, handleSuccess) =>
+  withInterval(getTask(pollTaskKey(key), task, handleSuccess));
 
 export const stopPollingTask = key => stopInterval(pollTaskKey(key));

--- a/webpack/scenes/Tasks/__tests__/__snapshots__/TaskActions.test.js.snap
+++ b/webpack/scenes/Tasks/__tests__/__snapshots__/TaskActions.test.js.snap
@@ -4,6 +4,7 @@ exports[`task actions can poll a task 1`] = `
 Object {
   "interval": 5000,
   "payload": Object {
+    "handleSuccess": undefined,
     "key": "TEST_POLL_TASK",
     "url": "/foreman_tasks/api/tasks/12345",
   },


### PR DESCRIPTION
## What are the changes introduced in this pull request?
Fix the task polling bug
## What are the testing steps for this pull request?
Promote a version on the ContentViewVersion page, keep an eye on the network tab after completion.
All polling for tasks should stop.