### PR TITLE
Fixes #34529 - Lint failure due to uncontrolled eslint-plugin

### DIFF
--- a/webpack/.eslintrc.js
+++ b/webpack/.eslintrc.js
@@ -25,6 +25,11 @@ module.exports = {
   ],
   parser: '@babel/eslint-parser',
   rules: {
+    // https://github.com/yannickcr/eslint-plugin-react/issues/1679 
+    // TODO: Add this to foreman rules somewhere
+    "indent": ["error", 2, {
+      "ignoredNodes": ['JSX*', 'JSXElement', 'JSXElement > *', 'JSXAttribute', 'JSXIdentifier', 'JSXNamespacedName', 'JSXMemberExpression', 'JSXSpreadAttribute', 'JSXExpressionContainer', 'JSXOpeningElement', 'JSXClosingElement', 'JSXText', 'JSXEmptyExpression', 'JSXSpreadChild']
+    }],
     'react/jsx-filename-extension': 'off',
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': ["warn", {
@@ -57,7 +62,7 @@ module.exports = {
       {
         'required': {
           // Some patternfly components don't play well with the 'nesting' check
-          "every": [ "id" ]
+          "every": ["id"]
         },
       }
     ],

--- a/webpack/components/Errata/index.js
+++ b/webpack/components/Errata/index.js
@@ -24,30 +24,30 @@ export const ErrataSummary = ({ type, count }) => {
   let url;
   let color;
   switch (type) {
-    case 'security':
-      label = __('Security');
-      ErrataIcon = SecurityIcon;
-      name = 'security advisories';
-      color = '#0066cc';
-      url = <a href="#/Content/errata?type=security"> {count} {name} </a>;
-      break;
-    case 'recommended':
-    case 'bugfix':
-      label = __('Bugfix');
-      ErrataIcon = BugIcon;
-      name = 'bug fixes';
-      color = '#8bc1f7';
-      url = <a href="#/Content/errata?type=bugfix"> {count} {name} </a>;
-      break;
-    case 'enhancement':
-    case 'optional':
-      label = __('Enhancement');
-      ErrataIcon = EnhancementIcon;
-      name = 'enhancements';
-      color = '#002f5d';
-      url = <a href="#/Content/errata?type=enhancement"> {count} {name} </a>;
-      break;
-    default:
+  case 'security':
+    label = __('Security');
+    ErrataIcon = SecurityIcon;
+    name = 'security advisories';
+    color = '#0066cc';
+    url = <a href="#/Content/errata?type=security"> {count} {name} </a>;
+    break;
+  case 'recommended':
+  case 'bugfix':
+    label = __('Bugfix');
+    ErrataIcon = BugIcon;
+    name = 'bug fixes';
+    color = '#8bc1f7';
+    url = <a href="#/Content/errata?type=bugfix"> {count} {name} </a>;
+    break;
+  case 'enhancement':
+  case 'optional':
+    label = __('Enhancement');
+    ErrataIcon = EnhancementIcon;
+    name = 'enhancements';
+    color = '#002f5d';
+    url = <a href="#/Content/errata?type=enhancement"> {count} {name} </a>;
+    break;
+  default:
   }
   if (!ErrataIcon) return null;
 
@@ -73,21 +73,21 @@ export const ErrataType = ({ type }) => {
   let ErrataIcon;
   let label;
   switch (type) {
-    case 'security':
-      label = __('Security');
-      ErrataIcon = SecurityIcon;
-      break;
-    case 'recommended':
-    case 'bugfix':
-      label = __('Bugfix');
-      ErrataIcon = BugIcon;
-      break;
-    case 'enhancement':
-    case 'optional':
-      label = __('Enhancement');
-      ErrataIcon = EnhancementIcon;
-      break;
-    default:
+  case 'security':
+    label = __('Security');
+    ErrataIcon = SecurityIcon;
+    break;
+  case 'recommended':
+  case 'bugfix':
+    label = __('Bugfix');
+    ErrataIcon = BugIcon;
+    break;
+  case 'enhancement':
+  case 'optional':
+    label = __('Enhancement');
+    ErrataIcon = EnhancementIcon;
+    break;
+  default:
   }
   if (!ErrataIcon) return null;
 
@@ -108,24 +108,24 @@ export const ErrataSeverity = ({ severity }) => {
   let label;
 
   switch (severity) {
-    case 'Low':
-      color = pfBlack.value;
-      label = __('Low');
-      break;
-    case 'Moderate':
-      color = pfGold.value;
-      label = __('Moderate');
-      break;
-    case 'Important':
-      color = pfOrange.value;
-      label = __('Important');
-      break;
-    case 'Critical':
-      color = pfRed.value;
-      label = __('Critical');
-      break;
-    default:
-      label = __('N/A');
+  case 'Low':
+    color = pfBlack.value;
+    label = __('Low');
+    break;
+  case 'Moderate':
+    color = pfGold.value;
+    label = __('Moderate');
+    break;
+  case 'Important':
+    color = pfOrange.value;
+    label = __('Important');
+    break;
+  case 'Critical':
+    color = pfRed.value;
+    label = __('Critical');
+    break;
+  default:
+    label = __('N/A');
   }
   return <TableText wrapModifier="nowrap">{color && <SecurityIcon color={color} title={label} />} {label} </TableText>;
 };

--- a/webpack/components/ErratumTypeLabel.js
+++ b/webpack/components/ErratumTypeLabel.js
@@ -5,22 +5,22 @@ import { translate as __ } from 'foremanReact/common/I18n';
 
 const ErratumTypeLabel = ({ type }) => {
   switch (type) {
-    case 'bugfix':
-      return (
-        <p><BugIcon />{' '}{__('Bugfix')}</p>
-      );
-    case 'enhancement':
-      return (
-        <p><EnhancementIcon />{' '}{__('Enhancement')}</p>
-      );
-    case 'security':
-      return (
-        <p><SecurityIcon />{' '}{__('Security')}</p>
-      );
-    default:
-      return (
-        <p><UnknownIcon /> {type}</p>
-      );
+  case 'bugfix':
+    return (
+      <p><BugIcon />{' '}{__('Bugfix')}</p>
+    );
+  case 'enhancement':
+    return (
+      <p><EnhancementIcon />{' '}{__('Enhancement')}</p>
+    );
+  case 'security':
+    return (
+      <p><SecurityIcon />{' '}{__('Security')}</p>
+    );
+  default:
+    return (
+      <p><UnknownIcon /> {type}</p>
+    );
   }
 };
 

--- a/webpack/components/MultiSelect/index.js
+++ b/webpack/components/MultiSelect/index.js
@@ -34,12 +34,12 @@ function MultiSelect(props) {
 }
 
 MultiSelect.defaultProps = {
-  onChange: () => {},
+  onChange: () => { },
   defaultValues: null,
 };
 
 MultiSelect.propTypes = {
-  options: PropTypes.arrayOf(PropTypes.object).isRequired,
+  options: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   onChange: PropTypes.func,
   defaultValues: PropTypes.arrayOf(PropTypes.string),
 };

--- a/webpack/components/Select/Select.js
+++ b/webpack/components/Select/Select.js
@@ -28,7 +28,7 @@ export default Select;
 
 Select.propTypes = {
   onChange: PropTypes.func.isRequired,
-  options: PropTypes.arrayOf(PropTypes.object).isRequired,
+  options: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   disabled: PropTypes.bool,
   placeholder: PropTypes.string.isRequired,
   value: PropTypes.string,

--- a/webpack/components/SelectOrg/SelectOrgReducer.js
+++ b/webpack/components/SelectOrg/SelectOrgReducer.js
@@ -11,23 +11,23 @@ export default (state = initialState, action) => {
   const { payload } = action;
 
   switch (action.type) {
-    case GET_ORGANIZATIONS_LIST_REQUEST:
-      return state.set('loading', true);
+  case GET_ORGANIZATIONS_LIST_REQUEST:
+    return state.set('loading', true);
 
-    case GET_ORGANIZATIONS_LIST_SUCCESS:
-      return state
-        .set('list', payload.results)
-        .set('loading', false);
+  case GET_ORGANIZATIONS_LIST_SUCCESS:
+    return state
+      .set('list', payload.results)
+      .set('loading', false);
 
-    case CHANGE_CURRENT_ORGANIZATION_SUCCESS:
-      return state
-        .set('currentId', payload)
-        .set('loading', false);
+  case CHANGE_CURRENT_ORGANIZATION_SUCCESS:
+    return state
+      .set('currentId', payload)
+      .set('loading', false);
 
-    case GET_ORGANIZATIONS_LIST_FAILURE:
-      return state
-        .set('error', payload);
-    default:
-      return state;
+  case GET_ORGANIZATIONS_LIST_FAILURE:
+    return state
+      .set('error', payload);
+  default:
+    return state;
   }
 };

--- a/webpack/components/SelectOrg/SetOrganization.js
+++ b/webpack/components/SelectOrg/SetOrganization.js
@@ -87,7 +87,7 @@ class SetOrganization extends Component {
 
 
 SetOrganization.propTypes = {
-  list: PropTypes.arrayOf(PropTypes.object),
+  list: PropTypes.arrayOf(PropTypes.shape({})),
   loading: PropTypes.bool.isRequired,
   history: PropTypes.shape({
     push: PropTypes.func,

--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -285,7 +285,7 @@ TableWrapper.propTypes = {
   ])),
   displaySelectAllCheckbox: PropTypes.bool,
   selectedCount: PropTypes.number,
-  selectedResults: PropTypes.arrayOf(PropTypes.object),
+  selectedResults: PropTypes.arrayOf(PropTypes.shape({})),
   clearSelectedResults: PropTypes.func,
   selectAll: PropTypes.func,
   selectAllMode: PropTypes.bool,

--- a/webpack/components/TypeAhead/helpers/commonPropTypes.js
+++ b/webpack/components/TypeAhead/helpers/commonPropTypes.js
@@ -26,7 +26,7 @@ export const commonInputPropTypes = {
 };
 
 export const commonItemPropTypes = {
-  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+  items: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   activeItems: PropTypes.arrayOf(PropTypes.string).isRequired,
   highlightedIndex: PropTypes.number.isRequired,
   getItemProps: PropTypes.func.isRequired,

--- a/webpack/components/TypeAhead/helpers/helpers.js
+++ b/webpack/components/TypeAhead/helpers/helpers.js
@@ -5,22 +5,22 @@ const keyPressHandler = (
   selectItem, userInputValue, onSearch,
 ) => {
   switch (e.keyCode) {
-    case KEYCODES.TAB_KEY:
-      if (isOpen && activeItems[highlightedIndex]) {
-        selectItem(activeItems[highlightedIndex]);
-        e.preventDefault();
-      }
-      break;
+  case KEYCODES.TAB_KEY:
+    if (isOpen && activeItems[highlightedIndex]) {
+      selectItem(activeItems[highlightedIndex]);
+      e.preventDefault();
+    }
+    break;
 
-    case KEYCODES.ENTER:
-      if (!isOpen || !activeItems[highlightedIndex]) {
-        onSearch(userInputValue);
-        e.preventDefault();
-      }
-      break;
+  case KEYCODES.ENTER:
+    if (!isOpen || !activeItems[highlightedIndex]) {
+      onSearch(userInputValue);
+      e.preventDefault();
+    }
+    break;
 
-    default:
-      break;
+  default:
+    break;
   }
 };
 

--- a/webpack/components/TypeAhead/pf3Search/TypeAheadSearch.js
+++ b/webpack/components/TypeAhead/pf3Search/TypeAheadSearch.js
@@ -18,7 +18,7 @@ const TypeAheadSearch = ({
         onKeyPress={e => keyPressHandler(
           e, isOpen, activeItems, highlightedIndex,
           selectItem, userInputValue, onSearch,
-)}
+        )}
         onInputFocus={openMenu}
         passedProps={getInputProps()}
       />

--- a/webpack/components/WithOrganization/withOrganization.js
+++ b/webpack/components/WithOrganization/withOrganization.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-indent */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
@@ -46,14 +47,13 @@ function withOrganization(WrappedComponent) {
 
       if (newOrgSelected) {
         if (!organization.label && !organization.loading) { this.props.loadOrganization(); }
-
         return <WrappedComponent {...this.props} />;
       } else if (this.state.orgId === '') {
         return (
-          <React.Fragment>
+          <>
             <Header title={__('Select Organization')} />
             <SetOrganization />
-          </React.Fragment>);
+          </>);
       }
       return <WrappedComponent {...this.props} />;
     }

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErratumExpansionContents.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErratumExpansionContents.js
@@ -50,10 +50,10 @@ ErratumExpansionContents.propTypes = {
     description: PropTypes.string,
     summary: PropTypes.string,
     solution: PropTypes.string,
-    bugs: PropTypes.arrayOf(PropTypes.object),
-    cves: PropTypes.arrayOf(PropTypes.object),
+    bugs: PropTypes.arrayOf(PropTypes.shape({})),
+    cves: PropTypes.arrayOf(PropTypes.shape({})),
     packages: PropTypes.arrayOf(PropTypes.string),
-    module_streams: PropTypes.arrayOf(PropTypes.object),
+    module_streams: PropTypes.arrayOf(PropTypes.shape({})),
   }).isRequired,
 };
 

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -28,14 +28,14 @@ const EnabledIcon = ({ streamText, streamInstallStatus, upgradable }) => {
   };
 
   switch (true) {
-    case (streamInstallStatus?.length > 0 && streamText === 'disabled'):
-      return <TableText wrapModifier="nowrap">{INSTALLED_STATE.INSTALLED}</TableText>;
-    case (streamInstallStatus?.length > 0 && streamText === 'enabled' && upgradable !== true):
-      return <><CheckIcon color="green" /> {INSTALLED_STATE.UPTODATE}</>;
-    case (streamInstallStatus?.length > 0 && streamText === 'enabled' && upgradable):
-      return <><LongArrowAltUpIcon color="blue" /> {INSTALLED_STATE.UPGRADEABLE}</>;
-    default:
-      return <InactiveText text={INSTALLED_STATE.NOTINSTALLED} />;
+  case (streamInstallStatus?.length > 0 && streamText === 'disabled'):
+    return <TableText wrapModifier="nowrap">{INSTALLED_STATE.INSTALLED}</TableText>;
+  case (streamInstallStatus?.length > 0 && streamText === 'enabled' && upgradable !== true):
+    return <><CheckIcon color="green" /> {INSTALLED_STATE.UPTODATE}</>;
+  case (streamInstallStatus?.length > 0 && streamText === 'enabled' && upgradable):
+    return <><LongArrowAltUpIcon color="blue" /> {INSTALLED_STATE.UPGRADEABLE}</>;
+  default:
+    return <InactiveText text={INSTALLED_STATE.NOTINSTALLED} />;
   }
 };
 
@@ -49,14 +49,14 @@ const StreamState = ({ moduleStreamStatus }) => {
   let streamText = moduleStreamStatus?.charAt(0)?.toUpperCase() + moduleStreamStatus?.slice(1);
   streamText = streamText?.replace('Unknown', 'Default');
   switch (true) {
-    case (streamText === 'Default'):
-      return <Label color="gray" variant="outline">{streamText}</Label>;
-    case (streamText === 'Disabled'):
-      return <Label color="gray" variant="filled">{streamText}</Label>;
-    case (streamText === 'Enabled'):
-      return <Label color="green" variant="filled">{streamText}</Label>;
-    default:
-      return null;
+  case (streamText === 'Default'):
+    return <Label color="gray" variant="outline">{streamText}</Label>;
+  case (streamText === 'Disabled'):
+    return <Label color="gray" variant="filled">{streamText}</Label>;
+  case (streamText === 'Enabled'):
+    return <Label color="green" variant="filled">{streamText}</Label>;
+  default:
+    return null;
   }
 };
 
@@ -177,18 +177,18 @@ export const ModuleStreamsTab = () => {
       <div id="modulestreams-tab">
         <TableWrapper
           {...{
-          metadata,
-          emptyContentTitle,
-          emptyContentBody,
-          emptySearchTitle,
-          emptySearchBody,
-          errorSearchTitle,
-          errorSearchBody,
-          searchQuery,
-          updateSearchQuery,
-          fetchItems,
-          status,
-        }}
+            metadata,
+            emptyContentTitle,
+            emptyContentBody,
+            emptySearchTitle,
+            emptySearchBody,
+            errorSearchTitle,
+            errorSearchBody,
+            searchQuery,
+            updateSearchQuery,
+            fetchItems,
+            status,
+          }}
           additionalListeners={[hostId, activeSortColumn, activeSortDirection]}
           fetchItems={fetchItems}
           autocompleteEndpoint={`/hosts/${hostId}/module_streams/auto_complete_search`}
@@ -207,52 +207,52 @@ export const ModuleStreamsTab = () => {
           </Thead>
           <Tbody>
             {results?.map(({
-                id,
-                status: moduleStreamStatus,
-                name,
-                stream,
-                installed_profiles: installedProfiles,
-                upgradable,
-                module_spec: moduleSpec,
-              }, index) =>
+              id,
+              status: moduleStreamStatus,
+              name,
+              stream,
+              installed_profiles: installedProfiles,
+              upgradable,
+              module_spec: moduleSpec,
+            }, index) =>
 
             /* eslint-disable react/no-array-index-key */
 
-             (
-               <Tr key={`${id} ${index}`}>
-                 <Td>
-                   <a
-                     href={`/module_streams?search=module_spec%3D${moduleSpec}+and+host%3D${hostName}`}
-                   >
-                     {name}
-                   </a>
-                 </Td>
-                 <Td>
-                   <StreamState moduleStreamStatus={moduleStreamStatus} />
-                 </Td>
-                 <Td>{stream}</Td>
-                 <Td>
-                   <EnabledIcon
-                     streamText={moduleStreamStatus}
-                     streamInstallStatus={installedProfiles}
-                     upgradable={upgradable}
-                   />
-                 </Td>
-                 <Td>
-                   <HostInstalledProfiles
-                     moduleStreamStatus={moduleStreamStatus}
-                     installedProfiles={installedProfiles}
-                   />
-                 </Td>
-                 <Td
-                   key={`rowActions-${id}`}
-                   actions={{
-                  items: rowActions,
-                }}
-                 />
-               </Tr>
-            ))
-          }
+              (
+                <Tr key={`${id} ${index}`}>
+                  <Td>
+                    <a
+                      href={`/module_streams?search=module_spec%3D${moduleSpec}+and+host%3D${hostName}`}
+                    >
+                      {name}
+                    </a>
+                  </Td>
+                  <Td>
+                    <StreamState moduleStreamStatus={moduleStreamStatus} />
+                  </Td>
+                  <Td>{stream}</Td>
+                  <Td>
+                    <EnabledIcon
+                      streamText={moduleStreamStatus}
+                      streamInstallStatus={installedProfiles}
+                      upgradable={upgradable}
+                    />
+                  </Td>
+                  <Td>
+                    <HostInstalledProfiles
+                      moduleStreamStatus={moduleStreamStatus}
+                      installedProfiles={installedProfiles}
+                    />
+                  </Td>
+                  <Td
+                    key={`rowActions-${id}`}
+                    actions={{
+                      items: rowActions,
+                    }}
+                  />
+                </Tr>
+              ))
+            }
           </Tbody>
         </TableWrapper>
       </div>

