### PR TITLE
Fixes #34414 - Errata mail should only list new errata

### DIFF
--- a/app/lib/actions/katello/repository/errata_mail.rb
+++ b/app/lib/actions/katello/repository/errata_mail.rb
@@ -4,17 +4,16 @@ module Actions
       class ErrataMail < Actions::EntryAction
         middleware.use Actions::Middleware::ExecuteIfContentsChanged
 
-        def plan(repo, last_updated = nil, contents_changed = nil)
-          last_updated ||= repo.repository_errata.order('updated_at ASC').last.try(:updated_at) || Time.now
-          plan_self(:repo => repo.id, :last_updated => last_updated.to_s, :contents_changed => contents_changed)
+        def plan(repo, contents_changed = nil)
+          plan_self(:repo => repo.id, :contents_changed => contents_changed)
         end
 
         def run
           ::User.current = ::User.anonymous_admin
-
           repo = ::Katello::Repository.find(input[:repo])
+          last_updated = repo.repository_errata.order('updated_at ASC').last.try(:updated_at) || Time.now
           users = ::User.select { |user| user.receives?(:sync_errata) && user.organization_ids.include?(repo.organization.id) && user.can?(:view_products, repo.product) }.compact
-          errata = ::Katello::Erratum.where(:id => repo.repository_errata.where('katello_repository_errata.updated_at > ?', input[:last_updated].to_datetime).pluck(:erratum_id))
+          errata = ::Katello::Erratum.where(:id => repo.repository_errata.where('katello_repository_errata.updated_at > ?', last_updated).pluck(:erratum_id))
 
           begin
             MailNotification[:sync_errata].deliver(:users => users, :repo => repo, :errata => errata) unless (users.blank? || errata.blank?)

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -51,11 +51,11 @@ module Actions
               plan_action(Katello::Repository::FetchPxeFiles, :id => repo.id)
               plan_action(Katello::Repository::CorrectChecksum, repo)
               concurrence do
-                plan_action(Katello::Repository::ErrataMail, repo, nil, contents_changed)
+                plan_action(Katello::Repository::ErrataMail, repo, output[:contents_changed])
                 plan_action(Actions::Katello::Applicability::Repository::Regenerate, :repo_ids => [repo.id]) if generate_applicability
               end
               plan_self(:id => repo.id, :sync_result => output, :skip_metadata_check => skip_metadata_check, :validate_contents => validate_contents,
-                        :contents_changed => contents_changed)
+                        :contents_changed => output[:contents_changed])
               plan_action(Katello::Repository::SyncHook, :id => repo.id)
             end
           end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -468,6 +468,13 @@ module ::Actions::Katello::Repository
       assert_action_planned_with(action, ::Actions::Katello::Repository::VerifyChecksum, repository)
     end
 
+    it 'plans errata mailer with contents_changed' do
+      action = create_action action_class
+      action.stubs(:action_subject).with(repository)
+      plan_action action, repository
+      assert_action_planned(action, ::Actions::Katello::Repository::ErrataMail)
+    end
+
     it 'plans pulp3 orchestration actions with file repo' do
       action = create_action pulp3_action_class
       action.stubs(:action_subject).with(repository_pulp3)
@@ -661,6 +668,16 @@ module ::Actions::Katello::Repository
           assert_in_delta pulp3_action.run_progress, 0.5
         end
       end
+    end
+  end
+
+  class ErrataMailerTest < TestBase
+    let(:action_class) { ::Actions::Katello::Repository::ErrataMail }
+
+    it 'plans' do
+      action = create_action action_class
+      planned_action = plan_action action, repository, true
+      assert_equal planned_action.execution_plan.planned_run_steps.first.input, "repo" => repository.id, "contents_changed" => true
     end
   end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Errata mailer should only list newly added errata if any for sync summary emails.
content_changed value should be set correctly.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. a) Set a valid email id for the admin user in your box and in Email Preferences > Subscribe to Sync errata emails.
    b) Go to Administer>settings>Email and click on Test email to verify you're getting emails from the dev box.
2. Sync a new repo with errata.
3. Check sync summary email.
4. Resync. You shouldn't get an email.

Without this change: You'd see an email on every sync regardless of contents_changed or errata being added.