### PR TITLE
Fixes #34314 - Rake task to set import_only flag

### DIFF
--- a/app/services/katello/pulp3/content_view_version/import.rb
+++ b/app/services/katello/pulp3/content_view_version/import.rb
@@ -131,7 +131,7 @@ module Katello
             msg = _("Unable to import in to Content View specified in the metadata - '%{name}'. "\
                      "The 'import_only' attribute for the content view is set to false. "\
                      "To mark this Content View as importable, have your system administrator"\
-                     " run the following command on the satellite. "\
+                     " run the following command on the server. "\
                         % { name: cv.name })
             command = "foreman-rake katello:set_content_view_import_only ID=#{cv.id}"
             fail msg + "\n" + command

--- a/lib/katello/tasks/content_view_import_only.rake
+++ b/lib/katello/tasks/content_view_import_only.rake
@@ -1,0 +1,34 @@
+namespace :katello do
+  desc <<-DESCRIPTION
+  Marks a content view import only or otherwise. Only 'import_only' Content Views can import content via import/export process.
+  Options:
+    ID - ID of the content view that will be marked import
+    VALUE - If true the provided content view will be marked as import_only. This is the default.
+            If false the import_only flag of provided content view will be reset.
+  DESCRIPTION
+
+  task :set_content_view_import_only => ["environment"] do
+    def fetch_content_view
+      if ENV['ID'].blank?
+        fail 'Content view `ID` required.'
+      end
+      ::Katello::ContentView.find_by(id: ENV['ID'])
+    end
+
+    def mark_import_only(value: true)
+      User.current = User.anonymous_admin
+      content_view = fetch_content_view
+      fail('Composite content views cannot be marked import_only. Check the content view id.') if content_view.composite?
+      fail('Default Organization View cannot be marked import_only. Check the content view id.') if content_view.default?
+      content_view.import_only = value
+      if content_view.save(validate: false)
+        $stdout.print("Content View '#{content_view.name}'s import_only value updated to #{content_view.import_only} ")
+      else
+        $stderr.print("Unable to set the content view import_only to #{value}. Check the content view id.")
+        $stderr.print(content_view.errors.inspect)
+      end
+    end
+    value = ENV['VALUE'].blank? || ::Foreman::Cast.to_bool(ENV['VALUE'])
+    mark_import_only(value: value)
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
A rake task that allows the admin user to set/unset the import_only flag of a
content view.

#### Considerations taken when implementing this change?
Whether it should be an api change or a rake task. The rake task was chosen to make it safer for the user since we don't want users changing between import_only and vice-versa.


#### What are the testing steps for this pull request?

- Create a content view without the  `import_only` flag
- Run the following command
```bash
# bundle exec rake katello:set_content_view_import_only ID=2
Content View 'great's import_only value updated to true

# bundle exec rake katello:set_content_view_import_only ID=2 VALUE=false
Content View 'great's import_only value updated to false
```

