### PR TITLE
Fixes #34448 - Truncate long audit comments for import/export

### DIFF
--- a/app/lib/actions/pulp3/content_view_version/create_import_history.rb
+++ b/app/lib/actions/pulp3/content_view_version/create_import_history.rb
@@ -18,8 +18,7 @@ module Actions
             content_view_version_id: input[:content_view_version_id],
             path: input[:path],
             metadata: input[:metadata],
-            audit_comment: ::Katello::ContentViewVersionImportHistory.generate_audit_comment(path: input[:path],
-                                                                                             user: User.current,
+            audit_comment: ::Katello::ContentViewVersionImportHistory.generate_audit_comment(user: User.current,
                                                                                              content_view_name: input[:content_view_name])
           )
           output[:import_history_id] = history.id

--- a/app/models/katello/concerns/audit_comment_extensions.rb
+++ b/app/models/katello/concerns/audit_comment_extensions.rb
@@ -1,0 +1,17 @@
+module Katello
+  module Concerns::AuditCommentExtensions
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # to prevent PG::StringDataRightTruncation: ERROR:  value too long for type character varying(255)
+      def truncate_audit_comment(long_comment)
+        if long_comment.length > 255
+          Rails.logger.info "Truncating audit comment: #{long_comment}"
+          "#{long_comment[0..250]}..."
+        else
+          long_comment
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/content_view_version_export_history.rb
+++ b/app/models/katello/content_view_version_export_history.rb
@@ -1,6 +1,7 @@
 module Katello
   class ContentViewVersionExportHistory < Katello::Model
     include Authorization::ContentViewVersionExportHistory
+    include Concerns::AuditCommentExtensions
     audited except: :metadata
     delegate :organization, to: :content_view_version
     delegate :id, to: :organization, prefix: true
@@ -58,7 +59,7 @@ module Katello
         export_descriptor = "export of content view '#{content_view_version.content_view.name}' version #{content_view_version.version}"
         export_descriptor += " from #{from_version.name}" if from_version
       end
-      "#{export_type&.capitalize} #{export_descriptor} created by #{user.to_label}"
+      truncate_audit_comment("#{export_type&.capitalize} #{export_descriptor} created by #{user.to_label}")
     end
   end
 end

--- a/app/models/katello/content_view_version_import_history.rb
+++ b/app/models/katello/content_view_version_import_history.rb
@@ -32,9 +32,8 @@ module Katello
     scoped_search :on => :id, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
     scoped_search :on => :import_type, :rename => :type, :complete_value => ContentViewVersionExportHistory::EXPORT_TYPES
 
-    def self.generate_audit_comment(user:, path:, content_view_name:)
-      truncate_audit_comment(_("Content imported from %{path} into content view '%{name}' by %{user}") % {
-        path: path,
+    def self.generate_audit_comment(user:, content_view_name:)
+      truncate_audit_comment(_("Content imported by %{user} into content view '%{name}'") % {
         user: user.to_label,
         name: content_view_name
       })

--- a/app/models/katello/content_view_version_import_history.rb
+++ b/app/models/katello/content_view_version_import_history.rb
@@ -1,6 +1,7 @@
 module Katello
   class ContentViewVersionImportHistory < Katello::Model
     include Authorization::ContentViewVersionImportHistory
+    include Concerns::AuditCommentExtensions
 
     audited except: :metadata
     delegate :organization, to: :content_view_version
@@ -32,11 +33,11 @@ module Katello
     scoped_search :on => :import_type, :rename => :type, :complete_value => ContentViewVersionExportHistory::EXPORT_TYPES
 
     def self.generate_audit_comment(user:, path:, content_view_name:)
-      _("Content imported from %{path} into content view '%{name}' by %{user}") % {
+      truncate_audit_comment(_("Content imported from %{path} into content view '%{name}' by %{user}") % {
         path: path,
         user: user.to_label,
         name: content_view_name
-      }
+      })
     end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Adds a new Rails concern, `AuditCommentExtensions`, which powers up your Katello class with a new method `truncate_audit_comment`. This method prevents the error `Error: PG::StringDataRightTruncation: ERROR: value too long for type character varying(255)` by doing the following
    - Check if the audit comment is going to be longer than 255 characters
    - If not, pass the comment thru as-is
    - If so,
      - Write a Rails logger message with the untruncated comment. (This is because the user that performed the import is near the end of the comment, and long content view names could be used to conceal the username that performed the action.)
      - Truncate the comment so that it's < 254 characters with a "..." at the end.

#### Considerations taken when implementing this change?

The bug was only filed for imports. But I wouldn't want to see the same type of thing pop up months down the road for exports as well. So I applied the fix to both, and also made it reusable should we ever need to do this somewhere else.

#### What are the testing steps for this pull request?

1. create a content view with a long name, for example:

`XXXX_Red_Hat_Software_Collections_RPMs_for_Red_Hat_Enterprise_Linux_7_Server_x86_64_7Server`

2. Add and sync a repo

2. Export and copy the archive to the corresponding place in `/var/lib/pulp/imports`

3. Create an import org and run the import:

```
hammer content-import version --organization-id 1 --path /var/lib/pulp/imports/XXX/XXXX_Red_Hat_Software_Collections_RPMs_for_Red_Hat_Enterprise_Linux_7_Server_x86_64_7Server/1.0/2022-01-29T02-54-30-10-30/
```

Before applying this patch:

The import will fail with:

```
ActiveRecord::ValueTooLong: PG::StringDataRightTruncation: ERROR: value too long for type character varying(255)
```

After applying this patch:

The import should be successful, and you should see logs and audit comments as described above.

