### PR TITLE
Fixes #34407 - Repo filtering shows all repos in different organizations

### DIFF
--- a/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
@@ -168,7 +168,7 @@ export const getRepositories = params => get({
 });
 
 export const getContentViewRepositories = (cvId, params, status) => {
-  const apiParams = { ...params };
+  const apiParams = { organization_id: orgId(), ...params };
   let apiUrl = `/content_views/${cvId}/repositories`;
 
   if (status === ALL_STATUSES) {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
The API call to get repos available for CV should be scoped by org.
#### What are the testing steps for this pull request?
1. Create 2 orgs (Default could be one)
2. Create and sync a product and repo within each of those orgs.
3. Create a cv in one org
4. Drill to repositories tab
5. filter status to "not added"
6. Repos from all orgs are listed.
