### PR TITLE
Fixes #34383 - No hammer output for composite incremental update

### DIFF
--- a/app/lib/actions/katello/content_view/incremental_updates.rb
+++ b/app/lib/actions/katello/content_view/incremental_updates.rb
@@ -58,9 +58,8 @@ module Actions
 
               action = plan_action(ContentViewVersion::IncrementalUpdate, composite_version, environments,
                                    :new_components => new_components, :description => description)
-              unless SmartProxy.pulp_primary.pulp3_repository_type_support?("yum")
-                output_for_version_ids << {:version_id => action.new_content_view_version.id, :output => action.output}
-              end
+
+              output_for_version_ids << {:version_id => action.new_content_view_version_id, :output => action.output}
             end
           end
         end

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -103,6 +103,7 @@ module Actions
           output[:content_view_id] = input[:content_view_id]
           output[:content_view_version_id] = input[:content_view_version_id]
           output[:skip_promotion] = input[:skip_promotion]
+          output[:history_id] = input[:history_id]
         end
 
         def rescue_strategy_for_self
@@ -140,6 +141,10 @@ module Actions
 
         def content_view_version_name
           input['content_view_version_name']
+        end
+
+        def history_id
+          input['history_id']
         end
 
         private

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -429,6 +429,7 @@ module ::Actions::Katello::ContentView
       SmartProxy.any_instance.stubs(:pulp_primary).returns(proxy)
 
       Dynflow::Testing::DummyPlannedAction.any_instance.stubs(:new_content_view_version).returns(new_version)
+      Dynflow::Testing::DummyPlannedAction.any_instance.stubs(:new_content_view_version_id).returns(1)
 
       plan_action(action, [{:content_view_version => component, :environments => []}], [{:content_view_version => composite_version, :environments => [library]}],
                   {:errata_ids => ["FOO"]}, true, [], "BadDescription")


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds "Added Content" output for composite content view when incremental updating CV with `--propagate-all-composites true`.
Also removed some code that was meant for pulp 2.
#### Considerations taken when implementing this change?
Compared the output to the 6.9 output. This bug was caused mainly by the "Incremental Update" task returning before `plan_self` for composites. This meant there was no task output, unlike with component content views, which is needed for the presenter to print the results.

The original issue also mentions not seeing the new content in the composite content view, but I could not reproduce that.
#### What are the testing steps for this pull request?
1. Create a content view with a yum repository, e.g. https://fixtures.pulpproject.org/rpm-with-modules/
2. Add filters to the content view to exclude some packages and/or errata.
3. Publish the content view
4. Create a composite content view, containing the content view and content view version you just published (_not_ "always latest version").
5. Publish the content view
6. Incrementally update the component content view with hammer, i.e. `hammer content-view version incremental-update --propagate-all-composite true --content-view-version-id [id] --package-ids [package ids]`
    - Without PR: Only shows "Added Content" output for component content view.
    - With PR: Shows "Added Content" output for component _and_ composite content view.
8. Check that a new incremental version was successfully published/promoted for the composite content view.
7. Incrementally update again and you should see the "Added Content" output for _only_ the component content view.