### PR TITLE
Fixes #34306 - Update how we parse CN from subman identity certs

### DIFF
--- a/app/services/cert/rhsm_client.rb
+++ b/app/services/cert/rhsm_client.rb
@@ -10,7 +10,7 @@ module Cert
     end
 
     def uuid
-      drop_cn_prefix_from_subject(@cert.subject.to_s)
+      @uuid ||= @cert.subject.to_a.detect { |name, _, _| name == 'CN' }&.second
     end
 
     private
@@ -24,10 +24,6 @@ module Cert
 
         OpenSSL::X509::Certificate.new(cert)
       end
-    end
-
-    def drop_cn_prefix_from_subject(subject_string)
-      subject_string.sub(/\/CN=/i, '')
     end
 
     def strip_cert(cert)

--- a/test/services/cert/rhsm_client_test.rb
+++ b/test/services/cert/rhsm_client_test.rb
@@ -4,7 +4,9 @@ require File.expand_path("#{Katello::Engine.root}/app/services/cert/rhsm_client.
 
 module Katello
   class RhsmClientTest < Minitest::Test
-    CERT = '
+    # Subject of old cert is
+    # Subject: CN = 14e98155-731a-4cae-b151-5c504cc30e1a
+    OLD_CERT = '
       -----BEGIN CERTIFICATE-----
       MIIEaTCCA1GgAwIBAgIIMAikOB+/HpowDQYJKoZIhvcNAQEFBQAwezELMAkGA1UE
       BhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9saW5hMRAwDgYDVQQHEwdSYWxlaWdo
@@ -32,9 +34,52 @@ module Katello
       okjCBjwYlp5cNyAJSQscLF7rj/iOJYhRdetWMZg=
       -----END CERTIFICATE-----'.freeze
 
+    # Subject of new cert is
+    # Subject: O=Default_Organization, CN=eb48d5a8-b759-417c-97f7-93dc2369de29
+    NEW_CERT = '
+      -----BEGIN CERTIFICATE-----
+    MIIGjDCCBHSgAwIBAgIIabvFmF/tIwkwDQYJKoZIhvcNAQELBQAwgZcxCzAJBgNV
+    BAYTAlVTMRcwFQYDVQQIDA5Ob3J0aCBDYXJvbGluYTEQMA4GA1UEBwwHUmFsZWln
+    aDEQMA4GA1UECgwHS2F0ZWxsbzEUMBIGA1UECwwLU29tZU9yZ1VuaXQxNTAzBgNV
+    BAMMLGNlbnRvczcta2F0ZWxsby1jYW5kbGVwaW4uYXJlYTUyLmV4YW1wbGUuY29t
+    MB4XDTIyMDEyMDIwMTIwNVoXDTM4MDEyMDIxMTIwNVowTjEdMBsGA1UECgwURGVm
+    YXVsdF9Pcmdhbml6YXRpb24xLTArBgNVBAMMJDU3YjI2Y2UzLWU0ZmUtNGY3OS1h
+    Mzc3LTJjNGQ5ZGVhNTIwNDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIB
+    ALikZKO/50yG6qcWkSIr6IzPT8ohENEro6TERhWMCAuwikHE+MKdhPpyUIOkdt56
+    GXRU2zGhuxP4o+uG4B6r1EtG6Apvy5J6asL+pXHIUEvLG4HQmNQp8AqztAmS/Fh+
+    5j6n2PyD7/iF5Moozf7Ew+HJJvjy+RPHin3EEm3QvWcG65/5HGQHF2F9vUfo2kAE
+    ENhum2RLJ0EYZqBz7FkkBzS+onkY/uwmuRkxm0v4sHdQk1Fe5tLnBBm6pFDZzswB
+    v134Gi/j6I865i9FvvPvxrOE+MsBW/x1JAwj54IMa2HDINQmAY8jWWyiPGUY5yLl
+    kwnJ/CUBs+6qqKoUt+8H4TpC9dHStEdf2u1+nm+MgjRLm07piWo/Qp/bDh1OwfBT
+    bsRl2riE/wSofjex6X8ZjRxImhWNjxvzJAn/VD6p5+rpxFDu5RjCoKsGF9Tbn5Vr
+    /QRsfuiy9kwrsQYfp3tBAgyKsblTUncCT4KMTtVDbIm8MxlTLIDCjPRxLwhB1yan
+    05FuYHMHAMKkH6NCypuGA4YF1XSPMgO6SfBLz61yoAqMEXT9ugkj7gFt8bFzMmVn
+    b2BXNBXnC13oWG+EPd3THTeFEIZpbljZvGciqXTCKBnWD3tNcQx+ZQEbmhfNiwMg
+    hVv6lonLbPat4zK3JkW920/Vc+rfdoPRbxImsjMKh24BAgMBAAGjggEiMIIBHjAO
+    BgNVHQ8BAf8EBAMCBLAwEwYDVR0lBAwwCgYIKwYBBQUHAwIwCQYDVR0TBAIwADAR
+    BglghkgBhvhCAQEEBAMCBaAwHQYDVR0OBBYEFOx+heEao9Xx+vY/e3ozUT2FeM3i
+    MB8GA1UdIwQYMBaAFBnHeIYJrfaf8/3O44D+GvLA2Pc3MIGYBgNVHREEgZAwgY2k
+    UDBOMR0wGwYDVQQKDBREZWZhdWx0X09yZ2FuaXphdGlvbjEtMCsGA1UEAwwkNTdi
+    MjZjZTMtZTRmZS00Zjc5LWEzNzctMmM0ZDlkZWE1MjA0pDkwNzE1MDMGA1UEAwws
+    Y2VudG9zNy1rYXRlbGxvLWNhbmRsZXBpbi5hcmVhNTIuZXhhbXBsZS5jb20wDQYJ
+    KoZIhvcNAQELBQADggIBAAirOKFelb8FqTa6aaFb7JA7A3bQw7gjCDgaLiWF2KrT
+    RUa1ayHQJ+Tm5jJPo9RNLzDnpKNjVFDK/E9zB8tcOTg8dZoeCvQ6FvjbRTi/8MWP
+    Be5m3ef64a8tQxhdJPeMkRAjKnUzsGZbBjttZue3B89XisKytssk1tkXnY62V42Z
+    m5aAiUfkTr/jeZkuZyLI9uF7Np4rws44/XmoEJp/LNWKmCTtvgIR6NP1W+J2LA/g
+    LOIDLNTyy8Ju95ZDdNQ8KJC+Hrb+OiL86SvwHK9gTAqNqbKmFmQkAtpsgmcObRZF
+    tQRzaHPwR+Pj1wmIoi6UMbeUKuPbVYRf2qVPtvtqFAIGhVBobmIHSE1+G2as0zqZ
+    4LkssrjsyRR02K2aoIOl6IB0s1U2vZ8SRUI4HabSYX/rw9iEdWO1f/gD76YBxSxF
+    5d/rtZUAUQEgS1hdrPlzeNsG5H8Mf05lJMghH8GFJfjkqm6OHkGYcJGCns1Mpai0
+    4RS8QEA83rtEmSdY/oubjNGUMeXk0mjkOrSIblSUYixJJYdi+66IjePyCGMRhtd4
+    0TV5WB3ONylUv777yuHRICFZyny63C1vtUIZMGtu67qYjKk4uMKnHC5lWMaSmepG
+    ifSe+u12fpxjD0UirYSMj38vDtCbcFSPcAAu/1YKw4uvN5zcv+YI91tjOkMJuVah
+    -----END CERTIFICATE-----'.freeze
+
     def test_uuid
-      rhsm_cert = ::Cert::RhsmClient.new(CERT)
-      assert_equal rhsm_cert.uuid, '14e98155-731a-4cae-b151-5c504cc30e1a'
+      rhsm_cert_old = ::Cert::RhsmClient.new(OLD_CERT)
+      rhsm_cert_new = ::Cert::RhsmClient.new(NEW_CERT)
+      assert_equal rhsm_cert_old.uuid, '14e98155-731a-4cae-b151-5c504cc30e1a'
+      assert_equal rhsm_cert_new.uuid, '57b26ce3-e4fe-4f79-a377-2c4d9dea5204'
     end
 
     def test_empty_cert


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

With the new build of Candlepin 4.1.10 they have changed the way entitlement certificates are generated. Before they would look like:

`Subject: CN=eb48d5a8-b759-417c-97f7-93dc2369de29`

Now the new cert looks like:

`Subject: O=Default_Organization, CN=eb48d5a8-b759-417c-97f7-93dc2369de29`

So, we get unauthorized because of the way we parse the ID which now comes back looking like:

`"/O=Default_Organizationeb48d5a8-b759-417c-97f7-93dc2369de29"`

This issue is to address the way we grab the CN from the cert, so it works for the latest version of Candlepin and the older versions.

#### Considerations taken when implementing this change?

Make sure to test with the current version of Candlepin and the updated version here:

https://bugzilla.redhat.com/show_bug.cgi?id=2034349

Steps to upgrade your devbox are here:

https://theforeman.org/plugins/katello/developers.html#upgrading-candlepin

ignore the glue tests and the other manual testing steps as I am doing that as part of the candlepin upgrade once this gets merged. See steps below what needs to be done.

Here are the benchmark stats from the way purposed in the pr to the first way I created. Props to jturel++ for finding the 2nd way.

```ruby
Benchmark.bm { |x| x.report { @cert.subject.to_a.select{|name, _, _| name == 'CN' }.first[1] }}
17:39:22 rails.1   |        user     system      total        real
17:39:22 rails.1   |    0.000127   0.000019   0.000146 (  0.000140)
17:39:22 rails.1   | => [#<Benchmark::Tms:0x00007fdd00c90c18
17:39:22 rails.1   |   @cstime=0.0,
17:39:22 rails.1   |   @cutime=0.0,
17:39:22 rails.1   |   @label="",
17:39:22 rails.1   |   @real=0.0001398190506733954,
17:39:22 rails.1   |   @stime=1.8999999999991246e-05,
17:39:22 rails.1   |   @total=0.00014599999999997948,
17:39:22 rails.1   |   @utime=0.00012699999999998823>]
```

```ruby
Benchmark.bm { |x| x.report { subject_string.sub!(/\/O=Default_Organization/i, '') }}
[1] pry(#<Cert::RhsmClient>)> Benchmark.bm { |x| x.report { subject_string.sub!(/\/O=Default_Organization/i, '') }}
17:47:39 rails.1   |        user     system      total        real
17:47:39 rails.1   |    0.000017   0.000006   0.000023 (  0.000015)
17:47:39 rails.1   | => [#<Benchmark::Tms:0x000000000b9fab90
17:47:39 rails.1   |   @cstime=0.0,
17:47:39 rails.1   |   @cutime=0.0,
17:47:39 rails.1   |   @label="",
17:47:39 rails.1   |   @real=1.4631019439548254e-05,
17:47:39 rails.1   |   @stime=6.0000000000060005e-06,
17:47:39 rails.1   |   @total=2.3000000000050758e-05,
17:47:39 rails.1   |   @utime=1.7000000000044757e-05>]
```

```ruby
Benchmark.bm { |x| x.report { subject_string.sub!(/\/CN=/i, '') }}
17:48:12 rails.1   |        user     system      total        real
17:48:12 rails.1   |    0.000017   0.000005   0.000022 (  0.000016)
17:48:12 rails.1   | => [#<Benchmark::Tms:0x000000000e63b9c0
17:48:12 rails.1   |   @cstime=0.0,
17:48:12 rails.1   |   @cutime=0.0,
17:48:12 rails.1   |   @label="",
17:48:12 rails.1   |   @real=1.6019039321690798e-05,
17:48:12 rails.1   |   @stime=4.999999999977245e-06,
17:48:12 rails.1   |   @total=2.2000000000022002e-05,
17:48:12 rails.1   |   @utime=1.7000000000044757e-05>]
```

Output showing the older version of Candlepin with this PR works with clients:

```bash
[root@centos7-katello-old-candlepin ~]# subscription-manager register
Registering to: centos7-katello-old-candlepin.area52.example.com:443/rhsm
Username: admin
Password: 
The system has been registered with ID: 3f139c78-281a-4252-a6eb-6dcebfb4c95b
The registered system name is: centos7-katello-old-candlepin.area52.example.com
```

I added in the disabled cops since I don't think or know how to do what it wants and return the value without making it unhappy. 

#### What are the testing steps for this pull request?

1. ctrl + c, apply PR and start foreman web server
2. Try to register a client and verify it does not return a 401
3. Attach a subscription of if you are running SCA try to attach a custom product and see if you can see the changes on the client with the new custom repo and make sure subscription manager refresh works
4. Follow the steps above to upgrade Candlepin and repeat the process to make sure the client communication works correctly.

