### PR TITLE
Refs #34072 - Address useBulkSelect slowness when per_page is high

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -135,6 +135,14 @@ export const ErrataTab = () => {
     initialSearchQuery: searchParam || '',
   });
 
+  const tdSelect = useCallback((errataId, rowIndex) => ({
+    disable: !isSelectable(errataId),
+    isSelected: isSelected(errataId),
+    onSelect: (event, selected) => selectOne(selected, errataId),
+    rowIndex,
+    variant: 'checkbox',
+  }), [isSelectable, isSelected, selectOne]);
+
   if (!hostId) return <Skeleton />;
 
   const applyErratumViaRemoteExecution = id => dispatch(installErrata({
@@ -412,14 +420,7 @@ export const ErrataTab = () => {
                         onToggle: (_event, _rInx, isOpen) => expandedErrata.onToggle(isOpen, id),
                       }}
                     />
-                    <Td select={{
-                      disable: !isSelectable(errataId),
-                      isSelected: isSelected(errataId),
-                      onSelect: (event, selected) => selectOne(selected, errataId),
-                      rowIndex,
-                      variant: 'checkbox',
-                    }}
-                    />
+                    <Td select={tdSelect(errataId, rowIndex)} />
                     <Td>
                       <a href={urlBuilder(`errata/${id}`, '')}>{errataId}</a>
                     </Td>
@@ -452,16 +453,20 @@ export const ErrataTab = () => {
                     />
                   </Tr>
                   <Tr key="child_row" isExpanded={isExpanded}>
-                    <Td colSpan={3}>
-                      <ExpandableRowContent>
-                        <ErratumExpansionContents erratum={erratum} />
-                      </ExpandableRowContent>
-                    </Td>
-                    <Td colSpan={4}>
-                      <ExpandableRowContent>
-                        <ErratumExpansionDetail erratum={erratum} />
-                      </ExpandableRowContent>
-                    </Td>
+                    {isExpanded && (
+                      <>
+                        <Td colSpan={3}>
+                          <ExpandableRowContent>
+                            <ErratumExpansionContents erratum={erratum} />
+                          </ExpandableRowContent>
+                        </Td>
+                        <Td colSpan={4}>
+                          <ExpandableRowContent>
+                            <ErratumExpansionDetail erratum={erratum} />
+                          </ExpandableRowContent>
+                        </Td>
+                      </>
+                    )}
                   </Tr>
                 </Tbody>
               );

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -434,6 +434,7 @@ export const PackagesTab = () => {
         isOpen={isModalOpen}
         closeModal={closeModal}
         hostId={hostId}
+        key={hostId}
         hostName={hostname}
         showKatelloAgent={showKatelloAgent}
       />

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
@@ -176,8 +176,8 @@ test('Can display expanded errata details', async (done) => {
   expect(queryByText(firstErrata.cves[0].cve_id)).not.toBeInTheDocument();
 
   firstExpansion.click();
-  // the errata details should now be hidden
-  expect(getByText(firstErrata.summary)).not.toBeVisible();
+  // the errata details should now be gone
+  expect(queryByText(firstErrata.summary)).not.toBeInTheDocument();
   // Assert request was made and completed, see helper function
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done); // Pass jest callback to confirm test is done


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

In tables that use `useBulkSelect` and `useSelectionSet`, table row selection was slow when per_page is set to a custom value of 100 or more. In other words, the time between the mouse click on the checkbox and the visual change to checked could be as much as 4-500ms. It was slowest on the Errata page, but the issue was also present on other tables. I was able to get it down to ~150, testing with 100 items per page. Not ideal but a significant improvement.

* Add `useCallback`, `useMemo`, and other optimizations to several `useBulkSelect` internal functions
* Add `useCallback` to one function in `ErrataTab.js`
* Don't render ErrataTab expanded table rows when the row is not expanded (This was the biggest source of improvement by far)

#### Considerations taken when implementing this change?

Ideally the goal should be 50-100ms for a user interaction (see https://web.dev/rail/?utm_source=devtools#goals-and-guidelines) so it's not perfect. The next thing I can think of is to have some sort of infinite scrolling component that only renders what's on screen (or just offscreen), but that would take a significant dev effort. Having a custom `perPage` value set seems like too small a use case to make that worth it.

#### What are the testing steps for this pull request?

1. Enable the Red Hat Repository "Red Hat Enterprise Linux 7 Server RPMs x86_64 7Server"
2. Make sure your Foreman VM has at least 16GB of RAM
3. Sync the repo and go have some coffee
4. Spin up a new RHEL7 box and register it. You should now have 100+ errata.
5. Administer > Settings > Set "Entries per page" to 100 or more
6. Hosts > All hosts > new host details for your new host > Content > Errata
7. Click a checkbox. Note the time from the mouse click to the box visually responding and becoming checked. Notice how excruciatingly slow it is.
8. Also look at Packages (you should have plenty) - The issue is still there but not as pronounced.  If you like, you can use DevTools Performance tab > CPU Throttling to magnify the issue (but remember to turn it off before doing the testing procedure below; it kept crashing on my system otherwise)
9. Navigate to the last page (which probably doesn't have a lot of items) and see how much faster it is
10. Perform the DevTools testing procedure below
11. Check out this change and perform the testing procedure again; Note your results.

#### DevTools testing procedure

1. Navigate to Content > Errata if you're not already there
2. In DevTools, click the Performance tab
3. Click the Record button in the upper left
4. Click to check two or three checkboxes - make sure to wait until the box is checked before clicking the next one
5. Click the select none button to clear the selection
6. In DevTools, click Stop to stop the recording
7. Look for the yellow mountains of CPU usage that coincide with your clicks:
![cpu_mountains](https://user-images.githubusercontent.com/22042343/157270414-29c65bb2-151d-4bb4-a103-5c9e9e1a1719.png)
8. Hover your mouse and look at the screenshots. You should see the checkbox becoming checked close to the right side of the yellow mountain.
![devtools_screenshot](https://user-images.githubusercontent.com/22042343/157270780-1b9323b9-9b90-4d8b-9506-565b65b1f913.png)
9. Click and _drag_ to select the mountain, and a bit before and after it. You should see something like this:
![devtools_dragged](https://user-images.githubusercontent.com/22042343/157271069-f53d2224-5475-4d2d-a059-6e527a17ab98.png)
Note the red tag in the corner; this indicates that particular task took too long in Chrome's opinion. 
10. Scroll down (not with your mouse wheel! Use the scroll bar on the right) until you see something similar to this:
![workLoopSync](https://user-images.githubusercontent.com/22042343/157271466-d2617d8d-0646-4b33-9dad-0a4bf40346a8.png)
The tiny items are React rendering the table after your click. Notice the `workLoopSync` function call, each of which contains several `performUnitOfWork` calls. These are the React internal functions doing their work. I find it useful to measure the `workLoopSync` because there's usually only one per click (on this one there are two, so add them up.) In this picture it's 269.87ms, plus the one to the left which was 60-something ms.  (Or you could just measure `performSyncWorkOnRoot` instead)

Using this testing procedure, we now have a repeatable, measurable way to measure click performance of the checkboxes. Repeat this with the change checked out, and hopefully you'll see a big improvement.

More DevTools tips:
* You can use the up and down arrow buttons (Load Profile and Save Profile) to save and load profiles after you've recorded them
* I recommend having DevTools in its own window for this (click the kebab / three dots menu > Dock Side icons)
* You can use the keyboard shortcut Alt+Tilde (Alt+~) to switch between Chrome windows. Similar to Alt+Tab but within the same app.
