### PR TITLE
Fixes #34630 - Errata Filters Date do not show "Start Date" & "End Date"

### DIFF
--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
@@ -7,6 +7,7 @@ import {
   Tooltip, Form, ActionGroup, Flex, FlexItem, Select,
   SelectOption, SelectVariant, ChipGroup, Chip,
   Tabs, Tab, TabTitleText, Button, DatePicker, Bullseye,
+  Divider, Text,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -53,6 +54,8 @@ const CVErrataDateFilterContent = ({
   const [selectedTypes, setSelectedTypes] = useState(types);
   const dispatch = useDispatch();
   const [activeTabKey, setActiveTabKey] = useState(0);
+  const [startEntry, setStartEntry] = useState(false);
+  const [endEntry, setEndEntry] = useState(false);
 
   const onSave = () => {
     dispatch(editCVFilterRule(
@@ -103,6 +106,7 @@ const CVErrataDateFilterContent = ({
   }, [showAffectedRepos, repositories.length]);
 
   const tabTitle = inclusion ? __('Included errata') : __('Excluded errata');
+  const invalidDateFormat = __('Enter a valid date: MM/DD/YYYY');
 
   return (
     <Tabs className="margin-0-24" activeKey={activeTabKey} onSelect={(_event, eventKey) => setActiveTabKey(eventKey)}>
@@ -153,7 +157,7 @@ const CVErrataDateFilterContent = ({
                   </SelectOption>
                 </Select>
               </FlexItem>
-              <FlexItem span={1} spacer={{ default: 'spacerMd' }}>
+              <FlexItem span={1} spacer={{ default: 'spacerNone' }}>
                 {(selectedTypes.length === 1) &&
                   <Tooltip
                     position="top"
@@ -165,7 +169,8 @@ const CVErrataDateFilterContent = ({
                   </Tooltip>
                 }
               </FlexItem>
-              <FlexItem span={2} spacer={{ default: 'spacerMd' }}>
+              <Divider isVertical />
+              <FlexItem span={2} spacer={{ default: 'spacerNone' }}>
                 <Select
                   selections={dateType}
                   onSelect={(_event, selection) => {
@@ -179,49 +184,51 @@ const CVErrataDateFilterContent = ({
                   aria-label="date_type_selector"
                   isDisabled={!hasPermission(permissions, 'edit_content_views')}
                 >
-                  <SelectOption key="issued" value="issued">{__('Issued')}</SelectOption>
-                  <SelectOption key="updated" value="updated">{__('Updated')}</SelectOption>
+                  <SelectOption key="issued" value="issued">{__('Issued from')}</SelectOption>
+                  <SelectOption key="updated" value="updated">{__('Updated from')}</SelectOption>
                 </Select>
               </FlexItem>
-              <FlexItem span={2} spacer={{ default: 'spacerXs' }}>
-                <Bullseye>
+              <FlexItem span={2} spacer={{ default: 'spacerNone' }}>
+                <Bullseye
+                  onFocus={() => setStartEntry(true)}
+                  onBlur={() => setStartEntry(false)}
+                >
                   <DatePicker
                     aria-label="start_date_input"
                     value={startDate}
+                    invalidFormatText={invalidDateFormat}
                     dateFormat={dateFormat}
                     onChange={setStartDate}
                     dateParse={dateParse}
-                    placeholder="MM/DD/YYYY"
+                    placeholder={startEntry ? 'MM/DD/YYYY' : __('Start Date')}
                     isDisabled={!hasPermission(permissions, 'edit_content_views')}
                   />
                 </Bullseye>
               </FlexItem>
+              <FlexItem spacer={{ default: 'spacerNone' }}>
+                <Bullseye style={{ padding: '0 5px' }}>
+                  <Text>{__('to')}</Text>
+                </Bullseye>
+              </FlexItem>
               <FlexItem span={2}>
-                <Bullseye>
+                <Bullseye
+                  onFocus={() => setEndEntry(true)}
+                  onBlur={() => setEndEntry(false)}
+                >
                   <DatePicker
                     aria-label="end_date_input"
                     value={endDate}
+                    invalidFormatText={invalidDateFormat}
                     dateFormat={dateFormat}
                     onChange={setEndDate}
                     dateParse={dateParse}
-                    placeholder="MM/DD/YYYY"
+                    placeholder={endEntry ? 'MM/DD/YYYY' : __('End Date')}
                     isDisabled={!hasPermission(permissions, 'edit_content_views')}
                   />
                 </Bullseye>
               </FlexItem>
             </Flex>
             <Flex>
-              <FlexItem>
-                <ChipGroup categoryName={dateType === 'issued' ? __('Issued') : __('Updated')}>
-                  <Chip key="startDate" onClick={() => setStartDate('')} isReadOnly={!startDate || !hasPermission(permissions, 'edit_content_views')}>
-                    {startDate || __('ANY')}
-                  </Chip>
-                  -
-                  <Chip key="endDate" onClick={() => setEndDate('')} isReadOnly={!endDate || !hasPermission(permissions, 'edit_content_views')}>
-                    {endDate || __('ANY')}
-                  </Chip>
-                </ChipGroup>
-              </FlexItem>
               <FlexItem>
                 <ChipGroup categoryName={__('Type')}>
                   {selectedTypes.map(type => (
@@ -233,6 +240,17 @@ const CVErrataDateFilterContent = ({
                       {capitalize(type)}
                     </Chip>
                   ))}
+                </ChipGroup>
+              </FlexItem>
+              <FlexItem>
+                <ChipGroup categoryName={dateType === 'issued' ? __('Issued from') : __('Updated from')}>
+                  <Chip key="startDate" onClick={() => setStartDate('')} isReadOnly={!startDate || !hasPermission(permissions, 'edit_content_views')}>
+                    {startDate || __('ANY')}
+                  </Chip>
+                  {__('to')}
+                  <Chip key="endDate" onClick={() => setEndDate('')} isReadOnly={!endDate || !hasPermission(permissions, 'edit_content_views')}>
+                    {endDate || __('ANY')}
+                  </Chip>
                 </ChipGroup>
               </FlexItem>
               {hasPermission(permissions, 'edit_content_views') &&

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
@@ -200,7 +200,7 @@ const CVErrataDateFilterContent = ({
                     dateFormat={dateFormat}
                     onChange={setStartDate}
                     dateParse={dateParse}
-                    placeholder={startEntry ? 'MM/DD/YYYY' : __('Start Date')}
+                    placeholder={startEntry ? 'MM/DD/YYYY' : __('Start date')}
                     isDisabled={!hasPermission(permissions, 'edit_content_views')}
                   />
                 </Bullseye>

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
@@ -222,7 +222,7 @@ const CVErrataDateFilterContent = ({
                     dateFormat={dateFormat}
                     onChange={setEndDate}
                     dateParse={dateParse}
-                    placeholder={endEntry ? 'MM/DD/YYYY' : __('End Date')}
+                    placeholder={endEntry ? 'MM/DD/YYYY' : __('End date')}
                     isDisabled={!hasPermission(permissions, 'edit_content_views')}
                   />
                 </Bullseye>

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
@@ -369,7 +369,7 @@ const CVErrataIDFilterContent = ({
                         dateFormat={dateFormat}
                         onChange={setValidStartDate}
                         dateParse={dateParse}
-                        placeholder={startEntry ? 'MM/DD/YYYY' : __('Start Date')}
+                        placeholder={startEntry ? 'MM/DD/YYYY' : __('Start date')}
                       />
                     </Bullseye>
                   </FlexItem>

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
@@ -7,7 +7,7 @@ import { TableVariant } from '@patternfly/react-table';
 import {
   Tabs, Tab, TabTitleText, Split, SplitItem, Select, SelectVariant,
   SelectOption, Button, Dropdown, DropdownItem, KebabToggle, Flex, FlexItem,
-  Bullseye, DatePicker, ChipGroup, Chip,
+  Bullseye, DatePicker, ChipGroup, Chip, Text,
 } from '@patternfly/react-core';
 import { STATUS } from 'foremanReact/constants';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -70,6 +70,9 @@ const CVErrataIDFilterContent = ({
   const [apiEndDate, setApiEndDate] = useState('');
   const [dateType, setDateType] = useState('issued');
   const [dateTypeSelectOpen, setDateTypeSelectOpen] = useState(false);
+  const [startEntry, setStartEntry] = useState(false);
+  const [endEntry, setEndEntry] = useState(false);
+
   const metadata = omit(response, ['results']);
   const { permissions } = details;
   const columnHeaders = [
@@ -241,6 +244,7 @@ const CVErrataIDFilterContent = ({
   const emptySearchTitle = __('No matching filter rules found.');
   const emptySearchBody = __('Try changing your search settings.');
 
+  const invalidDateFormat = __('Enter a valid date: MM/DD/YYYY');
 
   return (
     <Tabs className="margin-0-24" activeKey={activeTabKey} onSelect={(_event, eventKey) => setActiveTabKey(eventKey)}>
@@ -336,7 +340,7 @@ const CVErrataIDFilterContent = ({
             nodesBelowSearch={
               <>
                 <Flex>
-                  <FlexItem span={2}>
+                  <FlexItem span={2} spacer={{ default: 'spacerNone' }}>
                     <Select
                       selections={dateType}
                       onSelect={(_event, selection) => {
@@ -349,51 +353,64 @@ const CVErrataIDFilterContent = ({
                       name="date_type_selector"
                       aria-label="date_type_selector"
                     >
-                      <SelectOption key="issued" value="issued">{__('Issued')}</SelectOption>
-                      <SelectOption key="updated" value="updated">{__('Updated')}</SelectOption>
+                      <SelectOption key="issued" value="issued">{__('Issued from')}</SelectOption>
+                      <SelectOption key="updated" value="updated">{__('Updated from')}</SelectOption>
                     </Select>
                   </FlexItem>
-                  <FlexItem span={2} spacer={{ default: 'spacerXs' }}>
-                    <Bullseye>
+                  <FlexItem span={2} spacer={{ default: 'spacerNone' }}>
+                    <Bullseye
+                      onFocus={() => setStartEntry(true)}
+                      onBlur={() => setStartEntry(false)}
+                    >
                       <DatePicker
                         aria-label="start_date_input"
+                        invalidFormatText={invalidDateFormat}
                         value={startDate}
                         dateFormat={dateFormat}
                         onChange={setValidStartDate}
                         dateParse={dateParse}
-                        placeholder="MM/DD/YYYY"
+                        placeholder={startEntry ? 'MM/DD/YYYY' : __('Start Date')}
                       />
                     </Bullseye>
                   </FlexItem>
+                  <FlexItem spacer={{ default: 'spacerNone' }}>
+                    <Bullseye style={{ padding: '0 5px' }}>
+                      <Text>{__('to')}</Text>
+                    </Bullseye>
+                  </FlexItem>
                   <FlexItem span={2}>
-                    <Bullseye>
+                    <Bullseye
+                      onFocus={() => setEndEntry(true)}
+                      onBlur={() => setEndEntry(false)}
+                    >
                       <DatePicker
                         aria-label="end_date_input"
                         value={endDate}
+                        invalidFormatText={invalidDateFormat}
                         dateFormat={dateFormat}
                         onChange={setValidEndDate}
                         dateParse={dateParse}
-                        placeholder="MM/DD/YYYY"
+                        placeholder={endEntry ? 'MM/DD/YYYY' : __('End Date')}
                       />
                     </Bullseye>
                   </FlexItem>
                 </Flex>
                 <Flex>
                   <FlexItem>
-                    <ChipGroup categoryName={dateType === 'issued' ? __('Issued') : __('Updated')}>
-                      <Chip key="startDate" onClick={() => setValidStartDate('')} isReadOnly={startDate === ''}>
-                        {startDate || __('ANY')}
-                      </Chip>
-                      -
-                      <Chip key="endDate" onClick={() => setValidEndDate('')} isReadOnly={endDate === ''}>
-                        {endDate || __('ANY')}
+                    <ChipGroup categoryName={__('Status')}>
+                      <Chip key="status" onClick={() => setStatusSelected(ALL_STATUSES)} isReadOnly={statusSelected === ALL_STATUSES}>
+                        {statusSelected}
                       </Chip>
                     </ChipGroup>
                   </FlexItem>
                   <FlexItem>
-                    <ChipGroup categoryName={__('Status')}>
-                      <Chip key="status" onClick={() => setStatusSelected(ALL_STATUSES)} isReadOnly={statusSelected === ALL_STATUSES}>
-                        {statusSelected}
+                    <ChipGroup categoryName={dateType === 'issued' ? __('Issued from') : __('Updated from')}>
+                      <Chip key="startDate" onClick={() => setValidStartDate('')} isReadOnly={startDate === ''}>
+                        {startDate || __('ANY')}
+                      </Chip>
+                      {__('to')}
+                      <Chip key="endDate" onClick={() => setValidEndDate('')} isReadOnly={endDate === ''}>
+                        {endDate || __('ANY')}
                       </Chip>
                     </ChipGroup>
                   </FlexItem>

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
@@ -390,7 +390,7 @@ const CVErrataIDFilterContent = ({
                         dateFormat={dateFormat}
                         onChange={setValidEndDate}
                         dateParse={dateParse}
-                        placeholder={endEntry ? 'MM/DD/YYYY' : __('End Date')}
+                        placeholder={endEntry ? 'MM/DD/YYYY' : __('End date')}
                       />
                     </Bullseye>
                   </FlexItem>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

- Updated invalid date error text
![Screen Shot 2022-03-16 at 2 07 07 PM](https://user-images.githubusercontent.com/38083295/158681088-0b3cd8db-cd26-4603-b75b-899754ab8145.png)

- Made the placeholder text dynamic based on focus to act as label.
![Screen Shot 2022-03-16 at 2 07 36 PM](https://user-images.githubusercontent.com/38083295/158681172-593c1fbd-f634-4d95-9172-d8fae8e4f3c6.png)


#### What are the testing steps for this pull request?

- Create both types of errata filters
- Enter an invalid date, view copy.
- onFocus the placeholder text should convert to the expected date format
- onBlur the placeholder should return to its label (start or end date) if input left blank
