### PR TITLE
Fixes #341447 - ComponentViewPresenter default case presenter fix

### DIFF
--- a/app/services/katello/component_view_presenter.rb
+++ b/app/services/katello/component_view_presenter.rb
@@ -20,7 +20,7 @@ module Katello
         not_added_cvs = views.reject { |component_content_view| Katello::ContentViewComponent.where(composite_content_view_id: composite_cv.id, content_view_id: component_content_view.id).first }
         not_added_cvs.map { |component_content_view| ComponentViewPresenter.new(composite_cv, nil, Katello::ContentViewComponent.where(composite_content_view_id: composite_cv.id, content_view_id: component_content_view.id, latest: true).new) }
       else
-        views.map { |component_content_view| ComponentViewPresenter.new(cv, component_content_view) }
+        views.map { |component_content_view| ComponentViewPresenter.new(composite_cv, component_content_view) }
       end
     end
   end

--- a/webpack/scenes/ContentViews/ContentViewsConstants.js
+++ b/webpack/scenes/ContentViews/ContentViewsConstants.js
@@ -55,9 +55,9 @@ export const addComponentSuccessMessage = component => (component ? __('Updated 
 
 
 // Repo added to content view status display and key
-export const ADDED = __('Added');
-export const NOT_ADDED = __('Not added');
-export const ALL_STATUSES = __('All');
+export const ADDED = 'Added';
+export const NOT_ADDED = 'Not added';
+export const ALL_STATUSES = 'All';
 
 export const REPOSITORY_TYPES = 'REPOSITORY_TYPES';
 export const FILTER_TYPES = ['rpm', 'package_group', 'erratum_date', 'erratum_id', 'docker', 'modulemd'];


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The default case of the presenter incorrectly refers to `cv`. Should be `composite_cv`.

#### Considerations taken when implementing this change?

This case should theoretically never be hit from the UI but the user seems to be seeing this. Investigating that to see why this flow was hit at all by the user.

Update: This api call with invalid status happens because of translations around status values. The browser then send the translated status value to the API which is not recognized. Immediate fix is to remove translation for the status values. Filed issue : [projects.theforeman.org/issues/34158](https://projects.theforeman.org/issues/34158)

#### What are the testing steps for this pull request?

We can recreate this flow from the API with a malformed API call like:

https://your.server.com/katello/api/v2/content_views/COMPOSITE_CV_ID/content_view_components/show_all?status=blahblah

Note:
Valid statuses are All, Added and Not added

Defaulting in invalid cases to return unfiltered results while we identify any case where the UI actually fires a malformed API call.