### PR TITLE
Fixes #34373 - Delete importer if import fails

### DIFF
--- a/app/lib/actions/pulp3/content_view_version/import.rb
+++ b/app/lib/actions/pulp3/content_view_version/import.rb
@@ -19,6 +19,13 @@ module Actions
             metadata: input[:metadata]
           ).create_import(input[:importer_data][:pulp_href])
         end
+
+        def rescue_strategy_for_self
+          # There are various reasons the importing fails, not all of them are
+          # fatal: when fail on import, we continue with the task ending up
+          # in the warning state, but not locking further imports
+          Dynflow::Action::Rescue::Skip
+        end
       end
     end
   end


### PR DESCRIPTION


#### What are the changes introduced in this pull request?
This commit skips the import action and automatically deletes the
importer if the import fails. So if pulp fails we will skip this action
and run through all the other steps and then leave it to the user to
delete the version .

#### Considerations taken when implementing this change?
Before this commit if the import action from pulp fails for whatever reason, dynflow goes
in the paused state expecting user to resume/skip the action. Some users
have used foreman-task cleanup to delete tasks which removes tasks and
leaves the created importer alive instead of cleaning up.

This commit instead of pausing, skips the action on failure. While an unnecessary content view version is still created and the user has to to still manually remove the version,  this code will ensure that task skips on error and progresses along.

#### What are the testing steps for this pull request?
You can use the steps listed in the issue or just change the import action code to cause a failure.

For example 
* change the import url in  `katello/app/lib/actions/pulp3/content_view_version/import.rb` from `create_import(input[:importer_data][:pulp_href])` to `create_import("/fakeurl")`
* run the  import via hammer
* Notice that the hammer task completes but the in dynflow  it skips and warns about the task erroring.
* revert the `create-import` change and try importing again. It should work correctly.


