### PR TITLE
Fixes #34182 - fix error message when import attribute is missing

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -667,7 +667,7 @@ module Katello
     def check_import_parameters
       @repository.repository_type&.import_attributes&.each do |import_attribute|
         if import_attribute.required && params[import_attribute.api_param].blank?
-          fail HttpErrors::UnprocessableEntity, _("%s is required", import_attributes.api_param)
+          fail HttpErrors::UnprocessableEntity, _('%s is required') % import_attribute.api_param
         end
       end
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Corrects error message when there are import attributes missing.

Otherwise you get the following error:

    undefined local variable or method `import_attributes' for #<Katello::Api::V2::RepositoriesController:0x000055ecb351d600>
    Did you mean?  import_attribute

Or, fixing that:

    wrong number of arguments (given 2, expected 1)

Instead of e.g. "ostree_repository_name is required"

#### Considerations taken when implementing this change?

None, I just want the error to be correct ;-)

#### What are the testing steps for this pull request?

Trigger `import_uploads` for an OSTree content w/o setting `ostree_repository_name`