### PR TITLE
Fixes #34477 - Add act key and host ids to CV Api

### DIFF
--- a/app/views/katello/api/v2/content_views/base.json.rabl
+++ b/app/views/katello/api/v2/content_views/base.json.rabl
@@ -37,11 +37,15 @@ node :last_published do |content_view|
   end
 end
 
-child :environments => :environments do
-  attributes :id, :name, :label
-  node :permissions do |env|
+node :environments do |cv|
+  cv.environments.map do |env|
     {
-      :readable => env.readable?
+      id: env.id,
+      label: env.label,
+      name: env.label,
+      activation_keys: cv&.activation_keys&.in_environment(env)&.ids,
+      hosts: cv&.hosts&.in_environment(env)&.ids,
+      permissions: {readable: env.readable?}
     }
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add hosts and activation key Ids to the environment node for CV. This is to support the bulk deletion flow for versions.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Add an activation key and host to an env and a cv.
Go to CV index page/details page and check the API response. There should be activation_keys and hosts keys in the environment node with an array of Ids.