### PR TITLE
Fixes #34578 - fix custom subscriptions consumed field in the CSV file

### DIFF
--- a/app/controllers/katello/api/v2/subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/subscriptions_controller.rb
@@ -43,11 +43,11 @@ module Katello
           collection = scoped_search(*base_args, options)
           csv_response(collection,
                        [:id, :subscription_id, :name, :cp_id, :organization_id, :sockets, :cores,
-                        :start_date, :end_date, :available, :quantity, :account_number, :contract_number,
+                        :start_date, :end_date, :consumed, :quantity, :account_number, :contract_number,
                         :support_level, :ram, :stacking_id, :multi_entitlement, :type, :product_id,
                         :unmapped_guest, :virt_only, :virt_who, :upstream?],
                        ['Pool Id Number', 'Subscription Id', 'Name', 'Pool Id', 'Organization Id',
-                        'Sockets', 'Cores', 'Start Date', 'End Date', 'Available', 'Quantity', 'Account Number',
+                        'Sockets', 'Cores', 'Start Date', 'End Date', 'Consumed', 'Quantity', 'Account Number',
                         'Contract Number', 'Support Level', 'RAM', 'Stacking Id', 'Multi Entitlement', 'Type',
                         'Product Id', 'Unmapped Guest', 'Virt Only', 'Requires Virt Who', 'Upstream'])
         end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Custom subscriptions consumed is not correct in the exported CSV file.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a custom product
2. Content >> Subscriptions >> Export CSV
_Before_
Check the Available column in CSV file. It shows -1.
_After_
Display `Cusumer` column with correct value instead of `Available`.