### PR TITLE
Fixes #34382 - Add Module stream basic table

### DIFF
--- a/app/models/katello/host_available_module_stream.rb
+++ b/app/models/katello/host_available_module_stream.rb
@@ -37,6 +37,16 @@ module Katello
                                              :stream => available_module_stream.stream}).exists?
     end
 
+    def install_status
+      return 'Not installed' if installed_profiles.blank?
+      case status
+      when 'disabled'
+        'Installed'
+      when 'enabled'
+        upgradable? ? 'Upgradable' : 'Up-to-date'
+      end
+    end
+
     def self.upgradable(host)
       upgradable_module_name_streams = ModuleStream.installable_for_hosts([host]).select(:name, :stream)
 

--- a/app/views/katello/api/v2/host_module_streams/base.json.rabl
+++ b/app/views/katello/api/v2/host_module_streams/base.json.rabl
@@ -2,6 +2,7 @@ object @resource
 
 attributes :status, :installed_profiles
 attributes :upgradable? => :upgradable
+attributes :install_status? => :install_status
 
 glue(@object.available_module_stream) do
   attributes :name, :stream, :module_spec

--- a/webpack/components/extensions/HostDetails/Tabs/ContentTab/SecondaryTabsRoutes.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ContentTab/SecondaryTabsRoutes.js
@@ -2,19 +2,21 @@ import React from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
 import { PackagesTab } from '../PackagesTab';
 import { ErrataTab } from '../ErrataTab/ErrataTab.js';
+import { ModuleStreamsTab } from '../ModuleStreamsTab/ModuleStreamsTab';
 import { route } from './helpers';
 
 const SecondaryTabRoutes = () => (
   <Switch>
-    <Route exact path="/Content">
-      <Redirect to={route('errata')} />
-    </Route>
     <Route path={route('packages')}>
       <PackagesTab />
     </Route>
     <Route path={route('errata')}>
       <ErrataTab />
     </Route>
+    <Route path={route('module-streams')}>
+      <ModuleStreamsTab />
+    </Route>
+    <Redirect to={route('errata')} />
   </Switch>
 );
 