--- a/webpack/components/extensions/HostDetails/Tabs/PackageInstallModal.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackageInstallModal.js
@@ -238,11 +238,11 @@ const PackageInstallModal = ({
               <Tr key={id}>
                 <Td
                   select={{
-                      disable: false,
-                      isSelected: isSelected(id),
-                      onSelect: (_event, selected) => selectOne(selected, id, pkg),
-                      rowIndex,
-                      variant: 'checkbox',
+                    disable: false,
+                    isSelected: isSelected(id),
+                    onSelect: (_event, selected) => selectOne(selected, id, pkg),
+                    rowIndex,
+                    variant: 'checkbox',
                   }}
                 />
                 <Td>

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab.js
@@ -400,12 +400,12 @@ export const PackagesTab = () => {
               return (
                 <Tr key={`${id}`}>
                   <Td select={{
-                      disable: false,
-                      isSelected: isSelected(id),
-                      onSelect: (event, selected) => selectOne(selected, id, pkg),
-                      rowIndex,
-                      variant: 'checkbox',
-                    }}
+                    disable: false,
+                    isSelected: isSelected(id),
+                    onSelect: (event, selected) => selectOne(selected, id, pkg),
+                    rowIndex,
+                    variant: 'checkbox',
+                  }}
                   />
                   <Td>
                     {rpmId

--- a/webpack/components/extensions/RegistrationCommands/fields/ActivationKeys.js
+++ b/webpack/components/extensions/RegistrationCommands/fields/ActivationKeys.js
@@ -81,7 +81,7 @@ ActivationKeys.propTypes = {
   selectedKeys: PropTypes.array,
   hostGroupActivationKeys: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   hostGroupId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  pluginValues: PropTypes.object,
+  pluginValues: PropTypes.objectOf(PropTypes.shape({})),
   onChange: PropTypes.func.isRequired,
   handleInvalidField: PropTypes.func.isRequired,
   isLoading: PropTypes.bool,

--- a/webpack/components/extensions/RegistrationCommands/fields/LifecycleEnvironment.js
+++ b/webpack/components/extensions/RegistrationCommands/fields/LifecycleEnvironment.js
@@ -31,7 +31,7 @@ const LifecycleEnvironment = ({
       />
       {lifecycleEnvironments.map(lce => (
         <FormSelectOption key={lce.id} value={lce.id} label={lce.name} />
-        ))}
+      ))}
     </FormSelect>
   </FormGroup>
 );

--- a/webpack/components/extensions/about/SystemStatuses.js
+++ b/webpack/components/extensions/about/SystemStatuses.js
@@ -31,7 +31,7 @@ class SystemStatuses extends Component {
                     <td>{value.status.toUpperCase()}</td>
                     <td> {value.message}</td>
                   </tr>
-            ))}
+                ))}
               </tbody>
             </table>
           </LoadingState>

--- a/webpack/components/extensions/about/SystemStatusesReducer.js
+++ b/webpack/components/extensions/about/SystemStatusesReducer.js
@@ -12,15 +12,15 @@ const initialState = Immutable({
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case SYSTEM_STATUSES_REQUEST:
-      return state.set('loaderStatus', 'PENDING');
-    case SYSTEM_STATUSES_SUCCESS:
-      return state
-        .set('services', action.payload.services)
-        .set('loaderStatus', 'RESOLVED');
-    case SYSTEM_STATUSES_FAILURE:
-      return state.set('loaderStatus', 'ERROR');
-    default:
-      return state;
+  case SYSTEM_STATUSES_REQUEST:
+    return state.set('loaderStatus', 'PENDING');
+  case SYSTEM_STATUSES_SUCCESS:
+    return state
+      .set('services', action.payload.services)
+      .set('loaderStatus', 'RESOLVED');
+  case SYSTEM_STATUSES_FAILURE:
+    return state.set('loaderStatus', 'ERROR');
+  default:
+    return state;
   }
 };

