### PR TITLE
Fixes #34208 - handle missing mirroring policy on import

### DIFF
--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -136,6 +136,8 @@ module Katello
           repo_param[:download_policy] = Setting[:default_download_policy]
         end
 
+        repo_param[:mirroring_policy] = Katello::RootRepository::MIRRORING_POLICY_ADDITIVE if repo_param[:mirroring_policy].blank?
+
         RootRepository.new(repo_param.merge(:product_id => self.id))
       end
     end

--- a/app/services/katello/pulp3/content_view_version/metadata_generator.rb
+++ b/app/services/katello/pulp3/content_view_version/metadata_generator.rb
@@ -43,7 +43,7 @@ module Katello
 
         def generate_repository_metadata(repo)
           repo.slice(:name, :label, :description, :arch, :content_type, :unprotected,
-                     :checksum_type, :os_versions, :major, :minor).
+                     :checksum_type, :os_versions, :major, :minor, :download_policy, :mirroring_policy).
             merge(product: generate_product_metadata(repo.product),
                   gpg_key: generate_gpg_metadata(repo.gpg_key),
                   content: generate_content_metadata(repo.content),


### PR DESCRIPTION
and also export mirroring policy and download policy

#### What are the changes introduced in this pull request?
Add mirroring_policy and download_policy to exports.
If mirroring_policy is not provided, default to a sane value

#### Considerations taken when implementing this change?
This provides backwards compatibility with exports generated prior to https://github.com/Katello/katello/pull/9834

#### What are the testing steps for this pull request?
Import/export an RH repo and a custom repo