### PR TITLE
Fixes #34617 - correct ssl verify param for repo discovery

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
@@ -246,6 +246,9 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                 $scope.genericRemoteOptions = RepositoryTypesService.getAttribute($scope.repository, "generic_remote_options");
                 if ($scope.genericRemoteOptions && $scope.genericRemoteOptions !== []) {
                     remOptions = angular.fromJson($scope.repository.generic_remote_options);
+                    if (remOptions === null) {
+                        return null;
+                    }
                     Object.keys(remOptions).forEach(function(key) {
                         if (remOptions[key]) {
                             optionIndex = $scope.genericRemoteOptions.map(function(option) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery-create.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery-create.controller.js
@@ -37,7 +37,7 @@ angular.module('Bastion.products').controller('DiscoveryCreateController',
                 'content_type': repo.contentType,
                 'product_id': $scope.createRepoChoices.existingProductId,
                 unprotected: $scope.createRepoChoices.unprotected,
-                'verify_ssl': $scope.createRepoChoices.verifySsl,
+                'verify_ssl_on_sync': $scope.createRepoChoices.verifySsl,
                 'upstream_username': $scope.createRepoChoices.upstreamUsername,
                 'upstream_password': $scope.createRepoChoices.upstreamPassword
             };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery-create.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery-create.html
@@ -53,7 +53,7 @@
     <div class="checkbox" ng-show="discovery.contentType === 'yum'">
       <label>
         <input type="checkbox" id="unprotected" ng-model="createRepoChoices.unprotected" ng-disabled="creating()"/>
-        <span translate>Serve via HTTP</span>
+        <span translate>Unprotected</span>
       </label>
     </div>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.routes.js
@@ -43,6 +43,7 @@ angular.module('Bastion.products').config(['$stateProvider', function ($statePro
 
     $stateProvider.state("product-discovery", {
         url: '/products/discovery',
+        controller: 'DiscoveryController',
         templateUrl: 'products/discovery/views/discovery-base.html',
         permission: 'edit_products',
         redirectTo: 'product-discovery.scan'

--- a/engines/bastion_katello/test/products/discovery/discovery.controller.test.js
+++ b/engines/bastion_katello/test/products/discovery/discovery.controller.test.js
@@ -111,6 +111,7 @@ describe('Controller: DiscoveryController', function() {
 
         $scope.discover();
 
+        expect($scope.discovery.contentType === 'yum');
         expect(Organization.repoDiscover).toHaveBeenCalledWith({id: CurrentOrganization, url: 'http://fake/', 'content_type': 'yum', upstream_username: undefined, upstream_password: undefined, search: undefined},
                                                                jasmine.any(Function));
     });


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

We didn't have the correct param name for `verify_ssl` so that change was not getting sent to the controller correctly. 

We also in PR `Don't set global RestClient proxy during repo discover` removed the controller so none of the $scope objects from the parent controller were being passed down to the child controller which hid the unprotected button since that relies on the `content_type` being presented.

Updated HTTP to Unprotected so it matches all the other areas in the UI

Fixed a bug in this area of the code `https://github.com/Katello/katello/compare/master...chris1984:repooptions?expand=1#diff-5bfbc5a1b463f777363008fbee07e08560eb30b959f14cc6745d2571fb57ff9b` that was causing this error to show in the console when viewing a repo:

```javascript
TypeError: Cannot convert undefined or null to object
    at Function.getOwnPropertyNames (<anonymous>)
    at Function.../vendor-core/node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js.Object.keys (webcomponents-bundle.js:81:180)
    at repository-details-info.controller.source.js:249:1
    at Scope.$digest (angular.source.js:19270:1)
    at Scope.$apply (angular.source.js:19630:1)
    at done (angular.source.js:13473:1)
    at completeRequest (angular.source.js:13730:1)
    at XMLHttpRequest.requestLoaded (angular.source.js:13635:1)
```

#### Considerations taken when implementing this change?

Made sure nothing else was broke and added test coverage to make sure the parent controller param gets passed down correctly.

#### What are the testing steps for this pull request?

* Apply patch
* In Products, Repo discovery, search a URL and create a repo:
  * https://repos.fedorapeople.org/pulp/pulp/demo_repos/
* Play with the check boxes to make sure they both work correctly when doing the repo create
* Verify there are no console errors during the creation.
