### PR TITLE
Fixes #34425 - Update errata severity colors

### DIFF
--- a/webpack/components/Errata/index.js
+++ b/webpack/components/Errata/index.js
@@ -1,5 +1,11 @@
 import React from 'react';
 import { TableText } from '@patternfly/react-table';
+import {
+  chart_color_black_500 as pfBlack,
+  chart_color_gold_400 as pfGold,
+  chart_color_orange_300 as pfOrange,
+  chart_color_red_200 as pfRed,
+} from '@patternfly/react-tokens';
 import { translate as __ } from 'foremanReact/common/I18n';
 import {
   BugIcon,
@@ -102,16 +108,20 @@ export const ErrataSeverity = ({ severity }) => {
   let label;
 
   switch (severity) {
+    case 'Low':
+      color = pfBlack.value;
+      label = __('Low');
+      break;
     case 'Moderate':
-      color = 'yellow';
+      color = pfGold.value;
       label = __('Moderate');
       break;
     case 'Important':
-      color = 'orange';
+      color = pfOrange.value;
       label = __('Important');
       break;
     case 'Critical':
-      color = 'red';
+      color = pfRed.value;
       label = __('Critical');
       break;
     default:


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Per request from maria, update errata severity colors to be consistent with console
<img width="778" alt="Screenshot 2022-02-09 at 12 44 03" src="https://user-images.githubusercontent.com/22042343/153224758-556b4470-4292-4f0e-8cac-a3d46b82cfea.png">


#### Considerations taken when implementing this change?

I used the specific color values because I wasn't sure if the CSS variables would work in the patternfly components. It's fine!

#### What are the testing steps for this pull request?

View errata on the new host details page and confirm colors match the mockup.
Tip: In React dev tools, find one of the `<ErrataSeverity>` components and change the `severity` prop to "Low", "Critical", etc. to momentarily see that icon.
