### PR TITLE
Fixes #34522 - Add deprecation warnings for non-SCA

### DIFF
--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -90,8 +90,10 @@ module Katello
           self.providers.anonymous.first
         end
 
-        def manifest_imported?
-          owner_details['upstreamConsumer'].present?
+        def manifest_imported?(cached: false)
+          Rails.cache.fetch("#{self.label}_manifest_imported?", expires_in: 1.minute, force: !cached) do
+            owner_details['upstreamConsumer'].present?
+          end
         end
 
         def manifest_expired?

--- a/engines/bastion/README.md
+++ b/engines/bastion/README.md
@@ -35,6 +35,7 @@ BASTION_MODULES.push('myModuleName');
 Bastion supplies a common set of testing and development using Grunt.  To setup your development environment, from your plugin's checkout:
 
 ```
+sudo yum -y install npm chromium-headless chromium
 sudo npm install -g grunt-cli
 npm install
 npm install ../bastion/

--- a/engines/bastion/app/views/bastion/layouts/assets.html.erb
+++ b/engines/bastion/app/views/bastion/layouts/assets.html.erb
@@ -19,7 +19,7 @@
     angular.module('Bastion').value('currentLocale', '<%= I18n.locale %>');
     angular.module('Bastion').value('CurrentOrganization', "<%= Organization.current.id if Organization.current %>");
     angular.module('Bastion').value('simpleContentAccessEnabled', <%= Organization.current.simple_content_access? if Organization.current %>);
-    angular.module('Bastion').value('isManifestImported', <%= !!Organization.current&.owner_details&.[](:upstreamConsumer)&.[](:webUrl) %>)
+    angular.module('Bastion').value('isManifestImported', <%= !!Organization.current&.manifest_imported? %>)
     angular.module('Bastion').value('foreman', tfm);
     angular.module('Bastion').value('repositoryTypes', angular.fromJson('<%= Katello::RepositoryTypeManager.enabled_repository_types.values.to_json.html_safe %>'));
     angular.module('Bastion').value('deleteHostOnUnregister', angular.fromJson('<%= Setting[:unregister_delete_host] %>'));

--- a/engines/bastion/app/views/bastion/layouts/assets.html.erb
+++ b/engines/bastion/app/views/bastion/layouts/assets.html.erb
@@ -19,6 +19,7 @@
     angular.module('Bastion').value('currentLocale', '<%= I18n.locale %>');
     angular.module('Bastion').value('CurrentOrganization', "<%= Organization.current.id if Organization.current %>");
     angular.module('Bastion').value('simpleContentAccessEnabled', <%= Organization.current.simple_content_access? if Organization.current %>);
+    angular.module('Bastion').value('isManifestImported', <%= !!Organization.current&.owner_details&.[](:upstreamConsumer)&.[](:webUrl) %>)
     angular.module('Bastion').value('foreman', tfm);
     angular.module('Bastion').value('repositoryTypes', angular.fromJson('<%= Katello::RepositoryTypeManager.enabled_repository_types.values.to_json.html_safe %>'));
     angular.module('Bastion').value('deleteHostOnUnregister', angular.fromJson('<%= Setting[:unregister_delete_host] %>'));

--- a/engines/bastion/app/views/bastion/layouts/assets.html.erb
+++ b/engines/bastion/app/views/bastion/layouts/assets.html.erb
@@ -19,7 +19,7 @@
     angular.module('Bastion').value('currentLocale', '<%= I18n.locale %>');
     angular.module('Bastion').value('CurrentOrganization', "<%= Organization.current.id if Organization.current %>");
     angular.module('Bastion').value('simpleContentAccessEnabled', <%= Organization.current.simple_content_access? if Organization.current %>);
-    angular.module('Bastion').value('isManifestImported', <%= !!Organization.current&.manifest_imported? %>)
+    angular.module('Bastion').value('isManifestImported', <%= !!Organization.current&.manifest_imported?(cached: true) %>)
     angular.module('Bastion').value('foreman', tfm);
     angular.module('Bastion').value('repositoryTypes', angular.fromJson('<%= Katello::RepositoryTypeManager.enabled_repository_types.values.to_json.html_safe %>'));
     angular.module('Bastion').value('deleteHostOnUnregister', angular.fromJson('<%= Setting[:unregister_delete_host] %>'));

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
@@ -12,18 +12,20 @@
  * @requires Notification
  * @requires ApiErrorHandler
  * @requires simpleContentAccessEnabled
+ * @requires isManifestImported
  *
  * @description
  *   Provides the functionality for the activation key details action pane.
  */
 angular.module('Bastion.activation-keys').controller('ActivationKeyDetailsController',
-    ['$scope', '$state', '$q', 'translate', 'ActivationKey', 'Organization', 'CurrentOrganization', 'Notification', 'ApiErrorHandler', 'simpleContentAccessEnabled',
-    function ($scope, $state, $q, translate, ActivationKey, Organization, CurrentOrganization, Notification, ApiErrorHandler, simpleContentAccessEnabled) {
+    ['$scope', '$state', '$q', 'translate', 'ActivationKey', 'Organization', 'CurrentOrganization', 'Notification', 'ApiErrorHandler', 'simpleContentAccessEnabled', 'isManifestImported',
+    function ($scope, $state, $q, translate, ActivationKey, Organization, CurrentOrganization, Notification, ApiErrorHandler, simpleContentAccessEnabled, isManifestImported) {
         $scope.defaultRoles = ['Red Hat Enterprise Linux Server', 'Red Hat Enterprise Linux Workstation', 'Red Hat Enterprise Linux Compute Node'];
         $scope.defaultUsages = ['Production', 'Development/Test', 'Disaster Recovery'];
 
         $scope.purposeAddonsCount = 0;
         $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
+        $scope.isManifestImported = isManifestImported;
 
         $scope.organization = Organization.get({id: CurrentOrganization}, function(org) {
             $scope.purposeAddonsCount += org.system_purposes.addons.length;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
@@ -14,13 +14,14 @@
  * @requires deleteHostOnUnregister
  * @requires ContentHostsHelper
  * @requires simpleContentAccessEnabled
+ * @requires isManifestImported
  *
  * @description
  *   Provides the functionality for the content host details action pane.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostDetailsController',
-    ['$scope', '$state', '$q', '$location', 'translate', 'Host', 'HostSubscription', 'Organization', 'CurrentOrganization', 'Notification', 'MenuExpander', 'ApiErrorHandler', 'deleteHostOnUnregister', 'ContentHostsHelper', 'simpleContentAccessEnabled',
-    function ($scope, $state, $q, $location, translate, Host, HostSubscription, Organization, CurrentOrganization, Notification, MenuExpander, ApiErrorHandler, deleteHostOnUnregister, ContentHostsHelper, simpleContentAccessEnabled) {
+    ['$scope', '$state', '$q', '$location', 'translate', 'Host', 'HostSubscription', 'Organization', 'CurrentOrganization', 'Notification', 'MenuExpander', 'ApiErrorHandler', 'deleteHostOnUnregister', 'ContentHostsHelper', 'simpleContentAccessEnabled', 'isManifestImported',
+    function ($scope, $state, $q, $location, translate, Host, HostSubscription, Organization, CurrentOrganization, Notification, MenuExpander, ApiErrorHandler, deleteHostOnUnregister, ContentHostsHelper, simpleContentAccessEnabled, isManifestImported) {
         $scope.menuExpander = MenuExpander;
 
         $scope.getHostStatusIcon = ContentHostsHelper.getHostStatusIcon;
@@ -36,6 +37,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
 
         $scope.purposeAddonsCount = 0;
         $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
+        $scope.isManifestImported = isManifestImported;
 
         $scope.panel = {
             error: false,

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/content-access-mode-banner.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/content-access-mode-banner.html
@@ -1,5 +1,10 @@
-<div id="content-access-mode-banner" bst-alert="info" ng-show="simpleContentAccessEnabled">
+<div id="content-access-mode-banner" bst-alert="info" ng-if="simpleContentAccessEnabled">
   <span translate>
 This organization has Simple Content Access enabled.  Hosts are not required to have subscriptions attached to access repositories.
+  </span>
+</div>
+<div id="content-access-mode-banner" bst-alert="warning" ng-if="!simpleContentAccessEnabled">
+  <span translate>
+This organization is not using <a target="_blank" href="https://access.redhat.com/articles/simple-content-access">Simple Content Access.</a> Legacy subscription management is deprecated and will be removed in a future version.
   </span>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/content-access-mode-banner.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/content-access-mode-banner.html
@@ -3,7 +3,7 @@
 This organization has Simple Content Access enabled.  Hosts are not required to have subscriptions attached to access repositories.
   </span>
 </div>
-<div id="content-access-mode-banner" bst-alert="warning" ng-if="!simpleContentAccessEnabled">
+<div id="non-sca-banner" bst-alert="warning" ng-if="isManifestImported && !simpleContentAccessEnabled">
   <span translate>
 This organization is not using <a target="_blank" href="https://access.redhat.com/articles/simple-content-access">Simple Content Access.</a> Legacy subscription management is deprecated and will be removed in a future version.
   </span>

--- a/engines/bastion_katello/test/activation-keys/details/activation-key-details.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/details/activation-key-details.controller.test.js
@@ -79,7 +79,8 @@ describe('Controller: ActivationKeyDetailsController', function() {
             CurrentOrganization: CurrentOrganization,
             Notification: Notification,
             Organization: Organization,
-            simpleContentAccessEnabled: 'simpleContentAccessEnabled'
+            simpleContentAccessEnabled: 'simpleContentAccessEnabled',
+            isManifestImported: 'isManifestImported'
         });
     }));
 

--- a/engines/bastion_katello/test/content-hosts/details/content-host-details.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-details.controller.test.js
@@ -115,7 +115,8 @@ describe('Controller: ContentHostDetailsController', function() {
             Organization: Organization,
             HostSubscription: HostSubscription,
             MenuExpander: MenuExpander,
-            simpleContentAccessEnabled: false
+            simpleContentAccessEnabled: false,
+            isManifestImported: true,
         });
     }));
 

--- a/webpack/scenes/Subscriptions/SubscriptionConstants.js
+++ b/webpack/scenes/Subscriptions/SubscriptionConstants.js
@@ -38,6 +38,7 @@ export const SUBSCRIPTIONS_DISABLE_DELETE_BUTTON = 'SUBSCRIPTIONS_DISABLE_DELETE
 export const SUBSCRIPTIONS_ENABLE_DELETE_BUTTON = 'SUBSCRIPTIONS_ENABLE_DELETE_BUTTON';
 
 export const SUBSCRIPTION_WATCH_URL = 'https://access.redhat.com/articles/subscription-watch';
+export const SCA_URL = 'https://access.redhat.com/articles/simple-content-access';
 
 export const MANIFEST_DELETE_TASK_LABEL = 'Actions::Katello::Organization::ManifestDelete';
 

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -16,7 +16,7 @@ import { filterRHSubscriptions } from './SubscriptionHelpers';
 import api, { orgId } from '../../services/api';
 
 import { createSubscriptionParams } from './SubscriptionActions.js';
-import { SUBSCRIPTION_TABLE_NAME, SUBSCRIPTION_WATCH_URL } from './SubscriptionConstants';
+import { SUBSCRIPTION_TABLE_NAME, SUBSCRIPTION_WATCH_URL, SCA_URL } from './SubscriptionConstants';
 import './SubscriptionsPage.scss';
 
 class SubscriptionsPage extends Component {
@@ -218,21 +218,22 @@ class SubscriptionsPage extends Component {
       },
     };
 
-    const SCAAlert = simpleContentAccess ? (
-      <Alert type="info">
+    const SCAAlert = (
+      <Alert type={simpleContentAccess ? 'info' : 'warning'}>
         <FormattedMessage
           id="sca-alert"
           values={{
             subscriptionWatch: <a href={SUBSCRIPTION_WATCH_URL} target="_blank" rel="noreferrer">{__('Subscription Watch')}</a>,
             br: <br />,
+            scaLink: <a href={SCA_URL} target="_blank" rel="noreferrer">{__('Simple Content Access')}</a>,
           }}
-          defaultMessage={__(`This organization has Simple Content Access enabled.
+          defaultMessage={simpleContentAccess ? __(`This organization has Simple Content Access enabled.
           Hosts are not required to have subscriptions attached to access repositories.
           {br}
-          Learn more about your overall subscription usage at {subscriptionWatch}.`)}
+          Learn more about your overall subscription usage at {subscriptionWatch}.`) : __('This organization is not using {scaLink}. Legacy subscription management is deprecated and will be removed in a future version.')}
         />
       </Alert>
-    ) : null;
+    );
     return (
       <Grid bsClass="container-fluid">
         <Row>

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -272,7 +272,7 @@ class SubscriptionsPage extends Component {
             />
 
             <div id="subscriptions-table" className="modal-container">
-              {SCAAlert}
+              {isManifestImported && SCAAlert}
               <SubscriptionsTable
                 canManageSubscriptionAllocations={canManageSubscriptionAllocations}
                 loadSubscriptions={this.props.loadSubscriptions}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Traditional (non-SCA) entitlements and subscription management will be deprecated starting in Katello 4.5 and possibly removed in 4.7.  This updates all subscription-related UI pages with deprecation warning banners.

Deprecation warning banners in the following locations:

* Content hosts detail pages
* Activation Keys > detail page
* Subscriptions main page

#### Considerations taken when implementing this change?

Wording is not yet finalized.
The link opens in a new tab. I thought that would be appropriate since it's the way the Subscription Watch link works as well.

#### What are the testing steps for this pull request?

Register a host in both an SCA and a non-SCA org and view the banners.  Or just look at the screen shots:

![non_sca_content_host_warn](https://user-images.githubusercontent.com/22042343/155756886-7e2cd085-5dc2-41d9-8a7b-e92c6ea25ea1.png)
![non_sca_subs_page_warn](https://user-images.githubusercontent.com/22042343/155756898-a361e902-9b86-4dfb-b7a6-9845ea714410.png)
![non_sca_ak_warning](https://user-images.githubusercontent.com/22042343/155756920-76b29587-35c6-418b-96e6-83854ee26c88.png)




These banners display in the same place as the SCA banners.  So if SCA is turned on, you'll instead see those:
![sca_content_host](https://user-images.githubusercontent.com/22042343/155757067-0f8f13ca-12e0-4100-aad4-07426d98eadc.png)
![sca_subs_page](https://user-images.githubusercontent.com/22042343/155757033-f2bb640e-68c4-40cd-a156-b85f1952ca8b.png)
![sca_ak](https://user-images.githubusercontent.com/22042343/155757017-17c988d8-9a1d-4093-b6b9-6dae55fc5e47.png)

