### PR TITLE
Fixes #33554 - fix import_applicability and remove old related code

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -110,14 +110,6 @@ module Katello
         self.update_errata_status
       end
 
-      def import_applicability(partial = false)
-        import_module_stream_applicability(partial)
-        import_errata_applicability(partial)
-        import_deb_applicability(partial)
-        import_rpm_applicability(partial)
-        update_applicability_counts
-      end
-
       def update_applicability_counts
         self.assign_attributes(
             :installable_security_errata_count => self.installable_errata.security.count,
@@ -131,23 +123,6 @@ module Katello
             :upgradable_module_stream_count => self.installable_module_streams.count
         )
         self.save!(:validate => false)
-      end
-
-      def import_deb_applicability(partial)
-        ApplicableContentHelper.new(Deb, self).import(partial)
-      end
-
-      def import_rpm_applicability(partial)
-        ApplicableContentHelper.new(Rpm, self).import(partial)
-      end
-
-      def import_errata_applicability(partial)
-        ApplicableContentHelper.new(Erratum, self).import(partial)
-        self.update_errata_status
-      end
-
-      def import_module_stream_applicability(partial)
-        ApplicableContentHelper.new(ModuleStream, self).import(partial)
       end
 
       def self.in_content_view_version_environments(version_environments)

--- a/lib/katello/tasks/import_applicability.rake
+++ b/lib/katello/tasks/import_applicability.rake
@@ -1,7 +1,7 @@
 namespace :katello do
   task :import_applicability => ["environment"] do
     Katello::Host::ContentFacet.find_each do |facet|
-      facet.import_applicability
+      facet.calculate_and_import_applicability
     rescue StandardError => exception
       puts _('Error importing applicability for %{name} - %{id}: %{message}') %
           {:name => facet.host.name, :id => facet.host.id, :message => exception.message}

--- a/test/lib/tasks/import_applicability_test.rb
+++ b/test/lib/tasks/import_applicability_test.rb
@@ -11,7 +11,7 @@ module Katello
     end
 
     def test_success
-      Katello::Host::ContentFacet.any_instance.expects(:import_applicability).at_least_once
+      Katello::Host::ContentFacet.any_instance.expects(:calculate_and_import_applicability).at_least_once
 
       Rake.application.invoke_task('katello:import_applicability')
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Removes old applicability code and updates the import_applicability rake task to use the real applicability method.

#### Considerations taken when implementing this change?
This has been broken since we updated to using "Katello Applicability".

#### What are the testing steps for this pull request?
Run the `katello:import_applicability` rake task on some real hosts. Just make sure it runs okay.