### PR TITLE
Fixes #32379 -  Autopublish switch reloads entire page

### DIFF
--- a/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
@@ -1,5 +1,4 @@
 import { API_OPERATIONS, APIActions, get, put, post } from 'foremanReact/redux/API';
-import { addToast } from 'foremanReact/components/ToastsList';
 import { translate as __ } from 'foremanReact/common/I18n';
 import {
   RPM_PACKAGES_CONTENT,
@@ -49,7 +48,7 @@ import {
   DOCKER_TAGS_CONTENT,
 } from '../ContentViewsConstants';
 import api, { foremanApi, orgId } from '../../../services/api';
-import { getResponseErrorMsgs, apiError } from '../../../utils/helpers';
+import { getResponseErrorMsgs } from '../../../utils/helpers';
 import { renderTaskStartedToast } from '../../Tasks/helpers';
 import { cvErrorToast } from '../ContentViewsActions';
 
@@ -59,16 +58,6 @@ const getContentViewDetails = (cvId, extraParams = {}) => get({
   params: { organization_id: orgId(), include_permissions: true, ...extraParams },
   url: api.getApiUrl(`/content_views/${cvId}`),
 });
-
-const cvUpdateSuccess = (response, dispatch) => {
-  const { data: { id } } = response;
-  // Update CV info in redux with the updated CV info from API
-  dispatch(getContentViewDetails(id));
-  return dispatch(addToast({
-    type: 'success',
-    message: __(' Content view updated'),
-  }));
-};
 
 export const getRPMPackages = params => get({
   type: API_OPERATIONS.GET,
@@ -86,19 +75,21 @@ export const getFiles = params => get({
   errorToast: error => __(`Something went wrong while fetching files! ${getResponseErrorMsgs(error.response)}`),
 });
 
-export const updateContentView = (cvId, params) => dispatch => dispatch(put({
+export const updateContentView = (cvId, params, handleSuccess) => put({
   type: API_OPERATIONS.PUT,
   key: cvDetailsKey(cvId),
   url: api.getApiUrl(`/content_views/${cvId}`),
-  params,
-  handleSuccess: response => cvUpdateSuccess(response, dispatch),
-  handleError: error => dispatch(apiError(null, error)),
+  handleSuccess,
+  params: { include_permissions: true, ...params },
+  successToast: () => __(' Content view updated'),
+  errorToast: error => error,
+  updateData: (prevState, respState) => ({ ...prevState, ...respState }),
   actionTypes: {
     REQUEST: UPDATE_CONTENT_VIEW,
     SUCCESS: UPDATE_CONTENT_VIEW_SUCCESS,
     FAILURE: UPDATE_CONTENT_VIEW_FAILURE,
   },
-}));
+});
 
 export const addComponent = params => put({
   type: API_OPERATIONS.PUT,

--- a/webpack/scenes/ContentViews/Details/ContentViewInfo.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewInfo.js
@@ -44,9 +44,12 @@ const ContentViewInfo = ({ cvId, details }) => {
     dispatch(updateContentView(cvId, { [attribute]: val }));
   };
 
+  // Guarantees strings update despite render chain
+  const uniqueKey = name + label + description;
+
   return (
     <TextContent className="margin-0-24">
-      <TextList component={TextListVariants.dl}>
+      <TextList key={uniqueKey} component={TextListVariants.dl}>
         <ActionableDetail
           label={__('Name')}
           attribute="name"

--- a/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
@@ -143,14 +143,35 @@ const ContentViewRepositories = ({ cvId, details }) => {
 
   const onAdd = (repos) => {
     const { repository_ids: repositoryIds = [] } = details;
-    dispatch(updateContentView(cvId, { repository_ids: repositoryIds.concat(repos) }));
+    dispatch(updateContentView(
+      cvId,
+      { repository_ids: repositoryIds.concat(repos) },
+      () =>
+        dispatch(getContentViewRepositories(
+          cvId,
+          typeSelected !== 'All repositories' ? {
+            content_type: repoTypes[typeSelected],
+          } : {},
+          statusSelected,
+        )),
+    ));
   };
 
   const onRemove = (repos) => {
     const reposToDelete = [].concat(repos);
     const { repository_ids: repositoryIds = [] } = details;
     const deletedRepos = repositoryIds.filter(x => !reposToDelete.includes(x));
-    dispatch(updateContentView(cvId, { repository_ids: deletedRepos }));
+    dispatch(updateContentView(
+      cvId, { repository_ids: deletedRepos },
+      () =>
+        dispatch(getContentViewRepositories(
+          cvId,
+          typeSelected !== 'All repositories' ? {
+            content_type: repoTypes[typeSelected],
+          } : {},
+          statusSelected,
+        )),
+    ));
   };
 
   const addBulk = () => {

--- a/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewAddRemove.test.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewAddRemove.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderWithRedux, patientlyWaitFor } from 'react-testing-lib-wrapper';
+import { renderWithRedux, patientlyWaitFor, act } from 'react-testing-lib-wrapper';
 
 import nock, { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../../../test-utils/nockWrapper';
 import api from '../../../../../services/api';
@@ -66,7 +66,7 @@ test('Can enable and disable add repositories button', async (done) => {
 
 test('Can add repositories', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
-  const cvAddparams = { repository_ids: [58, 62, 64, 106] };
+  const cvAddparams = { include_permissions: true, repository_ids: [58, 62, 64, 106] };
 
   const repoAddscope = nockInstance
     .put(cvDetailsPath, cvAddparams)
@@ -92,16 +92,19 @@ test('Can add repositories', async (done) => {
   expect(getByLabelText('add_repositories')).toHaveAttribute('aria-disabled', 'true');
   getByLabelText('Select all rows').click();
   getByLabelText('add_repositories').click();
+  await patientlyWaitFor(() => expect(getByText(firstRepo.name)).toBeInTheDocument());
+
   assertNockRequest(repoAddscope);
 
   assertNockRequest(cvDetailScope);
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done);
+  act(done);
 });
 
 test('Can remove repositories', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
-  const cvRemoveParams = { repository_ids: [58, 62, 64] };
+  const cvRemoveParams = { include_permissions: true, repository_ids: [58, 62, 64] };
   const scope = nockInstance
     .get(cvAllRepos)
     .query(true)
@@ -131,9 +134,12 @@ test('Can remove repositories', async (done) => {
     expect(getByLabelText('bulk_remove')).toBeInTheDocument();
   });
   getByLabelText('bulk_remove').click();
+  await patientlyWaitFor(() => expect(getByText(firstRepo.name)).toBeInTheDocument());
+
   assertNockRequest(repoRemoveScope);
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(cvDetailScope);
   assertNockRequest(scope, done);
+  act(done);
 });

--- a/webpack/scenes/ContentViews/Details/__tests__/contentViewDetail.test.js
+++ b/webpack/scenes/ContentViews/Details/__tests__/contentViewDetail.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
+import { renderWithRedux, patientlyWaitFor, fireEvent, act } from 'react-testing-lib-wrapper';
 import { nockInstance, assertNockRequest } from '../../../../test-utils/nockWrapper';
 import api from '../../../../services/api';
 import ContentViewDetails from '../ContentViewDetails';
@@ -53,7 +53,7 @@ test('Can edit text details such as name', async (done) => {
     .query(true)
     .reply(200, cvDetailData);
   const updatescope = nockInstance
-    .put(cvDetailsPath, { name: newName })
+    .put(cvDetailsPath, { include_permissions: true, name: newName })
     .reply(200, updatedCVDetails);
   const afterUpdateScope = nockInstance
     .get(cvDetailsPath)
@@ -81,6 +81,7 @@ test('Can edit text details such as name', async (done) => {
   assertNockRequest(getscope);
   assertNockRequest(updatescope);
   assertNockRequest(afterUpdateScope, done);
+  act(done);
 });
 
 test('Can edit boolean details such as solve dependencies', async (done) => {
@@ -90,7 +91,7 @@ test('Can edit boolean details such as solve dependencies', async (done) => {
     .query(true)
     .reply(200, cvDetailData);
   const updatescope = nockInstance
-    .put(cvDetailsPath, { solve_dependencies: true })
+    .put(cvDetailsPath, { include_permissions: true, solve_dependencies: true })
     .reply(200, updatedCVDetails);
   const afterUpdateScope = nockInstance
     .get(cvDetailsPath)
@@ -115,6 +116,7 @@ test('Can edit boolean details such as solve dependencies', async (done) => {
   assertNockRequest(getscope);
   assertNockRequest(updatescope);
   assertNockRequest(afterUpdateScope, done);
+  act(done);
 });
 
 test('Can link to view tasks', async () => {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Prevents full page reload when updating information on the content view info page, as well as on the repository review after adding or removing a repo.

#### What are the testing steps for this pull request?
- Go to the contentView details page and change name, description and autopublish. 
- Only the details sub-page should update.

- Go to repositories and add/remove repos. (bulk or not)
- Only the repo sub-page should update.