### PR TITLE
Fixes #33591 - Wrong kickstart repo shown in Edit Host page

### DIFF
--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -205,9 +205,7 @@ module Katello
         return [] unless new_host.operatingsystem.is_a?(Redhat)
 
         if (host.is_a? ::Hostgroup)
-          new_host.content_facet = ::Katello::Host::ContentFacet.new(:lifecycle_environment_id => host.inherited_lifecycle_environment_id,
-                                                          :content_view_id => host.inherited_content_view_id,
-                                                          :content_source_id => host.inherited_content_source_id)
+          new_host.content_facet = hostgroup_content_facet(host, param_host)
         elsif host.content_facet.present?
           new_host.content_facet = ::Katello::Host::ContentFacet.new(:lifecycle_environment_id => host.content_facet.lifecycle_environment_id,
                                                           :content_view_id => host.content_facet.content_view_id,
@@ -269,6 +267,26 @@ module Katello
 
     def hosts_change_content_source
       [{ action: [_('Change Content Source'), '/change_host_content_source', false], priority: 100 }]
+    end
+
+    private
+
+    def hostgroup_content_facet(hostgroup, param_host)
+      lifecycle_environment_id = hostgroup.inherited_lifecycle_environment_id
+      content_view_id = hostgroup.inherited_content_view_id
+      content_source_id = hostgroup.inherited_content_source_id
+      if param_host.lifecycle_environment_id && (hostgroup.inherited_lifecycle_environment_id != param_host.lifecycle_environment_id)
+        lifecycle_environment_id = param_host.lifecycle_environment_id
+      end
+      if param_host.content_view_id && (hostgroup.inherited_content_view_id != param_host.content_view_id)
+        content_view_id = param_host.content_view_id
+      end
+      if param_host.content_source_id && (hostgroup.inherited_content_source_id != param_host.content_source_id)
+        content_source_id = param_host.content_source_id
+      end
+      ::Katello::Host::ContentFacet.new(:lifecycle_environment_id => lifecycle_environment_id,
+                                        :content_view_id => content_view_id,
+                                        :content_source_id => content_source_id)
     end
   end
 end

--- a/test/helpers/hosts_and_hostgroups_helper_test.rb
+++ b/test/helpers/hosts_and_hostgroups_helper_test.rb
@@ -186,6 +186,35 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
     refute_empty options
     assert_equal ret.first[:name], options.first.name
   end
+
+  test "kickstart_repository_options should provide options for a populated host with a selected_host_group and differing consumed content" do
+    host = ::Host.new
+    host.content_facet = ::Katello::Host::ContentFacet.new(:lifecycle_environment_id => 997,
+                                                           :content_view_id => 998,
+                                                           :content_source_id => 999)
+    hostgroup = ::Hostgroup.new(
+      :content_facet_attributes => {
+        :lifecycle_environment_id => @env.id,
+        :content_view_id => @cv.id})
+    hostgroup.architecture = @arch
+    hostgroup.operatingsystem = @os
+    hostgroup.content_source = @content_source
+
+    ret = [{:name => "boo" }]
+
+    @os.expects(:kickstart_repos).returns(ret).with do |param_host|
+      assert_instance_of ::Host::Managed, param_host
+      assert_equal @os, param_host.os
+      assert_equal 997, param_host.content_facet.lifecycle_environment_id
+      assert_equal 998, param_host.content_facet.content_view_id
+      assert_equal 999, param_host.content_facet.content_source_id
+      assert_equal @arch, param_host.architecture
+    end
+
+    options = kickstart_repository_options(host, :selected_host_group => hostgroup)
+    refute_empty options
+    assert_equal ret.first[:name], options.first.name
+  end
 end
 
 class HostsAndHostGroupsHelperKickstartRepositoryIDTest < HostsAndHostGroupsHelperTestBase


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The `kickstart_repository_options` method made the assumption that the host's content facet would have the same attributes as the host group.  If this was false, the wrong attributes would be assigned to the host's content facet and `new_host.operatingsystem.kickstart_repos(new_host)` would return `[]`.   This was caused by the `distribution_repositories` method seeing a mismatch between the host's OS and the host's LCE and CVE, causing no kickstart repositories to show up.

Now, there is a check to see if the host has a different LCE, CV, or content source from the host group.

#### Considerations taken when implementing this change?
None really, it's pretty straight-forward.

#### What are the testing steps for this pull request?
1) Follow the instructions on the redmine to check the main bug
2) Try playing around with the host group create + edit pages and the host create + edit pages and ensure everything makes sense.