### PR TITLE
Fixes #34488 - Delete any errata tied to ostree or puppet repos

### DIFF
--- a/db/migrate/20210119162528_delete_puppet_and_ostree_repos.rb
+++ b/db/migrate/20210119162528_delete_puppet_and_ostree_repos.rb
@@ -39,6 +39,8 @@ class DeletePuppetAndOstreeRepos < ActiveRecord::Migration[6.0]
     FakeContentViewPuppetEnvironment.delete_all
     FakePuppetModule.delete_all
 
+    ::Katello::RepositoryErratum.where(:repository_id => ::Katello::Repository.where(:root_id => ::Katello::RootRepository.where(:content_type => [:ostree, :puppet]))).delete_all
+
     if puppet_repositories.any?
       User.as_anonymous_admin do
         ::Katello::Repository.delete(puppet_repositories)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
For some reason, if ostree or puppet repos end up having errata associated, the deletion of those repos as part of the above migration fails.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Create a Katello::RepositoryErratum record with an erratum and a puppet/ostree repo.
Run the migration.
The repo should get deleted.