### PR TITLE
Fixes #34144 - Connected ISS from a CVE

### DIFF
--- a/app/lib/katello/resources/cdn.rb
+++ b/app/lib/katello/resources/cdn.rb
@@ -67,6 +67,8 @@ module Katello
             options[:username] = cdn_configuration.username
             options[:password] = cdn_configuration.password
             options[:organization_label] = cdn_configuration.upstream_organization_label
+            options[:content_view_label] = cdn_configuration.upstream_content_view_label
+            options[:lifecycle_environment_label] = cdn_configuration.upstream_lifecycle_environment_label
             options[:ssl_ca_cert] = cdn_configuration.ssl_ca
             CDN::KatelloCdn.new(cdn_configuration.url, options)
           end

--- a/app/services/katello/organization_creator.rb
+++ b/app/services/katello/organization_creator.rb
@@ -1,5 +1,11 @@
 module Katello
   class OrganizationCreator
+    DEFAULT_CONTENT_VIEW_NAME = 'Default Organization View'.freeze
+    DEFAULT_CONTENT_VIEW_LABEL = 'Default_Organization_View'.freeze
+
+    DEFAULT_LIFECYCLE_ENV_NAME = 'Library'.freeze
+    DEFAULT_LIFECYCLE_ENV_LABEL = 'Library'.freeze
+
     attr_reader :library_view, :library_environment, :library_cvv, :content_view_environment, :anonymous_provider, :redhat_provider
 
     def self.seed_all_organizations!
@@ -86,8 +92,8 @@ module Katello
 
     def create_library_environment
       @library_environment = Katello::KTEnvironment.where(
-        :name => "Library",
-        :label => "Library",
+        :name => DEFAULT_LIFECYCLE_ENV_NAME,
+        :label => DEFAULT_LIFECYCLE_ENV_LABEL,
         :library => true,
         :organization => @organization
       ).first_or_create!
@@ -96,7 +102,8 @@ module Katello
     def create_library_view
       @library_view = Katello::ContentView.where(
         default: true,
-        name: 'Default Organization View',
+        name: DEFAULT_CONTENT_VIEW_NAME,
+        label: DEFAULT_CONTENT_VIEW_LABEL,
         organization: @organization
       ).first_or_create!
     end

--- a/app/views/katello/api/v2/cdn_configurations/show.json.rabl
+++ b/app/views/katello/api/v2/cdn_configurations/show.json.rabl
@@ -1,4 +1,4 @@
-attributes :url, :username, :upstream_organization_label, :ssl_ca_credential_id
+attributes :url, :username, :upstream_organization_label, :ssl_ca_credential_id, :upstream_content_view_label, :upstream_lifecycle_environment_label
 
 node :password_exists do |config|
   config.password.present?

--- a/db/migrate/20211208034230_add_content_view_and_lifecycle_environment.rb
+++ b/db/migrate/20211208034230_add_content_view_and_lifecycle_environment.rb
@@ -1,0 +1,6 @@
+class AddContentViewAndLifecycleEnvironment < ActiveRecord::Migration[6.0]
+  def change
+    add_column :katello_cdn_configurations, :upstream_content_view_label, :string
+    add_column :katello_cdn_configurations, :upstream_lifecycle_environment_label, :string
+  end
+end

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationForm.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationForm.js
@@ -12,6 +12,7 @@ import {
   FormSelect,
   FormSelectOption,
   TextInput,
+  Tooltip,
 } from '@patternfly/react-core';
 
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -40,6 +41,12 @@ const CdnConfigurationForm = (props) => {
     useState(cdnConfiguration.upstream_organization_label);
   const [sslCaCredentialId, setSslCaCredentialId] = useState(cdnConfiguration.ssl_ca_credential_id);
   const updatingCdnConfiguration = useSelector(state => selectUpdatingCdnConfiguration(state));
+
+  const [contentViewLabel, setContentViewLabel] =
+    useState(cdnConfiguration.upstream_content_view_label);
+
+  const [lifecycleEnvironmentLabel, setLifecycleEnvironmentLabel] =
+    useState(cdnConfiguration.upstream_lifecycle_environment_label);
 
   const editPassword = (value) => {
     if (value === null) {
@@ -130,8 +137,35 @@ const CdnConfigurationForm = (props) => {
             aria-label="cdn-organization-label"
             type="text"
             value={organizationLabel || ''}
-            onChange={value => setOrganizationLabel(value)}
+            onChange={setOrganizationLabel}
           />
+        </FormGroup>
+        <FormGroup
+          label={__('Lifecycle Environment Label')}
+        >
+          <TextInput
+            aria-label="cdn-lifecycle-environment-label"
+            type="text"
+            value={lifecycleEnvironmentLabel || ''}
+            onChange={setLifecycleEnvironmentLabel}
+          />
+          <Tooltip>
+            {__('Leave blank if consuming Red Hat Content from the Library lifecycle environment or CDN ')}
+          </Tooltip>
+        </FormGroup>
+        <FormGroup
+          label={__('Content View Label')}
+        >
+          <TextInput
+            aria-label="cdn-content-view-label"
+            type="text"
+            value={contentViewLabel || ''}
+            onChange={setContentViewLabel}
+          />
+          <Tooltip>
+            {__('Leave blank if consuming Red Hat Content from the Default Content View or CDN ')}
+          </Tooltip>
+
         </FormGroup>
         <FormGroup
           label={__('SSL CA Content Credential')}
@@ -172,6 +206,8 @@ CdnConfigurationForm.propTypes = {
     url: PropTypes.string,
     username: PropTypes.string,
     upstream_organization_label: PropTypes.string,
+    upstream_content_view_label: PropTypes.string,
+    upstream_lifecycle_environment_label: PropTypes.string,
     ssl_ca_credential_id: PropTypes.number,
     password_exists: PropTypes.bool,
   }),


### PR DESCRIPTION
This PR enables one to sync from an upstream satellite's content view
environment

#### What are the changes introduced in this pull request?

In a Connected Inter Satellite Sync a downstream satellite can directly pull content from an upstream sat. This workflow is not enhanced in this PR to facilitate fetching content from a content view environment of the upstream sat. 

- Adds 2 entries to the CdnConfiguration
1. Content View label
2. Lifecycle Environment label 
- Uses this information to determine the CVE to pull content from the correct repository.
- Enables one to sync from a CVE
- 
#### Considerations taken when implementing this change?

- Can it handle custom content.? -  As of now Custom content can be easily imported in the master using the debug and ca certificate of the upstream sat. So this was not considered as a part of this PR.
- Should we  let you enable a RH Repo even if it is not in the CVE of the upstream satellite. This PR allows you to enable a RH Repo as long as the RH repo is enabled in the Library environment upstream. One will not be able to pull the content from a content view environment if the repo is not part of the content view environment. 


#### What are the testing steps for this pull request?

Very similar to the testing steps of https://github.com/Katello/katello/pull/8821 and https://github.com/Katello/katello/pull/9772
- Run the migration
- Go to `Subscriptions` -> `Manage Manifest` ->`Cdn Configurator` 
- Set the content view environment of the upstream
- Enable and sync :)
