### PR TITLE
Fixes #34626 - Default to Content only mirroring policy on the UI

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/mirroring-policy.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/mirroring-policy.service.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.repositories').service('MirroringPolicy',
     ['translate', function (translate) {
 
-        this.defaultMirroringPolicy = 'additive';
+        this.defaultMirroringPolicy = 'mirror_content_only';
 
         this.mirroringPolicies = function(repoType) {
             var policies = {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
The webUI default for mirroring policy is Additive while the controller default is Content only. The correct mirroring policy to default to would be Content only on the UI as well.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1. Create a new repository.
2. Select type: yum and scroll down to check the default value in the mirroring policy field.
3. It should default to "Content only"