### PR TITLE
Fixes #34494 - Make primary actions on tabs Primary buttons

### DIFF
--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
@@ -268,7 +268,7 @@ const ContentViewComponents = ({ cvId, details }) => {
               <SplitItem>
                 <ActionList>
                   <ActionListItem>
-                    <Button onClick={addBulk} isDisabled={!(bulkAddEnabled())} variant="secondary" aria-label="bulk_add_components">
+                    <Button onClick={addBulk} isDisabled={!(bulkAddEnabled())} variant="primary" aria-label="bulk_add_components">
                       {__('Add content views')}
                     </Button>
                   </ActionListItem>

--- a/webpack/scenes/ContentViews/Details/Filters/AffectedRepositories/AffectedRepositoryTable.js
+++ b/webpack/scenes/ContentViews/Details/Filters/AffectedRepositories/AffectedRepositoryTable.js
@@ -222,7 +222,7 @@ const AffectedRepositoryTable = ({
               <SplitItem>
                 <ActionList>
                   <ActionListItem>
-                    <Button onClick={addBulk} isDisabled={!hasNotAddedSelected} variant="secondary" aria-label="add_repositories">
+                    <Button onClick={addBulk} isDisabled={!hasNotAddedSelected} variant="primary" aria-label="add_repositories">
                       {__('Add repositories')}
                     </Button>
                   </ActionListItem>

--- a/webpack/scenes/ContentViews/Details/Filters/CVContainerImageFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVContainerImageFilterContent.js
@@ -141,7 +141,7 @@ const CVContainerImageFilterContent = ({
                   <SplitItem>
                     <Button
                       onClick={() => setModalOpen(true)}
-                      variant="secondary"
+                      variant="primary"
                       aria-label="add_filter_rule"
                     >
                       {__('Add filter rule')}

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
@@ -252,7 +252,7 @@ const CVErrataDateFilterContent = ({
               <ActionGroup>
                 <Button
                   aria-label="save_filter_rule"
-                  variant="secondary"
+                  variant="primary"
                   isDisabled={saveDisabled}
                   type="submit"
                 >

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
@@ -312,7 +312,7 @@ const CVErrataIDFilterContent = ({
                 </SplitItem>
                 {hasPermission(permissions, 'edit_content_views') &&
                   <SplitItem>
-                    <Button isDisabled={!hasNotAddedSelected} onClick={bulkAdd} variant="secondary" aria-label="add_filter_rule">
+                    <Button isDisabled={!hasNotAddedSelected} onClick={bulkAdd} variant="primary" aria-label="add_filter_rule">
                       {__('Add errata')}
                     </Button>
                   </SplitItem>

--- a/webpack/scenes/ContentViews/Details/Filters/CVModuleStreamFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVModuleStreamFilterContent.js
@@ -247,7 +247,7 @@ const CVModuleStreamFilterContent = ({
                   <Button
                     isDisabled={!hasNotAddedSelected}
                     onClick={bulkAdd}
-                    variant="secondary"
+                    variant="primary"
                     aria-label="add_filter_rule"
                   >
                     {__('Add filter rule')}

--- a/webpack/scenes/ContentViews/Details/Filters/CVPackageGroupFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVPackageGroupFilterContent.js
@@ -234,7 +234,7 @@ const CVPackageGroupFilterContent = ({
                   </Select>
                 </SplitItem>
                 <SplitItem>
-                  <Button isDisabled={!hasNotAddedSelected} onClick={bulkAdd} variant="secondary" aria-label="add_filter_rule">
+                  <Button isDisabled={!hasNotAddedSelected} onClick={bulkAdd} variant="primary" aria-label="add_filter_rule">
                     {__('Add filter rule')}
                   </Button>
                 </SplitItem>

--- a/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
@@ -179,7 +179,7 @@ const CVRpmFilterContent = ({
                 {hasPermission(permissions, 'edit_content_views') &&
                   <Split hasGutter>
                     <SplitItem>
-                      <Button onClick={() => setModalOpen(true)} variant="secondary" aria-label="add_rpm_rule">
+                      <Button onClick={() => setModalOpen(true)} variant="primary" aria-label="add_rpm_rule">
                         {__('Add RPM rule')}
                       </Button>
                     </SplitItem>

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
@@ -136,7 +136,7 @@ const ContentViewFilters = ({ cvId, details }) => {
         <>
           <Split hasGutter>
             <SplitItem>
-              <Button onClick={openAddModal} variant="secondary" aria-label="create_filter">
+              <Button onClick={openAddModal} variant="primary" aria-label="create_filter">
                 {__('Create filter')}
               </Button>
             </SplitItem>

--- a/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
@@ -307,7 +307,7 @@ const ContentViewRepositories = ({ cvId, details }) => {
             <SplitItem>
               <ActionList>
                 <ActionListItem>
-                  <Button onClick={addBulk} isDisabled={!hasNotAddedSelected || importOnly || generatedContentView} variant="secondary" aria-label="add_repositories">
+                  <Button onClick={addBulk} isDisabled={!hasNotAddedSelected || importOnly || generatedContentView} variant="primary" aria-label="add_repositories">
                     {__('Add repositories')}
                   </Button>
                 </ActionListItem>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
All primary actions on CV tabs should be primary buttons to make them more obvious and prominent on the UI.
#### Considerations taken when implementing this change?
The secondary buttons we currently use are white/grey and not immediately obvious to users based on initial feedback.
#### What are the testing steps for this pull request?
All primary action buttons on tabs, ex: Add repositories, add content view, add filter, add package group to filter etc etc should be primary buttons(Blue/Grey).
