### PR TITLE
Fixes #34455 - Migration error related to cdn configuration

### DIFF
--- a/db/migrate/20211019192121_create_cdn_configuration.katello.rb
+++ b/db/migrate/20211019192121_create_cdn_configuration.katello.rb
@@ -1,4 +1,8 @@
 class CreateCdnConfiguration < ActiveRecord::Migration[6.0]
+  class FakeCdnConfiguration < Katello::Model
+    self.table_name = 'katello_cdn_configurations'
+  end
+
   def up
     create_table :katello_cdn_configurations do |t|
       t.integer :organization_id
@@ -14,17 +18,22 @@ class CreateCdnConfiguration < ActiveRecord::Migration[6.0]
     add_foreign_key :katello_cdn_configurations, :taxonomies, name: 'katello_cdn_configurations_organization_id', column: :organization_id
     add_foreign_key :katello_cdn_configurations, :katello_content_credentials, name: 'katello_cdn_configurations_ssl_ca_credential_id', column: :ssl_ca_credential_id
 
+    FakeCdnConfiguration.reset_column_information
+
     ::Organization.all.each do |org|
-      Katello::CdnConfiguration.where(
-        organization: org,
+      FakeCdnConfiguration.where(
+        organization_id: org.id,
         url: org.redhat_provider.repository_url || ::Katello::Resources::CDN::CdnResource.redhat_cdn_url
       ).first_or_create!
     end
 
     remove_column :katello_providers, :repository_url
+    ::Katello::Provider.reset_column_information
   end
 
   def down
+    add_column :katello_providers, :repository_url, :string
+    ::Katello::Provider.reset_column_information
     drop_table :katello_cdn_configurations
   end
 end

--- a/test/migrations/20211019192121_create_cdn_configuration_katello_test.rb
+++ b/test/migrations/20211019192121_create_cdn_configuration_katello_test.rb
@@ -1,0 +1,38 @@
+require 'katello_test_helper'
+require Katello::Engine.root.join('db/migrate/20211019192121_create_cdn_configuration.katello')
+
+module Katello
+  class CreateCdnConfigurationTest < ActiveSupport::TestCase
+    let(:migrations_paths) { ActiveRecord::Migrator.migrations_paths + [Katello::Engine.root.join('db/migrate/').to_s] }
+    #let(:migrations) { ActiveRecord::MigrationContext.new(migrations_paths, ActiveRecord::SchemaMigration).migrations }
+    let(:previous_version) { '20211006161617'.to_i }
+    let(:current_version) { '20211019192121'.to_i }
+
+    #only load the two migrations we care about (previous one and current one)
+    let(:migrations) do
+      [
+        ActiveRecord::MigrationProxy.new("AddFilenameToKatelloGenericContentUnits", previous_version, "#{Katello::Engine.root}/db/migrate/20211006161617_add_filename_to_katello_generic_content_units.rb", ""),
+        ActiveRecord::MigrationProxy.new("CreateCdnConfiguration", current_version, "#{Katello::Engine.root}/db/migrate/20211019192121_create_cdn_configuration.katello.rb", "")
+      ]
+    end
+
+    def migrate_up
+      ActiveRecord::Migrator.new(:up, migrations, ActiveRecord::SchemaMigration, current_version).migrate
+    end
+
+    def setup
+      ActiveRecord::Migration.suppress_messages do
+        ActiveRecord::Migrator.new(:down, migrations, ActiveRecord::SchemaMigration, previous_version).migrate
+      end
+      ::Katello::Provider.reset_column_information
+    end
+
+    def test_cdn_configuration_successful_migration
+      repo_url = "http://foobar.com"
+      organization = get_organization
+      organization.redhat_provider.update_column(:repository_url, repo_url)
+      migrate_up
+      assert_equal "http://foobar.com", organization.reload.cdn_configuration.url
+    end
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This fixes a  migration snafu and uses a Fake object.

#### Considerations taken when implementing this change?
Previously when upgrading from 4.1-4.3 you would hit an error along the lines of

```ruby 
== 20211019192121 CreateCdnConfiguration: migrating ===========================
-- create_table(:katello_cdn_configurations)
   -> 0.0053s
-- add_foreign_key(:katello_cdn_configurations, :taxonomies, {:name=>"katello_cdn_configurations_organization_id", :column=>:organization_id})
   -> 0.0017s
-- add_foreign_key(:katello_cdn_configurations, :katello_content_credentials, {:name=>"katello_cdn_configurations_ssl_ca_credential_id", :column=>:ssl_ca_credential_id})
   -> 0.0011s
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

undefined local variable or method `type' for #<Katello::CdnConfiguration:0x00000000153c6198>
/opt/theforeman/tfm/root/usr/share/gems/gems/activemodel-6.0.3.7/lib/active_model/attribute_methods.rb:432:in `method_missing'
/opt/theforeman/tfm/root/usr/share/gems/gems/katello-4.3.0.2/app/models/katello/cdn_configuration.rb:40:in `upstream_server?'
/opt/theforeman/tfm/root/usr/share/gems/gems/katello-4.3.0.2/app/models/katello/cdn_configuration.rb:46:in `reset_fields'
```

This code fixes this by using FakeCdnConfiguration

#### What are the testing steps for this pull request?

- Setup a katello 4.1 server (or sat 6.10)
-  Create a few orgs
- Update the packages to 4.3 / 7.0
- Snap shot this vm
- foreman-upgrade should fail with the above error
- revert snapshot and apply the migration changes to `/opt/theforeman/tfm/root/usr/share/gems/gems/katello-4.3.0.2/db/migrate/20211019192121_create_cdn_configuration.katello.rb`
- foreman-upgrade should succeed.

