### PR TITLE
Fixes #34692 - Add ouia-id's to all PF4 tables

### DIFF
--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -243,6 +243,8 @@ const TableWrapper = ({
 };
 
 TableWrapper.propTypes = {
+  // ouiaId is needed on all tables for automation testing
+  ouiaId: PropTypes.string.isRequired,
   searchQuery: PropTypes.string.isRequired,
   updateSearchQuery: PropTypes.func.isRequired,
   fetchItems: PropTypes.func.isRequired,

--- a/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsModal.js
@@ -35,10 +35,9 @@ export const HostCollectionsModal = ({
 
   const response = useSelector(state =>
     (adding ? selectAvailableHostCollections(state) : selectRemovableHostCollections(state))) || {};
-  const status = useSelector(state =>
-    (adding ?
-      selectAvailableHostCollectionsStatus(state) :
-      selectRemovableHostCollectionsStatus(state))) || '';
+  const status = useSelector(state => (adding ?
+    selectAvailableHostCollectionsStatus(state) :
+    selectRemovableHostCollectionsStatus(state))) || '';
   const dispatch = useDispatch();
   const { results, error: errorSearchBody, ...metadata } = response;
   const [suppressFirstFetch, setSuppressFirstFetch] = useState(false);
@@ -161,6 +160,7 @@ export const HostCollectionsModal = ({
           selectNone,
         }
         }
+        ouiaId="host-collections-table"
         additionalListeners={[hostId, modalType, existingHostCollectionIds.join(',')]}
         fetchItems={fetchItems}
         searchPlaceholderText={__('Search host collections')}

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -345,6 +345,7 @@ export const ErrataTab = () => {
             toggleGroup,
           }
           }
+          ouiaId="host-errata-table"
           additionalListeners={[
             hostId, toggleGroupState, errataTypeSelected,
             errataSeveritySelected, activeSortColumn, activeSortDirection]}

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -189,6 +189,7 @@ export const ModuleStreamsTab = () => {
             fetchItems,
             status,
           }}
+          ouiaId="host-module-stream-table"
           additionalListeners={[hostId, activeSortColumn, activeSortDirection]}
           fetchItems={fetchItems}
           autocompleteEndpoint={`/hosts/${hostId}/module_streams/auto_complete_search`}
@@ -214,44 +215,41 @@ export const ModuleStreamsTab = () => {
               installed_profiles: installedProfiles,
               upgradable,
               module_spec: moduleSpec,
-            }, index) =>
-
-            /* eslint-disable react/no-array-index-key */
-
-              (
-                <Tr key={`${id} ${index}`}>
-                  <Td>
-                    <a
-                      href={`/module_streams?search=module_spec%3D${moduleSpec}+and+host%3D${hostName}`}
-                    >
-                      {name}
-                    </a>
-                  </Td>
-                  <Td>
-                    <StreamState moduleStreamStatus={moduleStreamStatus} />
-                  </Td>
-                  <Td>{stream}</Td>
-                  <Td>
-                    <EnabledIcon
-                      streamText={moduleStreamStatus}
-                      streamInstallStatus={installedProfiles}
-                      upgradable={upgradable}
-                    />
-                  </Td>
-                  <Td>
-                    <HostInstalledProfiles
-                      moduleStreamStatus={moduleStreamStatus}
-                      installedProfiles={installedProfiles}
-                    />
-                  </Td>
-                  <Td
-                    key={`rowActions-${id}`}
-                    actions={{
-                      items: rowActions,
-                    }}
+            }, index) => (
+              /* eslint-disable react/no-array-index-key */
+              <Tr key={`${id} ${index}`}>
+                <Td>
+                  <a
+                    href={`/module_streams?search=module_spec%3D${moduleSpec}+and+host%3D${hostName}`}
+                  >
+                    {name}
+                  </a>
+                </Td>
+                <Td>
+                  <StreamState moduleStreamStatus={moduleStreamStatus} />
+                </Td>
+                <Td>{stream}</Td>
+                <Td>
+                  <EnabledIcon
+                    streamText={moduleStreamStatus}
+                    streamInstallStatus={installedProfiles}
+                    upgradable={upgradable}
                   />
-                </Tr>
-              ))
+                </Td>
+                <Td>
+                  <HostInstalledProfiles
+                    moduleStreamStatus={moduleStreamStatus}
+                    installedProfiles={installedProfiles}
+                  />
+                </Td>
+                <Td
+                  key={`rowActions-${id}`}
+                  actions={{
+                    items: rowActions,
+                  }}
+                />
+              </Tr>
+            ))
             }
           </Tbody>
         </TableWrapper>

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.js
@@ -210,6 +210,7 @@ const PackageInstallModal = ({
           selectNone,
         }
         }
