### PR TITLE
Fixes #34157 - Accept URL params on Host details page tabs

### DIFF
--- a/webpack/components/Errata/index.js
+++ b/webpack/components/Errata/index.js
@@ -8,11 +8,10 @@ import {
   SquareIcon,
 } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
-import { urlBuilder } from 'foremanReact/common/urlHelpers';
 
 export const ErrataMapper = ({ data, id }) => data.map(({ x: type, y: count }) => <ErrataSummary count={count} type={type} key={`${count} ${type}`} id={id} />);
 
-export const ErrataSummary = ({ type, count, id }) => {
+export const ErrataSummary = ({ type, count }) => {
   let ErrataIcon;
   let label;
   let name;
@@ -24,7 +23,7 @@ export const ErrataSummary = ({ type, count, id }) => {
       ErrataIcon = SecurityIcon;
       name = 'security advisories';
       color = '#0066cc';
-      url = <a href={urlBuilder(`content_hosts/${id}/errata`, '')}> {count} {name} </a>;
+      url = <a href="#/Content/errata?type=security"> {count} {name} </a>;
       break;
     case 'recommended':
     case 'bugfix':
@@ -32,7 +31,7 @@ export const ErrataSummary = ({ type, count, id }) => {
       ErrataIcon = BugIcon;
       name = 'bug fixes';
       color = '#8bc1f7';
-      url = <a href={urlBuilder(`content_hosts/${id}/errata`, '')}> {count} {name} </a>;
+      url = <a href="#/Content/errata?type=bugfix"> {count} {name} </a>;
       break;
     case 'enhancement':
     case 'optional':
@@ -40,7 +39,7 @@ export const ErrataSummary = ({ type, count, id }) => {
       ErrataIcon = EnhancementIcon;
       name = 'enhancements';
       color = '#002f5d';
-      url = <a href={urlBuilder(`content_hosts/${id}/errata`, '')}> {count} {name} </a>;
+      url = <a href="#/Content/errata?type=enhancement"> {count} {name} </a>;
       break;
     default:
   }
@@ -62,7 +61,6 @@ export const ErrataSummary = ({ type, count, id }) => {
 ErrataSummary.propTypes = {
   type: PropTypes.string.isRequired,
   count: PropTypes.number.isRequired,
-  id: PropTypes.number.isRequired,
 };
 
 export const ErrataType = ({ type }) => {

--- a/webpack/components/Table/TableHooks.js
+++ b/webpack/components/Table/TableHooks.js
@@ -117,6 +117,8 @@ export const useBulkSelect = ({
   results,
   metadata,
   initialArry = [],
+  initialSearchQuery = '',
+  routerHistory,
   idColumn = 'id',
   isSelectable,
 }) => {
@@ -125,7 +127,7 @@ export const useBulkSelect = ({
                   results, metadata, initialArry, idColumn, isSelectable,
                 });
   const exclusionSet = useSet([]);
-  const [searchQuery, updateSearchQuery] = useState('');
+  const [searchQuery, updateSearchQuery] = useState(initialSearchQuery);
   const [selectAllMode, setSelectAllMode] = useState(false);
   const selectedCount = selectAllMode ?
     Number(metadata.selectable) - exclusionSet.size : selectOptions.selectedCount;
@@ -203,6 +205,13 @@ export const useBulkSelect = ({
       selectNone();
     }
   }, [searchQuery, selectAllMode, prevSearchRef, selectNone]);
+
+  // useEffect(() => {
+  //   routerHistory.replace({
+  //     ...routerHistory,
+  //     search: `?search=${encodeURIComponent(searchQuery)}`,
+  //   });
+  // }, [searchQuery, routerHistory]);
 
   return {
     ...selectOptions,

--- a/webpack/components/Table/TableHooks.js
+++ b/webpack/components/Table/TableHooks.js
@@ -223,11 +223,11 @@ export const useBulkSelect = ({
   };
 };
 
-// takes a url query like ?type=security&search=name=foo
+// takes a url query like ?type=security&search=name+~+foo
 // and returns an object
 // {
 //   type: 'security',
-//   searchParam: 'name=foo'
+//   searchParam: 'name ~ foo'
 // }
 export const useUrlParams = () => {
   const location = useLocation();

--- a/webpack/components/Table/TableHooks.js
+++ b/webpack/components/Table/TableHooks.js
@@ -1,5 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { isEmpty } from 'lodash';
+import { useLocation } from 'react-router-dom';
+import { friendlySearchParam } from '../../utils/helpers';
 
 class ReactConnectedSet extends Set {
   constructor(initialValue, forceRender) {
@@ -118,7 +120,6 @@ export const useBulkSelect = ({
   metadata,
   initialArry = [],
   initialSearchQuery = '',
-  routerHistory,
   idColumn = 'id',
   isSelectable,
 }) => {
@@ -206,13 +207,6 @@ export const useBulkSelect = ({
     }
   }, [searchQuery, selectAllMode, prevSearchRef, selectNone]);
 
-  // useEffect(() => {
-  //   routerHistory.replace({
-  //     ...routerHistory,
-  //     search: `?search=${encodeURIComponent(searchQuery)}`,
-  //   });
-  // }, [searchQuery, routerHistory]);
-
   return {
     ...selectOptions,
     selectPage,
@@ -226,5 +220,22 @@ export const useBulkSelect = ({
     selectOne,
     areAllRowsOnPageSelected,
     areAllRowsSelected,
+  };
+};
+
+// takes a url query like ?type=security&search=name=foo
+// and returns an object
+// {
+//   type: 'security',
+//   searchParam: 'name=foo'
+// }
+export const useUrlParams = () => {
+  const location = useLocation();
+  const { search: urlSearchParam, ...urlParams }
+    = Object.fromEntries(new URLSearchParams(location.search).entries());
+  const searchParam = urlSearchParam ? friendlySearchParam(urlSearchParam) : '';
+  return {
+    searchParam,
+    ...urlParams,
   };
 };

--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -182,6 +182,7 @@ const TableWrapper = ({
             <Search
               isDisabled={unresolvedStatusOrNoRows && !searchQuery}
               patternfly4
+              initialInputValue={searchQuery && searchQuery}
               onSearch={search => updateSearchQuery(search)}
               getAutoCompleteParams={getAutoCompleteParams}
               foremanApiAutoComplete={foremanApiAutoComplete}

--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
@@ -8,7 +8,6 @@ import {
   FlexItem,
   GridItem,
 } from '@patternfly/react-core';
-import { urlBuilder } from 'foremanReact/common/urlHelpers';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
 import PropTypes from 'prop-types';
@@ -38,7 +37,7 @@ function HostInstallableErrata({
         <CardBody>
           <Flex direction="column">
             <FlexItem>
-              <a href={urlBuilder(`content_hosts/${id}/errata`, '')}>
+              <a href="#/Content/errata">
                 {errataTotal} errata
               </a>
             </FlexItem>

--- a/webpack/components/extensions/HostDetails/HostDetailsActions.js
+++ b/webpack/components/extensions/HostDetails/HostDetailsActions.js
@@ -1,0 +1,2 @@
+const hostIdNotReady = { type: 'NOOP_HOST_ID_NOT_READY' };
+export default hostIdNotReady;

--- a/webpack/components/extensions/HostDetails/HostErrata/HostErrataConstants.js
+++ b/webpack/components/extensions/HostDetails/HostErrata/HostErrataConstants.js
@@ -29,6 +29,17 @@ export const SEVERITIES_TO_PARAM = {
   [ERRATA_SEVERITIES.CRITICAL]: 'Critical',
 };
 
+export const PARAM_TO_FRIENDLY_NAME = {
+  security: 'Security',
+  bugfix: 'Bugfix',
+  enhancement: 'Enhancement',
+  none: 'N/A',
+  low: 'Low',
+  moderate: 'Moderate',
+  important: 'Important',
+  critical: 'Critical',
+};
+
 export default HOST_ERRATA_KEY;
 
 export const ERRATA_SEARCH_QUERY = 'Errata search query';

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
@@ -32,6 +32,7 @@ import { HOST_ERRATA_KEY, ERRATA_TYPES, ERRATA_SEVERITIES, TYPES_TO_PARAM, SEVER
 import { installErrata } from './RemoteExecutionActions';
 import { errataInstallUrl } from './customizedRexUrlHelpers';
 import './ErrataTab.scss';
+import hostIdNotReady from '../HostDetailsActions';
 
 export const ErrataTab = () => {
   const hostDetails = useSelector(state => selectAPIResponse(state, 'HOST_DETAILS'));
@@ -79,7 +80,7 @@ export const ErrataTab = () => {
 
   const fetchItems = useCallback(
     (params) => {
-      if (!hostId) return null;
+      if (!hostId) return hostIdNotReady;
       const modifiedParams = { ...params };
       if (errataTypeSelected !== ERRATA_TYPE) {
         modifiedParams.type = TYPES_TO_PARAM[errataTypeSelected];

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
@@ -1,5 +1,6 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { useLocation, useHistory } from 'react-router-dom';
 import {
   Button, Split, SplitItem, ActionList, ActionListItem, Dropdown,
   DropdownItem, KebabToggle, Skeleton, Tooltip, ToggleGroup, ToggleGroupItem,
@@ -20,6 +21,7 @@ import { selectAPIResponse } from 'foremanReact/redux/API/APISelectors';
 import IsoDate from 'foremanReact/components/common/dates/IsoDate';
 import { urlBuilder } from 'foremanReact/common/urlHelpers';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
+import { friendlySearchParam } from '../../../../utils/helpers';
 import SelectableDropdown from '../../../SelectableDropdown';
 import { useSet, useBulkSelect } from '../../../../components/Table/TableHooks';
 import TableWrapper from '../../../../components/Table/TableWrapper';
@@ -95,6 +97,10 @@ export const ErrataTab = () => {
   const response = useSelector(state => selectAPIResponse(state, HOST_ERRATA_KEY));
   const { results, ...metadata } = response;
   const status = useSelector(state => selectHostErrataStatus(state));
+  const history = useHistory();
+  const location = useLocation();
+  const urlSearchParam = location.search.split('?search=')[1];
+  const searchParam = urlSearchParam ? friendlySearchParam(urlSearchParam) : '';
   const errataSearchQuery = id => `errata_id = ${id}`;
   const {
     selectOne, isSelected, searchQuery, selectedCount, isSelectable,
@@ -104,6 +110,8 @@ export const ErrataTab = () => {
     metadata,
     idColumn: 'errata_id',
     isSelectable: result => result.installable,
+    initialSearchQuery: searchParam || '',
+    routerHistory: history,
   });
 
   if (!hostId) return <Skeleton />;
@@ -239,7 +247,7 @@ export const ErrataTab = () => {
   );
 
   const hostIsNonLibrary = (
-    !contentFacet.contentViewDefault && !contentFacet.lifecycleEnvironmentLibrary
+    contentFacet?.contentViewDefault === false && contentFacet.lifecycleEnvironmentLibrary === false
   );
   const toggleGroup = (
     <Split hasGutter>

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab.js
@@ -46,13 +46,17 @@ export const ErrataTab = () => {
   const [ALL, INSTALLABLE] = toggleGroupStates;
   const ERRATA_TYPE = __('Type');
   const ERRATA_SEVERITY = __('Severity');
-  const [toggleGroupState, setToggleGroupState] = useState(INSTALLABLE);
-
   const [isBulkActionOpen, setIsBulkActionOpen] = useState(false);
   const toggleBulkAction = () => setIsBulkActionOpen(prev => !prev);
   const expandedErrata = useSet([]);
   const erratumIsExpanded = id => expandedErrata.has(id);
-  const { type: initialType, severity: initialSeverity, searchParam } = useUrlParams();
+  const {
+    type: initialType,
+    severity: initialSeverity,
+    show,
+    searchParam,
+  } = useUrlParams();
+  const [toggleGroupState, setToggleGroupState] = useState(show ?? INSTALLABLE);
   const [errataTypeSelected, setErrataTypeSelected]
     = useState(PARAM_TO_FRIENDLY_NAME[initialType] ?? ERRATA_TYPE);
   const [errataSeveritySelected, setErrataSeveritySelected]

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab.js
@@ -8,6 +8,7 @@ import { selectAPIResponse } from 'foremanReact/redux/API/APISelectors';
 import { urlBuilder } from 'foremanReact/common/urlHelpers';
 import SelectableDropdown from '../../../SelectableDropdown';
 import TableWrapper from '../../../../components/Table/TableWrapper';
+import { useUrlParams } from '../../../../components/Table/TableHooks';
 import { PackagesStatus, PackagesLatestVersion } from '../../../../components/Packages';
 import { getInstalledPackagesWithLatest } from '../HostPackages/HostPackagesActions';
 import { selectHostPackagesStatus } from '../HostPackages/HostPackagesSelectors';
@@ -19,7 +20,8 @@ export const PackagesTab = () => {
   const { id: hostId } = hostDetails;
   const actionButtons = <Button isDisabled> {__('Upgrade')} </Button>;
 
-  const [searchQuery, updateSearchQuery] = useState('');
+  const { searchParam } = useUrlParams();
+  const [searchQuery, updateSearchQuery] = useState(searchParam || '');
   const PACKAGE_STATUS = __('Status');
   const [packageStatusSelected, setPackageStatusSelected] = useState(PACKAGE_STATUS);
   const activeFilters = [packageStatusSelected];

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab.js
@@ -14,6 +14,7 @@ import { getInstalledPackagesWithLatest } from '../HostPackages/HostPackagesActi
 import { selectHostPackagesStatus } from '../HostPackages/HostPackagesSelectors';
 import { HOST_PACKAGES_KEY, PACKAGES_VERSION_STATUSES, VERSION_STATUSES_TO_PARAM } from '../HostPackages/HostPackagesConstants';
 import './PackagesTab.scss';
+import hostIdNotReady from '../HostDetailsActions';
 
 export const PackagesTab = () => {
   const hostDetails = useSelector(state => selectAPIResponse(state, 'HOST_DETAILS'));
@@ -40,7 +41,7 @@ export const PackagesTab = () => {
 
   const fetchItems = useCallback(
     (params) => {
-      if (!hostId) return null;
+      if (!hostId) return hostIdNotReady;
       const modifiedParams = { ...params };
       if (packageStatusSelected !== PACKAGE_STATUS) {
         modifiedParams.status = VERSION_STATUSES_TO_PARAM[packageStatusSelected];

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -20,7 +20,7 @@ import TableWrapper from '../../../../../components/Table/TableWrapper';
 import { enableRepoSetRepo, disableRepoSetRepo, resetRepoSetRepo, getHostRepositorySets } from './RepositorySetsActions';
 import { selectRepositorySetsStatus } from './RepositorySetsSelectors';
 import { selectHostDetailsStatus } from '../../HostDetailsSelectors.js';
-import { useBulkSelect } from '../../../../../components/Table/TableHooks';
+import { useBulkSelect, useUrlParams } from '../../../../../components/Table/TableHooks';
 import { REPOSITORY_SETS_KEY } from './RepositorySetsConstants.js';
 import './RepositorySetsTab.scss';
 
@@ -78,11 +78,12 @@ const RepositorySetsTab = () => {
     lifecycleEnvironmentLibrary === false;
   const simpleContentAccess = (Number(subscriptionStatus) === 5);
   const dispatch = useDispatch();
+  const { searchParam, show } = useUrlParams();
   const toggleGroupStates = ['noLimit', 'limitToEnvironment'];
   const [noLimit, limitToEnvironment] = toggleGroupStates;
   const defaultToggleGroupState = nonLibraryHost ? limitToEnvironment : noLimit;
   const [toggleGroupState, setToggleGroupState] =
-    useState(defaultToggleGroupState);
+    useState(show ?? defaultToggleGroupState);
   const [alertShowing, setAlertShowing] = useState(false);
   const emptyContentTitle = __('No repository sets to show.');
   const emptyContentBody = __('Repository sets will appear here when available.');
@@ -115,6 +116,7 @@ const RepositorySetsTab = () => {
     results,
     metadata,
     isSelectable: () => false,
+    initialSearchQuery: searchParam || '',
   });
 
   const hostDetailsStatus = useSelector(state => selectHostDetailsStatus(state));

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -23,6 +23,7 @@ import { selectHostDetailsStatus } from '../../HostDetailsSelectors.js';
 import { useBulkSelect, useUrlParams } from '../../../../../components/Table/TableHooks';
 import { REPOSITORY_SETS_KEY } from './RepositorySetsConstants.js';
 import './RepositorySetsTab.scss';
+import hostIdNotReady from '../../HostDetailsActions';
 
 const getEnabledValue = ({ enabled, enabledContentOverride }) => {
   const isOverridden = (enabledContentOverride !== null);
@@ -102,7 +103,7 @@ const RepositorySetsTab = () => {
         content_access_mode_all: simpleContentAccess,
         host_id: hostId,
         ...params,
-      }) : null),
+      }) : hostIdNotReady),
     [hostId, toggleGroupState, limitToEnvironment, simpleContentAccess],
   );
 

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab.js
@@ -15,6 +15,7 @@ import { resolveTraces } from './RemoteExecutionActions';
 import { selectHostTracesStatus } from './HostTracesSelectors';
 import { resolveTraceUrl } from './customizedRexUrlHelpers';
 import './TracesTab.scss';
+import hostIdNotReady from '../HostDetailsActions';
 
 const TracesTab = () => {
   const hostDetails = useSelector(state => selectAPIResponse(state, 'HOST_DETAILS'));
@@ -31,7 +32,7 @@ const TracesTab = () => {
   const emptySearchBody = __('Try changing your search settings.');
   const fetchItems = useCallback(
     params =>
-      (hostId ? getHostTraces(hostId, params) : null),
+      (hostId ? getHostTraces(hostId, params) : hostIdNotReady),
     [hostId],
   );
   const { searchParam } = useUrlParams();

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab.js
@@ -9,7 +9,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { selectAPIResponse } from 'foremanReact/redux/API/APISelectors';
 import EnableTracerEmptyState from './EnableTracerEmptyState';
 import TableWrapper from '../../../Table/TableWrapper';
-import { useBulkSelect } from '../../../Table/TableHooks';
+import { useBulkSelect, useUrlParams } from '../../../Table/TableHooks';
 import { getHostTraces } from './HostTracesActions';
 import { resolveTraces } from './RemoteExecutionActions';
 import { selectHostTracesStatus } from './HostTracesSelectors';
@@ -34,6 +34,7 @@ const TracesTab = () => {
       (hostId ? getHostTraces(hostId, params) : null),
     [hostId],
   );
+  const { searchParam } = useUrlParams();
   const [isBulkActionOpen, setIsBulkActionOpen] = useState(false);
   const toggleBulkAction = () => setIsBulkActionOpen(prev => !prev);
   const response = useSelector(state => selectAPIResponse(state, 'HOST_TRACES'));
@@ -46,6 +47,7 @@ const TracesTab = () => {
     results,
     metadata: meta,
     isSelectable: result => !!result.restart_command,
+    initialSearchQuery: searchParam || '',
   });
 
 

--- a/webpack/utils/helpers.js
+++ b/webpack/utils/helpers.js
@@ -121,3 +121,5 @@ export default {
   getResponseErrorMsgs,
   apiError,
 };
+
+export const friendlySearchParam = searchParam => decodeURIComponent(searchParam.replace(/\+/g, ' '));


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When loading host detail tabs, take into account URL params.  So
```
#/Repository%20sets?search=name+~+empty&show=noLimit
```

will get your search input filled in with
```
name ~ empty
```
and your toggle group selected "Show all".

Capabilities added to the following tabs:
* Errata
* Repository sets
* Traces
* Packages

This is done through a new hook, `useUrlParams`, which can take the URL search params and transform them into a useful object.

* Also, added links to the Errata Overview card demonstrating usage.


#### Considerations taken when implementing this change?

* Interacting with the page won't change the URL. I wanted to avoid infinite loops and multiple sources of truth.
* I realized that switching tabs clears out the URL params, so we got that for free.

#### What are the testing steps for this pull request?

Try the following URLs and variations of them (note you may have to refresh the page after entering each url):
* `#/Repository%20sets?search=name+~+empty&show=noLimit` <-- Do this with a non-library host. Note that it will select 'No limit' in the toggle group
* `#/Traces?search=app_type+=+session`
* `#/Content/errata?severity=none` <-- note "none" and not "N/A". Also note that this selects N/A in the dropdown.
* `#/Content/errata?search=issued++%3C++%22Dec+09,2021%22` <-- note that the URL params are transformed into friendly text
* `#/Content/errata?type=security&search=issued++<++"Dec+09,2021"` <-- note multiple params (type & search)
* `#/Content/packages?search=acl`
