### PR TITLE
Fixes #34587 - Delete unused settings from DB

### DIFF
--- a/db/migrate/20220404190836_delete_old_setting_data.rb
+++ b/db/migrate/20220404190836_delete_old_setting_data.rb
@@ -1,0 +1,9 @@
+class DeleteOldSettingData < ActiveRecord::Migration[6.0]
+  def up
+    Setting.where(name: ['default_location_puppet_content', 'pulp_sync_node_action_accept_timeout',
+                         'pulp_sync_node_action_finish_timeout', 'subscriptions_return_host_data']).delete_all
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Delete certain left-over setting values from DB
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Run the migration. You may or may not have the settings being removed from the db depending on your box and how recently the db was created and seeded.