### PR TITLE
Fixes #34184 - Add content_view_version filter to generic content units

### DIFF
--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -130,6 +130,9 @@ module Katello
       end
 
       def filter_by_content_view_version(version, collection)
+        if params[:content_type]
+          return collection.where(:id => version.send(controller_name, params[:content_type]))
+        end
         collection.where(:id => version.send(controller_name))
       end
 

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -239,6 +239,10 @@ module Katello
       Rpm.in_repositories(archived_repos)
     end
 
+    def generic_content_units(content_type)
+      GenericContentUnit.in_repositories(archived_repos).where(content_type: content_type)
+    end
+
     def library_packages
       Rpm.in_repositories(library_repos)
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds cv version filtering to generic content unit endpoints
#### Considerations taken when implementing this change?
#### What are the testing steps for this pull request?
Add a python repo to a cv and publish
Grab the cv version id : cv_version_id
Go to endpoint /katello/api/v2/python_packages?content_view_version_id=cv_version_id
