### PR TITLE
Fixes #34549 - Deduplicate errata records

### DIFF
--- a/db/migrate/20220303160220_remove_duplicate_errata.rb
+++ b/db/migrate/20220303160220_remove_duplicate_errata.rb
@@ -1,0 +1,34 @@
+class RemoveDuplicateErrata < ActiveRecord::Migration[6.0]
+  def up
+    #Update all unique errata records to have pulp_id = errata_id
+    ::Katello::Erratum.group(:errata_id).having("count(errata_id) = 1").pluck(:errata_id).each do |original_errata_id|
+      erratum = ::Katello::Erratum.find_by(errata_id: original_errata_id)
+      if (erratum.pulp_id != erratum.errata_id)
+        erratum.pulp_id = erratum.errata_id
+        erratum.save!
+      end
+    end
+
+    #For duplicate errata,
+    # a) update all RepositoryErrata to point to unique errata,
+    # b) if repo-errata association for that combination exists, delete duplicate errata association
+    # c) Delete all duplicate errata
+    ::Katello::Erratum.group(:errata_id).having("count(errata_id) > 1").pluck(:errata_id).each do |original_errata_id|
+      errata_to_keep = ::Katello::Erratum.find_by(pulp_id: original_errata_id)
+      errata_all = ::Katello::Erratum.where(errata_id: original_errata_id)
+      dup_errata = errata_all - [errata_to_keep]
+      ::Katello::RepositoryErratum.where(erratum_id: dup_errata&.map(&:id)).each do |repo_erratum|
+        if ::Katello::RepositoryErratum.find_by(repository_id: repo_erratum.repository_id, erratum_id: errata_to_keep.id)
+          repo_erratum.delete
+        else
+          repo_erratum.update(erratum_id: errata_to_keep.id)
+        end
+      end
+      ::Katello::Erratum.delete(dup_errata&.pluck(:id))
+    end
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Migration to remove duplicate errata records (where errata_id is not equal to pulp_id)
Migrate all associated RepositoryErrata records to use the correct erratum.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
How I tested this:
On a box in master, create a bunch of duplicate errata records.

err_dup = Katello::Erratum.find(id).dup
err_dup.pulp_id = "random_value"
err.dup.save!

Create a bunch of repository associations with the dup errata records.

repo_err_assoc = ::Katello::RepositoryErratum.new(repository_id: repo_id, erratum_id: err_dup.id)
repo_err_assoc.save!

Switch to PR branch and run db:migrate
All dup_errata should get deleted
All repo_assoc of duplicate errata should get associated with original errata.
If there's already a repo association record for repo and original errata, delete the repo association of duplicate errata.