### PR TITLE
Fixes #34586 - Add autocomplete for rpm and container rule modals

### DIFF
--- a/webpack/components/Search/Search.js
+++ b/webpack/components/Search/Search.js
@@ -23,6 +23,8 @@ const Search = ({
   foremanApiAutoComplete,
   bookmarkController,
   placeholder,
+  isTextInput,
+  setTextInputValue,
 }) => {
   const [items, setItems] = useState([]);
   const dispatch = useDispatch();
@@ -48,9 +50,16 @@ const Search = ({
       }
       // Checking whether the current component is mounted before state change events
       if (!mountedRef.current) return;
-      setItems(data?.data?.filter(({ error }) => !error).map(({ label }) => ({
-        text: label.trim(),
-      })));
+      switch (true) {
+      case endpoint.includes('auto_complete_arch'):
+      case endpoint.includes('auto_complete_name'):
+        setItems(data?.data?.map(label => ({ text: label.trim() })));
+        break;
+      default:
+        setItems(data?.data?.filter(({ error }) => !error).map(({ label }) => ({
+          text: label.trim(),
+        })));
+      }
     }
 
     if (autoSearchEnabled && patternfly4) {
@@ -83,6 +92,8 @@ const Search = ({
         patternfly4={patternfly4}
         autoSearchEnabled={autoSearchEnabled}
         placeholder={placeholder}
+        isTextInput={isTextInput}
+        setTextInputValue={setTextInputValue}
       />
     </div>
   );
@@ -102,6 +113,8 @@ Search.propTypes = {
   }),
   bookmarkController: PropTypes.string,
   placeholder: PropTypes.string,
+  isTextInput: PropTypes.bool,
+  setTextInputValue: PropTypes.func,
 };
 
 Search.defaultProps = {
@@ -115,6 +128,8 @@ Search.defaultProps = {
   isDisabled: undefined,
   bookmarkController: undefined,
   placeholder: undefined,
+  isTextInput: false,
+  setTextInputValue: undefined,
 };
 
 export default Search;

--- a/webpack/components/TypeAhead/TypeAhead.js
+++ b/webpack/components/TypeAhead/TypeAhead.js
@@ -23,6 +23,8 @@ const TypeAhead = ({
   autoSearchDelay,
   bookmarkController,
   placeholder,
+  isTextInput,
+  setTextInputValue,
 }) => {
   const [inputValue, setInputValue] = useState(initialInputValue);
 
@@ -38,6 +40,7 @@ const TypeAhead = ({
   const handleStateChange = ({ inputValue: value }) => {
     if (typeof value === 'string') {
       setInputValue(value);
+      if (setTextInputValue) setTextInputValue(value);
     }
   };
 
@@ -82,6 +85,7 @@ const TypeAhead = ({
           activeItems,
           placeholder,
           shouldShowItems: isOpen && items.length > 0,
+          isTextInput,
         };
 
         return (
@@ -115,6 +119,8 @@ TypeAhead.propTypes = {
   autoSearchDelay: PropTypes.number,
   bookmarkController: PropTypes.string,
   placeholder: PropTypes.string,
+  isTextInput: PropTypes.bool,
+  setTextInputValue: PropTypes.func,
 };
 
 TypeAhead.defaultProps = {
@@ -125,6 +131,8 @@ TypeAhead.defaultProps = {
   autoSearchDelay: 500,
   bookmarkController: undefined,
   placeholder: undefined,
+  isTextInput: false,
+  setTextInputValue: undefined,
 };
 
 export default TypeAhead;

--- a/webpack/components/TypeAhead/pf4Search/TypeAheadInput.js
+++ b/webpack/components/TypeAhead/pf4Search/TypeAheadInput.js
@@ -8,7 +8,7 @@ import { commonInputPropTypes } from '../helpers/commonPropTypes';
 import './TypeAheadInput.scss';
 
 const TypeAheadInput = ({
-  onKeyPress, onInputFocus, passedProps, isDisabled, autoSearchEnabled, placeholder,
+  onKeyPress, onInputFocus, passedProps, isDisabled, autoSearchEnabled, placeholder, isTextInput,
 }) => {
   const inputRef = useRef(null);
   const {
@@ -31,19 +31,19 @@ const TypeAheadInput = ({
         onFocus={onInputFocus}
         aria-label="text input for search"
         onChange={onChangeWrapper}
-        type="search"
-        iconVariant={autoSearchEnabled && 'search'}
+        type="text"
+        iconVariant={autoSearchEnabled && !isTextInput ? 'search' : undefined}
         placeholder={placeholder}
       />
       {
-        value && (
-          <Button
-            variant={autoSearchEnabled ? 'plain' : 'control'}
-            className="search-clear"
-            onClick={clearSearch}
-          >
-            <TimesIcon />
-          </Button>)}
+        (value && !isTextInput) &&
+        <Button
+          variant={autoSearchEnabled ? 'plain' : 'control'}
+          className="search-clear"
+          onClick={clearSearch}
+        >
+          <TimesIcon />
+        </Button>}
     </>);
 };
 
@@ -52,11 +52,13 @@ TypeAheadInput.propTypes = {
   autoSearchEnabled: PropTypes.bool.isRequired,
   ...commonInputPropTypes,
   placeholder: PropTypes.string,
+  isTextInput: PropTypes.bool,
 };
 
 TypeAheadInput.defaultProps = {
   isDisabled: undefined,
   placeholder: '',
+  isTextInput: false,
 };
 
 export default TypeAheadInput;

--- a/webpack/components/TypeAhead/pf4Search/TypeAheadSearch.js
+++ b/webpack/components/TypeAhead/pf4Search/TypeAheadSearch.js
@@ -12,7 +12,7 @@ import Bookmark from './../../../components/Bookmark';
 const TypeAheadSearch = ({
   userInputValue, clearSearch, getInputProps, getItemProps, isOpen, highlightedIndex,
   selectedItem, selectItem, openMenu, onSearch, items, activeItems, shouldShowItems,
-  autoSearchEnabled, isDisabled, bookmarkController, inputValue, placeholder,
+  autoSearchEnabled, isDisabled, bookmarkController, inputValue, placeholder, isTextInput,
 }) => (
   <>
     <InputGroup>
@@ -35,6 +35,7 @@ const TypeAheadSearch = ({
         passedProps={{ ...getInputProps(), clearSearch }}
         autoSearchEnabled={autoSearchEnabled}
         placeholder={placeholder}
+        isTextInput={isTextInput}
       />
       <>
         {bookmarkController &&
@@ -46,7 +47,7 @@ const TypeAheadSearch = ({
             }}
             controller={bookmarkController}
           />}
-        {!autoSearchEnabled &&
+        {(!autoSearchEnabled && !isTextInput) &&
           <Button aria-label="search button" variant="control" onClick={() => onSearch(inputValue)}>
             <SearchIcon />
           </Button>}
@@ -65,12 +66,14 @@ TypeAheadSearch.propTypes = {
   isDisabled: PropTypes.bool,
   autoSearchEnabled: PropTypes.bool.isRequired,
   bookmarkController: PropTypes.string,
+  isTextInput: PropTypes.bool,
   ...commonSearchPropTypes,
 };
 
 TypeAheadSearch.defaultProps = {
   bookmarkController: undefined,
   isDisabled: undefined,
+  isTextInput: false,
 };
 
 export default TypeAheadSearch;

--- a/webpack/scenes/ContentViews/Details/Filters/CVContainerImageFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVContainerImageFilterContent.js
@@ -65,6 +65,8 @@ const CVContainerImageFilterContent = ({
     __('Tag name'),
   ];
 
+  const repositoryIds = details.repository_ids;
+
   const bulkRemove = () => {
     setBulkActionOpen(false);
     const tagFilterIds =
@@ -163,7 +165,7 @@ const CVContainerImageFilterContent = ({
                 {modalOpen &&
                   <AddEditContainerTagRuleModal
                     {...{
-                      filterId, selectedFilterRuleData, onClose,
+                      filterId, selectedFilterRuleData, onClose, repositoryIds,
                     }}
                   />
                 }
@@ -189,6 +191,7 @@ CVContainerImageFilterContent.propTypes = {
   showAffectedRepos: PropTypes.bool,
   setShowAffectedRepos: PropTypes.func,
   details: PropTypes.shape({
+    repository_ids: PropTypes.arrayOf(PropTypes.number),
     permissions: PropTypes.shape({}),
   }).isRequired,
 };

--- a/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
@@ -207,6 +207,7 @@ const CVRpmFilterContent = ({
                     filterId={filterId}
                     onClose={onClose}
                     selectedFilterRuleData={selectedFilterRuleData}
+                    repositoryIds={details.repository_ids}
                   />}
               </>}
           />
@@ -230,6 +231,7 @@ CVRpmFilterContent.propTypes = {
   setShowAffectedRepos: PropTypes.func.isRequired,
   details: PropTypes.shape({
     permissions: PropTypes.shape({}),
+    repository_ids: PropTypes.arrayOf(PropTypes.number),
   }).isRequired,
 };
 

--- a/webpack/scenes/ContentViews/Details/Filters/Rules/ContainerTag/AddEditContainerTagRuleModal.js
+++ b/webpack/scenes/ContentViews/Details/Filters/Rules/ContainerTag/AddEditContainerTagRuleModal.js
@@ -2,17 +2,21 @@ import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { Modal, ModalVariant, Form, FormGroup, TextInput, ActionGroup, Button } from '@patternfly/react-core';
+import { Modal, ModalVariant, Form, FormGroup, ActionGroup, Button } from '@patternfly/react-core';
 import { addCVFilterRule, editCVFilterRule, getCVFilterRules } from '../../../ContentViewDetailActions';
+import { orgId } from '../../../../../../services/api';
+import Search from '../../../../../../components/Search/Search';
 
 const AddEditContainerTagRuleModal = ({
-  onClose, filterId, selectedFilterRuleData,
+  onClose, filterId, selectedFilterRuleData, repositoryIds,
 }) => {
   const { name, id } = selectedFilterRuleData;
   const dispatch = useDispatch();
   const [tagName, setTagName] = useState(name);
   const [saving, setSaving] = useState(false);
   const isEditing = name && id;
+
+  const autoCompleteEndpoint = '/docker_tags/auto_complete_name';
 
   const onSubmit = () => {
     setSaving(true);
@@ -32,6 +36,15 @@ const AddEditContainerTagRuleModal = ({
     onClose();
   };
 
+  const getAutoCompleteParams = term => ({
+    endpoint: autoCompleteEndpoint,
+    params: {
+      organization_id: orgId(),
+      term,
+      repoids: repositoryIds,
+    },
+  });
+
   return (
     <Modal
       title={isEditing ? __('Edit filter rule') : __('Add filter rule')}
@@ -46,15 +59,14 @@ const AddEditContainerTagRuleModal = ({
       }}
       >
         <FormGroup label={__('Tag name')} isRequired fieldId="tag_name">
-          <TextInput
-            autoFocus
-            isRequired
-            type="text"
-            id="tag_name"
-            aria-label="input_tag"
-            name="tagName"
-            value={tagName}
-            onChange={value => setTagName(value)}
+          <Search
+            patternfly4
+            initialInputValue={tagName}
+            onSearch={() => {}}
+            getAutoCompleteParams={getAutoCompleteParams}
+            foremanApiAutoComplete={false}
+            isTextInput
+            setTextInputValue={setTagName}
           />
         </FormGroup>
         <ActionGroup>
@@ -82,10 +94,12 @@ AddEditContainerTagRuleModal.propTypes = {
     name: PropTypes.string,
     id: PropTypes.number,
   }),
+  repositoryIds: PropTypes.arrayOf(PropTypes.number),
 };
 
 AddEditContainerTagRuleModal.defaultProps = {
   selectedFilterRuleData: { name: '', id: undefined },
+  repositoryIds: [],
 };
 
 export default AddEditContainerTagRuleModal;

--- a/webpack/scenes/ContentViews/Details/Filters/Rules/Package/AddEditPackageRuleModal.js
+++ b/webpack/scenes/ContentViews/Details/Filters/Rules/Package/AddEditPackageRuleModal.js
@@ -12,8 +12,12 @@ import { addCVFilterRule, editCVFilterRule, getCVFilterRules } from '../../../Co
 import {
   selectCreateFilterRuleStatus,
 } from '../../../ContentViewDetailSelectors';
+import { orgId } from '../../../../../../services/api';
+import Search from '../../../../../../components/Search/Search';
 
-const AddEditPackageRuleModal = ({ filterId, onClose, selectedFilterRuleData }) => {
+const AddEditPackageRuleModal = ({
+  filterId, onClose, selectedFilterRuleData, repositoryIds,
+}) => {
   const {
     id: editingId,
     name: editingName,
@@ -22,6 +26,9 @@ const AddEditPackageRuleModal = ({ filterId, onClose, selectedFilterRuleData }) 
     min_version: editingMinVersion,
     max_version: editingMaxVersion,
   } = selectedFilterRuleData || {};
+
+  const architectureAutoCompleteEndpoint = '/packages/auto_complete_arch';
+  const nameAutoCompleteEndpoint = '/packages/auto_complete_name';
 
   const isEditing = !!selectedFilterRuleData;
 
@@ -111,6 +118,16 @@ const AddEditPackageRuleModal = ({ filterId, onClose, selectedFilterRuleData }) 
     }
   }, [status, setSaving]);
 
+  const getAutoCompleteParams = (term, autoCompleteEndpoint) => ({
+    endpoint: autoCompleteEndpoint,
+    params: {
+      organization_id: orgId(),
+      term,
+      repoids: repositoryIds,
+      non_modular: true,
+    },
+  });
+
   return (
     <Modal
       title={selectedFilterRuleData ? __('Edit RPM rule') : __('Add RPM rule')}
@@ -125,24 +142,26 @@ const AddEditPackageRuleModal = ({ filterId, onClose, selectedFilterRuleData }) 
       }}
       >
         <FormGroup label={__('RPM name')} isRequired fieldId="name">
-          <TextInput
-            isRequired
-            type="text"
-            id="name"
-            aria-label="input_name"
-            name="name"
-            value={name}
-            onChange={value => setName(value)}
+          <Search
+            patternfly4
+            initialInputValue={name}
+            onSearch={() => {}}
+            getAutoCompleteParams={term => getAutoCompleteParams(term, nameAutoCompleteEndpoint)}
+            foremanApiAutoComplete={false}
+            isTextInput
+            setTextInputValue={setName}
           />
         </FormGroup>
         <FormGroup label={__('Architecture')} fieldId="architecture">
-          <TextInput
-            type="text"
-            id="architecture"
-            aria-label="input_architecture"
-            name="architecture"
-            value={architecture}
-            onChange={value => setArchitecture(value)}
+          <Search
+            patternfly4
+            initialInputValue={architecture}
+            onSearch={() => {}}
+            getAutoCompleteParams={term =>
+              getAutoCompleteParams(term, architectureAutoCompleteEndpoint)}
+            foremanApiAutoComplete={false}
+            isTextInput
+            setTextInputValue={setArchitecture}
           />
         </FormGroup>
         <FormGroup label={__('Version')} fieldId="version_comparator">
@@ -221,11 +240,13 @@ AddEditPackageRuleModal.propTypes = {
     min_version: PropTypes.string,
     max_version: PropTypes.string,
   }),
+  repositoryIds: PropTypes.arrayOf(PropTypes.number),
 };
 
 AddEditPackageRuleModal.defaultProps = {
   onClose: null,
   selectedFilterRuleData: undefined,
+  repositoryIds: [],
 };
 
 export default AddEditPackageRuleModal;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds autocomplete for the Name and Architecture fields when adding/editing a CV filter rpm rule.  Adds autocomplete for name field when adding CV filter Container Tag rule.
#### Considerations taken when implementing this change?
The search component (and related components) had 99% of what was needed to do this, so I tried to adapt it for text inputs instead of search bars.
#### What are the testing steps for this pull request?
1. Create yum and docker repositories with content.
1. In UI, Content -> Content View
2. Select any CV -> Go to "Filters" tab
3. Create "Create filter" -> Type: RPM -> Add RPM rule
4. Click in the Name box, should see autocomplete pop up for the names of the packages.
5. Click the architecture box, should see autocomplete.
6. Same thing when editing the rule.
7. Test similarly for Container Tag filter.