### PR TITLE
Fixes #34493 - Remove use of pulp_ prefixes in the tests

### DIFF
--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -138,16 +138,13 @@ module Katello
     end
 
     pulpcore_features = {
-      'pulp_rpm': Katello::Repository::YUM_TYPE,
       'rpm': Katello::Repository::YUM_TYPE,
-      'pulp_file': Katello::Repository::FILE_TYPE,
       'file': Katello::Repository::FILE_TYPE,
-      'pulp_container': Katello::Repository::DOCKER_TYPE,
       'container': Katello::Repository::DOCKER_TYPE,
-      'pulp_ansible': Katello::Repository::ANSIBLE_COLLECTION_TYPE,
       'ansible': Katello::Repository::ANSIBLE_COLLECTION_TYPE,
-      'pulp_deb': Katello::Repository::DEB_TYPE,
-      'deb': Katello::Repository::DEB_TYPE
+      'deb': Katello::Repository::DEB_TYPE,
+      'ostree': Katello::Repository::OSTREE_TYPE,
+      'python': 'python'
     }
 
     pulpcore_features.each_pair do |feature_name, repo_type|


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Removes the use of `pulp_` prefixed Pulp plugins.  They are no longer named this way.

#### Considerations taken when implementing this change?
This test sometimes causes errors because the repository type manager will not register types with Pulp plugins prefixed with `pulp_`.

#### What are the testing steps for this pull request?
Run the test a few times.