### PR TITLE
Fixes #34128 - Smart proxy syncing of a specific LCE fails on Katello 4.2

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync_capsule.rb
+++ b/app/lib/actions/katello/capsule_content/sync_capsule.rb
@@ -4,7 +4,7 @@ module Actions
       class SyncCapsule < ::Actions::EntryAction
         include Actions::Katello::PulpSelector
         def plan(smart_proxy, options = {})
-          plan_self(:smart_proxy_id => smart_proxy.id, :options => options)
+          plan_self(:smart_proxy_id => smart_proxy.id)
           action_subject(smart_proxy)
           environment = options[:environment]
           content_view = options[:content_view]


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When https://github.com/Katello/katello/commit/10b33c1a362651e7a7a9b098593bb97acf92c445 was cherry-picked in, the breaking change of having active record objects passed to `sync_capsule.rb`'s `plan_self` was brought in.  We simply need to stop passing the unused options into `plan_self`.

#### Considerations taken when implementing this change?
The options are unused, so they can be deleted with no side effects.

#### What are the testing steps for this pull request?
Trigger a smart proxy auto-sync by adding an LCE to a proxy and publishing a CVV with that LCE.  Check for the proxy sync task in the tasks viewer. It should not error out.