### PR TITLE
Align on pulp_content_url

### DIFF
--- a/app/helpers/katello/katello_urls_helper.rb
+++ b/app/helpers/katello/katello_urls_helper.rb
@@ -45,18 +45,16 @@ module Katello
     end
     def repository_url(content_path, _content_type = nil, schema = 'http')
       return content_path if content_path =~ %r|^([\w\-\+]+)://|
-      url = if @host.content_source
-              "#{schema}://#{@host.content_source.hostname}"
-            else
-              foreman_settings_url(schema)
-            end
+
+      url = @host.content_source.pulp_content_url
+      url.schema = schema
       content_path = content_path.sub(%r|^/|, '')
       if @host.content_view && !@host.content_view.default?
         content_path = [@host.content_view.label, content_path].join('/')
       end
       path = ::Katello::Glue::Pulp::Repos.repo_path_from_content_path(
         @host.lifecycle_environment, content_path)
-      "#{url}/pulp/content/#{path}"
+      "#{url}/#{path}"
     end
   end
 end

--- a/app/services/katello/pulp/repository/yum.rb
+++ b/app/services/katello/pulp/repository/yum.rb
@@ -24,6 +24,7 @@ module Katello
         end
 
         def partial_repo_path
+          # TODO: get /pulp/content from pulp_content_url
           "/pulp/content/#{repo.relative_path}/".sub('//', '/')
         end
 

--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -92,6 +92,7 @@ module Katello
         end
 
         def partial_repo_path
+          # TODO: get /pulp/content from pulp_content_url
           "/pulp/content/#{repo.relative_path}/".sub('//', '/')
         end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The Pulp content URLs should always respect what's exposed in the pulp_content_url setting. This includes the /pulp/content part.

It does highlight a missing setting for pulp_ansible content. Again, Katello should not have to guess URLs but discover it from the infrastructure.

#### Considerations taken when implementing this change?

It was extracted from https://github.com/Katello/katello/pull/9413, but it's probably incomplete. Consider it a start of a discussion.

#### What are the testing steps for this pull request?

There should be no changes for the user in default setup. If the user does change the content URL, it should be properly reflected.