### PR TITLE
Fixes #34632 - Add bookmarks to React content pages

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-module-streams.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-module-streams.controller.js
@@ -21,6 +21,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostModuleStreamsCont
         $scope.working = false;
 
         $scope.nutupaneParams = { id: $scope.$stateParams.hostId };
+        $scope.controllerName = 'katello_host_available_module_streams';
 
         $scope.moduleStreamsNutupane = new Nutupane(HostModuleStream, $scope.nutupaneParams);
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-installed.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-installed.controller.js
@@ -17,6 +17,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesInstalled
     ['$scope', '$timeout', '$window', 'HostPackage', 'translate', 'Nutupane', 'BastionConfig',
     function ($scope, $timeout, $window, HostPackage, translate, Nutupane, BastionConfig) {
         var packagesNutupane;
+        $scope.controllerName = 'katello_host_installed_packages';
 
         $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
         $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-traces.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-traces.controller.js
@@ -23,6 +23,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostTracesController'
 
         tracesNutupane = new Nutupane(HostTraces, params, 'get', {'disableAutoLoad': true});
         tracesNutupane.primaryOnly = true;
+        $scope.controllerName = 'katello_host_tracers';
         $scope.table = tracesNutupane.table;
         $scope.table.tracesFilterTerm = "";
         $scope.table.tracesCompare = function (item) {

--- a/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
@@ -98,6 +98,11 @@ describe('Controller: ContentHostErrataController', function() {
         expect($scope.table).toBeTruthy();
     });
 
+    it("verifies controller name", function() {
+        expect($scope.controllerName).toBeTruthy();
+        expect($scope.controllerName).toBe("katello_errata");
+    });
+
     it("provide a way to apply errata", function() {
         var bulk_errata_ids = angular.toJson({included: { ids: [mockErratum.errata_id], params: {} }});
 

--- a/engines/bastion_katello/test/content-hosts/content/content-host-packages-applicable.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-packages-applicable.controller.test.js
@@ -51,6 +51,11 @@ describe('Controller: ContentHostPackagesApplicableController', function() {
         expect($scope.table).toBeTruthy();
     });
 
+    it("verifies controller name", function() {
+        expect($scope.controllerName).toBeTruthy();
+        expect($scope.controllerName).toBe("katello_erratum_packages");
+    });
+
     it("formats selected items", function() {
         expect($scope.getSelectedPackages()[0]).toBe("foo-3-14.noarch");
     });

--- a/engines/bastion_katello/test/content-hosts/content/content-host-packages-installed.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-packages-installed.controller.test.js
@@ -58,6 +58,12 @@ describe('Controller: ContentHostPackagesInstalledController', function() {
         expect($scope.table).toBeTruthy();
     });
 
+    it("verifies controller name", function() {
+        expect($scope.controllerName).toBeTruthy();
+        expect($scope.controllerName).toBe("katello_host_installed_packages");
+    });
+    
+
     it("performs a selected package removal", function() {
         var mockPackage, mockPackageClone;
         mockPackage = {name: 'foo', version: '3', release: '14', arch: 'noarch'};

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -350,6 +350,7 @@ export const ErrataTab = () => {
             hostId, toggleGroupState, errataTypeSelected,
             errataSeveritySelected, activeSortColumn, activeSortDirection]}
           fetchItems={fetchItems}
+          bookmarkController="katello_errata"
           autocompleteEndpoint={`/hosts/${hostId}/errata/auto_complete_search`}
           foremanApiAutoComplete
           rowsCount={results?.length}

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -191,6 +191,7 @@ export const ModuleStreamsTab = () => {
           }}
           additionalListeners={[hostId, activeSortColumn, activeSortDirection]}
           fetchItems={fetchItems}
+          bookmarkController="katello_host_available_module_streams"
           autocompleteEndpoint={`/hosts/${hostId}/module_streams/auto_complete_search`}
           foremanApiAutoComplete
           rowsCount={results?.length}

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/__tests__/moduleStreamsTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/__tests__/moduleStreamsTab.test.js
@@ -6,6 +6,9 @@ import { foremanApi } from '../../../../../../services/api';
 import { ModuleStreamsTab } from '../ModuleStreamsTab';
 import mockModuleStreams from './modules.fixtures.json';
 import { MODULE_STREAMS_KEY } from '../ModuleStreamsConstants';
+import mockBookmarkData from '../../__tests__/bookmarks.fixtures.json';
+
+const moduleBookmarks = foremanApi.getApiUrl('/bookmarks?search=controller%3Dkatello_host_available_module_streams');
 
 const contentFacetAttributes = {
   id: 11,
@@ -36,10 +39,12 @@ const autocompleteUrl = '/hosts/1/module_streams/auto_complete_search';
 let firstModuleStreams;
 let searchDelayScope;
 let autoSearchScope;
+let bookmarkScope;
 
 beforeEach(() => {
   const { results } = mockModuleStreams;
   [firstModuleStreams] = results;
+  bookmarkScope = nockInstance.get(moduleBookmarks).reply(200, mockBookmarkData);
   searchDelayScope = mockSetting(nockInstance, 'autosearch_delay', 0);
   autoSearchScope = mockSetting(nockInstance, 'autosearch_while_typing');
 });
@@ -47,6 +52,7 @@ beforeEach(() => {
 afterEach(() => {
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
+  assertNockRequest(bookmarkScope);
 });
 
 beforeEach(() => {

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -348,6 +348,7 @@ export const PackagesTab = () => {
           additionalListeners={[hostId, packageStatusSelected,
             activeSortDirection, activeSortColumn]}
           fetchItems={fetchItems}
+          bookmarkController="katello_host_installed_packages"
           autocompleteEndpoint={`/hosts/${hostId}/packages/auto_complete_search`}
           foremanApiAutoComplete
           rowsCount={results?.length}

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
@@ -153,6 +153,7 @@ const TracesTab = () => {
         }
         }
         metadata={meta}
+        bookmarkController="katello_host_tracers"
         autocompleteEndpoint={`/hosts/${hostId}/traces/auto_complete_search`}
         foremanApiAutoComplete
         rowsCount={results?.length}

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
@@ -8,6 +8,7 @@ import { REX_FEATURES } from '../RemoteExecutionConstants';
 import { ErrataTab } from '../ErrataTab/ErrataTab.js';
 import mockErrataData from './errata.fixtures.json';
 import mockResolveErrataTask from './resolveErrata.fixtures.json';
+import mockBookmarkData from './bookmarks.fixtures.json';
 
 const contentFacetAttributes = {
   id: 11,
@@ -16,6 +17,8 @@ const contentFacetAttributes = {
   lifecycle_environment_library: false,
 };
 const hostName = 'foo.example.com';
+
+const errataBookmarks = foremanApi.getApiUrl('/bookmarks?search=controller%3Dkatello_errata');
 
 const renderOptions = (facetAttributes = contentFacetAttributes) => ({
   apiNamespace: HOST_ERRATA_KEY,
@@ -84,10 +87,12 @@ let firstErrata;
 let thirdErrata;
 let searchDelayScope;
 let autoSearchScope;
+let bookmarkScope;
 
 beforeEach(() => {
   const { results } = mockErrataData;
   [firstErrata, , thirdErrata] = results;
+  bookmarkScope = nockInstance.get(errataBookmarks).reply(200, mockBookmarkData);
   searchDelayScope = mockSetting(nockInstance, 'autosearch_delay', 0);
   autoSearchScope = mockSetting(nockInstance, 'autosearch_while_typing');
 });
@@ -95,6 +100,7 @@ beforeEach(() => {
 afterEach(() => {
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
+  assertNockRequest(bookmarkScope);
 });
 
 test('Can call API for errata and show on screen on page load', async (done) => {

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/packagesTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/packagesTab.test.js
@@ -7,6 +7,7 @@ import { PackagesTab } from '../PackagesTab/PackagesTab.js';
 import mockPackagesData from './packages.fixtures.json';
 import { REX_FEATURES } from '../RemoteExecutionConstants';
 import * as hooks from '../../../../Table/TableHooks';
+import mockBookmarkData from './bookmarks.fixtures.json';
 
 const contentFacetAttributes = {
   id: 11,
@@ -16,6 +17,8 @@ const contentFacetAttributes = {
 };
 
 const hostname = 'test-host.example.com';
+const packageBookmarks = foremanApi.getApiUrl('/bookmarks?search=controller%3Dkatello_host_installed_packages');
+
 const renderOptions = (facetAttributes = contentFacetAttributes) => ({
   apiNamespace: HOST_PACKAGES_KEY,
   initialState: {
@@ -52,10 +55,12 @@ let firstPackage;
 let secondPackage;
 let searchDelayScope;
 let autoSearchScope;
+let bookmarkScope;
 
 beforeEach(() => {
   const { results } = mockPackagesData;
   [firstPackage, secondPackage] = results;
+  bookmarkScope = nockInstance.get(packageBookmarks).reply(200, mockBookmarkData);
   searchDelayScope = mockSetting(nockInstance, 'autosearch_delay', 0);
   autoSearchScope = mockSetting(nockInstance, 'autosearch_while_typing');
 });
@@ -63,6 +68,7 @@ beforeEach(() => {
 afterEach(() => {
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
+  assertNockRequest(bookmarkScope);
 });
 
 test('Can call API for packages and show on screen on page load', async (done) => {

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
@@ -9,8 +9,12 @@ import mockTraceData from './traces.fixtures.json';
 import mockResolveTraceTask from './resolveTraces.fixtures.json';
 import emptyTraceResults from './tracerEmptyTraceResults.fixtures.json';
 import mockJobInvocationStatus from './tracerEnableJobInvocation.fixtures.json';
+import mockBookmarkData from './bookmarks.fixtures.json';
 
 const hostName = 'client.example.com';
+const tracesBookmarks = foremanApi.getApiUrl('/bookmarks?search=controller%3Dkatello_host_tracers');
+
+
 const tracerInstalledResponse = {
   id: 1,
   name: 'client.example.com',
@@ -49,11 +53,13 @@ const jobInvocations = foremanApi.getApiUrl('/job_invocations');
 let firstTrace;
 let searchDelayScope;
 let autoSearchScope;
+let bookmarkScope;
 
 describe('With tracer installed', () => {
   beforeEach(() => {
     const { results } = mockTraceData;
     [firstTrace] = results;
+    bookmarkScope = nockInstance.get(tracesBookmarks).reply(200, mockBookmarkData);
     searchDelayScope = mockSetting(nockInstance, 'autosearch_delay', 0);
     autoSearchScope = mockSetting(nockInstance, 'autosearch_while_typing');
   });
@@ -61,6 +67,7 @@ describe('With tracer installed', () => {
   afterEach(() => {
     assertNockRequest(searchDelayScope);
     assertNockRequest(autoSearchScope);
+    assertNockRequest(bookmarkScope);
     nock.cleanAll();
   });
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Tablewrapper now support bookmarks :beers: so adding them to the content tabs so we can make the new UI more 1:1 with the old one.

#### Considerations taken when implementing this change?

Traces and module_streams didn't work with bookmarks since who knows when. The bookmarks controller in Foreman looks at Angular for the controller name to gather the list of them. So I added the controller names to the traces and module_stream angular controllers.

I added unit tests as well for the React pages to test for the fake bookmark data that Jeremy created with the repo sets pr.

#### What are the testing steps for this pull request?

* Create some bookmarks and make sure they save on the following pages:
  * Errata
  * Traces
  * Module Streams
  * Packages
 
* Verify there are not an JS errors in the console
* Verify you can see the bookmarks after you save them in the dropdown list
