### PR TITLE
Fixes #34577 - Update sat/cap/tools/client repos for 6.11

### DIFF
--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -14,26 +14,27 @@ const recommendedRepositoriesRHEL = [
   'rhel-8-for-x86_64-baseos-kickstart',
   'rhel-8-for-x86_64-appstream-rpms',
   'rhel-8-for-x86_64-appstream-kickstart',
+  'rhel-8-for-x86_64-baseos-eus-rpms',
+  'rhel-8-for-x86_64-appstream-eus-rpms',
   'rhel-7-server-rpms',
   'rhel-7-server-optional-rpms',
   'rhel-7-server-extras-rpms',
-  'rhel-7-server-eus-rpms',
   'rhel-7-server-kickstart',
-  'rhel-6-server-els-rpms',
-  'rhel-6-server-kickstart',
 ];
 
 const recommendedRepositoriesSatTools = [
-  'satellite-tools-6.10-for-rhel-8-x86_64-rpms',
-  'rhel-7-server-satellite-tools-6.10-rpms',
-  'rhel-6-server-els-satellite-tools-6.10-rpms',
-  'rhel-7-server-satellite-maintenance-6-rpms',
+  'satellite-client-6-for-rhel-8-x86_64-rpms',
+  'rhel-7-server-satellite-client-6-rpms',
+  'rhel-7-server-satellite-maintenance-6.11-rpms',
+  'rhel-6-server-els-satellite-client-6-rpms',
 ];
 
 const recommendedRepositoriesMisc = [
   'rhel-server-rhscl-7-rpms',
-  'rhel-7-server-satellite-capsule-6.10-rpms',
+  'rhel-7-server-satellite-capsule-6.11-rpms',
+  'satellite-capsule-6.11-for-rhel-8-x86_64-rpms',
   'rhel-7-server-ansible-2.9-rpms',
+  'ansible-2-for-rhel-8-x86_64-rpms',
 ];
 
 const recommendedRepositorySetLables = recommendedRepositoriesRHEL


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

It's time again to update the recommended repos for the next version of Satellite!

#### Considerations taken when implementing this change?

Depending on your manifest you might not see the Sat 6.11 repos but the other changes should be reflected, you can cross reference the names from the doc listed in the Jira card for the sat repos, not linking here since it's an internal RH link.

#### What are the testing steps for this pull request?

* Checkout PR
* Import a manifest
* Goto RH Repos page and select recommended repos selector
* Verify you are not seeing RHEL 7 EUS repos
* Verify you see RHEL 8 EUS repos
* Verify that all RHEL 6 repos are out of the list
* Verify tools/maintenance/capsule/client repos are saying 6.11