### PR TITLE
Fixes #33670 - Get pulp username/password from katello settings

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -180,8 +180,9 @@ module Katello
           pulp3_ssl_configuration(config)
           config.debugging = false
           config.logger = ::Foreman::Logging.logger('katello/pulp_rest')
-          config.username = self.setting(PULP3_FEATURE, 'username')
-          config.password = self.setting(PULP3_FEATURE, 'password')
+          pulp_auth = SETTINGS[:katello][:pulp_auth].find { |proxy| proxy['url'] == uri.scheme + "://" + uri.hostname }
+          config.username = pulp_auth['username']
+          config.password = pulp_auth['password']
         end
       end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Previously, the username/password for pulp would be fetched from the smart proxy. Instead, this will get the username/password from `foreman/config/settings.plugins.d/katello.yml`.

Like this:

> :pulp_auth:
    - url: "https://proxy-1.localhost.example.com"
      username: "proxy1 username"
      password: "proxy1 password"
    - url: "https://proxy-2.localhost.example.com"
      username: "proxy2 username"
      password: "proxy2 password"

#### Considerations taken when implementing this change?
This fix is to avoid exposing the password on the smart proxy's `/v2/features` endpoint. Although exposing the password is the main issue, I changed both the username and password fields because they were originally exposed for the same purpose. This feature is only intended for developers as a convenient way to set up an external pulp server. 

#### What are the testing steps for this pull request?
1. Don't apply this PR yet.
2. Load up a capsule: https://github.com/theforeman/forklift/blob/master/docs/development.md#capsule-development. Make sure it's connected to your katello devel server properly.
3. SSH into capsule. Add username/password fields to this file: `/etc/foreman-proxy/settings.d/pulpcore.yml`
4. In Katello box, refresh smart proxy, then check username/password of smart proxy in console with: `PulpcoreClient::ApiClient.new(SmartProxy.find(2).pulp3_configuration(PulpcoreClient::Configuration))`.
5. See that it matches what you made the fields in step 4.
6. Apply this PR
7. Add `:pulp_auth:` to `katello.yml` as shown above, using the url of the capsule and a different username/password
8. In the console, check that the username/password for the capsule matches what you put in `katello.yml` (and not on the smart proxy).
