### PR TITLE
Fixes #34711 - Search hosts by repository

### DIFF
--- a/test/fixtures/models/katello_content_facet_repositories.yml
+++ b/test/fixtures/models/katello_content_facet_repositories.yml
@@ -1,0 +1,3 @@
+content_facet_repository:
+  repository_id: <%= ActiveRecord::FixtureSet.identify(:fedora_17_x86_64_acme_dev) %>
+  content_facet_id: <%= ActiveRecord::FixtureSet.identify(:content_facet_one) %>

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -408,8 +408,10 @@ module Katello
   end
 
   class ContentHostExtensions < ContentFacetBase
+    let(:host_one) { hosts(:one) }
     def setup
       assert host #force lazy load
+      assert host_one
     end
 
     def test_content_view_search
@@ -444,6 +446,16 @@ module Katello
       status.save!
 
       assert_includes ::Host::Managed.search_for("trace_status = process_restart_needed"), content_facet.host
+    end
+
+    def test_repository_search
+      name = host_one.bound_repositories.sort.find { |repo| repo.name == "Fedora 17 x86_64" }&.name
+      assert_includes ::Host::Managed.search_for("repository = \"#{name}\""), host_one
+    end
+
+    def test_content_label_search
+      label = host_one.bound_repositories.sort.find { |repo| repo&.content&.label == "fedora" }&.content&.label
+      assert_includes ::Host::Managed.search_for("repository_content_label = \"#{label}\""), host_one
     end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds scoped search for host based on repository name and content label

#### Considerations taken when implementing this change?
shrug

#### What are the testing steps for this pull request?
1. Subscribe some product with a repository to a host.
2. Log into your host and do `yum repolist all`.
3. In the rails console, search for the host by repository name using `Host.search_for('repository=[repository_name]')`. It should return the host that your repository is on. Don't forget the single quotes :) 
4. Search by content label with `Host.search_for('repository_content_label=[content_label]')`. You can get the content label with `Katello::Repository.find([id]).content.label`