### PR TITLE
Fixes #34408 - Fix package page initial repo filtering

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/packages.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/packages.controller.js
@@ -21,6 +21,7 @@ angular.module('Bastion.packages').controller('PackagesController',
         var nutupane, params = {
             'organization_id': CurrentOrganization,
             'search': $location.search().search || "",
+            'repository_id': $location.search().repositoryId || null,
             'paged': true
         };
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds repo id to params of initial table load on packages page.

#### Considerations taken when implementing this change?
There's a watcher that handles repository filtering on the Packages page. That works fine when the filter is actually changed using the repo dropdown. However on initial page load with repository selected, the behavior is not consistent.
#### What are the testing steps for this pull request?

1. Sync couple of yum repos.
2. Add them to a CV and publish a version
3. Go to version details > Repository
4. Go to _x_ Rpm packages link in the Content column for the repository.
5. The package page should open with repository pre-selected and results filtered by repository.
6. Refresh the page a couple of times and you should keep seeing repo pre-selected and filtered results.

Without this change, the package page with repositoryId specified results in all packages being listed. Refreshing that page will also work erratically. 
