### PR TITLE
Fixes #34733 - Display repository sets with Air-gapped

### DIFF
--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -13,7 +13,7 @@ module Katello
     before_action :find_authorized_host, :only => [:index, :auto_complete_search]
     before_action :find_organization
     before_action :find_product_content, :except => [:index, :auto_complete_search]
-    before_action :check_airgapped, :only => [:index]
+    before_action :check_airgapped, :only => [:available_repositories, :enable, :disable]
 
     resource_description do
       api_version "v2"
@@ -215,7 +215,7 @@ module Katello
 
     def check_airgapped
       if @organization.cdn_configuration.airgapped?
-        respond_for_index(:collection => { :error => _("Repositories are not available for enablement while CDN configuration is set to Air-gapped (disconnected).") }, :status => :forbidden)
+        fail HttpErrors::BadRequest, _("Repositories are not available for enablement while CDN configuration is set to Air-gapped (disconnected).")
       end
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Display repository sets as well even with Air-gapped
Turn off hammer `available_repositories`, `enable` and `disable` when it's Air-gapped

#### Considerations taken when implementing this change?
Followup of https://github.com/Katello/katello/pull/9812

#### What are the testing steps for this pull request?
Content - Subscriptions - Manage Manifest - CDN Configuration - Air-gapped - Update

_Before_
Activation Keys - add Subscription - Repository Sets empty

_After_
Activation Keys - add Subscription - Repository Sets populated

Tests with hammer
```
hammer repository-set list --organization-id 1
hammer repository-set available-repositories --organization-id 1 --id 1398
Repositories are not available for enablement while CDN configuration is set to Air-gapped (disconnected).
```
```
hammer repository-set enable --organization-id 1 --id 9330
Could not enable repository:
  Repositories are not available for enablement while CDN configuration is set to Air-gapped (disconnected).
```
or
```
hammer  repository-set disable --organization-id 1 --id 9330
Could not disable repository:
  Repositories are not available for enablement while CDN configuration is set to Air-gapped (disconnected).
```
