### PR TITLE
Fixes #34559 - Patternfly update causes tabs to navigate twice on click

### DIFF
--- a/webpack/components/RoutedTabs/index.js
+++ b/webpack/components/RoutedTabs/index.js
@@ -1,33 +1,18 @@
 import React from 'react';
 import { shape, string, number, element, arrayOf } from 'prop-types';
 import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
-import { Switch, Route, Redirect, useHistory, useLocation, withRouter, HashRouter } from 'react-router-dom';
+import { Switch, Route, Redirect, useLocation, withRouter, HashRouter } from 'react-router-dom';
 import { head, last } from 'lodash';
 
 const RoutedTabs = ({
   tabs, defaultTabIndex,
 }) => {
-  const { push } = useHistory();
   const {
     hash, key: locationKey,
   } = useLocation();
 
   // The below transforms #/history/6 to history
   const currentTabFromUrl = head(last(hash.split('#/')).split('/'));
-  // Allows navigation back to mainTab
-  const onSubTab = currentTabFromUrl !== last(last(hash.split('#/')).split('/'));
-
-  const onSelect = (e, key) => {
-    e.preventDefault();
-    // See the below links for understanding of this mouseEvent
-    // https://www.w3schools.com/jsref/event_which.asp
-    // https://www.w3schools.com/jsref/event_button.asp
-    const middleMouseButtonNotUsed = !(e.button === 1 || e.buttons === 4 || e.which === 2);
-    const notCurrentTab = currentTabFromUrl !== key;
-    if (middleMouseButtonNotUsed && (notCurrentTab || !!onSubTab)) {
-      push(`#/${key}`);
-    }
-  };
 
   return (
     <>
@@ -39,7 +24,6 @@ const RoutedTabs = ({
           <a
             key={key}
             href={`#/${key}`}
-            onMouseUp={e => onSelect(e, key)}
             style={{ textDecoration: 'none' }}
           >
             <Tab


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

An update to how <a> tags are handled within the <Tabs> component in patternfly has caused a previous work-around to navigate to pages twice.
This removes the previous work-around that is no longer needed, and corrects the duplicate api-call/navigation behaviour.

#### What are the testing steps for this pull request?

On master: 

- Pull latest foreman/katello, 
- Delete node_modules/package-lock inside foreman. 
- npm install

- navigate to contentViewDetails (content_views/<int>#/XXXX)  
- go through versions/Repositories/filters/history tabs
- Without this patch you should see double api calls on all pages after navigation.

