### PR TITLE
Fixes #34568 - Enabling ISO Repository Fails

### DIFF
--- a/app/models/katello/candlepin/repository_mapper.rb
+++ b/app/models/katello/candlepin/repository_mapper.rb
@@ -41,7 +41,7 @@ module Katello
           :content_type => katello_content_type,
           :unprotected => unprotected?,
           :download_policy => download_policy,
-          :mirroring_policy => Katello::RootRepository::MIRRORING_POLICY_COMPLETE
+          :mirroring_policy => mirroring_policy
         )
 
         Repository.new(:root => root,
@@ -142,6 +142,14 @@ module Katello
           Setting[:default_redhat_download_policy]
         else
           ""
+        end
+      end
+
+      def mirroring_policy
+        if katello_content_type == Repository::YUM_TYPE
+          Katello::RootRepository::MIRRORING_POLICY_COMPLETE
+        else
+          Katello::RootRepository::MIRRORING_POLICY_CONTENT
         end
       end
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fixes error when enabling ISO red hat repositories by adding a mirroring policy for non-yum types. I chose the `mirror_content_only` option. `mirror_complete` is invalid for file types.
#### Considerations taken when implementing this change?
Previously, the root repository was being created with the "mirror complete" policy, which caused an error for file repository types. The actual error exposed by katello was that `root_id` in the `Repository` object was `null`. However, this mirroring policy issue prevented `RootRepository` from being created, which caused the other error.
#### What are the testing steps for this pull request?
Before checking out PR:
1. In UI go to Content > Red Hat Repositories
2. Select 'Other' in the combo and try to enable any ISO (e.g rhel-7-server-satellite-6.4-isos). You may have to try a few different ones before you get the right error.
    - I used Red Hat Enterprise Linux 4 AS ISOs x86_64, so it might be good to try a different one.
4. You should see an error about a null value and won't be able to enable the repository.

After checking out PR:
1. Try enabling the same repository that failed before and it should succeed.