--- a/webpack/components/extensions/HostDetails/Tabs/ContentTab/constants.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ContentTab/constants.js
@@ -3,6 +3,7 @@ import { translate as __ } from 'foremanReact/common/I18n';
 const SECONDARY_TABS = [
   { key: 'packages', title: __('Packages') },
   { key: 'errata', title: __('Errata') },
+  { key: 'module-streams', title: __('Module streams') },
 ];
 
 export default SECONDARY_TABS;

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsActions.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsActions.js
@@ -1,0 +1,16 @@
+import { API_OPERATIONS, get } from 'foremanReact/redux/API';
+import { foremanApi } from '../../../../../services/api';
+import { getResponseErrorMsgs } from '../../../../../utils/helpers';
+import { MODULE_STREAMS_KEY } from './ModuleStreamsConstants';
+
+const errorToast = error => getResponseErrorMsgs(error.response);
+
+export const getHostModuleStreams = (hostId, params) => get({
+  type: API_OPERATIONS.GET,
+  key: MODULE_STREAMS_KEY,
+  url: foremanApi.getApiUrl(`/hosts/${hostId}/module_streams`),
+  errorToast: error => errorToast(error),
+  params,
+});
+
+export default getHostModuleStreams;

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsConstants.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsConstants.js
@@ -1,0 +1,3 @@
+export const MODULE_STREAMS_KEY = 'MODULE_STREAMS';
+
+export default MODULE_STREAMS_KEY;

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsSelectors.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsSelectors.js
@@ -1,0 +1,19 @@
+import {
+  selectAPIStatus,
+  selectAPIError,
+  selectAPIResponse,
+} from 'foremanReact/redux/API/APISelectors';
+import { STATUS } from 'foremanReact/constants';
+import { MODULE_STREAMS_KEY } from './ModuleStreamsConstants';
+
+export const selectModuleStream = state =>
+  selectAPIResponse(state, MODULE_STREAMS_KEY) ?? {};
+
+export const selectHostId = state =>
+  selectAPIResponse(state, MODULE_STREAMS_KEY) ?? {};
+
+export const selectModuleStreamStatus = state =>
+  selectAPIStatus(state, MODULE_STREAMS_KEY) ?? STATUS.PENDING;
+
+export const selecModuleStreamError = state =>
+  selectAPIError(state, MODULE_STREAMS_KEY);

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -1,0 +1,241 @@
+import React, { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { Skeleton, Label, Hint, HintBody, Button } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+import { upperFirst } from 'lodash';
+import { TableText, TableVariant, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import {
+  LongArrowAltUpIcon,
+  CheckIcon,
+} from '@patternfly/react-icons';
+import { urlBuilder } from 'foremanReact/common/urlHelpers';
+import { selectModuleStreamStatus, selectModuleStream } from './ModuleStreamsSelectors';
+import { useBulkSelect, useUrlParams } from '../../../../Table/TableHooks';
+import { getHostModuleStreams } from './ModuleStreamsActions';
+import InactiveText from '../../../../../scenes/ContentViews/components/InactiveText';
+import TableWrapper from '../../../../../components/Table/TableWrapper';
+import hostIdNotReady from '../../HostDetailsActions';
+import { selectHostDetails } from '../../HostDetailsSelectors';
+
+export const ModuleStreamsTab = () => {
+  const { id: hostId, name: hostName } = useSelector(selectHostDetails);
+
+  const emptyContentTitle = __('This host does not have any Module streams.');
+  const emptyContentBody = __('Module streams will appear here when available.');
+  const emptySearchTitle = __('Your search returned no matching Module streams.');
+  const emptySearchBody = __('Try changing your search criteria.');
+  const { searchParam } = useUrlParams();
+  const columnHeaders = [
+    __('Name'),
+    __('State'),
+    __('Stream'),
+    __('Installation status'),
+    __('Installed profile'),
+  ];
+
+  const fetchItems = useCallback(
+    (params) => {
+      if (!hostId) return hostIdNotReady;
+      return getHostModuleStreams(
+        hostId,
+        params,
+      );
+    },
+    [hostId],
+  );
+
+  const response = useSelector(selectModuleStream);
+  const { results, ...metadata } = response;
+  const status = useSelector(state => selectModuleStreamStatus(state));
+  /* eslint-disable no-unused-vars */
+  const {
+    selectOne, isSelected, searchQuery, selectedCount, isSelectable,
+    updateSearchQuery, selectNone, fetchBulkParams, ...selectAll
+  } = useBulkSelect({
+    results,
+    metadata,
+    isSelectable: _result => false,
+    initialSearchQuery: searchParam || '',
+  });
+  /* eslint-enable no-unused-vars */
+
+  if (!hostId) return <Skeleton />;
+
+  const rowActions = [
+    {
+      title: __('Install'), disabled: true,
+    },
+    {
+      title: __('Update'), disabled: true,
+    },
+    {
+      title: __('Enable'), disabled: true,
+    },
+    {
+      title: __('Disable'), disabled: true,
+    },
+    {
+      title: __('Reset'), disabled: true,
+    },
+    {
+      title: __('Remove'), disabled: true,
+    },
+  ];
+
+  const EnabledIcon = ({ streamText, streamInstallStatus, upgradable }) => {
+    const INSTALLED_STATE = {
+      INSTALLED: __('Installed'),
+      UPGRADEABLE: __('Upgradable'),
+      UPTODATE: __('Up-to-date'),
+      NOTINSTALLED: __('Not installed'),
+    };
+
+    switch (true) {
+      case (streamInstallStatus?.length > 0 && streamText === 'disabled'):
+        return <TableText wrapModifier="nowrap">{INSTALLED_STATE.INSTALLED}</TableText>;
+      case (streamInstallStatus?.length > 0 && streamText === 'enabled' && upgradable !== true):
+        return <><CheckIcon color="green" /> {INSTALLED_STATE.UPTODATE}</>;
+      case (streamInstallStatus?.length > 0 && streamText === 'enabled' && upgradable):
+        return <><LongArrowAltUpIcon color="blue" /> {INSTALLED_STATE.UPGRADEABLE}</>;
+      default:
+        return <InactiveText text={INSTALLED_STATE.NOTINSTALLED} />;
+    }
+  };
+
+  EnabledIcon.propTypes = {
+    streamText: PropTypes.string.isRequired,
+    streamInstallStatus: PropTypes.arrayOf(PropTypes.string).isRequired,
+    upgradable: PropTypes.bool.isRequired,
+  };
+
+  const StreamState = ({ moduleStreamStatus }) => {
+    let streamText = moduleStreamStatus?.charAt(0)?.toUpperCase() + moduleStreamStatus?.slice(1);
+    streamText = streamText?.replace('Unknown', 'Default');
+    switch (true) {
+      case (streamText === 'Default'):
+        return <Label color="gray" variant="outline">{streamText}</Label>;
+      case (streamText === 'Disabled'):
+        return <Label color="gray" variant="filled">{streamText}</Label>;
+      case (streamText === 'Enabled'):
+        return <Label color="green" variant="filled">{streamText}</Label>;
+      default:
+        return null;
+    }
+  };
+
+  StreamState.propTypes = {
+    moduleStreamStatus: PropTypes.string.isRequired,
+  };
+
+  const HostInstalledProfiles = ({ moduleStreamStatus, installedProfiles }) => {
+    let installedProfile;
+    if (installedProfiles?.length > 0) {
+      installedProfile = installedProfiles?.map(profile => upperFirst(profile)).join(', ');
+    } else {
+      installedProfile = 'No profile installed';
+    }
+    const disabledText = moduleStreamStatus === 'disabled' || moduleStreamStatus === 'unknown';
+    return disabledText ? <InactiveText text={installedProfile} /> : installedProfile;
+  };
+
+  HostInstalledProfiles.propTypes = {
+    moduleStreamStatus: PropTypes.string.isRequired,
+    installedProfiles: PropTypes.arrayOf(PropTypes.string).isRequired,
+  };
+
+  return (
+    <div>
+      <div id="modules-hint" className="margin-0-24 margin-top-16">
+        <Hint>
+          <HintBody>
+            {__('Module stream management functionality on this page is incomplete')}.
+            <br />
+            <Button component="a" variant="link" isInline href={urlBuilder(`content_hosts/${hostId}/module-streams`, '')}>
+              {__('Visit the previous Module stream page')}.
+            </Button>
+          </HintBody>
+        </Hint>
+      </div>
+      <div id="modulestreams-tab">
+        <TableWrapper
+          {...{
+          metadata,
+          emptyContentTitle,
+          emptyContentBody,
+          emptySearchTitle,
+          emptySearchBody,
+          searchQuery,
+          updateSearchQuery,
+          fetchItems,
+          status,
+        }}
+          additionalListeners={[hostId]}
+          fetchItems={fetchItems}
+          autocompleteEndpoint={`/hosts/${hostId}/module_streams/auto_complete_search`}
+          foremanApiAutoComplete
+          rowsCount={results?.length}
+          variant={TableVariant.compact}
+        >
+          <Thead>
+            <Tr>
+              {columnHeaders.map(col =>
+                <Th key={col}>{col}</Th>)}
+            </Tr>
+          </Thead>
+          <Tbody>
+            {results?.map(({
+                id,
+                status: moduleStreamStatus,
+                name,
+                stream,
+                installed_profiles: installedProfiles,
+                upgradable,
+                module_spec: moduleSpec,
+              }, index) =>
+
+            /* eslint-disable react/no-array-index-key */
+
+             (
+               <Tr key={`${id} ${index}`}>
+                 <Td>
+                   <a
+                     href={`/module_streams?search=module_spec%3D${moduleSpec}+and+host%3D${hostName}`}
+                   >
+                     {name}
+                   </a>
+                 </Td>
+                 <Td>
+                   <StreamState moduleStreamStatus={moduleStreamStatus} />
+                 </Td>
+                 <Td>{stream}</Td>
+                 <Td>
+                   <EnabledIcon
+                     streamText={moduleStreamStatus}
+                     streamInstallStatus={installedProfiles}
+                     upgradable={upgradable}
+                   />
+                 </Td>
+                 <Td>
+                   <HostInstalledProfiles
+                     moduleStreamStatus={moduleStreamStatus}
+                     installedProfiles={installedProfiles}
+                   />
+                 </Td>
+                 <Td
+                   key={`rowActions-${id}`}
+                   actions={{
+                  items: rowActions,
+                }}
+                 />
+               </Tr>
+            ))
+          }
+          </Tbody>
+        </TableWrapper>
+      </div>
+    </div>
+  );
+};
+
+export default ModuleStreamsTab;

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/__tests__/moduleStreamsTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/__tests__/moduleStreamsTab.test.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import { act } from 'react-test-renderer';
+import { renderWithRedux, patientlyWaitFor } from 'react-testing-lib-wrapper';
+import { nockInstance, assertNockRequest, mockForemanAutocomplete, mockSetting } from '../../../../../../test-utils/nockWrapper';
+import { foremanApi } from '../../../../../../services/api';
+import { ModuleStreamsTab } from '../ModuleStreamsTab';
+import mockModuleStreams from './modules.fixtures.json';
+import { MODULE_STREAMS_KEY } from '../ModuleStreamsConstants';
+
+const contentFacetAttributes = {
+  id: 11,
+  uuid: 'e5761ea3-4117-4ecf-83d0-b694f99b389e',
+  content_view_default: false,
+  lifecycle_environment_library: false,
+};
+
+const renderOptions = (facetAttributes = contentFacetAttributes) => ({
+  apiNamespace: MODULE_STREAMS_KEY,
+  initialState: {
+    API: {
+      HOST_DETAILS: {
+        response: {
+          id: 1,
+          name: 'test-host',
+          content_facet_attributes: { ...facetAttributes },
+        },
+        status: 'RESOLVED',
+      },
+    },
+  },
+});
+
+const hostModuleStreams = foremanApi.getApiUrl('/hosts/1/module_streams');
+const autocompleteUrl = '/hosts/1/module_streams/auto_complete_search';
+
+let firstModuleStreams;
+let searchDelayScope;
+let autoSearchScope;
+
+beforeEach(() => {
+  const { results } = mockModuleStreams;
+  [firstModuleStreams] = results;
+  searchDelayScope = mockSetting(nockInstance, 'autosearch_delay', 0);
+  autoSearchScope = mockSetting(nockInstance, 'autosearch_while_typing');
+});
+
+afterEach(() => {
+  assertNockRequest(searchDelayScope);
+  assertNockRequest(autoSearchScope);
+});
+
+beforeEach(() => {
+  const { results } = mockModuleStreams;
+  [firstModuleStreams] = results;
+  searchDelayScope = mockSetting(nockInstance, 'autosearch_delay', 0);
+  autoSearchScope = mockSetting(nockInstance, 'autosearch_while_typing');
+});
+
+afterEach(() => {
+  assertNockRequest(searchDelayScope);
+  assertNockRequest(autoSearchScope);
+});
+
+test('Can call API for Module streams and show on screen on page load', async (done) => {
+  // Setup autocomplete with mockForemanAutoComplete since we aren't adding /katello
+  const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
+  const scope = nockInstance
+    .get(hostModuleStreams)
+    .query(true)
+    .reply(200, mockModuleStreams);
+
+  const { getAllByText } = renderWithRedux(<ModuleStreamsTab />, renderOptions());
+
+  // Assert that the Module streams are now showing on the screen, but wait for them to appear.
+  await patientlyWaitFor(() =>
+    expect(getAllByText(firstModuleStreams.name)[0]).toBeInTheDocument());
+  // Assert request was made and completed, see helper function
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(scope, done); // Pass jest callback to confirm test is done
+  act(done);
+});
+
+test('Can handle no Module streams being present', async (done) => {
+  // Setup autocomplete with mockForemanAutoComplete since we aren't adding /katello
+  const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
+
+  const noResults = {
+    total: 0,
+    subtotal: 0,
+    page: 1,
+    per_page: 20,
+    results: [],
+  };
+
+  const scope = nockInstance
+    .get(hostModuleStreams)
+    .query(true)
+    .reply(200, noResults);
+
+  const { queryByText } = renderWithRedux(<ModuleStreamsTab />, renderOptions());
+
+  // Assert that there are not any Module streams showing on the screen.
+  await patientlyWaitFor(() => expect(queryByText('This host does not have any Module streams.')).toBeInTheDocument());
+  // Assert request was made and completed, see helper function
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(scope, done); // Pass jest callback to confirm test is done
+  act(done);
+});

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/__tests__/modules.fixtures.json
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/__tests__/modules.fixtures.json
@@ -1,0 +1,34 @@
+{
+  "total":3,
+  "subtotal":3,
+  "page":1,
+  "per_page":20,
+  "error":null,
+  "search":null,
+  "results":[
+     {
+        "status":"unknown",
+        "installed_profiles":[],
+        "upgradable":false,
+        "name":"horse",
+        "stream":"1.4",
+        "module_spec":"horse:1.4"
+     },
+     {
+        "status":"unknown",
+        "installed_profiles":[],
+        "upgradable":false,
+        "name":"monkey",
+        "stream":"1.8",
+        "module_spec":"monkey:1.8"
+     },
+     {
+        "status":"enabled",
+        "installed_profiles":["walrus"],
+        "upgradable":false,
+        "name":"walrus",
+        "stream":"2.4",
+        "module_spec":"walrus:2.4"
+     }
+  ]
+}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
With the new host details, we are converting the Module streams to the new layout, this PR serves to add a basic table with actions disabled, pagination and auto complete working as well what this mockup requests:

https://marvelapp.com/prototype/995cc27/screen/78342213

#### What are the testing steps for this pull request?

* Sync this repo: https://partha.fedorapeople.org/test-repos/pteradactyl/
* Register a EL8 client to your devel box
* Follow this to enable a stream: https://docs.pagure.org/modularity/
* Verify things look good, pagination etc looks ok and works
