### PR TITLE
Fixes #34041 - Clearer UI for Restrict to Architecture/OS

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -28,31 +28,37 @@
     </dl>
 
     <div class="divider"></div>
-    <h4 translate>Sync Settings</h4>
-    <dl class="dl-horizontal dl-horizontal-left">
-      <span ng-show="repository.content_type === 'yum'" >
-        <dt>
-          <span translate>Restrict to architecture</span>
-          <i class="pficon-info" title="{{ 'The repository will be enabled by default on content hosts with the selected architecture.' | translate }}"></i>
-        </dt>
-        <dd bst-edit-select="repository.arch==='noarch'?'No restriction':repository.arch"
-            selector="repository.arch"
-            options="architectures()"
-            on-save="save(repository)">
-        </dd>
-      </span>
 
-      <span ng-show="repository.content_type === 'yum'" >
-        <dt>
-          <span translate>Restrict to <br />OS version</span>
-          <i class="pficon-info" title="{{ 'The repository will be enabled by default on content hosts with the selected OS version.' | translate }}"></i>
-        </dt>
-        <dd bst-edit-select="repository.os_versions.length ? formatOSVersions() : 'No restriction'"
-            selector="selectedOSVersion"
-            options="osVersionsOptions()"
-            on-save="save(repository)">
-        </dd>
-      </span>
+    <div ng-show="repository.content_type === 'yum'" >
+      <h4 translate>Publishing Settings</h4>
+
+      <dl class="dl-horizontal dl-horizontal-left">
+          <dt>
+            <span translate>Restrict to architecture</span>
+            <i class="pficon-info" title="{{ 'The repository will be enabled by default on content hosts with the selected architecture.' | translate }}"></i>
+          </dt>
+          <dd bst-edit-select="repository.arch==='noarch'?'No restriction':repository.arch"
+              selector="repository.arch"
+              options="architectures()"
+              on-save="save(repository)">
+          </dd>
+
+          <dt>
+            <span translate>Restrict to <br />OS version</span>
+            <i class="pficon-info" title="{{ 'The repository will be enabled by default on content hosts with the selected OS version.' | translate }}"></i>
+          </dt>
+          <dd bst-edit-select="repository.os_versions.length ? formatOSVersions() : 'No restriction'"
+              selector="selectedOSVersion"
+              options="osVersionsOptions()"
+              on-save="save(repository)">
+          </dd>
+      </dl>
+      <div class="divider"></div>
+    </div>
+
+    <h4 translate>Sync Settings</h4>
+
+    <dl class="dl-horizontal dl-horizontal-left">
 
       <dt ng-show="repository.content_type !== 'docker'" translate>Upstream URL</dt>
       <dt ng-show="repository.content_type === 'docker'" translate>Registry URL</dt>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -39,29 +39,33 @@
         </select>
       </div>
 
-      <div bst-form-group label="{{ 'Restrict to Architecture' | translate }}" ng-show="repository.content_type === 'yum'">
+    </div>
+
+    <div ng-show="repository.content_type === 'yum'">
+      <h4 translate> Publishing Settings </h4>
+      <div bst-form-group label="{{ 'Restrict to Architecture' | translate }}">
         <select id="architecture_restricted"
                 name="architecture_restricted"
                 ng-model="repository.arch"
                 ng-options="arch.id as arch.name for arch in architecture">
         </select>
+        <p class="help-block" translate>
+          The repository will be enabled by default on content hosts with the selected architecture.
+        </p>
       </div>
 
-      <div
-        bst-form-group label="{{ 'Restrict to OS version' | translate }}"
-        ng-if="repository.content_type === 'yum'"
-      >
-       <select id="os_versions"
-               name="os_versions"
-               ng-model="repository.os_versions"
-               ng-options="tag as tag.name for tag in osVersionsOptions track by tag.id">
-       </select>
-       <p class="help-block" translate>
-         The repository will be enabled by default on content hosts with the selected OS version.
-       </p>
+      <div bst-form-group label="{{ 'Restrict to OS version' | translate }}">
+        <select id="os_versions"
+                name="os_versions"
+                ng-model="repository.os_versions"
+                ng-options="tag as tag.name for tag in osVersionsOptions track by tag.id">
+        </select>
+        <p class="help-block" translate>
+          The repository will be enabled by default on content hosts with the selected OS version.
+        </p>
       </div>
-
     </div>
+
     <div ng-show="repository.content_type !== undefined">
       <h4 translate> Sync Settings </h4>
       <div bst-form-group label="{{ 'Upstream URL' | translate }} ">


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
For yum type repos, moves "Restrict to Architecture" and "Restrict to OS"  repository settings under a new subheading "Publishing Settings". It also adds help text under "Restrict to Architecture".
#### Considerations taken when implementing this change?
In the repository create UI, these two settings were under "Basic Information". In the repository details UI, these two settings were under "Sync Settings". These settings don't really fit in either of those categories, hence "Publishing Settings". Previously, it was easy to mistake these settings for sync settings that would affect which content is synced.
#### What are the testing steps for this pull request?
1. Go to repository create page, select yum as the content type. Observe "Publishing Settings" and make sure everything looks okay.
2. Also select other content types and make sure "Publishing Settings" is not there, and that everything looks okay.
3. Go to the repository details for a yum repository and observe "Publishing Settings" and make sure everything looks okay.
4. Same thing for another type.
