### PR TITLE
Fixes #34355 - Remove parent_commit for ostree

### DIFF
--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -498,7 +498,6 @@ module Katello
         ostree_import.artifact = artifact_href
         ostree_import.repository_name = options[:ostree_repository_name]
         ostree_import.ref = options[:ostree_ref]
-        ostree_import.parent_commit = options[:ostree_parent_commit]
         api.repositories_api.import_commits(repository_reference.repository_href, ostree_import)
       end
 

--- a/lib/katello/repository_types/ostree.rb
+++ b/lib/katello/repository_types/ostree.rb
@@ -37,12 +37,6 @@ Katello::RepositoryTypeManager.register('ostree') do
                         :type => String,
                         :required => false
 
-  import_attribute :parent_commit, :content_type => 'ostree_ref',
-                        :api_param => :ostree_parent_commit,
-                        :description => "Checksum of a parent commit",
-                        :type => String,
-                        :required => false
-
   import_attribute :repository_name, :content_type => 'ostree_ref',
                         :api_param => :ostree_repository_name,
                         :description => "Name of the repository in the ostree archive",


### PR DESCRIPTION
its no longer needed, nor supported. So we can remove it.  

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Test ostree upload:

wget --no-parent -r https://fixtures.pulpproject.org/ostree/small/
tar --exclude="index.html" -cvf "fixtures_small_repo.tar" -C fixtures.pulpproject.org/ostree "small"\
hammer repository upload-content --id <repostory_id> --content-type ostree_ref --path <path to fixtures_small_repo.tar file> --ostree-repository-name small
