### PR TITLE
Fixes #34216 - use sync_policy instead of mirror for yum proxy syncs

### DIFF
--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -127,8 +127,12 @@ module Katello
       def sync(options = {})
         sync_params = repo_service.sync_url_params(options)
         sync_params[:remote] = remote_href
-        sync_params[:mirror] = true
-        sync_params.delete(:sync_policy)
+        if repo.yum?
+          sync_params[:sync_policy] = 'mirror_complete'
+        else
+          sync_params.delete(:sync_policy)
+          sync_params[:mirror] = true
+        end
         repository_sync_url_data = api.repository_sync_url_class.new(sync_params)
         [api.repositories_api.sync(repository_href, repository_sync_url_data)]
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
The `mirror` option is deprecated for pulp_rpm. `sync_policy` replaces it.  This PR causes only yum repos to use `sync_policy` for proxy syncs. All other types use `mirror`.

#### Considerations taken when implementing this change?
None, really.

#### What are the testing steps for this pull request?
Ensure that RPM proxy syncs still work.
