### PR TITLE
Fixes #34490 - Changing architecture setting for some rh repos causes issues

### DIFF
--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -100,6 +100,7 @@ module Katello
     api :PUT, "/repository_sets/:id/disable", N_("Disable a repository from the set")
     api :PUT, "/products/:product_id/repository_sets/:id/disable", N_("Disable a repository from the set")
     param :id, :number, :required => true, :desc => N_("ID of the repository set to disable")
+    param :repository_id, :number, :required => false, :desc => N_("ID of the repository within the set to disable")
     param :product_id, :number, :required => false, :desc => N_("ID of the product containing the repository set")
     param :basearch, String, :required => false, :desc => N_("Basearch to disable")
     param :releasever, String, :required => false, :desc => N_("Releasever to disable")
@@ -186,7 +187,7 @@ module Katello
     end
 
     def substitutions
-      params.permit(:basearch, :releasever).to_h
+      params.permit(:basearch, :releasever, :repository_id).to_h
     end
 
     def find_authorized_activation_key

--- a/app/lib/actions/katello/repository_set/disable_repository.rb
+++ b/app/lib/actions/katello/repository_set/disable_repository.rb
@@ -7,9 +7,14 @@ module Actions
         end
 
         def plan(product, content, options)
-          repository = repository_mapper(product,
-                                         content,
-                                         options).find_repository
+          if options[:repository_id]
+            repository = ::Katello::Repository.find(options[:repository_id])
+          else
+            repository = repository_mapper(product,
+                                           content,
+                                           options).find_repository
+          end
+
           if repository
             action_subject(repository)
             plan_action(Repository::Destroy, repository)

--- a/app/models/katello/candlepin/repository_mapper.rb
+++ b/app/models/katello/candlepin/repository_mapper.rb
@@ -10,10 +10,17 @@ module Katello
       end
 
       def find_repository
-        root = ::Katello::RootRepository.where(product_id: product.id,
-                                    content_id: content.cp_content_id,
-                                    minor: minor,
-                                    arch: arch).first
+        if substitutions[:basearch]
+          root = ::Katello::RootRepository.where(product_id: product.id,
+                                                 content_id: content.cp_content_id,
+                                                 minor: minor,
+                                                 arch: arch).first
+        else
+          root = ::Katello::RootRepository.where(product_id: product.id,
+                                                 content_id: content.cp_content_id,
+                                                 minor: minor).first
+        end
+
         if root
           Katello::Repository.where(root: root,
                                     environment_id: product.organization.library.id).first

--- a/webpack/redux/actions/RedHatRepositories/enabled.js
+++ b/webpack/redux/actions/RedHatRepositories/enabled.js
@@ -44,7 +44,7 @@ export const createEnabledRepoParams = (extendedParams = {}) => {
 
 export const disableRepository = repository => async (dispatch) => {
   const {
-    productId, contentId, arch, releasever,
+    productId, contentId, arch, releasever, id,
   } = repository;
 
   const repoData = {
@@ -52,6 +52,7 @@ export const disableRepository = repository => async (dispatch) => {
     product_id: productId,
     basearch: arch,
     releasever,
+    repository_id: id,
   };
   dispatch({ type: DISABLE_REPOSITORY_REQUEST, repository });
   const url = `/products/${productId}/repository_sets/${contentId}/disable`;

--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepository.js
@@ -19,10 +19,11 @@ class EnabledRepository extends Component {
 
   repoForAction = () => {
     const {
-      productId, contentId, arch, releasever, name, type,
+      id, productId, contentId, arch, releasever, name, type,
     } = this.props;
 
     return {
+      id,
       contentId,
       productId,
       name,

--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository/__tests__/EnabledRepository.test.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository/__tests__/EnabledRepository.test.js
@@ -60,6 +60,7 @@ describe('Enabled Repositories Component', () => {
         type: 'foo',
         arch: 'foo',
         releasever: '1.1.1',
+        id: 1,
       };
       expect(instance.repoForAction()).toEqual(expected);
     });
@@ -109,6 +110,7 @@ describe('Enabled Repositories Component', () => {
         type: 'foo',
         arch: 'foo',
         releasever: '1.1.1',
+        id: 1,
       };
       instance.reloadAndNotify = jest.fn();
       await instance.disableRepository();


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This has two changes:
1. The `find_repository` method used to find red hat repositories will now search without "arch", if it cannot find a repository with a particular "arch".
2. Deleting from the UI will delete by repository ID instead of filtering by product_id, content_id, minor, and arch.

This is to fix bugs where a repository couldn't be disabled, or the repository could be enabled despite already being enabled.
#### Considerations taken when implementing this change?
The arch setting is filtered out when using certain repo sets e.g. Red Hat Enterprise Linux 8 for x86_64 - AppStream RPMs, because it is not needed as a substitution in the content url (see here: https://projects.theforeman.org/issues/28644). When this happens, repositories from this set are always handled as having a "noarch" arch setting. If you change the arch setting to "x86_64" for a repository from this set, that repository cannot be disabled and is also not detected as an enabled repository (and so you can enable this repository a second time).

The reason for the first change is to make repositories find-able regardless of the arch setting. 

The reason for the second change is to prevent the first change from causing more weird behavior. If someone, because of this bug, enabled a duplicate repository, then the first change could prevent that user from easily disabling one of their repositories (since the query would find 2 repositories).
#### What are the testing steps for this pull request?
**Without PR**
1. Enable a repository from Red Hat Enterprise Linux 8 for x86_64 - AppStream RPMs.
  - `hammer repository-set enable  --name "Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)" --organization-id 1 --product "Red Hat Enterprise Linux for x86_64" --releasever "8.3"` or UI.
 2. Change the "Restrict to architecture" setting of this repository to "x86_64".
 3. In the UI, look at this list of enable-able repositories for this repository set. Notice, 8.3 is once again enable-able, despite already being enabled.
 4. Try to disable this repository; you can't.

**With PR**
1. Follow the same steps as above. This time, the repository should disable and you shouldn't see a duplicate listing.