### PR TITLE
Fixes #34540 - more resiliant content creation

### DIFF
--- a/app/lib/actions/katello/product/content_create.rb
+++ b/app/lib/actions/katello/product/content_create.rb
@@ -44,16 +44,18 @@ module Actions
           root = ::Katello::RootRepository.find(input[:root_repository_id])
           root.update(:content_id => input[:content_id])
 
-          content = ::Katello::Content.create!(name: root.name,
-                                               organization_id: root.product.organization_id,
-                                               cp_content_id: root.content_id,
-                                               content_type: root.content_type,
-                                               label: root.custom_content_label,
-                                               content_url: root.custom_content_path,
-                                               vendor: ::Katello::Provider::CUSTOM)
+          content = ::Katello::Content.where(organization_id: root.product.organization_id, cp_content_id: root.content_id).first_or_create do |new_content|
+            new_content.name = root.name
+            new_content.content_type = root.content_type
+            new_content.label = root.custom_content_label
+            new_content.content_url = root.custom_content_path
+            new_content.vendor = ::Katello::Provider::CUSTOM
+          end
 
           #custom product content is always enabled by default
-          ::Katello::ProductContent.create!(product: root.product, content: content, enabled: true)
+          ::Katello::ProductContent.where(product: root.product, content: content).first_or_create do |pc|
+            pc.enabled = true
+          end
         end
       end
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1.  create a library repository
2.  sync it or upload content
3.  delete it from pulp in rails console: Katello::Repository.first.backend_service(SmartProxy.pulp_primary).delete_repository
4. run `rake katello:correct_repositories COMMIT=true`
you should be able to re-sync the repo