### PR TITLE
Fixes #34465  - Can import correctly in an AirGapped setup

### DIFF
--- a/app/models/katello/candlepin/repository_mapper.rb
+++ b/app/models/katello/candlepin/repository_mapper.rb
@@ -74,6 +74,7 @@ module Katello
       end
 
       def feed_url
+        return if product.organization.cdn_configuration.airgapped?
         @feed_url ||= if product.cdn_resource&.respond_to?(:repository_url)
                         product.cdn_resource.repository_url(content_label: content.label)
                       else

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -62,7 +62,8 @@ module Katello
     validates_lengths_from_database :except => [:label]
     validates_with Validators::KatelloLabelFormatValidator, :attributes => :label
     validates_with Validators::KatelloNameFormatValidator, :attributes => :name
-    validates_with Validators::KatelloUrlFormatValidator, :attributes => :url, :nil_allowed => proc { |repo| repo.custom? },
+    validates_with Validators::KatelloUrlFormatValidator, :attributes => :url,
+                   :nil_allowed => proc { |repo| repo.custom? || repo.organization.cdn_configuration.airgapped? },
                    :field_name => :url
     validates_with Validators::RootRepositoryUniqueAttributeValidator, :attributes => :name
     validates_with Validators::RootRepositoryUniqueAttributeValidator, :attributes => :label

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -592,6 +592,13 @@ module Katello
       refute rhel.valid?
     end
 
+    def test_nil_rhel_url_on_airgapped
+      rhel = katello_root_repositories(:rhel_6_x86_64_root)
+      rhel.organization.cdn_configuration.update!(type: :airgapped)
+      rhel.url = nil
+      assert rhel.valid?
+    end
+
     def test_bad_checksum
       @fedora_root.checksum_type = 'XOR'
       refute @fedora_root.valid?


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Content Import on an Airgapped Setup did not set the rh repository feed url to nil. This caused a cryptic `unable to save root repository` and `Could not import the archive.: No upstream organization was specified` errors. 
  
#### Considerations taken when implementing this change?
This code sets the feed url to nil when enabling rh repos inside an air gapped setup. Also relaxes the non-nil validation rule for airgapped. 

#### What are the testing steps for this pull request?
Steps
------
In master

In the upstream server/org
Enable a couple of rh repositories

- Mark them immediate in repo details
- Sync
- Export with
 ```# hammer content-export complete repository --id <repo-id>```

In the Downstream Server /Org
- Subscriptions -> Manage Manifest -> CdnConfiguration -> Airgapped (click update to set it)
- Import a manifest with those repositories
```hammer content-import repository --path=.... --metadata-file=.. --organization-id=<org id>```

you should see an along
```
2022-02-16T12:16:39 [I|bac|cd026bec] Task {label: Actions::Katello::ContentViewVersion::Import, id: d1080d61-3c6b-4ea4-85a1-ffc06273bfec, execution_plan_id: 7bd59850-477c-4095-9ea4-565d94c5d73d} state changed: stopped  result: error
2022-02-16T12:16:39 [E|app|cd026bec] ArgumentError: No upstream organization was specified
 cd026bec | /usr/share/gems/gems/katello-4.3.0.2/app/lib/katello/resources/cdn/katello_cdn.rb:9:in `initialize'
 cd026bec | /usr/share/gems/gems/katello-4.3.0.2/app/lib/katello/resources/cdn.rb:73:in `new'
 cd026bec | /usr/share/gems/gems/katello-4.3.0.2/app/lib/katello/resources/cdn.rb:73:in `create'
 cd026bec | /usr/share/gems/gems/katello-4.3.0.2/app/models/katello/product.rb:219:in `cdn_resource'
 cd026bec | /usr/share/gems/gems/katello-4.3.0.2/app/models/katello/candlepin/repository_mapper.rb:77:in `feed_url'
 cd026bec | /usr/share/gems/gems/katello-4.3.0.2/app/models/katello/candlepin/repository_mapper.rb:33:in `build_repository'
 cd026bec | /usr/share/gems/gems/katello-4.3.0.2/app/lib/actions/katello/repository_set/enable_repository.rb:17:in `plan'
```
In the downstream server/org
- Apply this PR
- Retry the import and it should work seamlessly.