### PR TITLE
Fixes #34576 - Additional steps before deleting repo from CVs

### DIFF
--- a/app/models/katello/authorization/repository.rb
+++ b/app/models/katello/authorization/repository.rb
@@ -4,7 +4,7 @@ module Katello
 
     delegate :editable?, to: :product
 
-    def deletable?(remove_from_content_view_versions = false)
+    def deletable?(remove_from_content_view_versions = true)
       product.editable? && (remove_from_content_view_versions || !promoted? || !self.content_views.generated_for_none.exists?)
     end
 

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -158,7 +158,10 @@ class Setting::Content < Setting
                N_('Upload profiles without Dynflow')),
       self.set('orphan_protection_time', N_('Time in minutes to consider orphan content as orphaned.'), 1440, N_('Orphaned Content Protection Time')),
       self.set('remote_execution_prefer_registered_through_proxy', N_('Prefer using a proxy to which a host is registered when using remote execution'), false,
-               N_('Prefer registered through proxy for remote execution'))
+               N_('Prefer registered through proxy for remote execution')),
+      self.set('delete_repo_across_cv', N_("If this is enabled, repositories can be deleted even when they belong to published "\
+                 "content views. The deleted repository will be removed from all content view versions."),
+               true, N_('Allow deleting repositories in published content views'))
     ]
   end
 

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -70,7 +70,8 @@ end
 
 node :permissions do |repo|
   {
-    :deletable => repo.deletable?
+    :deletable => repo.deletable?,
+    :deletable_across_cv => Setting[:delete_repo_across_cv]
   }
 end
 

--- a/engines/bastion/app/assets/javascripts/bastion/components/bst-modal.directive.js
+++ b/engines/bastion/app/assets/javascripts/bastion/components/bst-modal.directive.js
@@ -59,6 +59,7 @@ angular.module('Bastion.components').directive('bstModal',
 
                     modalInstance.result.then(function () {
                         scope.action();
+                    }, function() {
                     });
                 };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details.controller.js
@@ -39,7 +39,12 @@
 
         $scope.repositoryWrapper = {
             repository: $scope.repository,
-            repositoryVersions: {}
+            repositoryVersions: {},
+            forceDelete: false
+        };
+
+        $scope.updateForceDelete = function () {
+            $scope.repositoryWrapper.forceDelete = !($scope.repositoryWrapper.forceDelete);
         };
 
         $scope.product = Product.get({id: $scope.$stateParams.productId}, function () {
@@ -144,7 +149,11 @@
                 if ($scope.denied('deletable', repo)) {
                     readOnlyReason = 'permissions';
                 }
+                if (readOnlyReason === null && !repo.permissions.deletable_across_cv && repo.content_view_versions.length > 0 ) {
+                    readOnlyReason = 'setting';
+                }
             }
+
             return readOnlyReason;
         };
     }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-details.html
@@ -78,6 +78,12 @@
                  tooltip-placement="left"
                  tooltip-append-to-body="true">
               </i>
+                <i class="fa fa-question-circle" ng-switch-when="setting"
+                   uib-tooltip="{{ 'Turn on Setting > Content > Allow deleting repositories in published content views' | translate }}"
+                   tooltip-animation="false"
+                   tooltip-placement="left"
+                   tooltip-append-to-body="true">
+              </i>
             </span>
           </span>
         </li>
@@ -113,9 +119,21 @@
                     </tbody>
                 </table>
             </div>
-            <span translate>Are you sure you want to remove repository {{ repositoryWrapper.repository.name }}?</span>
+            <input type="checkbox"
+                   ng-show="repositoryWrapper.repository.content_view_versions.length !== 0"
+                   ng-model="repositoryWrapper.forceDelete"
+                   ng-change="updateForceDelete()"/>
+            <span translate> Are you sure you want to remove repository {{ repositoryWrapper.repository.name }} from all content views?</span>
         </div>
-      </div>
+          <div data-block="modal-footer">
+            <span data-block="modal-confirm-button">
+              <button class="btn btn-danger" ng-disabled="repositoryWrapper.repository.content_view_versions.length !== 0 && !repositoryWrapper.forceDelete" ng-click="ok()">
+                <span translate>Delete</span>
+              </button>
+            </span>
+            <button class="btn btn-default" ng-click="cancel()" translate>Cancel</button>
+          </div>
+        </div>
     </span>
   </div>
 

--- a/engines/bastion_katello/test/products/details/repositories/details/repository-details.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/details/repository-details.controller.test.js
@@ -100,7 +100,7 @@ describe('Controller: RepositoryDetailsController', function() {
 
     it("should provide a valid reason for a repo deletion disablement", function() {
         var product = {id: 100, $resolved: true},
-            repository = {id: 200, $resolved: true};
+            repository = {id: 200, permissions: {deletable_across_cv: true}, $resolved: true};
 
         $scope.denied = function (perm, prod) {
             expect(perm).toBe("deletable");
@@ -113,6 +113,16 @@ describe('Controller: RepositoryDetailsController', function() {
             return false;
         };
         repository.promoted = true;
+        expect($scope.getRepoNonDeletableReason(repository, product)).toBe(null);
+        expect($scope.canRemove(repository, product)).toBe(true);
+
+        repository.promoted = true;
+        repository.permissions.deletable_across_cv = false;
+        repository.content_view_versions = ["id1", "id2"];
+        expect($scope.getRepoNonDeletableReason(repository, product)).toBe("setting");
+        expect($scope.canRemove(repository, product)).toBe(false);
+
+        repository.permissions.deletable_across_cv = true;
         expect($scope.getRepoNonDeletableReason(repository, product)).toBe(null);
         expect($scope.canRemove(repository, product)).toBe(true);
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Force deletion of repo should have additional layers of security when deleting repos from cv versions.
This PR adds an additional checkbox on the modal to confirm delete, and a setting which can be turned off to disallow force deletions of repositories.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1. Create a repo.
2. Add it to CVs and publish a few versions of those.
3. Go to Repo, action dropdown > Delete
4. You should see the modal with a checkbox.
5. Check it. Delete button should get enabled. Don't click it yet! Close the modal.
6. Go to settings > content > Allow deleting repositories in published content views : Set to No
7. Go back to same repo and Actions > Delete should not be an option. Instead you should see a Cannot remove with a help text.
8. Go to settings > content > Allow deleting repositories in published content views : Set to Yes
9. Go back to repository.
10. Delete. 

