### PR TITLE
Fixes #34229 - pin faraday until we can update to 2.0

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -53,6 +53,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "anemone"
 
   #pulp3
+  gem.add_dependency "faraday", "< 1.9"
   gem.add_dependency "pulpcore_client", ">= 3.16.0", "< 3.17.0"
   gem.add_dependency "pulp_file_client", ">= 1.10.0", "< 1.11.0"
   gem.add_dependency "pulp_ansible_client", ">= 0.10", "< 0.11"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
the pulp bindings do not support faraday 2.0, work is going on here to support it: https://github.com/pulp/pulp-openapi-generator/pull/56

until then, we need to pin to a lower version

#### Considerations taken when implementing this change?
1.9 was also released with a breaking change

#### What are the testing steps for this pull request?
