### PR TITLE
Fixes #33655 - Add GraphQL type for host collections

### DIFF
--- a/app/graphql/types/host_collection.rb
+++ b/app/graphql/types/host_collection.rb
@@ -1,0 +1,18 @@
+module Types
+  class HostCollection < BaseObject
+    description "A collection of hosts"
+    model_class ::Katello::HostCollection
+
+    global_id_field :id
+    timestamps
+    field :name, String
+    field :description, String
+    field :max_hosts, Integer
+    field :unlimited_hosts, Boolean
+    has_many :hosts, Types::Host
+
+    def self.graphql_definition
+      super.tap { |type| type.instance_variable_set(:@name, 'Katello::HostCollection') }
+    end
+  end
+end

--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -234,7 +234,7 @@ module Katello
         host_collection_ids.each do |host_collection_id|
           host_collection = ::Katello::HostCollection.find(host_collection_id)
           if !host_collection.unlimited_hosts && host_collection.max_hosts >= 0 &&
-             host_collection.systems.length >= host_collection.max_hosts
+             host_collection.hosts.length >= host_collection.max_hosts
             fail _("Host collection '%{name}' exceeds maximum usage limit of '%{limit}'") %
                      {:limit => host_collection.max_hosts, :name => host_collection.name}
           end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -199,6 +199,9 @@ Foreman::Plugin.register :katello do
 
   register_global_js_file 'global'
 
+  register_graphql_query_field :host_collection, '::Types::HostCollection', :record_field
+  register_graphql_query_field :host_collections, '::Types::HostCollection', :collection_field
+
   search_path_override("Katello") do |resource|
     "/#{Katello::Util::Model.model_to_controller_path(resource)}/auto_complete_search"
   end

--- a/test/controllers/api/v2/host_collections_controller_test.rb
+++ b/test/controllers/api/v2/host_collections_controller_test.rb
@@ -30,7 +30,7 @@ module Katello
 
       results = JSON.parse(@response.body)
       assert_equal results.keys.sort, ['error', 'page', 'per_page', 'results', 'search', 'selectable', 'sort', 'subtotal', 'total']
-      assert_equal results['results'].size, 3
+      assert_equal results['results'].size, 4
       assert_includes results['results'].map { |r| r['id'] }, @host_collection.id
     end
 
@@ -42,7 +42,7 @@ module Katello
 
       results = JSON.parse(@response.body)
       assert_equal results.keys.sort, ['error', 'page', 'per_page', 'results', 'search', 'selectable', 'sort', 'subtotal', 'total']
-      assert_equal results['results'].size, 3
+      assert_equal results['results'].size, 4
       assert_includes results['results'].map { |r| r['id'] }, @host_collection.id
     end
 

--- a/test/controllers/api/v2/host_collections_controller_test.rb
+++ b/test/controllers/api/v2/host_collections_controller_test.rb
@@ -30,7 +30,7 @@ module Katello
 
       results = JSON.parse(@response.body)
       assert_equal results.keys.sort, ['error', 'page', 'per_page', 'results', 'search', 'selectable', 'sort', 'subtotal', 'total']
-      assert_equal results['results'].size, 4
+      assert_equal results['results'].size, 5
       assert_includes results['results'].map { |r| r['id'] }, @host_collection.id
     end
 
@@ -42,7 +42,7 @@ module Katello
 
       results = JSON.parse(@response.body)
       assert_equal results.keys.sort, ['error', 'page', 'per_page', 'results', 'search', 'selectable', 'sort', 'subtotal', 'total']
-      assert_equal results['results'].size, 4
+      assert_equal results['results'].size, 5
       assert_includes results['results'].map { |r| r['id'] }, @host_collection.id
     end
 

--- a/test/fixtures/models/katello_host_collection_hosts.yml
+++ b/test/fixtures/models/katello_host_collection_hosts.yml
@@ -3,3 +3,9 @@ one_simple_host_collection:
   host_id:           <%= ActiveRecord::FixtureSet.identify(:one) %>
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
+
+limited_hosts:
+  host_collection_id:  <%= ActiveRecord::FixtureSet.identify(:limited_hosts_host_collection) %>
+  host_id:           <%= ActiveRecord::FixtureSet.identify(:one) %>
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>

