### PR TITLE
Fixes #34158 - Status translation fix

### DIFF
--- a/webpack/scenes/ContentViews/ContentViewsConstants.js
+++ b/webpack/scenes/ContentViews/ContentViewsConstants.js
@@ -56,9 +56,15 @@ export const addComponentSuccessMessage = component => (component ? __('Updated 
 
 
 // Repo added to content view status display and key
-export const ADDED = 'Added';
-export const NOT_ADDED = 'Not added';
-export const ALL_STATUSES = 'All';
+export const ADDED = __('Added');
+export const NOT_ADDED = __('Not added');
+export const ALL_STATUSES = __('All');
+
+export const STATUS_TRANSLATIONS_ENUM = {
+  [ADDED]: 'Added',
+  [NOT_ADDED]: 'Not added',
+  [ALL_STATUSES]: 'All',
+};
 
 export const REPOSITORY_TYPES = 'REPOSITORY_TYPES';
 export const FILTER_TYPES = ['rpm', 'package_group', 'erratum_date', 'erratum_id', 'docker', 'modulemd'];

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
@@ -47,6 +47,7 @@ import {
   DEB_PACKAGES_CONTENT,
   DOCKER_TAGS_CONTENT,
   generatedContentKey,
+  STATUS_TRANSLATIONS_ENUM,
 } from '../ContentViewsConstants';
 import api, { foremanApi, orgId } from '../../../services/api';
 import { getResponseErrorMsgs } from '../../../utils/helpers';
@@ -372,7 +373,7 @@ export const getCVFilterRules = (filterId, params) => get({
 });
 
 export const getContentViewComponents = (cvId, params, statusSelected) => {
-  const apiParams = { ...params, status: statusSelected };
+  const apiParams = { ...params, status: STATUS_TRANSLATIONS_ENUM[statusSelected] };
   const apiUrl = `/content_views/${cvId}/content_view_components/show_all`;
   return get({
     key: cvDetailsComponentKey(cvId),


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Fixes an issue with status translations that would either cause a lack of translation in the UI or a translated (incorrect value) as a status sent to the API.

#### What are the testing steps for this pull request?

As their appears to be a lack of translation in other languages, the only way I was able to confirm my change was the following...

- append a value to one of STATUS_TRANSLATIONS_ENUM's values 
- Navigate to a composite content view, select a status from the dropdown.
- check network tab, the status values should be the same as hardcoded within the enum above.

