### PR TITLE
Fixes #34591 - migrate deb-repo attributes

### DIFF
--- a/lib/katello/tasks/pulp2to3_migrate_deb_attributes.rake
+++ b/lib/katello/tasks/pulp2to3_migrate_deb_attributes.rake
@@ -1,0 +1,20 @@
+namespace :katello do
+  desc "Migrate deb content attributes to Pulp3"
+  task :migrate_deb_content_attributes_to_pulp3 => ["environment", "check_ping"] do
+    User.current = User.anonymous_api_admin
+    repos = Katello::Repository.deb_type.where(library_instance_id: nil)
+
+    repos.find_each.with_index do |repo, index|
+      puts "Processing Repository #{index + 1}/#{repos.count}: #{repo.name} (#{repo.id})"
+      begin
+        ForemanTasks.sync_task(::Actions::Katello::Repository::Update, repo.root,
+                               download_policy: 'immediate',
+                               deb_architectures: repo.root.deb_architectures&.gsub(',', ' '),
+                               deb_releases: repo.root.deb_releases&.gsub(',', ' ') || 'stable',
+                               deb_components: repo.root.deb_components&.gsub(',', ' '))
+      rescue => e
+        puts "Failed to update repository #{repo.name} (#{repo.id}): #{e.message}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
For APT repositories this fix makes sure that:

1. `download_policy` is set (default: immediate): Introduced in Katello-4.3 (https://github.com/Katello/katello/commit/53a31d6b8aaf4ba3a296e31b1dda7ee125b383ad)
2. `releases` is set (default: stable): requirement of pulp3; was implicitly assumed as stable by pulp2
3. `releases`, `architectures`, `components` are space-separated lists: pulp2 used comma-separation

We tried to do this as an upgrades-task but that failed due to dynflow not being available at the time they run during foreman-installer