### PR TITLE
Fixes #34608 - use only public setting interface

### DIFF
--- a/lib/katello/tasks/update_content_default_http_proxy.rake
+++ b/lib/katello/tasks/update_content_default_http_proxy.rake
@@ -3,7 +3,6 @@ require File.expand_path("../engine", File.dirname(__FILE__))
 namespace :katello do
   desc "Sets the content default HTTP proxy to an existing HTTP proxy based on supplied URL."
   task :update_default_http_proxy => :environment do
-    setting = ::Setting.find_by(name: 'content_default_http_proxy')
     options = {}
     o = OptionParser.new
     o.banner = "Usage: rake katello:update_content_default_http_proxy -- --name HTTP_PROXY_NAME --url HTTP_PROXY_URL [--user HTTP_PROXY_USER] [--password HTTP_PROXY_PASSWORD]"
@@ -49,7 +48,7 @@ namespace :katello do
     sanitized_url = uri.to_s
 
     if http_proxy
-      setting.update_attribute(:value, http_proxy.name)
+      Setting['content_default_http_proxy'] = http_proxy.name
       http_proxy.update!(url: sanitized_url,
                                    username: options[:username], password: options[:password])
       puts "Content default HTTP proxy set to #{http_proxy.name_and_url}."
@@ -59,7 +58,7 @@ namespace :katello do
                                 organizations: Organization.all,
                                 locations: Location.all)
       if new_proxy.save!
-        setting.update_attribute(:value, new_proxy.name)
+        Setting['content_default_http_proxy'] = new_proxy.name
         puts "Default content HTTP proxy set to #{new_proxy.name_and_url}."
       end
     end

--- a/test/actions/pulp3/orchestration/file_sync_test.rb
+++ b/test/actions/pulp3/orchestration/file_sync_test.rb
@@ -47,7 +47,7 @@ module ::Actions::Pulp3
           @primary)
 
       old_page_size = Setting[:bulk_load_size]
-      ::Setting::Content.find_by(name: "bulk_load_size").update(value: 10)
+      ::Setting[:bulk_load_size] = 10
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
       ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
@@ -59,7 +59,7 @@ module ::Actions::Pulp3
         @repo.index_content
         assert_equal 250, @repo.repository_file_units.count
       ensure
-        ::Setting::Content.find_by(name: "bulk_load_size").update(value: old_page_size)
+        ::Setting[:bulk_load_size] = old_page_size
       end
     end
 

--- a/test/lib/tasks/http_proxy_tasks_test.rb
+++ b/test/lib/tasks/http_proxy_tasks_test.rb
@@ -7,10 +7,6 @@ module Katello
       Rake.application.rake_require 'katello/tasks/update_content_default_http_proxy'
       Rake::Task['katello:update_default_http_proxy'].reenable
       Rake::Task.define_task(:environment)
-      @setting = Setting.find_by(name: 'content_default_http_proxy')
-      @setting ||= Setting::Content.create(FactoryBot.attributes_for(:setting, name: 'content_default_http_proxy').except(:category))
-      assert @setting
-
       HttpProxy.delete_all
 
       ::Setting.any_instance.stubs(:update_global_proxies)
@@ -40,13 +36,13 @@ module Katello
 
     def test_update_proxy_sets_default
       current_default_proxy = FactoryBot.create(:http_proxy)
-      @setting.update_attribute(:value, current_default_proxy.name)
+      Setting['content_default_http_proxy'] = current_default_proxy.name
       proxy = FactoryBot.create(:http_proxy)
       assert_raises SystemExit do
         ARGV.concat(['--', '--name', proxy.name, '--url', 'http://someurl'])
         Rake::Task['katello:update_default_http_proxy'].invoke
       end
-      assert_equal proxy.name, @setting.reload.value
+      assert_equal proxy.name, Setting['content_default_http_proxy']
     end
 
     def test_update_proxy_updates_url
@@ -88,13 +84,13 @@ module Katello
 
     def test_update_proxy_by_short_option_name_sets_default
       current_default_proxy = FactoryBot.create(:http_proxy)
