### PR TITLE
Fixes #34110 - Delay host global status update

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -109,7 +109,7 @@ module Katello
         self.host_statuses.where(type: ::Katello::HostStatusManager::STATUSES.map(&:name)).each do |status|
           status.refresh!
         end
-        refresh_global_status!
+        refresh_global_status
       end
 
       def queue_refresh_content_host_status


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
The issue tells more about what the problem is. I suggest to delay the global status actual save since this is done here [1] afterwards.
#### Considerations taken when implementing this change?
I've spent a lot of time to dig to this line :/ My steps are following:
  - [2] never gets triggered because sometimes `saved_changes_to_build?` is `false`, moreover `@host.saved_changes` are totally empty even if it should contain changes.
  - Build exit can be simulated by calling `@host.built(false)`, which is actually being called here [3].
  - `built` method sets the `build` flag to `false` and saves/updates the host.
  - If there is no orchestration code is called, then everything works.
  - Otherwise that `save` in `built` is surrounded by [4], thus more tasks are being processed before `save` in `built`.
  - One of the tasks that I've noticed will make the `saved_changes` empty is this one [5]
  - [5] calls [6] which has `refresh_global_status!`, which actually does `save` on `@host` and thus we save changes to a host while trying to save changes to a host :/
  - My main assumption is that there is callback hell in Rails when you don't trace which callback what actually does.
#### What are the testing steps for this pull request?
Have `foreman_webhooks` plugin installed, configured to listen to `build_exited` event, ensure it gets triggered. OR simply check the logs if `build_exited.event.foreman` gets triggered.

[1] - https://github.com/theforeman/foreman/blob/583ae2b619d813c71f176730a1da4790ecf0c3f1/app/models/host/managed.rb#L398
[2] - https://github.com/theforeman/foreman/blob/583ae2b619d813c71f176730a1da4790ecf0c3f1/app/models/host/managed.rb#L54 
[3] - https://github.com/theforeman/foreman/blob/583ae2b619d813c71f176730a1da4790ecf0c3f1/app/controllers/hosts_controller.rb#L242-L243
[4] - https://github.com/theforeman/foreman/blob/583ae2b619d813c71f176730a1da4790ecf0c3f1/app/models/concerns/orchestration.rb#L12
[5] - https://github.com/Katello/katello/blob/635132df79514fc293c1daf984f2c34181addb75/app/models/katello/concerns/host_managed_extensions.rb#L61
[6] - https://github.com/Katello/katello/blob/635132df79514fc293c1daf984f2c34181addb75/app/models/katello/concerns/host_managed_extensions.rb#L108
[7] - https://github.com/theforeman/foreman/blob/583ae2b619d813c71f176730a1da4790ecf0c3f1/app/models/host/managed.rb#L779