### PR TITLE
Refs #33951 - correct AIRGAPPED constant reference

### DIFF
--- a/db/migrate/20220124191056_add_type_to_cdn_configuration.rb
+++ b/db/migrate/20220124191056_add_type_to_cdn_configuration.rb
@@ -7,7 +7,7 @@ class AddTypeToCdnConfiguration < ActiveRecord::Migration[6.0]
       unless Setting[:subscription_connection_enabled]
         # if subscription connection is not enabled
         # the user most likely wants the type to be airgapped
-        config.update!(type: ::Katello::CdnConfiguration::AIRGAPPED)
+        config.update!(type: ::Katello::CdnConfiguration::AIRGAPPED_TYPE)
         next
       end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Ran into an error while migrating my local DB:

```
NameError: uninitialized constant Katello::CdnConfiguration::AIRGAPPED
/home/vagrant/katello/db/migrate/20220124191056_add_type_to_cdn_configuration.rb:10:in `block in change'
```

This PR references the correct constant

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

set Setting[:subscription_connection_enabled] to false and migrate the DB. You may need to roll back the migrations if you've already applied AddTypeToConfiguration
