### PR TITLE
Fixes #34528 - Show puppet module count on composite cv add page

### DIFF
--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -167,6 +167,10 @@ module Katello
       (!content_counts.blank? && content_counts.dig(PuppetModule::CONTENT_TYPE) > 0) || self.content_view.force_puppet_environment?
     end
 
+    def puppet_module_count
+      content_counts&.dig(PuppetModule::CONTENT_TYPE)
+    end
+
     def archived_repos
       self.default? ? self.repositories : self.repos(nil)
     end

--- a/test/models/content_view_version_test.rb
+++ b/test/models/content_view_version_test.rb
@@ -196,7 +196,6 @@ module Katello
       katello_content_view_puppet_environments(:library_dev_staging_view_library_puppet_env).puppet_modules << puppet_module
       puppet_cv_env = katello_content_view_puppet_environments(:dev_view_puppet_environment)
       puppet_cv_env.puppet_modules << puppet_module
-
       assert_include ContentViewVersion.with_puppet_module(puppet_module), puppet_cv_env.content_view_version
     end
 
@@ -208,6 +207,7 @@ module Katello
 
       @cvv.content_view.force_puppet_environment = false
       @cvv.content_counts = { "puppet_module" => 2 }
+      assert_equal 2, @cvv.puppet_module_count
       assert @cvv.promote_puppet_environment?
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Looking through the code, we deleted a method for the puppet module count, so recreated that and added a test on the method.

#### Considerations taken when implementing this change?

* Made sure nothing else broke around that area.

#### What are the testing steps for this pull request?

* Spin up a Katello 3.18 or Sat 6.9 box
* Create a custom product and repo of puppet type
* Upload a puppet module 
* Create a content view with the puppet module and publish
* Create a composite content view and add the content view, see that the puppet count is 0
* Apply patch and restart services
* Verify module count is correctly showing