### PR TITLE
Fixes #34158 - Add status value translations

### DIFF
--- a/webpack/scenes/ContentViews/ContentViewsConstants.js
+++ b/webpack/scenes/ContentViews/ContentViewsConstants.js
@@ -56,9 +56,9 @@ export const addComponentSuccessMessage = component => (component ? __('Updated 
 
 
 // Repo added to content view status display and key
-export const ADDED = 'Added';
-export const NOT_ADDED = 'Not added';
-export const ALL_STATUSES = 'All';
+export const ADDED = __('Added');
+export const NOT_ADDED = __('Not added');
+export const ALL_STATUSES = __('All');
 
 export const REPOSITORY_TYPES = 'REPOSITORY_TYPES';
 export const FILTER_TYPES = ['rpm', 'package_group', 'erratum_date', 'erratum_id', 'docker', 'modulemd'];

--- a/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
@@ -199,14 +199,14 @@ const ContentViewRepositories = ({ cvId, details }) => {
     if (parent || compoundParent || noactions) return null;
     return [
       {
-        title: 'Add',
+        title: __('Add'),
         isDisabled: added,
         onClick: (_event, _rowId, rowInfo) => {
           onAdd(rowInfo.repoId);
         },
       },
       {
-        title: 'Remove',
+        title: __('Remove'),
         isDisabled: !added,
         onClick: (_event, _rowId, rowInfo) => {
           onRemove(rowInfo.repoId);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add status translations.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
There are several pages on CV UI that use Status - Added/Not Added/All filters like Repository tab, Content View tab on Composite CVs, Fome types of filters like Module Streams, Errata by Id, etc. Make sure the translation doesn't break the filter.

1. Go to Admin User > Edit
2. Set language to something other than English.
3. Go to CV UI and test out status filters and make sure they work correctly.
