### PR TITLE
Fixes #34417 - Don't set global RestClient proxy during repo discover

### DIFF
--- a/app/lib/actions/katello/repository/discover.rb
+++ b/app/lib/actions/katello/repository/discover.rb
@@ -33,7 +33,7 @@ module Actions
                 password = decrypt_field(input[:upstream_password])
                 repo_discovery = ::Katello::RepoDiscovery.new(input[:url], input[:content_type],
                                                               input[:upstream_username], password,
-                                                              input[:search], proxy,
+                                                              input[:search],
                                                               output[:crawled], output[:repo_urls], output[:to_follow])
 
                 repo_discovery.run(output[:to_follow].shift)
@@ -48,19 +48,6 @@ module Actions
         # @return [Array<String>] urls found by the action
         def task_output
           output[:repo_urls] || []
-        end
-
-        def proxy
-          proxy_details = {}
-          if (proxy = ::HttpProxy.default_global_content_proxy)
-            uri = URI(proxy.url)
-            proxy_details[:proxy_host] = "#{uri.scheme}://#{uri.host}#{uri.path}"
-            proxy_details[:proxy_port] = uri.port
-            proxy_details[:proxy_user] = proxy.username
-            proxy_details[:proxy_password] = proxy.password
-          end
-
-          proxy_details
         end
       end
     end

--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -197,7 +197,7 @@ module Katello
 
         def latest_repo_discovery
           ForemanTasks::Task::DynflowTask.for_action(::Actions::Katello::Repository::Discover)
-            .for_resource(::User.current).order("started_at").last
+            .where(user: ::User.current).order("started_at").last
         end
 
         def cancel_repo_discovery

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
@@ -4,8 +4,6 @@
  *
  * @requires $scope
  * @requires $q
- * @requires $timeout
- * @requires $http
  * @requires Notification
  * @requires Task
  * @requires Organization
