### PR TITLE
Fixes #34695 - add methods to jail for new repo report template

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -45,7 +45,7 @@ module Katello
         prepend ::ForemanRemoteExecution::HostExtensions if ::Katello.with_remote_execution?
         prepend Overrides
 
-        delegate :content_source_id, :content_view_id, :lifecycle_environment_id, :kickstart_repository_id, to: :content_facet, allow_nil: true
+        delegate :content_source_id, :content_view_id, :lifecycle_environment_id, :kickstart_repository_id, :bound_repositories, to: :content_facet, allow_nil: true
 
         has_many :dispatch_histories, :class_name => "::Katello::Agent::DispatchHistory", :foreign_key => :host_id, :dependent => :delete_all
 
@@ -448,7 +448,7 @@ class ::Host::Managed::Jail < Safemode::Jail
   allow :content_source, :subscription_manager_configuration_url, :rhsm_organization_label,
         :host_collections, :pools, :hypervisor_host, :lifecycle_environment, :content_view,
         :installed_packages, :traces_helpers, :advisory_ids, :package_names_for_job_template,
-        :filtered_entitlement_quantity_consumed
+        :filtered_entitlement_quantity_consumed, :bound_repositories
 end
 
 class ActiveRecord::Associations::CollectionProxy::Jail < Safemode::Jail

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -968,7 +968,7 @@ module Katello
       property :docker_upstream_name, String, desc: 'Returns name of the upstream docker repository'
     end
     class Jail < ::Safemode::Jail
-      allow :name, :label, :docker_upstream_name
+      allow :name, :label, :docker_upstream_name, :content_counts
     end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Allows a host's `bound_repositories` and a repository's `content_counts` through the Safemode Jail.
These changes support the request for a new report template that shows hosts' repositories and CV content counts.

#### Considerations taken when implementing this change?
Only safe methods should be allowed through the jail.  I don't see anything wrong with these methods since they're purely informational.

#### What are the testing steps for this pull request?
Try out the report template below with some content hosts registered.  Ensure that Safemode is enabled.

```erb
<%- report_headers 'Host ID', 'Host Name', 'Repository Name', 'Package Count' -%>
<%- load_hosts(includes: [:content_facet => :bound_repositories]).each_record do |host| -%>
<%-   (host.bound_repositories || []).each do |repo| -%>
<%-     report_row(
          'Host ID': host.id,
          'Host Name': host.name,
          'Repository Name': repo,
          'Package Count': repo.content_counts['rpm']
      ) -%>
<%-   end -%>
<%- end -%>
<%= report_render -%>
```