### PR TITLE
Fixes #34187 - OSTree repository update error

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -648,7 +648,8 @@ module Katello
 
     def generic_remote_options_hash(repo_params)
       generic_remote_options = {}
-      RepositoryTypeManager.generic_remote_options(content_type: repo_params[:content_type]).each do |option|
+      content_type = @repository&.content_type || repo_params[:content_type]
+      RepositoryTypeManager.generic_remote_options(content_type: content_type).each do |option|
         generic_remote_options[option.name] = repo_params[option.name]
       end
       generic_remote_options


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fixes update bug for ostree repositories or any generic repository that's not python.
#### Considerations taken when implementing this change?
The generic remote options are supposed to be filtered by content type, but in the case of update "content_type" is not a parameter. The code has been updated to get the content type from either the repository object _or_ the params.

This should normally get a test, but since https://github.com/Katello/katello/pull/9867 is enabling OSTree tests, we may want to leave that out of this.
#### What are the testing steps for this pull request?
1. Trying creating/updating an OSTree repository and upstream URL, see there's no error.
2. Try it for Python too just to be sure that's still working.