+        ouiaId="host-package-install-table"
         additionalListeners={[hostId]}
         fetchItems={fetchItems}
         searchPlaceholderText={__('Search available packages')}

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -345,6 +345,7 @@ export const PackagesTab = () => {
             areAllRowsSelected,
           }
           }
+          ouiaId="host-packages-table"
           additionalListeners={[hostId, packageStatusSelected,
             activeSortDirection, activeSortColumn]}
           fetchItems={fetchItems}
@@ -430,14 +431,14 @@ export const PackagesTab = () => {
         </TableWrapper>
       </div>
       {hostId &&
-      <PackageInstallModal
-        isOpen={isModalOpen}
-        closeModal={closeModal}
-        hostId={hostId}
-        key={hostId}
-        hostName={hostname}
-        showKatelloAgent={showKatelloAgent}
-      />
+        <PackageInstallModal
+          isOpen={isModalOpen}
+          closeModal={closeModal}
+          hostId={hostId}
+          key={hostId}
+          hostName={hostname}
+          showKatelloAgent={showKatelloAgent}
+        />
       }
     </div>
   );

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -355,6 +355,7 @@ const RepositorySetsTab = () => {
             emptySearchBody,
           }
           }
+          ouiaId="host-repository-sets-table"
           errorSearchTitle={errorSearchTitle}
           errorSearchBody={errorSearchBody}
           activeFilters={[toggleGroupState]}

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
@@ -152,6 +152,7 @@ const TracesTab = () => {
           actionButtons,
         }
         }
+        ouiaId="host-traces-table"
         metadata={meta}
         autocompleteEndpoint={`/hosts/${hostId}/traces/auto_complete_search`}
         foremanApiAutoComplete

--- a/webpack/scenes/Content/Details/ContentRepositories.js
+++ b/webpack/scenes/Content/Details/ContentRepositories.js
@@ -42,6 +42,7 @@ const ContentRepositories = ({ contentType, id, tabKey }) => {
         emptySearchBody,
         emptyContentBody,
       }}
+      ouiaId="content-repositories-table"
       variant={TableVariant.compact}
       autocompleteEndpoint="/repositories/auto_complete_search"
       fetchItems={useCallback(

--- a/webpack/scenes/Content/Table/ContentTable.js
+++ b/webpack/scenes/Content/Table/ContentTable.js
@@ -30,6 +30,7 @@ const ContentTable = ({
         error,
         status,
       }}
+      ouiaId="content-table"
       key={selectedContentType}
       variant={TableVariant.compact}
       autocompleteEndpoint={`/${contentTypes[selectedContentType][1]}/auto_complete_search`}

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
@@ -244,6 +244,7 @@ const ContentViewComponents = ({ cvId, details }) => {
         activeFilters,
         defaultFilters,
       }}
+      ouiaId="content-view-components-table"
       actionResolver={hasPermission(permissions, 'edit_content_views') ? actionResolver : null}
       onSelect={onSelect(rows, setRows)}
       cells={columnHeaders}

--- a/webpack/scenes/ContentViews/Details/Filters/AffectedRepositories/AffectedRepositoryTable.js
+++ b/webpack/scenes/ContentViews/Details/Filters/AffectedRepositories/AffectedRepositoryTable.js
@@ -200,6 +200,7 @@ const AffectedRepositoryTable = ({
         error,
         status,
       }}
+      ouiaId="content-view-filter-affected-repository-table"
       onSelect={hasPermission(permissions, 'edit_content_views') ? onSelect(rows, setRows) : null}
       cells={columnHeaders}
       variant={TableVariant.compact}

--- a/webpack/scenes/ContentViews/Details/Filters/CVContainerImageFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVContainerImageFilterContent.js
@@ -131,6 +131,7 @@ const CVContainerImageFilterContent = ({
               updateSearchQuery,
               status,
             }}
+            ouiaId="content-view-container-image-filter"
             actionResolver={hasPermission(permissions, 'edit_content_views') ? actionResolver : null}
             onSelect={hasPermission(permissions, 'edit_content_views') ? onSelect(rows, setRows) : null}
             cells={columnHeaders}

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
@@ -265,6 +265,7 @@ const CVErrataIDFilterContent = ({
               activeFilters,
               defaultFilters,
             }}
+            ouiaId="content-view-errata-by-id-filter-table"
             actionResolver={hasPermission(permissions, 'edit_content_views') ? actionResolver : null}
             onSelect={hasPermission(permissions, 'edit_content_views') ? onSelect(rows, setRows) : null}
             cells={columnHeaders}

--- a/webpack/scenes/ContentViews/Details/Filters/CVModuleStreamFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVModuleStreamFilterContent.js
@@ -216,6 +216,7 @@ const CVModuleStreamFilterContent = ({
               error,
               status,
             }}
+            ouiaId="content-view-module-stream-filter-table"
             additionalListeners={[selectedIndex]}
             activeFilters={[selectedAdded]}
             defaultFilters={[allAddedNotAdded[0]]}

--- a/webpack/scenes/ContentViews/Details/Filters/CVPackageGroupFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVPackageGroupFilterContent.js
@@ -206,6 +206,7 @@ const CVPackageGroupFilterContent = ({
               error,
               status,
             }}
+            ouiaId="content-view-package-group-filter-table"
             additionalListeners={[selectedIndex]}
             activeFilters={[selectedAdded]}
             defaultFilters={[allAddedNotAdded[0]]}

--- a/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
@@ -161,6 +161,7 @@ const CVRpmFilterContent = ({
               updateSearchQuery,
               status,
             }}
+            ouiaId="content-view-rpm-filter-table"
             actionResolver={hasPermission(permissions, 'edit_content_views') ? actionResolver : null}
             onSelect={hasPermission(permissions, 'edit_content_views') ? onSelect(rows, setRows) : null}
             cells={columnHeaders}

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
@@ -126,6 +126,7 @@ const ContentViewFilters = ({ cvId, details }) => {
         error,
         status,
       }}
