### PR TITLE
Fixes #34279 - Use APT verbatim publisher for deb content on Pulp 3 foreman-proxy syncs

### DIFF
--- a/app/services/katello/pulp3/api/apt.rb
+++ b/app/services/katello/pulp3/api/apt.rb
@@ -4,6 +4,13 @@ module Katello
   module Pulp3
     module Api
       class Apt < Core
+        def publication_verbatim_class
+          PulpDebClient::DebVerbatimPublication
+        end
+
+        def publications_verbatim_api
+          PulpDebClient::PublicationsVerbatimApi.new(api_client)
+        end
       end
     end
   end

--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -79,7 +79,11 @@ module Katello
       end
 
       def publication_href
-        api.publications_api.list(:repository_version => version_href).results.first&.pulp_href
+        if repo_service.repo.content_type == "deb"
+          api.publications_verbatim_api.list(:repository_version => version_href).results.first&.pulp_href
+        else
+          api.publications_api.list(:repository_version => version_href).results.first&.pulp_href
+        end
       end
 
       def create_version(options = {})
@@ -171,8 +175,13 @@ module Katello
 
       def create_publication
         if (href = version_href)
-          publication_data = api.publication_class.new(publication_options(href))
-          api.publications_api.create(publication_data)
+          if repo_service.repo.content_type == "deb"
+            publication_data = api.publication_verbatim_class.new({repository_version: href})
+            api.publications_verbatim_api.create(publication_data)
+          else
+            publication_data = api.publication_class.new(publication_options(href))
+            api.publications_api.create(publication_data)
+          end
         end
       end
 


### PR DESCRIPTION
Use Apt verbatim publisher so as to eliminate the need to configure signing services on foreman proxies