### PR TITLE
Fixes #34628 - Add TranslatedPlural component

### DIFF
--- a/webpack/components/Errata/index.js
+++ b/webpack/components/Errata/index.js
@@ -37,6 +37,7 @@ export const ErrataSummary = ({ type, count }) => {
         plural="security advisories"
         singular="security advisory"
         zeroMsg="# security advisories"
+        ariaLabel={`${count} security advisories`}
       />
     );
     break;
@@ -45,7 +46,6 @@ export const ErrataSummary = ({ type, count }) => {
     label = __('Bugfix');
     ErrataIcon = BugIcon;
     color = '#8bc1f7';
-    // url = <a href="#/Content/errata?type=bugfix"> {count} {plural} </a>;
     url = (
       <TranslatedAnchor
         id="errata-card-bugfix-count"
@@ -55,6 +55,7 @@ export const ErrataSummary = ({ type, count }) => {
         plural="bug fixes"
         singular="bug fix"
         zeroMsg="# bug fixes"
+        ariaLabel={`${count} bug fixes`}
       />
     );
     break;
@@ -63,7 +64,6 @@ export const ErrataSummary = ({ type, count }) => {
     label = __('Enhancement');
     ErrataIcon = EnhancementIcon;
     color = '#002f5d';
-    // url = <a href="#/Content/errata?type=enhancement"> {count} {plural} </a>;
     url = (
       <TranslatedAnchor
         id="errata-card-enhancement-count"
@@ -73,6 +73,7 @@ export const ErrataSummary = ({ type, count }) => {
         plural="enhancements"
         singular="enhancement"
         zeroMsg="# enhancements"
+        ariaLabel={`${count} enhancements`}
       />
     );
     break;

--- a/webpack/components/Errata/index.js
+++ b/webpack/components/Errata/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { TableText } from '@patternfly/react-table';
 import {
   chart_color_black_500 as pfBlack,
@@ -13,39 +14,67 @@ import {
   EnhancementIcon,
   SquareIcon,
 } from '@patternfly/react-icons';
-import PropTypes from 'prop-types';
+import { TranslatedAnchor } from '../Table/components/TranslatedPlural';
 
 export const ErrataMapper = ({ data, id }) => data.map(({ x: type, y: count }) => <ErrataSummary count={count} type={type} key={`${count} ${type}`} id={id} />);
 
 export const ErrataSummary = ({ type, count }) => {
   let ErrataIcon;
   let label;
-  let name;
   let url;
   let color;
   switch (type) {
   case 'security':
     label = __('Security');
     ErrataIcon = SecurityIcon;
-    name = 'security advisories';
     color = '#0066cc';
-    url = <a href="#/Content/errata?type=security"> {count} {name} </a>;
+    url = (
+      <TranslatedAnchor
+        id="errata-card-security-count"
+        style={{ marginLeft: '0.4rem' }}
+        href="#/Content/errata?type=security"
+        count={count}
+        plural="security advisories"
+        singular="security advisory"
+        zeroMsg="# security advisories"
+      />
+    );
     break;
   case 'recommended':
   case 'bugfix':
     label = __('Bugfix');
     ErrataIcon = BugIcon;
-    name = 'bug fixes';
     color = '#8bc1f7';
-    url = <a href="#/Content/errata?type=bugfix"> {count} {name} </a>;
+    // url = <a href="#/Content/errata?type=bugfix"> {count} {plural} </a>;
+    url = (
+      <TranslatedAnchor
+        id="errata-card-bugfix-count"
+        style={{ marginLeft: '0.4rem' }}
+        href="#/Content/errata?type=bugfix"
+        count={count}
+        plural="bug fixes"
+        singular="bug fix"
+        zeroMsg="# bug fixes"
+      />
+    );
     break;
   case 'enhancement':
   case 'optional':
     label = __('Enhancement');
     ErrataIcon = EnhancementIcon;
-    name = 'enhancements';
     color = '#002f5d';
-    url = <a href="#/Content/errata?type=enhancement"> {count} {name} </a>;
+    // url = <a href="#/Content/errata?type=enhancement"> {count} {plural} </a>;
+    url = (
+      <TranslatedAnchor
+        id="errata-card-enhancement-count"
+        style={{ marginLeft: '0.4rem' }}
+        href="#/Content/errata?type=enhancement"
+        count={count}
+        plural="enhancements"
+        singular="enhancement"
+        zeroMsg="# enhancements"
+      />
+    );
     break;
   default:
   }

--- a/webpack/components/Table/components/TranslatedPlural.js
+++ b/webpack/components/Table/components/TranslatedPlural.js
@@ -3,8 +3,9 @@ import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
 // a defaultMessage like
-// "{errataTotal, plural, =0 {No errata} one {# erratum} other {# errata}}"
+// "{count, plural, =0 {No errata} one {# erratum} other {# errata}}"
 // will give us properly translated pluralized strings!
+// see https://formatjs.io/docs/react-intl/components/#message-syntax
 export const TranslatedPlural = ({
   count, singular,
   plural = `${singular}s`,
@@ -35,8 +36,10 @@ TranslatedPlural.defaultProps = {
   zeroMsg: undefined,
 };
 
-export const TranslatedAnchor = ({ href, style, ...props }) => (
-  <a href={href} style={style} >
+export const TranslatedAnchor = ({
+  href, style, ariaLabel, ...props
+}) => (
+  <a href={href} style={style} aria-label={ariaLabel}>
     <TranslatedPlural
       {...props}
     />
@@ -46,8 +49,9 @@ export const TranslatedAnchor = ({ href, style, ...props }) => (
 TranslatedAnchor.propTypes = {
   href: PropTypes.string.isRequired,
   style: PropTypes.shape({}),
+  ariaLabel: PropTypes.string.isRequired,
 };
 
 TranslatedAnchor.defaultProps = {
-  style: { marginLeft: 'initial' },
+  style: undefined,
 };

--- a/webpack/components/Table/components/TranslatedPlural.js
+++ b/webpack/components/Table/components/TranslatedPlural.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import PropTypes from 'prop-types';
+
+// a defaultMessage like
+// "{errataTotal, plural, =0 {No errata} one {# erratum} other {# errata}}"
+// will give us properly translated pluralized strings!
+export const TranslatedPlural = ({
+  count, singular,
+  plural = `${singular}s`,
+  zeroMsg = `No ${plural}`,
+  id,
+  ...props
+}) => (
+  <FormattedMessage
+    defaultMessage={`{count, plural, =0 {${zeroMsg}} one {# ${singular}} other {# ${plural}}}`}
+    values={{
+      count,
+    }}
+    id={id}
+    {...props}
+  />
+);
+
+TranslatedPlural.propTypes = {
+  count: PropTypes.number.isRequired,
+  singular: PropTypes.string.isRequired,
+  plural: PropTypes.string,
+  zeroMsg: PropTypes.string,
+  id: PropTypes.string.isRequired,
+};
+
+TranslatedPlural.defaultProps = {
+  plural: undefined,
+  zeroMsg: undefined,
+};
+
+export const TranslatedAnchor = ({ href, style, ...props }) => (
+  <a href={href} style={style} >
+    <TranslatedPlural
+      {...props}
+    />
+  </a>
+);
+
+TranslatedAnchor.propTypes = {
+  href: PropTypes.string.isRequired,
+  style: PropTypes.shape({}),
+};
+
+TranslatedAnchor.defaultProps = {
+  style: { marginLeft: 'initial' },
+};

--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import { ChartPie } from '@patternfly/react-charts';
 import { ErrataMapper } from '../../../../components/Errata';
 import { hostIsRegistered } from '../hostDetailsHelpers';
+import { TranslatedAnchor } from '../../../Table/components/TranslatedPlural';
 
 function HostInstallableErrata({
   id, errataCounts,
@@ -38,9 +39,14 @@ function HostInstallableErrata({
         <CardBody>
           <Flex direction="column">
             <FlexItem>
-              <a href="#/Content/errata">
-                {errataTotal} errata
-              </a>
+              <TranslatedAnchor
+                id="errata-card-total-count"
+                style={{ marginLeft: '0.4rem' }}
+                href="#/Content/errata"
+                count={errataTotal}
+                plural="errata"
+                singular="erratum"
+              />
             </FlexItem>
             <Flex flexWrap={{ xl: 'nowrap' }} direction="row" alignItems={{ default: 'alignItemsCenter' }}>
               <div className="piechart-overflow" style={{ overflow: 'visible', minWidth: '140px', maxHeight: '155px' }}>

--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
@@ -41,11 +41,11 @@ function HostInstallableErrata({
             <FlexItem>
               <TranslatedAnchor
                 id="errata-card-total-count"
-                style={{ marginLeft: '0.4rem' }}
                 href="#/Content/errata"
                 count={errataTotal}
                 plural="errata"
                 singular="erratum"
+                ariaLabel={`${errataTotal} total errata`}
               />
             </FlexItem>
             <Flex flexWrap={{ xl: 'nowrap' }} direction="row" alignItems={{ default: 'alignItemsCenter' }}>

--- a/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
@@ -15,7 +15,7 @@ describe('Without errata', () => {
     nock.cleanAll();
   });
 
-  test('does not show piechart when there are 0 errata', () => {
+  test('shows zero counts when there are 0 errata', () => {
     const hostDetails = {
       ...baseHostDetails,
       content_facet_attributes: {
@@ -28,10 +28,13 @@ describe('Without errata', () => {
       },
     };
     /* eslint-disable max-len */
-    const { queryByLabelText, getByText } = render(<ErrataOverviewCard hostDetails={hostDetails} />);
+    const { queryByLabelText, getByLabelText } = render(<ErrataOverviewCard hostDetails={hostDetails} />);
     /* eslint-enable max-len */
     expect(queryByLabelText('errataChart')).not.toBeInTheDocument();
-    expect(getByText('0 errata')).toBeInTheDocument();
+    expect(getByLabelText('0 total errata')).toBeInTheDocument();
+    expect(getByLabelText('0 security advisories')).toBeInTheDocument();
+    expect(getByLabelText('0 bug fixes')).toBeInTheDocument();
+    expect(getByLabelText('0 enhancements')).toBeInTheDocument();
   });
 
   test('does not show errata card when host not registered', () => {
@@ -60,7 +63,7 @@ describe('With errata', () => {
     nock.cleanAll();
   });
 
-  test('shows piechart when there are errata', () => {
+  test('shows links when there are errata', () => {
     const hostDetails = {
       ...baseHostDetails,
       content_facet_attributes: {
@@ -72,12 +75,13 @@ describe('With errata', () => {
         },
       },
     };
-    const { getByText, container } = render(<ErrataOverviewCard hostDetails={hostDetails} />);
+    const { getByLabelText, container } = render(<ErrataOverviewCard hostDetails={hostDetails} />);
     expect(container.getElementsByClassName('erratachart')).toHaveLength(1);
     expect(container.getElementsByClassName('erratalegend')).toHaveLength(1);
-    expect(getByText('60 errata')).toBeInTheDocument();
-    expect(getByText('30 security advisories')).toBeInTheDocument();
-    expect(getByText('10 bug fixes')).toBeInTheDocument();
-    expect(getByText('20 enhancements')).toBeInTheDocument();
+
+    expect(getByLabelText('60 total errata')).toBeInTheDocument();
+    expect(getByLabelText('30 security advisories')).toBeInTheDocument();
+    expect(getByLabelText('20 enhancements')).toBeInTheDocument();
+    expect(getByLabelText('10 bug fixes')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Adds two components:
* `<TranslatedPlural>` - Renders a `<FormattedMessage>` with proper translation and pluralization. So we can display messages like this

![errata_singular](https://user-images.githubusercontent.com/22042343/158620882-4cbb5f47-f31b-4822-ac7d-190a3f855ab8.png)

![errata_zero](https://user-images.githubusercontent.com/22042343/158620931-99915779-9da5-4be0-8fcf-c4c21816a388.png)

You can also customize what it says when there are zero items.

* `<TranslatedAnchor>` which renders an `<a>` with a `<TranslatedPlural>` inside, with optional styling.

#### Considerations taken when implementing this change?

see my inline review below

#### What are the testing steps for this pull request?

Get a host with one erratum and view the ErrataOverviewCard.
Do the same with a host with no errata, and with several errata.

Or, find the `<HostInstallableErrata>` component in React Dev Tools, and change the `errataCounts` prop!