### PR TITLE
Fixes #34491 - Redirect to repo/cv tab on CV create

### DIFF
--- a/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
+++ b/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
@@ -61,7 +61,8 @@ const CreateContentViewForm = ({ setModalOpen }) => {
 
   if (redirect) {
     const { id } = response;
-    return (<Redirect to={`/content_views/${id}`} />);
+    if (composite) { return (<Redirect to={`/content_views/${id}#/contentviews`} />); }
+    return (<Redirect to={`/content_views/${id}#/repositories`} />);
   }
 
   const submitDisabled = !name?.length || !label?.length || saving;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Creating repo should redirect to repository/content views tab for component/composite cvs instead of versions page
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Create a component CV
You should land on repository tab of new CV.
Create a composite CV
You should land on content view tab of the new CV.