### PR TITLE
Fixes #34357 - Incremental CV update fails with 400 HTTP error

### DIFF
--- a/app/lib/actions/pulp3/repository/copy_content.rb
+++ b/app/lib/actions/pulp3/repository/copy_content.rb
@@ -13,7 +13,7 @@ module Actions
           target = ::Katello::Repository.find(input[:target_repository_id] || input[:target_repository])
           service = target.backend_service(smart_proxy)
           output[:pulp_tasks] = if input[:copy_all]
-                                  service.copy_all(source, mirror: input[:mirror] || false)
+                                  service.copy_all(source, input)
                                 else
                                   service.copy_content_for_source(source, input)
                                 end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -285,6 +285,11 @@ module Katello
       ::Katello::Resources::CDN::CdnResource.ca_file if ::Katello::Resources::CDN::CdnResource.redhat_cdn?(url)
     end
 
+    def soft_copy_of_library?
+      return false if self.version_href.nil?
+      self.version_href.starts_with?(self.library_instance.backend_service(SmartProxy.pulp_primary).repository_reference.repository_href)
+    end
+
     def archive?
       self.environment.nil?
     end

--- a/test/actions/katello/content_view_version_test.rb
+++ b/test/actions/katello/content_view_version_test.rb
@@ -29,9 +29,7 @@ module ::Actions::Katello::ContentViewVersion
     end
 
     it 'plans' do
-      SmartProxy.stubs(:pulp_primary).returns(SmartProxy.find_by(name: "Unused Proxy"))
       SmartProxy.any_instance.stubs(:pulp3_support?).returns(false)
-      ::Actions::Katello::ContentViewVersion::IncrementalUpdate.any_instance.stubs(:pulp3_dest_base_version).returns(1)
       stub_remote_user
       @rpm = library_repo.rpms.first
 
@@ -63,9 +61,8 @@ module ::Actions::Katello::ContentViewVersion
       end
 
       def pulp3_cvv_setup
-        SmartProxy.stubs(:pulp_primary).returns(SmartProxy.find_by(name: "Unused Proxy"))
         SmartProxy.any_instance.stubs(:pulp3_support?).returns(true)
-        ::Actions::Katello::ContentViewVersion::IncrementalUpdate.any_instance.stubs(:pulp3_dest_base_version).returns(1)
+        content_view_version.repositories.where(version_href: nil).update(version_href: 'not-nil-href/1/')
         stub_remote_user
 
         repository_mapping = {}
@@ -83,20 +80,23 @@ module ::Actions::Katello::ContentViewVersion
 
       it 'respects dep solving false' do
         pulp3_cvv_setup
+        ::Katello::Repository.any_instance.stubs(:soft_copy_of_library?).returns(true)
         plan_action(action, content_view_version, [library], :resolve_dependencies => false, :content => {:package_ids => [old_rpm.id]})
 
         pulp3_repo_map = {}
-        pulp3_repo_map[[library_repo.id]] = { :dest_repo => new_repo.id, :base_version => 1 }
+        pulp3_repo_map[[library_repo.id]] = { :dest_repo => new_repo.id, :base_version => nil }
         assert_action_planned_with(action, ::Actions::Pulp3::Repository::MultiCopyUnits,
                                   pulp3_repo_map,
                                   { :errata => [], :rpms => [old_rpm.id] },
                                   :dependency_solving => false)
+        assert_action_planned_with(action, ::Actions::Pulp3::Repository::CopyContent, library_repo, SmartProxy.pulp_primary, new_repo, copy_all: true, remove_all: true)
         assert_action_planned_with(action, ::Actions::Katello::Repository::MetadataGenerate, new_repo)
         assert_action_planned_with(action, ::Actions::Katello::Repository::IndexContent, id: new_repo.id)
       end
 
       it 'respects dep solving true' do
         pulp3_cvv_setup
+        ::Katello::Repository.any_instance.stubs(:soft_copy_of_library?).returns(false)
         plan_action(action, content_view_version, [library], :resolve_dependencies => true, :content => {:package_ids => [old_rpm.id]})
 
         pulp3_repo_map = {}
