### PR TITLE
Fixes #34429 - properly return gpg key in repos json

### DIFF
--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -48,8 +48,8 @@ glue(@resource.root) do
     attributes :id => @resource.root&.ssl_client_key&.id, :name => @resource.root&.ssl_client_key&.name
   end
 
-  child :gpg_key do
-    attributes :id, :name
+  node :gpg_key do
+    attributes :id => @resource.root&.gpg_key&.id, :name => @resource.root&.gpg_key&.name
   end
 end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?
it seems like :child doesn't work within a glue() block in rabl, i'm unsure why, but other content credentials are done this way.

#### What are the testing steps for this pull request?
1.  create a content credential gpg key
2. create a repository, set the gpg key on the repository
3. visit the repo details page, verify that you can see the gpg key name in the ui