### PR TITLE
Fixes #34550 - run no migration tasks if nothing to migrate

### DIFF
--- a/app/services/katello/pulp3/migration.rb
+++ b/app/services/katello/pulp3/migration.rb
@@ -65,7 +65,11 @@ module Katello
 
       def create_and_run_migrations
         migs = create_migrations
-        migs.map { |href| start_migration(href) }
+        if migs.any?
+          migs.map { |href| start_migration(href) }
+        else
+          []
+        end
       end
 
       def self.ignorable_content_types

--- a/app/services/katello/pulp3/migration_plan.rb
+++ b/app/services/katello/pulp3/migration_plan.rb
@@ -18,12 +18,13 @@ module Katello
       end
 
       def generate_plugins
-        @repository_types.sort.map do |repository_type|
+        plugins = @repository_types.sort.map do |repository_type|
           {
             type: self.class.pulp2_repository_type(repository_type),
             repositories: repository_migrations(repository_type)
           }
         end
+        plugins.select { |plugin| plugin[:repositories].any? }
       end
 
       def self.pulp2_repository_type(repository_type)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Do not run a content migration if there are no repositories of a given type

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. install a fresh 3.18 w/ pulp2 or 6.9 with no repositories 
2.  run 'foreman-maintain content prepare'
3. check the created task in dynflow and verify that no pulp tasks were spawned in the output of the first step
4. create a new repository
5. repeat step 2
6. check the created task in dynflow and verify that now you do see a pulp task spawned in the output of the first step in dynflow