### PR TITLE
Fixes #34411 - set timeout for pulp api access

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -179,6 +179,7 @@ module Katello
           config.scheme = uri.scheme
           pulp3_ssl_configuration(config)
           config.debugging = false
+          config.timeout = SETTINGS[:katello][:rest_client_timeout]
           config.logger = ::Foreman::Logging.logger('katello/pulp_rest')
           config.username = self.setting(PULP3_FEATURE, 'username')
           config.password = self.setting(PULP3_FEATURE, 'password')


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

set the timeout on pulpcore api requests

#### Considerations taken when implementing this change?
There are multiple timeouts between katello and pulpcore, this client side timeout, the timeout of apache (with its reverse proxy), and gnuicorn's timeout.  This is the smallest at 90 seconds.

Apache's is 600 seconds, and guicorn is 90s.  

#### What are the testing steps for this pull request?
1.  cause a timeout:

edit:  /usr/lib/python3.8/site-packages/pulpcore/app/viewsets/orphans.py

find 
```
    def cleanup(self, request):
```
and add a sleep statement

```
    def cleanup(self, request):
        time.sleep(10)
```
restart pulpcore-api
```
systemctl restart pulpcore-api
```

Patch the bindings gem (there's a bug that prevents this from working):

edit /home/vagrant/git/foreman/vendor/ruby/2.7.0/gems/pulpcore_client-3.16.3/lib/pulpcore_client/api_client.rb
replace the build_request method with this:
```
    def build_request(http_method, path, request, opts = {})
      url = build_request_url(path)
      http_method = http_method.to_sym.downcase

      header_params = @default_headers.merge(opts[:header_params] || {})
      query_params = opts[:query_params] || {}
      form_params = opts[:form_params] || {}

      update_params_for_auth! header_params, query_params, opts[:auth_names]

      req_opts = {
        :params_encoding => @config.params_encoding,
        :timeout => @config.timeout,
      }

      if [:post, :patch, :put, :delete].include?(http_method)
        req_body = build_request_body(header_params, form_params, opts[:body])
        if @config.debugging
          @config.logger.debug "HTTP request body param ~BEGIN~\n#{req_body}\n~END~\n"
        end
      end
      request.options.update(req_opts)
      request.headers = header_params
      request.body = req_body
      request.url url
      request.params = query_params
      download_file(request) if opts[:return_type] == 'File'
      request
    end
```

set rest_client_timeout to something kinda small (like 3 seconds)   katello.yaml
```
:katello:
  :rest_client_timeout: 3
```

stop spring:

```
bundle exec spring stop
```

verify you don't see the timeout (as the katello fix isn't present)
```
foreman-rake console (or rails c)
    ::Katello::Pulp3::Api::Core.new(SmartProxy.pulp_primary).delete_orphans
```

now checkout this PR, and verify the timeout goes away

```
foreman-rake console (or rails c)
    ::Katello::Pulp3::Api::Core.new(SmartProxy.pulp_primary).delete_orphans
```