### PR TITLE
Fixes #34186 - consume Pagination from core

### DIFF
--- a/webpack/__mocks__/foremanReact/components/Pagination/PaginationHooks.js
+++ b/webpack/__mocks__/foremanReact/components/Pagination/PaginationHooks.js
@@ -1,2 +1,0 @@
-// eslint-disable-next-line import/prefer-default-export
-export const usePaginationOptions = () => [5, 10, 20, 50];

--- a/webpack/__mocks__/foremanReact/components/Pagination/PaginationWrapper.js
+++ b/webpack/__mocks__/foremanReact/components/Pagination/PaginationWrapper.js
@@ -1,2 +1,0 @@
-const PaginationWrapper = () => jest.fn();
-export default PaginationWrapper;

--- a/webpack/components/Content/Details/__tests__/ContentDetailInfo.test.js
+++ b/webpack/components/Content/Details/__tests__/ContentDetailInfo.test.js
@@ -4,8 +4,6 @@ import toJson from 'enzyme-to-json';
 import { Table } from 'react-bootstrap';
 import ContentDetailInfo from '../ContentDetailInfo';
 
-jest.mock('foremanReact/components/Pagination/PaginationWrapper', () => (<div>Pagination Mock</div>));
-
 describe('Content Details Info', () => {
   it('should render and contain appropriate components', async () => {
     const displayMap = new Map([

--- a/webpack/components/Content/Details/__tests__/ContentDetailRepositories.test.js
+++ b/webpack/components/Content/Details/__tests__/ContentDetailRepositories.test.js
@@ -1,8 +1,6 @@
 import { testComponentSnapshotsWithFixtures } from 'react-redux-test-utils';
 import ContentDetailRepositories from '../ContentDetailRepositories';
 
-jest.mock('foremanReact/components/Pagination/PaginationWrapper');
-
 const fixtures = {
   'renders with repositories': {
     repositories: [

--- a/webpack/components/Content/Details/__tests__/ContentDetails.test.js
+++ b/webpack/components/Content/Details/__tests__/ContentDetails.test.js
@@ -6,8 +6,6 @@ import ContentDetailInfo from '../ContentDetailInfo';
 import ContentDetailRepositories from '../ContentDetailRepositories';
 import ContentDetails from '../ContentDetails';
 
-jest.mock('foremanReact/components/Pagination/PaginationWrapper', () => (<div>Pagination Mock</div>));
-
 describe('Content Details Info', () => {
   it('should render and contain appropriate components', async () => {
     const detail = {

--- a/webpack/components/Content/__tests__/ContentPage.test.js
+++ b/webpack/components/Content/__tests__/ContentPage.test.js
@@ -5,8 +5,6 @@ import ContentPage from '../ContentPage';
 import ContentTable from '../ContentTable';
 import Search from '../../../components/Search/index';
 
-jest.mock('foremanReact/components/Pagination/PaginationWrapper', () => (<div>Pagination Mock</div>));
-
 describe('Content page', () => {
   it('should render and contain appropriate components', async () => {
     const contentHeader = 'Content Header';

--- a/webpack/components/Content/__tests__/ContentTable.test.js
+++ b/webpack/components/Content/__tests__/ContentTable.test.js
@@ -5,8 +5,6 @@ import ContentTable from '../ContentTable';
 import { LoadingState } from '../../../components/LoadingState';
 import { Table } from '../../../components/pf3Table';
 
-jest.mock('foremanReact/components/Pagination/PaginationWrapper', () => (<div>Pagination Mock</div>));
-
 describe('Content Table', () => {
   it('should render and contain appropriate components', async () => {
     const content = {

--- a/webpack/components/Table/PageControls.js
+++ b/webpack/components/Table/PageControls.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Pagination, PaginationVariant, FlexItem } from '@patternfly/react-core';
-import { usePaginationOptions } from 'foremanReact/components/Pagination/PaginationHooks';
+import { FlexItem } from '@patternfly/react-core';
+import Pagination from 'foremanReact/components/Pagination';
 
 import { getPageStats } from './helpers';
 
@@ -18,10 +18,7 @@ const PageControls = ({
         itemsEnd={lastIndex}
         page={page}
         perPage={perPage}
-        isCompact={variant === PaginationVariant.top}
-        onSetPage={(_evt, updated) => onPaginationUpdate({ page: updated })}
-        onPerPageSelect={(_evt, updated) => onPaginationUpdate({ per_page: updated })}
-        perPageOptions={usePaginationOptions().map(p => ({ title: p.toString(), value: p }))}
+        onChange={onPaginationUpdate}
         variant={variant}
       />
     </FlexItem>

--- a/webpack/components/pf3Table/components/Table.js
+++ b/webpack/components/pf3Table/components/Table.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Table as PfTable } from 'patternfly-react';
 import { noop } from 'foremanReact/common/helpers';
 import EmptyState from 'foremanReact/components/common/EmptyState';
-import Pagination from 'foremanReact/components/Pagination/PaginationWrapper';
+import Pagination from 'foremanReact/components/Pagination';
 
 import TableBody from './TableBody';
 
@@ -43,10 +43,9 @@ const Table = ({
       </PfTable.PfProvider>
       {shouldRenderPagination && (
         <Pagination
-          viewType="table"
           itemCount={itemCount}
-          pagination={pagination}
           onChange={onPaginationChange}
+          {...pagination}
         />
       )}
     </div>

--- a/webpack/components/pf3Table/components/Table.test.js
+++ b/webpack/components/pf3Table/components/Table.test.js
@@ -1,9 +1,6 @@
 import { testComponentSnapshotsWithFixtures } from 'react-redux-test-utils';
-
 import Table from './Table';
 import { columnsFixtures, rowsFixtures } from './TableFixtures';
-
-jest.mock('foremanReact/components/Pagination/PaginationWrapper');
 
 const fixtures = {
   'renders Table with emptyState': {

--- a/webpack/components/pf3Table/components/__snapshots__/Table.test.js.snap
+++ b/webpack/components/pf3Table/components/__snapshots__/Table.test.js.snap
@@ -137,16 +137,17 @@ exports[`Table renders Table with pagination 1`] = `
   >
     some children
   </TablePfProvider>
-  <PaginationWrapper
+  <Pagination
+    className={null}
     itemCount={2}
+    noSidePadding={false}
     onChange={[Function]}
-    pagination={
-      Object {
-        "page": 1,
-        "perPage": 20,
-      }
-    }
-    viewType="table"
+    onPerPageSelect={null}
+    onSetPage={null}
+    page={1}
+    perPage={20}
+    updateParamsByUrl={true}
+    variant="bottom"
   />
 </div>
 `;

--- a/webpack/scenes/AnsibleCollections/Details/__tests__/AnsibleCollectionDetails.test.js
+++ b/webpack/scenes/AnsibleCollections/Details/__tests__/AnsibleCollectionDetails.test.js
@@ -2,8 +2,6 @@ import { testComponentSnapshotsWithFixtures } from 'react-redux-test-utils';
 import AnsibleCollectionDetails from '../AnsibleCollectionDetails';
 import { details, loadingState } from './AnsibleCollectionDetails.fixtures';
 
-jest.mock('foremanReact/components/Pagination/PaginationWrapper');
-
 const mockFunc = jest.fn();
 
 const baseProps = {

--- a/webpack/scenes/AnsibleCollections/__tests__/AnsibleCollectionPage.test.js
+++ b/webpack/scenes/AnsibleCollections/__tests__/AnsibleCollectionPage.test.js
@@ -4,8 +4,6 @@ import toJson from 'enzyme-to-json';
 import AnsibleCollectionsPage from '../AnsibleCollectionsPage';
 import ContentPage from '../../../components/Content/ContentPage';
 
-jest.mock('foremanReact/components/Pagination/PaginationWrapper', () => (<div>Pagination Mock</div>));
-
 describe('Ansible Collections page', () => {
   it('should render and contain appropiate components', async () => {
     const ansibleCollections = {};

--- a/webpack/scenes/AnsibleCollections/__tests__/AnsibleCollectionsTable.test.js
+++ b/webpack/scenes/AnsibleCollections/__tests__/AnsibleCollectionsTable.test.js
@@ -5,8 +5,6 @@ import ContentTable from '../../../components/Content/ContentTable';
 import TableSchema from '../../AnsibleCollections/AnsibleCollectionsTableSchema';
 import { Table } from '../../../components/pf3Table';
 
-jest.mock('foremanReact/components/Pagination/PaginationWrapper', () => (<div>Pagination Mock</div>));
-
 describe('Ansible Collections table', () => {
   it('should render and contain appropiate components', async () => {
     const ansibleCollections = {

--- a/webpack/scenes/ModuleStreams/Details/Profiles/__tests__/ModuleStreamDetailProfiles.test.js
+++ b/webpack/scenes/ModuleStreams/Details/Profiles/__tests__/ModuleStreamDetailProfiles.test.js
@@ -2,7 +2,6 @@ import { testComponentSnapshotsWithFixtures } from 'react-redux-test-utils';
 import ModuleStreamDetailProfiles from '../ModuleStreamDetailProfiles';
 import { details } from '../../__tests__/moduleStreamDetails.fixtures';
 
-jest.mock('foremanReact/components/Pagination/PaginationWrapper');
 
 const fixtures = {
   'renders with profiles': {

--- a/webpack/scenes/ModuleStreams/Details/__tests__/ModuleStreamDetails.test.js
+++ b/webpack/scenes/ModuleStreams/Details/__tests__/ModuleStreamDetails.test.js
@@ -2,8 +2,6 @@ import { testComponentSnapshotsWithFixtures } from 'react-redux-test-utils';
 import ModuleStreamDetails from '../ModuleStreamDetails';
 import { details, loadingState } from './moduleStreamDetails.fixtures';
 
-jest.mock('foremanReact/components/Pagination/PaginationWrapper');
-
 const mockFunc = jest.fn();
 
 const baseProps = {

--- a/webpack/scenes/ModuleStreams/__tests__/ModuleStreamPage.test.js
+++ b/webpack/scenes/ModuleStreams/__tests__/ModuleStreamPage.test.js
@@ -4,8 +4,6 @@ import toJson from 'enzyme-to-json';
 import ModuleStreamsPage from '../ModuleStreamsPage';
 import ContentPage from '../../../components/Content/ContentPage';
 
-jest.mock('foremanReact/components/Pagination/PaginationWrapper', () => (<div>Pagination Mock</div>));
-
 describe('Module streams page', () => {
   it('should render and contain appropiate components', async () => {
     const moduleStreams = {};

--- a/webpack/scenes/ModuleStreams/__tests__/ModuleStreamsTable.test.js
+++ b/webpack/scenes/ModuleStreams/__tests__/ModuleStreamsTable.test.js
@@ -5,8 +5,6 @@ import ContentTable from '../../../components/Content/ContentTable';
 import TableSchema from '../../ModuleStreams/ModuleStreamsTableSchema';
 import { Table } from '../../../components/pf3Table';
 
-jest.mock('foremanReact/components/Pagination/PaginationWrapper', () => (<div>Pagination Mock</div>));
-
 describe('Module streams table', () => {
   it('should render and contain appropiate components', async () => {
     const moduleStreams = {

--- a/webpack/scenes/RedHatRepositories/__tests__/__snapshots__/RedHatRepositoriesPage.test.js.snap
+++ b/webpack/scenes/RedHatRepositories/__tests__/__snapshots__/RedHatRepositoriesPage.test.js.snap
@@ -112,9 +112,18 @@ exports[`RedHatRepositories page should render 1`] = `
           <div
             className="sticky-pagination sticky-pagination-grey"
           >
-            <PaginationWrapper
+            <Pagination
+              className={null}
+              isCompact={true}
+              itemCount={0}
+              noSidePadding={false}
               onChange={[Function]}
-              viewType="list"
+              onPerPageSelect={null}
+              onSetPage={null}
+              page={1}
+              perPage={null}
+              updateParamsByUrl={true}
+              variant="bottom"
             />
           </div>
         </ListView>

--- a/webpack/scenes/RedHatRepositories/helpers.js
+++ b/webpack/scenes/RedHatRepositories/helpers.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ListView } from 'patternfly-react';
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
-import Pagination from 'foremanReact/components/Pagination/PaginationWrapper';
+import Pagination from 'foremanReact/components/Pagination';
 
 import RepositorySet from './components/RepositorySet';
 import EnabledRepository from './components/EnabledRepository';
@@ -34,10 +34,10 @@ export const getSetsComponent = (repoSetsState, onPaginationChange) => {
     <ListView>
       <div className="sticky-pagination">
         <Pagination
-          viewType="list"
           itemCount={itemCount}
-          pagination={pagination}
           onChange={onPaginationChange}
+          isCompact
+          {...pagination}
         />
       </div>
       {results.map(set => <RepositorySet id={set.id} key={set.id} {...set} />)}
@@ -64,10 +64,10 @@ export const getEnabledComponent = (enabledReposState, onPaginationChange) => {
     <ListView>
       <div className="sticky-pagination sticky-pagination-grey">
         <Pagination
-          viewType="list"
+          isCompact
           itemCount={itemCount}
-          pagination={pagination}
           onChange={onPaginationChange}
+          {...pagination}
         />
       </div>
       {repositories.map(repo => <EnabledRepository key={repo.id} {...repo} />)}

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/UpstreamSubscriptionsPage.test.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/UpstreamSubscriptionsPage.test.js
@@ -6,7 +6,6 @@ import { successState } from './upstreamSubscriptions.fixtures';
 import { loadUpstreamSubscriptions, saveUpstreamSubscriptions } from '../UpstreamSubscriptionsActions';
 
 jest.mock('foremanReact/components/BreadcrumbBar');
-jest.mock('foremanReact/components/Pagination/PaginationWrapper');
 
 describe('upstream subscriptions page', () => {
   let shallowWrapper;

--- a/webpack/scenes/Subscriptions/__tests__/SubscriptionsPage.test.js
+++ b/webpack/scenes/Subscriptions/__tests__/SubscriptionsPage.test.js
@@ -9,7 +9,6 @@ import { checkSimpleContentAccessEligible } from '../Manifest/ManifestActions';
 import { createColumns, updateColumns } from '../../../scenes/Settings/Tables/TableActions';
 
 jest.mock('foremanReact/components/PermissionDenied');
-jest.mock('foremanReact/components/Pagination/PaginationWrapper', () => (<div>Pagination Mock</div>));
 jest.mock('foremanReact/components/ForemanModal', () => (<div>ForemanModal Mock</div>));
 
 const loadTables = () => new Promise((resolve) => {

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTable.test.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTable.test.js
@@ -8,6 +8,10 @@ import { successState, loadingState, emptyState, groupedSubscriptions } from '..
 import { loadSubscriptions, updateQuantity } from '../../../SubscriptionActions';
 
 jest.useFakeTimers();
+jest.mock('foremanReact/components/Pagination', () => ({
+  __esModule: true,
+  default: () => <div>MockPagination</div>,
+}));
 
 const tableColumns = [
   'id',

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
@@ -141,6 +141,9 @@ exports[`subscriptions table should disable checkboxes for custom subscriptions 
       </tr>
     </tbody>
   </table>
+  <div>
+    MockPagination
+  </div>
 </div>
 `;
 
@@ -306,6 +309,9 @@ exports[`subscriptions table should render a table 1`] = `
       </tr>
     </tbody>
   </table>
+  <div>
+    MockPagination
+  </div>
 </div>
 `;
 
@@ -405,5 +411,8 @@ exports[`subscriptions table should render subscription name without hyperlink f
       </tr>
     </tbody>
   </table>
+  <div>
+    MockPagination
+  </div>
 </div>
 `;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Refactor to use the PF4 pagination from core
#### Considerations taken when implementing this change?
Should be tested with https://github.com/theforeman/foreman/pull/8990
#### What are the testing steps for this pull request?
Checkout the PR branch from core and see if the pagination still works as expected and in some pages, the PF3 pagination should be replaced with the new implementation