### PR TITLE
Fixes #34420 - fix REX errata apply with no inc update

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
@@ -10,13 +10,14 @@
  * @requires ContentViewVersion
  * @requires CurrentOrganization
  * @requires Notification
+ * @requires BastionConfig
  *
  * @description
  *   Display confirmation screen and apply Errata.
  */
 angular.module('Bastion.errata').controller('ApplyErrataController',
-    ['$scope', '$window', 'translate', 'IncrementalUpdate', 'HostBulkAction', 'ContentViewVersion', 'CurrentOrganization', 'Notification',
-        function ($scope, $window, translate, IncrementalUpdate, HostBulkAction, ContentViewVersion, CurrentOrganization, Notification) {
+    ['$scope', '$window', 'translate', 'IncrementalUpdate', 'HostBulkAction', 'ContentViewVersion', 'CurrentOrganization', 'Notification', 'BastionConfig',
+        function ($scope, $window, translate, IncrementalUpdate, HostBulkAction, ContentViewVersion, CurrentOrganization, Notification, BastionConfig) {
             var applyErrata, incrementalUpdate;
 
             function transitionToTask(task) {
@@ -31,6 +32,8 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
 
             $scope.applyingErrata = false;
 
+            $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
+            $scope.remoteExecutionByDefault = BastionConfig.remoteExecutionByDefault;
             $scope.errataActionFormValues = {
                 authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, ''),
                 errata: IncrementalUpdate.getErrataIds().join(','),
@@ -133,7 +136,11 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
             $scope.confirmApply = function() {
                 $scope.applyingErrata = true;
                 if ($scope.updates.length === 0) {
-                    applyErrata();
+                    if ($scope.remoteExecutionPresent && $scope.remoteExecutionByDefault) {
+                        angular.element('#errataActionForm').submit();
+                    } else {
+                        applyErrata();
+                    }
                 } else {
                     incrementalUpdate();
                 }


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fix applying an errata with remote_execution_by_default=true from the Content > Errata page when an incremental update is not required. 

#### Considerations taken when implementing this change?
The changes here:  https://github.com/Katello/katello/pull/9175/files#diff-9124514bc0e0bfa5963c69825b69c895be7ad00040b77361fa97a6352bd082aa 
originally added support for this, but a bugfix:   https://github.com/Katello/katello/pull/9600/files#diff-9124514bc0e0bfa5963c69825b69c895be7ad00040b77361fa97a6352bd082aaR133   

accidentally removed the ability to apply an errata via REX from the errata page unless you are doing an incremental update.

#### What are the testing steps for this pull request?
1.  set the Setting remote_execution_by_default to true
2. enable remote execution on your dev environment
3. sync some repo such as https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/
4. register and subscribe a client to your repo in Library
5. ensure some errata is applicable
6. navigate to Content > errata
7. click on an applicable (and install-able errata)
8. click on the content hosts tab of the errata
9. try to apply it