### PR TITLE
Fixes #34384 - publish metadata for imported repos

### DIFF
--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -200,6 +200,11 @@ module Actions
                 plan_action(Katello::Repository::IndexContent, id: id, full_index: true)
               end
             end
+            concurrence do
+              version.importable_repositories.each do |repo|
+                plan_action(::Actions::Katello::Repository::MetadataGenerate, repo)
+              end
+            end
             plan_action(::Actions::Pulp3::Orchestration::ContentViewVersion::CopyVersionUnitsToLibrary, version)
           end
         end

--- a/db/seeds.d/111-upgrade_tasks.rb
+++ b/db/seeds.d/111-upgrade_tasks.rb
@@ -6,6 +6,7 @@ UpgradeTask.define_tasks(:katello) do
     {:name => 'katello:upgrades:4.1:sync_noarch_content'},
     {:name => 'katello:upgrades:4.1:fix_invalid_pools'},
     {:name => 'katello:upgrades:4.1:reupdate_content_import_export_perms'},
-    {:name => 'katello:upgrades:4.2:remove_checksum_values'}
+    {:name => 'katello:upgrades:4.2:remove_checksum_values'},
+    {:name => 'katello:upgrades:4.4:publish_import_cvvs'}
   ]
 end

--- a/lib/katello/tasks/upgrades/4.4/publish_import_cvvs.rake
+++ b/lib/katello/tasks/upgrades/4.4/publish_import_cvvs.rake
@@ -1,0 +1,17 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '4.4' do
+      desc "Republish imported CVs that aren't published"
+      task :publish_import_cvvs => ["environment"] do
+        ::ForemanTasks.dynflow.config.remote = true
+        ::ForemanTasks.dynflow.initialize!
+
+        User.current = User.anonymous_admin
+
+        Katello::Repository.in_content_views(Katello::ContentView.where(:import_only => true)).where(:publication_href => nil).pluck(:content_view_version_id).uniq.each do |cvv_id|
+          ForemanTasks.async_task(Actions::Katello::ContentViewVersion::RepublishRepositories, ::Katello::ContentViewVersion.find(cvv_id))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Causes a metadata generate to occur for archive cv version repositories on library import and CV import

#### Considerations taken when implementing this change?


#### What are the testing steps for this pull request?
* create a repo and sync it
* create an export of library:
   `hammer -u admin -p changeme content-export  complete  library  --destination-server=myfoo --organization-id=1`
* create a 2nd org 'foo'
* Deploy a smart proxy associate it to  foo's library
* copy the export from its location to /var/lib/pulp/imports/
* run the import
 `sudo hammer -u admin -p changeme content-import library  --organization=foo --path /var/lib/pulp/imports/022-02-02T15-52-04-00-00/`
 * sync the smart proxy, it should sync correction.
 * subscribe a system to the created 'import' cv, verify it can see the repo via yum repolist & install a package
 
* repeat the above but for a content view export (and a different org)