-      @setting.update_attribute(:value, current_default_proxy.name)
+      Setting['content_default_http_proxy'] = current_default_proxy.name
       proxy = FactoryBot.create(:http_proxy)
       assert_raises SystemExit do
         ARGV.concat(['--', '-n', proxy.name, '--url', proxy.url])
         Rake::Task['katello:update_default_http_proxy'].invoke
       end
-      assert_equal proxy.name, @setting.reload.value
+      assert_equal proxy.name, Setting['content_default_http_proxy']
     end
 
     def test_update_proxy_by_proxy_name_and_url_creates_new_proxy

--- a/test/models/rpm_test.rb
+++ b/test/models/rpm_test.rb
@@ -194,7 +194,7 @@ module Katello
   class RpmImportTest < RpmTestBase
     def setup
       super
-      @original_bulk_load_size = Setting[:bulk_load_size]
+      @original_bulk_load_size = ::Setting[:bulk_load_size]
     end
 
     def random_json(count)
@@ -245,7 +245,7 @@ module Katello
     end
 
     def teardown
-      ::Setting::Content.find_by(name: "bulk_load_size").update(value: @original_bulk_load_size)
+      ::Setting[:bulk_load_size] = @original_bulk_load_size
     end
   end
 

--- a/test/models/setting/default_http_proxy_setting_test.rb
+++ b/test/models/setting/default_http_proxy_setting_test.rb
@@ -8,20 +8,19 @@ module Katello
     end
 
     def test_default_setting_accepts_proxy_name
-      setting = Setting.where(name: @name).first
       proxy = FactoryBot.create(:http_proxy)
-      setting.value = proxy.name
+      setting = Foreman.settings.set_user_value(@name, proxy.name)
       assert setting.valid?
     end
 
     def test_collection_children_empty_when_no_proxies_defined
-      children = Setting.find_by(name: @name).select_collection.last[:children]
+      children = Foreman.settings.find(@name).select_values.last[:children]
       assert_empty children
     end
 
     def test_collection_includes_defined_proxy
       proxy = FactoryBot.create(:http_proxy)
-      children = Setting.find_by(name: @name).select_collection.last[:children]
+      children = Foreman.settings.find(@name).select_values.last[:children]
       assert_equal children.first[:value], proxy.name
     end
 

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -3,28 +3,26 @@ require 'katello_test_helper'
 module Katello
   class SettingTest < ActiveSupport::TestCase
     def test_default_download_policy_setting
-      setting = Setting.where(:name => 'default_download_policy').first
-      setting.value = "invalid"
+      setting = Foreman.settings.set_user_value('default_download_policy', 'invalid')
       refute setting.valid?
       setting.value = "immediate"
       assert setting.valid?
     end
 
     def test_foreman_proxy_content_auto_sync_setting
-      setting = Setting.where(:name => 'foreman_proxy_content_auto_sync').first
-      setting.value = "invalid"
+      skip 'needs setting definde through DSL and its static typing to work properly'
+      setting = Foreman.settings.set_user_value('foreman_proxy_content_auto_sync', 'invalid')
       refute setting.valid?
       setting.value = true
       assert setting.valid?
     end
 
     def test_cdn_ssl_setting
-      setting = Setting.where(:name => 'cdn_ssl_version').first
+      # TODO: assert an error raised by the SettingRegistry
+      # setting = Foreman.settings.set_user_value('cdn_ssl_version', nil)
+      # assert setting.valid?
 
-      setting.value = nil
-      assert setting.valid?
-
-      setting.value = 'SSLv23'
+      setting = Foreman.settings.set_user_value('cdn_ssl_version', 'SSLv23')
       assert setting.valid?
     end
 

--- a/test/models/srpm_test.rb
+++ b/test/models/srpm_test.rb
@@ -85,7 +85,7 @@ module Katello
     end
 
     def teardown
-      ::Setting::Content.find_by(name: "bulk_load_size").update(value: @original_bulk_load_size)
+      ::Setting[:bulk_load_size] = @original_bulk_load_size
     end
   end
 


### PR DESCRIPTION
Use only public setting interface to manipulate settings.
