### PR TITLE
Fixes #34320 - Hide Katello tabs & cards on new host detail page when host is unregistered

### DIFF
--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -297,6 +297,7 @@ module Katello
           host.content_facet.applicable_errata = []
           host.content_facet.uuid = nil
           host.content_facet.save!
+          host.content_facet.calculate_and_import_applicability
         end
 
         host.get_status(::Katello::ErrataStatus).destroy

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard.js
@@ -15,6 +15,7 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
 import PropTypes from 'prop-types';
 import ContentViewIcon from '../../../../scenes/ContentViews/components/ContentViewIcon';
+import { hostIsRegistered } from '../hostDetailsHelpers';
 
 const HostContentViewDetails = ({
   contentView, lifecycleEnvironment, contentViewVersionId,
@@ -61,7 +62,7 @@ const HostContentViewDetails = ({
 };
 
 const ContentViewDetailsCard = ({ hostDetails }) => {
-  if (hostDetails.content_facet_attributes) {
+  if (hostIsRegistered({ hostDetails }) && hostDetails.content_facet_attributes) {
     return <HostContentViewDetails {...propsToCamelCase(hostDetails.content_facet_attributes)} />;
   }
   return null;

--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
@@ -13,6 +13,7 @@ import { propsToCamelCase } from 'foremanReact/common/helpers';
 import PropTypes from 'prop-types';
 import { ChartPie } from '@patternfly/react-charts';
 import { ErrataMapper } from '../../../../components/Errata';
+import { hostIsRegistered } from '../hostDetailsHelpers';
 
 function HostInstallableErrata({
   id, errataCounts,
@@ -74,7 +75,7 @@ function HostInstallableErrata({
 }
 
 const ErrataOverviewCard = ({ hostDetails }) => {
-  if (hostDetails.content_facet_attributes) {
+  if (hostIsRegistered({ hostDetails }) && hostDetails.content_facet_attributes) {
     const { id: hostId } = hostDetails;
     return (<HostInstallableErrata
       {...propsToCamelCase(hostDetails.content_facet_attributes)}

--- a/webpack/components/extensions/HostDetails/Cards/__tests__/contentViewDetailsCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/__tests__/contentViewDetailsCard.test.js
@@ -2,48 +2,47 @@ import React from 'react';
 import { render } from 'react-testing-lib-wrapper';
 import ContentViewDetailsCard from '../ContentViewDetailsCard';
 
-test('shows host details when content facet is set', () => {
-  const hostDetails = {
-    content_facet_attributes: {
-      content_view: {
-        name: 'CV',
-        id: 100,
-        composite: false,
-      },
-      lifecycle_environment: {
-        name: 'ENV',
-        id: 300,
-      },
-      content_view_version_id: 1000,
-      content_view_version: '1.0',
-      content_view_version_latest: true,
+const baseHostDetails = {
+  content_facet_attributes: {
+    content_view: {
+      name: 'CV',
+      id: 100,
+      composite: false,
     },
-  };
-  const { getByText } = render(<ContentViewDetailsCard hostDetails={hostDetails} />);
+    lifecycle_environment: {
+      name: 'ENV',
+      id: 300,
+    },
+    content_view_version_id: 1000,
+    content_view_version: '1.0',
+    content_view_version_latest: true,
+  },
+  subscription_facet_attributes: {
+    uuid: '123',
+  },
+};
+
+test('shows content view details when host is registered', () => {
+  const { getByText } = render(<ContentViewDetailsCard hostDetails={baseHostDetails} />);
   expect(getByText('Version 1.0 (latest)')).toBeInTheDocument();
 });
 
 
-test('does not show host details when content facet is not set', () => {
-  const { queryByText } = render(<ContentViewDetailsCard />);
+test('does not show content view details when host is not registered', () => {
+  const hostDetails = {
+    ...baseHostDetails,
+    subscription_facet_attributes: undefined,
+  };
+  const { queryByText } = render(<ContentViewDetailsCard hostDetails={hostDetails} />);
   expect(queryByText('Version 1.0')).toBeNull();
 });
 
 
-test('shows host details not latest', () => {
+test('shows when the CV in use is not the latest version', () => {
   const hostDetails = {
+    ...baseHostDetails,
     content_facet_attributes: {
-      content_view: {
-        name: 'CV',
-        id: 100,
-        composite: false,
-      },
-      lifecycle_environment: {
-        name: 'ENV',
-        id: 300,
-      },
-      content_view_version_id: 1000,
-      content_view_version: '1.0',
+      ...baseHostDetails.content_facet_attributes,
       content_view_version_latest: false,
     },
   };

--- a/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
@@ -3,6 +3,13 @@ import { render } from 'react-testing-lib-wrapper';
 import ErrataOverviewCard from '../ErrataOverviewCard';
 import nock from '../../../../../test-utils/nockWrapper';
 
+const baseHostDetails = {
+  id: 2,
+  subscription_facet_attributes: {
+    uuid: '123',
+  },
+};
+
 describe('Without errata', () => {
   afterEach(() => {
     nock.cleanAll();
@@ -10,7 +17,7 @@ describe('Without errata', () => {
 
   test('does not show piechart when there are 0 errata', () => {
     const hostDetails = {
-      id: 2,
+      ...baseHostDetails,
       content_facet_attributes: {
         errata_counts: {
           bugfix: 0,
@@ -26,6 +33,26 @@ describe('Without errata', () => {
     expect(queryByLabelText('errataChart')).not.toBeInTheDocument();
     expect(getByText('0 errata')).toBeInTheDocument();
   });
+
+  test('does not show errata card when host not registered', () => {
+    const hostDetails = {
+      ...baseHostDetails,
+      content_facet_attributes: {
+        errata_counts: {
+          bugfix: 0,
+          enhancement: 0,
+          security: 0,
+          total: 0,
+        },
+      },
+      subscription_facet_attributes: undefined,
+    };
+    /* eslint-disable max-len */
+    const { queryByLabelText, queryByText } = render(<ErrataOverviewCard hostDetails={hostDetails} />);
+    /* eslint-enable max-len */
+    expect(queryByLabelText('errataChart')).not.toBeInTheDocument();
+    expect(queryByText('0 errata')).not.toBeInTheDocument();
+  });
 });
 
 describe('With errata', () => {
@@ -33,9 +60,9 @@ describe('With errata', () => {
     nock.cleanAll();
   });
 
-  test('show piechart when there are errata', () => {
+  test('shows piechart when there are errata', () => {
     const hostDetails = {
-      id: 2,
+      ...baseHostDetails,
       content_facet_attributes: {
         errata_counts: {
           bugfix: 10,

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -33,7 +33,7 @@ import { installErrata } from '../RemoteExecutionActions';
 import { errataInstallUrl } from '../customizedRexUrlHelpers';
 import './ErrataTab.scss';
 import hostIdNotReady from '../../HostDetailsActions';
-import defaultRemoteActionMethod, { KATELLO_AGENT } from '../../hostDetailsHelpers';
+import { defaultRemoteActionMethod, KATELLO_AGENT } from '../../hostDetailsHelpers';
 import SortableColumnHeaders from '../../../../Table/components/SortableColumnHeaders';
 
 export const ErrataTab = () => {

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -37,7 +37,7 @@ import { katelloPackageUpdateUrl, packagesUpdateUrl } from '../customizedRexUrlH
 import './PackagesTab.scss';
 import hostIdNotReady from '../../HostDetailsActions';
 import PackageInstallModal from './PackageInstallModal';
-import defaultRemoteActionMethod, { KATELLO_AGENT } from '../../hostDetailsHelpers';
+import { defaultRemoteActionMethod, KATELLO_AGENT } from '../../hostDetailsHelpers';
 import SortableColumnHeaders from '../../../../Table/components/SortableColumnHeaders';
 
 export const PackagesTab = () => {

--- a/webpack/components/extensions/HostDetails/hostDetailsHelpers.js
+++ b/webpack/components/extensions/HostDetails/hostDetailsHelpers.js
@@ -3,7 +3,7 @@ import { propsToCamelCase } from 'foremanReact/common/helpers';
 export const REMOTE_EXECUTION = 'remoteExecution';
 export const KATELLO_AGENT = 'katelloAgent';
 
-const defaultRemoteActionMethod = ({ hostDetails }) => {
+export const defaultRemoteActionMethod = ({ hostDetails }) => {
   const {
     content_facet_attributes: contentFacetAttributes,
   } = hostDetails;
@@ -15,5 +15,14 @@ const defaultRemoteActionMethod = ({ hostDetails }) => {
   }
   return KATELLO_AGENT;
 };
+
+export const hostIsNotRegistered = ({ hostDetails }) => {
+  const {
+    subscription_facet_attributes: subscriptionFacetAttributes,
+  } = hostDetails;
+  return !subscriptionFacetAttributes?.uuid;
+};
+
+export const hostIsRegistered = ({ hostDetails }) => !hostIsNotRegistered({ hostDetails });
 
 export default defaultRemoteActionMethod;

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -15,17 +15,18 @@ import TracesTab from './components/extensions/HostDetails/Tabs/TracesTab/Traces
 import extendReducer from './components/extensions/reducers';
 import rootReducer from './redux/reducers';
 import HostCollectionsCard from './components/extensions/HostDetails/Cards/HostCollectionsCard';
+import { hostIsNotRegistered } from './components/extensions/HostDetails/hostDetailsHelpers';
 
 registerReducer('katelloExtends', extendReducer);
 registerReducer('katello', rootReducer);
 
 addGlobalFill('aboutFooterSlot', '[katello]AboutSystemStatuses', <SystemStatuses key="katello-system-statuses" />, 100);
 addGlobalFill('registrationAdvanced', '[katello]RegistrationCommands', <RegistrationCommands key="katello-reg" />, 100);
-addGlobalFill('host-details-page-tabs', 'Content', <ContentTab key="content" />, 900, { title: __('Content') });
+addGlobalFill('host-details-page-tabs', 'Content', <ContentTab key="content" />, 900, { title: __('Content'), hideTab: hostIsNotRegistered });
 /* eslint-disable max-len */
 // addGlobalFill('host-details-page-tabs', 'Subscription', <SubscriptionTab key="subscription" />, 100, { title: __('Subscription') });
-addGlobalFill('host-details-page-tabs', 'Traces', <TracesTab key="traces" />, 800, { title: __('Traces') });
-addGlobalFill('host-details-page-tabs', 'Repository sets', <RepositorySetsTab key="repository-sets" />, 700, { title: __('Repository sets') });
+addGlobalFill('host-details-page-tabs', 'Traces', <TracesTab key="traces" />, 800, { title: __('Traces'), hideTab: hostIsNotRegistered });
+addGlobalFill('host-details-page-tabs', 'Repository sets', <RepositorySetsTab key="repository-sets" />, 700, { title: __('Repository sets'), hideTab: hostIsNotRegistered });
 
 addGlobalFill(
   'details-cards',


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

We need to allow Katello to hide its tabs and cards from the new host detail page.
* Adds new helper functions `hostIsNotRegistered` and `hostIsRegistered`
* Check if host is registered and if not, hide Errata and Content View overview cards
* Also hide Content, Traces, and Repository sets tabs for non-registered hosts. The way it works is as follows:
  - Adds a new slot metadata attribute, `hideTab`, that is sent to Foreman. This allows us to pass a function to Foreman which Foreman will then call with the host details when setting up the page.
  - If https://github.com/theforeman/foreman/pull/9104 is applied, and `hideTab` returns true for that tab, Foreman will hide the tab from the host details page.
  - I'm using `hostIsNotRegistered` as the `hideTab` function here, but other functions could be used for other slots in the future.

* Also, recalculates errata counts on the host when unregistering to ensure they're properly cleared out.

#### Considerations taken when implementing this change?

Hiding cards I can do from Katello, but I found that changing Foreman code is the only clean way to hide an entire tab.
I found that passing the `hideTab` function to Foreman is a good way to keep Katello code in Katello and Foreman code in Foreman. This way Katello can be the one that cares about _why_ we're hiding the tab, and Foreman doesn't have to touch such ugliness as subscription facets :scream:.

#### What are the testing steps for this pull request?

* Apply this Katello change
* Register a host and get some installable errata on it
* Find its content_facet in Rails console
* Unregister the host
* View the content facet's attributes and verify that the errata counts are cleared out:
```
installable_security_errata_count: 0,
installable_enhancement_errata_count: 0,
installable_bugfix_errata_count: 0,
```

* Apply the Foreman change: https://github.com/theforeman/foreman/pull/9104
* Reload the host detail page and verify:
  - Installable Errata card does not display
  - Content View overview card does not display
  - Content tab does not display
  - Traces tab does not display
  - Repository sets tab does not display

* Reregister the host and verify that
  - all tabs are back
  - errata counts are back to what they were before
