### PR TITLE
Default download policy for deb repos if not set

### DIFF
--- a/db/migrate/20220127120843_fix_debian_download_policy.rb
+++ b/db/migrate/20220127120843_fix_debian_download_policy.rb
@@ -1,0 +1,11 @@
+class FixDebianDownloadPolicy < ActiveRecord::Migration[6.0]
+  def up
+    Katello::RootRepository.where(content_type: "deb")
+                           .where(download_policy: [nil, ""])
+                           .update_all(:download_policy => "immediate")
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
**What are the changes introduced in this pull request?**
At the moment, setting a default for download policy is only available for yum content. We want to add the same policy for deb content. We also add a setting that allows to set the default download policy for deb content type, only.

**What are the testing steps for this pull request?**
Create repository of type deb and check if default download policy is set.

**EDIT: Considerations taken when implementing this change?**
Creating a `deb` repo without specifying a `download_policy` results in an error that the `download_policy` field is not supposed to be empty. 
