### PR TITLE
Fixes #34633 - Add Epoch to CV version RPM packages page

### DIFF
--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
@@ -149,6 +149,7 @@ export default ({ cvId, versionId }) => [
       { title: __('Version'), getProperty: item => item?.version },
       { title: __('Release'), getProperty: item => item?.release },
       { title: __('Arch'), getProperty: item => item?.arch },
+      { title: __('Epoch'), getProperty: item => item?.epoch },
     ],
   },
   {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Nothing major, Epoch was already being returned in the results, so just made it visible in the table.

#### Considerations taken when implementing this change?

Nothing major, Epoch was already being returned in the results, so just made it visible in the table.

#### What are the testing steps for this pull request?

* Apply patch
* Sync a repo with RPMS
* Create a content view and publish it
* View the version tab and select RPM packages
* Verify that the Epoch column is present in the table

See screenshot for example:

![Web capture_16-3-2022_141115_192 168 121 207](https://user-images.githubusercontent.com/1518655/158660720-617d3613-0511-4613-8001-556d1785bb8b.jpeg)



