### PR TITLE
Feature/debian errata working

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -62,6 +62,7 @@ module Katello
       param :deb_releases, String, :desc => N_("whitespace-separated list of releases to be synced from deb-archive")
       param :deb_components, String, :desc => N_("whitespace-separated list of repo components to be synced from deb-archive")
       param :deb_architectures, String, :desc => N_("whitespace-separated list of architectures to be synced from deb-archive")
+      param :deb_errata_url, String, :desc => N_("URL to a deb errata service (use only on the security repositories)")
       param :ignorable_content, Array, :desc => N_("List of content units to ignore while syncing a yum repository. Must be subset of %s") % RootRepository::IGNORABLE_CONTENT_UNIT_TYPES.join(",")
       param :ansible_collection_requirements, String, :desc => N_("Contents of requirement yaml file to sync from URL")
       param :ansible_collection_auth_url, String, :desc => N_("The URL to receive a session token from, e.g. used with Automation Hub.")
@@ -505,7 +506,7 @@ module Katello
       keys = [:download_policy, :mirror_on_sync, :mirroring_policy, :sync_policy, :arch, :verify_ssl_on_sync, :upstream_password,
               :upstream_username, :download_concurrency, :upstream_authentication_token,
               {:os_versions => []}, :deb_releases, :deb_components, :deb_architectures, :description,
-              :http_proxy_policy, :http_proxy_id, :retain_package_versions_count, {:ignorable_content => []}
+              :http_proxy_policy, :http_proxy_id, :retain_package_versions_count, {:ignorable_content => []}, :deb_errata_url
              ]
       keys += [{:docker_tags_whitelist => []}, :docker_upstream_name] if params[:action] == 'create' || @repository&.docker?
       keys += [:ansible_collection_requirements, :ansible_collection_auth_url, :ansible_collection_auth_token] if params[:action] == 'create' || @repository&.ansible_collection?
@@ -567,6 +568,7 @@ module Katello
         root.deb_releases = repo_params[:deb_releases] if repo_params[:deb_releases]
         root.deb_components = repo_params[:deb_components] if repo_params[:deb_components]
         root.deb_architectures = repo_params[:deb_architectures] if repo_params[:deb_architectures]
+	    root.deb_errata_url = repo_params[:deb_errata_url] if repo_params[:deb_errata_url]
       end
 
       if root.ansible_collection?

--- a/app/lib/actions/katello/content_view/incremental_updates.rb
+++ b/app/lib/actions/katello/content_view/incremental_updates.rb
@@ -93,6 +93,7 @@ module Actions
                 total_count[:errata_count] = added_units[:erratum].try(:count)
                 total_count[:modulemd_count] = added_units[:modulemd].try(:count)
                 total_count[:rpm_count] = added_units[:rpm].try(:count)
+		        total_count[:deb_count] = added_units[:deb].try(:count)
               end
             end
           end
@@ -135,6 +136,10 @@ module Actions
           if total_count[:rpm_count] && total_count[:rpm_count] > 0
             rpm = _(" %{package_count} Package(s)" % {:package_count => total_count[:rpm_count]})
             content << rpm
+          end
+	      if total_count[:deb_count] && total_count[:deb_count] > 0
+            deb = _(" %{deb_package_count} Package(s)" % {:deb_package_count => total_count[:deb_count]})
+            content << deb
           end
           content
         end

--- a/app/lib/actions/katello/content_view/presenters/incremental_updates_presenter.rb
+++ b/app/lib/actions/katello/content_view/presenters/incremental_updates_presenter.rb
@@ -6,7 +6,8 @@ module Actions
           HUMANIZED_TYPES = {
             ::Katello::Erratum::CONTENT_TYPE => "Errata",
             ::Katello::ModuleStream::CONTENT_TYPE => "Module Streams",
-            ::Katello::Rpm::CONTENT_TYPE => "Packages"
+	        ::Katello::Rpm::CONTENT_TYPE => "RPM Packages",
+            ::Katello::Deb::CONTENT_TYPE => "Deb Packages",
           }.freeze
 
           def humanized_output
