### PR TITLE
Fixes #34620 - Show toast linking to REX job

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.js
@@ -64,7 +64,6 @@ const InstallDropdown = ({
       onSelect={onActionSelect}
       toggle={
         <DropdownToggle
-          isPrimary
           isDisabled={isDisabled}
           splitButtonItems={[
             <DropdownToggleAction key="install" onClick={defaultRemoteAction}>
@@ -72,6 +71,7 @@ const InstallDropdown = ({
             </DropdownToggleAction>,
           ]}
           splitButtonVariant="action"
+          toggleVariant="primary"
           toggleIndicator={isActionOpen ? CaretUpIcon : CaretDownIcon}
           onToggle={onActionToggle}
         />

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -286,6 +286,7 @@ export const PackagesTab = () => {
                   ]}
                   isDisabled={disableUpgrade()}
                   splitButtonVariant="action"
+                  toggleVariant="primary"
                   onToggle={onActionToggle}
                 />
               }
@@ -306,7 +307,7 @@ export const PackagesTab = () => {
     </Split>
   );
 
-  const toggleGroup = (
+  const statusFilters = (
     <Split hasGutter>
       <SplitItem>
         <SelectableDropdown
@@ -339,7 +340,7 @@ export const PackagesTab = () => {
             actionButtons,
             searchQuery,
             updateSearchQuery,
-            toggleGroup,
+            toggleGroup: statusFilters,
             selectedCount,
             selectNone,
             areAllRowsSelected,

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
@@ -82,7 +82,7 @@ export const installPackage = ({ hostname, packageName }) => post({
   url: foremanApi.getApiUrl('/job_invocations'),
   params: katelloPackageInstallParams({ hostname, packageName }),
   handleSuccess: showRexToast,
-  errorToast: error => errorToast(error),
+  errorToast,
 });
 
 export const installPackageBySearch = ({ hostname, search }) => post({
@@ -91,7 +91,7 @@ export const installPackageBySearch = ({ hostname, search }) => post({
   url: foremanApi.getApiUrl('/job_invocations'),
   params: katelloPackageInstallBySearchParams({ hostname, search }),
   handleSuccess: showRexToast,
-  errorToast: error => errorToast(error),
+  errorToast,
 });
 
 export const removePackage = ({ hostname, packageName }) => post({
@@ -100,7 +100,7 @@ export const removePackage = ({ hostname, packageName }) => post({
   url: foremanApi.getApiUrl('/job_invocations'),
   params: katelloPackageRemoveParams({ hostname, packageName }),
   handleSuccess: showRexToast,
-  errorToast: error => errorToast(error),
+  errorToast,
 });
 
 export const removePackages = ({ hostname, search }) => post({
@@ -109,7 +109,7 @@ export const removePackages = ({ hostname, search }) => post({
   url: foremanApi.getApiUrl('/job_invocations'),
   params: katelloPackagesRemoveParams({ hostname, search }),
   handleSuccess: showRexToast,
-  errorToast: error => errorToast(error),
+  errorToast,
 });
 
 export const updatePackage = ({ hostname, packageName }) => post({
@@ -118,7 +118,7 @@ export const updatePackage = ({ hostname, packageName }) => post({
   url: foremanApi.getApiUrl('/job_invocations'),
   params: katelloPackageUpdateParams({ hostname, packageName }),
   handleSuccess: showRexToast,
-  errorToast: error => errorToast(error),
+  errorToast,
 });
 
 export const updatePackages = ({ hostname, search }) => post({
@@ -127,7 +127,7 @@ export const updatePackages = ({ hostname, search }) => post({
   url: foremanApi.getApiUrl('/job_invocations'),
   params: katelloPackagesUpdateParams({ hostname, search }),
   handleSuccess: showRexToast,
-  errorToast: error => errorToast(error),
+  errorToast,
 });
 
 export const resolveTraces = ({ hostname, search }) => post({
@@ -136,7 +136,7 @@ export const resolveTraces = ({ hostname, search }) => post({
   url: foremanApi.getApiUrl('/job_invocations'),
   params: katelloTracerResolveParams({ hostname, search }),
   handleSuccess: showRexToast,
-  errorToast: error => errorToast(error),
+  errorToast,
 });
 
 export const installErrata = ({
@@ -149,5 +149,5 @@ export const installErrata = ({
     hostname, search,
   }),
   handleSuccess: showRexToast,
-  errorToast: error => errorToast(error),
+  errorToast,
 });

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
@@ -1,7 +1,7 @@
 import { API_OPERATIONS, post } from 'foremanReact/redux/API';
 import { REX_JOB_INVOCATIONS_KEY, REX_FEATURES } from './RemoteExecutionConstants';
 import { foremanApi } from '../../../../services/api';
-import { errorToast, renderTaskStartedToast } from '../../../../scenes/Tasks/helpers';
+import { errorToast, renderRexJobStartedToast } from '../../../../scenes/Tasks/helpers';
 import { ERRATA_SEARCH_QUERY } from './ErrataTab/HostErrataConstants';
 import { TRACES_SEARCH_QUERY } from './TracesTab/HostTracesConstants';
 import { PACKAGE_SEARCH_QUERY } from './PackagesTab/YumInstallablePackagesConstants';
@@ -74,15 +74,14 @@ const katelloHostErrataInstallParams = ({
   feature: REX_FEATURES.KATELLO_HOST_ERRATA_INSTALL_BY_SEARCH,
 });
 
+const showRexToast = response => renderRexJobStartedToast(response.data);
+
 export const installPackage = ({ hostname, packageName }) => post({
   type: API_OPERATIONS.POST,
   key: REX_JOB_INVOCATIONS_KEY,
   url: foremanApi.getApiUrl('/job_invocations'),
   params: katelloPackageInstallParams({ hostname, packageName }),
-  handleSuccess: response => renderTaskStartedToast({
-    humanized: { action: `Install ${packageName} on ${hostname}` },
-    id: response?.data?.dynflow_task?.id,
-  }),
+  handleSuccess: showRexToast,
   errorToast: error => errorToast(error),
 });
 
@@ -91,10 +90,7 @@ export const installPackageBySearch = ({ hostname, search }) => post({
   key: REX_JOB_INVOCATIONS_KEY,
   url: foremanApi.getApiUrl('/job_invocations'),
   params: katelloPackageInstallBySearchParams({ hostname, search }),
-  handleSuccess: response => renderTaskStartedToast({
-    humanized: { action: `Install packages on ${hostname}` },
-    id: response?.data?.dynflow_task?.id,
-  }),
+  handleSuccess: showRexToast,
   errorToast: error => errorToast(error),
 });
 
@@ -103,10 +99,7 @@ export const removePackage = ({ hostname, packageName }) => post({
   key: REX_JOB_INVOCATIONS_KEY,
   url: foremanApi.getApiUrl('/job_invocations'),
   params: katelloPackageRemoveParams({ hostname, packageName }),
-  handleSuccess: response => renderTaskStartedToast({
-    humanized: { action: `Remove ${packageName} on ${hostname}` },
-    id: response?.data?.dynflow_task?.id,
-  }),
+  handleSuccess: showRexToast,
   errorToast: error => errorToast(error),
 });
 
@@ -115,10 +108,7 @@ export const removePackages = ({ hostname, search }) => post({
   key: REX_JOB_INVOCATIONS_KEY,
   url: foremanApi.getApiUrl('/job_invocations'),
   params: katelloPackagesRemoveParams({ hostname, search }),
-  handleSuccess: response => renderTaskStartedToast({
-    humanized: { action: `Remove packages on ${hostname}` },
-    id: response?.data?.dynflow_task?.id,
-  }),
+  handleSuccess: showRexToast,
   errorToast: error => errorToast(error),
 });
 
@@ -127,10 +117,7 @@ export const updatePackage = ({ hostname, packageName }) => post({
   key: REX_JOB_INVOCATIONS_KEY,
   url: foremanApi.getApiUrl('/job_invocations'),
   params: katelloPackageUpdateParams({ hostname, packageName }),
-  handleSuccess: response => renderTaskStartedToast({
-    humanized: { action: `Update ${packageName} on ${hostname}` },
-    id: response?.data?.dynflow_task?.id,
-  }),
+  handleSuccess: showRexToast,
   errorToast: error => errorToast(error),
 });
 
@@ -139,10 +126,7 @@ export const updatePackages = ({ hostname, search }) => post({
   key: REX_JOB_INVOCATIONS_KEY,
   url: foremanApi.getApiUrl('/job_invocations'),
   params: katelloPackagesUpdateParams({ hostname, search }),
-  handleSuccess: response => renderTaskStartedToast({
-    humanized: { action: `Update on ${hostname}` },
-    id: response?.data?.dynflow_task?.id,
-  }),
+  handleSuccess: showRexToast,
   errorToast: error => errorToast(error),
 });
 
@@ -151,10 +135,7 @@ export const resolveTraces = ({ hostname, search }) => post({
   key: REX_JOB_INVOCATIONS_KEY,
   url: foremanApi.getApiUrl('/job_invocations'),
   params: katelloTracerResolveParams({ hostname, search }),
-  handleSuccess: response => renderTaskStartedToast({
-    humanized: { action: `Resolve traces on ${hostname}` },
-    id: response?.data?.dynflow_task?.id,
-  }),
+  handleSuccess: showRexToast,
   errorToast: error => errorToast(error),
 });
 
@@ -167,9 +148,6 @@ export const installErrata = ({
   params: katelloHostErrataInstallParams({
     hostname, search,
   }),
-  handleSuccess: response => renderTaskStartedToast({
-    humanized: { action: `Install errata on ${hostname}` },
-    id: response?.data?.dynflow_task?.id,
-  }),
+  handleSuccess: showRexToast,
   errorToast: error => errorToast(error),
 });

--- a/webpack/scenes/Tasks/helpers.js
+++ b/webpack/scenes/Tasks/helpers.js
@@ -6,10 +6,11 @@ import { getResponseErrorMsgs } from '../../utils/helpers';
 export const bulkSearchKey = key => `${key}_TASK_SEARCH`;
 export const pollTaskKey = key => `${key}_POLL_TASK`;
 
-const link = id => ({
-  children: __('Go to task page'),
-  href: urlBuilder('foreman_tasks/tasks', '', id),
+const link = ({ id, message, baseUrl }) => ({
+  children: message,
+  href: urlBuilder(baseUrl, '', id),
 });
+
 const getErrors = task => (
   <ul>
     {task.humanized.errors.map(e => (
@@ -17,6 +18,18 @@ const getErrors = task => (
     ))}
   </ul>
 );
+
+const foremanTasksLink = id => link({
+  id,
+  message: __('Go to task page'),
+  baseUrl: 'foreman_tasks/tasks',
+});
+
+const rexJobLink = id => link({
+  id,
+  message: __('Go to job details'),
+  baseUrl: 'job_invocations',
+});
 
 export const renderTaskStartedToast = (task) => {
   if (!task) return;
@@ -26,8 +39,20 @@ export const renderTaskStartedToast = (task) => {
   window.tfm.toastNotifications.notify({
     message,
     type: 'info',
-    link: link(task.id),
+    link: foremanTasksLink(task.id),
 
+  });
+};
+
+export const renderRexJobStartedToast = ({ id, description }) => {
+  if (!id) return;
+
+  const message = (__(`Job ${description} has started.`));
+
+  window.tfm.toastNotifications.notify({
+    message,
+    type: 'info',
+    link: rexJobLink(id),
   });
 };
 
@@ -38,7 +63,7 @@ export const taskFinishedToast = (task) => {
   return {
     message,
     type: task.result,
-    link: link(task.id),
+    link: foremanTasksLink(task.id),
   };
 };
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

![rex_toast](https://user-images.githubusercontent.com/22042343/158665647-94da1a94-363c-4c00-bf24-40be80eb00da.png)


* Add `renderRexJobStartedToast` to go alongside `renderTaskStartedToast`. This will link directly to the Remote execution job details page, not just to its wrapper Foreman Task.
* Change PackageTab install button to primary
* also some other light refactoring

#### Considerations taken when implementing this change?

_BONUS REFACTOR:_ Now that we've updated Patternfly, `toggleVariant="primary"` actually works now. So it allows us to have the PackagesTab 'Upgrade' button turn blue when enabled, as intended in the original mockup.
![packages-upgrade](https://user-images.githubusercontent.com/22042343/158666482-6a7399fd-6122-4779-af9c-f7d0f3a9ee0e.png)


#### What are the testing steps for this pull request?

Perform REX actions on the new host detail page
Verify that toast comes up and links to job invocation detail page, not Foreman Tasks page
Also see if you can test an API error and verify that it shows up properly as well