--- a/webpack/components/pf3Table/components/Table.js
+++ b/webpack/components/pf3Table/components/Table.js
@@ -53,8 +53,8 @@ const Table = ({
 };
 
 Table.propTypes = {
-  columns: PropTypes.arrayOf(PropTypes.object).isRequired,
-  rows: PropTypes.arrayOf(PropTypes.object).isRequired,
+  columns: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  rows: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   emptyState: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   pagination: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   bodyMessage: PropTypes.node,

--- a/webpack/components/pf3Table/components/TableBody.js
+++ b/webpack/components/pf3Table/components/TableBody.js
@@ -15,8 +15,8 @@ const TableBody = ({
 };
 
 TableBody.propTypes = {
-  columns: PropTypes.arrayOf(PropTypes.object).isRequired,
-  rows: PropTypes.arrayOf(PropTypes.object).isRequired,
+  columns: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  rows: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   message: PropTypes.string,
 };
 

--- a/webpack/redux/OrganizationProducts/OrganizationProductsReducer.js
+++ b/webpack/redux/OrganizationProducts/OrganizationProductsReducer.js
@@ -16,23 +16,23 @@ export default (state = initialState, action) => {
   const { type, payload } = action;
 
   switch (type) {
-    case ORGANIZATION_PRODUCTS_REQUEST:
-      return state.set('loading', true);
+  case ORGANIZATION_PRODUCTS_REQUEST:
+    return state.set('loading', true);
 
-    case ORGANIZATION_PRODUCTS_SUCCESS:
-      return state.merge({
-        ...payload,
-        loading: false,
-      });
+  case ORGANIZATION_PRODUCTS_SUCCESS:
+    return state.merge({
+      ...payload,
+      loading: false,
+    });
 
-    case ORGANIZATION_PRODUCTS_FAILURE:
-      return state.merge({
-        error: payload,
-        loading: false,
-        results: [],
-      });
+  case ORGANIZATION_PRODUCTS_FAILURE:
+    return state.merge({
+      error: payload,
+      loading: false,
+      results: [],
+    });
 
-    default:
-      return state;
+  default:
+    return state;
   }
 };

--- a/webpack/redux/reducers/RedHatRepositories/enabled.js
+++ b/webpack/redux/reducers/RedHatRepositories/enabled.js
@@ -60,49 +60,49 @@ const changeRepoState = (state, repoToChange, stateDiff) => (
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case DISABLE_REPOSITORY_REQUEST:
-      return changeRepoState(state, action.repository, { loading: true });
-    case DISABLE_REPOSITORY_FAILURE:
-      return changeRepoState(state, action.payload.repository, { loading: false });
-    case ENABLED_REPOSITORIES_REQUEST:
-      if (!action.silent) {
-        return state.set(['loading'], true);
-      }
-      return state;
-    case ENABLED_REPOSITORIES_SUCCESS: {
-      const {
-        page,
-        per_page, // eslint-disable-line camelcase
-        subtotal,
-        results,
-      } = action.response;
-      return Immutable({
-        repositories: mapRepositories(results),
-        pagination: {
-          page: Number(page) || 1,
-          // server can return per_page: null when there's error in the search query,
-          // don't store it in such case
-          // eslint-disable-next-line camelcase
-          perPage: (per_page || state.pagination.perPage)
-          // eslint-disable-next-line camelcase
+  case DISABLE_REPOSITORY_REQUEST:
+    return changeRepoState(state, action.repository, { loading: true });
+  case DISABLE_REPOSITORY_FAILURE:
+    return changeRepoState(state, action.payload.repository, { loading: false });
+  case ENABLED_REPOSITORIES_REQUEST:
+    if (!action.silent) {
+      return state.set(['loading'], true);
+    }
+    return state;
+  case ENABLED_REPOSITORIES_SUCCESS: {
+    const {
+      page,
+      per_page, // eslint-disable-line camelcase
+      subtotal,
+      results,
+    } = action.response;
+    return Immutable({
+      repositories: mapRepositories(results),
+      pagination: {
+        page: Number(page) || 1,
+        // server can return per_page: null when there's error in the search query,
+        // don't store it in such case
+        // eslint-disable-next-line camelcase
+        perPage: (per_page || state.pagination.perPage)
+        // eslint-disable-next-line camelcase
             && Number(per_page || state.pagination.perPage),
-        },
-        itemCount: Number(subtotal),
-        loading: false,
-        searchIsActive: !isEmpty(action.search),
-        search: action.search,
-      });
-    }
-    case ENABLED_REPOSITORIES_FAILURE: {
-      const { error, missingPermissions } = action;
-      return Immutable({
-        repositories: [],
-        loading: false,
-        error,
-        missingPermissions,
-      });
-    }
-    default:
-      return state;
+      },
+      itemCount: Number(subtotal),
+      loading: false,
+      searchIsActive: !isEmpty(action.search),
+      search: action.search,
+    });
+  }
+  case ENABLED_REPOSITORIES_FAILURE: {
+    const { error, missingPermissions } = action;
+    return Immutable({
+      repositories: [],
+      loading: false,
+      error,
+      missingPermissions,
+    });
+  }
+  default:
+    return state;
   }
 };

--- a/webpack/redux/reducers/RedHatRepositories/repositorySetRepositories.js
+++ b/webpack/redux/reducers/RedHatRepositories/repositorySetRepositories.js
@@ -56,48 +56,48 @@ const initialState = Immutable({});
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case ENABLE_REPOSITORY_REQUEST:
-      return changeRepoState(state, action.repository, { loading: true });
+  case ENABLE_REPOSITORY_REQUEST:
+    return changeRepoState(state, action.repository, { loading: true });
 
-    case ENABLE_REPOSITORY_FAILURE:
-      return changeRepoState(state, action.payload.repository, { loading: false, error: true });
+  case ENABLE_REPOSITORY_FAILURE:
+    return changeRepoState(state, action.payload.repository, { loading: false, error: true });
 
-    case REPOSITORY_SET_REPOSITORIES_REQUEST:
-      return state.set(action.contentId, {
-        loading: true,
-        repositories: [],
-        error: null,
-      });
+  case REPOSITORY_SET_REPOSITORIES_REQUEST:
+    return state.set(action.contentId, {
+      loading: true,
+      repositories: [],
+      error: null,
+    });
 
-    case REPOSITORY_SET_REPOSITORIES_SUCCESS:
-      return state.set(action.contentId, {
-        loading: false,
-        repositories: normalizeContentSetRepositories(
-          action.results,
-          action.contentId,
-          action.productId,
-        ),
-        error: null,
-      });
+  case REPOSITORY_SET_REPOSITORIES_SUCCESS:
+    return state.set(action.contentId, {
+      loading: false,
+      repositories: normalizeContentSetRepositories(
+        action.results,
+        action.contentId,
+        action.productId,
+      ),
+      error: null,
+    });
 
-    case REPOSITORY_SET_REPOSITORIES_FAILURE:
-      return state.set(action.contentId, {
-        loading: false,
-        repositories: [],
-        error: action.error,
-      });
+  case REPOSITORY_SET_REPOSITORIES_FAILURE:
+    return state.set(action.contentId, {
+      loading: false,
+      repositories: [],
+      error: action.error,
+    });
 
-    case REPOSITORY_ENABLED:
-      return changeRepoState(state, action.repository, {
-        enabled: true,
-        loading: false,
-        error: false,
-      });
+  case REPOSITORY_ENABLED:
+    return changeRepoState(state, action.repository, {
+      enabled: true,
+      loading: false,
+      error: false,
+    });
 
-    case REPOSITORY_DISABLED:
-      return changeRepoState(state, action.repository, { enabled: false });
+  case REPOSITORY_DISABLED:
+    return changeRepoState(state, action.repository, { enabled: false });
 
-    default:
-      return state;
+  default:
+    return state;
   }
 };

--- a/webpack/redux/reducers/RedHatRepositories/sets.js
+++ b/webpack/redux/reducers/RedHatRepositories/sets.js
@@ -14,36 +14,36 @@ export default (state = initialState, action) => {
   const { payload } = action;
 
   switch (action.type) {
-    case REPOSITORY_SETS_REQUEST:
-      return state.set('loading', true);
+  case REPOSITORY_SETS_REQUEST:
+    return state.set('loading', true);
 
-    case REPOSITORY_SETS_UPDATE_RECOMMENDED:
-      return state
-        .set('recommended', payload);
+  case REPOSITORY_SETS_UPDATE_RECOMMENDED:
+    return state
+      .set('recommended', payload);
 
-    case REPOSITORY_SETS_SUCCESS:
-      return state
-        .set('results', payload.response.results)
-        .set('pagination', {
-          page: Number(payload.response.page),
-          // server can return per_page: null when there's error in the search query,
-          // don't store it in such case
-          // eslint-disable-next-line camelcase
-          perPage: Number(payload.response.per_page || state.pagination.perPage),
-        })
-        .set('itemCount', Number(payload.response.subtotal))
-        .set('loading', false)
-        .set('searchIsActive', !isEmpty(payload.search))
-        .set('search', payload.search);
+  case REPOSITORY_SETS_SUCCESS:
+    return state
+      .set('results', payload.response.results)
+      .set('pagination', {
+        page: Number(payload.response.page),
+        // server can return per_page: null when there's error in the search query,
+        // don't store it in such case
+        // eslint-disable-next-line camelcase
+        perPage: Number(payload.response.per_page || state.pagination.perPage),
+      })
+      .set('itemCount', Number(payload.response.subtotal))
+      .set('loading', false)
+      .set('searchIsActive', !isEmpty(payload.search))
+      .set('search', payload.search);
 
-    case REPOSITORY_SETS_FAILURE:
-      return Immutable({
-        error: payload,
-        loading: false,
-        missingPermissions: get(payload, ['response', 'data', 'error', 'missing_permissions']),
-      });
+  case REPOSITORY_SETS_FAILURE:
+    return Immutable({
+      error: payload,
+      loading: false,
+      missingPermissions: get(payload, ['response', 'data', 'error', 'missing_permissions']),
+    });
 
-    default:
-      return state;
+  default:
+    return state;
   }
 };

--- a/webpack/scenes/AnsibleCollections/AnsibleCollectionsReducer.js
+++ b/webpack/scenes/AnsibleCollections/AnsibleCollectionsReducer.js
@@ -9,31 +9,31 @@ const initialState = initialApiState;
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case ANSIBLE_COLLECTIONS_REQUEST: {
-      return state.set('loading', true);
-    }
-    case ANSIBLE_COLLECTIONS_SUCCESS: {
-      const {
-        results, page, per_page, subtotal, // eslint-disable-line camelcase
-      } = action.response;
-      return state.merge({
-        results,
-        loading: false,
-        pagination: {
-          page: Number(page),
-          perPage: Number(per_page || state.pagination.perPage), // eslint-disable-line camelcase
-        },
-        itemCount: Number(subtotal),
-      });
-    }
-    case ANSIBLE_COLLECTIONS_ERROR: {
-      return state.merge({
-        error: action.error,
-        loading: false,
-      });
-    }
-    default: {
-      return state;
-    }
+  case ANSIBLE_COLLECTIONS_REQUEST: {
+    return state.set('loading', true);
+  }
+  case ANSIBLE_COLLECTIONS_SUCCESS: {
+    const {
+      results, page, per_page, subtotal, // eslint-disable-line camelcase
+    } = action.response;
+    return state.merge({
+      results,
+      loading: false,
+      pagination: {
+        page: Number(page),
+        perPage: Number(per_page || state.pagination.perPage), // eslint-disable-line camelcase
+      },
+      itemCount: Number(subtotal),
+    });
+  }
+  case ANSIBLE_COLLECTIONS_ERROR: {
+    return state.merge({
+      error: action.error,
+      loading: false,
+    });
+  }
+  default: {
+    return state;
+  }
   }
 };

