### PR TITLE
Fixes #34671 - clarify sync error on smart proxy sync

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.controller.js
@@ -23,9 +23,14 @@ angular.module('Bastion.capsule-content').controller('CapsuleContentController',
         var urlMatcher = $urlMatcherFactory.compile("/smart_proxies/:capsuleId");
         var capsuleId = urlMatcher.exec($location.path()).capsuleId;
 
-        function processError(response) {
+        function processError(response, prependMsg) {
+            var msg = '';
             if (response.data && response.data.displayMessage) {
-                Notification.setErrorMessage(response.data.displayMessage);
+                if (angular.isDefined(prependMsg)) {
+                    msg = msg + prependMsg;
+                }
+                msg = msg + response.data.displayMessage;
+                Notification.setErrorMessage(msg);
             }
         }
 
@@ -113,7 +118,7 @@ angular.module('Bastion.capsule-content').controller('CapsuleContentController',
                     'active_sync_tasks': [],
                     'last_failed_sync_tasks': []
                 };
-                processError(response);
+                processError(response, translate('Last sync failed: '));
             });
         };
 
@@ -141,7 +146,7 @@ angular.module('Bastion.capsule-content').controller('CapsuleContentController',
                     $scope.syncTask = aggregateTasks($scope.syncStatus['active_sync_tasks']);
                     $scope.syncState.set(syncState.RECLAIMING_SPACE);
                 }, function (response) {
-                    processError(response);
+                    processError(response, translate('Last reclaim space failed: '));
                     $scope.syncState.set(syncState.DEFAULT);
                 });
             }
@@ -157,7 +162,7 @@ angular.module('Bastion.capsule-content').controller('CapsuleContentController',
                     $scope.syncTask = aggregateTasks($scope.syncStatus['active_sync_tasks']);
                     $scope.syncState.set(syncState.SYNCING);
                 }, function (response) {
-                    processError(response);
+                    processError(response, translate('Last sync failed: '));
                     $scope.syncState.set(syncState.DEFAULT);
                 });
             }


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
When a capsule sync task errors or is cancelled, a notification is displayed anytime you visit the smart proxy.  It can lead to confusing notifications, where the user may not realize it was from a previous sync.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. spin up a smart proxy 
2. create and sync a large-ish repo locally to katello
3. add library to the smart proxy
4. sync the smart proxy
5. as its running, restart pulpcore-worker@* on the smart proxy
6. notice the notification, refresh the page and see the notification there too