### PR TITLE
fixes #34518 - Content Import failure removes generated version

### DIFF
--- a/app/lib/actions/katello/content_view/destroy.rb
+++ b/app/lib/actions/katello/content_view/destroy.rb
@@ -25,7 +25,8 @@ module Actions
         end
 
         def finalize
-          content_view = ::Katello::ContentView.find(input[:content_view][:id])
+          content_view = ::Katello::ContentView.where(id: input[:content_view][:id]).first
+          return if content_view.blank?
           content_view.content_view_repositories.each(&:destroy)
           content_view.destroy!
         end

--- a/app/lib/actions/katello/content_view_version/import.rb
+++ b/app/lib/actions/katello/content_view_version/import.rb
@@ -36,6 +36,13 @@ module Actions
                           importing: true,
                           major: major,
                           minor: minor)
+            plan_self(content_view_id: content_view.id)
+          end
+        end
+
+        def finalize
+          if task.execution_plan.run_steps.any? { |s| s.action_class == ::Actions::Pulp3::ContentViewVersion::Import && s.state != :success }
+            ::Katello::EventQueue.push_event(::Katello::Events::DeleteLatestContentViewVersion::EVENT_TYPE, input[:content_view_id])
           end
         end
 

--- a/app/models/katello/events/delete_latest_content_view_version.rb
+++ b/app/models/katello/events/delete_latest_content_view_version.rb
@@ -1,0 +1,40 @@
+module Katello
+  module Events
+    class DeleteLatestContentViewVersion
+      EVENT_TYPE = 'delete_latest_content_view_version'.freeze
+
+      attr_reader :content_view
+      attr_accessor :metadata, :retry
+
+      def self.retry_seconds
+        180
+      end
+
+      def initialize(content_view_id)
+        @content_view = ::Katello::ContentView.find_by_id(content_view_id)
+        Rails.logger.warn "Content View not found for ID #{object_id}" if @content_view.nil?
+        yield(self) if block_given?
+      end
+
+      def run
+        return unless content_view
+
+        begin
+          ForemanTasks.async_task(::Actions::Katello::ContentView::Remove, content_view,
+                        content_view_versions: [content_view.latest_version_object],
+                        content_view_environments: content_view.latest_version_object.content_view_environments)
+        rescue => e
+          self.retry = true if e.is_a?(ForemanTasks::Lock::LockConflict)
+          deliver_failure_notification
+          raise e
+        end
+      end
+
+      private
+
+      def deliver_failure_notification
+        ::Katello::UINotifications::ContentView::DelelteLatestVersionFailure.deliver!(content_view)
+      end
+    end
+  end
+end

--- a/app/models/katello/events/delete_latest_content_view_version.rb
+++ b/app/models/katello/events/delete_latest_content_view_version.rb
@@ -7,7 +7,7 @@ module Katello
       attr_accessor :metadata, :retry
 
       def self.retry_seconds
-        180
+        18
       end
 
       def initialize(content_view_id)

--- a/app/services/katello/ui_notifications/content_view/delete_latest_version_failure.rb
+++ b/app/services/katello/ui_notifications/content_view/delete_latest_version_failure.rb
@@ -1,0 +1,22 @@
+module Katello
+  module UINotifications
+    module ContentView
+      class DelelteLatestVersionFailure < ::UINotifications::Base
+        private
+
+        def create
+          Notification.create!(
+            subject: subject,
+            initiator: initiator,
+            audience: ::Notification::AUDIENCE_ADMIN,
+            notification_blueprint: blueprint
+          )
+        end
+
+        def blueprint
+          @blueprint ||= NotificationBlueprint.find_by(name: 'content_view_auto_publish_error')
+        end
+      end
+    end
+  end
+end

--- a/db/seeds.d/110-content-view-autopublish.rb
+++ b/db/seeds.d/110-content-view-autopublish.rb
@@ -11,5 +11,18 @@
       [
       ]
     }
+  },
+  {
+    group: N_('Content View'),
+    name: 'delete_latest_content_view_version_error',
+    message: N_('Failed to delete latest content view version of Content View \'%{subject}\'.'),
+    level: 'error',
+    actions:
+    {
+      links:
+      [
+      ]
+    }
+
   }
 ].each { |blueprint| UINotifications::Seed.new(blueprint).configure }

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -235,6 +235,7 @@ module Katello
 
       Katello::EventQueue.register_event(Katello::Events::ImportPool::EVENT_TYPE, Katello::Events::ImportPool)
       Katello::EventQueue.register_event(Katello::Events::AutoPublishCompositeView::EVENT_TYPE, Katello::Events::AutoPublishCompositeView)
+      Katello::EventQueue.register_event(Katello::Events::DeleteLatestContentViewVersion::EVENT_TYPE, Katello::Events::DeleteLatestContentViewVersion)
       Katello::EventQueue.register_event(Katello::Events::GenerateHostApplicability::EVENT_TYPE, Katello::Events::GenerateHostApplicability)
       Katello::EventQueue.register_event(Katello::Events::DeleteHostAgentQueue::EVENT_TYPE, Katello::Events::DeleteHostAgentQueue)
       Katello::EventQueue.register_event(Katello::Events::DeletePool::EVENT_TYPE, Katello::Events::DeletePool)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
On content import failure this commit automatically deletes the generated content view version 
So if pulp Import fails we will skip this action and also delete the generated content view version so that user can reimport seamlessly.

#### Considerations taken when implementing this change?
Before this commit if the import action from pulp fails for whatever reason, dynflow 
would skip the action to delete importers and other cleanup but still leaves an unnecessary content view version.
The user would have to manually delete the content view and try again.

This commit automatically deletes the generated content view on import failure. There by the user can re run the import operation again and import properly.


#### What are the testing steps for this pull request?
You can use the steps listed in the issue or just change the import action code to cause a failure.


On export org/server
- Export a CVV -> `hammer content-export complete version --id=<version-id>`

On import org/server

1. Check out master
2. Induce an import action error by either killing the worker during import or  change the import url in  `katello/app/lib/actions/pulp3/content_view_version/import.rb` from `create_import(input[:importer_data][:pulp_href])` to `create_import("/fakeurl")`
3. run `hammer content-import version --path=<path> --metadata-file=<metadata-location> --organization <org>`
4. The hammer task completes but the in dynflow  it skips and warns about the task erroring.
5. Now go to content-view details of that imported content view. Notice that a new version has been created with no content.
6. `hammer content-import version --path=<path> --metadata-file=<metadata-location> --organization <org>` should fail with an error along ```Content View Version specified in the metadata - '<my content view> 2.0' already exists. If you wish to replace the existing version, delete '<my content view> 2.0' and try import again.```
7. Delete this content-view version

Check out PR
1. `bundle exec rake db:seed`
1. Follow the steps 2 - 4 as above
2. The hammer task completes but the in dynflow  it skips and warns about the task erroring.
3. Now go to content-view details of that imported content view. Notice that no new version has been created in the content view.
4. revert the induced error in `katello/app/lib/actions/pulp3/content_view_version/import.rb` and reimport
5. It should reimport successfully.

