### PR TITLE
Fixes #34208 - include mirroring_policy in export metadata

### DIFF
--- a/app/services/katello/pulp3/content_view_version/metadata_generator.rb
+++ b/app/services/katello/pulp3/content_view_version/metadata_generator.rb
@@ -43,7 +43,7 @@ module Katello
 
         def generate_repository_metadata(repo)
           repo.slice(:name, :label, :description, :arch, :content_type, :unprotected,
-                     :checksum_type, :os_versions, :major, :minor).
+                     :checksum_type, :os_versions, :major, :minor, :mirroring_policy).
             merge(product: generate_product_metadata(repo.product),
                   gpg_key: generate_gpg_metadata(repo.gpg_key),
                   content: generate_content_metadata(repo.content),


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Include mirroring_policy in export metadata.

Without it, import doesn't work as you can't create a repository without a mirroring_policy:

    Validation failed: Mirroring policy Invalid mirroring policy for repository type yum, only additive, mirror_complete, mirror_content_only are valid.

#### Considerations taken when implementing this change?

This means that imports of *older* versions of Katello (without this patch) still won't work, but I am not sure we define the exports as a "stable API" at all or require users to be on the same version across the board.

#### What are the testing steps for this pull request?

perform a full export/import cycle, it should succeed.