### PR TITLE
Fixes #34609 - Entitlement report double counts consumed entitlements

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -424,6 +424,12 @@ module Katello
         ::Katello::Erratum.installable_for_hosts([self]).search_for(search).pluck(:errata_id)
       end
 
+      def filtered_entitlement_quantity_consumed(pool)
+        entitlements = subscription_facet.candlepin_consumer.filter_entitlements(pool.cp_id)
+        return nil if entitlements.empty?
+        entitlements.sum { |e| e[:quantity] }
+      end
+
       protected
 
       def update_trace_status
@@ -441,7 +447,8 @@ end
 class ::Host::Managed::Jail < Safemode::Jail
   allow :content_source, :subscription_manager_configuration_url, :rhsm_organization_label,
         :host_collections, :pools, :hypervisor_host, :lifecycle_environment, :content_view,
-        :installed_packages, :traces_helpers, :advisory_ids, :package_names_for_job_template
+        :installed_packages, :traces_helpers, :advisory_ids, :package_names_for_job_template,
+        :filtered_entitlement_quantity_consumed
 end
 
 class ActiveRecord::Associations::CollectionProxy::Jail < Safemode::Jail


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds a method to grab the number of entitlements that a host in consuming for a particular pool.  Intended to be tested in conjunction with the report template change over in the Foreman repo: https://github.com/theforeman/foreman/pull/9151

The main issue is that `pool.consumed` is a global value, not per-host.  The report template is generating values per-host, so it makes much more sense to have this value be per-host as well.

#### Considerations taken when implementing this change?
It doesn't appear that we store this entitlement "quantity" value since it's also fetched from the Candlepin API for a host's add/list subscriptions page.

#### What are the testing steps for this pull request?
1) Register two content hosts.
2) Attach some subscriptions to both the hosts. Make sure that the hosts get some overlapping subscriptions.
3) Generate the Subscription - Entitlement Report.
4) See that the "Consumed" amount is both the same for all hosts and incorrect (too high and is actually the count across all hosts).
5) Apply this PR and the Foreman PR.
6) `bundle exec rake db:seed`
7) Ensure the report template changed and regenerate it. 
8) Check that the consumed amount is now correctly reflected for each host.