### PR TITLE
Fixes #34729 - Update name/checksum to required on repo upload

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -420,8 +420,8 @@ module Katello
       param 'id', String, :required => true
       param 'content_unit_id', String
       param 'size', String
-      param 'checksum', String
-      param 'name', String, :desc => N_("Needs to only be set for file repositories or docker tags")
+      param 'checksum', String, :required => true
+      param 'name', String, :required => true, :desc => N_("Needs to only be set for file repositories or docker tags")
       param 'digest', String, :desc => N_("Needs to only be set for docker tags")
     end
     Katello::RepositoryTypeManager.generic_repository_types.each_pair do |_, repo_type|
@@ -439,6 +439,12 @@ module Katello
       end
 
       uploads = (params[:uploads] || []).map do |upload|
+        if upload[:checksum].nil?
+          fail HttpErrors::BadRequest, _('Checksum is a required parameter.')
+        end
+        if upload[:name].nil?
+          fail HttpErrors::BadRequest, _('Name is a required parameter.')
+        end
         upload.permit(:id, :content_unit_id, :size, :checksum, :name, :digest).to_h
       end
 

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -941,6 +941,28 @@ module Katello
       assert_response :success
     end
 
+    def test_import_uploads_without_checksum
+      uploads = [{'id' => '1', 'size' => '12333', 'name' => 'test'}]
+
+      put :import_uploads, params: { id: @repository.id, uploads: uploads }
+
+      response = JSON.parse(@response.body)
+      assert response.key?('displayMessage')
+      assert_equal 'Checksum is a required parameter.', response['displayMessage']
+      assert_response :bad_request
+    end
+
+    def test_import_uploads_without_name
+      uploads = [{'id' => '1', 'size' => '12333', 'checksum' => 'asf23421324'}]
+
+      put :import_uploads, params: { id: @repository.id, uploads: uploads }
+
+      response = JSON.parse(@response.body)
+      assert response.key?('displayMessage')
+      assert_equal 'Name is a required parameter.', response['displayMessage']
+      assert_response :bad_request
+    end
+
     def test_import_uploads_file
       # make sure name does not get ignored for file repos
       # this is yum repo. So unit keys should accept name


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The API doc was showing that `checksum` and `name` were not required but they were and if not submitted would return the following error:

`Katello::HttpErrors::BadRequest: no implicit conversion of nil into String`

So I made them required

#### Considerations taken when implementing this change?

That uploads worked and tests still pass

#### What are the testing steps for this pull request?

Apply patch

Download an rpm from https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/

Create a product and repo

Grab the script from the redmine and update the credentials to match your box

Try to upload and make sure it goes through

Also if you have hammer do a --help on repo uploads and see if the api param is required.