### PR TITLE
Refs #30280 - Fixup yum repository copy_units_test.rb

### DIFF
--- a/test/services/katello/pulp3/repository/yum/copy_units_test.rb
+++ b/test/services/katello/pulp3/repository/yum/copy_units_test.rb
@@ -10,7 +10,6 @@ module Katello
           @mock_smart_proxy = mock('smart_proxy')
           @mock_smart_proxy.stubs(:pulp3_support?).returns(true)
           @mock_smart_proxy.stubs(:pulp2_preferred_for_type?).returns(false)
-          @mock_smart_proxy.stubs(:pulp_master?).returns(true)
           @repo = katello_repositories(:fedora_17_x86_64_duplicate)
           @repo_service = @repo.backend_service(@mock_smart_proxy)
         end


### PR DESCRIPTION
This appears to have been missed in 540e69 where
the method in smart_proxy_extensions.rb was renamed
