### PR TITLE
Fixes #34469 - Update retain package versions in pulp

### DIFF
--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -110,6 +110,14 @@ module ::Actions::Katello::Repository
       plan_action action, repository.root, :unprotected => true
       assert_action_planed action, candlepin_action_class
     end
+
+    it 'plans pulp3 update when retain_package_version is updated' do
+      action = create_action action_class
+      action.stubs(:action_subject).with(repository)
+
+      plan_action action, repository.root, :retain_package_versions_count => 17
+      assert_action_planed action, pulp3_action_class
+    end
   end
 
   class DestroyTest < TestBase

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -55,6 +55,28 @@ module Katello
       ]
     end
 
+    def test_invalid_retain_package_version_counts
+      @root.content_type = 'yum'
+      @root.url = 'http://inecas.fedorapeople.org/fakerepos/zoo2/'
+      @root.retain_package_versions_count = -2
+      assert_not_valid @root
+      assert_equal @root.errors[:retain_package_versions_count], ["must not be a negative value."]
+    end
+
+    def test_valid_retain_package_version_counts
+      @root.content_type = 'yum'
+      @root.url = 'http://inecas.fedorapeople.org/fakerepos/zoo2/'
+      @root.retain_package_versions_count = 2
+      assert_valid @root
+    end
+
+    def test_non_yum_retain_package_version_counts
+      @root.content_type = 'docker'
+      @root.retain_package_versions_count = 2
+      assert_not_valid @root
+      assert_equal @root.errors[:retain_package_versions_count], ["is only allowed for Yum repositories."]
+    end
+
     def test_invalid_content_type_with_os_versions
       @root.content_type = 'docker'
       @root.os_versions = ['rhel-7']


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
1. Ensure changes to retain_package_versions_count flows to pulp
2. Ensure retain_package_versions_count has valid non-negative values for only yum repos.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
A)
1. Create/Update a yum repo with a negative retain_package_versions_count value.
2. Should throw a validation error.
B)
1. Create a yum repo with retain_package_versions_count set to some valid value
2. Check repo in pulp `curl https://`hostname`/pulp/api/v3/repositories/rpm/rpm/   --cert /etc/pki/katello/certs/pulp-client.crt  --key /etc/pki/katello/private/pulp-client.key | python -m json.tool`
3. The retain_package_versions_count should be set
4. Update retain_package_versions_count value on the repo
5. The updated value should reflect on the pulp repo.
