### PR TITLE
Fixes #34743 - Disable update all if no katello-agent

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
@@ -60,7 +60,7 @@
         <div class="form-group">
           <button class="btn btn-default" type="button"
                   translate
-                  ng-disabled="!katelloAgentPresent || working"
+                  ng-disabled="remoteExecutionByDefault || !katelloAgentPresent || working"
                   ng-click="updateAll()">
             Update All Packages
           </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
@@ -49,7 +49,7 @@
         <button class="btn btn-default"
                 type="button"
                 translate
-                ng-disabled="working || !katelloAgentPresent"
+                ng-disabled="remoteExecutionByDefault || working || !katelloAgentPresent"
                 ng-click="updateAll()">
           Update All Packages
         </button>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Disable `Update All` in the hosts  if using remote exec by default since it requires Katello Agent .

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

###### Before ######

1. Set parameter 'remote_execution_by_default' to true in administer tab
2. Navigate to Hosts -> Content-Hosts -> <Host> -> Packages -> Actions -> Upgrade all Packages`

Notice it tries to use katello-agent to run this operation.

###### After ######
Notice the `Upgrade All Packages` is disabled.