### PR TITLE
Fixes #34660: Reload old recurring logic when updating sync plan

### DIFF
--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -83,7 +83,7 @@ module Katello
           ::Katello::Util::Support.active_record_retry do
             self.save!
           end
-          old_rec_logic.cancel
+          old_rec_logic.reload.cancel
           start_recurring_logic
         end
         toggle_enabled(params[:enabled]) if (params.key?(:enabled) && params[:enabled] != self.enabled?)


### PR DESCRIPTION
A change in Rails 6.0.4+ results in the old recurring logic retaining
a reference to the sync plan such that when the recurring logic is
cancelled, which triggers a save, that save resets the relationship
of sync plan to recurring logic. The resulting sync plan winds up
related to the old recurring logic instead of the new.

Relates to Foreman update to Rails 6.0.4.7: https://github.com/theforeman/foreman/pull/9157

The failures seen there (from Jenkins):

```
[Katello::Api::V2::SyncPlansControllerTest.test_recurring_logic_update_with_sync_date](https://ci.theforeman.org/job/test_develop_pr_katello/10470/database=postgresql,ruby=2.7,slave=fast/testReport/junit/(root)/Katello__Api__V2__SyncPlansControllerTest/test_recurring_logic_update_with_sync_date/)
[Katello::Api::V2::SyncPlansControllerTest.test_update](https://ci.theforeman.org/job/test_develop_pr_katello/10470/database=postgresql,ruby=2.7,slave=fast/testReport/junit/(root)/Katello__Api__V2__SyncPlansControllerTest/test_update/)
[Katello::Api::V2::SyncPlansControllerTest.test_recurring_logic_update_with_all_params](https://ci.theforeman.org/job/test_develop_pr_katello/10470/database=postgresql,ruby=2.7,slave=fast/testReport/junit/(root)/Katello__Api__V2__SyncPlansControllerTest/test_recurring_logic_update_with_all_params/)
[Katello::Api::V2::SyncPlansControllerTest.test_recurring_logic_update_with_interval](https://ci.theforeman.org/job/test_develop_pr_katello/10470/database=postgresql,ruby=2.7,slave=fast/testReport/junit/(root)/Katello__Api__V2__SyncPlansControllerTest/test_recurring_logic_update_with_interval/)
[Katello::SyncPlanTest.test_cron_update_with_interval](https://ci.theforeman.org/job/test_develop_pr_katello/10470/database=postgresql,ruby=2.7,slave=fast/testReport/junit/(root)/Katello__SyncPlanTest/test_cron_update_with_interval/)
```

One in detail:

```
Failure:
test_recurring_logic_update_with_sync_date(Minitest::Result) [/home/jenkins/workspace/test_develop_pr_katello/database/postgresql/ruby/2.7/slave/fast/plugin/test/controllers/api/v2/sync_plans_controller_test.rb:171]:
Expected 24 to not be equal to 24.
```