### PR TITLE
Fixes #34497 - Pulp 3 migration underestimates migration time

### DIFF
--- a/lib/katello/tasks/pulp3_migration_stats.rake
+++ b/lib/katello/tasks/pulp3_migration_stats.rake
@@ -25,8 +25,6 @@ namespace :katello do
                          0.000943 * immediate_unmigrated_deb_count - 3 + # copied from RPM, no scientific analysis has been done ;-)
                          0.000943 * immediate_unmigrated_rpm_count - 3 +
                          0.0746 * migratable_repo_count).to_i
-    hours = (migration_minutes / 60) % 60
-    minutes = migration_minutes % 60
 
     puts "============Migration Summary================"
     puts "Migrated/Total DEBs: #{migrated_deb_count}/#{::Katello::Deb.count}"
@@ -36,7 +34,12 @@ namespace :katello do
 
     # The timing formulas go negative if the amount of content is negligibly small
     if migration_minutes >= 5
-      puts "Estimated migration time based on yum/apt content: #{hours} hours, #{minutes} minutes"
+      fast_hours = (migration_minutes / 60) % 60
+      fast_minutes = migration_minutes % 60
+      slow_hours = ((migration_minutes * 4) / 60) % 60
+      slow_minutes = (migration_minutes * 4) % 60
+      puts "Estimated migration time based on yum/apt content, fast hardware, and low server load: #{fast_hours} hours, #{fast_minutes} minutes"
+      puts "Estimated migration time based on yum/apt content, slow hardware, and high server load: #{slow_hours} hours, #{slow_minutes} minutes"
     elsif migrated_rpm_count == ::Katello::Rpm.count &&
       migrated_deb_count == ::Katello::Deb.count &&
       migrated_erratum_count == ::Katello::RepositoryErratum.count &&


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds a suggested migration time for servers with slower hardware and/or higher server loads.  Currently just a factor of 4x based on the information in the redmine issue.

#### Considerations taken when implementing this change?
There isn't enough time to do more testing to determine a proper migration timing. The data will need to come from actual users if it's desired to get a more accurate time.

#### What are the testing steps for this pull request?
Run the migration stats command with a decent number of RPMs so it says something other than "fewer than 5 minutes".  Check that the timing increase matches the factor in the code and the hours + minutes make sense.