### PR TITLE
Fixes #34131 - Host packages filter by status

### DIFF
--- a/webpack/components/extensions/HostDetails/HostPackages/HostPackagesConstants.js
+++ b/webpack/components/extensions/HostDetails/HostPackages/HostPackagesConstants.js
@@ -1,2 +1,13 @@
 export const HOST_PACKAGES_KEY = 'HOST_PACKAGES';
+
+export const PACKAGES_VERSION_STATUSES = {
+  UPGRADABLE: 'Upgradable',
+  UP_TO_DATE: 'Up-to date',
+};
+
+export const VERSION_STATUSES_TO_PARAM = {
+  [PACKAGES_VERSION_STATUSES.UPGRADABLE]: 'upgradable',
+  [PACKAGES_VERSION_STATUSES.UP_TO_DATE]: 'up-to-date',
+};
+
 export default HOST_PACKAGES_KEY;

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/packages.fixtures.json
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/packages.fixtures.json
@@ -22,7 +22,7 @@
         "id": 676,
 	"name": "acl",
 	"nvra": "acl-2.2.53-1.el8.x86_64",
-	"upgradable_version": "acl-2.5.3-1.el8.x86_64"
+	"upgradable_version": null
      }
   ]
 }


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add Status dropdown to the new host detail page Packages tab

#### Considerations taken when implementing this change?
Followed the implementation in https://github.com/Katello/katello/pull/9761

#### What are the testing steps for this pull request?
- Filter each status
- Perform a search and then filter it
- Change pages while filtering