### PR TITLE
Fixes #34168 - Extend CV API to support bulk removing versions

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -2,6 +2,7 @@ module Katello
   class Api::V2::ContentViewsController < Api::V2::ApiController
     include Concerns::Authorization::Api::V2::ContentViewsController
     include Katello::Concerns::FilteredAutoCompleteSearch
+    include Katello::Concerns::Api::V2::BulkExtensions
 
     before_action :find_authorized_katello_resource, :except => [:index, :create, :copy, :auto_complete_search]
     before_action :ensure_non_default, :except => [:index, :create, :copy, :auto_complete_search]
@@ -22,6 +23,18 @@ module Katello
       param :auto_publish, :bool, :desc => N_("Enable/Disable auto publish of composite view")
       param :solve_dependencies, :bool, :desc => N_("Solve RPM dependencies by default on Content View publish, defaults to false")
       param :import_only, :bool, :desc => N_("Designate this Content View for importing from upstream servers only. Defaults to false")
+    end
+
+    def_param_group :bulk_content_view_version_ids do
+      param :included, Hash, :desc => N_("Versions to exclusively include in the action"), :required => true, :action_aware => true do
+        param :search, String, :required => false, :desc => N_("Search string for versions to perform an action on")
+        param :ids, Array, :required => false, :desc => N_("List of versions to perform an action on")
+      end
+      param :excluded, Hash, :desc => N_("Versions to explicitly exclude in the action."\
+                                         " All other versions will be included in the action,"\
+                                         " unless an included parameter is passed as well."), :required => true, :action_aware => true do
+        param :ids, Array, :required => false, :desc => N_("List of versions to exclude and not run an action on")
+      end
     end
 
     def filtered_associations
@@ -171,6 +184,44 @@ module Katello
       options[:content_view_versions] = versions
       options[:content_view_environments] = cv_envs
 
+      task = async_task(::Actions::Katello::ContentView::Remove, @content_view, options)
+      respond_for_async :resource => task
+    end
+
+    api :PUT, "/content_views/:id/bulk_remove", N_("Bulk remove versions from a content view and reassign systems and keys")
+    param_group :bulk_content_view_version_ids
+    param :id, :number, :desc => N_("content view numeric identifier"), :required => true
+    param :system_content_view_id, :number, :desc => N_("content view to reassign orphaned systems to")
+    param :system_environment_id, :number, :desc => N_("environment to reassign orphaned systems to")
+    param :key_content_view_id, :number, :desc => N_("content view to reassign orphaned activation keys to")
+    param :key_environment_id, :number, :desc => N_("environment to reassign orphaned activation keys to")
+    param :destroy_content_view, :boolean, :desc => N_("delete the content view with all the versions and environments")
+    def bulk_remove
+      if params[:destroy_content_view]
+        cv_envs = @content_view.content_view_environments
+        versions = @content_view.versions
+      else
+        versions = find_bulk_items(bulk_params: params[:bulk_content_view_version_ids],
+                                   model_scope: ::Katello::ContentViewVersion.where(content_view_id: @content_view.id),
+                                   key: :id)
+        cv_envs = ContentViewEnvironment.where(:content_view_version_id => versions.pluck(:id),
+                                               :content_view_id => @content_view.id
+        )
+      end
+
+      if !params[:destroy_content_view] && cv_envs.empty? && versions.empty?
+        fail _("There either were no environments nor versions specified or there were invalid environments/versions specified. "\
+               "Please check environment_ids and content_view_version_ids parameters.")
+      end
+
+      options = params.slice(:system_content_view_id,
+                             :system_environment_id,
+                             :key_content_view_id,
+                             :key_environment_id,
+                             :destroy_content_view
+      ).reject { |_k, v| v.nil? }.to_unsafe_h
+      options[:content_view_versions] = versions
+      options[:content_view_environments] = cv_envs
       task = async_task(::Actions::Katello::ContentView::Remove, @content_view, options)
       respond_for_async :resource => task
     end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -74,7 +74,7 @@ Katello::Engine.routes.draw do
             post :copy
             post :publish
             put :remove
-            put :bulk_remove
+            put :bulk_delete_versions
             put :remove_filters
             match '/environments/:environment_id' => "content_views#remove_from_environment", :via => :delete
           end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -74,6 +74,7 @@ Katello::Engine.routes.draw do
             post :copy
             post :publish
             put :remove
+            put :bulk_remove
             put :remove_filters
             match '/environments/:environment_id' => "content_views#remove_from_environment", :via => :delete
           end

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -124,7 +124,7 @@ module Katello
                          :finder_scope => :editable
       @plugin.permission :destroy_content_views,
                          {
-                           'katello/api/v2/content_views' => [:destroy, :remove, :bulk_remove],
+                           'katello/api/v2/content_views' => [:destroy, :remove, :bulk_delete_versions],
                            'katello/api/v2/content_view_versions' => [:destroy]
                          },
                          :resource_type => 'Katello::ContentView',

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -124,7 +124,7 @@ module Katello
                          :finder_scope => :editable
       @plugin.permission :destroy_content_views,
                          {
-                           'katello/api/v2/content_views' => [:destroy, :remove],
+                           'katello/api/v2/content_views' => [:destroy, :remove, :bulk_remove],
                            'katello/api/v2/content_view_versions' => [:destroy]
                          },
                          :resource_type => 'Katello::ContentView',

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -383,6 +383,35 @@ module Katello
       end
     end
 
+    def test_bulk_delete_versions
+      assert_async_task ::Actions::Katello::ContentView::Remove do |view, options|
+        @library_dev_staging_view == view &&
+          options[:system_content_view_id] == @library_dev_staging_view.id &&
+          options[:system_environment_id] == @library.id &&
+          options[:key_content_view_id] == @library_dev_staging_view.id &&
+          options[:key_environment_id] == @library.id &&
+          @library_dev_staging_view.versions.sort == options[:content_view_versions].sort &&
+          view.content_view_environments.sort == options[:content_view_environments].sort
+      end
+
+      put :bulk_delete_versions, params: {
+        key_content_view_id: @library_dev_staging_view.id,
+        key_environment_id: @library.id,
+        system_content_view_id: @library_dev_staging_view.id,
+        system_environment_id: @library.id,
+        bulk_content_view_version_ids: {
+          included: {
+            ids: @library_dev_staging_view.versions.map(&:id)
+          }
+        },
+        id: @library_dev_staging_view.id
+      }
+
+      assert_response :success
+
+      @library_dev_staging_view
+    end
+
     def test_remove_from_environment
       refute_includes @library_dev_view.environments, @staging
       delete :remove_from_environment, params: { id: @library_dev_view.id, environment_id: @staging.id }


### PR DESCRIPTION
What are the changes introduced in this pull request?

Adds support for bulk removing versions from a CV
Considerations taken when implementing this change?

    Ensure the versions deletion works.
    Ensure the reassignment of hosts and activation keys from deleted versions works
    Can select one cv/env combo for reassigning all hosts affected by bulk delete. Same for all affected activation keys.

What are the testing steps for this pull request?

One easy way to test this:
There's the closed PR: https://github.com/Katello/katello/pull/9864/files which switches to use bulk remove API.
Copy the JS changes from there and replace IDs on https://github.com/Katello/katello/pull/9864/files#diff-61fb2d50f776e164f9f3da714007d908978c2f22d80b3c915a576a2930e45d6fR72 with whatever versions you want to bulk delete.