@@ -25,7 +26,7 @@ module Actions
               if cvv
                 humanized_lines << "Content View: #{cvv.content_view.name} version #{cvv.version}"
                 humanized_lines << _("Added Content:")
-                [::Katello::Erratum, ::Katello::ModuleStream, ::Katello::Rpm].each do |content_type|
+		        [::Katello::Erratum, ::Katello::ModuleStream, ::Katello::Rpm, ::Katello::Deb].each do |content_type|
                   unless output[:added_units][content_type::CONTENT_TYPE].blank?
                     humanized_lines << "  #{HUMANIZED_TYPES[content_type::CONTENT_TYPE]}:"
                     humanized_lines += output[:added_units][content_type::CONTENT_TYPE].sort.map { |unit| "        #{unit}" }

--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -274,7 +274,7 @@ module Actions
 
         def generate_description(version, content)
           humanized_lines = []
-          [::Katello::Erratum, ::Katello::Rpm].each do |content_type|
+	      [::Katello::Erratum, ::Katello::Rpm, ::Katello::Deb].each do |content_type|
             unless content[content_type::CONTENT_TYPE].blank?
               humanized_lines << "#{HUMANIZED_TYPES[content_type::CONTENT_TYPE]}:"
               humanized_lines += content[content_type::CONTENT_TYPE].sort.map { |unit| "    #{unit}" }

--- a/app/lib/actions/katello/repository/clone_contents.rb
+++ b/app/lib/actions/katello/repository/clone_contents.rb
@@ -18,6 +18,11 @@ module Actions
                           SmartProxy.pulp_primary,
                           source_repositories,
                           filters: filters, rpm_filenames: rpm_filenames, solve_dependencies: solve_dependencies)
+	          source_repositories.select(&:deb?).each do |repository|
+              plan_action(Actions::Katello::Repository::CopyDebErratum,
+                          source_repo_id: repository.id,
+                          target_repo_id: new_repository.id)
+              end
             end
 
             matching_content = check_matching_content(new_repository, source_repositories)

