### PR TITLE
Fixes #34295 - add default download policy

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -51,7 +51,7 @@ module Katello
       param :checksum_type, String, :desc => N_("Checksum of the repository, currently 'sha1' & 'sha256' are supported")
       param :docker_upstream_name, String, :desc => N_("Name of the upstream docker repository")
       param :docker_tags_whitelist, Array, :desc => N_("Comma-separated list of tags to sync for Container Image repository")
-      param :download_policy, ["immediate", "on_demand"], :desc => N_("download policy for yum repos (either 'immediate' or 'on_demand')")
+      param :download_policy, ["immediate", "on_demand"], :desc => N_("download policy for yum, deb, and docker repos (either 'immediate' or 'on_demand')")
       param :download_concurrency, :number, :desc => N_("Used to determine download concurrency of the repository in pulp3. Use value less than 20. Defaults to 10")
       param :mirror_on_sync, :bool, :desc => N_("true if this repository when synced has to be mirrored from the source and stale rpms removed (Deprecated)")
       param :mirroring_policy, Katello::RootRepository::MIRRORING_POLICIES, :desc => N_("Policy to set for mirroring content.  Must be one of %s.") % RootRepository::MIRRORING_POLICIES

--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -132,7 +132,7 @@ module Katello
       def add_repo(repo_param)
         repo_param[:unprotected] = repo_param[:unprotected].nil? ? false : repo_param[:unprotected]
 
-        if repo_param[:download_policy].blank? && repo_param[:content_type] == Repository::YUM_TYPE
+        if repo_param[:download_policy].blank? && Katello::RootRepository::CONTENT_ATTRIBUTE_RESTRICTIONS[:download_policy].include?(repo_param[:content_type])
           repo_param[:download_policy] = Setting[:default_download_policy]
         end
 

--- a/db/migrate/20220120163252_fix_docker_download_policy.rb
+++ b/db/migrate/20220120163252_fix_docker_download_policy.rb
@@ -1,0 +1,11 @@
+class FixDockerDownloadPolicy < ActiveRecord::Migration[6.0]
+  def up
+    Katello::RootRepository.where(content_type: "docker")
+                           .where(download_policy: [nil, ""])
+                           .update_all(:download_policy => "immediate")
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds default download policy to non-yum types using download policy. Also adds migration to assign download policy to old docker repos.
#### Considerations taken when implementing this change?
The default download policy behavior is the same as the yum type. Without this, when creating a repository with hammer, the download policy is "nil" if you don't specify it.

Without the migration, the download policy for docker repos would be "". I made the migration irreversible because I figured if someone accidentally rolled-back their database, resetting the policy to "" would be an issue.
#### What are the testing steps for this pull request?
1. To test the default download policy, user hammer to create a docker repo, without using the --download-policy option.
  - `hammer repository create --product-id [id] --content-type docker --url "https://quay.io" --docker-upstream-name "quay/busybox" --name "docker repo"`
 2. Sync that repo. Without the change, you would get an error saying "policy cannot be nil".
 3. To test the migration, set your katello branch to before the recent "Add On Demand Policy for Docker" commit.
 4. Create a docker repo.
 5. Reload this PR
 6. Notice the docker repo you created has "" as the policy
 7. Run migration
 8. Now it should be "immediate"

you could also use this `Katello::RootRepository.where(:content_type => "docker").update_all(:download_policy => "")` to get "" as the download policy.