--- a/webpack/scenes/AnsibleCollections/Details/AnsibleCollectionDetailsReducer.js
+++ b/webpack/scenes/AnsibleCollections/Details/AnsibleCollectionDetailsReducer.js
@@ -7,24 +7,24 @@ import {
 
 export default (state = initialApiState, action) => {
   switch (action.type) {
-    case ANSIBLE_COLLECTION_DETAILS_REQUEST: {
-      return state.set('loading', true);
-    }
-    case ANSIBLE_COLLECTION_DETAILS_SUCCESS: {
-      const ansibleCollectionDetails = action.response;
-      return state.merge({
-        ...ansibleCollectionDetails,
-        loading: false,
-      });
-    }
-    case ANSIBLE_COLLECTION_DETAILS_ERROR: {
-      return state.merge({
-        error: action.payload.message,
-        loading: false,
-      });
-    }
-    default: {
-      return state;
-    }
+  case ANSIBLE_COLLECTION_DETAILS_REQUEST: {
+    return state.set('loading', true);
+  }
+  case ANSIBLE_COLLECTION_DETAILS_SUCCESS: {
+    const ansibleCollectionDetails = action.response;
+    return state.merge({
+      ...ansibleCollectionDetails,
+      loading: false,
+    });
+  }
+  case ANSIBLE_COLLECTION_DETAILS_ERROR: {
+    return state.merge({
+      error: action.payload.message,
+      loading: false,
+    });
+  }
+  default: {
+    return state;
+  }
   }
 };

--- a/webpack/scenes/Content/Table/ContentTable.js
+++ b/webpack/scenes/Content/Table/ContentTable.js
@@ -78,7 +78,7 @@ const ContentTable = ({
 ContentTable.propTypes = {
   selectedContentType: PropTypes.string.isRequired,
   setSelectedContentType: PropTypes.func.isRequired,
-  contentTypes: PropTypes.objectOf(PropTypes.array).isRequired,
+  contentTypes: PropTypes.shape({}).isRequired,
   showContentTypeSelector: PropTypes.bool,
 };
 

--- a/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignHostsForm.js
+++ b/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignHostsForm.js
@@ -107,8 +107,8 @@ const CVDeletionReassignHostsForm = () => {
       >
         <AffectedHosts
           {...{
-          cvId,
-        }}
+            cvId,
+          }}
           versionEnvironments={cvEnvironments}
           deleteCV
         />

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailReducer.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailReducer.js
@@ -11,13 +11,13 @@ const initialState = Immutable({
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case UPDATE_CONTENT_VIEW:
-      return state.set('updating', true);
-    case UPDATE_CONTENT_VIEW_SUCCESS:
-      return state.merge({ updating: false });
-    case UPDATE_CONTENT_VIEW_FAILURE:
-      return state.set('updating', false);
-    default:
-      return state;
+  case UPDATE_CONTENT_VIEW:
+    return state.set('updating', true);
+  case UPDATE_CONTENT_VIEW_SUCCESS:
+    return state.merge({ updating: false });
+  case UPDATE_CONTENT_VIEW_FAILURE:
+    return state.set('updating', false);
+  default:
+    return state;
   }
 };

--- a/webpack/scenes/ContentViews/Details/Filters/ArtifactsWithNoErrata.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ArtifactsWithNoErrata.js
@@ -22,14 +22,14 @@ export const ArtifactsWithNoErrataRenderer = ({ filterDetails }) => {
   };
   const getLabel = () => {
     switch (true) {
-      case type === 'modulemd' && inclusion:
-        return __('Include all Module Streams with no errata.');
-      case type === 'modulemd' && !inclusion:
-        return __('Exclude all Module Streams with no errata.');
-      case !inclusion:
-        return __('Exclude all RPMs with no errata.');
-      default:
-        return __('Include all RPMs with no errata.');
+    case type === 'modulemd' && inclusion:
+      return __('Include all Module Streams with no errata.');
+    case type === 'modulemd' && !inclusion:
+      return __('Exclude all Module Streams with no errata.');
+    case !inclusion:
+      return __('Exclude all RPMs with no errata.');
+    default:
+      return __('Include all RPMs with no errata.');
     }
   };
 

--- a/webpack/scenes/ContentViews/Details/Filters/CVFilterDetailType.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVFilterDetailType.js
@@ -12,24 +12,42 @@ const CVFilterDetailType = ({
   cvId, filterId, inclusion, type, showAffectedRepos, setShowAffectedRepos, rules, details,
 }) => {
   switch (type) {
-    case 'docker':
-      return (<CVContainerImageFilterContent
-        cvId={cvId}
-        filterId={filterId}
-        showAffectedRepos={showAffectedRepos}
-        setShowAffectedRepos={setShowAffectedRepos}
-        details={details}
-      />);
-    case 'package_group':
-      return (<CVPackageGroupFilterContent
-        cvId={cvId}
-        filterId={filterId}
-        showAffectedRepos={showAffectedRepos}
-        setShowAffectedRepos={setShowAffectedRepos}
-        details={details}
-      />);
-    case 'rpm':
-      return (<CVRpmFilterContent
+  case 'docker':
+    return (<CVContainerImageFilterContent
+      cvId={cvId}
+      filterId={filterId}
+      showAffectedRepos={showAffectedRepos}
+      setShowAffectedRepos={setShowAffectedRepos}
+      details={details}
+    />);
+  case 'package_group':
+    return (<CVPackageGroupFilterContent
+      cvId={cvId}
+      filterId={filterId}
+      showAffectedRepos={showAffectedRepos}
+      setShowAffectedRepos={setShowAffectedRepos}
+      details={details}
+    />);
+  case 'rpm':
+    return (<CVRpmFilterContent
+      cvId={cvId}
+      filterId={filterId}
+      inclusion={inclusion}
+      showAffectedRepos={showAffectedRepos}
+      setShowAffectedRepos={setShowAffectedRepos}
+      details={details}
+    />);
+  case 'modulemd':
+    return (<CVModuleStreamFilterContent
+      cvId={cvId}
+      filterId={filterId}
+      showAffectedRepos={showAffectedRepos}
+      setShowAffectedRepos={setShowAffectedRepos}
+      details={details}
+    />);
+  case 'erratum':
+    if (head(rules)?.types) {
+      return (<CVErrataDateFilterContent
         cvId={cvId}
         filterId={filterId}
         inclusion={inclusion}
@@ -37,34 +55,16 @@ const CVFilterDetailType = ({
         setShowAffectedRepos={setShowAffectedRepos}
         details={details}
       />);
-    case 'modulemd':
-      return (<CVModuleStreamFilterContent
-        cvId={cvId}
-        filterId={filterId}
-        showAffectedRepos={showAffectedRepos}
-        setShowAffectedRepos={setShowAffectedRepos}
-        details={details}
-      />);
-    case 'erratum':
-      if (head(rules)?.types) {
-        return (<CVErrataDateFilterContent
-          cvId={cvId}
-          filterId={filterId}
-          inclusion={inclusion}
-          showAffectedRepos={showAffectedRepos}
-          setShowAffectedRepos={setShowAffectedRepos}
-          details={details}
-        />);
-      }
-      return (<CVErrataIDFilterContent
-        cvId={cvId}
-        filterId={filterId}
-        showAffectedRepos={showAffectedRepos}
-        setShowAffectedRepos={setShowAffectedRepos}
-        details={details}
-      />);
-    default:
-      return null;
+    }
+    return (<CVErrataIDFilterContent
+      cvId={cvId}
+      filterId={filterId}
+      showAffectedRepos={showAffectedRepos}
+      setShowAffectedRepos={setShowAffectedRepos}
+      details={details}
+    />);
+  default:
+    return null;
   }
 };
 

--- a/webpack/scenes/ContentViews/Details/Filters/CVModuleStreamFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVModuleStreamFilterContent.js
@@ -78,19 +78,19 @@ const CVModuleStreamFilterContent = ({
   const fetchItems = useCallback((params) => {
     const adjustedParams = { ...params };
     switch (selectedIndex) {
-      case 0:
-        adjustedParams.show_all_for = 'content_view_filter';
-        adjustedParams.available_for = undefined;
-        break;
-      case 1:
-        adjustedParams.show_all_for = undefined;
-        adjustedParams.available_for = undefined;
-        break;
-      case 2:
-        adjustedParams.show_all_for = undefined;
-        adjustedParams.available_for = 'content_view_filter';
-        break;
-      default:
+    case 0:
+      adjustedParams.show_all_for = 'content_view_filter';
+      adjustedParams.available_for = undefined;
+      break;
+    case 1:
+      adjustedParams.show_all_for = undefined;
+      adjustedParams.available_for = undefined;
+      break;
+    case 2:
+      adjustedParams.show_all_for = undefined;
+      adjustedParams.available_for = 'content_view_filter';
+      break;
+    default:
     }
 
     return getCVFilterModuleStreams(cvId, filterId, adjustedParams);

--- a/webpack/scenes/ContentViews/Details/Filters/CVPackageGroupFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVPackageGroupFilterContent.js
@@ -74,19 +74,19 @@ const CVPackageGroupFilterContent = ({
   const fetchItems = useCallback((params) => {
     const adjustedParams = { ...params };
     switch (selectedIndex) {
-      case 0:
-        adjustedParams.show_all_for = 'content_view_filter';
-        adjustedParams.available_for = undefined;
-        break;
-      case 1:
-        adjustedParams.show_all_for = undefined;
-        adjustedParams.available_for = undefined;
-        break;
-      case 2:
-        adjustedParams.show_all_for = undefined;
-        adjustedParams.available_for = 'content_view_filter';
-        break;
-      default:
+    case 0:
+      adjustedParams.show_all_for = 'content_view_filter';
+      adjustedParams.available_for = undefined;
+      break;
+    case 1:
+      adjustedParams.show_all_for = undefined;
+      adjustedParams.available_for = undefined;
+      break;
+    case 2:
+      adjustedParams.show_all_for = undefined;
+      adjustedParams.available_for = 'content_view_filter';
+      break;
+    default:
     }
 
     return getCVFilterPackageGroups(cvId, filterId, adjustedParams);

--- a/webpack/scenes/ContentViews/Details/Filters/Rules/Package/AddEditPackageRuleModal.js
+++ b/webpack/scenes/ContentViews/Details/Filters/Rules/Package/AddEditPackageRuleModal.js
@@ -36,11 +36,11 @@ const AddEditPackageRuleModal = ({ filterId, onClose, selectedFilterRuleData }) 
 
   const versionText = () => {
     switch (true) {
-      case !!editingVersion: return VersionModifiers['Equal to'];
-      case !!editingMinVersion && !editingMaxVersion: return VersionModifiers['Greater than'];
-      case !editingMinVersion && !!editingMaxVersion: return VersionModifiers['Less than'];
-      case !!editingMinVersion && !!editingMaxVersion: return VersionModifiers.Range;
-      default: return VersionModifiers['All versions'];
+    case !!editingVersion: return VersionModifiers['Equal to'];
+    case !!editingMinVersion && !editingMaxVersion: return VersionModifiers['Greater than'];
+    case !editingMinVersion && !!editingMaxVersion: return VersionModifiers['Less than'];
+    case !!editingMinVersion && !!editingMaxVersion: return VersionModifiers.Range;
+    default: return VersionModifiers['All versions'];
     }
   };
 
@@ -64,18 +64,18 @@ const AddEditPackageRuleModal = ({ filterId, onClose, selectedFilterRuleData }) 
 
   const formVersionParams = () => {
     switch (versionComparator) {
-      case 'All versions':
-        return {};
-      case 'Equal to':
-        return { version };
-      case 'Greater than':
-        return { min_version: minVersion };
-      case 'Less than':
-        return { max_version: maxVersion };
-      case 'Range':
-        return { min_version: minVersion, max_version: maxVersion };
-      default:
-        return {};
+    case 'All versions':
+      return {};
+    case 'Equal to':
+      return { version };
+    case 'Greater than':
+      return { min_version: minVersion };
+    case 'Less than':
+      return { max_version: maxVersion };
+    case 'Range':
+      return { min_version: minVersion, max_version: maxVersion };
+    default:
+      return {};
     }
   };
 

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVEnvironmentSelectionForm.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVEnvironmentSelectionForm.js
@@ -96,24 +96,24 @@ const CVEnvironmentSelectionForm = () => {
               id, name, activation_key_count: akCount,
               host_count: hostCount,
             }, rowIndex) =>
-            (
-              <Tr key={`${name}_${id}`}>
-                <Td
-                  key={`${name}__${id}_select`}
-                  select={{
-                    rowIndex,
-                    onSelect: (event, isSelected) => onSelect(event, isSelected, id),
-                    isSelected: selectedEnvSet.has(id) || deleteFlow || removeDeletionFlow,
-                    disable: deleteFlow || removeDeletionFlow,
-                  }}
-                />
-                <Td>
-                  {name}
-                </Td>
-                <Td>{hostCount}</Td>
-                <Td>{akCount}</Td>
-              </Tr>
-            ))
+              (
+                <Tr key={`${name}_${id}`}>
+                  <Td
+                    key={`${name}__${id}_select`}
+                    select={{
+                      rowIndex,
+                      onSelect: (event, isSelected) => onSelect(event, isSelected, id),
+                      isSelected: selectedEnvSet.has(id) || deleteFlow || removeDeletionFlow,
+                      disable: deleteFlow || removeDeletionFlow,
+                    }}
+                  />
+                  <Td>
+                    {name}
+                  </Td>
+                  <Td>{hostCount}</Td>
+                  <Td>{akCount}</Td>
+                </Tr>
+              ))
             }
           </Tbody>
         </TableComposable>}

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignActivationKeysForm.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignActivationKeysForm.js
@@ -117,9 +117,9 @@ const CVReassignActivationKeysForm = () => {
       >
         <AffectedActivationKeys
           {...{
-          cvId,
-          versionEnvironments,
-          selectedEnvSet,
+            cvId,
+            versionEnvironments,
+            selectedEnvSet,
           }}
           deleteCV={false}
         />

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignHostsForm.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignHostsForm.js
@@ -114,9 +114,9 @@ const CVReassignHostsForm = () => {
       >
         <AffectedHosts
           {...{
-          cvId,
-          versionEnvironments,
-          selectedEnvSet,
+            cvId,
+            versionEnvironments,
+            selectedEnvSet,
           }}
           deleteCV={false}
         />

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/affectedActivationKeys.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/affectedActivationKeys.js
@@ -71,7 +71,7 @@ const AffectedActivationKeys = ({
             </Td>
             <Td><EnvironmentLabels environments={environment} /></Td>
           </Tr>
-            ))
+        ))
         }
       </Tbody>
     </TableWrapper>

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/affectedHosts.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/affectedHosts.js
@@ -72,7 +72,7 @@ const AffectedHosts = ({
             <Td><EnvironmentLabels environments={environment} /></Td>
           </Tr>
         ))
-      }
+        }
       </Tbody>
     </TableWrapper>
   );

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionRepositoryCell.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionRepositoryCell.js
@@ -76,14 +76,14 @@ const ContentViewVersionRepositoryCell = ({
 
   const getContentSpan = (num) => {
     switch (true) {
-      case num < 4:
-        return 12;
-      case num > 4 && num < 9:
-        return 6;
-      case num > 9:
-        return 4;
-      default:
-        return 12;
+    case num < 4:
+      return 12;
+    case num > 4 && num < 9:
+      return 6;
+    case num > 9:
+      return 4;
+    default:
+      return 12;
     }
   };
 
@@ -91,18 +91,18 @@ const ContentViewVersionRepositoryCell = ({
     const { to, url, name } = CONTENT_COUNTS[countKey];
     const count = ContentCounts[countKey];
     switch (true) {
-      case !!url:
-        return (
-          <a href={urlBuilder(url, '')}>
-            {count} {name}
-          </a>);
-      case !!to:
-        return (
-          <Link to={to}>
-            {count} {name}
-          </Link>);
-      default:
-        return `${count} ${name} `;
+    case !!url:
+      return (
+        <a href={urlBuilder(url, '')}>
+          {count} {name}
+        </a>);
+    case !!to:
+      return (
+        <Link to={to}>
+          {count} {name}
+        </Link>);
+    default:
+      return `${count} ${name} `;
     }
   };
 

--- a/webpack/scenes/ContentViews/Publish/CVPublishFinish.js
+++ b/webpack/scenes/ContentViews/Publish/CVPublishFinish.js
@@ -136,8 +136,8 @@ const CVPublishFinish = ({
             <Bullseye>
               <Button
                 onClick={() => {
-                handleEndTask({ taskComplete: false });
-              }}
+                  handleEndTask({ taskComplete: false });
+                }}
                 variant="primary"
                 aria-label="publish_content_view"
               >

--- a/webpack/scenes/ContentViews/Table/ContentViewsTable.js
+++ b/webpack/scenes/ContentViews/Table/ContentViewsTable.js
@@ -240,11 +240,11 @@ const ContentViewTable = () => {
             <Tr key={cvId}>
               <Td
                 expand={{
-                        rowIndex,
-                        isExpanded,
-                        onToggle: (_event, _rInx, isOpen) =>
-                          expandedTableRows.onToggle(isOpen, cvId),
-                      }}
+                  rowIndex,
+                  isExpanded,
+                  onToggle: (_event, _rInx, isOpen) =>
+                    expandedTableRows.onToggle(isOpen, cvId),
+                }}
               />
               <Td><ContentViewIcon composite={composite ? true : undefined} /></Td>
               <Td><Link to={`${urlBuilder('content_views', '')}${cvId}`}>{name}</Link></Td>
@@ -252,11 +252,11 @@ const ContentViewTable = () => {
               <Td><LastSync startedAt={startedAt} lastSync={lastTask} lastSyncWords={lastSyncWords} emptyMessage="N/A" /></Td>
               <Td>{latestVersion ?
                 <ContentViewVersionCell {...{
-                    id: cvId,
-                    latestVersion,
-                    latestVersionId: cvLatestVersionId,
-                    latestVersionEnvironments: cvLatestVersionEnvironments,
-                  }}
+                  id: cvId,
+                  latestVersion,
+                  latestVersionId: cvLatestVersionId,
+                  latestVersionEnvironments: cvLatestVersionEnvironments,
+                }}
                 /> :
                 <InactiveText style={{ marginTop: '0.5em', marginBottom: '0.5em' }} text={__('Not yet published')} />}
               </Td>

--- a/webpack/scenes/ContentViews/components/EnvironmentLabels.js
+++ b/webpack/scenes/ContentViews/components/EnvironmentLabels.js
@@ -5,24 +5,24 @@ const EnvironmentLabels = (environments) => {
   const { environments: singleEnvironment } = environments || {};
   const { name } = singleEnvironment || {};
   switch (environments) {
-    case Array:
-      return environments.map(env => (
-        <React.Fragment key={env.id} style={{ marginBottom: '5px' }}>
-          <Label
-            color="purple"
-            isTruncated
-          >{env.name}
-          </Label>
-        </React.Fragment>
-      ));
-    default:
-      return (
-        <React.Fragment>
-          <Label color="purple" isTruncated>
-            {name}
-          </Label>
-        </React.Fragment>
-      );
+  case Array:
+    return environments.map(env => (
+      <React.Fragment key={env.id} style={{ marginBottom: '5px' }}>
+        <Label
+          color="purple"
+          isTruncated
+        >{env.name}
+        </Label>
+      </React.Fragment>
+    ));
+  default:
+    return (
+      <React.Fragment>
+        <Label color="purple" isTruncated>
+          {name}
+        </Label>
+      </React.Fragment>
+    );
   }
 };
 

--- a/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.js
+++ b/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.js
@@ -47,19 +47,19 @@ const EnvironmentPaths = ({
               {index === 0 && <hr />}
               <FormGroup key={`fg-${index}`} isInline fieldId="environment-checkbox-group">
                 {environments.map(env =>
-                (<Checkbox
-                  isChecked={(publishing && env.library) ||
+                  (<Checkbox
+                    isChecked={(publishing && env.library) ||
                     envCheckedInList(env, userCheckedItems) ||
                     envCheckedInList(env, promotedEnvironments)}
-                  isDisabled={(publishing && env.library)
+                    isDisabled={(publishing && env.library)
                     || envCheckedInList(env, promotedEnvironments)}
-                  className="env-path__labels-with-pointer"
-                  key={`${env.id}${index}`}
-                  id={`${env.id}${index}`}
-                  label={<EnvironmentLabels environments={env} />}
-                  aria-label={env.label}
-                  onChange={checked => oncheckedChange(checked, env)}
-                />))}
+                    className="env-path__labels-with-pointer"
+                    key={`${env.id}${index}`}
+                    id={`${env.id}${index}`}
+                    label={<EnvironmentLabels environments={env} />}
+                    aria-label={env.label}
+                    onChange={checked => oncheckedChange(checked, env)}
+                  />))}
               </FormGroup>
               <hr />
             </div>

--- a/webpack/scenes/ContentViews/expansions/DetailsExpansion.js
+++ b/webpack/scenes/ContentViews/expansions/DetailsExpansion.js
@@ -25,8 +25,8 @@ const DetailsExpansion = ({
         <RelatedCompositeContentViewsModal
           key={cvId}
           {...{
-         cvName, cvId, relatedCVCount, relatedCompositeCVs,
-        }}
+            cvName, cvId, relatedCVCount, relatedCompositeCVs,
+          }}
         />
       </>
     );

--- a/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
@@ -26,9 +26,9 @@ const ContentSourceForm = ({
   isLoading,
 }) => {
   const formIsValid = () => (!!environmentId &&
-                             !!contentViewId &&
-                             !!contentSourceId &&
-                             contentHostsIds.length !== 0);
+    !!contentViewId &&
+    !!contentSourceId &&
+    contentHostsIds.length !== 0);
 
   return (
     <Form
@@ -50,7 +50,7 @@ const ContentSourceForm = ({
               isDisabled={isLoading || !formIsValid()}
               isLoading={isLoading}
             >
-              { __('Change content source')}
+              {__('Change content source')}
             </Button>
           </ActionGroup>
         </GridItem>
@@ -60,13 +60,13 @@ const ContentSourceForm = ({
 
 ContentSourceForm.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
-  environments: PropTypes.arrayOf(PropTypes.object),
+  environments: PropTypes.arrayOf(PropTypes.shape({})),
   handleEnvironment: PropTypes.func.isRequired,
   environmentId: PropTypes.string,
-  contentViews: PropTypes.arrayOf(PropTypes.object),
+  contentViews: PropTypes.arrayOf(PropTypes.shape({})),
   handleContentView: PropTypes.func.isRequired,
   contentViewId: PropTypes.string,
-  contentSources: PropTypes.arrayOf(PropTypes.object),
+  contentSources: PropTypes.arrayOf(PropTypes.shape({})),
   handleContentSource: PropTypes.func.isRequired,
   contentSourceId: PropTypes.string,
   contentHostsIds: PropTypes.arrayOf(PropTypes.number),

--- a/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceTemplate.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceTemplate.js
@@ -44,14 +44,14 @@ const ContentSourceTemplate = ({ template, jobInvocationPath }) => {
         </h1>
         <p>
           {jobInvocationPath && (
-          <>
-            <a href={jobInvocationPath}>
-              {__('Run job invocation')}
-            </a>
+            <>
+              <a href={jobInvocationPath}>
+                {__('Run job invocation')}
+              </a>
           &nbsp;
-            {__('to update configuration on all hosts, or')}
-          </>
-      )}
+              {__('to update configuration on all hosts, or')}
+            </>
+          )}
         &nbsp;
           {__('update configuration on the hosts manually:')}
         </p>

--- a/webpack/scenes/Hosts/ChangeContentSource/components/FormField.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/components/FormField.js
@@ -22,9 +22,9 @@ const FormField = ({
         isRequired
       >
         <FormSelectOption key={0} value="" label={__('Select ...')} />
-        { items.map(item => (
+        {items.map(item => (
           <FormSelectOption key={item.id} value={item.id} label={item.name} />
-          ))}
+        ))}
       </FormSelect>
     </FormGroup>
   </GridItem>
@@ -34,7 +34,7 @@ FormField.propTypes = {
   label: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
-  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+  items: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   onChange: PropTypes.func.isRequired,
   isLoading: PropTypes.bool.isRequired,
   contentHostsCount: PropTypes.number.isRequired,

--- a/webpack/scenes/ModuleStreams/Details/ModuleStreamDetailsReducer.js
+++ b/webpack/scenes/ModuleStreams/Details/ModuleStreamDetailsReducer.js
@@ -7,27 +7,27 @@ import {
 
 export default (state = initialApiState, action) => {
   switch (action.type) {
-    case MODULE_STREAM_DETAILS_REQUEST: {
-      return state.set('loading', true);
-    }
+  case MODULE_STREAM_DETAILS_REQUEST: {
+    return state.set('loading', true);
+  }
 
-    case MODULE_STREAM_DETAILS_SUCCESS: {
-      const moduleStreamDetails = action.response;
+  case MODULE_STREAM_DETAILS_SUCCESS: {
+    const moduleStreamDetails = action.response;
 
-      return state.merge({
-        ...moduleStreamDetails,
-        loading: false,
-      });
-    }
+    return state.merge({
+      ...moduleStreamDetails,
+      loading: false,
+    });
+  }
 
-    case MODULE_STREAM_DETAILS_FAILURE: {
-      return state.merge({
-        error: action.payload.message,
-        loading: false,
-      });
-    }
+  case MODULE_STREAM_DETAILS_FAILURE: {
+    return state.merge({
+      error: action.payload.message,
+      loading: false,
+    });
+  }
 
-    default:
-      return state;
+  default:
+    return state;
   }
 };

--- a/webpack/scenes/ModuleStreams/ModuleStreamsReducer.js
+++ b/webpack/scenes/ModuleStreams/ModuleStreamsReducer.js
@@ -9,35 +9,35 @@ const initialState = initialApiState;
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case MODULE_STREAMS_REQUEST: {
-      return state.set('loading', true);
-    }
+  case MODULE_STREAMS_REQUEST: {
+    return state.set('loading', true);
+  }
 
-    case MODULE_STREAMS_SUCCESS: {
-      const {
-        results, page, per_page, subtotal, // eslint-disable-line camelcase
-      } = action.response;
+  case MODULE_STREAMS_SUCCESS: {
+    const {
+      results, page, per_page, subtotal, // eslint-disable-line camelcase
+    } = action.response;
 
-      return state.merge({
-        results,
-        loading: false,
-        pagination: {
-          page: Number(page),
-          // eslint-disable-next-line camelcase
-          perPage: Number(per_page || state.pagination.perPage),
-        },
-        itemCount: Number(subtotal),
-      });
-    }
+    return state.merge({
+      results,
+      loading: false,
+      pagination: {
+        page: Number(page),
+        // eslint-disable-next-line camelcase
+        perPage: Number(per_page || state.pagination.perPage),
+      },
+      itemCount: Number(subtotal),
+    });
+  }
 
-    case MODULE_STREAMS_FAILURE: {
-      return state.merge({
-        error: action.error,
-        loading: false,
-      });
-    }
+  case MODULE_STREAMS_FAILURE: {
+    return state.merge({
+      error: action.error,
+      loading: false,
+    });
+  }
 
-    default:
-      return state;
+  default:
+    return state;
   }
 };

--- a/webpack/scenes/Organizations/OrganizationReducer.js
+++ b/webpack/scenes/Organizations/OrganizationReducer.js
@@ -10,16 +10,16 @@ const initialState = Immutable({ loading: false });
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case GET_ORGANIZATION_REQUEST:
-      return state.set('loading', true);
+  case GET_ORGANIZATION_REQUEST:
+    return state.set('loading', true);
 
-    case GET_ORGANIZATION_SUCCESS:
-      return Immutable({ loading: false, ...action.response });
+  case GET_ORGANIZATION_SUCCESS:
+    return Immutable({ loading: false, ...action.response });
 
-    case GET_ORGANIZATION_FAILURE:
-      return Immutable({ error: action.error });
+  case GET_ORGANIZATION_FAILURE:
+    return Immutable({ error: action.error });
 
-    default:
-      return state;
+  default:
+    return state;
   }
 };

--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepositoryContent.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepositoryContent.js
@@ -15,10 +15,10 @@ const EnabledRepositoryContent = ({ loading, disableTooltipId, disableRepository
       <button
         onClick={disableRepository}
         style={{
-            backgroundColor: 'initial',
-            border: 'none',
-            color: '#0388ce',
-          }}
+          backgroundColor: 'initial',
+          border: 'none',
+          color: '#0388ce',
+        }}
       >
         <i className={cx('fa-2x', 'fa fa-minus-circle')} />
       </button>

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
@@ -81,7 +81,7 @@ RepositorySetRepositories.propTypes = {
   type: PropTypes.string,
   data: PropTypes.shape({
     loading: PropTypes.bool.isRequired,
-    repositories: PropTypes.arrayOf(PropTypes.object),
+    repositories: PropTypes.arrayOf(PropTypes.shape({})),
     error: PropTypes.shape({
       displayMessage: PropTypes.string,
     }),

--- a/webpack/scenes/Settings/SettingsReducer.js
+++ b/webpack/scenes/Settings/SettingsReducer.js
@@ -13,21 +13,21 @@ export const initialSettingsState = Immutable({
 
 export default (state = initialSettingsState, action) => {
   switch (action.type) {
-    case GET_SETTING_SUCCESS: {
-      const { name, value } = action.response;
-      switch (name) {
-        case AUTOSEARCH_DELAY:
-          return state.set('autoSearchDelay', value);
-        case AUTOSEARCH_WHILE_TYPING:
-          return state.set('autoSearchEnabled', value);
-        case CONTENT_DISCONNECTED:
-          return state.set('disconnected', value);
-        default:
-          return state;
-      }
-    }
-
+  case GET_SETTING_SUCCESS: {
+    const { name, value } = action.response;
+    switch (name) {
+    case AUTOSEARCH_DELAY:
+      return state.set('autoSearchDelay', value);
+    case AUTOSEARCH_WHILE_TYPING:
+      return state.set('autoSearchEnabled', value);
+    case CONTENT_DISCONNECTED:
+      return state.set('disconnected', value);
     default:
       return state;
+    }
+  }
+
+  default:
+    return state;
   }
 };

--- a/webpack/scenes/Settings/Tables/TableReducer.js
+++ b/webpack/scenes/Settings/Tables/TableReducer.js
@@ -18,29 +18,29 @@ const initialState = Immutable({
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case TABLES_REQUEST:
-    case CREATE_TABLE:
-    case UPDATE_TABLE:
-      return state.set('loading', true);
+  case TABLES_REQUEST:
+  case CREATE_TABLE:
+  case UPDATE_TABLE:
+    return state.set('loading', true);
 
-    case TABLES_SUCCESS:
-      return state.merge({
-        loading: false,
-        ...mapTables(action.payload.results),
-      });
-    case CREATE_TABLE_SUCCESS:
-    case UPDATE_TABLE_SUCCESS:
-      return state.merge({
-        loading: false,
-        ...state,
-        ...mapTables(action.payload),
-      });
-    case TABLES_FAILURE:
-    case UPDATE_TABLE_FAILURE:
-    case CREATE_TABLE_FAILURE: {
-      return state.set('loading', false);
-    }
-    default:
-      return state;
+  case TABLES_SUCCESS:
+    return state.merge({
+      loading: false,
+      ...mapTables(action.payload.results),
+    });
+  case CREATE_TABLE_SUCCESS:
+  case UPDATE_TABLE_SUCCESS:
+    return state.merge({
+      loading: false,
+      ...state,
+      ...mapTables(action.payload),
+    });
+  case TABLES_FAILURE:
+  case UPDATE_TABLE_FAILURE:
+  case CREATE_TABLE_FAILURE: {
+    return state.set('loading', false);
+  }
+  default:
+    return state;
   }
 };

--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetailInfo.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetailInfo.js
@@ -44,7 +44,7 @@ const SubscriptionDetailInfo = ({ subscriptionDetails }) => {
               <td><b>{__(subscriptionAttributes[key])}</b></td>
               <td>{subscriptionDetailValue(subscriptionDetails, key)}</td>
             </tr>
-            ))}
+          ))}
           <tr>
             <td><b>{__('Limits')}</b></td>
             <td>{subscriptionLimits(subscriptionDetails)}</td>
@@ -63,7 +63,7 @@ const SubscriptionDetailInfo = ({ subscriptionDetails }) => {
               <td><b>{__(subscriptionPurposeAttributes[key])}</b></td>
               <td>{subscriptionDetailValue(subscriptionDetails, key)}</td>
             </tr>
-            ))}
+          ))}
         </tbody>
       </Table>
     </div>

--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetailProductContent.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetailProductContent.js
@@ -22,22 +22,22 @@ const SubscriptionDetailProductContent = ({ productContent }) => {
     return (
       <ListView>
         {listItems.map(({
-              index,
-              title,
-              availableContent,
-            }) => (
-              <ListView.Item
-                key={index}
-                heading={title}
-                hideCloseIcon
-              >
+          index,
+          title,
+          availableContent,
+        }) => (
+          <ListView.Item
+            key={index}
+            heading={title}
+            hideCloseIcon
+          >
 
-                <Col sm={12}>
-                  {availableContent.map(content => (
-                    <SubscriptionDetailProduct key={content.id} content={content} />
-                  ))}
-                </Col>
-              </ListView.Item>
+            <Col sm={12}>
+              {availableContent.map(content => (
+                <SubscriptionDetailProduct key={content.id} content={content} />
+              ))}
+            </Col>
+          </ListView.Item>
         ))}
       </ListView>
     );

--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetailProducts.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetailProducts.js
@@ -11,7 +11,7 @@ const SubscriptionDetailProducts = ({ subscriptionDetails }) => (
       {subscriptionDetails.provided_products &&
         subscriptionDetails.provided_products.map(prod => (
           <ListGroupItem key={prod.id}> {prod.name} </ListGroupItem>
-          ))}
+        ))}
     </ListGroup>
   </div>
 );

--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetailReducer.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetailReducer.js
@@ -20,47 +20,47 @@ const initialState = Immutable({
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case SUBSCRIPTION_DETAILS_REQUEST: {
-      return state.set('loading', true);
-    }
+  case SUBSCRIPTION_DETAILS_REQUEST: {
+    return state.set('loading', true);
+  }
 
-    case PRODUCTS_REQUEST: {
-      return state.set('loading', true);
-    }
+  case PRODUCTS_REQUEST: {
+    return state.set('loading', true);
+  }
 
-    case SUBSCRIPTION_DETAILS_SUCCESS: {
-      const subscriptionDetails = action.response;
+  case SUBSCRIPTION_DETAILS_SUCCESS: {
+    const subscriptionDetails = action.response;
 
-      return state.merge({
-        ...subscriptionDetails,
-        loading: false,
-      });
-    }
+    return state.merge({
+      ...subscriptionDetails,
+      loading: false,
+    });
+  }
 
-    case PRODUCTS_SUCCESS: {
-      const productContent = { productContent: action.response };
+  case PRODUCTS_SUCCESS: {
+    const productContent = { productContent: action.response };
 
-      return state.merge({
-        ...productContent,
-        loading: false,
-      });
-    }
+    return state.merge({
+      ...productContent,
+      loading: false,
+    });
+  }
 
-    case SUBSCRIPTION_DETAILS_FAILURE: {
-      return state.merge({
-        error: action.payload.message,
-        loading: false,
-      });
-    }
+  case SUBSCRIPTION_DETAILS_FAILURE: {
+    return state.merge({
+      error: action.payload.message,
+      loading: false,
+    });
+  }
 
-    case PRODUCTS_FAILURE: {
-      return state.merge({
-        error: action.payload.message,
-        loading: false,
-      });
-    }
+  case PRODUCTS_FAILURE: {
+    return state.merge({
+      error: action.payload.message,
+      loading: false,
+    });
+  }
 
-    default:
-      return state;
+  default:
+    return state;
   }
 };

--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetails.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetails.js
@@ -63,19 +63,19 @@ class SubscriptionDetails extends Component {
           <BreadcrumbsBar
             onSwitcherItemClick={(e, url) => this.handleBreadcrumbSwitcherItem(e, url)}
             data={{
-            isSwitchable: true,
-            breadcrumbItems: [
-              {
-                caption: __('Subscriptions'),
-                onClick: () =>
-                this.props.history.push('/subscriptions'),
-              },
-              {
-                caption: String(subscriptionDetails.name || __('Subscription Details')),
-              },
-            ],
-            resource,
-          }}
+              isSwitchable: true,
+              breadcrumbItems: [
+                {
+                  caption: __('Subscriptions'),
+                  onClick: () =>
+                    this.props.history.push('/subscriptions'),
+                },
+                {
+                  caption: String(subscriptionDetails.name || __('Subscription Details')),
+                },
+              ],
+              resource,
+            }}
           />}
 
         <TabContainer id="subscription-tabs-container" defaultActiveKey={1}>

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/AirGappedTypeForm.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/AirGappedTypeForm.js
@@ -37,7 +37,7 @@ const AirGappedTypeForm = ({ showUpdate, onUpdate }) => {
             id="cdn-configuration-type"
             defaultMessage={__('Red Hat content will be enabled and consumed via the {type} process.')}
             values={{
-                type: <strong>{__('Import/Export')}</strong>,
+              type: <strong>{__('Import/Export')}</strong>,
             }}
           />
           <br />
@@ -46,10 +46,10 @@ const AirGappedTypeForm = ({ showUpdate, onUpdate }) => {
               id="cdn-configuration-type-cdn"
               defaultMessage={__('Click {update} below to save changes.')}
               values={{
-                  update: <strong>{__('Update')}</strong>,
+                update: <strong>{__('Update')}</strong>,
               }}
             />
-        }
+          }
         </p>
       </div>
 

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/CdnTypeForm.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/CdnTypeForm.js
@@ -51,8 +51,8 @@ const CdnTypeForm = ({ showUpdate, onUpdate, url }) => {
             id="cdn-configuration-type"
             defaultMessage={__('Red Hat content will be consumed from the {type}.')}
             values={{
-                  type: <strong>{__('Red Hat CDN')}</strong>,
-              }}
+              type: <strong>{__('Red Hat CDN')}</strong>,
+            }}
           />
           <br />
           {showUpdate &&
@@ -60,8 +60,8 @@ const CdnTypeForm = ({ showUpdate, onUpdate, url }) => {
             id="cdn-configuration-type-cdn"
             defaultMessage={__('Click {update} below to save changes.')}
             values={{
-                    update: <strong>{__('Update')}</strong>,
-                }}
+              update: <strong>{__('Update')}</strong>,
+            }}
           />
           }
         </Text>

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/UpstreamServerTypeForm.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/UpstreamServerTypeForm.js
@@ -114,7 +114,7 @@ const UpstreamServerTypeForm = ({
               defaultMessage={__('Red Hat content will be consumed from an {type}.')}
               values={{
                 type: <strong>{__('upstream Foreman server')}</strong>,
-            }}
+              }}
             />
             <br />
             {showUpdate &&
@@ -122,10 +122,10 @@ const UpstreamServerTypeForm = ({
               id="cdn-configuration-type-upstream-server"
               defaultMessage={__('Provide the required information and click {update} below to save changes.')}
               values={{
-                  update: <strong>{__('Update')}</strong>,
+                update: <strong>{__('Update')}</strong>,
               }}
             />
-          }
+            }
           </Text>
         </div>
         <FormGroup

--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
@@ -159,7 +159,7 @@ class ManageManifestModal extends Component {
                           simpleContentAccessEligible={simpleContentAccessEligible}
                         />
                       </Row>
-                        }
+                      }
                       <Row>
                         <Col sm={5}>
                           <strong>{__('Subscription Allocation')}</strong>