--- a/app/lib/actions/katello/repository/copy_deb_erratum.rb
+++ b/app/lib/actions/katello/repository/copy_deb_erratum.rb
@@ -1,0 +1,31 @@
+module Actions
+  module Katello
+    module Repository
+      class CopyDebErratum < Actions::Base
+        input_format do
+          param :source_repo_id
+          param :target_repo_id
+          param :erratum_ids
+        end
+
+        def run
+          source_repo = ::Katello::Repository.find(input[:source_repo_id])
+          target_repo = ::Katello::Repository.find(input[:target_repo_id])
+          erratum_ids = input[:erratum_ids]
+
+          erratum_ids_to_copy = source_repo.erratum_ids
+          erratum_ids_to_copy &= ::Katello::Erratum.where(errata_id: erratum_ids).pluck(:id) if erratum_ids
+          erratum_ids_to_copy -= target_repo.erratum_ids
+          target_repo.erratum_ids |= erratum_ids_to_copy
+          target_repo.save
+
+          # fake output to make foreman task presenter happy
+          if erratum_ids
+            output[:pulp_tasks] = [{ :result => { :units_successful => ::Katello::Erratum.where(:id => erratum_ids_to_copy).pluck(:errata_id).map { |errata| { "type_id" => "erratum", "unit_key" => { id: errata } } } } }]
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/app/lib/actions/katello/repository/sync_deb_errata.rb
+++ b/app/lib/actions/katello/repository/sync_deb_errata.rb
@@ -1,0 +1,90 @@
+module Actions
+  module Katello
+    module Repository
+      class SyncDebErrata < Actions::EntryAction
+        def plan(repo, force = false)
+          plan_self(repo_id: repo.id, force_download: force)
+        end
+
+        def run
+          repo = ::Katello::Repository.find(input[:repo_id]).root
+          proxy = repo.http_proxy
+          params = {}
+          params['releases'] = repo.deb_releases.split(',').map { |comp| comp.split('/')[0] }.join(',') if repo.deb_releases
+          params['components'] = repo.deb_components if repo.deb_components
+          params['architectures'] = repo.deb_architectures if repo.deb_architectures
+          RestClient::Request.execute(
+            method: :get,
+            url: repo.deb_errata_url,
+            proxy: proxy&.full_url,
+            headers: {
+              params: params,
+              'If-None-Match' => input[:force_download] ? nil : repo.deb_errata_url_etag
+            }
+          ) do |response, _request, _result, &block|
+            case response.code
+            when 200
+              output[:etag] = response.headers[:etag] || ''
+              output[:modified] = true
+              output[:data] = response.body
+              Rails.logger.warn("MP sync #{response.body}")
+            when 304 # not modified
+              output[:modified] = false
+            else
+              response.return!(&block)
+            end
+          end
+        rescue => e
+          raise "Error while fetching errata information (#{e.to_s})"
+        end
+
+        # rubocop:disable Metrics/MethodLength
+        def finalize
+          if output[:modified]
+            repo = ::Katello::Repository.find(input[:repo_id])
+            erratum_list = JSON.parse(output[:data])
+            erratum_list.each do |data|
+              erratum = ::Katello::Erratum.find_or_initialize_by(errata_id: data['name'])
+              erratum.errata_id = data['name']
+              erratum.pulp_id = data['name']
+              erratum.title = data['title']
+              erratum.summary = data['summary'] || ''
+              erratum.description = data['description']
+              erratum.issued = data['issued']
+              erratum.updated = data['updated'] || data['issued']
+              erratum.severity = data['severity'] || ''
+              erratum.solution = data['solution'] || ''
+              erratum.reboot_suggested = data['reboot_suggested'] || false
+              erratum.errata_type = 'security'
+              erratum.save!
+              data['cves']&.each do |cve|
+                erratum.cves.find_or_initialize_by(cve_id: cve)
+              end
+              data['dbts_bugs']&.each do |dbts_bug|
+                erratum.dbts_bugs.find_or_initialize_by(bug_id: dbts_bug)
+              end
+              data['packages']&.each do |package|
+                affected_deb = erratum.deb_packages.find_or_initialize_by(name: package['name'], release: package['release'])
+                affected_deb.version = package['version']
+                affected_deb.version = package['architecture']
++               affected_deb.nva = "#{package['name']}_#{package['version']}_#{package['architecture']}"
+                affected_deb.save!
+              end
+              erratum.repositories |= [repo]
+              erratum.save!
+            end
+            repo.root.update(deb_errata_url_etag: output[:etag])
+          end
+        end
+
+        def humanized_output
+          output.dup.update(data: 'Trimmed')
+        end
+
+        def rescue_strategy
+          Dynflow::Action::Rescue::Skip
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -181,6 +181,11 @@ module Katello
         self.fact_values.joins(:fact_name).where("#{::FactName.table_name}.type = '#{Katello::RhsmFactName}'")
       end
 
+      def debs_for_erratum(erratum_name)
+        erratum = Katello::Erratum.find_by errata_id: erratum_name
+        erratum.deb_packages.where(release: self.operatingsystem.release_name).pluck(:name).join(' ')
+      end
+
       def self.available_locks
         [:update]
       end
@@ -414,7 +419,7 @@ end
 class ::Host::Managed::Jail < Safemode::Jail
   allow :content_source, :subscription_manager_configuration_url, :rhsm_organization_label,
         :host_collections, :pools, :hypervisor_host, :lifecycle_environment, :content_view,
-        :installed_packages, :traces_helpers, :advisory_ids
+        :installed_packages, :traces_helpers, :advisory_ids, :debs_for_erratum
 end
 
 class ActiveRecord::Associations::CollectionProxy::Jail < Safemode::Jail

