### PR TITLE
Fixes #34638 - Fail if errata search query matches nothing

### DIFF
--- a/app/views/foreman/job_templates/install_errata_by_search_query.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query.erb
@@ -20,6 +20,7 @@ foreign_input_sets:
     <%= render_template('Package Action - SSH Default', :action => 'install -n -t patch', :package => advisories) %>
 <% else %>
     <% advisory_ids = @host.advisory_ids(search: input("Errata search query")) %>
+    <% raise "No errata matching given search query" if !input("Errata search query").blank? && advisory_ids.empty? %>
 
     <% advisories = advisory_ids.map { |e| "--advisory=#{e}" }.join(' ') %>
     <%= render_template('Package Action - SSH Default', :action => 'update-minimal', :package => advisories) %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Install errata by search query job template now fails during rendering if a search query is provided, but does not match any errata at all.

#### Considerations taken when implementing this change?

The broken part was that if user provided a filter which matched nothing, the final template just had `yum update-minimal` which installed all available errata. If someone provides a filter then it should only act on what the filter matches. 

#### What are the testing steps for this pull request?

1) Run a job using the Install errata by search query template
2) Provide a bogus query which will match no errata
