### PR TITLE
Refs #34527 - Add Host Collections card

### DIFF
--- a/app/views/katello/api/v2/hosts/host_collections.json.rabl
+++ b/app/views/katello/api/v2/hosts/host_collections.json.rabl
@@ -1,3 +1,3 @@
 child :host_collections => :host_collections do
-  attributes :id, :name
+  attributes :id, :name, :description, :max_hosts, :unlimited_hosts, :total_hosts
 end

--- a/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard.js
@@ -1,0 +1,150 @@
+import React, { useState } from 'react';
+import {
+  Badge,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardBody,
+  Dropdown,
+  ExpandableSection,
+  KebabToggle,
+  Flex,
+  FlexItem,
+  GridItem,
+  DropdownItem,
+} from '@patternfly/react-core';
+
+import { translate as __ } from 'foremanReact/common/I18n';
+import { propsToCamelCase } from 'foremanReact/common/helpers';
+import PropTypes from 'prop-types';
+import { useSet } from '../../../Table/TableHooks';
+
+const HostCollectionsDetails = ({
+  hostCollections,
+}) => {
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const toggleBulkAction = () => setIsDropdownOpen(prev => !prev);
+
+  const expandedHostCollections = useSet([]);
+  const openAddHostCollectionsModal = () => {}; // TODO: implement
+  const openRemoveHostCollectionsModal = () => {}; // TODO: implement
+
+  const dropdownItems = [
+    <DropdownItem
+      aria-label="add_host_to_collections"
+      key="add_host_to_collections"
+      component="button"
+      isDisabled
+      onClick={openAddHostCollectionsModal}
+    >
+      {__('Add host to collections')}
+    </DropdownItem>,
+    <DropdownItem
+      aria-label="remove_host_from_collections"
+      key="remove_host_from_collections"
+      component="button"
+      isDisabled
+      onClick={openRemoveHostCollectionsModal}
+    >
+      {__('Remove host from collections')}
+    </DropdownItem>,
+  ];
+
+  return (
+    <GridItem rowSpan={1} md={6} lg={4} xl2={3} >
+      <Card isHoverable>
+        <CardHeader>
+          <Flex
+            alignItems={{ default: 'alignItemsCenter' }}
+            justifyContent={{ default: 'justifyContentSpaceBetween' }}
+            style={{ width: '100%' }}
+          >
+            <FlexItem>
+              <Flex
+                alignItems={{ default: 'alignItemsCenter' }}
+                justifyContent={{ default: 'justifyContentSpaceBetween' }}
+              >
+                <FlexItem>
+                  <CardTitle>{__('Host collections')}</CardTitle>
+                </FlexItem>
+                <FlexItem>
+                  {!!hostCollections?.length && <Badge isRead>{hostCollections.length}</Badge>}
+                </FlexItem>
+              </Flex>
+            </FlexItem>
+            <FlexItem>
+              <Dropdown
+                toggle={<KebabToggle aria-label="bulk_actions" onToggle={toggleBulkAction} />}
+                isOpen={isDropdownOpen}
+                isPlain
+                position="right"
+                dropdownItems={dropdownItems}
+              />
+            </FlexItem>
+          </Flex>
+        </CardHeader>
+        <CardBody>
+          {hostCollections?.map((hostCollection) => {
+            const {
+              id, name, description, maxHosts, unlimitedHosts, totalHosts,
+            } = propsToCamelCase(hostCollection);
+            const isExpanded = expandedHostCollections.has(id);
+            return (
+              <Flex
+                alignItems={{ default: 'alignItemsBaseline' }}
+                justifyContent={{ default: 'justifyContentSpaceBetween' }}
+                direction={{ default: 'row' }}
+                flexWrap={{ default: 'nowrap' }}
+                key={id}
+              >
+                <FlexItem
+                  grow={{ default: 'grow' }}
+                  style={{ whiteSpace: 'pre-line' }}
+                >
+                  <ExpandableSection
+                    toggleText={name}
+                    onToggle={() => expandedHostCollections.onToggle(!isExpanded, id)}
+                    isExpanded={isExpanded}
+                    isIndented
+                  >
+                    <div style={{ fontSize: '14px' }}>
+                      {description || <span style={{ color: '#c1c1c1' }}>{__('No description provided')}</span>}
+                    </div>
+                  </ExpandableSection>
+                </FlexItem>
+                <FlexItem component="span">
+                  {totalHosts}/{unlimitedHosts ? 'unlimited' : maxHosts}
+                </FlexItem>
+              </Flex>
+            );
+          })}
+        </CardBody>
+      </Card>
+    </GridItem>
+  );
+};
+
+const HostCollectionsDetailsCard = ({ hostDetails }) => {
+  if (hostDetails) {
+    return <HostCollectionsDetails {...propsToCamelCase(hostDetails)} />;
+  }
+  return null;
+};
+
+HostCollectionsDetails.propTypes = {
+  hostCollections: PropTypes.arrayOf(PropTypes.shape({})),
+};
+
+HostCollectionsDetails.defaultProps = {
+  hostCollections: [],
+};
+
+HostCollectionsDetailsCard.propTypes = {
+  hostDetails: PropTypes.shape({}),
+};
+
+HostCollectionsDetailsCard.defaultProps = {
+  hostDetails: null,
+};
+
+export default HostCollectionsDetailsCard;