--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -21,8 +21,10 @@ module Katello
     has_many :content_facets, :through => :content_facet_errata, :class_name => "Katello::Host::ContentFacet", :source => :content_facet
     has_many :content_facets_applicable, :through => :content_facet_errata, :class_name => "Katello::Host::ContentFacet", :source => :content_facet
     has_many :bugzillas, :class_name => "Katello::ErratumBugzilla", :dependent => :destroy, :inverse_of => :erratum
+    has_many :dbts_bugs, :class_name => "Katello::ErratumDbtsBug", :dependent => :destroy, :inverse_of => :erratum
     has_many :cves, :class_name => "Katello::ErratumCve", :dependent => :destroy, :inverse_of => :erratum
     has_many :packages, :class_name => "Katello::ErratumPackage", :dependent => :destroy, :inverse_of => :erratum
+    has_many :deb_packages, :class_name => "Katello::ErratumDebPackage", :dependent => :destroy, :inverse_of => :erratum
 
     scoped_search :on => :errata_id, :only_explicit => true
     scoped_search :on => :errata_id, :rename => :id, :complete_value => true, :only_explicit => true
@@ -36,8 +38,10 @@ module Katello
     scoped_search :on => :reboot_suggested, :complete_value => true
     scoped_search :relation => :cves, :on => :cve_id, :rename => :cve
     scoped_search :relation => :bugzillas, :on => :bug_id, :rename => :bug
+    scoped_search :relation => :dbts_bugs, :on => :bug_id, :rename => :bug
     scoped_search :relation => :packages, :on => :nvrea, :rename => :package, :complete_value => true, :only_explicit => true
     scoped_search :relation => :packages, :on => :name, :rename => :package_name, :complete_value => true, :only_explicit => true
+    scoped_search :relation => :deb_packages, :on => :name, :rename => :package_name, :complete_value => true, :only_explicit => true
 
     scoped_search :on => :modular,
                   :only_explicit => true,
@@ -182,6 +186,10 @@ module Katello
       Katello::ContentViewErratumFilterRule.where(errata_id: self.errata_id).eager_load(:filter).map(&:filter)
     end
 
+    def all_package_names
+      package_names + deb_packages.map { |pkg| pkg.name }
+    end
+
     apipie :class, desc: "A class representing #{model_name.human} object" do
       name 'Erratum'
       refs 'Erratum'
@@ -198,7 +206,7 @@ module Katello
       property :summary, String, desc: 'Returns the errata summary, the length can very, it is usually in range of 60 to 1000 characters. It can include empty line characters.'
     end
     class Jail < ::Safemode::Jail
-      allow :errata_id, :errata_type, :issued, :created_at, :severity, :package_names, :cves, :reboot_suggested, :title, :summary
+      allow :errata_id, :errata_type, :issued, :created_at, :severity, :package_names, :all_package_names, :cves, :reboot_suggested, :title, :summary
     end
   end
 end

--- a/app/models/katello/erratum_dbts_bug.rb
+++ b/app/models/katello/erratum_dbts_bug.rb
@@ -1,0 +1,9 @@
+module Katello
+  class ErratumDbtsBug < Katello::Model
+    belongs_to :erratum, inverse_of: :dbts_bugs, class_name: 'Katello::Erratum'
+
+    def href
+      "https://bugs.debian.org/#{bug_id}"
+    end
+  end
+end

--- a/app/models/katello/erratum_deb_package.rb
+++ b/app/models/katello/erratum_deb_package.rb
@@ -1,0 +1,5 @@
+module Katello
+  class ErratumDebPackage < Katello::Model
+    belongs_to :erratum, :inverse_of => :deb_packages, :class_name => 'Katello::Erratum'
+  end
+end

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -150,6 +150,27 @@ module Katello
         ApplicableContentHelper.new(ModuleStream, self).import(partial)
       end
 
