### PR TITLE
Fixes #34155 - block pulp actions if switchover has run

### DIFF
--- a/app/lib/actions/katello/content_view/promote.rb
+++ b/app/lib/actions/katello/content_view/promote.rb
@@ -2,6 +2,8 @@ module Actions
   module Katello
     module ContentView
       class Promote < Actions::EntryAction
+        middleware.use Actions::Middleware::SwitchoverCheck
+
         def plan(version, environments, is_force = false, description = nil, incremental_update = false)
           action_subject(version.content_view)
           version.check_ready_to_promote!(environments)

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -3,6 +3,8 @@ module Actions
   module Katello
     module ContentView
       class Publish < Actions::EntryAction
+        middleware.use Actions::Middleware::SwitchoverCheck
+
         include ::Katello::ContentViewHelper
         attr_accessor :version
         # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity

--- a/app/lib/actions/katello/content_view/remove.rb
+++ b/app/lib/actions/katello/content_view/remove.rb
@@ -2,6 +2,8 @@ module Actions
   module Katello
     module ContentView
       class Remove < Actions::EntryAction
+        middleware.use Actions::Middleware::SwitchoverCheck
+
         # Remove content view versions and/or environments from a content view
 
         # Options: (note that all are optional)

--- a/app/lib/actions/katello/content_view/remove_version.rb
+++ b/app/lib/actions/katello/content_view/remove_version.rb
@@ -3,6 +3,8 @@ module Actions
     module ContentView
       class RemoveVersion < Actions::EntryAction
         def plan(version)
+          middleware.use Actions::Middleware::SwitchoverCheck
+
           action_subject(version.content_view)
           version.validate_destroyable!
 

--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -3,6 +3,8 @@ module Actions
     module ContentViewVersion
       # rubocop:disable Metrics/ClassLength
       class IncrementalUpdate < Actions::EntryAction
+        middleware.use Actions::Middleware::SwitchoverCheck
+
         include ::Katello::ContentViewHelper
         attr_accessor :new_content_view_version
 

--- a/app/lib/actions/katello/repository/create_root.rb
+++ b/app/lib/actions/katello/repository/create_root.rb
@@ -2,6 +2,8 @@ module Actions
   module Katello
     module Repository
       class CreateRoot < Actions::EntryAction
+        middleware.use Actions::Middleware::SwitchoverCheck
+
         def plan(root)
           root.save!
           repository = ::Katello::Repository.new(:environment => root.organization.library,

--- a/app/lib/actions/katello/repository/import_upload.rb
+++ b/app/lib/actions/katello/repository/import_upload.rb
@@ -3,6 +3,8 @@ module Actions
   module Katello
     module Repository
       class ImportUpload < Actions::EntryAction
+        middleware.use Actions::Middleware::SwitchoverCheck
+
         include Actions::Katello::PulpSelector
         # rubocop:disable Metrics/MethodLength
         def plan(repository, uploads, options = {})

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -6,6 +6,7 @@ module Actions
         include Helpers::Presenter
         include Actions::Katello::PulpSelector
         middleware.use Actions::Middleware::ExecuteIfContentsChanged
+        middleware.use Actions::Middleware::SwitchoverCheck
 
         input_format do
           param :id, Integer

--- a/app/lib/actions/middleware/switchover_check.rb
+++ b/app/lib/actions/middleware/switchover_check.rb
@@ -1,0 +1,15 @@
+module Actions
+  module Middleware
+    class SwitchoverCheck < Dynflow::Middleware
+      def plan(*args)
+        if ::Katello::Rpm.where("pulp_id ilike '/pulp/api/v3/%'").any? && !SmartProxy.pulp_primary.pulp3_repository_type_support?('yum')
+          error = "It appears that the pulp 2 to 3 switchover has been performed, but the server is still running with Pulp2. \
+                   This action will cause data loss and has been stopped.  You will need to continue the upgrade \
+                   in order to perform this action. "
+          fail _(error)
+        end
+        pass(*args)
+      end
+    end
+  end
+end


### PR DESCRIPTION
but we are still using pulp2

#### What are the changes introduced in this pull request?
It is possible that users could run the content migration and switchover, but accidentally stay on pulp2.   If this happens and the user syncs content, repositories will be reindexed with pulp2 content units, while the current content units have been migrated to pulp3.   Then when they try to do a switchover again, it will fail.  This adds a check that prevents some operations if they are running in 'pulp2' mode, but some rpm content has already been 'switched' over.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1.  install katello 3.18/6.9 (with pulp2 enabled)
2. sync some repositories
3. run  'foreman-maintain content prepare'
4. run 'systemctl start pulpcore-api pulpcore-content pulpcore-resource-manager pulpcore-worker@1 pulpcore-worker@2'
5. run foreman-rake katello:pulp3_switchover
6. try to sync a repository, publish a cv, promote a cv, create a repository
