### PR TITLE
Fixes #34670 - Cross page bulk select for repository tab

### DIFF
--- a/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewAddRemove.test.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewAddRemove.test.js
@@ -54,9 +54,9 @@ test('Can enable and disable add repositories button', async (done) => {
   );
 
   await patientlyWaitFor(() => expect(getByText(firstRepo.name)).toBeInTheDocument());
-  expect(getByLabelText('Select all rows')).toBeInTheDocument();
+  expect(getByLabelText('Select all')).toBeInTheDocument();
   expect(getByLabelText('add_repositories')).toHaveAttribute('aria-disabled', 'true');
-  getByLabelText('Select all rows').click();
+  getByLabelText('Select all').click();
   await patientlyWaitFor(() => {
     expect(getByLabelText('add_repositories')).toHaveAttribute('aria-disabled', 'false');
   });
@@ -66,7 +66,7 @@ test('Can enable and disable add repositories button', async (done) => {
 
 test('Can add repositories', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
-  const cvAddparams = { include_permissions: true, repository_ids: [58, 62, 64, 106] };
+  const cvAddparams = { include_permissions: true, repository_ids: [58, 62, 64, 106, 107] };
 
   const repoAddscope = nockInstance
     .put(cvDetailsPath, cvAddparams)
@@ -88,9 +88,9 @@ test('Can add repositories', async (done) => {
   );
 
   await patientlyWaitFor(() => expect(getByText(firstRepo.name)).toBeInTheDocument());
-  expect(getByLabelText('Select all rows')).toBeInTheDocument();
+  expect(getByLabelText('Select all')).toBeInTheDocument();
   expect(getByLabelText('add_repositories')).toHaveAttribute('aria-disabled', 'true');
-  getByLabelText('Select all rows').click();
+  getByLabelText('Select all').click();
   getByLabelText('add_repositories').click();
   await patientlyWaitFor(() => expect(getByText(firstRepo.name)).toBeInTheDocument());
 
@@ -123,8 +123,8 @@ test('Can remove repositories', async (done) => {
   );
 
   await patientlyWaitFor(() => expect(getByText(firstRepo.name)).toBeInTheDocument());
-  expect(getByLabelText('Select all rows')).toBeInTheDocument();
-  getByLabelText('Select all rows').click();
+  expect(getByLabelText('Select all')).toBeInTheDocument();
+  getByLabelText('Select all').click();
   await patientlyWaitFor(() => {
     expect(getByLabelText('bulk_actions')).toHaveAttribute('aria-expanded', 'false');
   });


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Refactor Repository tab to use composable table.
Cross page select for repository tab on CV UI
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
If you need dummy repos, run this to create 1000 repos:
bundle exec rails c
```
1000.times { |i|
  root = ::Katello::RootRepository.new(name:"test1#{i}", label:"test1#{i}", product_id: 1, content_type:"file", mirroring_policy: "additive")
  root.save!
  root.reload
  repository = ::Katello::Repository.new(:environment => root.organization.library,
                                         :content_view_version => root.organization.library.default_content_view_version,
                                         :root => root)
  repository.relative_path = repository.custom_repo_path
  repository.save!
  ForemanTasks::sync_task(::Actions::Katello::Repository::Create, repository)
}
```
Test bulk actions on repository tab on CV-UI with cross-page selections etc.