### PR TITLE
Fixes #34143 - Show synced audit result in sync status page

### DIFF
--- a/app/views/katello/sync_management/_repo.html.erb
+++ b/app/views/katello/sync_management/_repo.html.erb
@@ -6,37 +6,48 @@
     </label>
   </td>
   <td class="start_time">
-    <%= @repo_status[repo.id][:start_time] %>
+    <%= @repo_status[repo.id][:sync_id] ? @repo_status[repo.id][:start_time] : _('N/A') %>
   </td>
   <td class="duration">
-    <%= @repo_status[repo.id][:duration] %>
+    <%= @repo_status[repo.id][:sync_id] ? @repo_status[repo.id][:duration] : _('N/A') %>
   </td>
   <td class="size" data-size="<%= @repo_status[repo.id][:size] %>">
-    <%= @repo_status[repo.id][:display_size] %>
+    <%= @repo_status[repo.id][:sync_id] ? @repo_status[repo.id][:display_size]  : _('N/A')%>
   </td>
-  <td class="result">
-    <span class="result-info">
-      <a href="/foreman_tasks/tasks/<%= @repo_status[repo.id][:sync_id] %>">
-        <%= @repo_status[repo.id][:state] %>
-      </a>
-    </span>
-    <a class="info-tipsy clickable fa fa-warning <%= 'hidden' if @repo_status[repo.id][:raw_state] != 'error' %>"
-       href="/foreman_tasks/tasks/<%= @repo_status[repo.id][:sync_id] %>">
-      <span class="hidden-text hidden">
-        <div class="la error-tipsy">
-          <ul>
-            <% if @repo_status[repo.id][:error_details].present? && error_state?(@repo_status[repo.id]) %>
-              <% @repo_status[repo.id][:error_details][:messages].each do |error| %>
-                <li>
-                  <%= error %>
-                </li>
-              <% end %>
-            <% end %>
-          </ul>
-        </div>
+  <% if @repo_status[repo.id][:sync_id] %>
+    <td class="result">
+      <span class="result-info">
+          <a href="/foreman_tasks/tasks/<%= @repo_status[repo.id][:sync_id] %>">
+            <%= @repo_status[repo.id][:state] %>
+          </a>
       </span>
-    </a>
-  </td>
+      <a class="info-tipsy clickable fa fa-warning <%= 'hidden' if @repo_status[repo.id][:raw_state] != 'error' %>"
+         href="/foreman_tasks/tasks/<%= @repo_status[repo.id][:sync_id] %>">
+        <span class="hidden-text hidden">
+          <div class="la error-tipsy">
+            <ul>
+              <% if @repo_status[repo.id][:error_details].present? && error_state?(@repo_status[repo.id]) %>
+                <% @repo_status[repo.id][:error_details][:messages].each do |error| %>
+                  <li>
+                    <%= error %>
+                  </li>
+                <% end %>
+              <% end %>
+            </ul>
+          </div>
+        </span>
+      </a>
+    </td>
+  <% elsif repo&.latest_sync_audit&.created_at %>
+    <td>
+      <%= _("Synced ") + time_ago_in_words(repo&.latest_sync_audit&.created_at) + _(" ago.") %>
+    </td>
+  <% else%>
+    <td>
+      <%= @repo_status[repo.id][:state] %>
+    </td>
+  <% end %>
+
   <% if @show_org %>
     <td></td>
   <% end %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Use audit log to display sync date/time when associated task has been deleted instead of "Never synced"

#### Considerations taken when implementing this change?

Never synced message can be confusing for users when the repo has been synced but the task has been deleted. We use audit of sync task in these cases on repo and product page already.

#### What are the testing steps for this pull request?

Create and sync a repo.
1. Note task ID and then in foreman console, run : 
`ForemanTasks::Task.find('$TASK_ID').destroy!`
2. Go to sync status page.

**Without this change:** 
Result will be "Never Synced"

**With this change:**
![Screenshot from 2021-12-13 14-45-33](https://user-images.githubusercontent.com/21146741/145880684-3a84e806-a06c-4168-afe8-52cd1f365761.png)