+      def applicable_deb_errata_uuids
+        # find 'base-repositories'
+        repositories = []
+        self.bound_repositories.each do |repo|
+          if repo.library_instance.nil?
+            repositories << repo.id
+          else
+            repositories << repo.library_instance.id
+          end
+        end
+
+        Katello::Erratum.joins([:deb_packages, :repositories],
+                               "INNER JOIN #{Katello::InstalledDeb.table_name} ON #{Katello::InstalledDeb.table_name}.name = #{Katello::ErratumDebPackage.table_name}.name",
+                               "INNER JOIN #{Katello::HostInstalledDeb.table_name} ON #{Katello::HostInstalledDeb.table_name}.installed_deb_id = #{Katello::InstalledDeb.table_name}.id")
+                              .where("deb_version_cmp(#{Katello::ErratumDebPackage.table_name}.version, #{Katello::InstalledDeb.table_name}.version) > 0")
+                              .where("#{Katello::ErratumDebPackage.table_name}.release": self.host.operatingsystem.release_name)
+                              .where("#{Katello::HostInstalledDeb.table_name}.host_id": self.host.id)
+                              .where("#{Katello::RepositoryErratum.table_name}.repository_id" => repositories)
+                              .distinct.pluck(:pulp_id)
+      end
+
       def self.in_content_view_version_environments(version_environments)
         #takes a structure of [{:content_view_version => ContentViewVersion, :environments => [KTEnvironment]}]
         queries = version_environments.map do |version_environment|

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -315,6 +315,10 @@ module Katello
       Katello::Content.find_by(:cp_content_id => self.content_id, :organization_id => self.product.organization_id)
     end
 
+    def repository_type
+      RepositoryTypeManager.find(self.content_type)
+    end
+
     def docker?
       self.content_type == Repository::DOCKER_TYPE
     end
@@ -363,6 +367,14 @@ module Katello
       changeable_attributes += %w(deb_releases deb_components deb_architectures gpg_key_id) if deb?
       changeable_attributes += %w(ansible_collection_requirements ansible_collection_auth_url ansible_collection_auth_token) if ansible_collection?
       changeable_attributes.any? { |key| previous_changes.key?(key) }
+    end
+
+    def supports_errata?
+      if deb?
+        self.deb_errata_url.present?
+      else
+        self.repository_type.supports_content_type Katello::Erratum
+      end
     end
 
     def raw_content_path

--- a/app/services/katello/pulp3/deb.rb
+++ b/app/services/katello/pulp3/deb.rb
@@ -31,6 +31,7 @@ module Katello
         custom_json['version'] = backend_data['version']
         custom_json['description'] = backend_data['description']
         custom_json['architecture'] = backend_data['architecture']
+        custom_json['nva'] = "#{backend_data['package']}_#{backend_data['version']}_#{backend_data['architecture']}"
         model.update!(custom_json)
       end
     end

--- a/app/services/katello/repository_type.rb
+++ b/app/services/katello/repository_type.rb
@@ -79,6 +79,13 @@ module Katello
       end
     end
 
+    def supports_content_type(model_class)
+      @content_types.each do |type|
+        return true if type.model_class == model_class
+      end
+      false
+    end
+
     def default_managed_content_type(label = nil)
       if label
         @default_managed_content_type_label = label.to_s

--- a/app/views/katello/api/v2/errata/show.json.rabl
+++ b/app/views/katello/api/v2/errata/show.json.rabl
@@ -29,3 +29,7 @@ end
 node :module_streams do |e|
   e.module_streams
 end
+
+child :deb_packages => :deb_packages do
+  attributes :name, :version, :release
+end

--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -11,6 +11,7 @@ attributes :mirroring_policy
 glue(@object.root) do
   attributes :content_type, :url, :arch, :os_versions, :content_id, :generic_remote_options
   attributes :major, :minor
+  attributes :supports_errata? => :supports_errata
 
   child :product do |_product|
     attributes :id, :cp_id, :name

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -22,6 +22,7 @@ glue(@resource.root) do
   attributes :product_type
   attributes :upstream_username
   attributes :deb_releases, :deb_components, :deb_architectures
