### PR TITLE
Fixes #34680 - return http 422 on lock conflict

### DIFF
--- a/app/lib/katello/api/v2/error_handling.rb
+++ b/app/lib/katello/api/v2/error_handling.rb
@@ -23,6 +23,7 @@ module Katello
           rescue_from Errors::CdnSubstitutionError, :with => :rescue_from_bad_data
           rescue_from Errors::RegistrationError, :with => :rescue_from_bad_data
           rescue_from ActionController::ParameterMissing, :with => :rescue_from_missing_param
+          rescue_from ::ForemanTasks::Lock::LockConflict, :with => :rescue_from_bad_data
         end
 
         protected


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
return a 422 instead of an ISE (500) when there's a foreman-tasks lock conflict. 422 :  
```
The HyperText Transfer Protocol (HTTP) 422 Unprocessable Entity response status code indicates that the server understands the content type of the request entity, and the syntax of the request entity is correct, but it was unable to process the contained instructions.
```
#### Considerations taken when implementing this change?
found another place doing very similar exception handling
#### What are the testing steps for this pull request?
create a repository with a url, run (replacing 25 with your repo id):
```
#  curl -v -X POST  http://`hostname`:3000/katello/api/v2/repositories/25/sync  -u admin:changeme -H "Content-Type: application/json" -d '{}'
```
and immediately run it again.  You should see a 422, not a 500 with this patch
