### PR TITLE
Fixes #34483 - Pulp 3 migration should fail earlier with missing errata

### DIFF
--- a/lib/katello/tasks/pulp3_migration.rake
+++ b/lib/katello/tasks/pulp3_migration.rake
@@ -47,6 +47,15 @@ namespace :katello do
               exit(-1)
             end
           end
+          repos_missing_errata = ::Katello::Repository.joins("inner join katello_repository_errata on katello_repositories.id = katello_repository_errata.repository_id").
+            joins("inner join katello_root_repositories on katello_repositories.root_id = katello_root_repositories.id").
+            where("katello_repository_errata.erratum_pulp3_href is null").pluck(:repository_id, :name).uniq
+          if repos_missing_errata.present?
+            puts "\nRepositories with the following IDs and names have unmigrated errata:\n"
+            repos_missing_errata.each { |r| puts(r[0].to_s + ', ' + r[1]) }
+            puts "\nResync these repositories and then run 'reimport_all=true foreman-maintain content prepare'.\n"
+            exit(-1)
+          end
           puts _("Content Migration completed successfully")
         end
       else


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Unmigrated errata are reported after the `content prepare` step now.

#### Considerations taken when implementing this change?
What is important for a user to see? I think the repository ID and name are the most helpful.

I put the check right in the rake task because it seemed the most straight-forward.

#### What are the testing steps for this pull request?
1) Run the migration on 3.18 with **a few** yum repositories.
2) Edit the repository errata to have `nil` `erratum_pulp3_href`s.
3) Run the migration again and the switchover.
4) See the error from the bug at the beginning of the switchover.
5) Patch in my PR.
6) Run the migration again.  See the new error.
7) Run the migration yet again with `reimport_all=true` this time.
8) The migration and switchover should now complete successfully if run.
