### PR TITLE
Fixes #34127 - Pulp 2 dep solving is wrong with cross-repo deps

### DIFF
--- a/app/lib/actions/katello/repository/clone_to_version.rb
+++ b/app/lib/actions/katello/repository/clone_to_version.rb
@@ -5,6 +5,8 @@ module Actions
         def plan(repositories, content_view_version, destination_repository, options = {})
           incremental = options.fetch(:incremental, false)
           content_view = content_view_version.content_view
+          solve_dependencies = options.fetch(:solve_dependencies, content_view.solve_dependencies)
+          pulp_copy_only = options.fetch(:pulp_copy_only, false)
           filters = incremental ? [] : content_view.filters.applicable(repositories.first)
           rpm_filenames = extract_rpm_filenames(options.fetch(:repos_units, nil), repositories.first.label)
           fail _('Cannot publish a composite with rpm filenames') if content_view.composite? && rpm_filenames&.any?
@@ -22,8 +24,9 @@ module Actions
                         filters: filters,
                         rpm_filenames: rpm_filenames,
                         copy_contents: copy_contents,
-                        solve_dependencies: content_view.solve_dependencies,
-                        metadata_generate: !incremental)
+                        solve_dependencies: solve_dependencies,
+                        metadata_generate: !incremental,
+                        pulp_copy_only: pulp_copy_only)
           end
         end
 

--- a/test/actions/katello/repository/clone_to_version_test.rb
+++ b/test/actions/katello/repository/clone_to_version_test.rb
@@ -30,7 +30,7 @@ module Actions
       assert_action_planed_with(action, Actions::Katello::Repository::CloneContents, [yum_repo], cloned_repo,
                                 :purge_empty_contents => true, :filters => [], :rpm_filenames => nil,
                                 :copy_contents => true, :metadata_generate => true,
-                                :solve_dependencies => false)
+                                :solve_dependencies => false, :pulp_copy_only => false)
     end
 
     it 'plans to clone yum units with dependency solving' do
@@ -41,12 +41,12 @@ module Actions
 
       cloned_repo.root = yum_repo.root
 
-      plan_action(action, [yum_repo], version_solve_deps, cloned_repo, {})
+      plan_action(action, [yum_repo], version_solve_deps, cloned_repo, {:pulp_copy_only => true})
 
       assert_action_planed_with(action, Actions::Katello::Repository::CloneContents, [yum_repo], cloned_repo,
                                 :purge_empty_contents => true, :filters => [], :rpm_filenames => nil,
                                 :copy_contents => true, :metadata_generate => true,
-                                :solve_dependencies => true)
+                                :solve_dependencies => true, :pulp_copy_only => true)
     end
 
     it 'plans to clone yum metadata' do
@@ -61,7 +61,7 @@ module Actions
       assert_action_planed_with(action, Actions::Katello::Repository::CloneContents, [yum_repo], cloned_repo,
                                 :purge_empty_contents => true, :filters => [], :rpm_filenames => nil,
                                 :copy_contents => true, :metadata_generate => true,
-                                :solve_dependencies => false)
+                                :solve_dependencies => false, :pulp_copy_only => false)
     end
 
     it 'plans to clone docker units' do
@@ -76,7 +76,7 @@ module Actions
       assert_action_planed_with(action, Actions::Katello::Repository::CloneContents, [docker_repo], cloned_repo,
                                 :purge_empty_contents => true, :filters => [], :rpm_filenames => nil,
                                 :copy_contents => true, :metadata_generate => true,
-                                :solve_dependencies => false)
+                                :solve_dependencies => false, :pulp_copy_only => false)
     end
 
     it 'plans to clone file units' do
@@ -89,7 +89,7 @@ module Actions
 
       assert_action_planed_with(action, Actions::Katello::Repository::CloneContents, [file_repo], cloned_repo,
                                 :purge_empty_contents => true, :filters => [], :rpm_filenames => nil, :copy_contents => true,
-                                :metadata_generate => true, :solve_dependencies => false)
+                                :metadata_generate => true, :solve_dependencies => false, :pulp_copy_only => false)
     end
 
     it 'fully plans out a clone with pulp3' do


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
When CV dep solving is enabled, we tell Pulp 2 to copy all content twice.  First, copy without dep solving.  Then, copy with dep solving.

#### Considerations taken when implementing this change?
With Pulp 2 dep solving, we copy repositories in the CV one by one.  The issue with this is that the dep solver sees an empty destinations repository and can copy in newer versions of packages that would be available in the other repositories within a content view.  This can cause errata to get it that are too new, messing up exclude filters.

Instead, if we copy content without dep solving first to pre-fill the repositories, and then dep solve, the empty repo issue will not occur.

#### What are the testing steps for this pull request?
1) Create a content view with the following repositories
  -> RHEL 8 BaseOS
  -> RHEL 8 AppStream
  -> RHEL 8 Supplemental
  -> RHEL 8 BaseOS Debug
  -> RHEL 8 AppStream Debug

2) Add a filter to exclude all errata after October 1st

3) Enable dep solving on the content view

4) Publish

5) Check that device-mapper-8:1.02.177-10.el8.x86_64 is not in the resulting content view version.

6) Check that you can `yum update` from the content view version using a RHEL 8 client

7) Try other content view related actions (perhaps on other content views) and ensure everything makes sense