### PR TITLE
Fixes #34127 - Purge empty content before generating metadata

### DIFF
--- a/app/lib/actions/katello/repository/clone_contents.rb
+++ b/app/lib/actions/katello/repository/clone_contents.rb
@@ -20,15 +20,15 @@ module Actions
                           filters: filters, rpm_filenames: rpm_filenames, solve_dependencies: solve_dependencies)
             end
 
+            if purge_empty_contents && new_repository.backend_service(SmartProxy.pulp_primary).should_purge_empty_contents?
+              plan_action(Katello::Repository::PurgeEmptyContent, id: new_repository.id)
+            end
+
             metadata_generate(source_repositories, new_repository, filters, rpm_filenames) if generate_metadata
 
             index_options = {id: new_repository.id}
             index_options[:source_repository_id] = source_repositories.first.id if source_repositories.count == 1 && filters.empty? && rpm_filenames.nil?
             plan_action(Katello::Repository::IndexContent, index_options)
-
-            if purge_empty_contents && new_repository.backend_service(SmartProxy.pulp_master).should_purge_empty_contents?
-              plan_action(Katello::Repository::PurgeEmptyContent, id: new_repository.id)
-            end
           end
         end
 


### PR DESCRIPTION
kudos to @pmoravec for figuring this one out

#### What are the changes introduced in this pull request?

Apparently due to order in which we perform steps when publishing a CV can lead to CV filter being ignored and then unwated packages ending up in the repository.

#### Considerations taken when implementing this change?

@pmoravec's analysis looks solid, publishing this as a jump-off point to start discussion. To be honest I can't really tell if the steps were intentionally ordered the way they were.

#### What are the testing steps for this pull request?

Sadly at this time we don't have a reliable reproducer.