@@ -176,7 +176,7 @@ class ManageManifestModal extends Component {
                           >
                             <div>{__('Import New Manifest')}</div>
                           </ControlLabel>
-                            }
+                          }
                         </Col>
                         <Col sm={7} className="manifest-actions">
                           <Spinner loading={actionInProgress} />
@@ -188,7 +188,7 @@ class ManageManifestModal extends Component {
                             disabled={actionInProgress}
                             onChange={e => this.uploadManifest(e.target.files)}
                           />
-                            }
+                          }
                           <div id="manifest-actions-row">
                             {canImportManifest &&
                             <TooltipButton
@@ -200,7 +200,7 @@ class ManageManifestModal extends Component {
                               disabled={!isManifestImported ||
                                     actionInProgress || disableManifestActions}
                             />
-                              }
+                            }
                             {canDeleteManifest &&
                             <React.Fragment>
                               <TooltipButton
@@ -213,7 +213,7 @@ class ManageManifestModal extends Component {
                                 tooltipPlacement="top"
                               />
                             </React.Fragment>
-                              }
+                            }
                           </div>
                           <ForemanModal title={__('Confirm delete manifest')} id={DELETE_MANIFEST_MODAL_ID}>
                             <DeleteManifestModalText />

--- a/webpack/scenes/Subscriptions/Manifest/ManifestHistoryReducer.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManifestHistoryReducer.js
@@ -10,25 +10,25 @@ const initialState = Immutable({ loading: true, results: [] });
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case MANIFEST_HISTORY_REQUEST:
-      return state.set('loading', true);
+  case MANIFEST_HISTORY_REQUEST:
+    return state.set('loading', true);
 