+  attributes :deb_errata_url
   attributes :http_proxy_policy
   attributes :http_proxy_id
   attributes :http_proxy_name

--- a/db/migrate/20180406112559_create_katello_erratum_dbts_bugs.rb
+++ b/db/migrate/20180406112559_create_katello_erratum_dbts_bugs.rb
@@ -1,0 +1,10 @@
+class CreateKatelloErratumDbtsBugs < ActiveRecord::Migration[4.2]
+  def change
+    create_table :katello_erratum_dbts_bugs do |t|
+      t.references :erratum
+      t.string :bug_id, limit: 255
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180406112600_create_katello_erratum_deb_packages.rb
+++ b/db/migrate/20180406112600_create_katello_erratum_deb_packages.rb
@@ -1,0 +1,13 @@
+class CreateKatelloErratumDebPackages < ActiveRecord::Migration[4.2]
+  def change
+    create_table :katello_erratum_deb_packages do |t|
+      t.references :erratum
+      t.string :name, limit: 255
+      t.string :version, limit: 255
+      t.string :filename, limit: 255
+      t.string :release, limit: 255
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190116131820_add_deb_errata_url_to_root_repositories.rb
+++ b/db/migrate/20190116131820_add_deb_errata_url_to_root_repositories.rb
@@ -1,0 +1,6 @@
+class AddDebErrataUrlToRootRepositories < ActiveRecord::Migration[5.1]
+  def change
+    add_column :katello_root_repositories, :deb_errata_url, :string, limit: 255
+    add_column :katello_root_repositories, :deb_errata_url_etag, :string, limit: 255
+  end
+end

--- a/db/migrate/20220113134429_add_nva_to_katello_erratum_deb_packages.rb
+++ b/db/migrate/20220113134429_add_nva_to_katello_erratum_deb_packages.rb
@@ -1,0 +1,6 @@
+class AddNvaToKatelloErratumDebPackages < ActiveRecord::Migration[6.0]
+  def change
+    add_column :katello_erratum_deb_packages, :architecture, :string
+    add_column :katello_erratum_deb_packages, :nva, :string
+  end
+end

--- a/db/migrate/20220113134622_add_nva_to_katello_deb.rb
+++ b/db/migrate/20220113134622_add_nva_to_katello_deb.rb
@@ -1,0 +1,5 @@
+class AddNvaToKatelloDeb < ActiveRecord::Migration[6.0]
+  def change
+    add_column :katello_debs, :nva, :string
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/errata-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/errata-details.html
@@ -38,6 +38,9 @@
       <li ng-repeat="package in erratum.packages">
         {{ package }}
       </li>
+      <li ng-repeat="deb_package in erratum.deb_packages">
+        {{ deb_package.name }} {{ deb_package.version }}
+      </li>
     </ul>
   </dd>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
@@ -101,7 +101,10 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
                     $scope.applyingErrata = false;
                 };
 
-                ContentViewVersion.incrementalUpdate(params, transitionToTask, error);
+                IncrementalUpdate.getDebIds().then(function (debIds) {
+                    params['add_content']['deb_ids'] = debIds;
+                    ContentViewVersion.incrementalUpdate(params, transitionToTask, error);
+                });
             };
 
             applyErrata = function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/erratum.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/erratum.controller.js
