### PR TITLE
Fixes #34597 - ignore remote options when there are none

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
@@ -244,11 +244,11 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
             $scope.$watch('repository.content_type', function () {
                 var remOptions, optionIndex;
                 $scope.genericRemoteOptions = RepositoryTypesService.getAttribute($scope.repository, "generic_remote_options");
-                if ($scope.genericRemoteOptions && $scope.genericRemoteOptions !== []) {
+                if ($scope.genericRemoteOptions && $scope.genericRemoteOptions !== [] && $scope.repository.generic_remote_options) {
                     remOptions = angular.fromJson($scope.repository.generic_remote_options);
-                    Object.keys(remOptions).forEach(function(key) {
+                    Object.keys(remOptions).forEach(function (key) {
                         if (remOptions[key]) {
-                            optionIndex = $scope.genericRemoteOptions.map(function(option) {
+                            optionIndex = $scope.genericRemoteOptions.map(function (option) {
                                 return option.name;
                             }).indexOf(key);
                             $scope.genericRemoteOptions[optionIndex].value = remOptions[key].join($scope.genericRemoteOptions[optionIndex].delimiter);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?
Not all repo types have generic remote options, if some repo doesn't, then this errors.

#### What are the testing steps for this pull request?
1. create a yum repo
2. visit the repo details page
3. check your browser console, before this change you should see an error.
4. create a python repo and make sure includes/excludes still show up on the repo details page