@@ -18,8 +16,8 @@
  *   Provides the functionality for the repo discovery action pane.
  */
 angular.module('Bastion.products').controller('DiscoveryController',
-    ['$scope', '$q', '$timeout', '$http', '$filter', 'Notification', 'Task', 'Organization', 'CurrentOrganization', 'DiscoveryRepositories', 'ContainerRegistries', 'translate',
-    function ($scope, $q, $timeout, $http, $filter, Notification, Task, Organization, CurrentOrganization, DiscoveryRepositories, ContainerRegistries, translate) {
+    ['$scope', '$q', '$filter', 'Notification', 'Task', 'Organization', 'CurrentOrganization', 'DiscoveryRepositories', 'ContainerRegistries', 'translate',
+    function ($scope, $q, $filter, Notification, Task, Organization, CurrentOrganization, DiscoveryRepositories, ContainerRegistries, translate) {
         var transformRows, setDiscoveryDetails;
 
         $scope.discovery = {
@@ -37,6 +35,9 @@ angular.module('Bastion.products').controller('DiscoveryController',
             {id: "docker", name: "Container Images"}
         ];
         $scope.hideSwitcher = true;
+
+        // scope.table may have been set when clicking in from products
+        // otherwise set a simple table since there is no BastionResource here
         if (!$scope.table) {
             $scope.table = {
                 rows: [],

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.routes.js
@@ -42,13 +42,14 @@ angular.module('Bastion.products').config(['$stateProvider', function ($statePro
     });
 
     $stateProvider.state("product-discovery", {
-        abstract: true,
         url: '/products/discovery',
-        controller: 'DiscoveryController',
-        templateUrl: 'products/discovery/views/discovery-base.html'
+        templateUrl: 'products/discovery/views/discovery-base.html',
+        permission: 'edit_products',
+        redirectTo: 'product-discovery.scan'
     })
     .state("product-discovery.scan", {
         url: '/scan',
+        controller: 'DiscoveryController',
         permission: 'edit_products',
         templateUrl: 'products/discovery/views/discovery.html',
         ncyBreadcrumb: {

--- a/test/actions/katello/repository/discover_test.rb
+++ b/test/actions/katello/repository/discover_test.rb
@@ -21,7 +21,7 @@ module Actions
 
       mock_discovery = mock
       url = 'http://foo.com'
-      ::Katello::RepoDiscovery.expects(:new).with(url, 'yum', 'admin', 'secret', nil, {}, [], [], [url]).returns(mock_discovery)
+      ::Katello::RepoDiscovery.expects(:new).with(url, 'yum', 'admin', 'secret', nil, [], [], [url]).returns(mock_discovery)
       mock_discovery.expects(:run).with("http://foo.com").once
 
       task = ForemanTasks.sync_task(action_class, url, 'yum', 'admin', 'secret', nil)
@@ -35,7 +35,7 @@ module Actions
 
       mock_discovery = mock
       url = 'http://foo.com'
-      ::Katello::RepoDiscovery.expects(:new).with(url, 'yum', 'admin', 'secret', nil, {}, [], [], [url]).returns(mock_discovery)
+      ::Katello::RepoDiscovery.expects(:new).with(url, 'yum', 'admin', 'secret', nil, [], [], [url]).returns(mock_discovery)
       mock_discovery.expects(:run).with("http://foo.com").once
 
       task = ForemanTasks.sync_task(action_class, url, 'yum', 'admin', 'secret', nil)

--- a/test/lib/repo_discovery_test.rb
+++ b/test/lib/repo_discovery_test.rb
@@ -24,11 +24,9 @@ module Katello
       proxy = {}
       search = 'busybox'
 
-      RestClient.expects(:get)
-        .with(base_url.to_s + "v1/search?q=#{search}", {:accept => :json})
+      RestClient::Request.expects(:execute)
+        .with(method: :get, url: base_url.to_s + "v1/search?q=#{search}", headers: {:accept => :json})
         .returns({results: ['busybox']}.to_json)
-
-      RestClient.expects(:proxy=).with(nil)
 
       rd = RepoDiscovery.new(base_url, 'docker', nil, nil, search, proxy, crawled, found, to_follow)
 
@@ -53,12 +51,9 @@ module Katello
       expected_proxy_uri.password = proxy[:proxy_password]
       expected_proxy_uri.port = proxy[:proxy_port]
 
-      RestClient.expects(:get)
-        .with(base_url.to_s + "v1/search?q=#{search}", {:accept => :json})
+      RestClient::Request.expects(:execute)
+        .with(method: :get, url: base_url.to_s + "v1/search?q=#{search}", proxy: "https://admin:redhat@proxy.example.com:8888", headers: {:accept => :json})
         .returns({results: ['busybox']}.to_json)
-
-      RestClient.expects(:proxy=).with(nil)
-      RestClient.expects(:proxy=).with('https://admin:redhat@proxy.example.com:8888')
 
       rd = RepoDiscovery.new(base_url, 'docker', nil, nil, search, proxy, crawled, found, to_follow)
 
@@ -83,16 +78,13 @@ module Katello
       expected_proxy_uri.password = proxy[:proxy_password]
       expected_proxy_uri.port = proxy[:proxy_port]
 
-      RestClient.expects(:get)
-        .with(base_url.to_s + "v1/search?q=#{search}", {:accept => :json})
+      RestClient::Request.expects(:execute)
+        .with(method: :get, url: base_url.to_s + "v1/search?q=#{search}", proxy: "https://admin:redhat@proxy.example.com:8888", headers: {:accept => :json})
         .returns({code: Net::HTTPNotFound}.to_json)
 
-      RestClient.expects(:get)
-        .with(base_url.to_s + "v2/_catalog", {:accept => :json})
+      RestClient::Request.expects(:execute)
+        .with(method: :get, url: base_url.to_s + "v2/_catalog", proxy: "https://admin:redhat@proxy.example.com:8888", headers: {:accept => :json})
         .returns({'repositories' => ['busybox']}.to_json)
-
-      RestClient.expects(:proxy=).with(nil)
-      RestClient.expects(:proxy=).with('https://admin:redhat@proxy.example.com:8888')
 
       rd = RepoDiscovery.new(base_url, 'docker', nil, nil, search, proxy, crawled, found, to_follow)
 

--- a/test/lib/repo_discovery_test.rb
+++ b/test/lib/repo_discovery_test.rb
@@ -1,13 +1,19 @@
 require 'katello_test_helper'
 
 module Katello
-  class FileRepoDiscoveryTest < ActiveSupport::TestCase
+  class RepoDiscoveryTest < ActiveSupport::TestCase
+    def setup
+      @http_proxy = http_proxies(:myhttpproxy)
+      @proxy_url = "proxys://mytest.com:443"
+      @proxy_uri = URI(@proxy_url)
+    end
+
     def test_run
       base_url = "file://#{Katello::Engine.root}/test/fixtures/"
       crawled = []
       found = []
       to_follow = [base_url]
-      rd = RepoDiscovery.new(base_url, 'yum', nil, nil, {}, crawled, found, to_follow)
+      rd = RepoDiscovery.new(base_url, 'yum', nil, nil, crawled, found, to_follow)
 
       rd.run(to_follow.shift)
       assert_equal 1, rd.crawled.size
@@ -16,19 +22,50 @@ module Katello
       assert_equal rd.crawled.first, "#{Katello::Engine.root}/test/fixtures/"
     end
 
+    def test_run_http_with_proxy
+      base_url = "http://yum.theforeman.org/"
+      crawled = []
+      found = []
+      to_follow = [base_url]
+      rd = RepoDiscovery.new(base_url, 'yum', nil, nil, crawled, found, to_follow)
+      rd.stubs(:proxy).returns(@http_proxy)
+
+      expected_proxy_params = {
+        proxy_host: @proxy_uri.host,
+        proxy_port: @proxy_uri.port,
+        proxy_user: @http_proxy.username,
+        proxy_password: @http_proxy.password
+      }
+
+      Anemone.expects(:crawl).with(rd.uri(base_url), expected_proxy_params).returns
+
+      rd.run(to_follow.shift)
+    end
+
+    def test_run_http
+      base_url = "http://yum.theforeman.org/"
+      crawled = []
+      found = []
+      to_follow = [base_url]
+      rd = RepoDiscovery.new(base_url, 'yum', nil, nil, crawled, found, to_follow)
+      Anemone.expects(:crawl).with(rd.uri(base_url), {}).returns
+
+      rd.run(to_follow.shift)
+    end
+
     def test_docker_with_v1_search_no_proxy
       base_url = "https://docker.io/"
       crawled = []
       found = []
       to_follow = [base_url]
-      proxy = {}
       search = 'busybox'
 
       RestClient::Request.expects(:execute)
         .with(method: :get, url: base_url.to_s + "v1/search?q=#{search}", headers: {:accept => :json})
         .returns({results: ['busybox']}.to_json)
 
-      rd = RepoDiscovery.new(base_url, 'docker', nil, nil, search, proxy, crawled, found, to_follow)
+      rd = RepoDiscovery.new(base_url, 'docker', nil, nil, search, crawled, found, to_follow)
+      rd.expects(:proxy).returns(nil)
 
       rd.run(to_follow.shift)
     end
@@ -38,24 +75,14 @@ module Katello
       crawled = []
       found = []
       to_follow = [base_url]
-      proxy = {
-        proxy_host: 'https://proxy.example.com',
-        proxy_user: 'admin',
-        proxy_password: 'redhat',
-        proxy_port: 8888
-      }
       search = 'busybox'
 
-      expected_proxy_uri = URI(proxy[:proxy_host])
-      expected_proxy_uri.user = proxy[:proxy_user]
-      expected_proxy_uri.password = proxy[:proxy_password]
-      expected_proxy_uri.port = proxy[:proxy_port]
-
       RestClient::Request.expects(:execute)
-        .with(method: :get, url: base_url.to_s + "v1/search?q=#{search}", proxy: "https://admin:redhat@proxy.example.com:8888", headers: {:accept => :json})
+        .with(method: :get, url: base_url.to_s + "v1/search?q=#{search}", proxy: @proxy_url, headers: {:accept => :json})
         .returns({results: ['busybox']}.to_json)
 
-      rd = RepoDiscovery.new(base_url, 'docker', nil, nil, search, proxy, crawled, found, to_follow)
+      rd = RepoDiscovery.new(base_url, 'docker', nil, nil, search, crawled, found, to_follow)
+      rd.stubs(:proxy).returns(@http_proxy)
 
       rd.run(to_follow.shift)
     end
@@ -65,28 +92,18 @@ module Katello
       crawled = []
       found = []
       to_follow = [base_url]
-      proxy = {
-        proxy_host: 'https://proxy.example.com',
-        proxy_user: 'admin',
-        proxy_password: 'redhat',
-        proxy_port: 8888
-      }
       search = 'busybox'
 
-      expected_proxy_uri = URI(proxy[:proxy_host])
-      expected_proxy_uri.user = proxy[:proxy_user]
-      expected_proxy_uri.password = proxy[:proxy_password]
-      expected_proxy_uri.port = proxy[:proxy_port]
-
       RestClient::Request.expects(:execute)
-        .with(method: :get, url: base_url.to_s + "v1/search?q=#{search}", proxy: "https://admin:redhat@proxy.example.com:8888", headers: {:accept => :json})
+        .with(method: :get, url: base_url.to_s + "v1/search?q=#{search}", proxy: @proxy_url, headers: {:accept => :json})
         .returns({code: Net::HTTPNotFound}.to_json)
 
       RestClient::Request.expects(:execute)
-        .with(method: :get, url: base_url.to_s + "v2/_catalog", proxy: "https://admin:redhat@proxy.example.com:8888", headers: {:accept => :json})
+        .with(method: :get, url: base_url.to_s + "v2/_catalog", proxy: @proxy_url, headers: {:accept => :json})
         .returns({'repositories' => ['busybox']}.to_json)
 
-      rd = RepoDiscovery.new(base_url, 'docker', nil, nil, search, proxy, crawled, found, to_follow)
+      rd = RepoDiscovery.new(base_url, 'docker', nil, nil, search, crawled, found, to_follow)
+      rd.stubs(:proxy).returns(@http_proxy)
 
       rd.run(to_follow.shift)
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

RestClient.proxy is a global value and should not be set unless the intention is to change the global http proxy (unlikely). Doing this in RepoDiscovery for docker repos forces even localhost traffic to go through the HTTP proxy meant for external traffic.

#### Considerations taken when implementing this change?

Avoid setting global rest client proxy which I found to be doable with RestClient::Request.execute!

#### What are the testing steps for this pull request?

You can follow the testing steps in the BZ if you want to go all the way: https://bugzilla.redhat.com/show_bug.cgi?id=2046337
Otherwise, you could also verify this via the rails console by calling repo discovery, and then calling a Candlepin resource.
