### PR TITLE
Fixes #33804 - Change size limit of deb attributes based on pulp deb

### DIFF
--- a/db/migrate/20220207140355_change_deb_attributes_size_limit.rb
+++ b/db/migrate/20220207140355_change_deb_attributes_size_limit.rb
@@ -1,0 +1,7 @@
+class ChangeDebAttributesSizeLimit < ActiveRecord::Migration[6.0]
+  def change
+    change_column :katello_root_repositories, :deb_releases, :text
+    change_column :katello_root_repositories, :deb_components, :text
+    change_column :katello_root_repositories, :deb_architectures, :text
+  end
+end


### PR DESCRIPTION
Changes size limit of deb attributes based on pulp deb issue https://pulp.plan.io/issues/9277