### PR TITLE
fixes #34531 - Resolving a bad migration for CdnConfiguration

### DIFF
--- a/app/services/katello/organization_creator.rb
+++ b/app/services/katello/organization_creator.rb
@@ -133,11 +133,15 @@ module Katello
     end
 
     def create_cdn_configuration
-      @cdn_configuration = Katello::CdnConfiguration.where(
-        organization: @organization,
-        url: ::Katello::Resources::CDN::CdnResource.redhat_cdn_url,
-        type: ::Katello::CdnConfiguration::CDN_TYPE
-      ).first_or_create!
+      @cdn_configuration = Katello::CdnConfiguration.where(organization: @organization)
+
+      if @cdn_configuration.blank?
+        Katello::CdnConfiguration.where(
+          organization: @organization,
+          url: ::Katello::Resources::CDN::CdnResource.redhat_cdn_url,
+          type: ::Katello::CdnConfiguration::CDN_TYPE
+        ).first_or_create!
+      end
     end
   end
 end

--- a/db/migrate/20220124191056_add_type_to_cdn_configuration.rb
+++ b/db/migrate/20220124191056_add_type_to_cdn_configuration.rb
@@ -1,16 +1,10 @@
 class AddTypeToCdnConfiguration < ActiveRecord::Migration[6.0]
   def change
+    add_index :katello_cdn_configurations, :organization_id, unique: true
     add_column :katello_cdn_configurations, :type, :string, default: ::Katello::CdnConfiguration::CDN_TYPE
 
     ::Katello::CdnConfiguration.reset_column_information
     ::Katello::CdnConfiguration.all.each do |config|
-      unless Setting[:subscription_connection_enabled]
-        # if subscription connection is not enabled
-        # the user most likely wants the type to be airgapped
-        config.update!(type: ::Katello::CdnConfiguration::AIRGAPPED_TYPE)
-        next
-      end
-
       unless config.username.blank? ||
              config.password.blank? ||
              config.upstream_organization_label.blank? ||


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This migration  https://github.com/Katello/katello/blob/master/db/migrate/20220124191056_add_type_to_cdn_configuration.rb#L7-L12 while adding the cdn configuration had a couple of glaring errors causing unintended side effects

1. It would mark every existing org before the migration as Airgapped even if it was not disconnected.
2. It would add duplicate entries to cdn configuration

This commit fixes this by 
1. Adding a unique index on organization for cdn configuration to error out on bad states
2. Removes the code setting  Airgapped from the migration.

#### Considerations taken when implementing this change?

Removes the setting of Airgapped from the migration. Instead leaves it to the administrator to update airgapped configuration accordingly. This is because there are 2 different definitions of the 'content_disconnected' and user might have set it and still consuming content from an internal cdn. We could try to be smart here but less risky is letting the administrator decide. 

#### What are the testing steps for this pull request?

- Checkout commit `c5f8e9532e61f9e5c7ec648decf81660628dd4ba` to simulate the pre-migration environment.
```bash
$ cd katello
$ git co c5f8e9532e61f9e5c7ec648decf81660628dd4ba
$ cd ../foreman
$ rm Gemfile.lock && bundle install && bundle exec rake katello:reset
```
- This should get you the pre-migration environment
- Now checkout master and complete the migration
```bash
$ cd ../katello
$ git co master
$ cd ../foreman
$ rm Gemfile.lock && bundle install && bundle exec rake db:migrate
```

- Finally go to the rails console and check on the CdnConfigurations
- You should see something like
```ruby
> ::Katello::CdnConfiguration.all
=> [#<Katello::CdnConfiguration:0x0000000017cbd6c8
  id: 1,
  organization_id: 1,
  ssl_ca_credential_id: nil,
  ssl_cert: nil,
  ssl_key: nil,
  username: nil,
  password: nil,
  upstream_organization_label: nil,
  url: nil,
  upstream_content_view_label: nil,
  upstream_lifecycle_environment_label: nil,
  type: "airgapped">,
 #<Katello::CdnConfiguration:0x0000000017cbd600
  id: 2,
  organization_id: 1,
  ssl_ca_credential_id: nil,
  ssl_cert: nil,
  ssl_key: nil,
  username: nil,
  password: nil,
  upstream_organization_label: nil,
  url: "https://cdn.redhat.com",
  upstream_content_view_label: nil,
  upstream_lifecycle_environment_label: nil,
  type: "redhat_cdn">]
```
- Which is incorrect in many ways. 

1. There should be 1 cdn configuration
2. That should be redhat_cdn


- Checkout commit `c5f8e9532e61f9e5c7ec648decf81660628dd4ba` to simulate the pre-migration environment.
```bash
$ cd katello
$ git co c5f8e9532e61f9e5c7ec648decf81660628dd4ba
$ cd ../foreman
$ rm Gemfile.lock && bundle install && bundle exec rake katello:reset
```
- This should get you the pre-migration environment
- Now checkout this PR and complete the migration
```bash
$ cd ../katello
$ git co <this pr branch>
$ cd ../foreman
$ rm Gemfile.lock && bundle install && bundle exec rake db:migrate
```
 
- Finally go to the rails console and check on the CdnConfigurations
- You should see something like
```ruby
> ::Katello::CdnConfiguration.all
=> [#<Katello::CdnConfiguration:0x0000000017cbd600
  id: 1,
  organization_id: 1,
  ssl_ca_credential_id: nil,
  ssl_cert: nil,
  ssl_key: nil,
  username: nil,
  password: nil,
  upstream_organization_label: nil,
  url: "https://cdn.redhat.com",
  upstream_content_view_label: nil,
  upstream_lifecycle_environment_label: nil,
  type: "redhat_cdn">]
```






