### PR TITLE
Fixes #34454 - Hammer repo reclaim-space

### DIFF
--- a/app/lib/actions/pulp3/repository/reclaim_space.rb
+++ b/app/lib/actions/pulp3/repository/reclaim_space.rb
@@ -11,7 +11,7 @@ module Actions
           if repositories.empty?
             fail _("Only On Demand repositories may have space reclaimed.")
           end
-          repository_hrefs = ::Katello::Pulp3::RepositoryReference.default_cv_repository_hrefs(repositories, Organization.current)
+          repository_hrefs = ::Katello::Pulp3::RepositoryReference.default_cv_repository_hrefs(repositories, Organization.current || repositories.first.organization)
           plan_self(repository_hrefs: repository_hrefs, smart_proxy_id: smart_proxy.id)
         end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Api fix related to https://github.com/Katello/hammer-cli-katello/pull/837

#### Considerations taken when implementing this change?

For some reason `Organization.current` was used instead of repositories's organization in the reclaim space call.


#### What are the testing steps for this pull request?
- Create and sync an on_demand repository
- `hammer repository reclaim-space --id=14` (look at the hammer PR)