### PR TITLE
Fixes #34209 - unset sync_policy for repository mirrors

### DIFF
--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -128,6 +128,7 @@ module Katello
         sync_params = repo_service.sync_url_params(options)
         sync_params[:remote] = remote_href
         sync_params[:mirror] = true
+        sync_params.delete(:sync_policy)
         repository_sync_url_data = api.repository_sync_url_class.new(sync_params)
         [api.repositories_api.sync(repository_href, repository_sync_url_data)]
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

pulp_rpm has deprecated the `mirror` parameter in favor of `sync_policy=mirror_complete`, but the other Pulpcore plugins don't yet support `sync_policy`.

When setting both, pulp_rpm raises an error:

    Cannot use 'mirror' and 'sync_policy' options simultaneously. The 'mirror' option is deprecated, please use 'sync_policy' only.

But replacing mirror with sync_policy globally raises:

    Error: `sync_policy` is not a valid attribute in `PulpContainerClient::RepositorySyncURL`. Please check the name to make sure it's valid. List of attributes: [:remote, :mirror]

As `mirror` is still supported by all plugins, let's keep that and just drop the `sync_policy` for now.

#### Considerations taken when implementing this change?

The alternative would be to set `sync_policy=mirror_complete` for YUM repositories, and keep `mirror=true` only for all the others, but that has no behavioral difference whatsoever, and I like simple code.

#### What are the testing steps for this pull request?

Create a Katello and a content proxy, create YUM and Container repos, try to sync these to the proxy.