### PR TITLE
Fixes #34356 - OSTree Refs label missing in repository details

### DIFF
--- a/lib/katello/repository_types/ostree.rb
+++ b/lib/katello/repository_types/ostree.rb
@@ -21,6 +21,7 @@ Katello::RepositoryTypeManager.register('ostree') do
   url_description N_("URL of an OSTree repository.")
 
   generic_content_type 'ostree_ref',
+                       pluralized_name: "OSTree Refs",
                        model_class: Katello::GenericContentUnit,
                        pulp3_api: PulpOstreeClient::ContentRefsApi,
                        pulp3_service_class: Katello::Pulp3::GenericContentUnit,


### PR DESCRIPTION

#### What are the changes introduced in this pull request?
The OSTree Refs label was missing under Content Counts in the repository details of an OSTree repository.
#### Considerations taken when implementing this change?
I had to be really careful to spell OSTree right
#### What are the testing steps for this pull request?
Make an OSTree repository and then look at the content count in the details page. It should say "OSTree Refs" to the left of the number.