-    case MANIFEST_HISTORY_SUCCESS: {
-      const results = action.response;
+  case MANIFEST_HISTORY_SUCCESS: {
+    const results = action.response;
 
-      return state.merge({
-        results,
-        loading: false,
-      });
-    }
+    return state.merge({
+      results,
+      loading: false,
+    });
+  }
 
-    case MANIFEST_HISTORY_FAILURE:
-      return state.merge({
-        error: action.payload.message,
-        loading: false,
-      });
+  case MANIFEST_HISTORY_FAILURE:
+    return state.merge({
+      error: action.payload.message,
+      loading: false,
+    });
 
-    default:
-      return state;
+  default:
+    return state;
   }
 };

--- a/webpack/scenes/Subscriptions/SubscriptionReducer.js
+++ b/webpack/scenes/Subscriptions/SubscriptionReducer.js
@@ -69,160 +69,160 @@ const initialState = Immutable({
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case SIMPLE_CONTENT_ACCESS_ELIGIBLE_SUCCESS:
-      return state.set('simpleContentAccessEligible', action.response.simple_content_access_eligible);
-    case PING_UPSTREAM_SUBSCRIPTIONS_SUCCESS:
-      return state.set('hasUpstreamConnection', true);
-    case PING_UPSTREAM_SUBSCRIPTIONS_FAILURE:
-      return state.set('hasUpstreamConnection', false);
-    case SUBSCRIPTIONS_REQUEST:
-      return state.set('loading', true);
-    case SUBSCRIPTIONS_COLUMNS_REQUEST:
-      return state
-        .set('tableColumns', action.payload.tableColumns);
-    case UPDATE_SUBSCRIPTION_COLUMNS:
-      return state
-        .set('selectedTableColumns', action.payload.enabledColumns);
-    case SUBSCRIPTIONS_SUCCESS: {
-      const {
-        page,
-        per_page, // eslint-disable-line camelcase
-        subtotal,
-        results,
-        can_import_manifest, // eslint-disable-line camelcase
-        can_delete_manifest, // eslint-disable-line camelcase
-        can_manage_subscription_allocations, // eslint-disable-line camelcase
-        can_edit_organizations, // eslint-disable-line camelcase
-      } = action.response;
+  case SIMPLE_CONTENT_ACCESS_ELIGIBLE_SUCCESS:
+    return state.set('simpleContentAccessEligible', action.response.simple_content_access_eligible);
+  case PING_UPSTREAM_SUBSCRIPTIONS_SUCCESS:
+    return state.set('hasUpstreamConnection', true);
+  case PING_UPSTREAM_SUBSCRIPTIONS_FAILURE:
+    return state.set('hasUpstreamConnection', false);
+  case SUBSCRIPTIONS_REQUEST:
+    return state.set('loading', true);
+  case SUBSCRIPTIONS_COLUMNS_REQUEST:
+    return state
+      .set('tableColumns', action.payload.tableColumns);
+  case UPDATE_SUBSCRIPTION_COLUMNS:
+    return state
+      .set('selectedTableColumns', action.payload.enabledColumns);
+  case SUBSCRIPTIONS_SUCCESS: {
+    const {
+      page,
+      per_page, // eslint-disable-line camelcase
+      subtotal,
+      results,
+      can_import_manifest, // eslint-disable-line camelcase
+      can_delete_manifest, // eslint-disable-line camelcase
+      can_manage_subscription_allocations, // eslint-disable-line camelcase
+      can_edit_organizations, // eslint-disable-line camelcase
+    } = action.response;
 
-      return state.merge({
-        results,
-        activePermissions: {
-          can_import_manifest,
-          can_delete_manifest,
-          can_manage_subscription_allocations,
-          can_edit_organizations,
-        },
-        loading: false,
-        searchIsActive: !!action.search,
-        search: action.search,
-        pagination: {
-          page: Number(page),
-          // eslint-disable-next-line camelcase
-          perPage: Number(per_page || state.pagination.perPage),
-        },
-        itemCount: Number(subtotal),
-      });
-    }
+    return state.merge({
+      results,
+      activePermissions: {
+        can_import_manifest,
+        can_delete_manifest,
+        can_manage_subscription_allocations,
+        can_edit_organizations,
+      },
+      loading: false,
+      searchIsActive: !!action.search,
+      search: action.search,
+      pagination: {
+        page: Number(page),
+        // eslint-disable-next-line camelcase
+        perPage: Number(per_page || state.pagination.perPage),
+      },
+      itemCount: Number(subtotal),
+    });
+  }
 
-    case SUBSCRIPTIONS_FAILURE:
-      return state
-        .set('loading', false)
-        .set('results', [])
-        .set('itemCount', 0)
-        .set(
-          'missingPermissions',
-          get(action, ['payload', 'messages', 0, 'missing_permissions']),
-        );
+  case SUBSCRIPTIONS_FAILURE:
+    return state
+      .set('loading', false)
+      .set('results', [])
+      .set('itemCount', 0)
+      .set(
+        'missingPermissions',
+        get(action, ['payload', 'messages', 0, 'missing_permissions']),
+      );
 
-    case SUBSCRIPTIONS_QUANTITIES_REQUEST:
-      return state.merge({
-        quantitiesLoading: true,
-        availableQuantities: null,
-      });
+  case SUBSCRIPTIONS_QUANTITIES_REQUEST:
+    return state.merge({
+      quantitiesLoading: true,
+      availableQuantities: null,
+    });
 
-    case SUBSCRIPTIONS_QUANTITIES_SUCCESS: {
-      return state.merge({
-        quantitiesLoading: false,
-        availableQuantities: action.payload,
-      });
-    }
+  case SUBSCRIPTIONS_QUANTITIES_SUCCESS: {
+    return state.merge({
+      quantitiesLoading: false,
+      availableQuantities: action.payload,
+    });
+  }
 
-    case SUBSCRIPTIONS_QUANTITIES_FAILURE: {
-      return state.merge({
-        quantitiesLoading: false,
-        availableQuantities: {},
-      });
-    }
+  case SUBSCRIPTIONS_QUANTITIES_FAILURE: {
+    return state.merge({
+      quantitiesLoading: false,
+      availableQuantities: {},
+    });
+  }
 
-    case SUBSCRIPTIONS_TASK_SEARCH_SUCCESS: {
-      if (!state.task) {
-        const tasks = action.response.results;
-        if (tasks.length > 0) {
-          return state
-            .set('task', tasks[0]); // this will be the oldest pending task
-        }
+  case SUBSCRIPTIONS_TASK_SEARCH_SUCCESS: {
+    if (!state.task) {
+      const tasks = action.response.results;
+      if (tasks.length > 0) {
+        return state
+          .set('task', tasks[0]); // this will be the oldest pending task
       }
-
-      return state;
     }
 
-    case DELETE_MANIFEST_SUCCESS:
-      return state.merge({
-        task: action.response,
-        hasUpstreamConnection: false,
-        manifestActionStarted: false,
-      });
+    return state;
+  }
 
-    case SUBSCRIPTIONS_POLL_TASK_SUCCESS:
-      return state
-        .set('task', action.response);
+  case DELETE_MANIFEST_SUCCESS:
+    return state.merge({
+      task: action.response,
+      hasUpstreamConnection: false,
+      manifestActionStarted: false,
+    });
 
-    case UPDATE_QUANTITY_SUCCESS:
-    case UPLOAD_MANIFEST_SUCCESS:
-    case REFRESH_MANIFEST_SUCCESS:
-    case ENABLE_SIMPLE_CONTENT_ACCESS_SUCCESS:
-    case DISABLE_SIMPLE_CONTENT_ACCESS_SUCCESS:
-      return state
-        .set('task', action.response)
-        .set('manifestActionStarted', false);
+  case SUBSCRIPTIONS_POLL_TASK_SUCCESS:
+    return state
+      .set('task', action.response);
 
-    case ENABLE_SIMPLE_CONTENT_ACCESS_REQUEST:
-    case DISABLE_SIMPLE_CONTENT_ACCESS_REQUEST:
-    case REFRESH_MANIFEST_REQUEST:
-    case UPLOAD_MANIFEST_REQUEST:
-    case DELETE_MANIFEST_REQUEST:
-    case UPDATE_QUANTITY_REQUEST:
-    case DELETE_SUBSCRIPTIONS_REQUEST:
-      return state
-        .set('manifestActionStarted', true);
+  case UPDATE_QUANTITY_SUCCESS:
+  case UPLOAD_MANIFEST_SUCCESS:
+  case REFRESH_MANIFEST_SUCCESS:
+  case ENABLE_SIMPLE_CONTENT_ACCESS_SUCCESS:
+  case DISABLE_SIMPLE_CONTENT_ACCESS_SUCCESS:
+    return state
+      .set('task', action.response)
+      .set('manifestActionStarted', false);
 
-    case ENABLE_SIMPLE_CONTENT_ACCESS_FAILURE:
-    case DISABLE_SIMPLE_CONTENT_ACCESS_FAILURE:
-    case REFRESH_MANIFEST_FAILURE:
-    case UPLOAD_MANIFEST_FAILURE:
-    case DELETE_MANIFEST_FAILURE:
-    case DELETE_SUBSCRIPTIONS_FAILURE:
-    case UPDATE_QUANTITY_FAILURE:
-      return state
-        .set('manifestActionStarted', false);
+  case ENABLE_SIMPLE_CONTENT_ACCESS_REQUEST:
+  case DISABLE_SIMPLE_CONTENT_ACCESS_REQUEST:
+  case REFRESH_MANIFEST_REQUEST:
+  case UPLOAD_MANIFEST_REQUEST:
+  case DELETE_MANIFEST_REQUEST:
+  case UPDATE_QUANTITY_REQUEST:
+  case DELETE_SUBSCRIPTIONS_REQUEST:
+    return state
+      .set('manifestActionStarted', true);
 
-    case DELETE_SUBSCRIPTIONS_SUCCESS:
-      return state
-        .set('task', action.response)
-        .set('manifestActionStarted', false)
-        .set('deleteButtonDisabled', true);
+  case ENABLE_SIMPLE_CONTENT_ACCESS_FAILURE:
+  case DISABLE_SIMPLE_CONTENT_ACCESS_FAILURE:
+  case REFRESH_MANIFEST_FAILURE:
+  case UPLOAD_MANIFEST_FAILURE:
+  case DELETE_MANIFEST_FAILURE:
+  case DELETE_SUBSCRIPTIONS_FAILURE:
+  case UPDATE_QUANTITY_FAILURE:
+    return state
+      .set('manifestActionStarted', false);
 
-    case SUBSCRIPTIONS_RESET_TASKS:
-    case SUBSCRIPTIONS_TASK_SEARCH_FAILURE:
-    case SUBSCRIPTIONS_POLL_TASK_FAILURE:
-      return state
-        .set('task', null);
+  case DELETE_SUBSCRIPTIONS_SUCCESS:
+    return state
+      .set('task', action.response)
+      .set('manifestActionStarted', false)
+      .set('deleteButtonDisabled', true);
 
-    case SUBSCRIPTIONS_UPDATE_SEARCH_QUERY:
-      return state.set('searchQuery', action.payload);
+  case SUBSCRIPTIONS_RESET_TASKS:
+  case SUBSCRIPTIONS_TASK_SEARCH_FAILURE:
+  case SUBSCRIPTIONS_POLL_TASK_FAILURE:
+    return state
+      .set('task', null);
 
-    case SUBSCRIPTIONS_OPEN_DELETE_MODAL:
-      return state.set('deleteModalOpened', true);
-    case SUBSCRIPTIONS_CLOSE_DELETE_MODAL:
-      return state.set('deleteModalOpened', false);
+  case SUBSCRIPTIONS_UPDATE_SEARCH_QUERY:
+    return state.set('searchQuery', action.payload);
 
-    case SUBSCRIPTIONS_DISABLE_DELETE_BUTTON:
-      return state.set('deleteButtonDisabled', true);
-    case SUBSCRIPTIONS_ENABLE_DELETE_BUTTON:
-      return state.set('deleteButtonDisabled', false);
+  case SUBSCRIPTIONS_OPEN_DELETE_MODAL:
+    return state.set('deleteModalOpened', true);
+  case SUBSCRIPTIONS_CLOSE_DELETE_MODAL:
+    return state.set('deleteModalOpened', false);
 
-    default:
-      return state;
+  case SUBSCRIPTIONS_DISABLE_DELETE_BUTTON:
+    return state.set('deleteButtonDisabled', true);
+  case SUBSCRIPTIONS_ENABLE_DELETE_BUTTON:
+    return state.set('deleteButtonDisabled', false);
+
+  default:
+    return state;
   }
 };

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsReducer.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsReducer.js
@@ -13,46 +13,46 @@ const initialState = initialApiState;
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case UPSTREAM_SUBSCRIPTIONS_REQUEST:
-      return state.set('loading', true);
+  case UPSTREAM_SUBSCRIPTIONS_REQUEST:
+    return state.set('loading', true);
 
-    case UPSTREAM_SUBSCRIPTIONS_SUCCESS: {
-      const {
-        page, per_page, total, results, // eslint-disable-line camelcase
+  case UPSTREAM_SUBSCRIPTIONS_SUCCESS: {
+    const {
+      page, per_page, total, results, // eslint-disable-line camelcase
 
-      } = action.response;
+    } = action.response;
 
-      return state.merge({
-        results,
-        loading: false,
-        searchIsActive: !!action.search,
-        search: action.search,
-        pagination: {
-          page: Number(page),
-          // eslint-disable-next-line camelcase
-          perPage: Number(per_page || state.pagination.perPage),
-        },
-        itemCount: Number(total),
-      });
-    }
+    return state.merge({
+      results,
+      loading: false,
+      searchIsActive: !!action.search,
+      search: action.search,
+      pagination: {
+        page: Number(page),
+        // eslint-disable-next-line camelcase
+        perPage: Number(per_page || state.pagination.perPage),
+      },
+      itemCount: Number(total),
+    });
+  }
 
-    case UPSTREAM_SUBSCRIPTIONS_FAILURE:
-      return state.merge({
-        error: action.payload.message,
-        loading: false,
-      });
+  case UPSTREAM_SUBSCRIPTIONS_FAILURE:
+    return state.merge({
+      error: action.payload.message,
+      loading: false,
+    });
 
-    case SAVE_UPSTREAM_SUBSCRIPTIONS_REQUEST:
-      return state.set('loading', true);
+  case SAVE_UPSTREAM_SUBSCRIPTIONS_REQUEST:
+    return state.set('loading', true);
 
-    case SAVE_UPSTREAM_SUBSCRIPTIONS_SUCCESS:
-      return state.set('task', action.response).set('loading', false);
+  case SAVE_UPSTREAM_SUBSCRIPTIONS_SUCCESS:
+    return state.set('task', action.response).set('loading', false);
 
-    case SAVE_UPSTREAM_SUBSCRIPTIONS_FAILURE: {
-      return state.set('error', action.payload.message).set('loading', false);
-    }
+  case SAVE_UPSTREAM_SUBSCRIPTIONS_FAILURE: {
+    return state.set('error', action.payload.message).set('loading', false);
+  }
 
-    default:
-      return state;
+  default:
+    return state;
   }
 };

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/components/Dialogs/DeleteDialog.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/components/Dialogs/DeleteDialog.js
@@ -13,15 +13,15 @@ const DeleteDialog = ({
       // eslint-disable-next-line react/no-danger
       <p dangerouslySetInnerHTML={{
         __html: sprintf(
-              __(`Are you sure you want to delete %(entitlementCount)s
+          __(`Are you sure you want to delete %(entitlementCount)s
                   subscription(s)? This action will remove the subscription(s) and
                   refresh your manifest. All systems using these subscription(s) will
                   lose them and also may lose access to updates and Errata.`),
-              {
-                entitlementCount: `<b>${selectedRows.length}</b>`,
-              },
-          ),
-        }}
+          {
+            entitlementCount: `<b>${selectedRows.length}</b>`,
+          },
+        ),
+      }}
       />
     }
     primaryActionButtonContent={__('Delete')}

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/components/Table.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/components/Table.js
@@ -65,10 +65,10 @@ const Table = ({
       bodyMessage={bodyMessage}
       rows={rows}
       components={{
-      header: {
-        row: PFtable.TableInlineEditHeaderRow,
-      },
-    }}
+        header: {
+          row: PFtable.TableInlineEditHeaderRow,
+        },
+      }}
       itemCount={subscriptions.itemCount}
       pagination={subscriptions.pagination}
       onPaginationChange={onPaginationChange}
@@ -76,11 +76,11 @@ const Table = ({
     >
       <PFtable.Header
         onRow={() => ({
-        role: 'row',
-        isEditing: () => editing,
-        onCancel: () => inlineEditController.onCancel(),
-        onConfirm: () => inlineEditController.onConfirm(),
-      })}
+          role: 'row',
+          isEditing: () => editing,
+          onCancel: () => inlineEditController.onCancel(),
+          onConfirm: () => inlineEditController.onConfirm(),
+        })}
       />
       <ForemanTableBody
         columns={columnsDefinition}
@@ -88,8 +88,8 @@ const Table = ({
         rowKey="id"
         message={bodyMessage}
         onRow={rowData => ({
-        className: classNames({ 'open-grouped-row': !groupingController.isCollapsed({ rowData }) }),
-      })}
+          className: classNames({ 'open-grouped-row': !groupingController.isCollapsed({ rowData }) }),
+        })}
       />
     </ForemanTable>
   );
@@ -115,7 +115,7 @@ Table.propTypes = {
   }).isRequired,
   groupedSubscriptions: PropTypes.shape({}).isRequired,
   editing: PropTypes.bool.isRequired,
-  rows: PropTypes.arrayOf(PropTypes.object).isRequired,
+  rows: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   selectionEnabled: PropTypes.bool.isRequired,
 };
 

--- a/webpack/services/index.js
+++ b/webpack/services/index.js
@@ -3,42 +3,42 @@ export function getTypeIcon(type) {
   const typeIcon = { name: '', type: '' };
 
   switch (type) {
-    case 'yum':
-      typeIcon.name = 'bundle';
-      typeIcon.type = 'pf';
-      break;
-    case 'source_rpm':
-      typeIcon.name = 'code';
-      typeIcon.type = 'fa';
-      break;
-    case 'file':
-      typeIcon.name = 'file';
-      typeIcon.type = 'fa';
-      break;
-    case 'debug':
-      typeIcon.name = 'bug';
-      typeIcon.type = 'fa';
-      break;
-    case 'iso':
-      typeIcon.name = 'file-image-o';
-      typeIcon.type = 'fa';
-      break;
-    case 'beta':
-      typeIcon.name = 'bold';
-      typeIcon.type = 'fa';
-      break;
-    case 'kickstart':
-      typeIcon.name = 'futbol-o';
-      typeIcon.type = 'fa';
-      break;
-    case 'containerimage':
-      typeIcon.name = 'cube';
-      typeIcon.type = 'fa';
-      break;
-    default:
-      typeIcon.name = 'question';
-      typeIcon.type = 'fa';
-      break;
+  case 'yum':
+    typeIcon.name = 'bundle';
+    typeIcon.type = 'pf';
+    break;
+  case 'source_rpm':
+    typeIcon.name = 'code';
+    typeIcon.type = 'fa';
+    break;
+  case 'file':
+    typeIcon.name = 'file';
+    typeIcon.type = 'fa';
+    break;
+  case 'debug':
+    typeIcon.name = 'bug';
+    typeIcon.type = 'fa';
+    break;
+  case 'iso':
+    typeIcon.name = 'file-image-o';
+    typeIcon.type = 'fa';
+    break;
+  case 'beta':
+    typeIcon.name = 'bold';
+    typeIcon.type = 'fa';
+    break;
+  case 'kickstart':
+    typeIcon.name = 'futbol-o';
+    typeIcon.type = 'fa';
+    break;
+  case 'containerimage':
+    typeIcon.name = 'cube';
+    typeIcon.type = 'fa';
+    break;
+  default:
+    typeIcon.name = 'question';
+    typeIcon.type = 'fa';
+    break;
   }
   return typeIcon;
 }

--- a/webpack/utils/helpers.js
+++ b/webpack/utils/helpers.js
@@ -23,11 +23,11 @@ export const getBookmarkErrorMsgs = ({ data: { error } } = {}) => {
 const getCustomMessage = (actionType, message) => {
   let customMessage;
   switch (actionType) {
-    case SUBSCRIPTIONS_QUANTITIES_FAILURE:
-      customMessage = getSubscriptionsErrorMessage(message);
-      break;
-    default:
-      customMessage = null;
+  case SUBSCRIPTIONS_QUANTITIES_FAILURE:
+    customMessage = getSubscriptionsErrorMessage(message);
+    break;
+  default:
+    customMessage = null;
   }
   return customMessage;
 };


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The lint package, eslint-plugin-react, was updated from: "7.28.0" to "7.29.1" due to the lack of a committed package-lock in foreman.

Related changelog for eslint-plugin-react [here](https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md).

This fixes some breaking lint changes introduced by that update.

#### Considerations taken when implementing this change?
- I thought it prudent to use the updated rules instead of just turning them off for a solution. 
- If this becomes problematic or slows down the dev process, one can simply change two lines in the eslintrc.js file.

`
'indent': 'off',
'react/forbid-prop-types': 'off',
`

#### What are the testing steps for this pull request?

- Check if the Katello lint and react tests pass on CI.
- ???? 
- Profit
