### PR TITLE
Fixes #34470 - Hide columns that are nil on lce page

### DIFF
--- a/app/views/katello/api/v2/errata/_counts.json.rabl
+++ b/app/views/katello/api/v2/errata/_counts.json.rabl
@@ -1,7 +1,7 @@
 totals = @object.relation.group(:errata_type).count.with_indifferent_access
 
 node :security do |_presenter|
-  totals[:security]
+  totals[:security].to_i
 end
 
 node :bugfix do |_presenter|
@@ -13,5 +13,5 @@ node :enhancement do |_presenter|
 end
 
 node :total do |_presenter|
-  totals.values.inject(:+)
+  totals.values.inject(:+).to_i
 end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environments.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environments.controller.js
@@ -27,6 +27,7 @@ angular.module('Bastion.environments').controller('EnvironmentsController',
 
             var nutupane = new Nutupane(Environment, params);
             $scope.table = nutupane.table;
+            $scope.loading = true;
 
             PathsService.getActualPaths().then(function (data) {
                 $scope.library = data.library;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/views/environments.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/views/environments.html
@@ -21,28 +21,28 @@
   <section class="row">
     <div class="col-sm-12">
       <div ng-hide="denied('view_lifecycle_environments', library)">
-        <table class="table table-bordered info-blocks">
+        <table class="table table-bordered info-blocks" ng-hide="loading">
           <tbody>
             <tr>
               <td class="info-block-head"><a ui-sref="environment.details({environmentId: library.id})" translate>Library</a></td>
               <td class="info-block" translate>Content Views <div>{{ library.counts.content_views || 0 }}</div></td>
               <td class="info-block" translate>Products <div>{{ library.counts.products || 0 }}</div></td>
-              <td class="info-block" ng-hide="library.counts.yum_repositories == 0" translate>
+              <td class="info-block" ng-show="library.counts.yum_repositories > 0" translate>
                 Yum Repositories <div>{{ library.counts.yum_repositories || 0 }}</div>
               </td>
-              <td class="info-block" ng-hide="library.counts.ostree_repositories == 0" translate>
+              <td class="info-block" ng-show="library.counts.ostree_repositories > 0" translate>
                 OSTree Repositories <div>{{ library.counts.ostree_repositories || 0 }}</div>
               </td>
-              <td class="info-block" ng-hide="library.counts.docker_repositories == 0" translate>
+              <td class="info-block" ng-show="library.counts.docker_repositories > 0" translate>
                 Docker Repositories <div>{{ library.counts.docker_repositories || 0 }}</div>
               </td>
-              <td class="info-block" ng-hide="library.counts.packages == 0" translate>
+              <td class="info-block" ng-show="library.counts.packages > 0" translate>
                 Packages <div>{{ library.counts.packages || 0 }}</div>
               </td>
-              <td class="info-block" ng-hide="library.counts.errata.total == 0" translate>
+              <td class="info-block" ng-show="library.counts.errata.total > 0" translate>
                 Errata <div>{{ library.counts.errata.total || 0 }}</div>
               </td>
-              <td class="info-block" ng-hide="library.counts.module_streams == 0"  translate>
+              <td class="info-block" ng-show="library.counts.module_streams > 0"  translate>
                 Module Streams <div>{{ library.counts.module_streams || 0 }}</div>
               </td>
             </tr>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Added `loading=true` to the start of the page until the data gets loaded in
Found out that errata count `total` and `security` were coming back as null instead of 0 so fixed that in the rabl file for errata
Added an `ng-hide` to the table to hide it until the data gets loaded in from the API

#### Considerations taken when implementing this change?

Verified the errata controller and module tests still function
Verified the lce page shows more columns when there is content loaded

#### What are the testing steps for this pull request?

* Create an org with 0 content in it
* Goto Content -> Lifecycle Environments
* Watch it show ostree/docker/errata then quickly hide ostree/docker
* Apply patch and restart devel box
* View page and columns should be blank except for content views and products
 
