### PR TITLE
Fixes #34749 - Add ouia-ids to CV buttons

### DIFF
--- a/webpack/scenes/ContentViews/Copy/CopyContentViewForm.js
+++ b/webpack/scenes/ContentViews/Copy/CopyContentViewForm.js
@@ -59,6 +59,7 @@ const CopyContentViewForm = ({ cvId, setModalOpen }) => {
       </FormGroup>
       <ActionGroup>
         <Button
+          ouiaId="copy-form-submit-button"
           aria-label="copy_content_view"
           variant="primary"
           isDisabled={!name?.length || saving}
@@ -66,7 +67,7 @@ const CopyContentViewForm = ({ cvId, setModalOpen }) => {
         >
           {__('Copy content view')}
         </Button>
-        <Button variant="link" onClick={() => setModalOpen(false)}>{__('Cancel')}</Button>
+        <Button ouiaId="copy-form-cancel" variant="link" onClick={() => setModalOpen(false)}>{__('Cancel')}</Button>
       </ActionGroup>
     </Form >
   );

--- a/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
+++ b/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
@@ -170,6 +170,7 @@ const CreateContentViewForm = ({ setModalOpen }) => {
         </FormGroup>}
       <ActionGroup>
         <Button
+          ouia-id="create-content-view-form-submit"
           aria-label="create_content_view"
           variant="primary"
           isDisabled={submitDisabled}
@@ -177,7 +178,7 @@ const CreateContentViewForm = ({ setModalOpen }) => {
         >
           {__('Create content view')}
         </Button>
-        <Button variant="link" onClick={() => setModalOpen(false)}>
+        <Button ouia-id="create-content-view-form-cancel" variant="link" onClick={() => setModalOpen(false)}>
           {__('Cancel')}
         </Button>
       </ActionGroup>

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewAddModal.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewAddModal.js
@@ -137,8 +137,8 @@ const ComponentContentViewAddModal = ({
           </Flex>
         </FormGroup>
         <ActionGroup>
-          <Button aria-label="add_component" variant="primary" type="submit">{__('Submit')}</Button>
-          <Button variant="link" onClick={() => setIsOpen(false)}>{__('Cancel')}</Button>
+          <Button ouiaId="add-component-submit" aria-label="add_component" variant="primary" type="submit">{__('Submit')}</Button>
+          <Button ouiaId="add-component-cancel" variant="link" onClick={() => setIsOpen(false)}>{__('Cancel')}</Button>
         </ActionGroup>
       </Form>
     </Modal >);

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewBulkAddModal.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewBulkAddModal.js
@@ -112,8 +112,8 @@ const ComponentContentViewBulkAddModal = ({ cvId, rowsToAdd, onClose }) => {
           </Card>
         ))}
         <ActionGroup>
-          <Button aria-label="add_components" variant="primary" type="submit">{__('Add')}</Button>
-          <Button variant="link" onClick={onClose}>{__('Cancel')}</Button>
+          <Button ouia-id="add-components-modal-add" aria-label="add_components" variant="primary" type="submit">{__('Add')}</Button>
+          <Button ouia-id="add-components-modal-cancel" variant="link" onClick={onClose}>{__('Cancel')}</Button>
         </ActionGroup>
       </Form>
     </Modal >);

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
@@ -148,6 +148,7 @@ const ContentViewComponents = ({ cvId, details }) => {
               {hasPermission(permissions, 'edit_content_views') && componentCvId && cvVersion &&
                 <SplitItem>
                   <Button
+                    ouiaId={`edit-component-version-${componentCvId}`}
                     className="foreman-edit-icon"
                     aria-label="edit_version"
                     variant="plain"
@@ -269,7 +270,7 @@ const ContentViewComponents = ({ cvId, details }) => {
               <SplitItem>
                 <ActionList>
                   <ActionListItem>
-                    <Button onClick={addBulk} isDisabled={!(bulkAddEnabled())} variant="primary" aria-label="bulk_add_components">
+                    <Button ouiaId="add-content-views" onClick={addBulk} isDisabled={!(bulkAddEnabled())} variant="primary" aria-label="bulk_add_components">
                       {__('Add content views')}
                     </Button>
                   </ActionListItem>

--- a/webpack/scenes/ContentViews/Details/ContentViewDetails.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetails.js
@@ -161,9 +161,10 @@ export default () => {
               {hasPermission(permissions, 'publish_content_views') &&
                 <FlexItem>
                   <Button
+                    ouiaId="cv-details-publish-button"
                     isDisabled={importOnly || generatedContentView}
                     onClick={() => setIsPublishModalOpen(true)}
-                    variant="primary"
+                    variant="secondary"
                     aria-label="publish_content_view"
                   >
                     {__('Publish new version')}
@@ -182,6 +183,7 @@ export default () => {
               }
               <FlexItem>
                 <Button
+                  ouiaId="cv-details-view-tasks-button"
                   component="a"
                   aria-label="view tasks button"
                   href={`/foreman_tasks/tasks?search=resource_type%3D+Katello%3A%3AContentView+resource_id%3D${cvId}`}

--- a/webpack/scenes/ContentViews/Details/Filters/Add/CVFilterAddModal.js
+++ b/webpack/scenes/ContentViews/Details/Filters/Add/CVFilterAddModal.js
@@ -161,6 +161,7 @@ const CVFilterAddModal = ({ cvId, onClose }) => {
         </FormGroup>
         <ActionGroup>
           <Button
+            ouiaId="create-filter-form-submit-button"
             aria-label="create_filter"
             variant="primary"
             isDisabled={saving || name.length === 0}
@@ -168,7 +169,7 @@ const CVFilterAddModal = ({ cvId, onClose }) => {
           >
             {__('Create filter')}
           </Button>
-          <Button variant="link" onClick={onClose}>
+          <Button ouiaId="create-filter-form-cancel-button" variant="link" onClick={onClose}>
             {__('Cancel')}
           </Button>
         </ActionGroup>

--- a/webpack/scenes/ContentViews/Details/Filters/AffectedRepositories/AffectedRepositoryTable.js
+++ b/webpack/scenes/ContentViews/Details/Filters/AffectedRepositories/AffectedRepositoryTable.js
@@ -223,7 +223,7 @@ const AffectedRepositoryTable = ({
               <SplitItem>
                 <ActionList>
                   <ActionListItem>
-                    <Button onClick={addBulk} isDisabled={!hasNotAddedSelected} variant="primary" aria-label="add_repositories">
+                    <Button ouiaId="add-repositories" onClick={addBulk} isDisabled={!hasNotAddedSelected} variant="primary" aria-label="add_repositories">
                       {__('Add repositories')}
                     </Button>
                   </ActionListItem>

--- a/webpack/scenes/ContentViews/Details/Filters/CVContainerImageFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVContainerImageFilterContent.js
@@ -143,6 +143,7 @@ const CVContainerImageFilterContent = ({
                 <Split hasGutter>
                   <SplitItem>
                     <Button
+                      ouiaId="add-content-view-container-image-filter-button"
                       onClick={() => setModalOpen(true)}
                       variant="primary"
                       aria-label="add_filter_rule"

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
@@ -256,6 +256,7 @@ const CVErrataDateFilterContent = ({
               {hasPermission(permissions, 'edit_content_views') &&
                 <FlexItem>
                   <Button
+                    ouiaId="errata-date-reset-filters-button"
                     isDisabled={saveDisabled}
                     variant="link"
                     onClick={resetFilters}
@@ -269,6 +270,7 @@ const CVErrataDateFilterContent = ({
             {hasPermission(permissions, 'edit_content_views') &&
               <ActionGroup>
                 <Button
+                  ouiaId="save-filter-rule-button"
                   aria-label="save_filter_rule"
                   variant="primary"
                   isDisabled={saveDisabled}
@@ -277,7 +279,7 @@ const CVErrataDateFilterContent = ({
                   {__('Edit rule')}
                 </Button>
                 <Link to={`/content_views/${cvId}#/filters`}>
-                  <Button variant="link">
+                  <Button ouiaId="cancel-save-filter-rule-button" variant="link">
                     {__('Cancel')}
                   </Button>
                 </Link>

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
@@ -317,7 +317,7 @@ const CVErrataIDFilterContent = ({
                 </SplitItem>
                 {hasPermission(permissions, 'edit_content_views') &&
                   <SplitItem>
-                    <Button isDisabled={!hasNotAddedSelected} onClick={bulkAdd} variant="primary" aria-label="add_filter_rule">
+                    <Button ouiaId="add-errata-id-button" isDisabled={!hasNotAddedSelected} onClick={bulkAdd} variant="primary" aria-label="add_filter_rule">
                       {__('Add errata')}
                     </Button>
                   </SplitItem>
@@ -429,7 +429,7 @@ const CVErrataIDFilterContent = ({
                     </ChipGroup>
                   </FlexItem>
                   <FlexItem>
-                    <Button isDisabled={resetFiltersDisabled} variant="link" onClick={resetFilters} isInline>
+                    <Button ouiaId="errata-reset-filters-button" isDisabled={resetFiltersDisabled} variant="link" onClick={resetFilters} isInline>
                       {__('Reset filters')}
                     </Button>
                   </FlexItem>

--- a/webpack/scenes/ContentViews/Details/Filters/CVModuleStreamFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVModuleStreamFilterContent.js
@@ -246,6 +246,7 @@ const CVModuleStreamFilterContent = ({
                 </SplitItem>
                 <SplitItem>
                   <Button
+                    ouiaId="add-module-stream-rule-button"
                     isDisabled={!hasNotAddedSelected}
                     onClick={bulkAdd}
                     variant="primary"

--- a/webpack/scenes/ContentViews/Details/Filters/CVPackageGroupFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVPackageGroupFilterContent.js
@@ -235,7 +235,13 @@ const CVPackageGroupFilterContent = ({
                   </Select>
                 </SplitItem>
                 <SplitItem>
-                  <Button isDisabled={!hasNotAddedSelected} onClick={bulkAdd} variant="primary" aria-label="add_filter_rule">
+                  <Button
+                    ouiaId="add-package-group-filter-rule-button"
+                    isDisabled={!hasNotAddedSelected}
+                    onClick={bulkAdd}
+                    variant="primary"
+                    aria-label="add_filter_rule"
+                  >
                     {__('Add filter rule')}
                   </Button>
                 </SplitItem>

--- a/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
@@ -180,7 +180,12 @@ const CVRpmFilterContent = ({
                 {hasPermission(permissions, 'edit_content_views') &&
                   <Split hasGutter>
                     <SplitItem>
-                      <Button onClick={() => setModalOpen(true)} variant="primary" aria-label="add_rpm_rule">
+                      <Button
+                        ouiaId="add-rpm-rule-button"
+                        onClick={() => setModalOpen(true)}
+                        variant="primary"
+                        aria-label="add_rpm_rule"
+                      >
                         {__('Add RPM rule')}
                       </Button>
                     </SplitItem>

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
@@ -137,7 +137,7 @@ const ContentViewFilters = ({ cvId, details }) => {
         <>
           <Split hasGutter>
             <SplitItem>
-              <Button onClick={openAddModal} variant="primary" aria-label="create_filter">
+              <Button ouiaId="create-filter-button" onClick={openAddModal} variant="primary" aria-label="create_filter">
                 {__('Create filter')}
               </Button>
             </SplitItem>

--- a/webpack/scenes/ContentViews/Details/Filters/Rules/ContainerTag/AddEditContainerTagRuleModal.js
+++ b/webpack/scenes/ContentViews/Details/Filters/Rules/ContainerTag/AddEditContainerTagRuleModal.js
@@ -71,6 +71,7 @@ const AddEditContainerTagRuleModal = ({
         </FormGroup>
         <ActionGroup>
           <Button
+            ouia-id="add-edit-container-tag-filter-rule-submit"
             aria-label="add_edit_filter_rule"
             variant="primary"
             isDisabled={saving || tagName.length === 0}
@@ -78,7 +79,7 @@ const AddEditContainerTagRuleModal = ({
           >
             {isEditing ? __('Edit rule') : __('Add rule')}
           </Button>
-          <Button variant="link" onClick={onClose}>
+          <Button ouia-id="add-edit-container-tag-filter-rule-cancel" variant="link" onClick={onClose}>
             {__('Cancel')}
           </Button>
         </ActionGroup>

--- a/webpack/scenes/ContentViews/Details/Filters/Rules/Package/AddEditPackageRuleModal.js
+++ b/webpack/scenes/ContentViews/Details/Filters/Rules/Package/AddEditPackageRuleModal.js
@@ -213,6 +213,7 @@ const AddEditPackageRuleModal = ({
           </FormGroup>}
         <ActionGroup>
           <Button
+            ouiaId="add-edit-package-modal-submit"
             aria-label="add_package_filter_rule"
             variant="primary"
             isDisabled={saving || submitDisabled}
@@ -220,7 +221,7 @@ const AddEditPackageRuleModal = ({
           >
             {selectedFilterRuleData ? __('Edit rule') : __('Add rule')}
           </Button>
-          <Button variant="link" onClick={onClose}>
+          <Button ouiaId="add-edit-package-modal-cancel" variant="link" onClick={onClose}>
             {__('Cancel')}
           </Button>
         </ActionGroup>

--- a/webpack/scenes/ContentViews/Details/Promote/ContentViewVersionPromote.js
+++ b/webpack/scenes/ContentViews/Details/Promote/ContentViewVersionPromote.js
@@ -159,6 +159,7 @@ const ContentViewVersionPromote = ({
           />
           <ActionGroup style={{ margin: 0 }}>
             <Button
+              ouiaId="cv-version-promote-submit"
               aria-label="promote_content_view"
               variant="primary"
               isDisabled={submitDisabled}
@@ -166,7 +167,7 @@ const ContentViewVersionPromote = ({
             >
               {__('Promote')}
             </Button>
-            <Button variant="link" onClick={() => setIsOpen(false)}>
+            <Button ouiaId="cv-version-promote-cancel" variant="link" onClick={() => setIsOpen(false)}>
               {__('Cancel')}
             </Button>
           </ActionGroup>

--- a/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
@@ -275,7 +275,7 @@ const ContentViewRepositories = ({ cvId, details }) => {
             <SplitItem>
               <ActionList>
                 <ActionListItem>
-                  <Button onClick={addBulk} isDisabled={!hasNotAddedSelected || importOnly || generatedContentView} variant="primary" aria-label="add_repositories">
+                  <Button ouiaId="add-repositories" onClick={addBulk} isDisabled={!hasNotAddedSelected || importOnly || generatedContentView} variant="primary" aria-label="add_repositories">
                     {__('Add repositories')}
                   </Button>
                 </ActionListItem>

--- a/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
@@ -192,6 +192,7 @@ const ContentViewRepositories = ({ cvId, details }) => {
   const rowDropdownItems = ({ id }) => [
     {
       title: 'Add',
+      ouiaId: `add-repository-${id}`,
       isDisabled: importOnly || generatedContentView || repositoryIds.includes(id),
       onClick: () => {
         onAdd(id);
@@ -199,6 +200,7 @@ const ContentViewRepositories = ({ cvId, details }) => {
     },
     {
       title: 'Remove',
+      ouiaId: `remove-repository-${id}`,
       isDisabled: importOnly || generatedContentView || !repositoryIds.includes(id),
       onClick: () => {
         onRemove(id);
@@ -220,7 +222,7 @@ const ContentViewRepositories = ({ cvId, details }) => {
   const defaultFilters = [allRepositories, ALL_STATUSES];
 
   const dropdownItems = [
-    <DropdownItem aria-label="bulk_remove" key="bulk_remove" isDisabled={!hasAddedSelected} component="button" onClick={removeBulk}>
+    <DropdownItem ouiaId="bulk-remove-repositories" aria-label="bulk_remove" key="bulk_remove" isDisabled={!hasAddedSelected} component="button" onClick={removeBulk}>
       {__('Remove')}
     </DropdownItem>,
   ];
@@ -281,6 +283,7 @@ const ContentViewRepositories = ({ cvId, details }) => {
                 </ActionListItem>
                 <ActionListItem>
                   <Dropdown
+                    ouiaId="repositoies-bulk-actions"
                     toggle={<KebabToggle aria-label="bulk_actions" onToggle={toggleBulkAction} />}
                     isOpen={bulkActionOpen}
                     isPlain
@@ -317,7 +320,7 @@ const ContentViewRepositories = ({ cvId, details }) => {
             last_sync: lastSync,
           } = repo;
           return (
-            <Tr key={id}>
+            <Tr key={id} ouiaId={`repositories-table-row-${productName}-${name}`}>
               {hasPermission(permissions, 'edit_content_views') &&
                 <Td>
                   <Checkbox

--- a/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignActivationKeys.js
+++ b/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignActivationKeys.js
@@ -143,7 +143,7 @@ export default () => {
                   __('Before removing versions you must move activation keys to an environment where the associated version is not in use.')
                 }
               >
-                <Button style={{ padding: '8px' }} variant="plain" aria-label="popoverButton">
+                <Button ouiaId="reassign-activation-keys-info" style={{ padding: '8px' }} variant="plain" aria-label="popoverButton">
                   <OutlinedQuestionCircleIcon />
                 </Button>
               </Popover>

--- a/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignHosts.js
+++ b/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignHosts.js
@@ -167,7 +167,7 @@ export default () => {
                   </>
                 }
               >
-                <Button style={{ padding: '8px' }} variant="plain" aria-label="popoverButton">
+                <Button ouiaId="reassign-hosts-info" style={{ padding: '8px' }} variant="plain" aria-label="popoverButton">
                   <OutlinedQuestionCircleIcon />
                 </Button>
               </Popover>

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
@@ -75,10 +75,11 @@ const ContentViewVersionDetailsHeader = ({
       </GridItem>
       <GridItem sm={6} style={{ display: 'flex' }}>
         <Button
+          ouiaId="cv-details-promote-button"
           style={{ marginLeft: 'auto' }}
           onClick={() => setPromoting(true)}
           variant="primary"
-          aria-label="publish_content_view"
+          aria-label="promote_content_view"
         >
           {__('Promote')}
         </Button>

--- a/webpack/scenes/ContentViews/Publish/CVPublishFinish.js
+++ b/webpack/scenes/ContentViews/Publish/CVPublishFinish.js
@@ -118,6 +118,7 @@ const CVPublishFinish = ({
         <GridItem style={{ marginTop: '10px' }} span={12} rowSpan={1}>
           <Bullseye>
             <Button
+              ouiaId="publish-wizard-close"
               onClick={() => {
                 dispatch(stopPollingTask(POLLING_TASK_KEY));
                 onClose(true);
@@ -128,6 +129,7 @@ const CVPublishFinish = ({
               {__('Close')}
             </Button>
             <Button
+              ouiaId="publish-wizard-view-task-button"
               component="a"
               aria-label="view tasks button"
               href={`/foreman_tasks/tasks/${pollResponse.id}`}

--- a/webpack/scenes/ContentViews/Table/ContentViewsTable.js
+++ b/webpack/scenes/ContentViews/Table/ContentViewsTable.js
@@ -160,7 +160,7 @@ const ContentViewTable = () => {
       actionButtons={
         <>
           {canCreate &&
-            <Button onClick={openForm} variant="primary" aria-label="create_content_view">
+            <Button ouiaId="create-content-view" onClick={openForm} variant="primary" aria-label="create_content_view">
               {__('Create content view')}
             </Button>
           }

--- a/webpack/scenes/ContentViews/expansions/RelatedCompositeContentViewsModal.js
+++ b/webpack/scenes/ContentViews/expansions/RelatedCompositeContentViewsModal.js
@@ -30,7 +30,7 @@ const RelatedCompositeContentViewsModal = ({
   const columns = ['Name'];
   return (
     <>
-      <Button aria-label={`button_${cvId}`} variant="link" isInline onClick={handleModalToggle}>
+      <Button ouiaId="related-cv-count" aria-label={`button_${cvId}`} variant="link" isInline onClick={handleModalToggle}>
         {relatedCVCount}
       </Button>
       <Modal

--- a/webpack/scenes/ContentViews/expansions/RelatedContentViewComponentsModal.js
+++ b/webpack/scenes/ContentViews/expansions/RelatedContentViewComponentsModal.js
@@ -43,7 +43,7 @@ const RelatedContentViewsModal = ({ cvName, cvId, relatedCVCount }) => {
 
   return (
     <>
-      <Button aria-label={`button_${cvId}`} variant="link" isInline onClick={handleModalToggle}>
+      <Button ouiaId="related-cv-count" aria-label={`button_${cvId}`} variant="link" isInline onClick={handleModalToggle}>
         {relatedCVCount}
       </Button>
       <Grid>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This is to aid in airgun automation. These are the buttons that needs to have ouia-ID:
- create cv
- publish cv
- next, back, and cancel button in the publish screen
- add/remove repositories
- close button in the progress bar workflow screen
- add, remove repo from the kebab menu
#### Considerations taken when implementing this change?
Some components in PF4 don't support ouia-id. Example: Wizard footer buttons in basic wizard setup, Kebab dropdown button.
The publish wizard next/close buttons will not have static ouia-id in this case.
#### What are the testing steps for this pull request?
Make sure all primary/secondary buttons visible on the CV UI pages have ouia-ids.
For Repository tab:
Check ouia-id for bulk button, bulk action dropdown, the dropdown actions.