+      ouiaId="content-view-filters-table"
       actionResolver={hasPermission(permissions, 'edit_content_views') ? actionResolver : null}
       onSelect={hasPermission(permissions, 'edit_content_views') ? onSelect(rows, setRows) : null}
       cells={columnHeaders}

--- a/webpack/scenes/ContentViews/Details/Filters/MatchContentModal/CVRpmMatchContentModal.js
+++ b/webpack/scenes/ContentViews/Details/Filters/MatchContentModal/CVRpmMatchContentModal.js
@@ -53,6 +53,7 @@ const CVRpmMatchContentModal = ({ filterId, onClose, filterRuleId }) => {
           fetchItems,
           status,
         }}
+        ouiaId="content-view-rpm-match-content-table"
         autocompleteEndpoint="/packages/auto_complete_search"
         variant={TableVariant.compact}
       >

--- a/webpack/scenes/ContentViews/Details/Histories/ContentViewHistories.js
+++ b/webpack/scenes/ContentViews/Details/Histories/ContentViewHistories.js
@@ -49,9 +49,9 @@ const ContentViewHistories = ({ cvId }) => {
     const taskType = task ? task.label : taskTypes[action];
 
     if (taskType === taskTypes.removal) {
-      return <>{__('Deleted from ')} <Label isTruncated key="1" color="blue" href={`/lifecycle_environments/${environment?.id}`}>{`${environment?.name ?? __('all environments')}`}</Label>{}</>;
+      return <>{__('Deleted from ')} <Label isTruncated key="1" color="blue" href={`/lifecycle_environments/${environment?.id}`}>{`${environment?.name ?? __('all environments')}`}</Label></>;
     } else if (action === 'promotion' || taskType === taskTypes.promotion) {
-      return <>{__('Promoted to ')}<Label isTruncated key="2" color="blue" href={`/lifecycle_environments/${environment?.id}`}>{`${environment?.name}`}</Label>{}</>;
+      return <>{__('Promoted to ')}<Label isTruncated key="2" color="blue" href={`/lifecycle_environments/${environment?.id}`}>{`${environment?.name}`}</Label></>;
     } else if (taskType === taskTypes.publish) {
       return __('Published new version');
     } else if (taskType === taskTypes.export) {
@@ -81,6 +81,7 @@ const ContentViewHistories = ({ cvId }) => {
         error,
         status,
       }}
+      ouiaId="content-view-history-table"
       variant={TableVariant.compact}
       autocompleteEndpoint={`/content_views/${cvId}/history/auto_complete_search`}
       fetchItems={useCallback(params => getContentViewHistories(cvId, params), [cvId])}

--- a/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
@@ -274,6 +274,7 @@ const ContentViewRepositories = ({ cvId, details }) => {
         activeFilters,
         defaultFilters,
       }}
