### PR TITLE
Fixes #34184 - Add content_view_version filter to generic content units

### DIFF
--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -130,6 +130,9 @@ module Katello
       end
 
       def filter_by_content_view_version(version, collection)
+        if params[:content_type]
+          return collection.where(:id => version.send(controller_name, params[:content_type]))
+        end
         collection.where(:id => version.send(controller_name))
       end
 

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -239,6 +239,10 @@ module Katello
       Rpm.in_repositories(archived_repos)
     end
 
+    def generic_content_units(content_type)
+      GenericContentUnit.in_repositories(archived_repos).where(content_type: content_type)
+    end
+
     def library_packages
       Rpm.in_repositories(library_repos)
     end

--- a/test/controllers/api/v2/generic_content_units_controller_test.rb
+++ b/test/controllers/api/v2/generic_content_units_controller_test.rb
@@ -33,6 +33,17 @@ module Katello
       assert_template "katello/api/v2/generic_content_units/index"
     end
 
+    def test_python_package_index_cvv
+      @cvv = katello_content_view_versions(:library_dev_view_version)
+      Katello::Repository.create!(:root_id => @repo.root_id, :content_view_version_id => @cvv.id, :pulp_id => 'bkjaskdjfdf',
+                                  :relative_path => '/some_path')
+
+      response = get :index, params: { content_view_version_id: @cvv.id, content_type: "python_package" }
+
+      assert_response :success
+      assert JSON.parse(response.body)['results']
+    end
+
     def test_python_package_show
       get :show, params: { id: @generic.id, content_type: "python_package" }
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Adds cv version filtering to generic content unit endpoints
#### Considerations taken when implementing this change?
#### What are the testing steps for this pull request?

Add a python repo to a cv and publish
Grab the cv version id : cv_version_id
Go to endpoint /katello/api/v2/python_packages?content_view_version_id=cv_version_id