### PR TITLE
Fixes #34418 - Incorrect CVV 'Content' column counts

### DIFF
--- a/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
@@ -132,7 +132,7 @@ export const getDockerTags = params => get({
   key: DOCKER_TAGS_CONTENT,
   url: api.getApiUrl('/docker_tags'),
   params,
-  errorToast: error => __(`Something went wrong while getting docker tags! ${getResponseErrorMsgs(error.response)}`),
+  errorToast: error => __(`Something went wrong while getting container tags! ${getResponseErrorMsgs(error.response)}`),
 });
 
 export const getErrata = params => get({

--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionContent.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionContent.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { camelCase } from 'lodash';
-import { Link } from 'react-router-dom';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { urlBuilder } from 'foremanReact/common/urlHelpers';
-import ContentConfig from './../../../Content/ContentConfig';
+import { camelCase } from 'lodash';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import ContentConfig from '../../../Content/ContentConfig';
 import InactiveText from '../../components/InactiveText';
 
 const ContentViewVersionContent = ({ cvId, versionId, cvVersion }) => {
@@ -19,19 +19,20 @@ const ContentViewVersionContent = ({ cvId, versionId, cvVersion }) => {
 
 
   const contentConfigTypes = ContentConfig.filter(({ names: { singularLabel } }) =>
-    !!cvVersion[`${singularLabel}_count`]).map(({
-    names: {
-      singularLabel, singularLowercase, pluralLowercase, pluralLabel,
-    },
-  }) => {
-    const countParam = `${singularLabel}_count`;
-    const count = cvVersion[countParam];
-    return {
-      pluralLabel,
-      label: count > 1 ? pluralLowercase : singularLowercase,
-      count,
-    };
-  });
+    !!cvVersion[`${singularLabel}_count`])
+    .map(({
+      names: {
+        singularLabel, singularLowercase, pluralLowercase, pluralLabel,
+      },
+    }) => {
+      const countParam = `${singularLabel}_count`;
+      const count = cvVersion[countParam];
+      return {
+        pluralLabel,
+        label: count > 1 ? pluralLowercase : singularLowercase,
+        count,
+      };
+    });
 
   const noCounts =
     !Number(debCount) && !Number(dockerManifestCount) && !Number(dockerTagCount) &&
@@ -61,7 +62,7 @@ const ContentViewVersionContent = ({ cvId, versionId, cvVersion }) => {
       {dockerManifestCount > 0 && dockerTagCount > 0 &&
         <>
           <Link to={`/versions/${versionId}/dockerTags`}>
-            {`${dockerTagCount} Docker tags`}
+            {`${dockerTagCount} Container tags`}
           </Link><br />
           <a href={urlBuilder(`content_views/${cvId}#/versions/${versionId}/dockerTags`, '')}>{`${dockerManifestCount} Container manifests`}</a><br />
         </>

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
@@ -284,7 +284,7 @@ export default ({ cvId, versionId }) => [
     ],
   },
   {
-    name: __('Docker Tags'),
+    name: __('Container tags'),
     route: 'dockerTags',
     repoType: 'docker',
     getCountKey: item => item?.docker_tag_count,

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionRepositoryCell.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionRepositoryCell.js
@@ -1,14 +1,18 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { urlBuilder } from 'foremanReact/common/urlHelpers';
-import { isEmpty } from 'lodash';
+import {
+  camelCase,
+  isEmpty,
+} from 'lodash';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import {
   Grid,
   GridItem,
 } from '@patternfly/react-core';
-import InactiveText from '../../../components/InactiveText';
 import ContentConfig from '../../../../Content/ContentConfig';
+import InactiveText from '../../../components/InactiveText';
 
 const ContentViewVersionRepositoryCell = ({
   data: {
@@ -18,49 +22,45 @@ const ContentViewVersionRepositoryCell = ({
   },
 }) => {
   const CONTENT_COUNTS = {
-    ansible_collection: {
-      name: __('Ansible collections'),
-      url: `ansible_collections?repositoryId=${libraryInstanceId}`,
-    },
-    deb: {
-      name: __('Deb packages'),
-      url: `debs?repositoryId=${libraryInstanceId}`,
-    },
-    docker_manifest: {
-      name: __('Container manifests'),
-      url: `products/${id}/repositories/${libraryInstanceId}/content/content/docker_manifests`,
-    },
-    docker_manifest_list: {
-      name: __('Container manifest lists'),
-      url: `products/${id}/repositories/${libraryInstanceId}/content/content/docker_manifest_lists`,
-    },
-    docker_tag: {
-      name: __('Container image tags'),
-      url: `docker_tags?repositoryId=${libraryInstanceId}`,
-    },
-    erratum: {
-      name: __('Errata'),
-      url: `errata?repositoryId=${libraryInstanceId}`,
-    },
-    file: {
-      name: __('Files'),
-      url: `files?repositoryId=${libraryInstanceId}`,
+    rpm: {
+      name: __('RPM packages'),
+      to: `rpmPackages?repository_id=${libraryInstanceId}`,
     },
     module_stream: {
       name: __('Module streams'),
-      url: `products/${id}/repositories/${libraryInstanceId}/content/module_streams`,
+      to: `moduleStreams?repository_id=${libraryInstanceId}`,
     },
-    package: {
-      name: __('Packages'),
-      url: `products/${id}/repositories/${libraryInstanceId}/content/packages`,
+    erratum: {
+      name: __('Errata'),
+      to: `errata?repository_id=${libraryInstanceId}`,
+    },
+    deb: {
+      name: __('Deb packages'),
+      to: `debPackages?repository_id=${libraryInstanceId}`,
+    },
+    ansible_collection: {
+      name: __('Ansible collections'),
+      to: `ansibleCollections?repository_id=${libraryInstanceId}`,
+    },
+    docker_manifest: {
+      name: __('Container manifests'),
+      url: `products/${id}/repositories/${libraryInstanceId}/content/docker_manifests`,
+    },
+    docker_manifest_list: {
+      name: __('Container manifest lists'),
+      url: `products/${id}/repositories/${libraryInstanceId}/content/docker_manifest_lists`,
+    },
+    docker_tag: {
+      name: __('Container image tags'),
+      to: `dockerTags?repository_id=${libraryInstanceId}`,
+    },
+    file: {
+      name: __('Files'),
+      to: `files?repository_id=${libraryInstanceId}`,
     },
     package_group: {
       name: __('Package groups'),
-      url: `products/${id}/repositories/${libraryInstanceId}/content/package_groups`,
-    },
-    rpm: {
-      name: __('Rpm packages'),
-      url: `packages?repositoryId=${libraryInstanceId}`,
+      to: `rpmPackageGroups?repository_id=${libraryInstanceId}`,
     },
     srpm: {
       name: __('Source RPMs'),
@@ -70,7 +70,7 @@ const ContentViewVersionRepositoryCell = ({
   ContentConfig.forEach((type) => {
     CONTENT_COUNTS[type.names.singularLabel] = {
       name: type.names.pluralLowercase,
-      url: `products/${id}/repositories/${libraryInstanceId}/content/${type.names.pluralLabel}`,
+      to: `${camelCase(type.names.pluralLabel)}?repository_id=${libraryInstanceId}`,
     };
   });
 
@@ -87,23 +87,40 @@ const ContentViewVersionRepositoryCell = ({
     }
   };
 
+  const CountComponent = ({ countKey }) => {
+    const { to, url, name } = CONTENT_COUNTS[countKey];
+    const count = ContentCounts[countKey];
+    switch (true) {
+      case !!url:
+        return (
+          <a href={urlBuilder(url, '')}>
+            {count} {name}
+          </a>);
+      case !!to:
+        return (
+          <Link to={to}>
+            {count} {name}
+          </Link>);
+      default:
+        return `${count} ${name} `;
+    }
+  };
+
+  CountComponent.propTypes = {
+    countKey: PropTypes.string.isRequired,
+  };
+
   const contentCountArray = Object.keys(CONTENT_COUNTS);
   const contentCountToShow = contentCountArray.filter(key => !!ContentCounts[key]);
   const contentSpan = getContentSpan(contentCountToShow.length);
+
   return (
     <Grid>
       {!isEmpty(contentCountToShow) ?
-        contentCountToShow.map((countKey) => {
-          const { url = undefined, name } = CONTENT_COUNTS[countKey];
-          const count = ContentCounts[countKey];
-          return (
-            <GridItem key={countKey} span={contentSpan}>
-              {url ?
-                <a href={urlBuilder(url, '')}>
-                  {count} {name}
-                </a> : `${count} ${name} `}
-            </GridItem>);
-        }) : <InactiveText text={__('N/A')} />
+        contentCountToShow.map(countKey => (
+          <GridItem key={countKey} span={contentSpan}>
+            <CountComponent countKey={countKey} />
+          </GridItem>)) : <InactiveText text={__('N/A')} />
       }
     </Grid >
   );

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/__tests__/ContentViewVersionDetails.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/__tests__/ContentViewVersionDetails.test.js
@@ -176,7 +176,7 @@ const testConfig = [
       last(ContentViewVersionAnsibleCollectionsData.results).checksum],
   },
   {
-    name: 'Docker Tags',
+    name: 'Container tags',
     countKey: 'docker_tag_count',
     autoCompleteUrl: '/docker_tags/auto_complete_search',
     dataUrl: api.getApiUrl('/docker_tags'),


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

- Changes redirects within the repositories tab of CVV to direct to the related CVV subtab when able. 
- Passes library_instance_id as an url param, which pre-selects the correct repository filter on sub-tab.

#### What are the testing steps for this pull request?

Navigate to the CVV details page and select the repositories tab. 
- Click on all available count links and ensure they navigate to their appropriate pages, while also passing in their library_instance_id where applicable. 
- When arriving on the new tab the Repository select will either choose the only option, or preselect the repository corresponding with the library_instance_id.