### PR TITLE
Fixes #34112 - Reword verify checksum suggestion during migration

### DIFF
--- a/lib/katello/tasks/pulp3_migration_stats.rake
+++ b/lib/katello/tasks/pulp3_migration_stats.rake
@@ -74,7 +74,7 @@ namespace :katello do
 
     if found_missing
       puts "Corrupted or missing content has been detected, you can examine the list of content in #{path} and take action by either:"
-      puts "1. Performing a 'Verify Checksum' sync under Advanced Sync Options, let it complete, and re-running the migration"
+      puts "1. Performing a 'Validate Content Sync' under Advanced Sync Options, let it complete, and re-running the migration"
       puts "2. Deleting/disabling the affected repositories and running orphan cleanup (foreman-rake katello:delete_orphaned_content) and re-running the migration"
       puts "3. Manually correcting files on the filesystem in /var/lib/pulp/content/ and re-running the migration"
       puts "4. Mark currently corrupted or missing content as skipped (foreman-rake katello:approve_corrupted_migration_content).  This will skip migration of missing or corrupted content."


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Changes the wording to fit what is in the UI.  In Katello 3.18, there is no "Verify Checksum" under the advanced sync options.

#### Considerations taken when implementing this change?

We could've also included where to find the actual "Verify Checksum" option in Katello 3.18, but that seems overkill to me.

#### What are the testing steps for this pull request?
None really, it's just a wording change. Just double check in Katello 3.18 / Sat 6.9 that there exists a "Validate Content Sync" under the advanced sync options.