### PR TITLE
Fixes #32379 -  Autopublish switch reloads entire page

### DIFF
--- a/webpack/components/ActionableDetail.js
+++ b/webpack/components/ActionableDetail.js
@@ -4,6 +4,7 @@ import {
   TextListItemVariants,
   Tooltip,
   TooltipPosition,
+  Spinner,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
@@ -23,33 +24,43 @@ const ActionableDetail = ({
   currentAttribute,
   setCurrentAttribute,
   disabled,
+  loading,
+  ...rest
 }) => {
   const displayProps = {
-    attribute, value, onEdit, disabled,
+    attribute, value, onEdit, disabled, currentAttribute, setCurrentAttribute, ...rest,
   };
 
   return (
     <React.Fragment key={label}>
-      <TextListItem component={TextListItemVariants.dt}>
-        {label}
-        {tooltip &&
-          <span className="foreman-spaced-icon">
-            <Tooltip
-              position={TooltipPosition.top}
-              content={tooltip}
-            >
-              <OutlinedQuestionCircleIcon />
-            </Tooltip>
-          </span>
-        }
-      </TextListItem>
+      {label &&
+        <TextListItem component={TextListItemVariants.dt}>
+          {label}
+          {tooltip &&
+            <span className="foreman-spaced-icon">
+              <Tooltip
+                position={TooltipPosition.top}
+                content={tooltip}
+              >
+                <OutlinedQuestionCircleIcon />
+              </Tooltip>
+            </span>
+          }
+        </TextListItem>
+      }
       <TextListItem component={TextListItemVariants.dd} className="foreman-spaced-list">
-        {boolean ?
-          <EditableSwitch {...displayProps} /> :
-          <EditableTextInput {...{
-            ...displayProps, textArea, onEdit, currentAttribute, setCurrentAttribute,
-          }}
-          />}
+        {loading ?
+          <Spinner
+            key={label + currentAttribute}
+            size="lg"
+          /> :
+          <>{boolean ?
+            <EditableSwitch {...displayProps} /> :
+            <EditableTextInput {...{
+              ...displayProps, textArea,
+            }}
+            />}
+          </>}
       </TextListItem>
     </React.Fragment>
   );
@@ -57,7 +68,7 @@ const ActionableDetail = ({
 
 ActionableDetail.propTypes = {
   attribute: PropTypes.string.isRequired, // back-end name for API call
-  label: PropTypes.string.isRequired, // displayed label
+  label: PropTypes.string,
   value: PropTypes.oneOfType([ // displayed value
     PropTypes.string,
     PropTypes.bool,
@@ -69,9 +80,11 @@ ActionableDetail.propTypes = {
   currentAttribute: PropTypes.string,
   setCurrentAttribute: PropTypes.func,
   disabled: PropTypes.bool,
+  loading: PropTypes.bool,
 };
 
 ActionableDetail.defaultProps = {
+  label: undefined,
   textArea: false,
   boolean: false,
   tooltip: null,
@@ -79,6 +92,7 @@ ActionableDetail.defaultProps = {
   currentAttribute: undefined,
   setCurrentAttribute: undefined,
   disabled: false,
+  loading: false,
 };
 
 export default ActionableDetail;

--- a/webpack/components/EditableSwitch.js
+++ b/webpack/components/EditableSwitch.js
@@ -4,16 +4,20 @@ import { noop } from 'foremanReact/common/helpers';
 import PropTypes from 'prop-types';
 
 const EditableSwitch = ({
-  value, attribute, onEdit, disabled,
+  value, attribute, onEdit, disabled, setCurrentAttribute,
 }) => {
   const identifier = `${attribute} switch`;
+  const onSwitch = (val) => {
+    if (setCurrentAttribute) setCurrentAttribute(attribute);
+    onEdit(val, attribute);
+  };
 
   return (
     <Switch
       id={identifier}
       aria-label={identifier}
       isChecked={value}
-      onChange={v => onEdit(v, attribute)}
+      onChange={onSwitch}
       disabled={disabled}
     />
   );
@@ -24,12 +28,14 @@ EditableSwitch.propTypes = {
   attribute: PropTypes.string,
   onEdit: PropTypes.func,
   disabled: PropTypes.bool,
+  setCurrentAttribute: PropTypes.func,
 };
 
 EditableSwitch.defaultProps = {
   attribute: '',
   onEdit: noop,
   disabled: false,
+  setCurrentAttribute: undefined,
 };
 
 export default EditableSwitch;

--- a/webpack/components/EditableTextInput/__tests__/editableTextInput.test.js
+++ b/webpack/components/EditableTextInput/__tests__/editableTextInput.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
+import { head } from 'lodash';
 import EditableTextInput from '../EditableTextInput';
 
 const actualValue = 'burger';
@@ -17,7 +18,6 @@ test('Passed function is called after editing and clicking submit', async () => 
   getByLabelText(`edit ${attribute}`).click();
   fireEvent.change(getByLabelText(`${attribute} text input`), { target: { value: actualValue } });
   getByLabelText(`submit ${attribute}`).click();
-
   await patientlyWaitFor(() => expect(mockEdit.mock.calls).toHaveLength(1));
   expect(mockEdit.mock.calls[0][0]).toBe(actualValue); // first arg
 });
@@ -29,10 +29,10 @@ test('Passed function is called after editing and hitting enter', async () => {
   getByLabelText(`edit ${attribute}`).click();
   const textInputLabel = `${attribute} text input`;
   fireEvent.change(getByLabelText(textInputLabel), { target: { value: actualValue } });
-  fireEvent.keyDown(getByLabelText(textInputLabel), { key: 'Enter', code: 'Enter' });
+  fireEvent.keyUp(getByLabelText(textInputLabel), { key: 'Enter', code: 'Enter' });
 
   await patientlyWaitFor(() => expect(mockEdit.mock.calls).toHaveLength(1));
-  expect(mockEdit.mock.calls[0][0]).toBe(actualValue); // first arg
+  expect(head(mockEdit.mock.calls)).toContain(actualValue); // first arg
 });
 
 test('input is set back to original value after clearing', () => {

--- a/webpack/scenes/ContentViews/Details/ContentViewInfo.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewInfo.js
@@ -15,7 +15,6 @@ import { translate as __ } from 'foremanReact/common/I18n';
 
 import { updateContentView } from './ContentViewDetailActions';
 import { selectIsCVUpdating } from './ContentViewDetailSelectors';
-import Loading from '../../../components/Loading';
 import ContentViewIcon from '../components/ContentViewIcon';
 import ActionableDetail from '../../../components/ActionableDetail';
 import './contentViewInfo.scss';
@@ -37,8 +36,6 @@ const ContentViewInfo = ({ cvId, details }) => {
     permissions,
   } = details;
 
-  if (updating) return <Loading size="sm" showText={false} />;
-
   const onEdit = (val, attribute) => {
     if (val === details[attribute]) return;
     dispatch(updateContentView(cvId, { [attribute]: val }));
@@ -48,8 +45,10 @@ const ContentViewInfo = ({ cvId, details }) => {
     <TextContent className="margin-0-24">
       <TextList component={TextListVariants.dl}>
         <ActionableDetail
+          key={name}
           label={__('Name')}
           attribute="name"
+          loading={updating && currentAttribute === 'name'}
           onEdit={onEdit}
           disabled={!hasPermission(permissions, 'edit_content_views')}
           value={name}
@@ -76,9 +75,11 @@ const ContentViewInfo = ({ cvId, details }) => {
           </Flex>
         </TextListItem>
         <ActionableDetail
+          key={description}
           textArea
           label={__('Description')}
           attribute="description"
+          loading={updating && currentAttribute === 'description'}
           onEdit={onEdit}
           disabled={!hasPermission(permissions, 'edit_content_views')}
           value={description}
@@ -86,8 +87,10 @@ const ContentViewInfo = ({ cvId, details }) => {
         />
         {composite ?
           (<ActionableDetail
+            key={autoPublish}
             label={__('Autopublish')}
             attribute="auto_publish"
+            loading={updating && currentAttribute === 'auto_publish'}
             value={autoPublish}
             onEdit={onEdit}
             disabled={!hasPermission(permissions, 'edit_content_views')}
@@ -98,6 +101,8 @@ const ContentViewInfo = ({ cvId, details }) => {
           (<ActionableDetail
             label={__('Solve dependencies')}
             attribute="solve_dependencies"
+            key={solveDependencies}
+            loading={updating && currentAttribute === 'solve_dependencies'}
             value={solveDependencies}
             onEdit={onEdit}
             disabled={!hasPermission(permissions, 'edit_content_views')}

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetails.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetails.js
@@ -50,8 +50,8 @@ const ContentViewFilterDetails = ({ cvId, details }) => {
       {loaded && (Object.keys(filterDetails).length > 0) ?
         <ContentViewFilterDetailsHeader
           {...{
- cvId, filterId, filterDetails, setShowAffectedRepos, details,
-}}
+            cvId, filterId, filterDetails, setShowAffectedRepos, details,
+          }}
         /> :
         <Loading />
       }

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetailsHeader.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetailsHeader.js
@@ -8,15 +8,16 @@ import { getCVFilterDetails, editCVFilter } from '../ContentViewDetailActions';
 import AffectedRepositorySelection from './AffectedRepositories/AffectedRepositorySelection';
 import RepoIcon from '../Repositories/RepoIcon';
 import { repoType } from '../../../../utils/helpers';
-import EditableTextInput from '../../../../components/EditableTextInput';
 import { hasPermission } from '../../helpers';
 import { typeName } from './ContentType';
+import ActionableDetail from '../../../../components/ActionableDetail';
 
 const ContentViewFilterDetailsHeader = ({
   cvId, filterId, filterDetails, setShowAffectedRepos, details,
 }) => {
   const dispatch = useDispatch();
   const [currentAttribute, setCurrentAttribute] = useState('');
+  const [loading, setLoading] = useState(false);
   const {
     type, name, inclusion, description, rules,
   } = filterDetails;
@@ -26,12 +27,17 @@ const ContentViewFilterDetailsHeader = ({
 
   const displayedType = () => typeName(type, errataByDate);
 
-  const onEdit = (val, attribute) => {
+  const onEdit = async (val, attribute) => {
     if (val === filterDetails[attribute]) return;
-    dispatch(editCVFilter(
+    setLoading(true);
+    await dispatch(editCVFilter(
       filterId,
       { [attribute]: val },
-      () => dispatch(getCVFilterDetails(cvId, filterId)),
+      () => {
+        setLoading(false);
+        dispatch(getCVFilterDetails(cvId, filterId));
+      },
+      () => setLoading(false),
     ));
   };
 
@@ -39,10 +45,10 @@ const ContentViewFilterDetailsHeader = ({
     <Grid className="margin-0-24">
       <GridItem span={9}>
         <TextContent>
-          <EditableTextInput
+          <ActionableDetail
             key={name} // This fixes a render issue with the initial value
-            label={__('Name')}
             attribute="name"
+            loading={loading && currentAttribute === 'name'}
             placeholder={__('Enter a name')}
             onEdit={onEdit}
             disabled={!hasPermission(permissions, 'edit_content_views')}
@@ -53,11 +59,11 @@ const ContentViewFilterDetailsHeader = ({
           />
         </TextContent>
         <TextContent style={{ padding: '24px 0 12px' }}>
-          <EditableTextInput
+          <ActionableDetail
             key={description} // This fixes a render issue with the initial value
             textArea
-            label={__('Description')}
             attribute="description"
+            loading={loading && currentAttribute === 'description'}
             placeholder={__('No description')}
             onEdit={onEdit}
             disabled={!hasPermission(permissions, 'edit_content_views')}

--- a/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
@@ -143,14 +143,35 @@ const ContentViewRepositories = ({ cvId, details }) => {
 
   const onAdd = (repos) => {
     const { repository_ids: repositoryIds = [] } = details;
-    dispatch(updateContentView(cvId, { repository_ids: repositoryIds.concat(repos) }));
+    dispatch(updateContentView(
+      cvId,
+      { repository_ids: repositoryIds.concat(repos) },
+      () =>
+        dispatch(getContentViewRepositories(
+          cvId,
+          typeSelected !== 'All repositories' ? {
+            content_type: repoTypes[typeSelected],
+          } : {},
+          statusSelected,
+        )),
+    ));
   };
 
   const onRemove = (repos) => {
     const reposToDelete = [].concat(repos);
     const { repository_ids: repositoryIds = [] } = details;
     const deletedRepos = repositoryIds.filter(x => !reposToDelete.includes(x));
-    dispatch(updateContentView(cvId, { repository_ids: deletedRepos }));
+    dispatch(updateContentView(
+      cvId, { repository_ids: deletedRepos },
+      () =>
+        dispatch(getContentViewRepositories(
+          cvId,
+          typeSelected !== 'All repositories' ? {
+            content_type: repoTypes[typeSelected],
+          } : {},
+          statusSelected,
+        )),
+    ));
   };
 
   const addBulk = () => {

--- a/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewAddRemove.test.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewAddRemove.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderWithRedux, patientlyWaitFor } from 'react-testing-lib-wrapper';
+import { renderWithRedux, patientlyWaitFor, act } from 'react-testing-lib-wrapper';
 
 import nock, { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../../../test-utils/nockWrapper';
 import api from '../../../../../services/api';
@@ -66,7 +66,7 @@ test('Can enable and disable add repositories button', async (done) => {
 
 test('Can add repositories', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
-  const cvAddparams = { repository_ids: [58, 62, 64, 106] };
+  const cvAddparams = { include_permissions: true, repository_ids: [58, 62, 64, 106] };
 
   const repoAddscope = nockInstance
     .put(cvDetailsPath, cvAddparams)
@@ -92,16 +92,19 @@ test('Can add repositories', async (done) => {
   expect(getByLabelText('add_repositories')).toHaveAttribute('aria-disabled', 'true');
   getByLabelText('Select all rows').click();
   getByLabelText('add_repositories').click();
+  await patientlyWaitFor(() => expect(getByText(firstRepo.name)).toBeInTheDocument());
+
   assertNockRequest(repoAddscope);
 
   assertNockRequest(cvDetailScope);
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done);
+  act(done);
 });
 
 test('Can remove repositories', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
-  const cvRemoveParams = { repository_ids: [58, 62, 64] };
+  const cvRemoveParams = { include_permissions: true, repository_ids: [58, 62, 64] };
   const scope = nockInstance
     .get(cvAllRepos)
     .query(true)
@@ -131,9 +134,12 @@ test('Can remove repositories', async (done) => {
     expect(getByLabelText('bulk_remove')).toBeInTheDocument();
   });
   getByLabelText('bulk_remove').click();
+  await patientlyWaitFor(() => expect(getByText(firstRepo.name)).toBeInTheDocument());
+
   assertNockRequest(repoRemoveScope);
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(cvDetailScope);
   assertNockRequest(scope, done);
+  act(done);
 });

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetails.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetails.js
@@ -75,6 +75,7 @@ const ContentViewVersionDetails = ({ cvId, details }) => {
       <ContentViewVersionDetailsHeader
         versionDetails={versionDetails}
         onEdit={editDiscription}
+        loading={status === STATUS.PENDING}
         details={details}
       />
       {showTabs &&

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
@@ -6,9 +6,7 @@ import {
   GridItem,
   TextContent,
   Text,
-  TextList,
   TextVariants,
-  TextListVariants,
   Label,
   Flex,
   FlexItem,
@@ -18,11 +16,11 @@ import {
   DropdownPosition,
 } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
-import EditableTextInput from '../../../../../components/EditableTextInput';
 import { hasPermission } from '../../../helpers';
 import ContentViewVersionPromote from '../../Promote/ContentViewVersionPromote';
 import getEnvironmentPaths from '../../../components/EnvironmentPaths/EnvironmentPathActions';
 import RemoveCVVersionWizard from '../Delete/RemoveCVVersionWizard';
+import ActionableDetail from '../../../../../components/ActionableDetail';
 
 const ContentViewVersionDetailsHeader = ({
   versionDetails: {
@@ -30,6 +28,7 @@ const ContentViewVersionDetailsHeader = ({
   },
   onEdit,
   details: { permissions },
+  loading,
 }) => {
   const dispatch = useDispatch();
   useEffect(
@@ -98,18 +97,16 @@ const ContentViewVersionDetailsHeader = ({
       </GridItem>
       <GridItem className="content-view-header-content" span={12}>
         <TextContent>
-          <TextList component={TextListVariants.dl}>
-            <EditableTextInput
-              key={description} // This fixes a render issue with the initial value
-              textArea
-              label={__('Description')}
-              attribute="description"
-              placeholder={__('No description')}
-              onEdit={onEdit}
-              disabled={!hasPermission(permissions, 'edit_content_views')}
-              value={description}
-            />
-          </TextList>
+          <ActionableDetail
+            key={description} // This fixes a render issue with the initial value
+            textArea
+            attribute="description"
+            loading={loading}
+            placeholder={__('No description')}
+            onEdit={onEdit}
+            disabled={!hasPermission(permissions, 'edit_content_views')}
+            value={description}
+          />
         </TextContent>
         <Flex>
           {environments?.map(({ name, id: envId }) =>
@@ -164,6 +161,7 @@ ContentViewVersionDetailsHeader.propTypes = {
   details: PropTypes.shape({
     permissions: PropTypes.shape({}),
   }).isRequired,
+  loading: PropTypes.bool.isRequired,
 };
 
 export default ContentViewVersionDetailsHeader;

--- a/webpack/scenes/ContentViews/Details/__tests__/contentViewDetail.test.js
+++ b/webpack/scenes/ContentViews/Details/__tests__/contentViewDetail.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
+import { renderWithRedux, patientlyWaitFor, fireEvent, act } from 'react-testing-lib-wrapper';
 import { nockInstance, assertNockRequest } from '../../../../test-utils/nockWrapper';
 import api from '../../../../services/api';
 import ContentViewDetails from '../ContentViewDetails';
@@ -53,7 +53,7 @@ test('Can edit text details such as name', async (done) => {
     .query(true)
     .reply(200, cvDetailData);
   const updatescope = nockInstance
-    .put(cvDetailsPath, { name: newName })
+    .put(cvDetailsPath, { include_permissions: true, name: newName })
     .reply(200, updatedCVDetails);
   const afterUpdateScope = nockInstance
     .get(cvDetailsPath)
@@ -81,6 +81,7 @@ test('Can edit text details such as name', async (done) => {
   assertNockRequest(getscope);
   assertNockRequest(updatescope);
   assertNockRequest(afterUpdateScope, done);
+  act(done);
 });
 
 test('Can edit boolean details such as solve dependencies', async (done) => {
@@ -90,7 +91,7 @@ test('Can edit boolean details such as solve dependencies', async (done) => {
     .query(true)
     .reply(200, cvDetailData);
   const updatescope = nockInstance
-    .put(cvDetailsPath, { solve_dependencies: true })
+    .put(cvDetailsPath, { include_permissions: true, solve_dependencies: true })
     .reply(200, updatedCVDetails);
   const afterUpdateScope = nockInstance
     .get(cvDetailsPath)
@@ -115,6 +116,7 @@ test('Can edit boolean details such as solve dependencies', async (done) => {
   assertNockRequest(getscope);
   assertNockRequest(updatescope);
   assertNockRequest(afterUpdateScope, done);
+  act(done);
 });
 
 test('Can link to view tasks', async () => {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Prevents full page reload when updating information on the content view info page, as well as on the repository review after adding or removing a repo.

#### What are the testing steps for this pull request?
- Go to the contentView details page and change name, description and autopublish. 
- Only the change detail item should show a spinner.

- Go to repositories and add/remove repos. (bulk or not)
- Only the repo sub-page should update.