@@ -11,6 +11,7 @@
  */
 angular.module('Bastion.errata').controller('ErratumController', ['$scope', 'Erratum', 'ApiErrorHandler',
     function ($scope, Erratum, ApiErrorHandler) {
+        $scope.encodeURIComponent = encodeURIComponent;
         $scope.panel = {
             error: false,
             loading: true

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-packages.html
@@ -4,11 +4,17 @@
   <div data-block="left-column">
     <h3 translate>Independent Packages</h3>
     <ul>
-      <p ng-show="!errata.packages.length" >No Packages to show</p>
+      <p ng-show="!(errata.packages.length || errata.deb_packages.length)" >No Packages to show</p>
       <li ng-show="errata.packages.length" ng-repeat="package in errata.packages">
         <a href="/packages?search={{package}}">
           {{ package }}
         </a>
+      </li>
+      <li ng-show="errata.deb_packages.length" ng-repeat="deb_package in errata.deb_packages">
+        <a href="/debs?search={{ encodeURIComponent('name==' + deb_package.name + ' and version>=' + deb_package.version) }}">
+          {{ deb_package.name }} {{ deb_package.version }}
+        </a>
+        ({{ deb_package.release }})
       </li>
     </ul>
   </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/incremental-update.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/incremental-update.service.js
@@ -8,7 +8,7 @@
      *   Provides a helper service for Incremental Updates.
      *
      */
-    function IncrementalUpdate($q, $httpParamSerializer, Task, CurrentOrganization) {
+    function IncrementalUpdate($q, $httpParamSerializer, Task, CurrentOrganization, Erratum, Deb) {
         var getIdsFromBulk;
 
         getIdsFromBulk = function (bulkResource) {
@@ -43,6 +43,39 @@
         this.getErrataIds = function () {
             return this.errataIds;
         };
+
+        /**
+         * Return Deb packages mentioned in Errata
+         *
+         * @returns {Promise} future array of Deb Ids
+         */
+        this.getDebIds = function () {
+            return Promise.all(this.errataIds.map(function (erratumId) {
+                return Erratum.get({id: erratumId}).$promise.then(function (erratum) {
+                    return Promise.all(erratum.deb_packages.map(function (debPackage) {
+                        var searchString = 'name==' + debPackage.name + ' and version==' + debPackage.version;
+                        return Deb.get({
+                            'per_page': 1 << 32,
+                            'search': searchString,
+                            'organization_id': CurrentOrganization
+                        }).$promise.then(function (debs) {
+                            return debs.results.map(function (deb) {
+                                return deb.id;
+                            });
+                        });
+                    })).then(function (res) {
+                        return res.reduce(function (a, b) {
+                            return a.concat(b);
+                        }, []);
+                    });
+                });
+            })).then(function (res) {
+                return res.reduce(function (a, b) {
+                    return a.concat(b);
+                }, []);
+            });
+        };
+
 
         /**
          * Allows setting the Content Host Ids.
@@ -134,6 +167,6 @@
 
     angular.module('Bastion.errata').service('IncrementalUpdate', IncrementalUpdate);
 
-    IncrementalUpdate.$inject = ['$q', '$httpParamSerializer', 'Task', 'CurrentOrganization'];
+    IncrementalUpdate.$inject = ['$q', '$httpParamSerializer', 'Task', 'CurrentOrganization', 'Erratum', 'Deb'];
 
 })();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -82,6 +82,7 @@
             readonly="denied('edit_products', product)">
         </dd>
       </span>
+      
       <span ng-if="repository.content_type == 'deb'">
         <dt translate>Components</dt>
         <dd bst-edit-text="repository.deb_components"
@@ -92,6 +93,14 @@
       <span ng-if="repository.content_type == 'deb'">
         <dt translate>Architectures</dt>
         <dd bst-edit-text="repository.deb_architectures"
+            on-save="save(repository)"
+            readonly="denied('edit_products', product)">
+        </dd>
+      </span>
+
+      <span ng-if="repository.content_type == 'deb'">
+        <dt translate>Errata URL</dt>
+        <dd bst-edit-text="repository.deb_errata_url"
             on-save="save(repository)"
             readonly="denied('edit_products', product)">
         </dd>
@@ -192,6 +201,15 @@
             selector="repository.checksum_type"
             options="checksums"
             on-save="save(repository)">
+        </dd>
+      </span>
+
+      <span ng-hide="repository.content_type === 'ostree'">
+        <dt translate>Mirror on Sync</dt>
+        <dd bst-edit-checkbox="repository.mirror_on_sync"
+            formatter="booleanToYesNo"
+            on-save="save(repository)"
+            readonly="denied('edit_products', product)">
         </dd>
       </span>
 
@@ -414,6 +432,24 @@
           </td>
         </tr>
 
+        <tr ng-show="repository.content_type === 'deb'">
+          <td translate>deb Packages</td>
+          <td class="align-center">
+            <a ui-sref="product.repository.manage-content.debs({productId: product.id, repositoryId: repository.id})">
+              {{ repository.content_counts.deb || 0 }}
+            </a>
+          </td>
+        </tr>
+
+        <tr ng-show="repository.supports_errata">
+          <td translate>Errata</td>
+          <td class="align-center">
+            <a ui-sref="errata({repositoryId: repository.id})">
+              {{ repository.content_counts.erratum || 0 }}
+            </a>
+          </td>
+        </tr>
+
         <tr ng-show="repository.content_type === 'yum'">
           <td translate>Errata</td>
           <td class="align-center">
@@ -468,14 +504,6 @@
           <td class="align-center">
             <a ui-sref="product.repository.manage-content.files({productId: product.id, repositoryId: repository.id})">
               {{ repository.content_counts.file || 0 }}
-            </a>
-          </td>
-        </tr>
-        <tr ng-show="repository.content_type === 'deb'">
-          <td translate>deb Packages</td>
-          <td class="align-center">
-            <a ui-sref="product.repository.manage-content.debs({productId: product.id, repositoryId: repository.id})">
-              {{ repository.content_counts.deb || 0 }}
             </a>
           </td>
         </tr>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -170,6 +170,15 @@
                 <br />
                 <div class="alert alert-danger" ><strong>Warning. </strong>Are you sure you want to add a comma in this whitespace separated list of architectures?</div>
        </div>
+       <div ng-show="repository.content_type === 'deb'" bst-form-group label="{{ 'Errata URL' | translate }}">
+        <input id="deb_errata_url"
+               name="deb_errata_url"
+               ng-model="repository.deb_errata_url"
+               type="text"/>
+        <p class="help-block" translate>
+          URL to a deb errata service. Example: https://dep.atix.de/dep/api/v1/debian
+        </p>
+       </div>
       </div>
 
       <div bst-form-group label="{{ 'Upstream Repository Name' | translate }}"  ng-if="repository.content_type === 'docker'">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
@@ -177,6 +177,13 @@
                   {{ repository.content_counts.deb || 0 }} deb Packages
                 </a>
               </div>
+	        <span ng-show="repository.supports_errata">
+                <div>
+                  <a ui-sref="errata({repositoryId: repository.id})" translate>
+                    {{ repository.content_counts.erratum || 0 }} Errata
+                  </a>
+                </div>
+              </span>
             </span>
 
             <span ng-show="repository.content_type == 'ansible_collection'">

--- a/lib/katello/repository_types/deb.rb
+++ b/lib/katello/repository_types/deb.rb
@@ -23,4 +23,11 @@ Katello::RepositoryTypeManager.register(::Katello::Repository::DEB_TYPE) do
     :pulp3_service_class => ::Katello::Pulp3::Deb,
     :removable => true,
     :uploadable => true
+  content_type Katello::Erratum,
+    :pulp2_service_class => ::Katello::Pulp::Erratum,
+    :pulp3_service_class => ::Katello::Pulp3::Erratum,
+    :priority => 3,
+    :primary_content => true,
+    :index => true
+
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

It is basically PR #7961 but with some changes to make it work with foreman 4.3.0 rc4.

It introduces a table column `nva` for tables `katello_debs` and `katello_erratum_deb_packages` to calculate the errata for a package more quickly and easily. The rest are minor adjustments.
    
#### Considerations taken when implementing this change?

The changes are made for a specific customer of our company. So the changes might not be completely suitable for the merge. But we thought we share our changes to help the progress with the debian errata feature.

#### What are the testing steps for this pull request?

We did manual testing on several `real` systems. The contract does not have budget for automated testing in katello, sorry.