### PR TITLE
Fixes #34520 - Promote on contentViewVersion Details page

### DIFF
--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
+  Button,
   Grid,
   GridItem,
   TextContent,
@@ -12,7 +13,7 @@ import {
   FlexItem,
   Dropdown,
   DropdownItem,
-  DropdownToggle,
+  KebabToggle,
   DropdownPosition,
 } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -44,14 +45,6 @@ const ContentViewVersionDetailsHeader = ({
   const [deleteVersion, setDeleteVersion] = useState(false);
   const dropDownItems = [
     <DropdownItem
-      key="promote"
-      onClick={() => {
-        setPromoting(true);
-      }}
-    >
-      {__('Promote')}
-    </DropdownItem>,
-    <DropdownItem
       key="remove"
       onClick={() => {
         setRemovingFromEnv(true);
@@ -73,23 +66,26 @@ const ContentViewVersionDetailsHeader = ({
 
   return (
     <Grid className="margin-0-24">
-      <GridItem span={10}>
+      <GridItem sm={6} >
         <TextContent>
           <Text component={TextVariants.h2}>{__('Version ')}{version}</Text>
         </TextContent>
       </GridItem>
-      <GridItem span={2} style={{ display: 'flex' }}>
-        <Dropdown
-          aria-label="version-action-dropdown"
-          position={DropdownPosition.right}
+      <GridItem sm={6} style={{ display: 'flex' }}>
+        <Button
           style={{ marginLeft: 'auto' }}
+          onClick={() => setPromoting(true)}
+          variant="primary"
+          aria-label="publish_content_view"
+        >
+          {__('Promote')}
+        </Button>
+        <Dropdown
+          isPlain
+          style={{ width: 'inherit' }}
+          position={DropdownPosition.right}
           toggle={
-            <DropdownToggle
-              onToggle={setDropdownOpen}
-              id="toggle-id"
-            >
-              {__('Actions')}
-            </DropdownToggle>
+            <KebabToggle onToggle={setDropdownOpen} id="toggle-dropdown" />
           }
           isOpen={dropdownOpen}
           dropdownItems={dropDownItems}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This converts a menu item to a primary button and makes the "Actions" selection button a kebab to match consistency in other areas.

#### What are the testing steps for this pull request?

Open ContentViewVersion Details page and press the fancy new "Promote" button. Ensure it still works as intended.
![Screen Shot 2022-02-24 at 2 34 52 PM](https://user-images.githubusercontent.com/38083295/155612781-c865210c-56b9-4629-8268-ffb012d96b77.png)

