### PR TITLE
Fixes #34444 - Missing modulemd defaults in published repo

### DIFF
--- a/app/lib/katello/util/pulpcore_content_filters.rb
+++ b/app/lib/katello/util/pulpcore_content_filters.rb
@@ -28,6 +28,10 @@ module Katello
       def filter_metadatafiles_by_pulp_hrefs(metadatafiles_results, _package_pulp_hrefs)
         metadatafiles_results.collect { |result| result.pulp_href }.flatten.uniq
       end
+
+      def filter_modulemd_defaults_by_pulp_hrefs(modulemd_defaults_results, content_pulp_hrefs)
+        modulemd_defaults_results.collect { |result| result.pulp_href }.flatten.uniq
+      end
     end
   end
 end

--- a/app/services/katello/pulp3/api/yum.rb
+++ b/app/services/katello/pulp3/api/yum.rb
@@ -43,6 +43,10 @@ module Katello
         def content_distribution_trees_api
           PulpRpmClient::ContentDistributionTreesApi.new(api_client)
         end
+
+        def content_modulemd_defaults_api
+          PulpRpmClient::ContentModulemdDefaultsApi.new(api_client)
+        end
       end
     end
   end

--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -236,6 +236,10 @@ module Katello
           api.content_distribution_trees_api.list(options)
         end
 
+        def modulemd_defaults(options = {})
+          api.content_modulemd_defaults_api.list(options)
+        end
+
         def add_filter_content(source_repo_ids, filters, filter_list_map)
           filters.each do |filter|
             if filter.inclusion
@@ -382,6 +386,10 @@ module Katello
 
           package_groups_to_include = filter_package_groups_by_pulp_href(source_repository.package_groups, content_unit_hrefs)
           content_unit_hrefs += package_groups_to_include.pluck(:pulp_id)
+
+          modulemd_defaults_hrefs_to_include = filter_modulemd_defaults_by_pulp_hrefs(
+            repo_service.modulemd_defaults(options)&.results, content_unit_hrefs)
+          content_unit_hrefs += modulemd_defaults_hrefs_to_include
 
           metadata_file_hrefs_to_include = filter_metadatafiles_by_pulp_hrefs(
             repo_service.metadatafiles(options)&.results, content_unit_hrefs)


### PR DESCRIPTION
Modulemd defaults are not copied to the target repository when
publishing a content view with filters.
