### PR TITLE
Fixes #34582 - Add policy streamed for smart-proxy

### DIFF
--- a/app/helpers/katello/concerns/smart_proxy_helper_extensions.rb
+++ b/app/helpers/katello/concerns/smart_proxy_helper_extensions.rb
@@ -36,6 +36,10 @@ module Katello
             :label => ::Katello::RootRepository::DOWNLOAD_IMMEDIATE
           },
           {
+            :name => _("Streamed"),
+            :label => SmartProxy::DOWNLOAD_STREAMED
+          },
+          {
             :name => _("Inherit from Repository"),
             :label => SmartProxy::DOWNLOAD_INHERIT
           }

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -22,7 +22,8 @@ module Katello
       CONTAINER_GATEWAY_FEATURE = "Container_Gateway".freeze
 
       DOWNLOAD_INHERIT = 'inherit'.freeze
-      DOWNLOAD_POLICIES = [::Katello::RootRepository::DOWNLOAD_ON_DEMAND, ::Katello::RootRepository::DOWNLOAD_IMMEDIATE, DOWNLOAD_INHERIT].freeze
+      DOWNLOAD_STREAMED = 'streamed'.freeze
+      DOWNLOAD_POLICIES = [::Katello::RootRepository::DOWNLOAD_ON_DEMAND, ::Katello::RootRepository::DOWNLOAD_IMMEDIATE, DOWNLOAD_INHERIT, DOWNLOAD_STREAMED].freeze
 
       included do
         include ForemanTasks::Concerns::ActionSubject


### PR DESCRIPTION
Adds SmartProxy download_policy `streamed`.
See https://docs.pulpproject.org/pulpcore/workflows/on-demand-downloading.html#overview