### PR TITLE
Fix regression errata install identifier

### DIFF
--- a/app/controllers/katello/remote_execution_controller.rb
+++ b/app/controllers/katello/remote_execution_controller.rb
@@ -48,7 +48,7 @@ module Katello
 
       def inputs
         if feature_name == 'katello_errata_install'
-          { "Errata Search Query" => "errata_id ^ (#{errata_inputs.join(',')})" }
+          { :errata => errata_inputs }
         elsif feature_name == 'katello_service_restart'
           { :helper => params[:name] }
         elsif feature_name == 'katello_module_stream_action'

--- a/app/views/foreman/job_templates/install_errata.erb
+++ b/app/views/foreman/job_templates/install_errata.erb
@@ -19,7 +19,7 @@ foreign_input_sets:
     <% advisories = input(:errata).split(',').join(' ') %>
     <%= render_template('Package Action - SSH Default', :action => 'install -n -t patch', :package => advisories) %>
 <% else %>
-    <% advisory_ids = @host.advisory_ids(search: input("Errata search query")) %>
+    <% advisory_ids = @host.advisory_ids(search: input(:errata)) %>
 
     <% advisories = advisory_ids.map { |e| "--advisory=#{e}" }.join(' ') %>
     <%= render_template('Package Action - SSH Default', :action => 'update-minimal', :package => advisories) %>

--- a/app/views/foreman/job_templates/install_errata.erb
+++ b/app/views/foreman/job_templates/install_errata.erb
@@ -19,8 +19,6 @@ foreign_input_sets:
     <% advisories = input(:errata).split(',').join(' ') %>
     <%= render_template('Package Action - SSH Default', :action => 'install -n -t patch', :package => advisories) %>
 <% else %>
-    <% advisory_ids = @host.advisory_ids(search: input(:errata)) %>
-
-    <% advisories = advisory_ids.map { |e| "--advisory=#{e}" }.join(' ') %>
+    <% advisories = input(:errata).split(',').map { |e| "--advisory=#{e}" }.join(' ') %>
     <%= render_template('Package Action - SSH Default', :action => 'update-minimal', :package => advisories) %>
 <% end %>


### PR DESCRIPTION
Fixes #34175 which is caused by a regression by a commit to fix #33852

#### What are the changes introduced in this pull request?

The parameter of the `katello_errata_install` job is changed to its former shape in order to fix #34175.

#### Considerations taken when implementing this change?

It seems to be introduced by 0e7f14ce3b639b36ab968d460cc441228d991b16 as mentioned in the bug tracker. I don't see a reason for this change; maybe the author @parthaa can help with this.

#### What are the testing steps for this pull request?

We tested it manually on a customer system.