### PR TITLE
Fixes #34663 - Filter module streams by status and installation status

### DIFF
--- a/app/models/katello/host_available_module_stream.rb
+++ b/app/models/katello/host_available_module_stream.rb
@@ -48,6 +48,17 @@ module Katello
       end
     end
 
+    def self.installed_status(status, host)
+      case status
+      when 'not installed'
+        where(installed_profiles: [])
+      when 'upgradable'
+        where(id: upgradable(host).pluck(:id))
+      when 'up to date'
+        where(status: 'enabled').where.not(installed_profiles: []).where.not(id: upgradable(host).pluck(:id))
+      end
+    end
+
     def self.upgradable(host)
       upgradable_module_name_streams = ModuleStream.installable_for_hosts([host]).select(:name, :stream)
 

--- a/app/views/katello/api/v2/host_module_streams/base.json.rabl
+++ b/app/views/katello/api/v2/host_module_streams/base.json.rabl
@@ -2,7 +2,7 @@ object @resource
 
 attributes :status, :installed_profiles
 attributes :upgradable? => :upgradable
-attributes :install_status? => :install_status
+attributes :install_status => :install_status
 
 glue(@object.available_module_stream) do
   attributes :name, :stream, :module_spec

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsConstants.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsConstants.js
@@ -1,3 +1,31 @@
 export const MODULE_STREAMS_KEY = 'MODULE_STREAMS';
 
+export const INSTALLED_STATE = {
+  UPGRADEABLE: 'Upgradable',
+  UPTODATE: 'Up-to-date',
+  NOTINSTALLED: 'Not installed',
+};
+
+export const HOST_MODULE_STREAM_STATUSES = {
+  ENABLED: 'Enabled',
+  INSTALLED: 'Installed',
+  DISABLED: 'Disabled',
+  UNKNOWN: 'Unknown',
+  UPGRADABLE: 'Upgradable',
+};
+
+export const STATUS_PARAM_TO_FRIENDLY_NAME = {
+  enabled: 'Enabled',
+  installed: 'Installed',
+  disabled: 'Disabled',
+  unknown: 'Unknown',
+  upgradable: 'Upgradable',
+};
+
+export const INSTALL_STATUS_PARAM_TO_FRIENDLY_NAME = {
+  not_installed: 'Not installed',
+  up_to_date: 'Up-to-date',
+  upgradable: 'Upgradable',
+};
+
 export default MODULE_STREAMS_KEY;


### PR DESCRIPTION
[TODO] Tests after some initial reviews around the new filters.
#### What are the changes introduced in this pull request?
Add filtering by status and installation status to module streams table on Host UI.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Navigate to module streams tab of a registered host.
2. You should see the 2 new filters on the table.
3. Apply the filters and check results.