### PR TITLE
Fixes #34372 - ignore path on proxy url

### DIFF
--- a/app/lib/katello/resources/cdn.rb
+++ b/app/lib/katello/resources/cdn.rb
@@ -186,7 +186,7 @@ module Katello
         def net_http_class
           if proxy
             uri = URI(proxy.url) #Net::HTTP::Proxy ignores port as part of the url
-            Net::HTTP::Proxy("#{uri.host}#{uri.path}", uri.port, proxy.username, proxy.password)
+            Net::HTTP::Proxy("#{uri.host}", uri.port, proxy.username, proxy.password)
           else
             Net::HTTP
           end


### PR DESCRIPTION
for repo enablement

#### What are the changes introduced in this pull request?
Ignore the proxy path when trying to enable a repository

#### Considerations taken when implementing this change?
http proxy urls don't really have a path that makes sense

#### What are the testing steps for this pull request?
1.  use these steps to setup a proxy: https://projects.theforeman.org/projects/katello/wiki/HttpProxyTesting
2. create an http proxy and point it to your proxy
3. set it as the default http proxy setting  on the  content tab of the administer > settings page
4. import a manifest
5. try to enable a repository (no repos will be listed)