### PR TITLE
Fixes #34183  -  Add generic content pages to CVV details

### DIFF
--- a/lib/katello/repository_types/ostree.rb
+++ b/lib/katello/repository_types/ostree.rb
@@ -27,6 +27,7 @@ Katello::RepositoryTypeManager.register('ostree') do
                        model_name: lambda { |pulp_unit| pulp_unit["name"] },
                        model_version: lambda { |pulp_unit| pulp_unit["checksum"] },
                        uploadable: true,
+                       generic_browser: true,
                        repository_import_on_upload: true
 
   import_attribute :ref, :content_type => 'ostree_ref',

--- a/webpack/scenes/Content/ContentConfig.js
+++ b/webpack/scenes/Content/ContentConfig.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { urlBuilder } from 'foremanReact/common/urlHelpers';
 import { translate as __ } from 'foremanReact/common/I18n';
 import ContentInfo from './Details/ContentInfo';
@@ -7,7 +6,8 @@ import LastSync from '../ContentViews/Details/Repositories/LastSync';
 import ContentRepositories from './Details/ContentRepositories';
 import ContentCounts from '../ContentViews/Details/Repositories/ContentCounts';
 
-export default () => [
+// Keep in mind when editing this file that the ContentViewVersionDetailConfig consumes this array.
+export default [
   {
     names: {
       pluralTitle: __('Python Packages'),
@@ -18,7 +18,7 @@ export default () => [
       singularLabel: 'python_package',
     },
     columnHeaders: [
-      { title: __('Name'), getProperty: unit => (<Link to={urlBuilder(`content/python_packages/${unit?.id}`, '')}>{unit?.name}</Link>) },
+      { title: __('Name'), getProperty: unit => (<a href={urlBuilder(`content/python_packages/${unit?.id}`, '')}>{unit?.name}</a>) },
       { title: __('Version'), getProperty: unit => unit?.version },
       { title: __('Filename'), getProperty: unit => unit?.filename },
     ],
@@ -82,6 +82,57 @@ export default () => [
       pluralLabel: 'ostree_refs',
       singularLabel: 'ostree_ref',
     },
+    columnHeaders: [
+      { title: __('Name'), getProperty: unit => (<a href={urlBuilder(`content/ostree_refs/${unit?.id}`, '')}>{unit?.name}</a>) },
+      { title: __('Version'), getProperty: unit => unit?.version },
+    ],
+    tabs: [
+      {
+        tabKey: 'details',
+        title: __('Details'),
+        getContent: (contentType, id, tabKey) => <ContentInfo {...{ contentType, id, tabKey }} />,
+        columnHeaders: [
+          { title: __('Name'), getProperty: unit => unit?.name },
+          { title: __('Version'), getProperty: unit => unit?.version },
+        ],
+      },
+      {
+        tabKey: 'repositories',
+        title: __('Repositories'),
+        getContent: (contentType, id, tabKey) =>
+          <ContentRepositories {...{ contentType, id, tabKey }} />,
+        columnHeaders: [
+          {
+            title: __('Name'),
+            getProperty: unit =>
+              <a href={urlBuilder(`products/${unit?.product.id}/repositories/${unit?.id}`, '')}>{unit?.name}</a>,
+          },
+          {
+            title: __('Product'),
+            getProperty: unit =>
+              <a href={urlBuilder(`products/${unit?.product.id}`, '')}>{unit?.product.name}</a>,
+          },
+          {
+            title: __('Sync Status'),
+            getProperty: unit =>
+              (<LastSync
+                startedAt={unit?.started_at}
+                lastSyncWords={unit?.last_sync_words}
+                lastSync={unit?.last_sync}
+              />),
+          },
+          {
+            title: __('Content Count'),
+            getProperty: unit =>
+              (<ContentCounts
+                productId={unit.product.id}
+                repoId={unit.id}
+                counts={unit.content_counts}
+              />),
+          },
+        ],
+      },
+    ],
   },
   {
     names: {
@@ -93,11 +144,10 @@ export default () => [
       singularLabel: 'ansible_collection',
     },
     columnHeaders: [
-      { title: __('Name'), getProperty: unit => (<Link to={urlBuilder(`content/ansible_collections/${unit?.id}`, '')}>{unit?.name}</Link>) },
+      { title: __('Name'), getProperty: unit => (<a href={urlBuilder(`content/ansible_collections/${unit?.id}`, '')}>{unit?.name}</a>) },
       { title: __('Author'), getProperty: unit => unit?.namespace },
       { title: __('Version'), getProperty: unit => unit?.version },
       { title: __('Checksum'), getProperty: unit => unit?.checksum },
-
     ],
     tabs: [
       {

--- a/webpack/scenes/Content/ContentPage.js
+++ b/webpack/scenes/Content/ContentPage.js
@@ -27,7 +27,7 @@ const ContentPage = () => {
       const types = {};
       contentTypesResponse.forEach((type) => {
         if (type.generic_browser) {
-          const typeConfig = ContentConfig().find(config =>
+          const typeConfig = ContentConfig.find(config =>
             config.names.singularLabel === type.label);
           if (typeConfig) {
             const { names } = typeConfig;

--- a/webpack/scenes/Content/Details/ContentDetails.js
+++ b/webpack/scenes/Content/Details/ContentDetails.js
@@ -16,7 +16,7 @@ const ContentDetails = () => {
 
   const { id, content_type: contentType } = useParams();
   const contentId = Number(id);
-  const config = ContentConfig().find(type =>
+  const config = ContentConfig.find(type =>
     type.names.pluralLabel === contentType);
   const { pluralTitle, pluralLabel } = config.names;
 

--- a/webpack/scenes/Content/Details/ContentInfo.js
+++ b/webpack/scenes/Content/Details/ContentInfo.js
@@ -19,7 +19,7 @@ const ContentInfo = ({ contentType, id, tabKey }) => {
   const detailsResponse = useSelector(selectContentDetails);
   const detailsStatus = useSelector(selectContentDetailsStatus);
 
-  const config = contentConfig().find(type => type.names.pluralLabel === contentType);
+  const config = contentConfig.find(type => type.names.pluralLabel === contentType);
   const { columnHeaders } = config.tabs.find(header => header.tabKey === tabKey);
 
   useEffect(() => {

--- a/webpack/scenes/Content/Details/ContentRepositories.js
+++ b/webpack/scenes/Content/Details/ContentRepositories.js
@@ -20,7 +20,7 @@ const ContentRepositories = ({ contentType, id, tabKey }) => {
   const [searchQuery, updateSearchQuery] = useState('');
   const { results, ...metadata } = response;
 
-  const config = contentConfig().find(type => type.names.pluralLabel === contentType);
+  const config = contentConfig.find(type => type.names.pluralLabel === contentType);
   const typeSingularLabel = config.names.singularLabel;
   const { columnHeaders } = config.tabs.find(header => header.tabKey === tabKey);
 

--- a/webpack/scenes/Content/Table/ContentTable.js
+++ b/webpack/scenes/Content/Table/ContentTable.js
@@ -18,7 +18,7 @@ const ContentTable = ({
   const [searchQuery, updateSearchQuery] = useState('');
   const { results, ...metadata } = response;
 
-  const { columnHeaders } = contentConfig().find(type =>
+  const { columnHeaders } = contentConfig.find(type =>
     type.names.singularLabel === contentTypes[selectedContentType][0]);
 
   return (

--- a/webpack/scenes/ContentViews/ContentViewsConstants.js
+++ b/webpack/scenes/ContentViews/ContentViewsConstants.js
@@ -1,4 +1,5 @@
 import { translate as __ } from 'foremanReact/common/I18n';
+import { toUpper } from 'lodash';
 
 const CONTENT_VIEWS_KEY = 'CONTENT_VIEWS';
 export const CREATE_CONTENT_VIEW_KEY = 'CONTENT_VIEW_CREATE';
@@ -22,11 +23,11 @@ export const RPM_PACKAGE_GROUPS_CONTENT = 'RPM_PACKAGE_GROUPS_CONTENT';
 export const REPOSITORY_CONTENT = 'REPOSITORY_CONTENT';
 export const ERRATA_CONTENT = 'ERRATA_CONTENT';
 export const DOCKER_TAGS_CONTENT = 'DOCKER_TAGS_CONTENT';
-export const ANSIBLE_COLLECTIONS_CONTENT = 'ANSIBLE_COLLECTIONS_CONTENT';
 export const MODULE_STREAMS_CONTENT = 'MODULE_STREAMS_CONTENT';
 export const DEB_PACKAGES_CONTENT = 'DEB_PACKAGES_CONTENT';
 export const RPM_PACKAGES_CONTENT = 'RPM_PACKAGES_CONTENT';
 export const FILE_CONTENT = 'FILE_CONTENT';
+export const generatedContentKey = pluralLabel => `${toUpper(pluralLabel)}_CONTENT`;
 export const cvDetailsKey = cvId => `${CONTENT_VIEWS_KEY}_${cvId}`;
 export const cvDetailsRepoKey = cvId => `${CONTENT_VIEWS_KEY}_REPOSITORIES_${cvId}`;
 export const cvFilterRepoKey = filterId => `CV_FILTER_REPOSITORIES_${filterId}`;

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
@@ -1,5 +1,6 @@
 import { API_OPERATIONS, APIActions, get, put, post } from 'foremanReact/redux/API';
 import { translate as __ } from 'foremanReact/common/I18n';
+import { lowerCase } from 'lodash';
 import {
   RPM_PACKAGES_CONTENT,
   RPM_PACKAGE_GROUPS_CONTENT,
@@ -44,8 +45,8 @@ import {
   ERRATA_CONTENT,
   MODULE_STREAMS_CONTENT,
   DEB_PACKAGES_CONTENT,
-  ANSIBLE_COLLECTIONS_CONTENT,
   DOCKER_TAGS_CONTENT,
+  generatedContentKey,
 } from '../ContentViewsConstants';
 import api, { foremanApi, orgId } from '../../../services/api';
 import { getResponseErrorMsgs } from '../../../utils/helpers';
@@ -57,6 +58,14 @@ const getContentViewDetails = (cvId, extraParams = {}) => get({
   key: cvDetailsKey(cvId),
   params: { organization_id: orgId(), include_permissions: true, ...extraParams },
   url: api.getApiUrl(`/content_views/${cvId}`),
+});
+
+export const getContent = (pluralLabel, params) => get({
+  type: API_OPERATIONS.GET,
+  key: generatedContentKey(pluralLabel),
+  url: api.getApiUrl(`/${pluralLabel}`),
+  params,
+  errorToast: error => __(`Something went wrong while fetching ${lowerCase(pluralLabel)}! ${getResponseErrorMsgs(error.response)}`),
 });
 
 export const getRPMPackages = params => get({
@@ -124,14 +133,6 @@ export const getDockerTags = params => get({
   url: api.getApiUrl('/docker_tags'),
   params,
   errorToast: error => __(`Something went wrong while getting docker tags! ${getResponseErrorMsgs(error.response)}`),
-});
-
-export const getAnsibleCollections = params => get({
-  type: API_OPERATIONS.GET,
-  key: ANSIBLE_COLLECTIONS_CONTENT,
-  url: api.getApiUrl('/ansible_collections'),
-  params,
-  errorToast: error => __(`Something went wrong while getting ansible collections! ${getResponseErrorMsgs(error.response)}`),
 });
 
 export const getErrata = params => get({

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
@@ -33,8 +33,8 @@ import {
   ERRATA_CONTENT,
   MODULE_STREAMS_CONTENT,
   DEB_PACKAGES_CONTENT,
-  ANSIBLE_COLLECTIONS_CONTENT,
   DOCKER_TAGS_CONTENT,
+  generatedContentKey,
 } from '../ContentViewsConstants';
 import { pollTaskKey } from '../../Tasks/helpers';
 
@@ -131,11 +131,11 @@ export const selectCVFilterRules = (state, filterId) =>
 export const selectCVFilterRulesStatus = (state, filterId) =>
   selectAPIStatus(state, cvFilterRulesKey(filterId)) || STATUS.PENDING;
 
-export const selectAnsibleCollections = state =>
-  selectAPIResponse(state, ANSIBLE_COLLECTIONS_CONTENT);
+export const selectContent = (pluralLabel, state) =>
+  selectAPIResponse(state, generatedContentKey(pluralLabel));
 
-export const selectAnsibleCollectionsStatus = state =>
-  selectAPIStatus(state, ANSIBLE_COLLECTIONS_CONTENT) || STATUS.PENDING;
+export const selectContentStatus = (pluralLabel, state) =>
+  selectAPIStatus(state, generatedContentKey(pluralLabel)) || STATUS.PENDING;
 
 export const selectDockerTags = state =>
   selectAPIResponse(state, DOCKER_TAGS_CONTENT);

--- a/webpack/scenes/ContentViews/Details/Repositories/ContentCounts.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/ContentCounts.js
@@ -41,7 +41,7 @@ const ContentCounts = ({ productId, repoId, counts }) => {
   Object.keys(counts).forEach((type) => {
     const count = counts[type];
     let info = repoLabels[type];
-    const config = ContentConfig().find(typeConfig =>
+    const config = ContentConfig.find(typeConfig =>
       typeConfig.names.singularLabel === type);
 
     if (config) {

--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
@@ -92,7 +92,7 @@ const ContentViewVersions = ({ cvId, details }) => {
       { title: <ContentViewVersionEnvironments {...{ environments }} /> },
       {
         title: Number(packageCount) ?
-          <a href={urlBuilder(`content_views/${cvId}#/versions/${versionId}/packages`, '')}>{packageCount}</a> :
+          <a href={urlBuilder(`content_views/${cvId}#/versions/${versionId}/rpmPackages`, '')}>{packageCount}</a> :
           <InactiveText text={__('No packages')} />,
       },
       { title: <ContentViewVersionErrata {...{ cvId, versionId, errataCounts }} /> },

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetails.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetails.js
@@ -3,7 +3,7 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 import { useParams, Route, useHistory, useLocation, Redirect, Switch } from 'react-router-dom';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { STATUS } from 'foremanReact/constants';
-import { isEmpty, camelCase, first } from 'lodash';
+import { isEmpty, first } from 'lodash';
 import { Grid, Tabs, Tab, TabTitleText, Label } from '@patternfly/react-core';
 import { number, shape } from 'prop-types';
 import './ContentViewVersionDetails.scss';
@@ -68,7 +68,7 @@ const ContentViewVersionDetails = ({ cvId, details }) => {
   const filteredTableConfigs = tableConfigs.filter(({ getCountKey }) => !!getCountKey(response));
   const { repositories } = versionDetails;
   const showTabs = filteredTableConfigs.length > 0 && repositories;
-  const getCurrentActiveKey = tab ?? camelCase(first(filteredTableConfigs)?.name);
+  const getCurrentActiveKey = tab ?? first(filteredTableConfigs)?.route;
 
   return (
     <Grid>
@@ -85,10 +85,10 @@ const ContentViewVersionDetails = ({ cvId, details }) => {
             onSelect={onSelect}
             isVertical
           >
-            {filteredTableConfigs.map(({ name, getCountKey }) => (
+            {filteredTableConfigs.map(({ route, name, getCountKey }) => (
               <Tab
-                key={name}
-                eventKey={camelCase(name)}
+                key={route}
+                eventKey={route}
                 title={
                   <>
                     <TabTitleText>{name}</TabTitleText>
@@ -101,9 +101,9 @@ const ContentViewVersionDetails = ({ cvId, details }) => {
           <Switch>
             {filteredTableConfigs.map(config => (
               <Route
-                key={camelCase(config.name)}
+                key={config.route}
                 exact
-                path={`/versions/:versionId([0-9]+)/${camelCase(config.name)}`}
+                path={`/versions/:versionId([0-9]+)/${config.route}`}
               >
                 <ContentViewVersionDetailsTable
                   tableConfig={config}
@@ -112,7 +112,7 @@ const ContentViewVersionDetails = ({ cvId, details }) => {
               </Route>))
             }
             <Redirect
-              to={`/versions/${versionId}/${camelCase(first(filteredTableConfigs).name)}`}
+              to={`/versions/${versionId}/${first(filteredTableConfigs).route}`}
             />
           </Switch>
         </div>

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionRepositoryCell.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionRepositoryCell.js
@@ -67,7 +67,7 @@ const ContentViewVersionRepositoryCell = ({
     },
   };
 
-  ContentConfig().forEach((type) => {
+  ContentConfig.forEach((type) => {
     CONTENT_COUNTS[type.names.singularLabel] = {
       name: type.names.pluralLowercase,
       url: `products/${id}/repositories/${libraryInstanceId}/content/${type.names.pluralLabel}`,

--- a/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersions.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersions.test.js
@@ -122,7 +122,7 @@ test('Can show package and erratas and link to list page', async () => {
 
   await patientlyWaitFor(() => {
     expect(getAllByText(8)[0].closest('a'))
-      .toHaveAttribute('href', '/content_views/5#/versions/11/packages/');
+      .toHaveAttribute('href', '/content_views/5#/versions/11/rpmPackages/');
     expect(getAllByText(15)[0].closest('a'))
       .toHaveAttribute('href', '/content_views/5#/versions/11/errata/');
     expect(getByText(5)).toBeInTheDocument();


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

- [x] Add new subtab on CVV page to support python & ostree
- [x] Make all generic content for the CVV page generated dynamically from the webpack/scenes/Content/ContentConfig.js

#### What are the testing steps for this pull request?
- View the new ostree page at content/ostree_refs
- View CVV page after publishing ostree/python content to a contentView to see those appear there.

<img width="271" alt="Screen Shot 2022-01-05 at 3 23 12 PM" src="https://user-images.githubusercontent.com/38083295/148298244-e437ecac-dc27-404a-9361-88a5399def6f.png">
<img width="1003" alt="Screen Shot 2022-01-05 at 3 23 31 PM" src="https://user-images.githubusercontent.com/38083295/148298290-d6df11d1-d52f-4422-bbff-8f69dfeeefa1.png">
<img width="688" alt="Screen Shot 2022-01-05 at 3 24 47 PM" src="https://user-images.githubusercontent.com/38083295/148298299-70d75ee4-9cc6-440f-b762-4b0e98f5bd3d.png">


#### Additional Changes: 
- Fixed a bug around translations that would make routing not work for contentViewVersionDetails.