--- a/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard.js
@@ -124,7 +124,7 @@ const HostCollectionsDetails = ({
   );
 };
 
-const HostCollectionsDetailsCard = ({ hostDetails }) => {
+const HostCollectionsCard = ({ hostDetails }) => {
   if (hostDetails) {
     return <HostCollectionsDetails {...propsToCamelCase(hostDetails)} />;
   }
@@ -139,12 +139,12 @@ HostCollectionsDetails.defaultProps = {
   hostCollections: [],
 };
 
-HostCollectionsDetailsCard.propTypes = {
+HostCollectionsCard.propTypes = {
   hostDetails: PropTypes.shape({}),
 };
 
-HostCollectionsDetailsCard.defaultProps = {
+HostCollectionsCard.defaultProps = {
   hostDetails: null,
 };
 
-export default HostCollectionsDetailsCard;
+export default HostCollectionsCard;

--- a/webpack/components/extensions/HostDetails/Cards/__tests__/contentViewDetailsCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/__tests__/contentViewDetailsCard.test.js
@@ -24,7 +24,7 @@ test('shows host details when content facet is set', () => {
 });
 
 
-test('doesnot show host details when content facet is not set', () => {
+test('does not show host details when content facet is not set', () => {
   const { queryByText } = render(<ContentViewDetailsCard />);
   expect(queryByText('Version 1.0')).toBeNull();
 });

--- a/webpack/components/extensions/HostDetails/Cards/__tests__/hostCollectionsCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/__tests__/hostCollectionsCard.test.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, fireEvent } from 'react-testing-lib-wrapper';
+import HostCollectionsCard from '../HostCollectionsCard';
+
+const hostDetails = {
+  host_collections: [
+    {
+      id: 1,
+      name: 'Jer Hosts',
+      description: null,
+      max_hosts: null,
+      unlimited_hosts: true,
+      total_hosts: 2,
+    },
+    {
+      id: 3,
+      name: 'Partha hosts',
+      description: null,
+      max_hosts: 1,
+      unlimited_hosts: false,
+      total_hosts: 1,
+    },
+    {
+      id: 2,
+      name: 'Jturel hosts',
+      description: 'This is my awesome description',
+      max_hosts: 43,
+      unlimited_hosts: false,
+      total_hosts: 1,
+    },
+  ],
+};
+
+const emptyHostDetails = {
+  host_collections: [],
+};
+
+test('shows host collections and host limits when present', () => {
+  const { getByText } = render(<HostCollectionsCard hostDetails={hostDetails} />);
+  expect(getByText('Host collections')).toBeInTheDocument();
+  expect(getByText('Jturel hosts')).toBeInTheDocument();
+  expect(getByText('1/43')).toBeInTheDocument();
+  expect(getByText('1/1')).toBeInTheDocument();
+  expect(getByText('2/unlimited')).toBeInTheDocument();
+});
+
+test('shows empty card when no host collections present', () => {
+  const { queryByText } = render(<HostCollectionsCard hostDetails={emptyHostDetails} />);
+  expect(queryByText('Host collections')).toBeInTheDocument();
+  expect(queryByText('Jturel hosts')).not.toBeInTheDocument();
+});
+
+test('expands to show description', () => {
+  const { getByText, queryByText } = render(<HostCollectionsCard hostDetails={hostDetails} />);
+  expect(getByText('Jturel hosts')).toBeInTheDocument();
+  expect(queryByText('This is my awesome description')).not.toBeVisible();
+  fireEvent.click(getByText('Jturel hosts'));
+  expect(getByText('This is my awesome description')).toBeVisible();
+});
+
+test('expands to show when no description provided', () => {
+  const { getAllByText, queryAllByText } = render(<HostCollectionsCard
+    hostDetails={hostDetails}
+  />);
+  const indescribableHostCollection = getAllByText('Jer Hosts')[0];
+  expect(indescribableHostCollection).toBeInTheDocument();
+  queryAllByText('No description provided').forEach(element => expect(element).not.toBeVisible());
+  fireEvent.click(indescribableHostCollection);
+  expect(getAllByText('No description provided')[0]).toBeVisible();
+});

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -14,7 +14,7 @@ import RepositorySetsTab from './components/extensions/HostDetails/Tabs/Reposito
 import TracesTab from './components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js';
 import extendReducer from './components/extensions/reducers';
 import rootReducer from './redux/reducers';
-import HostCollectionsDetailsCard from './components/extensions/HostDetails/Cards/HostCollectionsCard';
+import HostCollectionsCard from './components/extensions/HostDetails/Cards/HostCollectionsCard';
 
 registerReducer('katelloExtends', extendReducer);
 registerReducer('katello', rootReducer);
@@ -36,7 +36,7 @@ addGlobalFill(
 addGlobalFill(
   'details-cards',
   'Host collections',
-  <HostCollectionsDetailsCard key="host-collections-details" />,
+  <HostCollectionsCard key="host-collections-details" />,
   700,
 );
 addGlobalFill('details-cards', 'Installable errata', <ErrataOverviewCard key="errata-overview" />, 1900);

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -14,6 +14,7 @@ import RepositorySetsTab from './components/extensions/HostDetails/Tabs/Reposito
 import TracesTab from './components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js';
 import extendReducer from './components/extensions/reducers';
 import rootReducer from './redux/reducers';
+import HostCollectionsDetailsCard from './components/extensions/HostDetails/Cards/HostCollectionsCard';
 
 registerReducer('katelloExtends', extendReducer);
 registerReducer('katello', rootReducer);
@@ -28,8 +29,14 @@ addGlobalFill('host-details-page-tabs', 'Repository sets', <RepositorySetsTab ke
 
 addGlobalFill(
   'details-cards',
-  'Content View Details',
+  'Content view details',
   <ContentViewDetailsCard key="content-view-details" />,
   2000,
+);
+addGlobalFill(
+  'details-cards',
+  'Host collections',
+  <HostCollectionsDetailsCard key="host-collections-details" />,
+  700,
 );
 addGlobalFill('details-cards', 'Installable errata', <ErrataOverviewCard key="errata-overview" />, 1900);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

- [x] Adds a Host collections overview card to the host details page.
- [x] add tests

![host_collections_card](https://user-images.githubusercontent.com/22042343/156068292-f5d9e7ea-b60e-41d7-9b4c-6bf33789b4b4.png)

#### Considerations taken when implementing this change?

I used flexbox rather than a table since it's such a simple layout. It worked out pretty well.
I had to add a few attributes to the rabl for host collections.
Dropdown menu items are disabled for now - they will be enabled in upcoming PRs.

#### What are the testing steps for this pull request?

* Add your host to at least 3 host collections
* Make sure at least one of the host collections has unlimited hosts
* Make sure at least one of the host collections does _not_ have unlimited hosts
* Make sure some of your host collections have descriptions
* Also view a host that is not part of any collections - the card will be blank but the dropdown will still be accessible