@@ -105,6 +105,7 @@ module ::Actions::Katello::ContentViewVersion
                                   pulp3_repo_map,
                                   { :errata => [], :rpms => [old_rpm.id] },
                                   :dependency_solving => true)
+        refute_action_planned(action, ::Actions::Pulp3::Repository::CopyContent)
       end
     end
   end

--- a/test/actions/pulp3/orchestration/multi_copy_all_units_test.rb
+++ b/test/actions/pulp3/orchestration/multi_copy_all_units_test.rb
@@ -12,6 +12,8 @@ module ::Actions::Pulp3
       @repo_clone.update!(:environment_id => nil)
       @repo_clone.root.update!(:url => 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/')
 
+      ::Katello::Repository.any_instance.stubs(:soft_copy_of_library?).returns(false)
+
       ensure_creatable(@repo, @primary)
       create_repo(@repo, @primary)
       ensure_creatable(@repo_clone, @primary)
@@ -26,6 +28,7 @@ module ::Actions::Pulp3
     end
 
     def test_yum_copy_all_no_filter_rules
+      ::Katello::Repository.any_instance.stubs(:soft_copy_of_library?).returns(true)
       filter = FactoryBot.build(:katello_content_view_package_filter)
       @repo_clone_original_version_href = @repo_clone.version_href
       extended_repo_map = { [@repo] => { :dest_repo => @repo_clone, :filters => [filter] } }
@@ -81,6 +84,7 @@ module ::Actions::Pulp3
     end
 
     def test_yum_copy_all_no_filter_rules_without_dependency_solving
+      ::Katello::Repository.any_instance.stubs(:soft_copy_of_library?).returns(true)
       filter = FactoryBot.create(:katello_content_view_package_filter, :inclusion => true)
       FactoryBot.create(:katello_content_view_package_filter_rule, :filter => filter, :name => "trout")
 
@@ -134,6 +138,7 @@ module ::Actions::Pulp3
     end
 
     def test_yum_copy_all_no_filter_rules_with_dependency_solving
+      ::Katello::Repository.any_instance.stubs(:soft_copy_of_library?).returns(true)
       filter = FactoryBot.build(:katello_content_view_package_filter, :inclusion => true)
       FactoryBot.create(:katello_content_view_package_filter_rule, :filter => filter, :name => "trout")
 
@@ -280,6 +285,8 @@ module ::Actions::Pulp3
       @repo_clone.update!(:environment_id => nil)
       @repo_clone.root.update!(:url => 'https://fixtures.pulpproject.org/srpm-unsigned/')
 
+      ::Katello::Repository.any_instance.stubs(:soft_copy_of_library?).returns(false)
+
       ensure_creatable(@repo, @primary)
       create_repo(@repo, @primary)
       ensure_creatable(@repo_clone, @primary)
@@ -321,6 +328,8 @@ module ::Actions::Pulp3
       @repo_clone.update!(:environment_id => nil)
       @repo_clone.root.update!(:url => 'file:///var/lib/pulp/sync_imports/test_repos/zoo/', :download_policy => 'immediate')
 
+      ::Katello::Repository.any_instance.stubs(:soft_copy_of_library?).returns(false)
+
       ensure_creatable(@repo, @primary)
       create_repo(@repo, @primary)
       ensure_creatable(@repo_clone, @primary)
@@ -335,6 +344,7 @@ module ::Actions::Pulp3
     end
 
     def test_all_errata_copied_if_no_filter_rules
+      ::Katello::Repository.any_instance.stubs(:soft_copy_of_library?).returns(true)
       filter = FactoryBot.build(:katello_content_view_package_filter, :inclusion => true)
 
       extended_repo_map = { [@repo] => { :dest_repo => @repo_clone, :filters => [filter] } }
@@ -409,6 +419,8 @@ module ::Actions::Pulp3
       @repo_clone = katello_repositories(:fedora_17_x86_64_dev)
       @repo_clone.update!(:environment_id => nil)
       @repo_clone.root.update!(:url => 'file:///var/lib/pulp/sync_imports/test_repos/zoo/', :download_policy => 'immediate')
+
+      ::Katello::Repository.any_instance.stubs(:soft_copy_of_library?).returns(false)
 
       ensure_creatable(@repo, @primary)
       create_repo(@repo, @primary)
@@ -496,6 +508,8 @@ module ::Actions::Pulp3
       @repo_clone.update!(:environment_id => nil)
       @repo_clone.root.update!(:url => 'file:///var/lib/pulp/sync_imports/test_repos/zoo/', :download_policy => 'immediate')
 
+      ::Katello::Repository.any_instance.stubs(:soft_copy_of_library?).returns(false)
+
       ensure_creatable(@repo, @primary)
       create_repo(@repo, @primary)
       ensure_creatable(@repo_clone, @primary)
@@ -510,6 +524,7 @@ module ::Actions::Pulp3
     end
 
     def test_all_package_groups_copied_with_no_filter_rules
+      ::Katello::Repository.any_instance.stubs(:soft_copy_of_library?).returns(true)
       filter = FactoryBot.build(:katello_content_view_package_filter, :inclusion => true)
 
       @repo_clone_original_version_href = @repo_clone.version_href
@@ -581,6 +596,8 @@ module ::Actions::Pulp3
       @repo_clone.update!(:environment_id => nil)
       @repo_clone.root.update!(:url => 'file:///var/lib/pulp/sync_imports/test_repos/zoo/', :download_policy => 'immediate')
 
+      ::Katello::Repository.any_instance.stubs(:soft_copy_of_library?).returns(false)
+
       ensure_creatable(@repo, @primary)
       create_repo(@repo, @primary)
       ensure_creatable(@repo_clone, @primary)
@@ -644,6 +661,8 @@ module ::Actions::Pulp3
       @repo_clone = katello_repositories(:fedora_17_x86_64_dev)
       @repo_clone.update!(:environment_id => nil)
       @repo_clone.root.update!(:url => 'file:///var/lib/pulp/sync_imports/test_repos/zoo/', :download_policy => 'immediate')
+
+      ::Katello::Repository.any_instance.stubs(:soft_copy_of_library?).returns(false)
 
       ensure_creatable(@repo, @primary)
       create_repo(@repo, @primary)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Incremental update was not properly handling the case where the source content view version is a "soft copy" of a library repo, i.e., there were no content view filters used.  The Pulp `dest_base_version` was being calculated as if filters were used, which was causing the 400 error.

The PR adds a check for repositories that are not using filters during incremental update.  If that is the case, the Library content (from the proper version when the CVV was published) is copied over to the CV repository before adding the incremental update content.  No `dest_base_version` is used since the repository is starting from fresh.

#### Considerations taken when implementing this change?
We clear out the CV repository completely before copying any Library content because a user could run the incremental update multiple times on the same CVV with different content.  Normally, I would use the `dest_base_version` argument in the Pulp Copy API to avoid clearing out the repo, but the archived version_href will be pointing to the Library repository, so there is nothing to generate a base version from.

The code I've added should only come into affect when incrementally updating a "point-zero" version of a content view.  For point-release versions, the old code path works fine granted that the archived CV repo is no longer a "soft copy" of its library repo.

#### What are the testing steps for this pull request?
**Reproduce the error**

1)  Create some repo and sync it
2) Delete some packages from the repo
3) Create a CV, add the repo, and publish
4) Re-sync the repo to get the deleted RPMs back
5) Incrementally add one or more RPMs back in and see the error

**Fix the error**

1) Apply this PR
2) Skip through the errored incremental update tasks
3) Delete the broken incremental CV version
4) Incremental update again with the same args
5) Ensure there is no error. Check that all of the expected content is there

**Other scenarios to test**

1) Incremental updating with composite content views
2) Incremental updating filtered content back in to a content view version
3) Incremental updating with other content types in the content view version
4) Incremental updating the same CVV multiple times with and without different content
5) Incremental updating "point-release" CVVs