### PR TITLE
Fixes #34530 - update smart proxy after setting unauthenticated pull

### DIFF
--- a/app/controllers/katello/api/v2/environments_controller.rb
+++ b/app/controllers/katello/api/v2/environments_controller.rb
@@ -107,7 +107,7 @@ module Katello
       fail HttpErrors::BadRequest, _("Can't update the '%s' environment") % "Library" if @environment.library? && update_params.empty?
       update_params[:name] = params[:environment][:new_name] if params[:environment][:new_name]
       @environment.update!(update_params)
-      if update_params[:registry_name_pattern]
+      if update_params[:registry_name_pattern] || update_params[:registry_unauthenticated_pull]
         task = send(async ? :async_task : :sync_task, ::Actions::Katello::Environment::PublishRepositories,
                     @environment, content_type: Katello::Repository::DOCKER_TYPE)
       end

--- a/test/controllers/api/v2/environments_controller_test.rb
+++ b/test/controllers/api/v2/environments_controller_test.rb
@@ -198,6 +198,47 @@ module Katello
       assert_equal original_label, @staging.label
     end
 
+    def test_update_pull_async
+      original_label = @staging.label
+
+      assert_async_task(::Actions::Katello::Environment::PublishRepositories, @staging,
+                        content_type: Katello::Repository::DOCKER_TYPE)
+      put :update, params: {
+        :organization_id => @organization.id, :id => @staging.id,
+        :environment => {
+          :new_name => 'New Name',
+          :label => 'New Label',
+          :registry_unauthenticated_pull => true
+        }
+      }
+
+      assert_response :success
+      assert_equal 'New Name', @staging.reload.name
+      # note: label is not editable; therefore, confirm that it is unchanged
+      assert_equal original_label, @staging.label
+    end
+
+    def test_update_pull_sync
+      original_label = @staging.label
+
+      assert_sync_task(::Actions::Katello::Environment::PublishRepositories, @staging,
+                       content_type: Katello::Repository::DOCKER_TYPE)
+      put :update, params: {
+        :organization_id => @organization.id, :id => @staging.id,
+        :async => false,
+        :environment => {
+          :new_name => 'New Name',
+          :label => 'New Label',
+          :registry_unauthenticated_pull => true
+        }
+      }
+
+      assert_response :success
+      assert_equal 'New Name', @staging.reload.name
+      # note: label is not editable; therefore, confirm that it is unchanged
+      assert_equal original_label, @staging.label
+    end
+
     def test_update_pattern_spaces
       put :update, params: { :organization_id => @organization.id, :id => @staging.id, :environment => {
         :new_name => 'New Name',


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Smart proxy will automatically sync after updating "Unauthenticated Pull" in LCE details. Addresses bug where manual sync is necessary for unauthenticated pull update to take affect on smart proxy.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
On Katello:
1. Create and sync a container repo
2. Create a CV and add the container repo to it
3. Publish and Promote the CV and make sure Capsule sync is triggered.
4. Wait for the Capsule sync to finish
5. Go the the LCE page and set "Unauthenticated Pull: Yes".

On Capsule:
1. `sqlite3 /var/lib/foreman-proxy/smart_proxy_container_gateway.db`
2. sqlite> `.header on`
3. sqlite> `select * from repositories;`
id|name|auth_required
6|busybox|1 <======== 0 when false, 1 when true. Should be updated after changing unauthenticated pull setting.