### PR TITLE
Fixes #34432 - Remove drpm from ignorable_content for roots

### DIFF
--- a/db/migrate/20220228173251_remove_drpm_from_ignorable_content.rb
+++ b/db/migrate/20220228173251_remove_drpm_from_ignorable_content.rb
@@ -1,0 +1,12 @@
+class RemoveDrpmFromIgnorableContent < ActiveRecord::Migration[6.0]
+  def up
+    Katello::RootRepository.select { |r| r&.ignorable_content&.include? "drpm" }.each do |root|
+      root.ignorable_content = root.ignorable_content - ["drpm"]
+      root.save!
+    end
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds a migration to remove drpm from irgnorable_content list for root repositories.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
How I tested this:
1. Change katello/app/models/katello/root_repository.rb L20 to allow drpm as ignorable_content type:
`IGNORABLE_CONTENT_UNIT_TYPES = %w(srpm drpm).freeze`
2. Change katello/app/lib/actions/katello/repository/update.rb file L13 to add 
`repo_params[:ignorable_content] = ['srpm', 'drpm']`
3. The changes above mean that any yum repo you update will get srpm and drpm as ignorable content. So update a couple yum repos, ex: name in your setup.
4. Go to foreman console: bundle exec rails c
5. Run `Katello::RootRepository.select {|r| r&.ignorable_content&.include? "drpm"}`
6. You should see a few root repository with drpm in the ignorable content list
7. Checkout this PR and run bundle exec rails db:migrate
8. Check `Katello::RootRepository.select {|r| r&.ignorable_content&.include? "drpm"}`. You shouldn't have any records.