--- a/test/fixtures/models/katello_host_collections.yml
+++ b/test/fixtures/models/katello_host_collections.yml
@@ -1,6 +1,8 @@
 simple_host_collection:
   name:         Simple Host Collection
   description:  The simplest of host collections.
+  max_hosts:    5
+  unlimited_hosts: false
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
 
 another_simple_host_collection:

--- a/test/fixtures/models/katello_host_collections.yml
+++ b/test/fixtures/models/katello_host_collections.yml
@@ -1,6 +1,11 @@
 simple_host_collection:
   name:         Simple Host Collection
   description:  The simplest of host collections.
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+
+limited_hosts_host_collection:
+  name:         Five Host Collection
+  description:  A collection of five hosts
   max_hosts:    5
   unlimited_hosts: false
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>

--- a/test/fixtures/models/katello_host_collections.yml
+++ b/test/fixtures/models/katello_host_collections.yml
@@ -10,6 +10,13 @@ limited_hosts_host_collection:
   unlimited_hosts: false
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
 
+one_host_limit_host_collection:
+  name:         Single-host Collection
+  description:  A collection of one host
+  max_hosts:    1
+  unlimited_hosts: false
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+
 another_simple_host_collection:
   name:         Another Simple Host Collection
   description:  Another collection,keeping it simple.

--- a/test/graphql/queries/host_collection_query_test.rb
+++ b/test/graphql/queries/host_collection_query_test.rb
@@ -1,0 +1,39 @@
+require 'katello_test_helper'
+
+module Queries
+  class HostCollectionQueryTest < GraphQLQueryTestCase
+    let(:query) do
+      <<-GRAPHQL
+        query($id:String!) {
+          hostCollection(id: $id) {
+            id
+            name
+            description
+            maxHosts
+            unlimitedHosts
+            hosts {
+              nodes {
+                id
+                name
+              }
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    let(:host_collection) { katello_host_collections(:limited_hosts_host_collection) }
+    let(:global_id) { Foreman::GlobalId.for(host_collection) }
+    let(:variables) { { id: global_id } }
+    let(:data) { result['data']['hostCollection'] }
+
+    test 'should host collection' do
+      assert_equal global_id, data['id']
+      assert_equal host_collection.name, data['name']
+      assert_equal host_collection.description, data['description']
+      refute data['unlimitedHosts']
+      assert_equal 5, data['maxHosts']
+      assert_not_empty data['hosts']['nodes']
+    end
+  end
+end

--- a/test/graphql/queries/host_collections_query_test.rb
+++ b/test/graphql/queries/host_collections_query_test.rb
@@ -1,0 +1,22 @@
+require 'katello_test_helper'
+
+module Queries
+  class HostCollectionsQueryTest < GraphQLQueryTestCase
+    let(:query) do
+      <<-GRAPHQL
+        query {
+          hostCollections {
+            nodes {
+              id
+              name
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    test 'should host collection' do
+      assert_not_empty result['data']['hostCollections']['nodes']
+    end
+  end
+end

--- a/test/models/host_collection_test.rb
+++ b/test/models/host_collection_test.rb
@@ -5,6 +5,7 @@ module Katello
     def setup
       @organization = get_organization
       @simple_collection = katello_host_collections(:simple_host_collection)
+      @limited_collection = katello_host_collections(:limited_hosts_host_collection)
       @host_one = hosts(:one)
       @host_two = hosts(:two)
     end
@@ -15,7 +16,7 @@ module Katello
     end
 
     def test_search_by_host
-      assert_equal HostCollection.search_for("host = \"#{@host_one.name}\""), [@simple_collection]
+      assert_equal HostCollection.search_for("host = \"#{@host_one.name}\""), [@simple_collection, @limited_collection]
       assert_equal HostCollection.search_for("host = \"#{@host_two.name}\""), []
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Picking up https://github.com/Katello/katello/pull/9705

#### Considerations taken when implementing this change?
Fixed the 3 failing tests.

#### What are the testing steps for this pull request?
Use GraphiQL web interface to query host collections