### PR TITLE
Fixes #34145 - Errata href not updated

### DIFF
--- a/app/models/katello/concerns/pulp_database_unit.rb
+++ b/app/models/katello/concerns/pulp_database_unit.rb
@@ -190,7 +190,7 @@ module Katello
                 service.update_model(model, generic_content_type)
               elsif self == ::Katello::Erratum
                 # Errata will change pulp_hrefs if the upstream repo updates them
-                erratum_updated_ids << service.update_model(model)
+                erratum_updated_ids << service.update_model(model, repository)
               else
                 service.update_model(model)
               end


### PR DESCRIPTION
Like any other content in Pulp 3, advisories are immutable. So when
there is some change to it, a new one is created, it is then
associated to a repository as a part of a new repository version and
the old one is unassociated and becomes orphaned.

There are some advisory's fields that Katello doesn't store in the
database but Pulp does, such as version, pushcount, fromstr, rights
etc. If any of those fields is changed after syncing repo, Katello
can't detect the change and it is still referring to the orphaned
hrefs.

When user publishing an incremental content view, Katello will use the
orphaned hrefs to copy advisories from source repo to the destination
repo. If the orphaned advisories are removed by Pulp then nothing will
be copied.