### PR TITLE
Fixes #34419 - remove Katello ping from corrupted migration content approval task

### DIFF
--- a/lib/katello/tasks/pulp3_migration_approve_corrupted.rake
+++ b/lib/katello/tasks/pulp3_migration_approve_corrupted.rake
@@ -1,9 +1,6 @@
 namespace :katello do
   desc "Marks corrupted or missing content as approved to be ignored during the migration"
   task :approve_corrupted_migration_content => ["dynflow:client"] do
-    services = [:candlepin, :foreman_tasks, :pulp3, :pulp, :pulp_auth]
-    Katello::Ping.ping!(services: services)
-
     Katello::Pulp3::Migration::CORRUPTABLE_CONTENT_TYPES.each do |type|
       type.missing_migrated_content.update_all(:ignore_missing_from_migration => true)
     end
@@ -11,8 +8,6 @@ namespace :katello do
   end
 
   task :unapprove_corrupted_migration_content => ["dynflow:client"] do
-    services = [:candlepin, :foreman_tasks, :pulp3, :pulp, :pulp_auth]
-    Katello::Ping.ping!(services: services)
     Katello::Pulp3::Migration::CORRUPTABLE_CONTENT_TYPES.each do |type|
       type.ignored_missing_migrated_content.update_all(:ignore_missing_from_migration => false)
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Removes the Katello ping from `katello:approve_corrupted_migration_content` and `katello:unapprove_corrupted_migration_content`.

#### Considerations taken when implementing this change?
No backend services are used by the task, so the Katello ping is unneeded.

#### What are the testing steps for this pull request?
Run `katello:approve_corrupted_migration_content` and `katello:unapprove_corrupted_migration_content` without the Pulp 3 services running on 3.18.