### PR TITLE
Refs #34698 - Add kebab to change a host's content view

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -96,6 +96,7 @@ module Katello
     scoped_search :on => :label, :complete_value => true
     scoped_search :on => :composite, :complete_value => true
     scoped_search :on => :generated_for, :complete_value => true
+    scoped_search :on => :default # just for ordering
 
     enum generated_for: {
       none: 0,

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -1,14 +1,38 @@
-import React from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Modal, Button } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
+import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
+import EnvironmentPaths from '../../../../../scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths';
+import { ENVIRONMENT_PATHS_KEY } from '../../../../../scenes/ContentViews/components/EnvironmentPaths/EnvironmentPathConstants';
+import api from '../../../../../services/api';
+
+const ENV_PATH_OPTIONS = { key: ENVIRONMENT_PATHS_KEY };
 
 const ChangeHostCVModal = ({
   isOpen,
   closeModal,
-  hostId,
-  hostName,
+  hostEnvId,
+  orgId,
 }) => {
+  const { response } = useAPI(
+    'get',
+    api.getApiUrl(`/organizations/${orgId}/environments/paths?permission_type=promotable`),
+    ENV_PATH_OPTIONS,
+  );
+  const { results: envPaths } = response ?? [];
+  const initialEnvFromId = useCallback((paths, envId) => {
+    const envFlatPaths = paths?.map(p => p.environments ?? []).flat();
+    return envFlatPaths?.filter(e => e.id === envId) ?? [];
+  }, []);
+  const [selectedEnvForHost, setSelectedEnvForHost]
+    = useState([]);
+
+  useEffect(() => {
+    // set selectedEnvForHost when hostCurrentEnv is populated
+    setSelectedEnvForHost(initialEnvFromId(envPaths, hostEnvId));
+  }, [envPaths, hostEnvId, initialEnvFromId]);
+
   const modalActions = ([
     <Button key="add" variant="primary" onClick={closeModal} isDisabled={false}>
       {__('Save')}
@@ -27,7 +51,14 @@ const ChangeHostCVModal = ({
       position="top"
       actions={modalActions}
       id="change-host-cv-modal"
-    >{hostId} {hostName}
+    >
+      <EnvironmentPaths
+        userCheckedItems={selectedEnvForHost}
+        setUserCheckedItems={setSelectedEnvForHost}
+        publishing={false}
+        multiSelect={false}
+        headerText={__('Select environment')}
+      />
     </Modal>
   );
 };
@@ -35,14 +66,14 @@ const ChangeHostCVModal = ({
 ChangeHostCVModal.propTypes = {
   isOpen: PropTypes.bool,
   closeModal: PropTypes.func,
-  hostId: PropTypes.number.isRequired,
-  hostName: PropTypes.string,
+  hostEnvId: PropTypes.number,
+  orgId: PropTypes.number.isRequired,
 };
 
 ChangeHostCVModal.defaultProps = {
   isOpen: false,
   closeModal: () => {},
-  hostName: '',
+  hostEnvId: null,
 };
 
 

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -37,6 +37,13 @@ const ChangeHostCVModal = ({
     ENV_PATH_OPTIONS,
   );
 
+  const handleModalClose = () => {
+    setCVSelectOpen(false);
+    setSelectedCVForHost(null);
+    setSelectedEnvForHost([]);
+    closeModal();
+  };
+
   const selectedEnv = selectedEnvForHost?.[0];
 
   const handleCVSelect = (event, selection) => {
@@ -57,10 +64,14 @@ const ChangeHostCVModal = ({
   const { results: contentViewsInEnv = [] } = contentViewsInEnvResponse;
   const canSave = !!(selectedCVForHost && selectedEnvForHost.length);
 
-  const relevantVersionFromCv = (cv, env) => {
+  const relevantVersionObjFromCv = (cv, env) => { // returns the entire version object
     const versions = cv.versions.filter(version => new Set(version.environment_ids).has(env.id));
-    return uniq(versions)?.[0]?.version;
+    return uniq(versions)?.[0];
   };
+  const relevantVersionFromCv = (cv, env) =>
+    relevantVersionObjFromCv(cv, env)?.version; // returns the version text e.g. "1.0"
+  const relevantVersionIdFromCv = (cv, env) =>
+    relevantVersionObjFromCv(cv, env)?.id; // returns the version's database id
 
   const cvPlaceholderText = useCallback(() => {
     if (contentViewsInEnvStatus === STATUS.PENDING) return __('Loading...');
@@ -68,10 +79,10 @@ const ChangeHostCVModal = ({
   }, [contentViewsInEnv.length, contentViewsInEnvStatus]);
 
   const modalActions = ([
-    <Button key="add" variant="primary" onClick={closeModal} isDisabled={!canSave}>
+    <Button key="add" variant="primary" onClick={handleModalClose} isDisabled={!canSave}>
       {__('Save')}
     </Button>,
-    <Button key="cancel" variant="link" onClick={closeModal}>
+    <Button key="cancel" variant="link" onClick={handleModalClose}>
       Cancel
     </Button>,
   ]);
@@ -79,7 +90,8 @@ const ChangeHostCVModal = ({
   return (
     <Modal
       isOpen={isOpen}
-      onClose={closeModal}
+      onClose={handleModalClose}
+      onEscapePress={handleModalClose}
       title={__('Edit content view assignment')}
       width="50%"
       position="top"
@@ -112,7 +124,7 @@ const ChangeHostCVModal = ({
           {contentViewsInEnv?.map(cv => (
             <SelectOption
               key={cv.id}
-              value={cv}
+              value={cv.id}
               description={cv.default ? __('Library') :
               <FormattedMessage
                 id={`content-view-${cv.id}-version-${cv.latest_version}`}

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import { Modal, Button, Select, SelectOption } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
+import { STATUS } from 'foremanReact/constants';
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
 import EnvironmentPaths from '../../../../../scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths';
 import { ENVIRONMENT_PATHS_KEY } from '../../../../../scenes/ContentViews/components/EnvironmentPaths/EnvironmentPathConstants';
@@ -55,7 +56,11 @@ const ChangeHostCVModal = ({
   };
   const { results: contentViewsInEnv = [] } = contentViewsInEnvResponse;
   const canSave = !!(selectedCVForHost && selectedEnvForHost.length);
-  console.log(contentViewsInEnv);
+
+  const cvPlaceholderText = useCallback(() => {
+    if (contentViewsInEnvStatus === STATUS.PENDING) return __('Loading...');
+    return (contentViewsInEnv.length === 0) ? __('No content views available') : __('Select a content view');
+  }, [contentViewsInEnv.length, contentViewsInEnvStatus]);
 
   const modalActions = ([
     <Button key="add" variant="primary" onClick={closeModal} isDisabled={!canSave}>
@@ -97,7 +102,7 @@ const ChangeHostCVModal = ({
           id="selectCV"
           name="selectCV"
           aria-label="selectCV"
-          placeholderText={(contentViewsInEnv.length === 0) ? __('No content views available') : __('Select a content view')}
+          placeholderText={cvPlaceholderText()}
         >
           {contentViewsInEnv?.map(cv => (
             <SelectOption

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -67,7 +67,6 @@ const ChangeHostCVModal = ({
   const contentViewsInEnvResponse = useSelector(state => selectContentViews(state, `FOR_ENV_${hostEnvId}`));
   const contentViewsInEnvStatus = useSelector(state => selectContentViewStatus(state, `FOR_ENV_${hostEnvId}`));
   const hostUpdateStatus = useSelector(state => selectAPIStatus(state, HOST_CV_AND_ENV_KEY));
-
   useAPI( // No TableWrapper here, so we can useAPI from Foreman
     'get',
     api.getApiUrl(`/organizations/${orgId}/environments/paths?permission_type=promotable`),
@@ -156,7 +155,6 @@ const ChangeHostCVModal = ({
       Cancel
     </Button>,
   ]);
-
   return (
     <Modal
       isOpen={isOpen}

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
-import { Modal, Button, Select, SelectOption } from '@patternfly/react-core';
+import { Modal, Button, Select, SelectOption, Alert } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
@@ -98,6 +98,17 @@ const ChangeHostCVModal = ({
       actions={modalActions}
       id="change-host-cv-modal"
     >
+      {contentViewsInEnvStatus === STATUS.RESOLVED &&
+        !!selectedEnvForHost.length && contentViewsInEnv.length === 0 &&
+        <Alert
+          variant="warning"
+          isInline
+          title={__('No content views available for the selected environment')}
+          style={{ marginBottom: '1rem' }}
+        >
+          {__('View the Content Views page to manage and promote content views, or select a different environment.')}
+        </Alert>
+      }
       <EnvironmentPaths
         userCheckedItems={selectedEnvForHost}
         setUserCheckedItems={handleEnvSelect}

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Modal, Button } from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+const ChangeHostCVModal = ({
+  isOpen,
+  closeModal,
+  hostId,
+  hostName,
+}) => {
+  const modalActions = ([
+    <Button key="add" variant="primary" onClick={closeModal} isDisabled={false}>
+      {__('Save')}
+    </Button>,
+    <Button key="cancel" variant="link" onClick={closeModal}>
+      Cancel
+    </Button>,
+  ]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={closeModal}
+      title={__('Edit content view assignment')}
+      width="50%"
+      position="top"
+      actions={modalActions}
+      id="change-host-cv-modal"
+    >{hostId} {hostName}
+    </Modal>
+  );
+};
+
+ChangeHostCVModal.propTypes = {
+  isOpen: PropTypes.bool,
+  closeModal: PropTypes.func,
+  hostId: PropTypes.number.isRequired,
+  hostName: PropTypes.string,
+};
+
+ChangeHostCVModal.defaultProps = {
+  isOpen: false,
+  closeModal: () => {},
+  hostName: '',
+};
+
+
+export default ChangeHostCVModal;

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -1,13 +1,16 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Modal, Button } from '@patternfly/react-core';
+import { FormattedMessage } from 'react-intl';
+import { Modal, Button, Select, SelectOption } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
 import EnvironmentPaths from '../../../../../scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths';
 import { ENVIRONMENT_PATHS_KEY } from '../../../../../scenes/ContentViews/components/EnvironmentPaths/EnvironmentPathConstants';
 import api from '../../../../../services/api';
+import CONTENT_VIEWS_KEY from '../../../../../scenes/ContentViews/ContentViewsConstants';
 
 const ENV_PATH_OPTIONS = { key: ENVIRONMENT_PATHS_KEY };
+const CV_OPTIONS = { key: CONTENT_VIEWS_KEY };
 
 const ChangeHostCVModal = ({
   isOpen,
@@ -15,12 +18,19 @@ const ChangeHostCVModal = ({
   hostEnvId,
   orgId,
 }) => {
-  const { response } = useAPI(
+  const { response: envResponse } = useAPI( // No TableWrapper here, so we can useAPI from Foreman
     'get',
     api.getApiUrl(`/organizations/${orgId}/environments/paths?permission_type=promotable`),
     ENV_PATH_OPTIONS,
   );
-  const { results: envPaths } = response ?? [];
+  const { response: cvResponse } = useAPI(
+    'get',
+    api.getApiUrl(`/organizations/${orgId}/content_views`),
+    CV_OPTIONS,
+  );
+  const { results: allContentViews } = cvResponse;
+  const { results: envPaths } = envResponse ?? [];
+
   const initialEnvFromId = useCallback((paths, envId) => {
     const envFlatPaths = paths?.map(p => p.environments ?? []).flat();
     return envFlatPaths?.filter(e => e.id === envId) ?? [];
@@ -28,13 +38,48 @@ const ChangeHostCVModal = ({
   const [selectedEnvForHost, setSelectedEnvForHost]
     = useState([]);
 
+  const cvSelectionsFromEnvironment = useCallback((env) => {
+    if (!env) return [];
+    const defaultOrgView = allContentViews?.find(cv => cv.default);
+    const cvIds = new Set(env.content_views.map(cv => cv.id));
+    const cvSelections = allContentViews?.filter(cv => cvIds.has(cv.id));
+    if (defaultOrgView && cvSelections && env.library) {
+      return [defaultOrgView, ...cvSelections];
+    }
+    return cvSelections ?? [];
+  }, [allContentViews]);
+
+  const [selectedCVForHost, setSelectedCVForHost] = useState(null);
+  const [cvSelectOpen, setCVSelectOpen] = useState(false);
+  const [cvSelectOptions, setCvSelectOptions] = useState([]);
+
   useEffect(() => {
     // set selectedEnvForHost when hostCurrentEnv is populated
     setSelectedEnvForHost(initialEnvFromId(envPaths, hostEnvId));
   }, [envPaths, hostEnvId, initialEnvFromId]);
 
+  useEffect(() => {
+    // set cvSelectOptions when selectedEnvForHost is populated
+    setCvSelectOptions(cvSelectionsFromEnvironment(selectedEnvForHost[0]));
+  }, [selectedEnvForHost, cvSelectionsFromEnvironment]);
+
+  const onSelect = (event, selection) => {
+    setSelectedCVForHost(selection);
+    setCVSelectOpen(false);
+  };
+
+  const canSave = selectedCVForHost && selectedEnvForHost.length;
+
+  useEffect(() => {
+    const selectedCVIsValid = selectedCVForHost &&
+        new Set(cvSelectOptions.map(cv => cv.latest_version_id)).has(selectedCVForHost);
+    if (!selectedCVIsValid) {
+      setSelectedCVForHost(null);
+    }
+  }, [cvSelectOptions, selectedCVForHost]);
+
   const modalActions = ([
-    <Button key="add" variant="primary" onClick={closeModal} isDisabled={false}>
+    <Button key="add" variant="primary" onClick={closeModal} isDisabled={!canSave}>
       {__('Save')}
     </Button>,
     <Button key="cancel" variant="link" onClick={closeModal}>
@@ -59,6 +104,40 @@ const ChangeHostCVModal = ({
         multiSelect={false}
         headerText={__('Select environment')}
       />
+      {selectedEnvForHost.length > 0 &&
+      <div style={{ marginTop: '1em' }}>
+        <h3>{__('Select content view')}</h3>
+        <Select
+          selections={selectedCVForHost}
+          onSelect={onSelect}
+          isOpen={cvSelectOpen}
+          menuAppendTo="parent"
+          isDisabled={cvSelectOptions.length === 0}
+          onToggle={isExpanded => setCVSelectOpen(isExpanded)}
+          ouiaId="select-content-view"
+          id="selectCV"
+          name="selectCV"
+          aria-label="selectCV"
+          placeholderText={(cvSelectOptions.length === 0) ? __('No content views available') : __('Select a content view')}
+        >
+          {cvSelectOptions.map(cv => (
+            <SelectOption
+              key={cv.id}
+              value={cv.latest_version_id}
+              description={
+                <FormattedMessage
+                  id={`content-view-${cv.id}-version-${cv.latest_version}`}
+                  defaultMessage="Version {versionNumber}"
+                  values={{ versionNumber: cv.latest_version }}
+                />}
+            >
+              {cv.name}
+            </SelectOption>
+          ))
+          }
+        </Select>
+      </div>
+      }
     </Modal>
   );
 };

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -130,7 +130,10 @@ const ChangeHostCVModal = ({
         },
       },
     };
-    dispatch(updateHostContentViewAndEnvironment(requestBody, hostId, refreshHostDetails));
+    dispatch(updateHostContentViewAndEnvironment(
+      requestBody, hostId,
+      refreshHostDetails, handleModalClose,
+    ));
   };
 
   const cvPlaceholderText = useCallback(() => {

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -25,7 +25,7 @@ import ChangeHostCVModal from './ChangeHostCVModal';
 
 const HostContentViewDetails = ({
   contentView, lifecycleEnvironment, contentViewVersionId,
-  contentViewVersion, contentViewVersionLatest, hostId, hostName,
+  contentViewVersion, contentViewVersionLatest, hostId, hostName, orgId, hostEnvId,
 }) => {
   let versionLabel = `Version ${contentViewVersion}`;
   if (contentViewVersionLatest) {
@@ -126,6 +126,8 @@ const HostContentViewDetails = ({
           isOpen={isModalOpen}
           closeModal={closeModal}
           hostId={hostId}
+          hostEnvId={hostEnvId}
+          orgId={orgId}
           key={`cv-change-modal-${hostId}`}
           hostName={hostName}
         />
@@ -135,10 +137,13 @@ const HostContentViewDetails = ({
 };
 
 const ContentViewDetailsCard = ({ hostDetails }) => {
-  if (hostIsRegistered({ hostDetails }) && hostDetails.content_facet_attributes) {
+  if (hostIsRegistered({ hostDetails })
+    && hostDetails.content_facet_attributes && hostDetails.organization_id) {
     return (<HostContentViewDetails
       hostId={hostDetails.id}
       hostName={hostDetails.name}
+      orgId={hostDetails.organization_id}
+      hostEnvId={hostDetails.content_facet_attributes.lifecycle_environment_id}
       {...propsToCamelCase(hostDetails.content_facet_attributes)}
     />);
   }
@@ -160,18 +165,23 @@ HostContentViewDetails.propTypes = {
   contentViewVersionLatest: PropTypes.bool.isRequired,
   id: PropTypes.number,
   name: PropTypes.string,
+  hostEnvId: PropTypes.number,
 };
 
 HostContentViewDetails.defaultProps = {
   id: null,
   name: '',
+  hostEnvId: null,
 };
 
 ContentViewDetailsCard.propTypes = {
   hostDetails: PropTypes.shape({
     id: PropTypes.number,
     name: PropTypes.string,
-    content_facet_attributes: PropTypes.shape({}),
+    organization_id: PropTypes.number,
+    content_facet_attributes: PropTypes.shape({
+      lifecycle_environment_id: PropTypes.number,
+    }),
   }),
 };
 

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -21,10 +21,11 @@ import { propsToCamelCase } from 'foremanReact/common/helpers';
 import PropTypes from 'prop-types';
 import ContentViewIcon from '../../../../../scenes/ContentViews/components/ContentViewIcon';
 import { hostIsRegistered } from '../../hostDetailsHelpers';
+import ChangeHostCVModal from './ChangeHostCVModal';
 
 const HostContentViewDetails = ({
   contentView, lifecycleEnvironment, contentViewVersionId,
-  contentViewVersion, contentViewVersionLatest,
+  contentViewVersion, contentViewVersionLatest, hostId, hostName,
 }) => {
   let versionLabel = `Version ${contentViewVersion}`;
   if (contentViewVersionLatest) {
@@ -32,14 +33,20 @@ const HostContentViewDetails = ({
   }
 
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const toggleBulkAction = () => setIsDropdownOpen(prev => !prev);
+  const toggleHamburger = () => setIsDropdownOpen(prev => !prev);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const closeModal = () => setIsModalOpen(false);
+  const openModal = () => {
+    setIsDropdownOpen(false);
+    setIsModalOpen(true);
+  };
 
   const dropdownItems = [
     <DropdownItem
       aria-label="change-host-content-view"
       key="change-host-content-view"
       component="button"
-      onClick={toggleBulkAction}
+      onClick={openModal}
     >
       {__('Edit content view assignment')}
     </DropdownItem>,
@@ -66,7 +73,7 @@ const HostContentViewDetails = ({
             </FlexItem>
             <FlexItem>
               <Dropdown
-                toggle={<KebabToggle aria-label="change_content_view_hamburger" onToggle={toggleBulkAction} />}
+                toggle={<KebabToggle aria-label="change_content_view_hamburger" onToggle={toggleHamburger} />}
                 isOpen={isDropdownOpen}
                 isPlain
                 ouiaId="change-host-content-view-kebab"
@@ -114,13 +121,26 @@ const HostContentViewDetails = ({
           </Flex>
         </CardBody>
       </Card>
+      {hostId &&
+        <ChangeHostCVModal
+          isOpen={isModalOpen}
+          closeModal={closeModal}
+          hostId={hostId}
+          key={`cv-change-modal-${hostId}`}
+          hostName={hostName}
+        />
+      }
     </GridItem>
   );
 };
 
 const ContentViewDetailsCard = ({ hostDetails }) => {
   if (hostIsRegistered({ hostDetails }) && hostDetails.content_facet_attributes) {
-    return <HostContentViewDetails {...propsToCamelCase(hostDetails.content_facet_attributes)} />;
+    return (<HostContentViewDetails
+      hostId={hostDetails.id}
+      hostName={hostDetails.name}
+      {...propsToCamelCase(hostDetails.content_facet_attributes)}
+    />);
   }
   return null;
 };
@@ -138,10 +158,19 @@ HostContentViewDetails.propTypes = {
   contentViewVersionId: PropTypes.number.isRequired,
   contentViewVersion: PropTypes.string.isRequired,
   contentViewVersionLatest: PropTypes.bool.isRequired,
+  id: PropTypes.number,
+  name: PropTypes.string,
+};
+
+HostContentViewDetails.defaultProps = {
+  id: null,
+  name: '',
 };
 
 ContentViewDetailsCard.propTypes = {
   hostDetails: PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
     content_facet_attributes: PropTypes.shape({}),
   }),
 };

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -1,12 +1,15 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Card,
   CardHeader,
   CardTitle,
   CardBody,
+  Dropdown,
+  DropdownItem,
   Flex,
   FlexItem,
   GridItem,
+  KebabToggle,
   Label,
 } from '@patternfly/react-core';
 
@@ -14,8 +17,8 @@ import { urlBuilder } from 'foremanReact/common/urlHelpers';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
 import PropTypes from 'prop-types';
-import ContentViewIcon from '../../../../scenes/ContentViews/components/ContentViewIcon';
-import { hostIsRegistered } from '../hostDetailsHelpers';
+import ContentViewIcon from '../../../../../scenes/ContentViews/components/ContentViewIcon';
+import { hostIsRegistered } from '../../hostDetailsHelpers';
 
 const HostContentViewDetails = ({
   contentView, lifecycleEnvironment, contentViewVersionId,
@@ -26,11 +29,50 @@ const HostContentViewDetails = ({
     versionLabel += ' (latest)';
   }
 
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const toggleBulkAction = () => setIsDropdownOpen(prev => !prev);
+
+  const dropdownItems = [
+    <DropdownItem
+      aria-label="change-host-content-view"
+      key="change-host-content-view"
+      component="button"
+      onClick={toggleBulkAction}
+    >
+      {__('Edit content view assignment')}
+    </DropdownItem>,
+  ];
+
   return (
     <GridItem rowSpan={1} md={6} lg={4} xl2={3} >
       <Card isHoverable>
         <CardHeader>
-          <CardTitle>{__('Content view details')}</CardTitle>
+          <Flex
+            alignItems={{ default: 'alignItemsCenter' }}
+            justifyContent={{ default: 'justifyContentSpaceBetween' }}
+            style={{ width: '100%' }}
+          >
+            <FlexItem>
+              <Flex
+                alignItems={{ default: 'alignItemsCenter' }}
+                justifyContent={{ default: 'justifyContentSpaceBetween' }}
+              >
+                <FlexItem>
+                  <CardTitle>{__('Content view details')}</CardTitle>
+                </FlexItem>
+              </Flex>
+            </FlexItem>
+            <FlexItem>
+              <Dropdown
+                toggle={<KebabToggle aria-label="change_content_view_hamburger" onToggle={toggleBulkAction} />}
+                isOpen={isDropdownOpen}
+                isPlain
+                ouiaId="change-host-content-view-kebab"
+                position="right"
+                dropdownItems={dropdownItems}
+              />
+            </FlexItem>
+          </Flex>
         </CardHeader>
         <CardBody>
           <Flex direction={{ default: 'column' }}>

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -24,7 +24,7 @@ import { hostIsRegistered } from '../../hostDetailsHelpers';
 import ChangeHostCVModal from './ChangeHostCVModal';
 
 const HostContentViewDetails = ({
-  contentView, lifecycleEnvironment, contentViewVersionId,
+  contentView, lifecycleEnvironment, contentViewVersionId, contentViewDefault,
   contentViewVersion, contentViewVersionLatest, hostId, orgId, hostEnvId,
 }) => {
   let versionLabel = `Version ${contentViewVersion}`;
@@ -51,6 +51,8 @@ const HostContentViewDetails = ({
       {__('Edit content view assignment')}
     </DropdownItem>,
   ];
+
+  console.log(contentView)
 
   return (
     <GridItem rowSpan={1} md={6} lg={4} xl2={3} >
@@ -111,6 +113,7 @@ const HostContentViewDetails = ({
               </Tooltip>
             </Flex>
           </Flex>
+          {!contentViewDefault &&
           <Flex direction={{ default: 'column' }}>
             <FlexItem>
               <h3>{__('Version in use')}</h3>
@@ -119,6 +122,7 @@ const HostContentViewDetails = ({
               </a>
             </FlexItem>
           </Flex>
+      }
         </CardBody>
       </Card>
       {hostId &&
@@ -153,6 +157,7 @@ HostContentViewDetails.propTypes = {
     name: PropTypes.string,
     id: PropTypes.number,
     composite: PropTypes.bool,
+    contentViewDefault: PropTypes.bool,
   }).isRequired,
   lifecycleEnvironment: PropTypes.shape({
     name: PropTypes.string,

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -25,7 +25,7 @@ import ChangeHostCVModal from './ChangeHostCVModal';
 
 const HostContentViewDetails = ({
   contentView, lifecycleEnvironment, contentViewVersionId, contentViewDefault,
-  contentViewVersion, contentViewVersionLatest, hostId, orgId, hostEnvId,
+  contentViewVersion, contentViewVersionLatest, hostId, hostName, orgId, hostEnvId,
 }) => {
   let versionLabel = `Version ${contentViewVersion}`;
   if (contentViewVersionLatest) {
@@ -128,6 +128,7 @@ const HostContentViewDetails = ({
           isOpen={isModalOpen}
           closeModal={closeModal}
           hostId={hostId}
+          hostName={hostName}
           hostEnvId={hostEnvId}
           orgId={orgId}
           key={`cv-change-modal-${hostId}`}
@@ -142,6 +143,7 @@ const ContentViewDetailsCard = ({ hostDetails }) => {
     && hostDetails.content_facet_attributes && hostDetails.organization_id) {
     return (<HostContentViewDetails
       hostId={hostDetails.id}
+      hostName={hostDetails.name}
       orgId={hostDetails.organization_id}
       hostEnvId={hostDetails.content_facet_attributes.lifecycle_environment_id}
       {...propsToCamelCase(hostDetails.content_facet_attributes)}
@@ -167,6 +169,7 @@ HostContentViewDetails.propTypes = {
   id: PropTypes.number,
   name: PropTypes.string,
   hostId: PropTypes.number,
+  hostName: PropTypes.string,
   orgId: PropTypes.number,
   hostEnvId: PropTypes.number,
 };
@@ -176,6 +179,7 @@ HostContentViewDetails.defaultProps = {
   name: '',
   hostEnvId: null,
   hostId: null,
+  hostName: '',
   orgId: null,
   contentViewDefault: false,
 };

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -127,7 +127,6 @@ const HostContentViewDetails = ({
           closeModal={closeModal}
           hostId={hostId}
           hostEnvId={hostEnvId}
-          contentViewVersionId={contentViewVersionId}
           orgId={orgId}
           key={`cv-change-modal-${hostId}`}
         />

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -52,8 +52,6 @@ const HostContentViewDetails = ({
     </DropdownItem>,
   ];
 
-  console.log(contentView)
-
   return (
     <GridItem rowSpan={1} md={6} lg={4} xl2={3} >
       <Card isHoverable>
@@ -157,8 +155,8 @@ HostContentViewDetails.propTypes = {
     name: PropTypes.string,
     id: PropTypes.number,
     composite: PropTypes.bool,
-    contentViewDefault: PropTypes.bool,
   }).isRequired,
+  contentViewDefault: PropTypes.bool,
   lifecycleEnvironment: PropTypes.shape({
     name: PropTypes.string,
     id: PropTypes.number,
@@ -179,6 +177,7 @@ HostContentViewDetails.defaultProps = {
   hostEnvId: null,
   hostId: null,
   orgId: null,
+  contentViewDefault: false,
 };
 
 ContentViewDetailsCard.propTypes = {

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -11,7 +11,9 @@ import {
   GridItem,
   KebabToggle,
   Label,
+  Tooltip,
 } from '@patternfly/react-core';
+import { FormattedMessage } from 'react-intl';
 
 import { urlBuilder } from 'foremanReact/common/urlHelpers';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -81,12 +83,25 @@ const HostContentViewDetails = ({
               flexWrap={{ default: 'nowrap' }}
               alignItems={{ default: 'alignItemsCenter', sm: 'alignItemsCenter' }}
             >
-              <ContentViewIcon composite={contentView.composite} style={{ marginRight: '2px' }} />
+              <ContentViewIcon composite={contentView.composite} style={{ marginRight: '2px' }} position="left" />
               <h3>{__('Content view')}</h3>
             </Flex>
             <Flex direction={{ default: 'row', sm: 'row' }} flexWrap={{ default: 'wrap' }}>
               <a style={{ fontSize: '14px' }} href={`/content_views/${contentView.id}`}>{`${contentView.name}`}</a>
-              <Label isTruncated color="purple" href={`/lifecycle_environments/${lifecycleEnvironment.id}`}>{`${lifecycleEnvironment.name}`}</Label>
+              <Tooltip
+                position="top"
+                enableFlip
+                entryDelay={400}
+                content={<FormattedMessage
+                  id="cv-card-lce-tooltip"
+                  defaultMessage={__('Lifecycle environment: {lce}')}
+                  values={{
+                    lce: lifecycleEnvironment.name,
+                  }}
+                />}
+              >
+                <Label isTruncated color="purple" href={`/lifecycle_environments/${lifecycleEnvironment.id}`}>{`${lifecycleEnvironment.name}`}</Label>
+              </Tooltip>
             </Flex>
           </Flex>
           <Flex direction={{ default: 'column' }}>

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -25,7 +25,7 @@ import ChangeHostCVModal from './ChangeHostCVModal';
 
 const HostContentViewDetails = ({
   contentView, lifecycleEnvironment, contentViewVersionId,
-  contentViewVersion, contentViewVersionLatest, hostId, hostName, orgId, hostEnvId,
+  contentViewVersion, contentViewVersionLatest, hostId, orgId, hostEnvId,
 }) => {
   let versionLabel = `Version ${contentViewVersion}`;
   if (contentViewVersionLatest) {
@@ -129,7 +129,6 @@ const HostContentViewDetails = ({
           hostEnvId={hostEnvId}
           orgId={orgId}
           key={`cv-change-modal-${hostId}`}
-          hostName={hostName}
         />
       }
     </GridItem>
@@ -141,7 +140,6 @@ const ContentViewDetailsCard = ({ hostDetails }) => {
     && hostDetails.content_facet_attributes && hostDetails.organization_id) {
     return (<HostContentViewDetails
       hostId={hostDetails.id}
-      hostName={hostDetails.name}
       orgId={hostDetails.organization_id}
       hostEnvId={hostDetails.content_facet_attributes.lifecycle_environment_id}
       {...propsToCamelCase(hostDetails.content_facet_attributes)}
@@ -165,6 +163,8 @@ HostContentViewDetails.propTypes = {
   contentViewVersionLatest: PropTypes.bool.isRequired,
   id: PropTypes.number,
   name: PropTypes.string,
+  hostId: PropTypes.number,
+  orgId: PropTypes.number,
   hostEnvId: PropTypes.number,
 };
 
@@ -172,6 +172,8 @@ HostContentViewDetails.defaultProps = {
   id: null,
   name: '',
   hostEnvId: null,
+  hostId: null,
+  orgId: null,
 };
 
 ContentViewDetailsCard.propTypes = {

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -127,6 +127,7 @@ const HostContentViewDetails = ({
           closeModal={closeModal}
           hostId={hostId}
           hostEnvId={hostEnvId}
+          contentViewVersionId={contentViewVersionId}
           orgId={orgId}
           key={`cv-change-modal-${hostId}`}
         />

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/HostContentViewActions.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/HostContentViewActions.js
@@ -4,12 +4,13 @@ import { errorToast } from '../../../../../scenes/Tasks/helpers';
 import { foremanApi } from '../../../../../services/api';
 import HOST_CV_AND_ENV_KEY from './HostContentViewConstants';
 
-const updateHostContentViewAndEnvironment = (params, hostId, handleSuccess) => put({
+const updateHostContentViewAndEnvironment = (params, hostId, handleSuccess, handleError) => put({
   type: API_OPERATIONS.PUT,
   key: HOST_CV_AND_ENV_KEY,
   url: foremanApi.getApiUrl(`/hosts/${hostId}`),
   successToast: () => __('Host content view and environment updated'),
   handleSuccess,
+  handleError,
   errorToast,
   params,
 });

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/HostContentViewActions.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/HostContentViewActions.js
@@ -1,0 +1,18 @@
+import { translate as __ } from 'foremanReact/common/I18n';
+import { API_OPERATIONS, put } from 'foremanReact/redux/API';
+import { errorToast } from '../../../../../scenes/Tasks/helpers';
+import { foremanApi } from '../../../../../services/api';
+import HOST_CV_AND_ENV_KEY from './HostContentViewConstants';
+
+const updateHostContentViewAndEnvironment = (params, hostId, handleSuccess) => put({
+  type: API_OPERATIONS.PUT,
+  key: HOST_CV_AND_ENV_KEY,
+  url: foremanApi.getApiUrl(`/hosts/${hostId}`),
+  successToast: () => __('Host content view and environment updated'),
+  handleSuccess,
+  errorToast,
+  params,
+});
+
+export default updateHostContentViewAndEnvironment;
+

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/HostContentViewConstants.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/HostContentViewConstants.js
@@ -1,0 +1,2 @@
+const HOST_CV_AND_ENV_KEY = 'HOST_CV_AND_ENV';
+export default HOST_CV_AND_ENV_KEY;

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/__tests__/changeHostCVModal.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/__tests__/changeHostCVModal.test.js
@@ -1,0 +1,131 @@
+import React from 'react';
+import { renderWithRedux, patientlyWaitFor, act } from 'react-testing-lib-wrapper';
+import userEvent from '@testing-library/user-event';
+import ChangeHostCVModal from '../ChangeHostCVModal';
+import mockEnvPaths from './envPaths.fixtures.json';
+import mockContentViews from './contentViews.fixtures.json';
+import HOST_CV_AND_ENV_KEY from '../HostContentViewConstants';
+import { assertNockRequest, nockInstance } from '../../../../../../test-utils/nockWrapper';
+import katelloApi from '../../../../../../services/api';
+
+const contentViews = katelloApi.getApiUrl('/content_views');
+// const hostDetailsUrl = '/api/hosts/test-host';
+
+const renderOptions = () => ({
+  apiNamespace: HOST_CV_AND_ENV_KEY,
+  initialState: {
+    API: {
+      HOST_DETAILS: {
+        response: {
+          id: 1,
+          name: 'test-host',
+          content_facet_attributes: {
+            content_view_id: 1,
+            lifecycle_environment_id: 1,
+          },
+          organization_id: 1,
+        },
+        status: 'RESOLVED',
+      },
+      ENVIRONMENT_PATHS: {
+        response: mockEnvPaths,
+        status: 'RESOLVED',
+      },
+    },
+  },
+});
+
+let firstEnvPath;
+let firstCV;
+let secondCV;
+let firstEnv;
+
+const cvQuery = {
+  organization_id: 1,
+  include_permissions: true,
+  include_default: true,
+  environment_id: 1,
+  full_result: true,
+  order: 'default DESC',
+};
+
+beforeEach(() => {
+  const { results } = mockEnvPaths;
+  [firstEnvPath] = results;
+  const { environments: envResults } = firstEnvPath;
+  [firstEnv] = envResults;
+  const { results: cvResults } = mockContentViews;
+  [firstCV, secondCV] = cvResults;
+});
+
+jest.mock('foremanReact/common/hooks/API/APIHooks', () => ({
+  useAPI: jest.fn(),
+}));
+
+test('Displays environment paths', async (done) => {
+  const { getAllByText }
+     = renderWithRedux(<ChangeHostCVModal
+       isOpen
+       closeModal={jest.fn()}
+       hostId={1}
+       hostName="test-host"
+       hostEnvId={1}
+       orgId={1}
+     />, renderOptions());
+
+  await patientlyWaitFor(() =>
+    expect(getAllByText(firstEnv.name)[0]).toBeInTheDocument());
+  done();
+});
+
+test('Select an env > call CV API > select a CV > Save button is enabled', async (done) => {
+  const contentViewsScope = nockInstance
+    .get(contentViews)
+    .query(cvQuery)
+    .reply(200, mockContentViews);
+
+  const {
+    getAllByText, getByText,
+    findByText, getAllByRole,
+  } = renderWithRedux(<ChangeHostCVModal
+    isOpen
+    closeModal={jest.fn()}
+    hostId={1}
+    hostName="test-host"
+    hostEnvId={1}
+    orgId={1}
+  />, renderOptions());
+
+  await patientlyWaitFor(() => {
+    const envLabel = getAllByText(firstEnv.name)[0];
+    expect(envLabel).toBeInTheDocument();
+  });
+
+  const envRadio = getAllByRole('radio', { name: firstEnv.name })[0];
+  expect(envRadio).toBeInTheDocument();
+
+  await act(async () => {
+    userEvent.click(envRadio); // Select the Library environment
+
+    const cvDropdown = await findByText('Select a content view');
+    expect(cvDropdown).toBeInTheDocument();
+
+    userEvent.click(cvDropdown); // Open the CV dropdown
+
+
+    [firstCV, secondCV].forEach((cv) => {
+      expect(getByText(cv.name)).toBeInTheDocument(); // the content view names should be showing
+    });
+
+
+    userEvent.click(getByText(secondCV.name)); // Select the second content view
+  });
+
+  // find the Save button and assert that it is enabled
+  const saveButton = getAllByRole('button', { name: 'Save' })[0];
+  expect(saveButton).toBeInTheDocument();
+  expect(saveButton).toHaveAttribute('aria-disabled', 'false');
+
+  assertNockRequest(contentViewsScope, done);
+  act(done);
+});

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/__tests__/contentViewDetailsCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/__tests__/contentViewDetailsCard.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from 'react-testing-lib-wrapper';
-import ContentViewDetailsCard from '../ContentViewDetailsCard/ContentViewDetailsCard';
+import ContentViewDetailsCard from '../ContentViewDetailsCard';
 
 const baseHostDetails = {
   organization_id: 1,
@@ -52,3 +52,23 @@ test('shows when the CV in use is not the latest version', () => {
   expect(getByText('Version 1.0')).toBeInTheDocument();
   expect(queryByText('Version 1.0 (latest)')).toBeNull();
 });
+
+test('does not show version info when using Default Organization View', () => {
+  const hostDetails = {
+    ...baseHostDetails,
+    content_facet_attributes: {
+      ...baseHostDetails.content_facet_attributes,
+      content_view:
+        {
+          ...baseHostDetails.content_facet_attributes.content_view,
+          content_view_default: true,
+          name: 'Default Organization View',
+        },
+    },
+  };
+
+  const { queryByText } = render(<ContentViewDetailsCard hostDetails={hostDetails} />);
+  expect(queryByText('Default Organization View')).toBeInTheDocument();
+  expect(queryByText('Version 1.0')).toBeNull();
+});
+

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/__tests__/contentViews.fixtures.json
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/__tests__/contentViews.fixtures.json
@@ -1,0 +1,443 @@
+{
+    "total": 3,
+    "subtotal": 3,
+    "selectable": 3,
+    "page": 1,
+    "per_page": 3,
+    "error": null,
+    "search": null,
+    "sort": {
+        "by": "default",
+        "order": "DESC"
+    },
+    "can_create": true,
+    "results": [
+        {
+            "composite": false,
+            "component_ids": [],
+            "default": true,
+            "version_count": 1,
+            "latest_version": "1.0",
+            "latest_version_id": 1,
+            "auto_publish": false,
+            "solve_dependencies": false,
+            "import_only": false,
+            "generated_for": "none",
+            "related_cv_count": 0,
+            "related_composite_cvs": [],
+            "repository_ids": [],
+            "id": 1,
+            "name": "Default Organization View",
+            "label": "Default_Organization_View",
+            "description": null,
+            "organization_id": 1,
+            "organization": {
+                "name": "Default Organization",
+                "label": "Default_Organization",
+                "id": 1
+            },
+            "created_at": "2022-03-18 14:11:05 -0400",
+            "updated_at": "2022-03-18 14:11:05 -0400",
+            "last_task": null,
+            "latest_version_environments": [
+                {
+                    "id": 1,
+                    "name": "Library",
+                    "label": "Library"
+                }
+            ],
+            "repositories": [],
+            "versions": [
+                {
+                    "id": 1,
+                    "version": "1.0",
+                    "published": "2022-03-18 14:11:05 -0400",
+                    "environment_ids": [
+                        1
+                    ]
+                }
+            ],
+            "components": [],
+            "content_view_components": [],
+            "activation_keys": [
+                {
+                    "id": 1,
+                    "name": "ak1"
+                }
+            ],
+            "hosts": [],
+            "next_version": "1.0",
+            "last_published": "2022-03-18 14:11:05 -0400",
+            "environments": [
+                {
+                    "id": 1,
+                    "label": "Library",
+                    "name": "Library",
+                    "activation_keys": [
+                        1
+                    ],
+                    "hosts": [],
+                    "permissions": {
+                        "readable": true
+                    }
+                }
+            ],
+            "permissions": {
+                "view_content_views": true,
+                "edit_content_views": true,
+                "destroy_content_views": true,
+                "publish_content_views": true,
+                "promote_or_remove_content_views": true
+            }
+        },
+        {
+            "composite": true,
+            "component_ids": [
+                3
+            ],
+            "default": false,
+            "version_count": 3,
+            "latest_version": "3.0",
+            "latest_version_id": 6,
+            "auto_publish": false,
+            "solve_dependencies": false,
+            "import_only": false,
+            "generated_for": "none",
+            "related_cv_count": 1,
+            "related_composite_cvs": [],
+            "repository_ids": [
+                9
+            ],
+            "id": 3,
+            "name": "composite_cv",
+            "label": "composite_cv",
+            "description": "",
+            "organization_id": 1,
+            "organization": {
+                "name": "Default Organization",
+                "label": "Default_Organization",
+                "id": 1
+            },
+            "created_at": "2022-04-01 15:55:49 -0400",
+            "updated_at": "2022-04-05 13:25:34 -0400",
+            "last_task": {
+                "id": "c6621455-0fbf-430e-bf70-b8aadbae282c",
+                "started_at": "2022-04-05 13:30:04 -0400",
+                "result": "success",
+                "last_sync_words": "2 days"
+            },
+            "latest_version_environments": [
+                {
+                    "id": 1,
+                    "name": "Library",
+                    "label": "Library"
+                }
+            ],
+            "repositories": [
+                {
+                    "id": 9,
+                    "name": "Zoo Repo",
+                    "label": "Zoo_Repo",
+                    "content_type": "yum"
+                }
+            ],
+            "versions": [
+                {
+                    "id": 4,
+                    "version": "1.0",
+                    "published": "2022-04-01 15:56:35 -0400",
+                    "environment_ids": [
+                        3
+                    ]
+                },
+                {
+                    "id": 5,
+                    "version": "2.0",
+                    "published": "2022-04-05 13:25:13 -0400",
+                    "environment_ids": [
+                        2
+                    ]
+                },
+                {
+                    "id": 6,
+                    "version": "3.0",
+                    "published": "2022-04-05 13:25:34 -0400",
+                    "environment_ids": [
+                        1
+                    ]
+                }
+            ],
+            "components": [
+                {
+                    "id": 3,
+                    "name": "cv_1 2.0",
+                    "content_view_id": 2,
+                    "version": "2.0",
+                    "environments": [
+                        {
+                            "id": 1,
+                            "name": "Library",
+                            "label": "Library"
+                        },
+                        {
+                            "id": 2,
+                            "name": "dev",
+                            "label": "dev"
+                        }
+                    ],
+                    "content_view": {
+                        "id": 2,
+                        "name": "cv_1",
+                        "label": "cv_1",
+                        "description": "",
+                        "next_version": 3,
+                        "latest_version": "2.0"
+                    },
+                    "repositories": [
+                        {
+                            "id": 9,
+                            "name": "Zoo Repo",
+                            "label": "Zoo_Repo",
+                            "description": null
+                        }
+                    ]
+                }
+            ],
+            "content_view_components": [
+                {
+                    "latest": true,
+                    "id": 1,
+                    "created_at": "2022-04-01 15:56:02 -0400",
+                    "updated_at": "2022-04-01 15:56:02 -0400",
+                    "composite_content_view": {
+                        "id": 3,
+                        "name": "composite_cv",
+                        "label": "composite_cv",
+                        "description": "",
+                        "next_version": 4,
+                        "latest_version": "3.0",
+                        "version_count": 3
+                    },
+                    "content_view": {
+                        "id": 2,
+                        "name": "cv_1",
+                        "label": "cv_1",
+                        "description": "",
+                        "next_version": 3,
+                        "latest_version": "2.0",
+                        "version_count": 2
+                    },
+                    "content_view_version": {
+                        "id": 3,
+                        "name": "cv_1 2.0",
+                        "content_view_id": 2,
+                        "version": "2.0",
+                        "content_view": {
+                            "id": 2,
+                            "name": "cv_1",
+                            "label": "cv_1",
+                            "description": ""
+                        },
+                        "environments": [
+                            {
+                                "id": 1,
+                                "name": "Library",
+                                "label": "Library"
+                            },
+                            {
+                                "id": 2,
+                                "name": "dev",
+                                "label": "dev"
+                            }
+                        ],
+                        "repositories": [
+                            {
+                                "id": 9,
+                                "name": "Zoo Repo",
+                                "label": "Zoo_Repo",
+                                "description": null
+                            }
+                        ]
+                    },
+                    "component_content_view_versions": [
+                        {
+                            "id": 2,
+                            "version": "1.0"
+                        },
+                        {
+                            "id": 3,
+                            "version": "2.0"
+                        }
+                    ]
+                }
+            ],
+            "activation_keys": [],
+            "hosts": [],
+            "next_version": "4.0",
+            "last_published": "2022-04-05 13:25:34 -0400",
+            "environments": [
+                {
+                    "id": 3,
+                    "label": "stages",
+                    "name": "stages",
+                    "activation_keys": [],
+                    "hosts": [],
+                    "permissions": {
+                        "readable": true
+                    }
+                },
+                {
+                    "id": 1,
+                    "label": "Library",
+                    "name": "Library",
+                    "activation_keys": [],
+                    "hosts": [],
+                    "permissions": {
+                        "readable": true
+                    }
+                },
+                {
+                    "id": 2,
+                    "label": "dev",
+                    "name": "dev",
+                    "activation_keys": [],
+                    "hosts": [],
+                    "permissions": {
+                        "readable": true
+                    }
+                }
+            ],
+            "permissions": {
+                "view_content_views": true,
+                "edit_content_views": true,
+                "destroy_content_views": true,
+                "publish_content_views": true,
+                "promote_or_remove_content_views": true
+            }
+        },
+        {
+            "composite": false,
+            "component_ids": [],
+            "default": false,
+            "version_count": 2,
+            "latest_version": "2.0",
+            "latest_version_id": 3,
+            "auto_publish": false,
+            "solve_dependencies": false,
+            "import_only": false,
+            "generated_for": "none",
+            "related_cv_count": 1,
+            "related_composite_cvs": [
+                {
+                    "id": 3,
+                    "name": "composite_cv"
+                }
+            ],
+            "repository_ids": [
+                1
+            ],
+            "id": 2,
+            "name": "cv_1",
+            "label": "cv_1",
+            "description": "",
+            "organization_id": 1,
+            "organization": {
+                "name": "Default Organization",
+                "label": "Default_Organization",
+                "id": 1
+            },
+            "created_at": "2022-03-29 15:57:07 -0400",
+            "updated_at": "2022-04-01 15:54:48 -0400",
+            "last_task": {
+                "id": "44c73343-54c1-411d-8e3e-e80b9d158cc1",
+                "started_at": "2022-04-01 15:54:48 -0400",
+                "result": "success",
+                "last_sync_words": "6 days"
+            },
+            "latest_version_environments": [
+                {
+                    "id": 1,
+                    "name": "Library",
+                    "label": "Library"
+                },
+                {
+                    "id": 2,
+                    "name": "dev",
+                    "label": "dev"
+                }
+            ],
+            "repositories": [
+                {
+                    "id": 1,
+                    "name": "Zoo Repo",
+                    "label": "Zoo_Repo",
+                    "content_type": "yum"
+                }
+            ],
+            "versions": [
+                {
+                    "id": 2,
+                    "version": "1.0",
+                    "published": "2022-03-29 15:57:45 -0400",
+                    "environment_ids": []
+                },
+                {
+                    "id": 3,
+                    "version": "2.0",
+                    "published": "2022-04-01 15:54:48 -0400",
+                    "environment_ids": [
+                        1,
+                        2
+                    ]
+                }
+            ],
+            "components": [],
+            "content_view_components": [],
+            "activation_keys": [],
+            "hosts": [
+                {
+                    "id": 2,
+                    "name": "rhel9.fedora.example.com"
+                },
+                {
+                    "id": 3,
+                    "name": "rhel7.fedora.example.com"
+                }
+            ],
+            "next_version": "3.0",
+            "last_published": "2022-04-01 15:54:48 -0400",
+            "environments": [
+                {
+                    "id": 1,
+                    "label": "Library",
+                    "name": "Library",
+                    "activation_keys": [],
+                    "hosts": [],
+                    "permissions": {
+                        "readable": true
+                    }
+                },
+                {
+                    "id": 2,
+                    "label": "dev",
+                    "name": "dev",
+                    "activation_keys": [],
+                    "hosts": [
+                        2,
+                        3
+                    ],
+                    "permissions": {
+                        "readable": true
+                    }
+                }
+            ],
+            "permissions": {
+                "view_content_views": true,
+                "edit_content_views": true,
+                "destroy_content_views": true,
+                "publish_content_views": true,
+                "promote_or_remove_content_views": true
+            }
+        }
+    ]
+}

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/__tests__/envPaths.fixtures.json
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/__tests__/envPaths.fixtures.json
@@ -1,0 +1,320 @@
+{
+    "total": 2,
+    "subtotal": 2,
+    "selectable": 2,
+    "page": null,
+    "per_page": null,
+    "error": null,
+    "search": null,
+    "sort": {
+        "by": null,
+        "order": null
+    },
+    "results": [
+        {
+            "environments": [
+                {
+                    "library": true,
+                    "registry_name_pattern": null,
+                    "registry_unauthenticated_pull": false,
+                    "id": 1,
+                    "name": "Library",
+                    "label": "Library",
+                    "description": null,
+                    "organization_id": 1,
+                    "organization": {
+                        "name": "Default Organization",
+                        "label": "Default_Organization",
+                        "id": 1
+                    },
+                    "created_at": "2022-03-18 14:11:05 -0400",
+                    "updated_at": "2022-03-18 14:11:05 -0400",
+                    "prior": null,
+                    "successor": null,
+                    "counts": {
+                        "content_hosts": 0,
+                        "content_views": 2,
+                        "packages": 55250,
+                        "module_streams": 445,
+                        "errata": {
+                            "security": 1701,
+                            "bugfix": 4272,
+                            "enhancement": 952,
+                            "total": 6927
+                        },
+                        "yum_repositories": 6,
+                        "docker_repositories": 0,
+                        "ostree_repositories": 0,
+                        "products": 4
+                    },
+                    "permissions": {
+                        "create_lifecycle_environments": true,
+                        "view_lifecycle_environments": true,
+                        "edit_lifecycle_environments": true,
+                        "destroy_lifecycle_environments": false,
+                        "promote_or_remove_content_views_to_environments": true
+                    },
+                    "content_views": [
+                        {
+                            "name": "cv_1",
+                            "id": 2
+                        },
+                        {
+                            "name": "composite_cv",
+                            "id": 3
+                        }
+                    ]
+                },
+                {
+                    "library": false,
+                    "registry_name_pattern": null,
+                    "registry_unauthenticated_pull": false,
+                    "id": 2,
+                    "name": "dev",
+                    "label": "dev",
+                    "description": null,
+                    "organization_id": 1,
+                    "organization": {
+                        "name": "Default Organization",
+                        "label": "Default_Organization",
+                        "id": 1
+                    },
+                    "created_at": "2022-03-29 15:58:06 -0400",
+                    "updated_at": "2022-03-29 15:58:06 -0400",
+                    "prior": {
+                        "name": "Library",
+                        "id": 1
+                    },
+                    "successor": {
+                        "name": "stages",
+                        "id": 3
+                    },
+                    "counts": {
+                        "content_hosts": 2,
+                        "content_views": 2
+                    },
+                    "permissions": {
+                        "create_lifecycle_environments": true,
+                        "view_lifecycle_environments": true,
+                        "edit_lifecycle_environments": true,
+                        "destroy_lifecycle_environments": false,
+                        "promote_or_remove_content_views_to_environments": true
+                    },
+                    "content_views": [
+                        {
+                            "name": "cv_1",
+                            "id": 2
+                        },
+                        {
+                            "name": "composite_cv",
+                            "id": 3
+                        }
+                    ]
+                },
+                {
+                    "library": false,
+                    "registry_name_pattern": null,
+                    "registry_unauthenticated_pull": false,
+                    "id": 3,
+                    "name": "stages",
+                    "label": "stages",
+                    "description": null,
+                    "organization_id": 1,
+                    "organization": {
+                        "name": "Default Organization",
+                        "label": "Default_Organization",
+                        "id": 1
+                    },
+                    "created_at": "2022-03-29 15:58:20 -0400",
+                    "updated_at": "2022-03-29 15:58:20 -0400",
+                    "prior": {
+                        "name": "dev",
+                        "id": 2
+                    },
+                    "successor": {
+                        "name": "prod",
+                        "id": 4
+                    },
+                    "counts": {
+                        "content_hosts": 0,
+                        "content_views": 1
+                    },
+                    "permissions": {
+                        "create_lifecycle_environments": true,
+                        "view_lifecycle_environments": true,
+                        "edit_lifecycle_environments": true,
+                        "destroy_lifecycle_environments": true,
+                        "promote_or_remove_content_views_to_environments": true
+                    },
+                    "content_views": [
+                        {
+                            "name": "composite_cv",
+                            "id": 3
+                        }
+                    ]
+                },
+                {
+                    "library": false,
+                    "registry_name_pattern": null,
+                    "registry_unauthenticated_pull": false,
+                    "id": 4,
+                    "name": "prod",
+                    "label": "prod",
+                    "description": null,
+                    "organization_id": 1,
+                    "organization": {
+                        "name": "Default Organization",
+                        "label": "Default_Organization",
+                        "id": 1
+                    },
+                    "created_at": "2022-03-29 15:58:31 -0400",
+                    "updated_at": "2022-03-29 15:58:31 -0400",
+                    "prior": {
+                        "name": "stages",
+                        "id": 3
+                    },
+                    "successor": null,
+                    "counts": {
+                        "content_hosts": 0,
+                        "content_views": 0
+                    },
+                    "permissions": {
+                        "create_lifecycle_environments": true,
+                        "view_lifecycle_environments": true,
+                        "edit_lifecycle_environments": true,
+                        "destroy_lifecycle_environments": true,
+                        "promote_or_remove_content_views_to_environments": true
+                    },
+                    "content_views": []
+                }
+            ]
+        },
+        {
+            "environments": [
+                {
+                    "library": true,
+                    "registry_name_pattern": null,
+                    "registry_unauthenticated_pull": false,
+                    "id": 1,
+                    "name": "Library",
+                    "label": "Library",
+                    "description": null,
+                    "organization_id": 1,
+                    "organization": {
+                        "name": "Default Organization",
+                        "label": "Default_Organization",
+                        "id": 1
+                    },
+                    "created_at": "2022-03-18 14:11:05 -0400",
+                    "updated_at": "2022-03-18 14:11:05 -0400",
+                    "prior": null,
+                    "successor": null,
+                    "counts": {
+                        "content_hosts": 0,
+                        "content_views": 2,
+                        "packages": 55250,
+                        "module_streams": 445,
+                        "errata": {
+                            "security": 1701,
+                            "bugfix": 4272,
+                            "enhancement": 952,
+                            "total": 6927
+                        },
+                        "yum_repositories": 6,
+                        "docker_repositories": 0,
+                        "ostree_repositories": 0,
+                        "products": 4
+                    },
+                    "permissions": {
+                        "create_lifecycle_environments": true,
+                        "view_lifecycle_environments": true,
+                        "edit_lifecycle_environments": true,
+                        "destroy_lifecycle_environments": false,
+                        "promote_or_remove_content_views_to_environments": true
+                    },
+                    "content_views": [
+                        {
+                            "name": "cv_1",
+                            "id": 2
+                        },
+                        {
+                            "name": "composite_cv",
+                            "id": 3
+                        }
+                    ]
+                },
+                {
+                    "library": false,
+                    "registry_name_pattern": null,
+                    "registry_unauthenticated_pull": false,
+                    "id": 5,
+                    "name": "Path Two",
+                    "label": "Path_Two",
+                    "description": null,
+                    "organization_id": 1,
+                    "organization": {
+                        "name": "Default Organization",
+                        "label": "Default_Organization",
+                        "id": 1
+                    },
+                    "created_at": "2022-04-04 11:35:21 -0400",
+                    "updated_at": "2022-04-04 11:35:21 -0400",
+                    "prior": {
+                        "name": "Library",
+                        "id": 1
+                    },
+                    "successor": {
+                        "name": "path2_2",
+                        "id": 6
+                    },
+                    "counts": {
+                        "content_hosts": 0,
+                        "content_views": 0
+                    },
+                    "permissions": {
+                        "create_lifecycle_environments": true,
+                        "view_lifecycle_environments": true,
+                        "edit_lifecycle_environments": true,
+                        "destroy_lifecycle_environments": true,
+                        "promote_or_remove_content_views_to_environments": true
+                    },
+                    "content_views": []
+                },
+                {
+                    "library": false,
+                    "registry_name_pattern": null,
+                    "registry_unauthenticated_pull": false,
+                    "id": 6,
+                    "name": "path2_2",
+                    "label": "path2_2",
+                    "description": null,
+                    "organization_id": 1,
+                    "organization": {
+                        "name": "Default Organization",
+                        "label": "Default_Organization",
+                        "id": 1
+                    },
+                    "created_at": "2022-04-04 11:35:33 -0400",
+                    "updated_at": "2022-04-04 11:35:33 -0400",
+                    "prior": {
+                        "name": "Path Two",
+                        "id": 5
+                    },
+                    "successor": null,
+                    "counts": {
+                        "content_hosts": 0,
+                        "content_views": 0
+                    },
+                    "permissions": {
+                        "create_lifecycle_environments": true,
+                        "view_lifecycle_environments": true,
+                        "edit_lifecycle_environments": true,
+                        "destroy_lifecycle_environments": true,
+                        "promote_or_remove_content_views_to_environments": true
+                    },
+                    "content_views": []
+                }
+            ]
+        }
+    ]
+}

--- a/webpack/components/extensions/HostDetails/Cards/__tests__/contentViewDetailsCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/__tests__/contentViewDetailsCard.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from 'react-testing-lib-wrapper';
-import ContentViewDetailsCard from '../ContentViewDetailsCard';
+import ContentViewDetailsCard from '../ContentViewDetailsCard/ContentViewDetailsCard';
 
 const baseHostDetails = {
   content_facet_attributes: {

--- a/webpack/components/extensions/HostDetails/Cards/__tests__/contentViewDetailsCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/__tests__/contentViewDetailsCard.test.js
@@ -3,11 +3,13 @@ import { render } from 'react-testing-lib-wrapper';
 import ContentViewDetailsCard from '../ContentViewDetailsCard/ContentViewDetailsCard';
 
 const baseHostDetails = {
+  organization_id: 1,
   content_facet_attributes: {
     content_view: {
       name: 'CV',
       id: 100,
       composite: false,
+      content_view_default: false,
     },
     lifecycle_environment: {
       name: 'ENV',

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -6,7 +6,7 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import SystemStatuses from './components/extensions/about';
 import RegistrationCommands from './components/extensions/RegistrationCommands';
 import ContentTab from './components/extensions/HostDetails/Tabs/ContentTab';
-import ContentViewDetailsCard from './components/extensions/HostDetails/Cards/ContentViewDetailsCard';
+import ContentViewDetailsCard from './components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard';
 import ErrataOverviewCard from './components/extensions/HostDetails/Cards/ErrataOverviewCard';
 
 // import SubscriptionTab from './components/extensions/HostDetails/Tabs/SubscriptionTab';

--- a/webpack/global_test_setup.js
+++ b/webpack/global_test_setup.js
@@ -1,9 +1,11 @@
-// runs before each test to make sure console.error output will
 import nock from 'nock';
 
+// runs before each test to make sure console.error output will
 // fail a test (i.e. default PropType missing). Check the error
 // output and traceback for actual error.
+const originalConsoleError = global.console.error;
 global.console.error = (error, stack) => {
+  originalConsoleError(error); // ensure error is printed to console
   /* eslint-disable-next-line no-console */
   if (stack) console.log(stack); // Prints out original stack trace
   throw new Error(error);

--- a/webpack/scenes/ContentViews/Table/ContentViewsTable.js
+++ b/webpack/scenes/ContentViews/Table/ContentViewsTable.js
@@ -244,7 +244,7 @@ const ContentViewTable = () => {
                     expandedTableRows.onToggle(isOpen, cvId),
                 }}
               />
-              <Td><ContentViewIcon composite={composite ? true : undefined} /></Td>
+              <Td><ContentViewIcon position="right" composite={composite} /></Td>
               <Td><Link to={`${urlBuilder('content_views', '')}${cvId}`}>{name}</Link></Td>
               <Td>{lastPublished ? <LongDateTime date={lastPublished} showRelativeTimeTooltip /> : <InactiveText text={__('Not yet published')} />}</Td>
               <Td><LastSync startedAt={startedAt} lastSync={lastTask} lastSyncWords={lastSyncWords} emptyMessage="N/A" /></Td>

--- a/webpack/scenes/ContentViews/components/ContentViewIcon.js
+++ b/webpack/scenes/ContentViews/components/ContentViewIcon.js
@@ -1,20 +1,31 @@
 import React from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
 import PropTypes from 'prop-types';
+import { Tooltip } from '@patternfly/react-core';
 import { EnterpriseIcon, RegistryIcon } from '@patternfly/react-icons';
 import './contentViewIcon.scss';
 
 const ContentViewIcon = ({
-  composite, count, description, style,
+  composite, count, description, style, ...toolTipProps
 }) => {
   const props = {
-    title: composite ? __('Composite') : __('Component'),
     className: composite ? 'svg-icon-composite' : 'svg-icon-component',
   };
+  const cvIcon = (
+    <Tooltip
+      position="auto"
+      enableFlip
+      entryDelay={400}
+      content={composite ? __('Composite content view') : __('Component content view')}
+      {...toolTipProps}
+    >
+      {composite ? <RegistryIcon size="md" {...props} /> : <EnterpriseIcon size="sm" {...props} />}
+    </Tooltip>
+  );
   return (
     <div aria-label="content_view_icon" className="svg-centered-container" style={style}>
       {count && <span className="composite-component-count">{count}</span>}
-      {composite ? <RegistryIcon size="md" {...props} /> : <EnterpriseIcon size="sm" {...props} />}
+      {cvIcon}
       <span>{description}</span>
     </div>
   );

--- a/webpack/scenes/ContentViews/components/EnvironmentLabels.js
+++ b/webpack/scenes/ContentViews/components/EnvironmentLabels.js
@@ -2,14 +2,15 @@ import React from 'react';
 import { Label } from '@patternfly/react-core';
 
 const EnvironmentLabels = (environments) => {
-  const { environments: singleEnvironment } = environments || {};
+  const { environments: singleEnvironment, isDisabled } = environments || {};
   const { name } = singleEnvironment || {};
+  const labelColor = isDisabled ? 'grey' : 'purple';
   switch (environments) {
   case Array:
     return environments.map(env => (
       <React.Fragment key={env.id} style={{ marginBottom: '5px' }}>
         <Label
-          color="purple"
+          color={labelColor}
           isTruncated
         >{env.name}
         </Label>
@@ -18,7 +19,7 @@ const EnvironmentLabels = (environments) => {
   default:
     return (
       <React.Fragment>
-        <Label color="purple" isTruncated>
+        <Label color={labelColor} isTruncated>
           {name}
         </Label>
       </React.Fragment>

--- a/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.js
+++ b/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.js
@@ -10,7 +10,8 @@ import './EnvironmentPaths.scss';
 import Loading from '../../../../components/Loading';
 
 const EnvironmentPaths = ({
-  userCheckedItems, setUserCheckedItems, promotedEnvironments, publishing, headerText, multiSelect,
+  userCheckedItems, setUserCheckedItems, promotedEnvironments,
+  publishing, headerText, multiSelect, isDisabled,
 }) => {
   const environmentPathResponse = useSelector(selectEnvironmentPaths);
   const environmentPathStatus = useSelector(selectEnvironmentPathsStatus);
@@ -51,12 +52,12 @@ const EnvironmentPaths = ({
                     isChecked={(publishing && env.library) ||
                     envCheckedInList(env, userCheckedItems) ||
                     envCheckedInList(env, promotedEnvironments)}
-                    isDisabled={(publishing && env.library)
+                    isDisabled={isDisabled || (publishing && env.library)
                     || envCheckedInList(env, promotedEnvironments)}
                     className="env-path__labels-with-pointer"
                     key={`${env.id}${index}`}
                     id={`${env.id}${index}`}
-                    label={<EnvironmentLabels environments={env} />}
+                    label={<EnvironmentLabels environments={env} isDisabled={isDisabled} />}
                     aria-label={env.label}
                     onChange={checked => oncheckedChange(checked, env)}
                   />))}
@@ -79,6 +80,7 @@ EnvironmentPaths.propTypes = {
   publishing: PropTypes.bool,
   headerText: PropTypes.string,
   multiSelect: PropTypes.bool,
+  isDisabled: PropTypes.bool,
 };
 
 EnvironmentPaths.defaultProps = {
@@ -86,5 +88,6 @@ EnvironmentPaths.defaultProps = {
   publishing: true,
   headerText: __('Select a lifecycle environment from the available promotion paths to promote new version.'),
   multiSelect: true,
+  isDisabled: false,
 };
 export default EnvironmentPaths;

--- a/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.js
+++ b/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.js
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { STATUS } from 'foremanReact/constants';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { FormGroup, Checkbox, TextContent } from '@patternfly/react-core';
+import { FormGroup, Checkbox, Radio, TextContent } from '@patternfly/react-core';
 import { selectEnvironmentPaths, selectEnvironmentPathsStatus } from './EnvironmentPathSelectors';
 import EnvironmentLabels from '../EnvironmentLabels';
 import './EnvironmentPaths.scss';
@@ -16,6 +16,7 @@ const EnvironmentPaths = ({
   const environmentPathResponse = useSelector(selectEnvironmentPaths);
   const environmentPathStatus = useSelector(selectEnvironmentPathsStatus);
   const environmentPathLoading = environmentPathStatus === STATUS.PENDING;
+  const CheckboxOrRadio = multiSelect ? Checkbox : Radio;
 
   const oncheckedChange = (checked, env) => {
     if (checked) {
@@ -48,7 +49,7 @@ const EnvironmentPaths = ({
               {index === 0 && <hr />}
               <FormGroup key={`fg-${index}`} isInline fieldId="environment-checkbox-group">
                 {environments.map(env =>
-                  (<Checkbox
+                  (<CheckboxOrRadio
                     isChecked={(publishing && env.library) ||
                     envCheckedInList(env, userCheckedItems) ||
                     envCheckedInList(env, promotedEnvironments)}

--- a/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.scss
+++ b/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.scss
@@ -6,12 +6,17 @@
   .env-path__labels-with-pointer {
     &:not(:last-child):after {
       content: '>';
-      margin-top: 3px;
+      margin-top: 0px;
+      margin-right: 0.5rem;
     }
 
     display: inline-flex;
     margin: 3px 1px;
     align-items: center;
+
+    input {
+      margin-top: 0px;
+    }
   }
 
   hr {

--- a/webpack/utils/helpers.js
+++ b/webpack/utils/helpers.js
@@ -106,6 +106,8 @@ export const apiError = (actionType, result, additionalData = {}) => (dispatch) 
   return resultWithSuccessFlag(result);
 };
 
+export const uniq = items => [...new Set(items)];
+
 export const capitalize = s => s && s[0].toUpperCase() + s.slice(1);
 
 export const truncate = (str = '', truncateLimit = 50) => (str.length > truncateLimit ? `${str.substring(0, truncateLimit - 3)}...` : str);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Add modal to Content view details card to allow you to change the host's CV & LCE
* Don't display 'Version x.x' when using Default Organization View
* Add tooltips to Content view details card
* Add tooltips to CV icons (previously they just had `title` attributes) *
* Change environment selector to use radio buttons instead of checkboxes when not using multiSelect *

\* These changes will also affect CV UI screens!

#### Considerations taken when implementing this change?

The content view selection dropdown displays the version number of the content view that will be in use if that CV is selected. Along with the change to radio buttons, this is new functionality that wasn't previously anywhere else.

#### What are the testing steps for this pull request?

Test with several CV's and environments:
* at least one environment with _no_ CV's promoted to it
* at least one CV which has different versions promoted to different environments
* etc

Make sure that
* modal interactions are as expected
* CV version numbers are correct in the dropdown
* Save button works as expected
* CV version number does not show on CV card when using Default Organization View

#### ~~Still on the to-do list~~
- [x] Tests
- [x] Change environment selector to radio buttons