+      ouiaId="content-view-repositories-table"
       actionResolver={hasPermission(permissions, 'edit_content_views') ? actionResolver : null}
       onSelect={hasPermission(permissions, 'edit_content_views') && !(importOnly || generatedContentView) ? onSelect(rows, setRows) : null}
       cells={columnHeaders}

--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
@@ -240,6 +240,7 @@ const ContentViewVersions = ({ cvId, details }) => {
         status,
         selectedCount,
       }}
+      ouiaId="content-view-versions-table"
       variant={TableVariant.compact}
       autocompleteEndpoint={`/content_view_versions/auto_complete_search?content_view_id=${cvId}`}
       fetchItems={useCallback((params) => {

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/affectedActivationKeys.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/affectedActivationKeys.js
@@ -54,6 +54,7 @@ const AffectedActivationKeys = ({
         fetchItems,
         status,
       }}
+      ouiaId="content-view-delete-modal-affected-activation-keys"
       autocompleteEndpoint="/activation_keys/auto_complete_search"
       variant={TableVariant.compact}
     >

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/affectedHosts.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/affectedHosts.js
@@ -49,6 +49,7 @@ const AffectedHosts = ({
         fetchItems,
         status,
       }}
+      ouiaId="content-view-delete-modal-affected-hosts-table"
       autocompleteEndpoint="/hosts/auto_complete_search"
       foremanApiAutoComplete
       variant={TableVariant.compact}

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsTable.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsTable.js
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
 import PropTypes from 'prop-types';
+import { kebabCase } from 'lodash';
 import {
   shallowEqual,
   useSelector,
@@ -34,6 +35,7 @@ const ContentViewVersionDetailsTable = ({
     fetchItems,
     columnHeaders,
     disableSearch,
+    route,
   }, repositories,
 }) => {
   const ALL_REPOSITORIES = __('All Repositories');
@@ -77,6 +79,7 @@ const ContentViewVersionDetailsTable = ({
           autocompleteEndpoint,
           disableSearch,
         }}
+        ouiaId={`content-view-version-details-${kebabCase(route)}-table`}
         additionalListeners={[selected]}
         fetchItems={fetchItemsWithRepositoryId}
         emptySearchTitle={__('Your search returned no matching ') + name}

--- a/webpack/scenes/ContentViews/Table/ContentViewsTable.js
+++ b/webpack/scenes/ContentViews/Table/ContentViewsTable.js
@@ -156,6 +156,7 @@ const ContentViewTable = () => {
         updateSearchQuery,
         fetchItems,
       }}
+      ouiaId="content-views-table"
       additionalListeners={[isPublishModalOpen, activeSortColumn, activeSortDirection]}
       bookmarkController="katello_content_views"
       variant={TableVariant.compact}

--- a/webpack/scenes/ContentViews/expansions/RelatedContentViewComponentsModal.js
+++ b/webpack/scenes/ContentViews/expansions/RelatedContentViewComponentsModal.js
@@ -58,7 +58,6 @@ const RelatedContentViewsModal = ({ cvName, cvId, relatedCVCount }) => {
             }}
             appendTo={document.body}
           >
-
             <TableWrapper
               {...{
                 metadata,
@@ -67,6 +66,7 @@ const RelatedContentViewsModal = ({ cvName, cvId, relatedCVCount }) => {
                 error,
                 status,
               }}
+              ouiaId="related-content-view-components-table"
               fetchItems={useCallback(params => getContentViewComponents(cvId, params, 'Added'), [cvId])}
               variant={TableVariant.compact}
               autocompleteEndpoint="/content_views/auto_complete_search"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

- The ticket required only a targetable ouiaId on a single table, this PR simply adds the id's to all tables, and makes 'ouiaId'  a required prop on  the Tablewrapper component.

#### What are the testing steps for this pull request?

- Open chrome dev tools. 
- Navigate to all PF4 tables in the app to ensure that the 'data-ouia-component-id' prop is now static. 

For more information on how this prop works see [here](https://www.patternfly.org/v4/developer-resources/open-ui-automation/). 

TLDR: 'ouiaId' on a component translates to a static 'data-ouia-component-id' on the dom element.
