### PR TITLE
Refs #33010 - fix slot's id

### DIFF
--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -27,9 +27,9 @@ addGlobalFill('host-details-page-tabs', 'Traces', <TracesTab key="traces" />, 80
 addGlobalFill('host-details-page-tabs', 'Repository sets', <RepositorySetsTab key="repository-sets" />, 700, { title: __('Repository sets') });
 
 addGlobalFill(
-  'details-cards',
+  'host-overview-cards',
   'Content View Details',
   <ContentViewDetailsCard key="content-view-details" />,
   2000,
 );
-addGlobalFill('details-cards', 'Installable errata', <ErrataOverviewCard key="errata-overview" />, 1900);
+addGlobalFill('host-overview-cards', 'Installable errata', <ErrataOverviewCard key="errata-overview" />, 1900);


### PR DESCRIPTION
Fixing the overview tab cards slot's id, once we add the new details tab, the `details-cards` id is too ambiguous.

 blocked by https://github.com/theforeman/foreman/pull/9054
