### PR TITLE
Fixes #34149 - Fix autocomplete search

### DIFF
--- a/webpack/components/TypeAhead/pf4Search/TypeAheadItems.js
+++ b/webpack/components/TypeAhead/pf4Search/TypeAheadItems.js
@@ -3,7 +3,6 @@ import {
   Dropdown,
   DropdownItem,
   DropdownSeparator,
-  DropdownPosition,
 } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 
@@ -38,7 +37,6 @@ const TypeAheadItems = ({
   // satisfy the requirement
   return (
     <Dropdown
-      position={DropdownPosition.right}
       toggle={<React.Fragment />}
       isOpen={isOpen}
       dropdownItems={buildDropdownItems()}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fixes missing autocomplete search.

#### Considerations taken when implementing this change?
Turns out a recent change just moved the dropdown menu to the far right outside the visible screen with a scrollbar at the bottom. This just reverses that..Everything else is working as expected.
![0c3ecbf61874d185e96f6ef7caf1f772](https://user-images.githubusercontent.com/21146741/146059408-210998e0-9132-4dad-985d-b7e09a3373c8.jpg)

#### What are the testing steps for this pull request?
Load any page with search and click in the search input field. You should see a dropdown with autocomplete items.