### PR TITLE
Fixes #34102 - Bump up distributor version to 6.10

### DIFF
--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -1,6 +1,6 @@
 module Katello
   module Glue::Provider
-    DISTRIBUTOR_VERSION = 'sat-6.7'.freeze
+    DISTRIBUTOR_VERSION = 'sat-6.10'.freeze
 
     def self.included(base)
       base.send :include, InstanceMethods


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Bump up distributor version to 6.10
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
- create a manifest and select a version prior to '6.10'.
- import that manifest and refresh it.
- portal should reflect 6.10 as the version instead of whatever was set intially