### PR TITLE
Fixes #34707 - Uploaded Rpm(s) replaces Rpm(s) currently in repository

### DIFF
--- a/app/lib/actions/katello/repository/filtered_index_content.rb
+++ b/app/lib/actions/katello/repository/filtered_index_content.rb
@@ -36,7 +36,7 @@ module Actions
             else
               unit_ids = search_units(repo)
             end
-            ::Katello::Deb.import_all(unit_ids, repo)
+            ::Katello::Deb.import_all(unit_ids, repo, {filtered_indexing: true})
           elsif repo.yum?
             if input[:import_upload_task] && input[:import_upload_task][:content_unit_href]
               unit_ids = [input[:import_upload_task][:content_unit_href]]
@@ -48,9 +48,9 @@ module Actions
               unit_ids = search_units(repo)
             end
             if input[:content_type] == ::Katello::Srpm::CONTENT_TYPE
-              ::Katello::Srpm.import_all(unit_ids, repo)
+              ::Katello::Srpm.import_all(unit_ids, repo, {filtered_indexing: true})
             else
-              ::Katello::Rpm.import_all(unit_ids, repo)
+              ::Katello::Rpm.import_all(unit_ids, repo, {filtered_indexing: true})
             end
           end
         end

--- a/app/models/katello/concerns/pulp_database_unit.rb
+++ b/app/models/katello/concerns/pulp_database_unit.rb
@@ -81,7 +81,8 @@ module Katello
 
       def import_all(unit_ids, repository = nil, options = {})
         content_type = options[:content_type] || self.content_type
-        Katello::ContentUnitIndexer.new(content_type: Katello::RepositoryTypeManager.find_content_type(content_type), repository: repository, pulp_content_ids: unit_ids).import_all
+        filtered_indexing = options[:filtered_indexing] || false
+        Katello::ContentUnitIndexer.new(content_type: Katello::RepositoryTypeManager.find_content_type(content_type), repository: repository, pulp_content_ids: unit_ids).import_all(filtered_indexing)
       end
 
       def copy_repository_associations(source_repo, dest_repo)

--- a/app/services/katello/content_unit_indexer.rb
+++ b/app/services/katello/content_unit_indexer.rb
@@ -21,9 +21,9 @@ module Katello
       end
     end
 
-    def import_all
+    def import_all(filtered_indexing = false)
+      additive = filtered_indexing || (@repository&.mirroring_policy == 'additive')
       association_tracker = RepoAssociationTracker.new(@content_type, @service_class, @repository)
-
       units_from_pulp.each do |units|
         units.each do |unit|
           association_tracker.push(unit)
@@ -52,7 +52,7 @@ module Katello
       end
 
       if @model_class.many_repository_associations && @repository
-        sync_repository_associations(association_tracker)
+        sync_repository_associations(association_tracker, additive: additive)
       end
     end
 

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:40 GMT
+      - Thu, 07 Apr 2022 17:17:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -41,7 +41,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ee2cba3aead34b5c8c2c11f40b6e23ff
+      - 30b2b1c445794d7985dbfd7f3a60747b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -52,7 +52,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:40 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:06 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
@@ -76,7 +76,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:40 GMT
+      - Thu, 07 Apr 2022 17:17:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -94,7 +94,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 77001c9de2984233bfb7f69f395d3174
+      - 3f4f436c9e8a4c9db8ed40c4ddf49a27
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -105,7 +105,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:40 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:06 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
@@ -129,7 +129,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:40 GMT
+      - Thu, 07 Apr 2022 17:17:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -147,7 +147,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 52943ab613764d3cba2eb01e0b76c48e
+      - cb9bdbc3811a493abf599ac142004b6f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -158,7 +158,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:40 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:06 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
@@ -182,7 +182,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:40 GMT
+      - Thu, 07 Apr 2022 17:17:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -200,7 +200,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5c9ddbc5f789446faec256d87d69b131
+      - ea28ce0e8fe8461094b958f943b23d74
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -211,7 +211,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:40 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:06 GMT
 - request:
     method: post
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -243,13 +243,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:40 GMT
+      - Thu, 07 Apr 2022 17:17:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/47b07c0c-718c-4afa-b9bf-b5544f321c9f/"
+      - "/pulp/api/v3/remotes/rpm/rpm/7510f3c5-c3db-4db6-bc86-1c139fffa347/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -263,7 +263,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a25bd3831ab8433b8a66029c0d27178d
+      - 9e38b7900f664087bb51b5ee83d1752c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -271,20 +271,20 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQ3
-        YjA3YzBjLTcxOGMtNGFmYS1iOWJmLWI1NTQ0ZjMyMWM5Zi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTAzLTIyVDE0OjI1OjQwLjI1MTMzNFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc1
+        MTBmM2M1LWMzZGItNGRiNi1iYzg2LTFjMTM5ZmZmYTM0Ny8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA0LTA3VDE3OjE3OjA2LjkzODIyOVoiLCJuYW1lIjoi
         RmVkb3JhXzE3IiwidXJsIjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0
         IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRy
         dWUsInByb3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjItMDMtMjJUMTQ6MjU6NDAuMjUxMzUxWiIsImRv
+        c3RfdXBkYXRlZCI6IjIwMjItMDQtMDdUMTc6MTc6MDYuOTM4MjQ5WiIsImRv
         d25sb2FkX2NvbmN1cnJlbmN5IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwi
         cG9saWN5Ijoib25fZGVtYW5kIiwidG90YWxfdGltZW91dCI6MzYwMC4wLCJj
         b25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfY29ubmVjdF90aW1lb3V0Ijo2
         MC4wLCJzb2NrX3JlYWRfdGltZW91dCI6MzYwMC4wLCJoZWFkZXJzIjpudWxs
         LCJyYXRlX2xpbWl0IjowLCJzbGVzX2F1dGhfdG9rZW4iOm51bGx9
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:40 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:06 GMT
 - request:
     method: post
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -310,13 +310,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:40 GMT
+      - Thu, 07 Apr 2022 17:17:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/a0b9b63e-8754-4e58-b619-73b1e87c968e/"
+      - "/pulp/api/v3/repositories/rpm/rpm/caa09a0e-2510-48ee-ad57-b034fc13b777/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -330,7 +330,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 81f78368e1d24049a19e4eb5ca023ced
+      - 9b6c146f12f647ccb6096113f0936fc3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -339,13 +339,13 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYTBiOWI2M2UtODc1NC00ZTU4LWI2MTktNzNiMWU4N2M5NjhlLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDMtMjJUMTQ6MjU6NDAuNDAzNTQwWiIsInZl
+        cG0vY2FhMDlhMGUtMjUxMC00OGVlLWFkNTctYjAzNGZjMTNiNzc3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDQtMDdUMTc6MTc6MDcuMDc5MzQ5WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYTBiOWI2M2UtODc1NC00ZTU4LWI2MTktNzNiMWU4N2M5NjhlL3ZlcnNp
+        cG0vY2FhMDlhMGUtMjUxMC00OGVlLWFkNTctYjAzNGZjMTNiNzc3L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hMGI5YjYzZS04
-        NzU0LTRlNTgtYjYxOS03M2IxZTg3Yzk2OGUvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jYWEwOWEwZS0y
+        NTEwLTQ4ZWUtYWQ1Ny1iMDM0ZmMxM2I3NzcvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiRmVkb3JhXzE3IiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBv
         X3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpm
         YWxzZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5f
@@ -353,10 +353,10 @@ http_interactions:
         bnVsbCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6
         MCwicmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:40 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:07 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/remotes/rpm/rpm/47b07c0c-718c-4afa-b9bf-b5544f321c9f/
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/remotes/rpm/rpm/7510f3c5-c3db-4db6-bc86-1c139fffa347/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -377,7 +377,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:41 GMT
+      - Thu, 07 Apr 2022 17:17:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -395,7 +395,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 66e1a96d9093406bb42cb77a97c724e2
+      - d8d3ee9a7c2c438a96da327c3ae3c41e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -403,13 +403,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNiNDIwMDE1LTNlNDEtNDgz
-        OC1iZGFiLWMwMjc0MjM5N2ZkZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q3YjgxOTY4LTFhMDEtNDIw
+        ZC05YzA3LWI4NTk4ODNlNzEwMS8ifQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:41 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:08 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/3b420015-3e41-4838-bdab-c02742397fdd/
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/d7b81968-1a01-420d-9c07-b859883e7101/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -417,7 +417,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.16.5/ruby
+      - OpenAPI-Generator/3.16.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -430,7 +430,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:41 GMT
+      - Thu, 07 Apr 2022 17:17:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -446,7 +446,125 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 18e5b9081b2d4e76a1218839d1584180
+      - d233676cbea74a96ad6069cf7314dff3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '370'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDdiODE5NjgtMWEw
+        MS00MjBkLTljMDctYjg1OTg4M2U3MTAxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTc6MDguNjM0MTg1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkOGQzZWU5YTdjMmM0MzhhOTZkYTMyN2Mz
+        YWUzYzQxZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE3OjA4LjY4
+        NjQ1N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTc6MDguNzMy
+        NDg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8zNzI3MDBmOC1jYjk1LTQyMzMtOGFkNy04ZDdjZjg1M2YyMWIvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzc1MTBmM2M1LWMzZGItNGRiNi1iYzg2
+        LTFjMTM5ZmZmYTM0Ny8iXX0=
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:08 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/caa09a0e-2510-48ee-ad57-b034fc13b777/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 35ac1297c95746458f98d3652283a2de
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNkNTRlYTEwLWRmZjItNDBk
+        NC04YzhjLTI0ZWRiZjc4MzYyNS8ifQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:08 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/3d54ea10-dff2-40d4-8c8c-24edbf783625/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 601aa45b4d26466b8e7f699ba4176603
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -456,140 +574,22 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2I0MjAwMTUtM2U0
-        MS00ODM4LWJkYWItYzAyNzQyMzk3ZmRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDMtMjJUMTQ6MjU6NDEuODA3MTEzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2Q1NGVhMTAtZGZm
+        Mi00MGQ0LThjOGMtMjRlZGJmNzgzNjI1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTc6MDguODc3MTEyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2NmUxYTk2ZDkwOTM0MDZiYjQyY2I3N2E5
-        N2M3MjRlMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTAzLTIyVDE0OjI1OjQxLjg1
-        NjYzOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDMtMjJUMTQ6MjU6NDEuOTAy
-        MTc1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wNjJhZjI0MS1hMTQ1LTQyYzUtOGRhOC0zOGMzNDhjZjk0Y2IvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIzNWFjMTI5N2M5NTc0NjQ1OGY5OGQzNjUy
+        MjgzYTJkZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE3OjA4Ljkz
+        Mjc2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTc6MDguOTk5
+        MzY1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy82MTM3ZDU3Yy1jZDU0LTRjNzctOTM1Ny00ZWUxM2RmZjE1OGEvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzQ3YjA3YzBjLTcxOGMtNGFmYS1iOWJm
-        LWI1NTQ0ZjMyMWM5Zi8iXX0=
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vY2FhMDlhMGUtMjUxMC00OGVl
+        LWFkNTctYjAzNGZjMTNiNzc3LyJdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:41 GMT
-- request:
-    method: delete
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/a0b9b63e-8754-4e58-b619-73b1e87c968e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 22 Mar 2022 14:25:42 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - bb68a588591643f78b2261a402e1f150
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.samir.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg0NDNjOTgxLWM4YmUtNDVk
-        Yy1iZDk3LTgyYjM0YzAzNGUxNS8ifQ==
-    http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:42 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/8443c981-c8be-45dc-bd97-82b34c034e15/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.16.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 22 Mar 2022 14:25:42 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 8c0468448ad1449a87bfe07dbdddfc42
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.samir.example.com
-      Content-Length:
-      - '374'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODQ0M2M5ODEtYzhi
-        ZS00NWRjLWJkOTctODJiMzRjMDM0ZTE1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDMtMjJUMTQ6MjU6NDIuMDI3MTg4WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJiYjY4YTU4ODU5MTY0M2Y3OGIyMjYxYTQw
-        MmUxZjE1MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTAzLTIyVDE0OjI1OjQyLjA3
-        NDc3MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDMtMjJUMTQ6MjU6NDIuMTM3
-        NTg1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wNjJhZjI0MS1hMTQ1LTQyYzUtOGRhOC0zOGMzNDhjZjk0Y2IvIiwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTBiOWI2M2UtODc1NC00ZTU4
-        LWI2MTktNzNiMWU4N2M5NjhlLyJdfQ==
-    http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:42 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:09 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -613,7 +613,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:42 GMT
+      - Thu, 07 Apr 2022 17:17:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -629,51 +629,130 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2ba0e51d8d00488391e8b23af61def00
+      - a79dc3220ffb4eae93e9dcf817fa77f3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
       - 1.1 centos8-katello-devel.samir.example.com
       Content-Length:
-      - '385'
+      - '714'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS81ZDQ2OTM4YS1mZjhlLTRhMGItYjg5OS00ZWQzMzk4YjdkNGQv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wMy0yMVQxNDoyOTozNC45NjUxOTJa
+        cnBtL3JwbS9mYmQ4YWJhZi02YjZiLTQwNzktYTMwZC1kMGUzNDcyYWU0ZDEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNC0wN1QxMzowOToyNi45MDcwOTVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS81ZDQ2OTM4YS1mZjhlLTRhMGItYjg5OS00ZWQzMzk4YjdkNGQv
+        cnBtL3JwbS9mYmQ4YWJhZi02YjZiLTQwNzktYTMwZC1kMGUzNDcyYWU0ZDEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzVkNDY5
-        MzhhLWZmOGUtNGEwYi1iODk5LTRlZDMzOThiN2Q0ZC92ZXJzaW9ucy8wLyIs
-        Im5hbWUiOiJtb2R1bGFyX3Rlc3QtMjE4MyIsImRlc2NyaXB0aW9uIjpudWxs
-        LCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJh
-        dXRvcHVibGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6
-        bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2No
-        ZWNrc3VtX3R5cGUiOm51bGwsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVs
-        bCwiZ3BnY2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRh
-        ZGF0YSI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzdiZDQxNjA3LWJjMTgtNDYxZS04OTkyLWIyYmUz
-        NWJjMDljZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTAzLTIxVDE0OjA2OjI2
-        LjcxOTcyMloiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzdiZDQxNjA3LWJjMTgtNDYxZS04OTkyLWIyYmUz
-        NWJjMDljZC92ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30sImxhdGVzdF92
-        ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vN2JkNDE2MDctYmMxOC00NjFlLTg5OTItYjJiZTM1YmMwOWNkL3ZlcnNp
-        b25zLzAvIiwibmFtZSI6InRlc3QtMTg2MTIiLCJkZXNjcmlwdGlvbiI6bnVs
-        bCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwi
-        YXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2Ui
-        Om51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowLCJtZXRhZGF0YV9j
-        aGVja3N1bV90eXBlIjpudWxsLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOm51
-        bGwsImdwZ2NoZWNrIjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0
-        YWRhdGEiOmZhbHNlfV19
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2ZiZDhh
+        YmFmLTZiNmItNDA3OS1hMzBkLWQwZTM0NzJhZTRkMS92ZXJzaW9ucy8wLyIs
+        Im5hbWUiOiJ0ZXN0LTgwODc3IiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFp
+        bl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJs
+        aXNoIjpmYWxzZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJy
+        ZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1f
+        dHlwZSI6bnVsbCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdj
+        aGVjayI6MCwicmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L3JwbS9ycG0vNjUzZTdhMDQtMjllZi00MWRjLWExZmQtNzgyYWVlYTc5MDli
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDQtMDdUMTE6MTQ6MjUuOTA1MzAx
+        WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L3JwbS9ycG0vNjUzZTdhMDQtMjllZi00MWRjLWExZmQtNzgyYWVlYTc5MDli
+        L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82NTNl
+        N2EwNC0yOWVmLTQxZGMtYTFmZC03ODJhZWVhNzkwOWIvdmVyc2lvbnMvMC8i
+        LCJuYW1lIjoiUmVkX0hhdF9BbnNpYmxlX0VuZ2luZV8yXzlfUlBNc19mb3Jf
+        UmVkX0hhdF9FbnRlcnByaXNlX0xpbnV4XzdfU2VydmVyX3g4Nl82NC0yMzk1
+        OTIiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMi
+        Om51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRh
+        ZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3Zl
+        cnNpb25zIjowLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjpudWxsLCJwYWNr
+        YWdlX2NoZWNrc3VtX3R5cGUiOm51bGwsImdwZ2NoZWNrIjowLCJyZXBvX2dw
+        Z2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zZGRiYmQy
+        OS0yODA3LTRhNTItYmFmMC1lZTE1MDdjNjIwYzkvIiwicHVscF9jcmVhdGVk
+        IjoiMjAyMi0wNC0wN1QxMToxMzo1Ny41NzUyNjhaIiwidmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zZGRiYmQy
+        OS0yODA3LTRhNTItYmFmMC1lZTE1MDdjNjIwYzkvdmVyc2lvbnMvIiwicHVs
+        cF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzNkZGJiZDI5LTI4MDctNGE1Mi1i
+        YWYwLWVlMTUwN2M2MjBjOS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJSZWRfSGF0
+        X0Fuc2libGVfRW5naW5lXzJfOV9SUE1zX2Zvcl9SZWRfSGF0X0VudGVycHJp
+        c2VfTGludXhfN19TZXJ2ZXJfeDg2XzY0LTE5MzM1IiwiZGVzY3JpcHRpb24i
+        Om51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51
+        bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2
+        aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6MCwibWV0YWRh
+        dGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFja2FnZV9jaGVja3N1bV90eXBl
+        IjpudWxsLCJncGdjaGVjayI6MCwicmVwb19ncGdjaGVjayI6MCwic3FsaXRl
+        X21ldGFkYXRhIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vZTIyZTU0ZmMtMTc1Ni00NDllLTk2YzUt
+        YTZlNTMwYzNiZDdjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDQtMDdUMTE6
+        MTM6MzMuMzg1OTUyWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vZTIyZTU0ZmMtMTc1Ni00NDllLTk2YzUt
+        YTZlNTMwYzNiZDdjL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0
+        ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9lMjJlNTRmYy0xNzU2LTQ0OWUtOTZjNS1hNmU1MzBjM2JkN2Mv
+        dmVyc2lvbnMvMC8iLCJuYW1lIjoiUmVkX0hhdF9BbnNpYmxlX0VuZ2luZV8y
+        XzlfUlBNc19mb3JfUmVkX0hhdF9FbnRlcnByaXNlX0xpbnV4XzdfU2VydmVy
+        X3g4Nl82NC0xMzM0NSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVw
+        b192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6
+        ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWlu
+        X3BhY2thZ2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUi
+        Om51bGwsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2si
+        OjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
+        cnBtL2YwZDdiNTE1LTZjNmEtNDUzNy05NGNiLTU1NjQ4NzY4ODgyMC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDExOjEzOjAyLjU5MDkwMFoiLCJ2
+        ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
+        cnBtL2YwZDdiNTE1LTZjNmEtNDUzNy05NGNiLTU1NjQ4NzY4ODgyMC92ZXJz
+        aW9ucy8iLCJwdWxwX2xhYmVscyI6e30sImxhdGVzdF92ZXJzaW9uX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZjBkN2I1MTUt
+        NmM2YS00NTM3LTk0Y2ItNTU2NDg3Njg4ODIwL3ZlcnNpb25zLzAvIiwibmFt
+        ZSI6IlJlZF9IYXRfQW5zaWJsZV9FbmdpbmVfMl85X1JQTXNfZm9yX1JlZF9I
+        YXRfRW50ZXJwcmlzZV9MaW51eF83X1NlcnZlcl94ODZfNjQtMTEyMjI5Iiwi
+        ZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxs
+        LCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWV0YWRhdGFf
+        c2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9u
+        cyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFja2FnZV9j
+        aGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwicmVwb19ncGdjaGVj
+        ayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjI4YzAyOGItZTIw
+        Yi00MWJlLTkxN2EtOGFjMmNjNjk5MDg4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTE6MTA6MDYuMTY0ODE5WiIsInZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjI4YzAyOGItZTIw
+        Yi00MWJlLTkxN2EtOGFjMmNjNjk5MDg4L3ZlcnNpb25zLyIsInB1bHBfbGFi
+        ZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvcnBtL3JwbS8yMjhjMDI4Yi1lMjBiLTQxYmUtOTE3YS04
+        YWMyY2M2OTkwODgvdmVyc2lvbnMvMC8iLCJuYW1lIjoiUmVkX0hhdF9BbnNp
+        YmxlX0VuZ2luZV8yXzlfUlBNc19mb3JfUmVkX0hhdF9FbnRlcnByaXNlX0xp
+        bnV4XzdfU2VydmVyX3g4Nl82NC00MjM2IiwiZGVzY3JpcHRpb24iOm51bGws
+        InJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1
+        dG9wdWJsaXNoIjpmYWxzZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpu
+        dWxsLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hl
+        Y2tzdW1fdHlwZSI6bnVsbCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxs
+        LCJncGdjaGVjayI6MCwicmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFk
+        YXRhIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL3JwbS9ycG0vZGVmZDI3ZGMtZTE3Ni00YTBjLTliZTMtNWVkYzcx
+        NjU0MjJkLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDQtMDdUMTA6NTg6MDEu
+        OTU2MzkyWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL3JwbS9ycG0vZGVmZDI3ZGMtZTE3Ni00YTBjLTliZTMtNWVkYzcx
+        NjU0MjJkL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3Zl
+        cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS9kZWZkMjdkYy1lMTc2LTRhMGMtOWJlMy01ZWRjNzE2NTQyMmQvdmVyc2lv
+        bnMvMC8iLCJuYW1lIjoiUmVkX0hhdF9BbnNpYmxlX0VuZ2luZV8yXzlfUlBN
+        c19mb3JfUmVkX0hhdF9FbnRlcnByaXNlX0xpbnV4XzdfU2VydmVyX3g4Nl82
+        NC0xNzQ0NSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJz
+        aW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2Us
+        Im1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2th
+        Z2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOm51bGws
+        InBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJl
+        cG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:42 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/5d46938a-ff8e-4a0b-b899-4ed3398b7d4d/versions/?limit=2000&offset=0
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/fbd8abaf-6b6b-4079-a30d-d0e3472ae4d1/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -694,7 +773,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:42 GMT
+      - Thu, 07 Apr 2022 17:17:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -710,30 +789,30 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5f673a7cb14d450e926443c55cf95dc6
+      - 3c2d29bd1f154b26bb80bc56b1ff825a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
       - 1.1 centos8-katello-devel.samir.example.com
       Content-Length:
-      - '231'
+      - '230'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS81ZDQ2OTM4YS1mZjhlLTRhMGItYjg5OS00ZWQzMzk4YjdkNGQv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTAzLTIxVDE0OjI5
-        OjM0Ljk3MDY4NVoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNWQ0NjkzOGEtZmY4ZS00YTBi
-        LWI4OTktNGVkMzM5OGI3ZDRkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        cnBtL3JwbS9mYmQ4YWJhZi02YjZiLTQwNzktYTMwZC1kMGUzNDcyYWU0ZDEv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDEzOjA5
+        OjI2LjkxMTQyNloiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJkOGFiYWYtNmI2Yi00MDc5
+        LWEzMGQtZDBlMzQ3MmFlNGQxLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
         dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
         bnQiOnt9fX1dfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:42 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/7bd41607-bc18-461e-8992-b2be35bc09cd/versions/?limit=2000&offset=0
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/653e7a04-29ef-41dc-a1fd-782aeea7909b/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -754,7 +833,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:42 GMT
+      - Thu, 07 Apr 2022 17:17:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -770,7 +849,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b88fd5b320e34cfbb36a6fefa181bd08
+      - d9f9106399b54bb180fb023574bcbba2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -782,15 +861,315 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83YmQ0MTYwNy1iYzE4LTQ2MWUtODk5Mi1iMmJlMzViYzA5Y2Qv
-        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTAzLTIxVDE0OjA2
-        OjI2LjcyNTg2MFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2JkNDE2MDctYmMxOC00NjFl
-        LTg5OTItYjJiZTM1YmMwOWNkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        cnBtL3JwbS82NTNlN2EwNC0yOWVmLTQxZGMtYTFmZC03ODJhZWVhNzkwOWIv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDExOjE0
+        OjI1LjkxMjEzOFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjUzZTdhMDQtMjllZi00MWRj
+        LWExZmQtNzgyYWVlYTc5MDliLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
         dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
         bnQiOnt9fX1dfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:42 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:09 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/3ddbbd29-2807-4a52-baf0-ee1507c620c9/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3730d7b39fbd4f4c8e546db9da85ddf5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '231'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8zZGRiYmQyOS0yODA3LTRhNTItYmFmMC1lZTE1MDdjNjIwYzkv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDExOjEz
+        OjU3LjU4NDg0NVoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2RkYmJkMjktMjgwNy00YTUy
+        LWJhZjAtZWUxNTA3YzYyMGM5LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:09 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/e22e54fc-1756-449e-96c5-a6e530c3bd7c/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5e66e9fc65ca4d8c958454b4b2ed02a3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '229'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9lMjJlNTRmYy0xNzU2LTQ0OWUtOTZjNS1hNmU1MzBjM2JkN2Mv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDExOjEz
+        OjMzLjM5MTE5MFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTIyZTU0ZmMtMTc1Ni00NDll
+        LTk2YzUtYTZlNTMwYzNiZDdjLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:09 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/f0d7b515-6c6a-4537-94cb-556487688820/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5b70f5b320994ed5a607d57e191875a4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '232'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9mMGQ3YjUxNS02YzZhLTQ1MzctOTRjYi01NTY0ODc2ODg4MjAv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDExOjEz
+        OjAyLjU5NTI3OFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZjBkN2I1MTUtNmM2YS00NTM3
+        LTk0Y2ItNTU2NDg3Njg4ODIwLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:09 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/228c028b-e20b-41be-917a-8ac2cc699088/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8d0e62dae53d47a0b5543234c1e9fad7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '230'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8yMjhjMDI4Yi1lMjBiLTQxYmUtOTE3YS04YWMyY2M2OTkwODgv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDExOjEw
+        OjA2LjE2OTUxMFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjI4YzAyOGItZTIwYi00MWJl
+        LTkxN2EtOGFjMmNjNjk5MDg4LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:09 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/defd27dc-e176-4a0c-9be3-5edc7165422d/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ac394c879f7849199e2d6adfff9caa56
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '230'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9kZWZkMjdkYy1lMTc2LTRhMGMtOWJlMy01ZWRjNzE2NTQyMmQv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDEwOjU4
+        OjAxLjk2MzkwMVoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGVmZDI3ZGMtZTE3Ni00YTBj
+        LTliZTMtNWVkYzcxNjU0MjJkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:09 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
@@ -814,7 +1193,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:42 GMT
+      - Thu, 07 Apr 2022 17:17:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -832,7 +1211,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 39408172af4a4d3bb0662231185c7bf0
+      - af8d547e0dda4e2485caf5e2e95e6187
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -843,7 +1222,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:42 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:09 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -867,7 +1246,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:42 GMT
+      - Thu, 07 Apr 2022 17:17:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -885,7 +1264,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1fe422f8d48a4c5c87782dbf35fc2cc1
+      - 1ff8ae3287f24d4881b5f6980bac7c81
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -896,7 +1275,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:42 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:09 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -920,7 +1299,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:42 GMT
+      - Thu, 07 Apr 2022 17:17:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -938,7 +1317,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ca06a143eee54377a8bac20816e84f53
+      - 113543467c5c4c0d914950c24ae9b0b0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -949,7 +1328,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:42 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:09 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -973,39 +1352,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:42 GMT
+      - Thu, 07 Apr 2022 17:17:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
-      Content-Length:
-      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 79598235224e46a5a612b5b369eab97d
+      - 57efd5b8b8e84486bdbfc197de327f25
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
       - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '283'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ZmlsZS9maWxlLzc0YWU2MjY5LWE4ZWEtNDkzZC1hNjM2LTY1YzNhMzBhN2Jm
+        Ni8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDE2OjEwOjQxLjIzMjMw
+        N1oiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvNzRhZTYyNjktYThlYS00OTNkLWE2MzYtNjVjM2EzMGE3
+        YmY2L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
+        b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
+        Lzc0YWU2MjY5LWE4ZWEtNDkzZC1hNjM2LTY1YzNhMzBhN2JmNi92ZXJzaW9u
+        cy8wLyIsIm5hbWUiOiJmaWxlMS04MTUzODEiLCJkZXNjcmlwdGlvbiI6bnVs
+        bCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwi
+        YXV0b3B1Ymxpc2giOmZhbHNlLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
+        fV19
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:42 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/file/file/74ae6269-a8ea-493d-a636-65c3a30a7bf6/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1013,7 +1403,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0a6.dev1647573875/ruby
+      - OpenAPI-Generator/1.10.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1026,7 +1416,67 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:42 GMT
+      - Thu, 07 Apr 2022 17:17:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 63fb638bffd54f3fb4e92c05cfe51e49
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '231'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ZmlsZS9maWxlLzc0YWU2MjY5LWE4ZWEtNDkzZC1hNjM2LTY1YzNhMzBhN2Jm
+        Ni92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDQtMDdUMTY6
+        MTA6NDEuMjM2NTA5WiIsIm51bWJlciI6MCwicmVwb3NpdG9yeSI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzc0YWU2MjY5LWE4ZWEt
+        NDkzZC1hNjM2LTY1YzNhMzBhN2JmNi8iLCJiYXNlX3ZlcnNpb24iOm51bGws
+        ImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJw
+        cmVzZW50Ijp7fX19XX0=
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:09 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.0.0a6.dev1649216856/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1044,7 +1494,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d19e106df3b24555b8be097d95ae2692
+      - dc916fdcf80b4a51bdd09b59a38b362c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1055,7 +1505,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:42 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:09 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -1079,7 +1529,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:42 GMT
+      - Thu, 07 Apr 2022 17:17:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1097,7 +1547,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 83ca8675cf6e40919ba7c43b4c9a0bfa
+      - acbda4efd6d94af7b5eb3c9d4e3d09c5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1108,7 +1558,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:42 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:09 GMT
 - request:
     method: post
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/orphans/cleanup/
@@ -1121,7 +1571,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.16.5/ruby
+      - OpenAPI-Generator/3.16.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -1134,7 +1584,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:42 GMT
+      - Thu, 07 Apr 2022 17:17:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1152,7 +1602,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6e9ce44c7419443ab73db5c7e55030b4
+      - 4c03f893e4e14cb19630971b72331e7e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1160,13 +1610,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FlYTI1N2E4LTQwMzAtNDIw
-        Yi1hMjUxLTA0Nzk0ZDFjMzY2My8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkODMwZjI5LWUzM2EtNGVm
+        Yy04YjAyLThhNzc3MDFiNjkxMi8ifQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:42 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:09 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/aea257a8-4030-420b-a251-04794d1c3663/
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/2d830f29-e33a-4efc-8b02-8a77701b6912/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1174,7 +1624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.16.5/ruby
+      - OpenAPI-Generator/3.16.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -1187,7 +1637,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:43 GMT
+      - Thu, 07 Apr 2022 17:17:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1203,34 +1653,34 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dd590af7e39a41c69ade0da6fa2013d6
+      - 17ba7d8954294078b87a808be10d07d0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
       - 1.1 centos8-katello-devel.samir.example.com
       Content-Length:
-      - '417'
+      - '409'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWVhMjU3YTgtNDAz
-        MC00MjBiLWEyNTEtMDQ3OTRkMWMzNjYzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDMtMjJUMTQ6MjU6NDIuNzE1MTMxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmQ4MzBmMjktZTMz
+        YS00ZWZjLThiMDItOGE3NzcwMWI2OTEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTc6MDkuODg1NzA5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJsb2dnaW5nX2NpZCI6IjZlOWNlNDRjNzQxOTQ0M2FiNzNkYjVj
-        N2U1NTAzMGI0Iiwic3RhcnRlZF9hdCI6IjIwMjItMDMtMjJUMTQ6MjU6NDIu
-        NzY5NTMwWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wMy0yMlQxNDoyNTo0My44
-        MzU0NTJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzLzY3YTZmNjJlLWRiYzQtNDBjMy04NWRiLTBkYzYzYzdhZDhmMS8i
+        ZWFudXAiLCJsb2dnaW5nX2NpZCI6IjRjMDNmODkzZTRlMTRjYjE5NjMwOTcx
+        YjcyMzMxZTdlIiwic3RhcnRlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTc6MDku
+        OTM2MTMzWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNC0wN1QxNzoxNzowOS45
+        ODA1MDlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzM3MjcwMGY4LWNiOTUtNDIzMy04YWQ3LThkN2NmODUzZjIxYi8i
         LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
         b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xl
         YW4gdXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVu
-        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjIsImRvbmUiOjIsInN1
+        dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1
         ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQ2xlYW4gdXAgb3JwaGFuIEFydGlm
         YWN0cyIsImNvZGUiOiJjbGVhbi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNy
         ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
         ZCI6W119
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:43 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:10 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload_binary.yml
@@ -1,93 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/content/rpm/packages/?pkgId=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 22 Mar 2022 14:25:40 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 2c4e5c377f2d4a71af2477b15b41cb19
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.samir.example.com
-      Content-Length:
-      - '917'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9mZWZhYmFjYi0xMGFkLTQ5YzItODBlMC03ZTNlYTMwMzA3Y2Ev
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wMy0yMVQxMzozODoxNi4yMzY0NTJa
-        IiwibWQ1IjpudWxsLCJzaGExIjoiYzkxOGJkOTFhMDQyMTg1NWY5MjI5OGU0
-        OGI1NTdjNTdmYjY1YWM5YSIsInNoYTIyNCI6ImE3ZjU1NDJkNTI5NjU3Mjk3
-        Y2FjMDlkMGU3YjExNmQ5ODM1NTEyMTNiMTQ0M2QzMWIyODY3ODVkIiwic2hh
-        MjU2IjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
-        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInNoYTM4NCI6ImZjZWFhZDk4
-        ZjI5ODI1MzIwYzYwY2RhM2E4ZDJiYzdmZTc2YWEzZjdiMmRiOWU2YjI2MWJi
-        OGFkZTYwNmNhZDgwNDU0N2M3YzM1YjExYmU5NDllNmM0ZDdiMzM3ZTMzZCIs
-        InNoYTUxMiI6Ijc0ZjBhZTBiOGJhM2Q3ZjJiOGYxNjc3NGE1ZjQwOTc5Y2Fj
-        MjgwMmVhODZmZDg0ZGZhODM5MDIzYjM4NjcxNWY4ZTQ5YTllMmVjMTg5OTgw
-        MmY5NzA1OTRmMGU4ZjZkMmE0MDY2YjI1OTQwNmQyMjM3YmE4YmI5MjJlMTNi
-        YmUyIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2MxOGFi
-        M2UzLWYxZjctNDg3Yy04YzQ4LTliNDZiZjc4NTE2Ni8iLCJuYW1lIjoiZHVj
-        ayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJyZWxlYXNlIjoiMSIs
-        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4NjBhZDY3ODMyMTdj
-        YmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIi
-        LCJjaGVja3N1bV90eXBlIjoic2hhMjU2Iiwic3VtbWFyeSI6IlF1YWNrIGxp
-        a2UgYSBkdWNrIGF0IHRoZSBwYXJrLiIsImRlc2NyaXB0aW9uIjoiQSBmaXh0
-        dXJlIFJQTSBmb3IgdGVzdGluZyBQdWxwLiIsInVybCI6IiIsImNoYW5nZWxv
-        Z3MiOltdLCJmaWxlcyI6W1siIiwiL3Vzci9iaW4vIiwiZHVjay50eHQiXV0s
-        InJlcXVpcmVzIjpbXSwicHJvdmlkZXMiOltbImR1Y2siLCJFUSIsIjAiLCIw
-        LjciLCIxIixmYWxzZV1dLCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMiOltd
-        LCJzdWdnZXN0cyI6W10sImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6W10s
-        InN1cHBsZW1lbnRzIjpbXSwibG9jYXRpb25fYmFzZSI6IiIsImxvY2F0aW9u
-        X2hyZWYiOiJkdWNrLTAuNy4xLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0
-        IjoibG9jYWxob3N0LmxvY2FsZG9tYWluIiwicnBtX2dyb3VwIjoiVW5zcGVj
-        aWZpZWQiLCJycG1fbGljZW5zZSI6IlB1YmxpYyBEb21haW4iLCJycG1fcGFj
-        a2FnZXIiOiIiLCJycG1fc291cmNlcnBtIjoiZHVjay0wLjctMS5zcmMucnBt
-        IiwicnBtX3ZlbmRvciI6IiIsInJwbV9oZWFkZXJfc3RhcnQiOjQ1MDQsInJw
-        bV9oZWFkZXJfZW5kIjo2MzY0LCJpc19tb2R1bGFyIjpmYWxzZSwic2l6ZV9h
-        cmNoaXZlIjoyNjQsInNpemVfaW5zdGFsbGVkIjo1LCJzaXplX3BhY2thZ2Ui
-        OjY1NDAsInRpbWVfYnVpbGQiOjE1MzMwNjYwMTcsInRpbWVfZmlsZSI6MTY0
-        Nzg2OTg5Nn1dfQ==
-    http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:40 GMT
-- request:
     method: post
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/a0b9b63e-8754-4e58-b619-73b1e87c968e/modify/
     body:
@@ -210,4 +123,1083 @@ http_interactions:
         LWI2MTktNzNiMWU4N2M5NjhlLyJdfQ==
     http_version: 
   recorded_at: Tue, 22 Mar 2022 14:25:41 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/artifacts/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:36 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 637f3ab053604314bb1e4ddf6de5f78f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:36 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjo2NTQwfQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:37 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/e3928287-eb33-466a-8eb8-de078a77a67e/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '131'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - eb303c698e3443c28392bb25bbcadec5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9lMzkyODI4Ny1l
+        YjMzLTQ2NmEtOGViOC1kZTA3OGE3N2E2N2UvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMi0wNC0wN1QxNzoxNDozNy4xMzc4NjdaIiwic2l6ZSI6NjU0MH0=
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:37 GMT
+- request:
+    method: put
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/uploads/e3928287-eb33-466a-8eb8-de078a77a67e/
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTk1MDEwNzY5NGVhYjdm
+        YmQ4ZDY4OWEzMTg3NDdlMzMzDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMjA0
+        MDctMTI3NTI3LTFiN2hrYWUiDQpDb250ZW50LUxlbmd0aDogNjU0MA0KQ29u
+        dGVudC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQt
+        VHJhbnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQrtq+7bAwAAAAABZHVjay0w
+        LjctMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAEABQAAAAAAAAAAAAAAAAAAAACOregBAAAAAAAA
+        AAcAABC0AAAAPgAAAAcAABCkAAAAEAAAAQ0AAAAGAAAAAAAAAAEAAAERAAAA
+        BgAAACkAAAABAAAD6AAAAAQAAABsAAAAAQAAA+wAAAAHAAAAcAAAABAAAAPv
+        AAAABAAAAIAAAAABAAAD8AAAAAcAAACEAAAQIGU1MDY1NGViMTI0ZTQ0MzA5
+        YmMyMjFhODBmMGUyODdhM2E3MWEwODMAOTEzOTc3Y2NkMmFkM2E1MTA2MjQ4
+        ZWIwMWNlZmJjYTM2ZTM1NDNmZWE4YThiMzI5YWNmMjI5NTlkOTJjODdhNgAA
+        AAAAB/SmN0ItGeeq51+3RVsgqsCyAAABCAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAD4AAAAH////kAAAABAAAAAAjq3oAQAAAAAAAAA0
+        AAAD9AAAAD8AAAAHAAAD5AAAABAAAABkAAAACAAAAAAAAAABAAAD6AAAAAYA
+        AAACAAAAAQAAA+kAAAAGAAAABwAAAAEAAAPqAAAABgAAAAsAAAABAAAD7AAA
+        AAkAAAANAAAAAQAAA+0AAAAJAAAALAAAAAEAAAPuAAAABAAAAEwAAAABAAAD
+        7wAAAAYAAABQAAAAAQAAA/EAAAAEAAAAaAAAAAEAAAP2AAAABgAAAGwAAAAB
+        AAAD+AAAAAkAAAB6AAAAAQAAA/0AAAAGAAAAhgAAAAEAAAP+AAAABgAAAIwA
+        AAABAAAEBAAAAAQAAACUAAAAAQAABAYAAAADAAAAmAAAAAEAAAQJAAAAAwAA
+        AJoAAAABAAAECgAAAAQAAACcAAAAAQAABAsAAAAIAAAAoAAAAAEAAAQMAAAA
+        CAAAAOEAAAABAAAEDQAAAAQAAADkAAAAAQAABA8AAAAIAAAA6AAAAAEAAAQQ
+        AAAACAAAAO0AAAABAAAEFAAAAAYAAADyAAAAAQAABBUAAAAEAAABCAAAAAEA
+        AAQXAAAACAAAAQwAAAABAAAEGAAAAAQAAAEUAAAABAAABBkAAAAIAAABJAAA
+        AAQAAAQaAAAACAAAAYcAAAAEAAAEKAAAAAYAAAGjAAAAAQAABEYAAAAGAAAB
+        qgAAAAEAAARHAAAABAAAAcwAAAABAAAESAAAAAQAAAHQAAAAAQAABEkAAAAI
+        AAAB1AAAAAEAAARYAAAABAAAAdgAAAABAAAEWQAAAAgAAAHcAAAAAQAABFwA
+        AAAEAAAB5AAAAAEAAARdAAAACAAAAegAAAABAAAEXgAAAAgAAAHxAAAAAQAA
+        BGIAAAAGAAAB+wAAAAEAAARkAAAABgAAA0sAAAABAAAEZQAAAAYAAANQAAAA
+        AQAABGYAAAAGAAADUwAAAAEAAARsAAAABgAAA1UAAAABAAAEdAAAAAQAAANw
+        AAAAAQAABHUAAAAEAAADdAAAAAEAAAR2AAAACAAAA3gAAAABAAAEegAAAAcA
+        AAODAAAAEAAAE5MAAAAEAAADlAAAAAEAABPGAAAABgAAA5gAAAABAAAT5AAA
+        AAgAAAOeAAAAAQAAE+UAAAAEAAAD4AAAAAFDAGR1Y2sAMC43ADEAUXVhY2sg
+        bGlrZSBhIGR1Y2sgYXQgdGhlIHBhcmsuAEEgZml4dHVyZSBSUE0gZm9yIHRl
+        c3RpbmcgUHVscC4AW2C7IWxvY2FsaG9zdC5sb2NhbGRvbWFpbgAAAAAAAAVQ
+        dWJsaWMgRG9tYWluAFVuc3BlY2lmaWVkAGxpbnV4AG5vYXJjaAAAAAAABYGk
+        AABbX3SmNTE4OTE0OGJlZjY2ZjQ3NDNhODIxNGYwYzk5MGFkYjJmZDc2NjFh
+        MTk5MGM3NGM4MmJlY2U0Zjg0MjFiMTYzMQAAAAAAAAAAcm9vdAByb290AGR1
+        Y2stMC43LTEuc3JjLnJwbQAAAAD/////ZHVjawAAAAABAAAKAQAACgEAAAoB
+        AAAKcnBtbGliKENvbXByZXNzZWRGaWxlTmFtZXMpAHJwbWxpYihGaWxlRGln
+        ZXN0cykAcnBtbGliKFBheWxvYWRGaWxlc0hhdmVQcmVmaXgpAHJwbWxpYihQ
+        YXlsb2FkSXNYeikAMy4wLjQtMQA0LjYuMC0xADQuMC0xADUuMi0xADQuMTQu
+        MQBsb2NhbGhvc3QubG9jYWxkb21haW4gMTUzMzA2NjAxNwAAAAAAAQAAAAEA
+        AAAAAAAACDAuNy0xAAAAAAAAAGR1Y2sudHh0AC91c3IvYmluLwAtTzIgLWcg
+        LXBpcGUgLVdhbGwgLVdlcnJvcj1mb3JtYXQtc2VjdXJpdHkgLVdwLC1EX0ZP
+        UlRJRllfU09VUkNFPTIgLVdwLC1EX0dMSUJDWFhfQVNTRVJUSU9OUyAtZmV4
+        Y2VwdGlvbnMgLWZzdGFjay1wcm90ZWN0b3Itc3Ryb25nIC1ncmVjb3JkLWdj
+        Yy1zd2l0Y2hlcyAtc3BlY3M9L3Vzci9saWIvcnBtL3JlZGhhdC9yZWRoYXQt
+        aGFyZGVuZWQtY2MxIC1zcGVjcz0vdXNyL2xpYi9ycG0vcmVkaGF0L3JlZGhh
+        dC1hbm5vYmluLWNjMSAtbTY0IC1tdHVuZT1nZW5lcmljIC1mYXN5bmNocm9u
+        b3VzLXVud2luZC10YWJsZXMgLWZzdGFjay1jbGFzaC1wcm90ZWN0aW9uIC1m
+        Y2YtcHJvdGVjdGlvbgBjcGlvAHh6ADIAbm9hcmNoLXJlZGhhdC1saW51eC1n
+        bnUAAAAAAAAAAAAAAABBU0NJSSB0ZXh0AB9bibZgHKpDzuiaAVGd1awAAAAA
+        CHV0Zi04ADg0ZTM3NjczMDFhOTQ1MTU1ZDQ5MDhlNzQyMjkwOWQ0MDkzMTIx
+        MWQyYTE1MTI3YTUxMTM2MDVlMmYyNmFlYzkAAAAAAAgAAAA/AAAAB////MAA
+        AAAQ/Td6WFoAAArh+wyhAgAhARIAAAAjuIcs4AEHAFVdABgN3QRiMvl1C4Ci
+        vQ9RBnvESxeBuM5yo2cm959uPqkXJ2YtagnSD8aDWoQMDesVpeiIx9jmw5ZE
+        ryMCdogZz71sdjY57taJhhrxJaiMHhag3tw6rfQAAAAA31/TVVoeyYhpWvwS
+        lJBFLZvGCWsTUErdmlngbW2rp3wAAYkBiAIAAMfy4+y26d8cAgAAAAAKWVoN
+        Ci0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC05NTAxMDc2OTRlYWI3
+        ZmJkOGQ2ODlhMzE4NzQ3ZTMzMy0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-950107694eab7fbd8d689a318747e333
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-6539/6540
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '6863'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:37 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 02101cc1fa6a4228aacddb01f42ebd19
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy9lMzkyODI4Ny1l
+        YjMzLTQ2NmEtOGViOC1kZTA3OGE3N2E2N2UvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMi0wNC0wN1QxNzoxNDozNy4xMzc4NjdaIiwic2l6ZSI6NjU0MH0=
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:37 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/artifacts/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:37 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b8139a5d07a342dda4b00e0373ecf61c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:37 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/uploads/e3928287-eb33-466a-8eb8-de078a77a67e/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiI1YmQzNjNiODYwYWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBm
+        OThkMTQwZmZiMTIxYmY0YzIwOGUzZjY2YzI0NzEyIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:37 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f345756786494331be95c8dd2cc741f3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRkZDA2NmE5LTM2MjAtNDI5
+        YS04OWFmLWY3OTg3MDdjZmU4Ni8ifQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:37 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/4dd066a9-3620-429a-89af-f798707cfe86/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:37 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 88fe3e24b57f435492d25a1f6f0131fa
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '396'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGRkMDY2YTktMzYy
+        MC00MjlhLTg5YWYtZjc5ODcwN2NmZTg2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTQ6MzcuMjUzNDczWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiJmMzQ1NzU2Nzg2NDk0MzMxYmU5NWM4ZGQyY2M3NDFm
+        MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE0OjM3LjMzMjQyNVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTQ6MzcuNDIwNTY4WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8z
+        NzI3MDBmOC1jYjk1LTQyMzMtOGFkNy04ZDdjZjg1M2YyMWIvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNjk1ZjU4YzctN2UxMy00N2M1LWFh
+        YzYtNzhiZjc0NWM0MGFmLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzL2UzOTI4Mjg3LWViMzMtNDY2YS04
+        ZWI4LWRlMDc4YTc3YTY3ZS8iXX0=
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:37 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/artifacts/?sha256=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:37 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ecff535afa3e40418a1b351c206c6e38
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '442'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNjk1
+        ZjU4YzctN2UxMy00N2M1LWFhYzYtNzhiZjc0NWM0MGFmLyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjItMDQtMDdUMTc6MTQ6MzcuMzg3Mzg5WiIsImZpbGUiOiJh
+        cnRpZmFjdC81Yi9kMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4
+        ZDE0MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInNpemUiOjY1NDAsIm1k
+        NSI6bnVsbCwic2hhMSI6ImM5MThiZDkxYTA0MjE4NTVmOTIyOThlNDhiNTU3
+        YzU3ZmI2NWFjOWEiLCJzaGEyMjQiOiJhN2Y1NTQyZDUyOTY1NzI5N2NhYzA5
+        ZDBlN2IxMTZkOTgzNTUxMjEzYjE0NDNkMzFiMjg2Nzg1ZCIsInNoYTI1NiI6
+        IjViZDM2M2I4NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIx
+        MjFiZjRjMjA4ZTNmNjZjMjQ3MTIiLCJzaGEzODQiOiJmY2VhYWQ5OGYyOTgy
+        NTMyMGM2MGNkYTNhOGQyYmM3ZmU3NmFhM2Y3YjJkYjllNmIyNjFiYjhhZGU2
+        MDZjYWQ4MDQ1NDdjN2MzNWIxMWJlOTQ5ZTZjNGQ3YjMzN2UzM2QiLCJzaGE1
+        MTIiOiI3NGYwYWUwYjhiYTNkN2YyYjhmMTY3NzRhNWY0MDk3OWNhYzI4MDJl
+        YTg2ZmQ4NGRmYTgzOTAyM2IzODY3MTVmOGU0OWE5ZTJlYzE4OTk4MDJmOTcw
+        NTk0ZjBlOGY2ZDJhNDA2NmIyNTk0MDZkMjIzN2JhOGJiOTIyZTEzYmJlMiJ9
+        XX0=
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:37 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/content/rpm/packages/?pkgId=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:37 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f246be83ac7a48948386bc28c3bc3ea7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:37 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/content/rpm/packages/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWYwNTZiZGNiYTBmODM0
+        ZmViYWY0NzM1ZDUzYzFjNzU4DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCmR1Y2stMC43LjEubm9h
+        cmNoLnJwbQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWYwNTZi
+        ZGNiYTBmODM0ZmViYWY0NzM1ZDUzYzFjNzU4DQpDb250ZW50LURpc3Bvc2l0
+        aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0KDQovcHVscC9hcGkv
+        djMvYXJ0aWZhY3RzLzY5NWY1OGM3LTdlMTMtNDdjNS1hYWM2LTc4YmY3NDVj
+        NDBhZi8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC1mMDU2YmRj
+        YmEwZjgzNGZlYmFmNDczNWQ1M2MxYzc1OC0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-f056bdcba0f834febaf4735d53c1c758
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '389'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:37 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1639546d4d534a8bb15a17ffae641529
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZiNzY3YTdhLTM0MmEtNGQz
+        Zi1hODcyLTU2OTFkNTZhZjU4NS8ifQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:37 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/fb767a7a-342a-4d3f-a872-5691d56af585/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e4262facf50842269f7fe12983585fc6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '374'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZmI3NjdhN2EtMzQy
+        YS00ZDNmLWE4NzItNTY5MWQ1NmFmNTg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTQ6MzcuNjM5NzY4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiIxNjM5NTQ2ZDRkNTM0YThiYjE1YTE3ZmZh
+        ZTY0MTUyOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE0OjM3Ljcw
+        MTk5NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTQ6MzcuOTIw
+        NTM0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy82MTM3ZDU3Yy1jZDU0LTRjNzctOTM1Ny00ZWUxM2RmZjE1OGEvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy8yYjUw
+        ZDY2Zi1kYWVhLTQ4OWYtODVjZi03MTMwMzM2ZTBlOWQvIl0sInJlc2VydmVk
+        X3Jlc291cmNlc19yZWNvcmQiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:38 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/19375c79-e9ac-4f52-98f1-deb3ae60db65/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvMmI1MGQ2NmYtZGFlYS00ODlmLTg1Y2YtNzEzMDMzNmUw
+        ZTlkLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 46e6c2d9e8f043baa6ae78078afc5b2a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhjOTM3NTNkLWI3NjQtNDkx
+        NS1iN2Q5LTNmZWQzZTYwNzc3Yi8ifQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/8c93753d-b764-4915-b7d9-3fed3e60777b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4258e9a841134627b0b07ea79ffe3c4c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '387'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGM5Mzc1M2QtYjc2
+        NC00OTE1LWI3ZDktM2ZlZDNlNjA3NzdiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTQ6MzguMDc5ODUxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0NmU2YzJkOWU4ZjA0M2JhYTZh
+        ZTc4MDc4YWZjNWIyYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE0
+        OjM4LjEzNjIxMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTQ6
+        MzguMzQxNjIxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8zNzI3MDBmOC1jYjk1LTQyMzMtOGFkNy04ZDdjZjg1M2Yy
+        MWIvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS8xOTM3NWM3OS1lOWFjLTRmNTItOThmMS1kZWIzYWU2MGRiNjUvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTkzNzVjNzktZTlhYy00ZjUy
+        LTk4ZjEtZGViM2FlNjBkYjY1LyJdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/content/rpm/packages/?pkgId=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1d99f50d41b94dbcb486357ce5147999
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '916'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy8yYjUwZDY2Zi1kYWVhLTQ4OWYtODVjZi03MTMwMzM2ZTBlOWQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNC0wN1QxNzoxNDozNy44OTQzNjFa
+        IiwibWQ1IjpudWxsLCJzaGExIjoiYzkxOGJkOTFhMDQyMTg1NWY5MjI5OGU0
+        OGI1NTdjNTdmYjY1YWM5YSIsInNoYTIyNCI6ImE3ZjU1NDJkNTI5NjU3Mjk3
+        Y2FjMDlkMGU3YjExNmQ5ODM1NTEyMTNiMTQ0M2QzMWIyODY3ODVkIiwic2hh
+        MjU2IjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInNoYTM4NCI6ImZjZWFhZDk4
+        ZjI5ODI1MzIwYzYwY2RhM2E4ZDJiYzdmZTc2YWEzZjdiMmRiOWU2YjI2MWJi
+        OGFkZTYwNmNhZDgwNDU0N2M3YzM1YjExYmU5NDllNmM0ZDdiMzM3ZTMzZCIs
+        InNoYTUxMiI6Ijc0ZjBhZTBiOGJhM2Q3ZjJiOGYxNjc3NGE1ZjQwOTc5Y2Fj
+        MjgwMmVhODZmZDg0ZGZhODM5MDIzYjM4NjcxNWY4ZTQ5YTllMmVjMTg5OTgw
+        MmY5NzA1OTRmMGU4ZjZkMmE0MDY2YjI1OTQwNmQyMjM3YmE4YmI5MjJlMTNi
+        YmUyIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzY5NWY1
+        OGM3LTdlMTMtNDdjNS1hYWM2LTc4YmY3NDVjNDBhZi8iLCJuYW1lIjoiZHVj
+        ayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJyZWxlYXNlIjoiMSIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4NjBhZDY3ODMyMTdj
+        YmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIi
+        LCJjaGVja3N1bV90eXBlIjoic2hhMjU2Iiwic3VtbWFyeSI6IlF1YWNrIGxp
+        a2UgYSBkdWNrIGF0IHRoZSBwYXJrLiIsImRlc2NyaXB0aW9uIjoiQSBmaXh0
+        dXJlIFJQTSBmb3IgdGVzdGluZyBQdWxwLiIsInVybCI6IiIsImNoYW5nZWxv
+        Z3MiOltdLCJmaWxlcyI6W1siIiwiL3Vzci9iaW4vIiwiZHVjay50eHQiXV0s
+        InJlcXVpcmVzIjpbXSwicHJvdmlkZXMiOltbImR1Y2siLCJFUSIsIjAiLCIw
+        LjciLCIxIixmYWxzZV1dLCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMiOltd
+        LCJzdWdnZXN0cyI6W10sImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6W10s
+        InN1cHBsZW1lbnRzIjpbXSwibG9jYXRpb25fYmFzZSI6IiIsImxvY2F0aW9u
+        X2hyZWYiOiJkdWNrLTAuNy4xLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0
+        IjoibG9jYWxob3N0LmxvY2FsZG9tYWluIiwicnBtX2dyb3VwIjoiVW5zcGVj
+        aWZpZWQiLCJycG1fbGljZW5zZSI6IlB1YmxpYyBEb21haW4iLCJycG1fcGFj
+        a2FnZXIiOiIiLCJycG1fc291cmNlcnBtIjoiZHVjay0wLjctMS5zcmMucnBt
+        IiwicnBtX3ZlbmRvciI6IiIsInJwbV9oZWFkZXJfc3RhcnQiOjQ1MDQsInJw
+        bV9oZWFkZXJfZW5kIjo2MzY0LCJpc19tb2R1bGFyIjpmYWxzZSwic2l6ZV9h
+        cmNoaXZlIjoyNjQsInNpemVfaW5zdGFsbGVkIjo1LCJzaXplX3BhY2thZ2Ui
+        OjY1NDAsInRpbWVfYnVpbGQiOjE1MzMwNjYwMTcsInRpbWVfZmlsZSI6MTY0
+        OTM1MTY3N31dfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:07 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/caa09a0e-2510-48ee-ad57-b034fc13b777/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvMmI1MGQ2NmYtZGFlYS00ODlmLTg1Y2YtNzEzMDMzNmUw
+        ZTlkLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 794f23f218bd4f9ab0d0ae5da867f7c8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JjZDRlZDM3LWQxMGMtNGUz
+        OS04ZjEyLTM4Y2ZlNTY2NWQxMy8ifQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:07 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/bcd4ed37-d10c-4e39-8f12-38cfe5665d13/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 34fb015918274772a1ba76d6082a7274
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '386'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmNkNGVkMzctZDEw
+        Yy00ZTM5LThmMTItMzhjZmU1NjY1ZDEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTc6MDcuNDIxNDE4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI3OTRmMjNmMjE4YmQ0ZjlhYjBk
+        MGFlNWRhODY3ZjdjOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE3
+        OjA3LjQ3MDAyNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTc6
+        MDcuNjQxNzg5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8zNzI3MDBmOC1jYjk1LTQyMzMtOGFkNy04ZDdjZjg1M2Yy
+        MWIvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS9jYWEwOWEwZS0yNTEwLTQ4ZWUtYWQ1Ny1iMDM0ZmMxM2I3NzcvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vY2FhMDlhMGUtMjUxMC00OGVl
+        LWFkNTctYjAzNGZjMTNiNzc3LyJdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:07 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload_binary_duplicate.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/duplicate_upload_binary_duplicate.yml
@@ -1,93 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/content/rpm/packages/?pkgId=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 22 Mar 2022 14:25:41 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 24e2ec32de104049aadd876df03956f8
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.samir.example.com
-      Content-Length:
-      - '917'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9mZWZhYmFjYi0xMGFkLTQ5YzItODBlMC03ZTNlYTMwMzA3Y2Ev
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wMy0yMVQxMzozODoxNi4yMzY0NTJa
-        IiwibWQ1IjpudWxsLCJzaGExIjoiYzkxOGJkOTFhMDQyMTg1NWY5MjI5OGU0
-        OGI1NTdjNTdmYjY1YWM5YSIsInNoYTIyNCI6ImE3ZjU1NDJkNTI5NjU3Mjk3
-        Y2FjMDlkMGU3YjExNmQ5ODM1NTEyMTNiMTQ0M2QzMWIyODY3ODVkIiwic2hh
-        MjU2IjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
-        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInNoYTM4NCI6ImZjZWFhZDk4
-        ZjI5ODI1MzIwYzYwY2RhM2E4ZDJiYzdmZTc2YWEzZjdiMmRiOWU2YjI2MWJi
-        OGFkZTYwNmNhZDgwNDU0N2M3YzM1YjExYmU5NDllNmM0ZDdiMzM3ZTMzZCIs
-        InNoYTUxMiI6Ijc0ZjBhZTBiOGJhM2Q3ZjJiOGYxNjc3NGE1ZjQwOTc5Y2Fj
-        MjgwMmVhODZmZDg0ZGZhODM5MDIzYjM4NjcxNWY4ZTQ5YTllMmVjMTg5OTgw
-        MmY5NzA1OTRmMGU4ZjZkMmE0MDY2YjI1OTQwNmQyMjM3YmE4YmI5MjJlMTNi
-        YmUyIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2MxOGFi
-        M2UzLWYxZjctNDg3Yy04YzQ4LTliNDZiZjc4NTE2Ni8iLCJuYW1lIjoiZHVj
-        ayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJyZWxlYXNlIjoiMSIs
-        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4NjBhZDY3ODMyMTdj
-        YmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIi
-        LCJjaGVja3N1bV90eXBlIjoic2hhMjU2Iiwic3VtbWFyeSI6IlF1YWNrIGxp
-        a2UgYSBkdWNrIGF0IHRoZSBwYXJrLiIsImRlc2NyaXB0aW9uIjoiQSBmaXh0
-        dXJlIFJQTSBmb3IgdGVzdGluZyBQdWxwLiIsInVybCI6IiIsImNoYW5nZWxv
-        Z3MiOltdLCJmaWxlcyI6W1siIiwiL3Vzci9iaW4vIiwiZHVjay50eHQiXV0s
-        InJlcXVpcmVzIjpbXSwicHJvdmlkZXMiOltbImR1Y2siLCJFUSIsIjAiLCIw
-        LjciLCIxIixmYWxzZV1dLCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMiOltd
-        LCJzdWdnZXN0cyI6W10sImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6W10s
-        InN1cHBsZW1lbnRzIjpbXSwibG9jYXRpb25fYmFzZSI6IiIsImxvY2F0aW9u
-        X2hyZWYiOiJkdWNrLTAuNy4xLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0
-        IjoibG9jYWxob3N0LmxvY2FsZG9tYWluIiwicnBtX2dyb3VwIjoiVW5zcGVj
-        aWZpZWQiLCJycG1fbGljZW5zZSI6IlB1YmxpYyBEb21haW4iLCJycG1fcGFj
-        a2FnZXIiOiIiLCJycG1fc291cmNlcnBtIjoiZHVjay0wLjctMS5zcmMucnBt
-        IiwicnBtX3ZlbmRvciI6IiIsInJwbV9oZWFkZXJfc3RhcnQiOjQ1MDQsInJw
-        bV9oZWFkZXJfZW5kIjo2MzY0LCJpc19tb2R1bGFyIjpmYWxzZSwic2l6ZV9h
-        cmNoaXZlIjoyNjQsInNpemVfaW5zdGFsbGVkIjo1LCJzaXplX3BhY2thZ2Ui
-        OjY1NDAsInRpbWVfYnVpbGQiOjE1MzMwNjYwMTcsInRpbWVfZmlsZSI6MTY0
-        Nzg2OTg5Nn1dfQ==
-    http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:41 GMT
-- request:
     method: post
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/a0b9b63e-8754-4e58-b619-73b1e87c968e/modify/
     body:
@@ -208,4 +121,333 @@ http_interactions:
         NC00ZTU4LWI2MTktNzNiMWU4N2M5NjhlLyJdfQ==
     http_version: 
   recorded_at: Tue, 22 Mar 2022 14:25:41 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/19375c79-e9ac-4f52-98f1-deb3ae60db65/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvMmI1MGQ2NmYtZGFlYS00ODlmLTg1Y2YtNzEzMDMzNmUw
+        ZTlkLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b541b648a64d4fadaf2b51af1a5a55f4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMxZGEzOWY1LTM2NjYtNGJk
+        Ny05ZWQ5LTBiOGIxYTQ3NjhjMi8ifQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/31da39f5-3666-4bd7-9ed9-0b8b1a4768c2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 12ed7301f4d2427aa7cf2c3eceff918e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '378'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzFkYTM5ZjUtMzY2
+        Ni00YmQ3LTllZDktMGI4YjFhNDc2OGMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTQ6MzguODI5ODM0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiJiNTQxYjY0OGE2NGQ0ZmFkYWYy
+        YjUxYWYxYTVhNTVmNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE0
+        OjM4Ljg3NzMzNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTQ6
+        MzkuMDM4MTI0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8zNzI3MDBmOC1jYjk1LTQyMzMtOGFkNy04ZDdjZjg1M2Yy
+        MWIvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTkzNzVjNzktZTlh
+        Yy00ZjUyLTk4ZjEtZGViM2FlNjBkYjY1LyJdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/content/rpm/packages/?pkgId=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3631300ccb7743ceb320b676da9c6374
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '916'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy8yYjUwZDY2Zi1kYWVhLTQ4OWYtODVjZi03MTMwMzM2ZTBlOWQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNC0wN1QxNzoxNDozNy44OTQzNjFa
+        IiwibWQ1IjpudWxsLCJzaGExIjoiYzkxOGJkOTFhMDQyMTg1NWY5MjI5OGU0
+        OGI1NTdjNTdmYjY1YWM5YSIsInNoYTIyNCI6ImE3ZjU1NDJkNTI5NjU3Mjk3
+        Y2FjMDlkMGU3YjExNmQ5ODM1NTEyMTNiMTQ0M2QzMWIyODY3ODVkIiwic2hh
+        MjU2IjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInNoYTM4NCI6ImZjZWFhZDk4
+        ZjI5ODI1MzIwYzYwY2RhM2E4ZDJiYzdmZTc2YWEzZjdiMmRiOWU2YjI2MWJi
+        OGFkZTYwNmNhZDgwNDU0N2M3YzM1YjExYmU5NDllNmM0ZDdiMzM3ZTMzZCIs
+        InNoYTUxMiI6Ijc0ZjBhZTBiOGJhM2Q3ZjJiOGYxNjc3NGE1ZjQwOTc5Y2Fj
+        MjgwMmVhODZmZDg0ZGZhODM5MDIzYjM4NjcxNWY4ZTQ5YTllMmVjMTg5OTgw
+        MmY5NzA1OTRmMGU4ZjZkMmE0MDY2YjI1OTQwNmQyMjM3YmE4YmI5MjJlMTNi
+        YmUyIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzY5NWY1
+        OGM3LTdlMTMtNDdjNS1hYWM2LTc4YmY3NDVjNDBhZi8iLCJuYW1lIjoiZHVj
+        ayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJyZWxlYXNlIjoiMSIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4NjBhZDY3ODMyMTdj
+        YmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIi
+        LCJjaGVja3N1bV90eXBlIjoic2hhMjU2Iiwic3VtbWFyeSI6IlF1YWNrIGxp
+        a2UgYSBkdWNrIGF0IHRoZSBwYXJrLiIsImRlc2NyaXB0aW9uIjoiQSBmaXh0
+        dXJlIFJQTSBmb3IgdGVzdGluZyBQdWxwLiIsInVybCI6IiIsImNoYW5nZWxv
+        Z3MiOltdLCJmaWxlcyI6W1siIiwiL3Vzci9iaW4vIiwiZHVjay50eHQiXV0s
+        InJlcXVpcmVzIjpbXSwicHJvdmlkZXMiOltbImR1Y2siLCJFUSIsIjAiLCIw
+        LjciLCIxIixmYWxzZV1dLCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMiOltd
+        LCJzdWdnZXN0cyI6W10sImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6W10s
+        InN1cHBsZW1lbnRzIjpbXSwibG9jYXRpb25fYmFzZSI6IiIsImxvY2F0aW9u
+        X2hyZWYiOiJkdWNrLTAuNy4xLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0
+        IjoibG9jYWxob3N0LmxvY2FsZG9tYWluIiwicnBtX2dyb3VwIjoiVW5zcGVj
+        aWZpZWQiLCJycG1fbGljZW5zZSI6IlB1YmxpYyBEb21haW4iLCJycG1fcGFj
+        a2FnZXIiOiIiLCJycG1fc291cmNlcnBtIjoiZHVjay0wLjctMS5zcmMucnBt
+        IiwicnBtX3ZlbmRvciI6IiIsInJwbV9oZWFkZXJfc3RhcnQiOjQ1MDQsInJw
+        bV9oZWFkZXJfZW5kIjo2MzY0LCJpc19tb2R1bGFyIjpmYWxzZSwic2l6ZV9h
+        cmNoaXZlIjoyNjQsInNpemVfaW5zdGFsbGVkIjo1LCJzaXplX3BhY2thZ2Ui
+        OjY1NDAsInRpbWVfYnVpbGQiOjE1MzMwNjYwMTcsInRpbWVfZmlsZSI6MTY0
+        OTM1MTY3N31dfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:07 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/caa09a0e-2510-48ee-ad57-b034fc13b777/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvMmI1MGQ2NmYtZGFlYS00ODlmLTg1Y2YtNzEzMDMzNmUw
+        ZTlkLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5904dae2d8564356ab1d22971e94b19f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI0MDk5YzBhLWFkZWQtNDhl
+        My1iZTllLTdhMjI0ZTM3ZTI5ZC8ifQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:08 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/24099c0a-aded-48e3-be9e-7a224e37e29d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 41abaeba14884e968746b268b34437cd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '376'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjQwOTljMGEtYWRl
+        ZC00OGUzLWJlOWUtN2EyMjRlMzdlMjlkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTc6MDguMDczMDkyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI1OTA0ZGFlMmQ4NTY0MzU2YWIx
+        ZDIyOTcxZTk0YjE5ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE3
+        OjA4LjE0MTQ3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTc6
+        MDguMzAxMjk0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8zNzI3MDBmOC1jYjk1LTQyMzMtOGFkNy04ZDdjZjg1M2Yy
+        MWIvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vY2FhMDlhMGUtMjUx
+        MC00OGVlLWFkNTctYjAzNGZjMTNiNzc3LyJdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:08 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/upload.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:34 GMT
+      - Thu, 07 Apr 2022 17:17:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -41,7 +41,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5c870f586be84494bd0c228703e28cf8
+      - 2c8c942e00d040c3bba92b26017dc1f4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -52,7 +52,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:34 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:00 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
@@ -76,7 +76,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:34 GMT
+      - Thu, 07 Apr 2022 17:17:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -94,7 +94,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 96ce927843f34297bf4b9ef4c7ad27e8
+      - 0424ea48713c428880a02b863ba6c972
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -105,7 +105,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:34 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:00 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
@@ -129,7 +129,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:34 GMT
+      - Thu, 07 Apr 2022 17:17:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -147,7 +147,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 339daa17e83a4990ba9b4405faa3e74f
+      - fa77c03ca7a546cc9a563c33c00c8e7b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -158,7 +158,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:34 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:00 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
@@ -182,7 +182,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:34 GMT
+      - Thu, 07 Apr 2022 17:17:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -200,7 +200,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - baf5c64e012b40628bfedc87b8d89747
+      - bf49332b47df4a829a0445955511ce7a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -211,7 +211,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:34 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:00 GMT
 - request:
     method: post
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -243,13 +243,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:34 GMT
+      - Thu, 07 Apr 2022 17:17:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/9172ba90-e490-47e2-a87f-34ce0604fd0d/"
+      - "/pulp/api/v3/remotes/rpm/rpm/0d5bf689-54d3-406b-bb75-e26f7f9106b0/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -263,7 +263,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4ca07698f4f949d3acddcb453afdb0f1
+      - e372b7b6c2e84a8296b90e302c4c84fd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -271,20 +271,20 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzkx
-        NzJiYTkwLWU0OTAtNDdlMi1hODdmLTM0Y2UwNjA0ZmQwZC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTAzLTIyVDE0OjI1OjM0LjU1MTIzMFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzBk
+        NWJmNjg5LTU0ZDMtNDA2Yi1iYjc1LWUyNmY3ZjkxMDZiMC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA0LTA3VDE3OjE3OjAwLjk4OTM4OVoiLCJuYW1lIjoi
         RmVkb3JhXzE3IiwidXJsIjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0
         IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRy
         dWUsInByb3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjItMDMtMjJUMTQ6MjU6MzQuNTUxMjUyWiIsImRv
+        c3RfdXBkYXRlZCI6IjIwMjItMDQtMDdUMTc6MTc6MDAuOTg5NDA4WiIsImRv
         d25sb2FkX2NvbmN1cnJlbmN5IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwi
         cG9saWN5Ijoib25fZGVtYW5kIiwidG90YWxfdGltZW91dCI6MzYwMC4wLCJj
         b25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfY29ubmVjdF90aW1lb3V0Ijo2
         MC4wLCJzb2NrX3JlYWRfdGltZW91dCI6MzYwMC4wLCJoZWFkZXJzIjpudWxs
         LCJyYXRlX2xpbWl0IjowLCJzbGVzX2F1dGhfdG9rZW4iOm51bGx9
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:34 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:00 GMT
 - request:
     method: post
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -310,13 +310,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:34 GMT
+      - Thu, 07 Apr 2022 17:17:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/7cb0be09-677d-42c3-8d4e-61251bfbe7fc/"
+      - "/pulp/api/v3/repositories/rpm/rpm/fc6d4c62-d504-4776-84da-eb3bfb79e4a3/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -330,7 +330,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8caf4d8f127e4aed8f686f8290799d7e
+      - 9db37cc69fe4442fa78602c17400ecc7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -339,13 +339,13 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vN2NiMGJlMDktNjc3ZC00MmMzLThkNGUtNjEyNTFiZmJlN2ZjLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDMtMjJUMTQ6MjU6MzQuODAzNDg3WiIsInZl
+        cG0vZmM2ZDRjNjItZDUwNC00Nzc2LTg0ZGEtZWIzYmZiNzllNGEzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDQtMDdUMTc6MTc6MDEuMTkyNzM1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vN2NiMGJlMDktNjc3ZC00MmMzLThkNGUtNjEyNTFiZmJlN2ZjL3ZlcnNp
+        cG0vZmM2ZDRjNjItZDUwNC00Nzc2LTg0ZGEtZWIzYmZiNzllNGEzL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83Y2IwYmUwOS02
-        NzdkLTQyYzMtOGQ0ZS02MTI1MWJmYmU3ZmMvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9mYzZkNGM2Mi1k
+        NTA0LTQ3NzYtODRkYS1lYjNiZmI3OWU0YTMvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiRmVkb3JhXzE3IiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBv
         X3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpm
         YWxzZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5f
@@ -353,10 +353,10 @@ http_interactions:
         bnVsbCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6
         MCwicmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:34 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:01 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/remotes/rpm/rpm/9172ba90-e490-47e2-a87f-34ce0604fd0d/
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/remotes/rpm/rpm/0d5bf689-54d3-406b-bb75-e26f7f9106b0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -377,7 +377,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:37 GMT
+      - Thu, 07 Apr 2022 17:17:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -395,7 +395,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 86dea56b8c874c8dba385f524c185d19
+      - d3a66bf7ea4b4cfcaea8d87f06783b98
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -403,13 +403,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZiZjM0ODgwLWMyYzctNGQz
-        Mi1hMWUxLWIwYTZlZTIxNjI2Ny8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JjNDg0NDhjLTlkZjctNDY1
+        NC1iNjhmLWE2NzY0Zjg5MzAyNi8ifQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:37 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/6bf34880-c2c7-4d32-a1e1-b0a6ee216267/
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/bc48448c-9df7-4654-b68f-a6764f893026/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -417,7 +417,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.16.5/ruby
+      - OpenAPI-Generator/3.16.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -430,7 +430,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:37 GMT
+      - Thu, 07 Apr 2022 17:17:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -446,35 +446,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0dcec23788754bda95a4ccd539b50e7a
+      - 8aad07861df74e1a80d5881783d2e265
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
       - 1.1 centos8-katello-devel.samir.example.com
       Content-Length:
-      - '371'
+      - '370'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmJmMzQ4ODAtYzJj
-        Ny00ZDMyLWExZTEtYjBhNmVlMjE2MjY3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDMtMjJUMTQ6MjU6MzcuNjI4MDY1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmM0ODQ0OGMtOWRm
+        Ny00NjU0LWI2OGYtYTY3NjRmODkzMDI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTc6MDQuMjIyOTE5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI4NmRlYTU2YjhjODc0YzhkYmEzODVmNTI0
-        YzE4NWQxOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTAzLTIyVDE0OjI1OjM3LjY4
-        MDkwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDMtMjJUMTQ6MjU6MzcuNzUw
-        NzU0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wNjJhZjI0MS1hMTQ1LTQyYzUtOGRhOC0zOGMzNDhjZjk0Y2IvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkM2E2NmJmN2VhNGI0Y2ZjYWVhOGQ4N2Yw
+        Njc4M2I5OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE3OjA0LjI3
+        NDczM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTc6MDQuMzIx
+        NTkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8zNzI3MDBmOC1jYjk1LTQyMzMtOGFkNy04ZDdjZjg1M2YyMWIvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzkxNzJiYTkwLWU0OTAtNDdlMi1hODdm
-        LTM0Y2UwNjA0ZmQwZC8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzBkNWJmNjg5LTU0ZDMtNDA2Yi1iYjc1
+        LWUyNmY3ZjkxMDZiMC8iXX0=
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:37 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:04 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/7cb0be09-677d-42c3-8d4e-61251bfbe7fc/
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/distributions/rpm/rpm/ac29c6af-f242-4b7b-a260-0fbbfd16f10e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -495,7 +495,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:37 GMT
+      - Thu, 07 Apr 2022 17:17:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -513,7 +513,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2f262322c6d44010b6a62d87d467c430
+      - e58567918581448eb8de7189535768f4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -521,13 +521,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFjODllODE4LTEwZTctNDAw
-        Ny1iMzdlLTg3MWFiZGQxNTA3MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEzZjAwZjQwLTk0ZDgtNGYx
+        OC05OTVlLTc5MWU0NWQzZGIxNi8ifQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:37 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:04 GMT
 - request:
-    method: get
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/1c89e818-10e7-4007-b37e-871abdd15070/
+    method: delete
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/fc6d4c62-d504-4776-84da-eb3bfb79e4a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -535,7 +535,60 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.16.5/ruby
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b1226baf0e3d4570ac8a349926253358
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM3YWQ2ZmI0LTNhOTQtNDVm
+        Ni05ZDEzLTM0MTY0MTVjYzAzMi8ifQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:04 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/37ad6fb4-3a94-45f6-9d13-3416415cc032/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -548,7 +601,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:38 GMT
+      - Thu, 07 Apr 2022 17:17:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -564,7 +617,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d4f1ccac8cfa49d0b8117b9995b5de8d
+      - 5ce36720e22948f092706fc1ae1ee98d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -574,22 +627,22 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWM4OWU4MTgtMTBl
-        Ny00MDA3LWIzN2UtODcxYWJkZDE1MDcwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDMtMjJUMTQ6MjU6MzcuODcxNjgxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzdhZDZmYjQtM2E5
+        NC00NWY2LTlkMTMtMzQxNjQxNWNjMDMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTc6MDQuNTY4NTUxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIyZjI2MjMyMmM2ZDQ0MDEwYjZhNjJkODdk
-        NDY3YzQzMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTAzLTIyVDE0OjI1OjM3Ljkz
-        MTQwOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDMtMjJUMTQ6MjU6MzguMDAz
-        MTc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wNjJhZjI0MS1hMTQ1LTQyYzUtOGRhOC0zOGMzNDhjZjk0Y2IvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJiMTIyNmJhZjBlM2Q0NTcwYWM4YTM0OTky
+        NjI1MzM1OCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE3OjA0LjY1
+        ODAyM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTc6MDQuODE1
+        MjM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8zNzI3MDBmOC1jYjk1LTQyMzMtOGFkNy04ZDdjZjg1M2YyMWIvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2NiMGJlMDktNjc3ZC00MmMz
-        LThkNGUtNjEyNTFiZmJlN2ZjLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmM2ZDRjNjItZDUwNC00Nzc2
+        LTg0ZGEtZWIzYmZiNzllNGEzLyJdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:38 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:04 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -613,7 +666,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:38 GMT
+      - Thu, 07 Apr 2022 17:17:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -629,51 +682,130 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 47dcfd62f41242959d5b5b02b1239462
+      - 12e77ea8294f4803ac8056b0a00fa949
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
       - 1.1 centos8-katello-devel.samir.example.com
       Content-Length:
-      - '385'
+      - '714'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6NywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS81ZDQ2OTM4YS1mZjhlLTRhMGItYjg5OS00ZWQzMzk4YjdkNGQv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wMy0yMVQxNDoyOTozNC45NjUxOTJa
+        cnBtL3JwbS9mYmQ4YWJhZi02YjZiLTQwNzktYTMwZC1kMGUzNDcyYWU0ZDEv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNC0wN1QxMzowOToyNi45MDcwOTVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS81ZDQ2OTM4YS1mZjhlLTRhMGItYjg5OS00ZWQzMzk4YjdkNGQv
+        cnBtL3JwbS9mYmQ4YWJhZi02YjZiLTQwNzktYTMwZC1kMGUzNDcyYWU0ZDEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzVkNDY5
-        MzhhLWZmOGUtNGEwYi1iODk5LTRlZDMzOThiN2Q0ZC92ZXJzaW9ucy8xLyIs
-        Im5hbWUiOiJtb2R1bGFyX3Rlc3QtMjE4MyIsImRlc2NyaXB0aW9uIjpudWxs
-        LCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJh
-        dXRvcHVibGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6
-        bnVsbCwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2No
-        ZWNrc3VtX3R5cGUiOm51bGwsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVs
-        bCwiZ3BnY2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRh
-        ZGF0YSI6ZmFsc2V9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzdiZDQxNjA3LWJjMTgtNDYxZS04OTkyLWIyYmUz
-        NWJjMDljZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTAzLTIxVDE0OjA2OjI2
-        LjcxOTcyMloiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzdiZDQxNjA3LWJjMTgtNDYxZS04OTkyLWIyYmUz
-        NWJjMDljZC92ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30sImxhdGVzdF92
-        ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vN2JkNDE2MDctYmMxOC00NjFlLTg5OTItYjJiZTM1YmMwOWNkL3ZlcnNp
-        b25zLzEvIiwibmFtZSI6InRlc3QtMTg2MTIiLCJkZXNjcmlwdGlvbiI6bnVs
-        bCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwi
-        YXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2Ui
-        Om51bGwsInJldGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowLCJtZXRhZGF0YV9j
-        aGVja3N1bV90eXBlIjpudWxsLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOm51
-        bGwsImdwZ2NoZWNrIjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0
-        YWRhdGEiOmZhbHNlfV19
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2ZiZDhh
+        YmFmLTZiNmItNDA3OS1hMzBkLWQwZTM0NzJhZTRkMS92ZXJzaW9ucy8wLyIs
+        Im5hbWUiOiJ0ZXN0LTgwODc3IiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFp
+        bl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJs
+        aXNoIjpmYWxzZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJy
+        ZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1f
+        dHlwZSI6bnVsbCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdj
+        aGVjayI6MCwicmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpm
+        YWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L3JwbS9ycG0vNjUzZTdhMDQtMjllZi00MWRjLWExZmQtNzgyYWVlYTc5MDli
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDQtMDdUMTE6MTQ6MjUuOTA1MzAx
+        WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L3JwbS9ycG0vNjUzZTdhMDQtMjllZi00MWRjLWExZmQtNzgyYWVlYTc5MDli
+        L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS82NTNl
+        N2EwNC0yOWVmLTQxZGMtYTFmZC03ODJhZWVhNzkwOWIvdmVyc2lvbnMvMC8i
+        LCJuYW1lIjoiUmVkX0hhdF9BbnNpYmxlX0VuZ2luZV8yXzlfUlBNc19mb3Jf
+        UmVkX0hhdF9FbnRlcnByaXNlX0xpbnV4XzdfU2VydmVyX3g4Nl82NC0yMzk1
+        OTIiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMi
+        Om51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRh
+        ZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFpbl9wYWNrYWdlX3Zl
+        cnNpb25zIjowLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjpudWxsLCJwYWNr
+        YWdlX2NoZWNrc3VtX3R5cGUiOm51bGwsImdwZ2NoZWNrIjowLCJyZXBvX2dw
+        Z2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNlfSx7InB1bHBfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zZGRiYmQy
+        OS0yODA3LTRhNTItYmFmMC1lZTE1MDdjNjIwYzkvIiwicHVscF9jcmVhdGVk
+        IjoiMjAyMi0wNC0wN1QxMToxMzo1Ny41NzUyNjhaIiwidmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zZGRiYmQy
+        OS0yODA3LTRhNTItYmFmMC1lZTE1MDdjNjIwYzkvdmVyc2lvbnMvIiwicHVs
+        cF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzNkZGJiZDI5LTI4MDctNGE1Mi1i
+        YWYwLWVlMTUwN2M2MjBjOS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJSZWRfSGF0
+        X0Fuc2libGVfRW5naW5lXzJfOV9SUE1zX2Zvcl9SZWRfSGF0X0VudGVycHJp
+        c2VfTGludXhfN19TZXJ2ZXJfeDg2XzY0LTE5MzM1IiwiZGVzY3JpcHRpb24i
+        Om51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51
+        bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2
+        aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6MCwibWV0YWRh
+        dGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFja2FnZV9jaGVja3N1bV90eXBl
+        IjpudWxsLCJncGdjaGVjayI6MCwicmVwb19ncGdjaGVjayI6MCwic3FsaXRl
+        X21ldGFkYXRhIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vZTIyZTU0ZmMtMTc1Ni00NDllLTk2YzUt
+        YTZlNTMwYzNiZDdjLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDQtMDdUMTE6
+        MTM6MzMuMzg1OTUyWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vZTIyZTU0ZmMtMTc1Ni00NDllLTk2YzUt
+        YTZlNTMwYzNiZDdjL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0
+        ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9lMjJlNTRmYy0xNzU2LTQ0OWUtOTZjNS1hNmU1MzBjM2JkN2Mv
+        dmVyc2lvbnMvMC8iLCJuYW1lIjoiUmVkX0hhdF9BbnNpYmxlX0VuZ2luZV8y
+        XzlfUlBNc19mb3JfUmVkX0hhdF9FbnRlcnByaXNlX0xpbnV4XzdfU2VydmVy
+        X3g4Nl82NC0xMzM0NSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVw
+        b192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6
+        ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWlu
+        X3BhY2thZ2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUi
+        Om51bGwsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2si
+        OjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+        LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
+        cnBtL2YwZDdiNTE1LTZjNmEtNDUzNy05NGNiLTU1NjQ4NzY4ODgyMC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDExOjEzOjAyLjU5MDkwMFoiLCJ2
+        ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0v
+        cnBtL2YwZDdiNTE1LTZjNmEtNDUzNy05NGNiLTU1NjQ4NzY4ODgyMC92ZXJz
+        aW9ucy8iLCJwdWxwX2xhYmVscyI6e30sImxhdGVzdF92ZXJzaW9uX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZjBkN2I1MTUt
+        NmM2YS00NTM3LTk0Y2ItNTU2NDg3Njg4ODIwL3ZlcnNpb25zLzAvIiwibmFt
+        ZSI6IlJlZF9IYXRfQW5zaWJsZV9FbmdpbmVfMl85X1JQTXNfZm9yX1JlZF9I
+        YXRfRW50ZXJwcmlzZV9MaW51eF83X1NlcnZlcl94ODZfNjQtMTEyMjI5Iiwi
+        ZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxs
+        LCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWV0YWRhdGFf
+        c2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9u
+        cyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFja2FnZV9j
+        aGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6MCwicmVwb19ncGdjaGVj
+        ayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjI4YzAyOGItZTIw
+        Yi00MWJlLTkxN2EtOGFjMmNjNjk5MDg4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTE6MTA6MDYuMTY0ODE5WiIsInZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjI4YzAyOGItZTIw
+        Yi00MWJlLTkxN2EtOGFjMmNjNjk5MDg4L3ZlcnNpb25zLyIsInB1bHBfbGFi
+        ZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvcnBtL3JwbS8yMjhjMDI4Yi1lMjBiLTQxYmUtOTE3YS04
+        YWMyY2M2OTkwODgvdmVyc2lvbnMvMC8iLCJuYW1lIjoiUmVkX0hhdF9BbnNp
+        YmxlX0VuZ2luZV8yXzlfUlBNc19mb3JfUmVkX0hhdF9FbnRlcnByaXNlX0xp
+        bnV4XzdfU2VydmVyX3g4Nl82NC00MjM2IiwiZGVzY3JpcHRpb24iOm51bGws
+        InJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1
+        dG9wdWJsaXNoIjpmYWxzZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpu
+        dWxsLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hl
+        Y2tzdW1fdHlwZSI6bnVsbCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxs
+        LCJncGdjaGVjayI6MCwicmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFk
+        YXRhIjpmYWxzZX0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL3JwbS9ycG0vZGVmZDI3ZGMtZTE3Ni00YTBjLTliZTMtNWVkYzcx
+        NjU0MjJkLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDQtMDdUMTA6NTg6MDEu
+        OTU2MzkyWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL3JwbS9ycG0vZGVmZDI3ZGMtZTE3Ni00YTBjLTliZTMtNWVkYzcx
+        NjU0MjJkL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3Zl
+        cnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS9kZWZkMjdkYy1lMTc2LTRhMGMtOWJlMy01ZWRjNzE2NTQyMmQvdmVyc2lv
+        bnMvMC8iLCJuYW1lIjoiUmVkX0hhdF9BbnNpYmxlX0VuZ2luZV8yXzlfUlBN
+        c19mb3JfUmVkX0hhdF9FbnRlcnByaXNlX0xpbnV4XzdfU2VydmVyX3g4Nl82
+        NC0xNzQ0NSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJz
+        aW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2Us
+        Im1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwicmV0YWluX3BhY2th
+        Z2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOm51bGws
+        InBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOjAsInJl
+        cG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9XX0=
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:38 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/5d46938a-ff8e-4a0b-b899-4ed3398b7d4d/versions/?limit=2000&offset=0
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/fbd8abaf-6b6b-4079-a30d-d0e3472ae4d1/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -694,7 +826,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:38 GMT
+      - Thu, 07 Apr 2022 17:17:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -710,94 +842,30 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 405074ecc70b42a2bbb3b096f059b844
+      - 465f3b4769fe41519dfce78412bada2d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
       - 1.1 centos8-katello-devel.samir.example.com
       Content-Length:
-      - '427'
+      - '230'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS81ZDQ2OTM4YS1mZjhlLTRhMGItYjg5OS00ZWQzMzk4YjdkNGQv
-        dmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTAzLTIxVDE0OjI5
-        OjQ0LjcyOTAwMVoiLCJudW1iZXIiOjEsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNWQ0NjkzOGEtZmY4ZS00YTBi
-        LWI4OTktNGVkMzM5OGI3ZDRkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5hZHZpc29yeSI6eyJjb3Vu
-        dCI6NywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzVkNDY5MzhhLWZmOGUtNGEwYi1iODk5LTRl
-        ZDMzOThiN2Q0ZC92ZXJzaW9ucy8xLyJ9LCJycG0uZGlzdHJpYnV0aW9uX3Ry
-        ZWUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vZGlzdHJpYnV0aW9uX3RyZWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRk
-        ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzVkNDY5Mzhh
-        LWZmOGUtNGEwYi1iODk5LTRlZDMzOThiN2Q0ZC92ZXJzaW9ucy8xLyJ9LCJy
-        cG0ubW9kdWxlbWQiOnsiY291bnQiOjE0LCJocmVmIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnQvcnBtL21vZHVsZW1kcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2Fk
-        ZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81ZDQ2OTM4
-        YS1mZjhlLTRhMGItYjg5OS00ZWQzMzk4YjdkNGQvdmVyc2lvbnMvMS8ifSwi
-        cnBtLm1vZHVsZW1kX2RlZmF1bHRzIjp7ImNvdW50IjozLCJocmVmIjoiL3B1
-        bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVsZW1kX2RlZmF1bHRzLz9yZXBv
-        c2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9ycG0vcnBtLzVkNDY5MzhhLWZmOGUtNGEwYi1iODk5LTRlZDMzOThiN2Q0
-        ZC92ZXJzaW9ucy8xLyJ9LCJycG0ucGFja2FnZSI6eyJjb3VudCI6MjIsImhy
-        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvP3JlcG9z
-        aXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
-        L3JwbS9ycG0vNWQ0NjkzOGEtZmY4ZS00YTBiLWI4OTktNGVkMzM5OGI3ZDRk
-        L3ZlcnNpb25zLzEvIn0sInJwbS5wYWNrYWdlY2F0ZWdvcnkiOnsiY291bnQi
-        OjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZWNh
-        dGVnb3JpZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNWQ0NjkzOGEtZmY4ZS00YTBiLWI4
-        OTktNGVkMzM5OGI3ZDRkL3ZlcnNpb25zLzEvIn0sInJwbS5wYWNrYWdlZ3Jv
-        dXAiOnsiY291bnQiOjIsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9y
-        cG0vcGFja2FnZWdyb3Vwcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81ZDQ2OTM4YS1mZjhl
-        LTRhMGItYjg5OS00ZWQzMzk4YjdkNGQvdmVyc2lvbnMvMS8ifX0sInJlbW92
-        ZWQiOnt9LCJwcmVzZW50Ijp7InJwbS5hZHZpc29yeSI6eyJjb3VudCI6Nywi
-        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLz9y
-        ZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
-        cG0vcnBtLzVkNDY5MzhhLWZmOGUtNGEwYi1iODk5LTRlZDMzOThiN2Q0ZC92
-        ZXJzaW9ucy8xLyJ9LCJycG0uZGlzdHJpYnV0aW9uX3RyZWUiOnsiY291bnQi
-        OjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vZGlzdHJpYnV0
-        aW9uX3RyZWVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzVkNDY5MzhhLWZmOGUtNGEwYi1iODk5LTRl
-        ZDMzOThiN2Q0ZC92ZXJzaW9ucy8xLyJ9LCJycG0ubW9kdWxlbWQiOnsiY291
-        bnQiOjE0LCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21vZHVs
-        ZW1kcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvcnBtL3JwbS81ZDQ2OTM4YS1mZjhlLTRhMGItYjg5OS00ZWQzMzk4
-        YjdkNGQvdmVyc2lvbnMvMS8ifSwicnBtLm1vZHVsZW1kX2RlZmF1bHRzIjp7
-        ImNvdW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL21v
-        ZHVsZW1kX2RlZmF1bHRzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBp
-        L3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzVkNDY5MzhhLWZmOGUtNGEwYi1i
-        ODk5LTRlZDMzOThiN2Q0ZC92ZXJzaW9ucy8xLyJ9LCJycG0ucGFja2FnZSI6
-        eyJjb3VudCI6MjIsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL3JwbS9ycG0vNWQ0NjkzOGEtZmY4ZS00YTBiLWI4OTktNGVk
-        MzM5OGI3ZDRkL3ZlcnNpb25zLzEvIn0sInJwbS5wYWNrYWdlY2F0ZWdvcnki
-        OnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0v
-        cGFja2FnZWNhdGVnb3JpZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNWQ0NjkzOGEtZmY4ZS00YTBi
-        LWI4OTktNGVkMzM5OGI3ZDRkL3ZlcnNpb25zLzEvIn0sInJwbS5wYWNrYWdl
-        Z3JvdXAiOnsiY291bnQiOjIsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
-        dC9ycG0vcGFja2FnZWdyb3Vwcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81ZDQ2OTM4YS1mZjhlLTRh
-        MGItYjg5OS00ZWQzMzk4YjdkNGQvdmVyc2lvbnMvMS8ifX19fSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81ZDQ2
-        OTM4YS1mZjhlLTRhMGItYjg5OS00ZWQzMzk4YjdkNGQvdmVyc2lvbnMvMC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTAzLTIxVDE0OjI5OjM0Ljk3MDY4NVoi
-        LCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vNWQ0NjkzOGEtZmY4ZS00YTBiLWI4OTktNGVkMzM5
-        OGI3ZDRkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5
-        Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        cnBtL3JwbS9mYmQ4YWJhZi02YjZiLTQwNzktYTMwZC1kMGUzNDcyYWU0ZDEv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDEzOjA5
+        OjI2LjkxMTQyNloiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmJkOGFiYWYtNmI2Yi00MDc5
+        LWEzMGQtZDBlMzQ3MmFlNGQxLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:38 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/7bd41607-bc18-461e-8992-b2be35bc09cd/versions/?limit=2000&offset=0
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/653e7a04-29ef-41dc-a1fd-782aeea7909b/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -818,7 +886,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:38 GMT
+      - Thu, 07 Apr 2022 17:17:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -834,49 +902,327 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5f75c4d6f9914623ad6a717136ae5dff
+      - f6f2dba255fb4cf58e8037abc77ba922
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
       - 1.1 centos8-katello-devel.samir.example.com
       Content-Length:
-      - '326'
+      - '231'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS83YmQ0MTYwNy1iYzE4LTQ2MWUtODk5Mi1iMmJlMzViYzA5Y2Qv
-        dmVyc2lvbnMvMS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTAzLTIxVDE0OjE3
-        OjUxLjU2MTUzM1oiLCJudW1iZXIiOjEsInJlcG9zaXRvcnkiOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2JkNDE2MDctYmMxOC00NjFl
-        LTg5OTItYjJiZTM1YmMwOWNkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
-        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7InJwbS5hZHZpc29yeSI6eyJjb3Vu
-        dCI6MiwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9hZHZpc29y
-        aWVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtLzdiZDQxNjA3LWJjMTgtNDYxZS04OTkyLWIy
-        YmUzNWJjMDljZC92ZXJzaW9ucy8xLyJ9LCJycG0ucGFja2FnZSI6eyJjb3Vu
-        dCI6OCwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdl
-        cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcnBtL3JwbS83YmQ0MTYwNy1iYzE4LTQ2MWUtODk5Mi1iMmJl
-        MzViYzA5Y2QvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9LCJwcmVzZW50
-        Ijp7InJwbS5hZHZpc29yeSI6eyJjb3VudCI6MiwiaHJlZiI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L3JwbS9hZHZpc29yaWVzLz9yZXBvc2l0b3J5X3ZlcnNp
-        b249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzdiZDQxNjA3
-        LWJjMTgtNDYxZS04OTkyLWIyYmUzNWJjMDljZC92ZXJzaW9ucy8xLyJ9LCJy
-        cG0ucGFja2FnZSI6eyJjb3VudCI6OCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
-        b250ZW50L3JwbS9wYWNrYWdlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83YmQ0MTYwNy1iYzE4LTQ2
-        MWUtODk5Mi1iMmJlMzViYzA5Y2QvdmVyc2lvbnMvMS8ifX19fSx7InB1bHBf
-        aHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS83YmQ0
-        MTYwNy1iYzE4LTQ2MWUtODk5Mi1iMmJlMzViYzA5Y2QvdmVyc2lvbnMvMC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTAzLTIxVDE0OjA2OjI2LjcyNTg2MFoi
-        LCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vN2JkNDE2MDctYmMxOC00NjFlLTg5OTItYjJiZTM1
-        YmMwOWNkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5
-        Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
+        cnBtL3JwbS82NTNlN2EwNC0yOWVmLTQxZGMtYTFmZC03ODJhZWVhNzkwOWIv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDExOjE0
+        OjI1LjkxMjEzOFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNjUzZTdhMDQtMjllZi00MWRj
+        LWExZmQtNzgyYWVlYTc5MDliLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:38 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/3ddbbd29-2807-4a52-baf0-ee1507c620c9/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0fea8de9a28a40379b1e022fb2999413
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '231'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8zZGRiYmQyOS0yODA3LTRhNTItYmFmMC1lZTE1MDdjNjIwYzkv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDExOjEz
+        OjU3LjU4NDg0NVoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vM2RkYmJkMjktMjgwNy00YTUy
+        LWJhZjAtZWUxNTA3YzYyMGM5LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/e22e54fc-1756-449e-96c5-a6e530c3bd7c/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c67b7c7ad912422c8fdd712b0d482c11
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '229'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9lMjJlNTRmYy0xNzU2LTQ0OWUtOTZjNS1hNmU1MzBjM2JkN2Mv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDExOjEz
+        OjMzLjM5MTE5MFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZTIyZTU0ZmMtMTc1Ni00NDll
+        LTk2YzUtYTZlNTMwYzNiZDdjLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/f0d7b515-6c6a-4537-94cb-556487688820/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ed8c096f827643118250d7cfeb38b899
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '232'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9mMGQ3YjUxNS02YzZhLTQ1MzctOTRjYi01NTY0ODc2ODg4MjAv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDExOjEz
+        OjAyLjU5NTI3OFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZjBkN2I1MTUtNmM2YS00NTM3
+        LTk0Y2ItNTU2NDg3Njg4ODIwLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/228c028b-e20b-41be-917a-8ac2cc699088/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6cb558eab7c84500b5ea46c0449c031f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '230'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS8yMjhjMDI4Yi1lMjBiLTQxYmUtOTE3YS04YWMyY2M2OTkwODgv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDExOjEw
+        OjA2LjE2OTUxMFoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMjI4YzAyOGItZTIwYi00MWJl
+        LTkxN2EtOGFjMmNjNjk5MDg4LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/defd27dc-e176-4a0c-9be3-5edc7165422d/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - bb9a0de82ebb4732b01d3183139025ba
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '230'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9kZWZkMjdkYy1lMTc2LTRhMGMtOWJlMy01ZWRjNzE2NTQyMmQv
+        dmVyc2lvbnMvMC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDEwOjU4
+        OjAxLjk2MzkwMVoiLCJudW1iZXIiOjAsInJlcG9zaXRvcnkiOiIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGVmZDI3ZGMtZTE3Ni00YTBj
+        LTliZTMtNWVkYzcxNjU0MjJkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:05 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
@@ -900,7 +1246,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:38 GMT
+      - Thu, 07 Apr 2022 17:17:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -918,7 +1264,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ad4d81296efc4ce78cfac57b13514de0
+      - c38cc0fc964344d493e217e1cc678212
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -929,7 +1275,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:38 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:05 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -953,7 +1299,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:38 GMT
+      - Thu, 07 Apr 2022 17:17:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -971,7 +1317,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 78eafb50bf964029b5210dc66c362d10
+      - '0292618e005942bc80d59186c76702ec'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -982,7 +1328,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:38 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:05 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -1006,7 +1352,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:38 GMT
+      - Thu, 07 Apr 2022 17:17:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1024,7 +1370,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d122c0989b734794a91266107d7d97d2
+      - 143f997b2998483dbbcff965b6ad9b0f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1035,7 +1381,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:38 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:05 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -1059,39 +1405,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:38 GMT
+      - Thu, 07 Apr 2022 17:17:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept,Cookie,Accept-Encoding
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
-      Content-Length:
-      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3405b3cdfd85498cb263c8e56f30c5e5
+      - d678609b35a44646bd5096fdd91e9b5a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
       - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '283'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ZmlsZS9maWxlLzc0YWU2MjY5LWE4ZWEtNDkzZC1hNjM2LTY1YzNhMzBhN2Jm
+        Ni8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDE2OjEwOjQxLjIzMjMw
+        N1oiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvNzRhZTYyNjktYThlYS00OTNkLWE2MzYtNjVjM2EzMGE3
+        YmY2L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
+        b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
+        Lzc0YWU2MjY5LWE4ZWEtNDkzZC1hNjM2LTY1YzNhMzBhN2JmNi92ZXJzaW9u
+        cy8wLyIsIm5hbWUiOiJmaWxlMS04MTUzODEiLCJkZXNjcmlwdGlvbiI6bnVs
+        bCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwi
+        YXV0b3B1Ymxpc2giOmZhbHNlLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
+        fV19
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:38 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/file/file/74ae6269-a8ea-493d-a636-65c3a30a7bf6/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1099,7 +1456,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.0.0a6.dev1647573875/ruby
+      - OpenAPI-Generator/1.10.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -1112,7 +1469,67 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:38 GMT
+      - Thu, 07 Apr 2022 17:17:05 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 978ed84ce80749538db3e34a5a3b3d4c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '231'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ZmlsZS9maWxlLzc0YWU2MjY5LWE4ZWEtNDkzZC1hNjM2LTY1YzNhMzBhN2Jm
+        Ni92ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDQtMDdUMTY6
+        MTA6NDEuMjM2NTA5WiIsIm51bWJlciI6MCwicmVwb3NpdG9yeSI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzc0YWU2MjY5LWE4ZWEt
+        NDkzZC1hNjM2LTY1YzNhMzBhN2JmNi8iLCJiYXNlX3ZlcnNpb24iOm51bGws
+        ImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30sInJlbW92ZWQiOnt9LCJw
+        cmVzZW50Ijp7fX19XX0=
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:05 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.0.0a6.dev1649216856/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1130,7 +1547,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 31158dd8f5934e06a5fe22488ba18f5b
+      - 987b9e737f244ee5b95a2547e914b90a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1141,7 +1558,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:38 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:05 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -1165,7 +1582,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:38 GMT
+      - Thu, 07 Apr 2022 17:17:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1183,7 +1600,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 82d69d68cff74dee925b8e6dfd7c501b
+      - cb1b9bfa206b4f6ba57748e5c2694a72
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1194,113 +1611,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:38 GMT
-- request:
-    method: delete
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/5d46938a-ff8e-4a0b-b899-4ed3398b7d4d/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 22 Mar 2022 14:25:38 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 8f0770bb52964f8eb0333e1ca86f673e
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.samir.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjOTk3NmU5LThmNmYtNGE3
-        OS1hYTkzLTA3NjE2OTZjNDU0My8ifQ==
-    http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:38 GMT
-- request:
-    method: delete
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/7bd41607-bc18-461e-8992-b2be35bc09cd/versions/1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 22 Mar 2022 14:25:38 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 4d2e36614d7e470692386d86216561db
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.samir.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I2MmYyMTI1LWZiYjgtNDg5
-        NS05MWFiLTI2MTViYjdjYjQ2Ni8ifQ==
-    http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:38 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:05 GMT
 - request:
     method: post
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/orphans/cleanup/
@@ -1313,7 +1624,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.16.5/ruby
+      - OpenAPI-Generator/3.16.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -1326,7 +1637,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:38 GMT
+      - Thu, 07 Apr 2022 17:17:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1344,7 +1655,7 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8e862c6bdcfd407f9c1fd3fe1205da7e
+      - e358c008fa4e4e8aae7242757f2cfdc1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1352,13 +1663,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E2MmNjOGRhLTZiZDYtNDNh
-        Yi1iMjNhLTI5MTRlNTk4NzFiOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzljYTBmYjBiLWQ3NjQtNGI2
+        YS1iYjQ0LTExZGQ5NGZhZmJlMi8ifQ==
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:38 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:05 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/a62cc8da-6bd6-43ab-b23a-2914e59871b8/
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/9ca0fb0b-d764-4b6a-bb44-11dd94fafbe2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1366,7 +1677,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.16.5/ruby
+      - OpenAPI-Generator/3.16.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -1379,7 +1690,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 14:25:39 GMT
+      - Thu, 07 Apr 2022 17:17:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1395,34 +1706,34 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dde0140ad49346ac94b6e09eca453df6
+      - f4ae9e5322da48e785a6a0d6e107981f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
       - 1.1 centos8-katello-devel.samir.example.com
       Content-Length:
-      - '414'
+      - '409'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTYyY2M4ZGEtNmJk
-        Ni00M2FiLWIyM2EtMjkxNGU1OTg3MWI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDMtMjJUMTQ6MjU6MzguOTM3ODQ0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWNhMGZiMGItZDc2
+        NC00YjZhLWJiNDQtMTFkZDk0ZmFmYmUyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTc6MDUuNzc0OTUyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5vcnBoYW4ub3JwaGFuX2Ns
-        ZWFudXAiLCJsb2dnaW5nX2NpZCI6IjhlODYyYzZiZGNmZDQwN2Y5YzFmZDNm
-        ZTEyMDVkYTdlIiwic3RhcnRlZF9hdCI6IjIwMjItMDMtMjJUMTQ6MjU6Mzku
-        MDg5NjcwWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wMy0yMlQxNDoyNTozOS4y
-        MzY5MzhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
-        b3JrZXJzLzA2MmFmMjQxLWExNDUtNDJjNS04ZGE4LTM4YzM0OGNmOTRjYi8i
+        ZWFudXAiLCJsb2dnaW5nX2NpZCI6ImUzNThjMDA4ZmE0ZTRlOGFhZTcyNDI3
+        NTdmMmNmZGMxIiwic3RhcnRlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTc6MDUu
+        ODQxMTI3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNC0wN1QxNzoxNzowNS44
+        OTMwMDhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzYxMzdkNTdjLWNkNTQtNGM3Ny05MzU3LTRlZTEzZGZmMTU4YS8i
         LCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dy
         b3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xl
         YW4gdXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVu
         dCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1
         ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQ2xlYW4gdXAgb3JwaGFuIEFydGlm
         YWN0cyIsImNvZGUiOiJjbGVhbi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21w
-        bGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6NSwic3VmZml4IjpudWxsfV0sImNy
+        bGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNy
         ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
         ZCI6W119
     http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:39 GMT
+  recorded_at: Thu, 07 Apr 2022 17:17:05 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/rpm_upload/upload_binary.yml
@@ -1,93 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/content/rpm/packages/?pkgId=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 22 Mar 2022 14:25:35 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 394c142458ec4cffbd9424f9d746a744
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.samir.example.com
-      Content-Length:
-      - '917'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy9mZWZhYmFjYi0xMGFkLTQ5YzItODBlMC03ZTNlYTMwMzA3Y2Ev
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wMy0yMVQxMzozODoxNi4yMzY0NTJa
-        IiwibWQ1IjpudWxsLCJzaGExIjoiYzkxOGJkOTFhMDQyMTg1NWY5MjI5OGU0
-        OGI1NTdjNTdmYjY1YWM5YSIsInNoYTIyNCI6ImE3ZjU1NDJkNTI5NjU3Mjk3
-        Y2FjMDlkMGU3YjExNmQ5ODM1NTEyMTNiMTQ0M2QzMWIyODY3ODVkIiwic2hh
-        MjU2IjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
-        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInNoYTM4NCI6ImZjZWFhZDk4
-        ZjI5ODI1MzIwYzYwY2RhM2E4ZDJiYzdmZTc2YWEzZjdiMmRiOWU2YjI2MWJi
-        OGFkZTYwNmNhZDgwNDU0N2M3YzM1YjExYmU5NDllNmM0ZDdiMzM3ZTMzZCIs
-        InNoYTUxMiI6Ijc0ZjBhZTBiOGJhM2Q3ZjJiOGYxNjc3NGE1ZjQwOTc5Y2Fj
-        MjgwMmVhODZmZDg0ZGZhODM5MDIzYjM4NjcxNWY4ZTQ5YTllMmVjMTg5OTgw
-        MmY5NzA1OTRmMGU4ZjZkMmE0MDY2YjI1OTQwNmQyMjM3YmE4YmI5MjJlMTNi
-        YmUyIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2MxOGFi
-        M2UzLWYxZjctNDg3Yy04YzQ4LTliNDZiZjc4NTE2Ni8iLCJuYW1lIjoiZHVj
-        ayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJyZWxlYXNlIjoiMSIs
-        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4NjBhZDY3ODMyMTdj
-        YmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIi
-        LCJjaGVja3N1bV90eXBlIjoic2hhMjU2Iiwic3VtbWFyeSI6IlF1YWNrIGxp
-        a2UgYSBkdWNrIGF0IHRoZSBwYXJrLiIsImRlc2NyaXB0aW9uIjoiQSBmaXh0
-        dXJlIFJQTSBmb3IgdGVzdGluZyBQdWxwLiIsInVybCI6IiIsImNoYW5nZWxv
-        Z3MiOltdLCJmaWxlcyI6W1siIiwiL3Vzci9iaW4vIiwiZHVjay50eHQiXV0s
-        InJlcXVpcmVzIjpbXSwicHJvdmlkZXMiOltbImR1Y2siLCJFUSIsIjAiLCIw
-        LjciLCIxIixmYWxzZV1dLCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMiOltd
-        LCJzdWdnZXN0cyI6W10sImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6W10s
-        InN1cHBsZW1lbnRzIjpbXSwibG9jYXRpb25fYmFzZSI6IiIsImxvY2F0aW9u
-        X2hyZWYiOiJkdWNrLTAuNy4xLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0
-        IjoibG9jYWxob3N0LmxvY2FsZG9tYWluIiwicnBtX2dyb3VwIjoiVW5zcGVj
-        aWZpZWQiLCJycG1fbGljZW5zZSI6IlB1YmxpYyBEb21haW4iLCJycG1fcGFj
-        a2FnZXIiOiIiLCJycG1fc291cmNlcnBtIjoiZHVjay0wLjctMS5zcmMucnBt
-        IiwicnBtX3ZlbmRvciI6IiIsInJwbV9oZWFkZXJfc3RhcnQiOjQ1MDQsInJw
-        bV9oZWFkZXJfZW5kIjo2MzY0LCJpc19tb2R1bGFyIjpmYWxzZSwic2l6ZV9h
-        cmNoaXZlIjoyNjQsInNpemVfaW5zdGFsbGVkIjo1LCJzaXplX3BhY2thZ2Ui
-        OjY1NDAsInRpbWVfYnVpbGQiOjE1MzMwNjYwMTcsInRpbWVfZmlsZSI6MTY0
-        Nzg2OTg5Nn1dfQ==
-    http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:35 GMT
-- request:
     method: post
     uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/7cb0be09-677d-42c3-8d4e-61251bfbe7fc/modify/
     body:
@@ -208,93 +121,6 @@ http_interactions:
         bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
         cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vN2NiMGJlMDktNjc3ZC00MmMz
         LThkNGUtNjEyNTFiZmJlN2ZjLyJdfQ==
-    http_version: 
-  recorded_at: Tue, 22 Mar 2022 14:25:36 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/content/rpm/packages/?pkgId=833af594bc0ba31256045ed1fb17d3df2d8341a89b0c5a9bf610dd6103ce4cc8
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.4/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 22 Mar 2022 14:25:36 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - aa8e4f30c7d74eb6b02b4ede156ea0b7
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.samir.example.com
-      Content-Length:
-      - '905'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
-        YWNrYWdlcy8yNTIzMGY5My1iODA2LTRkYWYtODVjMy0yNzBhOGViOWIwMWYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wMy0yMVQxMzozODoyMS4xNjM1MDFa
-        IiwibWQ1IjpudWxsLCJzaGExIjoiMDA0ZWUyOWMwMjlkMTQyNTcwNWVjYTQ2
-        MWU0ODlkMGYzNzhkM2U4YyIsInNoYTIyNCI6IjAxZTNmMmE1YjJlZDNmMTE5
-        OWEwNmU2YzQ0YWFjODM5MzVjYmQ2NmY5NThhMzBhYTdkMjVhNGY0Iiwic2hh
-        MjU2IjoiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFh
-        ODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsInNoYTM4NCI6Ijc1MGE1Yjc0
-        YWZlNzc3Nzc1NDI1ZGM1OWY1MDA2MjM4NTJiYTFkZTdkOGQxY2U0ODc5ZmVl
-        NDI2Y2JiZmVhOTU5YzFkYjFjNTEwYmNhNGEwZGJhZjBjODRlZmMwZTE5YiIs
-        InNoYTUxMiI6IjM1YmE2OTJhN2E3YjJkODQzNjZiMDE1ODE0N2U3ZWRlNDZm
-        MzgwYzBlNmFjZGYzOTE4YzRiMDllOGI3MjIxNmRhMTU4NTQ1ZTg0OGFiMThk
-        NzlhZWEwNDA0ZjM0MGU1ZjIwYWZmNzc3MmRmNmE0MDQ3MTBjNzE0YmFkMjIy
-        NzczIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzA0OTQ5
-        ZDlkLTVlZDItNDlhMi1iNjUwLWYxZTA4ZDQ0OTJjOS8iLCJuYW1lIjoia2Fu
-        Z2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yIiwicmVsZWFzZSI6
-        IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzNhZjU5NGJjMGJhMzEy
-        NTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIwYzVhOWJmNjEwZGQ2MTAzY2U0
-        Y2M4IiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiIsInN1bW1hcnkiOiJBIGR1
-        bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJkZXNjcmlwdGlvbiI6IkEgZHVt
-        bXkgcGFja2FnZSBvZiBrYW5nYXJvbyIsInVybCI6Imh0dHA6Ly90c3RyYWNo
-        b3RhLmZlZG9yYXBlb3BsZS5vcmciLCJjaGFuZ2Vsb2dzIjpbXSwiZmlsZXMi
-        OltbIiIsIi90bXAvIiwia2FuZ2Fyb28udHh0Il1dLCJyZXF1aXJlcyI6W10s
-        InByb3ZpZGVzIjpbWyJrYW5nYXJvbyIsIkVRIiwiMCIsIjAuMiIsIjEiLGZh
-        bHNlXV0sImNvbmZsaWN0cyI6W10sIm9ic29sZXRlcyI6W10sInN1Z2dlc3Rz
-        IjpbXSwiZW5oYW5jZXMiOltdLCJyZWNvbW1lbmRzIjpbXSwic3VwcGxlbWVu
-        dHMiOltdLCJsb2NhdGlvbl9iYXNlIjoiIiwibG9jYXRpb25faHJlZiI6Imth
-        bmdhcm9vLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0Ijoic21x
-        ZS13czE1IiwicnBtX2dyb3VwIjoiSW50ZXJuZXQvQXBwbGljYXRpb25zIiwi
-        cnBtX2xpY2Vuc2UiOiJHUEx2MiIsInJwbV9wYWNrYWdlciI6IiIsInJwbV9z
-        b3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwicnBtX3ZlbmRv
-        ciI6IiIsInJwbV9oZWFkZXJfc3RhcnQiOjI4MCwicnBtX2hlYWRlcl9lbmQi
-        OjE3MjEsImlzX21vZHVsYXIiOmZhbHNlLCJzaXplX2FyY2hpdmUiOjMwMCwi
-        c2l6ZV9pbnN0YWxsZWQiOjQyLCJzaXplX3BhY2thZ2UiOjE4NzUsInRpbWVf
-        YnVpbGQiOjEzMzE4MzEzNzYsInRpbWVfZmlsZSI6MTY0Nzg2OTkwMX1dfQ==
     http_version: 
   recorded_at: Tue, 22 Mar 2022 14:25:36 GMT
 - request:
@@ -420,4 +246,1962 @@ http_interactions:
         LThkNGUtNjEyNTFiZmJlN2ZjLyJdfQ==
     http_version: 
   recorded_at: Tue, 22 Mar 2022 14:25:37 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/75ccb04f-5799-4bac-a771-e796c1fa41d9/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvMmI1MGQ2NmYtZGFlYS00ODlmLTg1Y2YtNzEzMDMzNmUw
+        ZTlkLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 48b3c30a536d418e998d7440bad062d9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QwN2VkMTA2LWYxMjctNGE1
+        Yi1iZDNhLTgzMmExMzY1NjNlMC8ifQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:53 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/d07ed106-f127-4a5b-bd3a-832a136563e0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - cef2295f433a44bcb5d1912a2458a101
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '390'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDA3ZWQxMDYtZjEy
+        Ny00YTViLWJkM2EtODMyYTEzNjU2M2UwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTQ6NTMuNzY4NzQ4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI0OGIzYzMwYTUzNmQ0MThlOTk4
+        ZDc0NDBiYWQwNjJkOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE0
+        OjUzLjgzNjY0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTQ6
+        NTQuMDM1NzY2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8zNzI3MDBmOC1jYjk1LTQyMzMtOGFkNy04ZDdjZjg1M2Yy
+        MWIvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS83NWNjYjA0Zi01Nzk5LTRiYWMtYTc3MS1lNzk2YzFmYTQxZDkvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzVjY2IwNGYtNTc5OS00YmFj
+        LWE3NzEtZTc5NmMxZmE0MWQ5LyJdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:54 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/artifacts/?sha256=833af594bc0ba31256045ed1fb17d3df2d8341a89b0c5a9bf610dd6103ce4cc8
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8a22f8989c1442d795f26ca659383fcb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:54 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjoxODc1fQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/5e962eab-f047-4e23-8b94-6cc79c9a86a8/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '131'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 439a8cfb3e774e0a866764459100aee1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy81ZTk2MmVhYi1m
+        MDQ3LTRlMjMtOGI5NC02Y2M3OWM5YTg2YTgvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMi0wNC0wN1QxNzoxNDo1NC42NTkzNDZaIiwic2l6ZSI6MTg3NX0=
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:54 GMT
+- request:
+    method: put
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/uploads/5e962eab-f047-4e23-8b94-6cc79c9a86a8/
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTJmMGQxM2ZlNGQ4ZDBm
+        MmU0NzM2NzY0N2RmMGFmZjVhDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyMjA0
+        MDctMTI3NTI3LWUzMWs0dyINCkNvbnRlbnQtTGVuZ3RoOiAxODc1DQpDb250
+        ZW50LVR5cGU6IGFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbQ0KQ29udGVudC1U
+        cmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNCu2r7tsDAAAAAAFrYW5nYXJv
+        by0wLjItMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAQAFAAAAAAAAAAAAAAAAAAAAAI6t6AEAAAAAAAAA
+        BQAAAFQAAAA+AAAABwAAAEQAAAAQAAABDQAAAAYAAAAAAAAAAQAAA+gAAAAE
+        AAAALAAAAAEAAAPsAAAABwAAADAAAAAQAAAD7wAAAAQAAABAAAAAATM2Njg2
+        ZDUyN2VlNTE4ZmFlYjkwYWQ4YWNiNjNmMzMwN2VmYjc4ZWEAAAAAAAAGO3+u
+        XDt8X78QcIrmtQmsOIUAAAEsAAAAPgAAAAf///+wAAAAEAAAAACOregBAAAA
+        AAAAADUAAAJBAAAAPwAAAAcAAAIxAAAAEAAAAGQAAAAIAAAAAAAAAAEAAAPo
+        AAAABgAAAAIAAAABAAAD6QAAAAYAAAALAAAAAQAAA+oAAAAGAAAADwAAAAEA
+        AAPsAAAACQAAABEAAAABAAAD7QAAAAkAAAAtAAAAAQAAA+4AAAAEAAAATAAA
+        AAEAAAPvAAAABgAAAFAAAAABAAAD8QAAAAQAAABcAAAAAQAAA/YAAAAGAAAA
+        YAAAAAEAAAP4AAAACQAAAGYAAAABAAAD/AAAAAYAAAB8AAAAAQAAA/0AAAAG
+        AAAAnwAAAAEAAAP+AAAABgAAAKUAAAABAAAEBAAAAAQAAACsAAAAAQAABAYA
+        AAADAAAAsAAAAAEAAAQJAAAAAwAAALIAAAABAAAECgAAAAQAAAC0AAAAAQAA
+        BAsAAAAIAAAAuAAAAAEAAAQMAAAACAAAANkAAAABAAAEDQAAAAQAAADcAAAA
+        AQAABA8AAAAIAAAA4AAAAAEAAAQQAAAACAAAAOUAAAABAAAEFAAAAAYAAADq
+        AAAAAQAABBUAAAAEAAABBAAAAAEAAAQXAAAACAAAAQgAAAABAAAEGAAAAAQA
+        AAEUAAAAAgAABBkAAAAIAAABHAAAAAIAAAQaAAAACAAAAVcAAAACAAAEKAAA
+        AAYAAAFlAAAAAQAABEYAAAAGAAABbQAAAAEAAARHAAAABAAAAYQAAAABAAAE
+        SAAAAAQAAAGIAAAAAQAABEkAAAAIAAABjAAAAAEAAARYAAAABAAAAZAAAAAB
+        AAAEWQAAAAgAAAGUAAAAAQAABFwAAAAEAAABnAAAAAEAAARdAAAACAAAAaAA
+        AAABAAAEXgAAAAgAAAGtAAAAAQAABGIAAAAGAAABswAAAAEAAARkAAAABgAA
+        Ac4AAAABAAAEZQAAAAYAAAHTAAAAAQAABGYAAAAGAAAB2AAAAAEAAARrAAAA
+        BgAAAdoAAAABAAAEbAAAAAYAAAHhAAAAAQAABHQAAAAEAAAB+AAAAAEAAAR1
+        AAAABAAAAfwAAAABAAAEdgAAAAgAAAIAAAAAAwAABHcAAAAEAAACGAAAAAEA
+        AAR4AAAABAAAAhwAAAABAAAEegAAAAcAAAIgAAAAEAAABHsAAAAIAAACMAAA
+        AAFDAGthbmdhcm9vADAuMgAxAEEgZHVtbXkgcGFja2FnZSBvZiBrYW5nYXJv
+        bwBBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28AAAAAT2IiUHNtcWUtd3Mx
+        NQAAAAAAACpHUEx2MgBJbnRlcm5ldC9BcHBsaWNhdGlvbnMAaHR0cDovL3Rz
+        dHJhY2hvdGEuZmVkb3JhcGVvcGxlLm9yZwBsaW51eABub2FyY2gAAAAAKoGk
+        AABPYiJQZjA1OGQzMmRkMmIxNTAyMWIyYjBmNjIwMzJiYWUxNmUAAAAAAAAA
+        AHJvb3QAcm9vdABrYW5nYXJvby0wLjItMS5zcmMucnBtAAAAAP////9rYW5n
+        YXJvbwAAAAABAABKAQAASnJwbWxpYihDb21wcmVzc2VkRmlsZU5hbWVzKQBy
+        cG1saWIoUGF5bG9hZEZpbGVzSGF2ZVByZWZpeCkAMy4wLjQtMQA0LjAtMQA0
+        LjQuMi4zAHNtcWUtd3MxNSAxMzMxODMxMzc2AAAAAAD8AAADgCgAAAAAAAAA
+        CDAuMi0xAAAAAAAAAGthbmdhcm9vLnR4dAAvdG1wLwAtTzIgLWcgLW02NCAt
+        bXR1bmU9Z2VuZXJpYwBjcGlvAGd6aXAAOQBub2FyY2gAbm9hcmNoLXJlZGhh
+        dC1saW51eAAAAAAAAAAAAAAAAQBBU0NJSSB0ZXh0AGRpcmVjdG9yeQAAAAAA
+        AAAAAAAA57TbglDp8Lak6J4bSZJA/QAAAAA/AAAAB////LAAAAAQH4sIAAAA
+        AAAAAzMwNzA3MDQwMDC2MDCyANIGFoaJJgbYgaFJmpmRkZEplGuUCKHTkg3w
+        AkNjGEtPvyS3QD87MS89sSg/X6+kooQBCAISk7MT01MVMvOKSxJzchRKMnNT
+        rRQMLawMLK2MzRQMjHUNTXWNDAyNuBgYDGDuJQYQqw4dJMEYIUGOnj6uQYqK
+        iiB3AgAPro5vLAEAAA0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0
+        LTJmMGQxM2ZlNGQ4ZDBmMmU0NzM2NzY0N2RmMGFmZjVhLS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-2f0d13fe4d8d0f2e47367647df0aff5a
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-1874/1875
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '2197'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d65fa1d1ed7b4248b9f0a85f166fd697
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '134'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy81ZTk2MmVhYi1m
+        MDQ3LTRlMjMtOGI5NC02Y2M3OWM5YTg2YTgvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMi0wNC0wN1QxNzoxNDo1NC42NTkzNDZaIiwic2l6ZSI6MTg3NX0=
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:54 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/artifacts/?sha256=833af594bc0ba31256045ed1fb17d3df2d8341a89b0c5a9bf610dd6103ce4cc8
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a62f0a04b5194a16b6181081d46adff2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:54 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/uploads/5e962eab-f047-4e23-8b94-6cc79c9a86a8/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJk
+        ODM0MWE4OWIwYzVhOWJmNjEwZGQ2MTAzY2U0Y2M4In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 625cdcd0ae45457ab09fc7eb7ec6851e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM0N2Q0MmM0LTM3MTYtNGU0
+        OS1iMjlmLTc2YzI5YTk5YmFhOS8ifQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:54 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/347d42c4-3716-4e49-b29f-76c29a99baa9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3fececc82de74568965667fae1c36393
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzQ3ZDQyYzQtMzcx
+        Ni00ZTQ5LWIyOWYtNzZjMjlhOTliYWE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTQ6NTQuNzc1NjI4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy51cGxvYWQuY29tbWl0Iiwi
+        bG9nZ2luZ19jaWQiOiI2MjVjZGNkMGFlNDU0NTdhYjA5ZmM3ZWI3ZWM2ODUx
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE0OjU0LjgyNzUxNloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTQ6NTQuODkyNzYwWiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy82
+        MTM3ZDU3Yy1jZDU0LTRjNzctOTM1Ny00ZWUxM2RmZjE1OGEvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpb
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZmNiYWEzMjAtNDMxOC00MDkwLTk5
+        ZDMtYzQ5OWZhNmJkYjcxLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9wdWxwL2FwaS92My91cGxvYWRzLzVlOTYyZWFiLWYwNDctNGUyMy04
+        Yjk0LTZjYzc5YzlhODZhOC8iXX0=
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:54 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/artifacts/?sha256=833af594bc0ba31256045ed1fb17d3df2d8341a89b0c5a9bf610dd6103ce4cc8
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9163a600f17d4d0ba49064b43da5de0e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '438'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZmNi
+        YWEzMjAtNDMxOC00MDkwLTk5ZDMtYzQ5OWZhNmJkYjcxLyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjItMDQtMDdUMTc6MTQ6NTQuODYxNDg4WiIsImZpbGUiOiJh
+        cnRpZmFjdC84My8zYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgz
+        NDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsInNpemUiOjE4NzUsIm1k
+        NSI6bnVsbCwic2hhMSI6IjAwNGVlMjljMDI5ZDE0MjU3MDVlY2E0NjFlNDg5
+        ZDBmMzc4ZDNlOGMiLCJzaGEyMjQiOiIwMWUzZjJhNWIyZWQzZjExOTlhMDZl
+        NmM0NGFhYzgzOTM1Y2JkNjZmOTU4YTMwYWE3ZDI1YTRmNCIsInNoYTI1NiI6
+        IjgzM2FmNTk0YmMwYmEzMTI1NjA0NWVkMWZiMTdkM2RmMmQ4MzQxYTg5YjBj
+        NWE5YmY2MTBkZDYxMDNjZTRjYzgiLCJzaGEzODQiOiI3NTBhNWI3NGFmZTc3
+        Nzc3NTQyNWRjNTlmNTAwNjIzODUyYmExZGU3ZDhkMWNlNDg3OWZlZTQyNmNi
+        YmZlYTk1OWMxZGIxYzUxMGJjYTRhMGRiYWYwYzg0ZWZjMGUxOWIiLCJzaGE1
+        MTIiOiIzNWJhNjkyYTdhN2IyZDg0MzY2YjAxNTgxNDdlN2VkZTQ2ZjM4MGMw
+        ZTZhY2RmMzkxOGM0YjA5ZThiNzIyMTZkYTE1ODU0NWU4NDhhYjE4ZDc5YWVh
+        MDQwNGYzNDBlNWYyMGFmZjc3NzJkZjZhNDA0NzEwYzcxNGJhZDIyMjc3MyJ9
+        XX0=
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:54 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/content/rpm/packages/?pkgId=833af594bc0ba31256045ed1fb17d3df2d8341a89b0c5a9bf610dd6103ce4cc8
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - '0780bdb663c84e0eb455b63d3e1a8aa8'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:55 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/content/rpm/packages/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWVhMzk0NTcxZjdhYTUx
+        ZWYyMmIxN2FjZTNkMzhiMjU2DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCmthbmdhcm9vLTAuMi0x
+        Lm5vYXJjaC5ycG0NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC1l
+        YTM5NDU3MWY3YWE1MWVmMjJiMTdhY2UzZDM4YjI1Ng0KQ29udGVudC1EaXNw
+        b3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJhcnRpZmFjdCINCg0KL3B1bHAv
+        YXBpL3YzL2FydGlmYWN0cy9mY2JhYTMyMC00MzE4LTQwOTAtOTlkMy1jNDk5
+        ZmE2YmRiNzEvDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtZWEz
+        OTQ1NzFmN2FhNTFlZjIyYjE3YWNlM2QzOGIyNTYtLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-ea394571f7aa51ef22b17ace3d38b256
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '393'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b0af4667d19d445dab70c3b33c51b87a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgzNzhjNTE4LTIyYzktNDFi
+        MC05YTFiLTlkZDQxNmFiY2FmOS8ifQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:55 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/8378c518-22c9-41b0-9a1b-9dd416abcaf9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 74ad6c46d0d74ad8be5c3c2c2b6ef446
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '374'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvODM3OGM1MTgtMjJj
+        OS00MWIwLTlhMWItOWRkNDE2YWJjYWY5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTQ6NTUuMDkwMDk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJiMGFmNDY2N2QxOWQ0NDVkYWI3MGMzYjMz
+        YzUxYjg3YSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE0OjU1LjE0
+        NTU5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTQ6NTUuMzA3
+        Njc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8zNzI3MDBmOC1jYjk1LTQyMzMtOGFkNy04ZDdjZjg1M2YyMWIvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L3JwbS9wYWNrYWdlcy81ZTUx
+        ZDI5NS02YTFkLTQ4YmMtYWUyMS01MmJkNTI4MzJmMzAvIl0sInJlc2VydmVk
+        X3Jlc291cmNlc19yZWNvcmQiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:55 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/75ccb04f-5799-4bac-a771-e796c1fa41d9/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNWU1MWQyOTUtNmExZC00OGJjLWFlMjEtNTJiZDUyODMy
+        ZjMwLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 30b9e1fe61e84819acfd6074db836403
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FjOGU2NTJjLWIwM2UtNDYy
+        NC04ZmY1LTFkYmUwMWQ3ZDM4Mi8ifQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:55 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/ac8e652c-b03e-4624-8ff5-1dbe01d7d382/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 93ce5c5cd49f482f80fe9bca9ea1da94
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '390'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWM4ZTY1MmMtYjAz
+        ZS00NjI0LThmZjUtMWRiZTAxZDdkMzgyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTQ6NTUuNDUwMjQ0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIzMGI5ZTFmZTYxZTg0ODE5YWNm
+        ZDYwNzRkYjgzNjQwMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE0
+        OjU1LjUyNTUwOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTQ6
+        NTUuNzQwOTA3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy82MTM3ZDU3Yy1jZDU0LTRjNzctOTM1Ny00ZWUxM2RmZjE1
+        OGEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS83NWNjYjA0Zi01Nzk5LTRiYWMtYTc3MS1lNzk2YzFmYTQxZDkvdmVyc2lv
+        bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vNzVjY2IwNGYtNTc5OS00YmFj
+        LWE3NzEtZTc5NmMxZmE0MWQ5LyJdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:55 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/2b49e1d8-8c59-41b7-b734-8a042343c18a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a4db6e8e3f9743e3b0ad56fb4e9f9915
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '474'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmI0OWUxZDgtOGM1
+        OS00MWI3LWI3MzQtOGEwNDIzNDNjMThhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTQ6NTYuMjYwMDE2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
+        c2giLCJsb2dnaW5nX2NpZCI6IjEwMTcxNDIzYzY4NzQ3ZjJiNTQ2ZjYwYzE2
+        MjhjOTJmIiwic3RhcnRlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTQ6NTYuMzI4
+        NzAzWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNC0wN1QxNzoxNDo1Ni41NjY1
+        OTFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzYxMzdkNTdjLWNkNTQtNGM3Ny05MzU3LTRlZTEzZGZmMTU4YS8iLCJw
+        YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
+        IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
+        dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
+        ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
+        OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNTAyMzNj
+        ZDUtMjhjZC00ZDQ3LTk3OTktMDdkZmQyNWEwMzI5LyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL3JwbS9ycG0vNzVjY2IwNGYtNTc5OS00YmFjLWE3NzEtZTc5NmMx
+        ZmE0MWQ5LyJdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:56 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/3a451e8f-e9ec-47cc-a849-c474d005a56c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fd36b3829cc94415bdab22d4ea954128
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '379'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2E0NTFlOGYtZTll
+        Yy00N2NjLWE4NDktYzQ3NGQwMDVhNTZjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTQ6NTYuNzU3OTQ0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJhYzEwNjcwNmVjNWM0NWJkOTZhMzI3ZGNi
+        YjVmMzExOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE0OjU2Ljg0
+        MTQwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTQ6NTcuMDU0
+        Nzg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8zNzI3MDBmOC1jYjk1LTQyMzMtOGFkNy04ZDdjZjg1M2YyMWIvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDc5
+        NTQxZGUtNzBjNy00ZTBiLWFjZjgtNTUwZjg4MDE5YzhmLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:57 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/distributions/rpm/rpm/079541de-70c7-4e0b-acf8-550f88019c8f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:14:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - bbf586f095f041bfb14f0a40d34fdc2b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '303'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzA3OTU0MWRlLTcwYzctNGUwYi1hY2Y4LTU1MGY4ODAxOWM4Zi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDE3OjE0OjU3LjAwODE3NFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3
+        X2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0ZWxsby1k
+        ZXZlbC5zYW1pci5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9saWJyYXJ5L2ZlZG9yYV8xN19sYWJlbC8iLCJjb250ZW50X2d1
+        YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiJGZWRvcmFfMTci
+        LCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92
+        My9wdWJsaWNhdGlvbnMvcnBtL3JwbS81MDIzM2NkNS0yOGNkLTRkNDctOTc5
+        OS0wN2RmZDI1YTAzMjkvIn0=
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:14:57 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/content/rpm/packages/?pkgId=5bd363b860ad6783217cbca3bbc3ef260f98d140ffb121bf4c208e3f66c24712
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:01 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 19803e5d169c496890f4b022c1a7a339
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '916'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy8yYjUwZDY2Zi1kYWVhLTQ4OWYtODVjZi03MTMwMzM2ZTBlOWQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNC0wN1QxNzoxNDozNy44OTQzNjFa
+        IiwibWQ1IjpudWxsLCJzaGExIjoiYzkxOGJkOTFhMDQyMTg1NWY5MjI5OGU0
+        OGI1NTdjNTdmYjY1YWM5YSIsInNoYTIyNCI6ImE3ZjU1NDJkNTI5NjU3Mjk3
+        Y2FjMDlkMGU3YjExNmQ5ODM1NTEyMTNiMTQ0M2QzMWIyODY3ODVkIiwic2hh
+        MjU2IjoiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0
+        MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsInNoYTM4NCI6ImZjZWFhZDk4
+        ZjI5ODI1MzIwYzYwY2RhM2E4ZDJiYzdmZTc2YWEzZjdiMmRiOWU2YjI2MWJi
+        OGFkZTYwNmNhZDgwNDU0N2M3YzM1YjExYmU5NDllNmM0ZDdiMzM3ZTMzZCIs
+        InNoYTUxMiI6Ijc0ZjBhZTBiOGJhM2Q3ZjJiOGYxNjc3NGE1ZjQwOTc5Y2Fj
+        MjgwMmVhODZmZDg0ZGZhODM5MDIzYjM4NjcxNWY4ZTQ5YTllMmVjMTg5OTgw
+        MmY5NzA1OTRmMGU4ZjZkMmE0MDY2YjI1OTQwNmQyMjM3YmE4YmI5MjJlMTNi
+        YmUyIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzY5NWY1
+        OGM3LTdlMTMtNDdjNS1hYWM2LTc4YmY3NDVjNDBhZi8iLCJuYW1lIjoiZHVj
+        ayIsImVwb2NoIjoiMCIsInZlcnNpb24iOiIwLjciLCJyZWxlYXNlIjoiMSIs
+        ImFyY2giOiJub2FyY2giLCJwa2dJZCI6IjViZDM2M2I4NjBhZDY3ODMyMTdj
+        YmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIi
+        LCJjaGVja3N1bV90eXBlIjoic2hhMjU2Iiwic3VtbWFyeSI6IlF1YWNrIGxp
+        a2UgYSBkdWNrIGF0IHRoZSBwYXJrLiIsImRlc2NyaXB0aW9uIjoiQSBmaXh0
+        dXJlIFJQTSBmb3IgdGVzdGluZyBQdWxwLiIsInVybCI6IiIsImNoYW5nZWxv
+        Z3MiOltdLCJmaWxlcyI6W1siIiwiL3Vzci9iaW4vIiwiZHVjay50eHQiXV0s
+        InJlcXVpcmVzIjpbXSwicHJvdmlkZXMiOltbImR1Y2siLCJFUSIsIjAiLCIw
+        LjciLCIxIixmYWxzZV1dLCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMiOltd
+        LCJzdWdnZXN0cyI6W10sImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6W10s
+        InN1cHBsZW1lbnRzIjpbXSwibG9jYXRpb25fYmFzZSI6IiIsImxvY2F0aW9u
+        X2hyZWYiOiJkdWNrLTAuNy4xLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0
+        IjoibG9jYWxob3N0LmxvY2FsZG9tYWluIiwicnBtX2dyb3VwIjoiVW5zcGVj
+        aWZpZWQiLCJycG1fbGljZW5zZSI6IlB1YmxpYyBEb21haW4iLCJycG1fcGFj
+        a2FnZXIiOiIiLCJycG1fc291cmNlcnBtIjoiZHVjay0wLjctMS5zcmMucnBt
+        IiwicnBtX3ZlbmRvciI6IiIsInJwbV9oZWFkZXJfc3RhcnQiOjQ1MDQsInJw
+        bV9oZWFkZXJfZW5kIjo2MzY0LCJpc19tb2R1bGFyIjpmYWxzZSwic2l6ZV9h
+        cmNoaXZlIjoyNjQsInNpemVfaW5zdGFsbGVkIjo1LCJzaXplX3BhY2thZ2Ui
+        OjY1NDAsInRpbWVfYnVpbGQiOjE1MzMwNjYwMTcsInRpbWVfZmlsZSI6MTY0
+        OTM1MTY3N31dfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:01 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/fc6d4c62-d504-4776-84da-eb3bfb79e4a3/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvMmI1MGQ2NmYtZGFlYS00ODlmLTg1Y2YtNzEzMDMzNmUw
+        ZTlkLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:01 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 62c2d605cb064796b99134d21a2f8319
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UyODA4NDMxLTEyMWYtNDVh
+        NS05NDNmLTNiMzBiZjhlZGRkMC8ifQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:01 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/e2808431-121f-45a5-943f-3b30bf8eddd0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:01 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5d4f9a0916f94497b54199b4304cfc84
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTI4MDg0MzEtMTIx
+        Zi00NWE1LTk0M2YtM2IzMGJmOGVkZGQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTc6MDEuNTY2OTEwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiI2MmMyZDYwNWNiMDY0Nzk2Yjk5
+        MTM0ZDIxYTJmODMxOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE3
+        OjAxLjYyMTQ1NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTc6
+        MDEuNzk5NTMyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy82MTM3ZDU3Yy1jZDU0LTRjNzctOTM1Ny00ZWUxM2RmZjE1
+        OGEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS9mYzZkNGM2Mi1kNTA0LTQ3NzYtODRkYS1lYjNiZmI3OWU0YTMvdmVyc2lv
+        bnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmM2ZDRjNjItZDUwNC00Nzc2
+        LTg0ZGEtZWIzYmZiNzllNGEzLyJdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:01 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/content/rpm/packages/?pkgId=833af594bc0ba31256045ed1fb17d3df2d8341a89b0c5a9bf610dd6103ce4cc8
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ecc202b9c7ee4eff9d04e6a37d658b39
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '906'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3JwbS9w
+        YWNrYWdlcy81ZTUxZDI5NS02YTFkLTQ4YmMtYWUyMS01MmJkNTI4MzJmMzAv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNC0wN1QxNzoxNDo1NS4yODY4MzZa
+        IiwibWQ1IjpudWxsLCJzaGExIjoiMDA0ZWUyOWMwMjlkMTQyNTcwNWVjYTQ2
+        MWU0ODlkMGYzNzhkM2U4YyIsInNoYTIyNCI6IjAxZTNmMmE1YjJlZDNmMTE5
+        OWEwNmU2YzQ0YWFjODM5MzVjYmQ2NmY5NThhMzBhYTdkMjVhNGY0Iiwic2hh
+        MjU2IjoiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFh
+        ODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsInNoYTM4NCI6Ijc1MGE1Yjc0
+        YWZlNzc3Nzc1NDI1ZGM1OWY1MDA2MjM4NTJiYTFkZTdkOGQxY2U0ODc5ZmVl
+        NDI2Y2JiZmVhOTU5YzFkYjFjNTEwYmNhNGEwZGJhZjBjODRlZmMwZTE5YiIs
+        InNoYTUxMiI6IjM1YmE2OTJhN2E3YjJkODQzNjZiMDE1ODE0N2U3ZWRlNDZm
+        MzgwYzBlNmFjZGYzOTE4YzRiMDllOGI3MjIxNmRhMTU4NTQ1ZTg0OGFiMThk
+        NzlhZWEwNDA0ZjM0MGU1ZjIwYWZmNzc3MmRmNmE0MDQ3MTBjNzE0YmFkMjIy
+        NzczIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2ZjYmFh
+        MzIwLTQzMTgtNDA5MC05OWQzLWM0OTlmYTZiZGI3MS8iLCJuYW1lIjoia2Fu
+        Z2Fyb28iLCJlcG9jaCI6IjAiLCJ2ZXJzaW9uIjoiMC4yIiwicmVsZWFzZSI6
+        IjEiLCJhcmNoIjoibm9hcmNoIiwicGtnSWQiOiI4MzNhZjU5NGJjMGJhMzEy
+        NTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIwYzVhOWJmNjEwZGQ2MTAzY2U0
+        Y2M4IiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiIsInN1bW1hcnkiOiJBIGR1
+        bW15IHBhY2thZ2Ugb2Yga2FuZ2Fyb28iLCJkZXNjcmlwdGlvbiI6IkEgZHVt
+        bXkgcGFja2FnZSBvZiBrYW5nYXJvbyIsInVybCI6Imh0dHA6Ly90c3RyYWNo
+        b3RhLmZlZG9yYXBlb3BsZS5vcmciLCJjaGFuZ2Vsb2dzIjpbXSwiZmlsZXMi
+        OltbIiIsIi90bXAvIiwia2FuZ2Fyb28udHh0Il1dLCJyZXF1aXJlcyI6W10s
+        InByb3ZpZGVzIjpbWyJrYW5nYXJvbyIsIkVRIiwiMCIsIjAuMiIsIjEiLGZh
+        bHNlXV0sImNvbmZsaWN0cyI6W10sIm9ic29sZXRlcyI6W10sInN1Z2dlc3Rz
+        IjpbXSwiZW5oYW5jZXMiOltdLCJyZWNvbW1lbmRzIjpbXSwic3VwcGxlbWVu
+        dHMiOltdLCJsb2NhdGlvbl9iYXNlIjoiIiwibG9jYXRpb25faHJlZiI6Imth
+        bmdhcm9vLTAuMi0xLm5vYXJjaC5ycG0iLCJycG1fYnVpbGRob3N0Ijoic21x
+        ZS13czE1IiwicnBtX2dyb3VwIjoiSW50ZXJuZXQvQXBwbGljYXRpb25zIiwi
+        cnBtX2xpY2Vuc2UiOiJHUEx2MiIsInJwbV9wYWNrYWdlciI6IiIsInJwbV9z
+        b3VyY2VycG0iOiJrYW5nYXJvby0wLjItMS5zcmMucnBtIiwicnBtX3ZlbmRv
+        ciI6IiIsInJwbV9oZWFkZXJfc3RhcnQiOjI4MCwicnBtX2hlYWRlcl9lbmQi
+        OjE3MjEsImlzX21vZHVsYXIiOmZhbHNlLCJzaXplX2FyY2hpdmUiOjMwMCwi
+        c2l6ZV9pbnN0YWxsZWQiOjQyLCJzaXplX3BhY2thZ2UiOjE4NzUsInRpbWVf
+        YnVpbGQiOjEzMzE4MzEzNzYsInRpbWVfZmlsZSI6MTY0OTM1MTY5NX1dfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:02 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/repositories/rpm/rpm/fc6d4c62-d504-4776-84da-eb3bfb79e4a3/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9y
+        cG0vcGFja2FnZXMvNWU1MWQyOTUtNmExZC00OGJjLWFlMjEtNTJiZDUyODMy
+        ZjMwLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 28eea66bc0104636bf7c951391faeaeb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q4N2FlYmU4LTQxZjctNGU4
+        NS04NTdmLWRkNGZjMGQ2NjIyYi8ifQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:02 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/d87aebe8-41f7-4e85-857f-dd4fc0d6622b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d0fc8a55280243a6b27dadf2757543d9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '386'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDg3YWViZTgtNDFm
+        Ny00ZTg1LTg1N2YtZGQ0ZmMwZDY2MjJiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTc6MDIuMzE4NjU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwibG9nZ2luZ19jaWQiOiIyOGVlYTY2YmMwMTA0NjM2YmY3
+        Yzk1MTM5MWZhZWFlYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE3
+        OjAyLjM3NTU1MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTc6
+        MDIuNTQwNzc2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy82MTM3ZDU3Yy1jZDU0LTRjNzctOTM1Ny00ZWUxM2RmZjE1
+        OGEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3Jw
+        bS9mYzZkNGM2Mi1kNTA0LTQ3NzYtODRkYS1lYjNiZmI3OWU0YTMvdmVyc2lv
+        bnMvMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZmM2ZDRjNjItZDUwNC00Nzc2
+        LTg0ZGEtZWIzYmZiNzllNGEzLyJdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:02 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/publications/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL3JwbS9ycG0vZmM2ZDRjNjItZDUwNC00Nzc2LTg0ZGEtZWIzYmZiNzll
+        NGEzL3ZlcnNpb25zLzIvIiwiZ3BnY2hlY2siOjAsInJlcG9fZ3BnY2hlY2si
+        OjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fe854f769758411d9b50cbadd3a721ad
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZkYTllNGEwLWM4ZTEtNDQ3
+        OC1iNTc0LWVkZDdiOGFlZjZlYy8ifQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:03 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/content/rpm/packages/5e51d295-6a1d-48bc-ae21-52bd52832f30/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0ed7a1b9da1540768fd63fe34011b45b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '877'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2Fn
+        ZXMvNWU1MWQyOTUtNmExZC00OGJjLWFlMjEtNTJiZDUyODMyZjMwLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDQtMDdUMTc6MTQ6NTUuMjg2ODM2WiIsIm1k
+        NSI6bnVsbCwic2hhMSI6IjAwNGVlMjljMDI5ZDE0MjU3MDVlY2E0NjFlNDg5
+        ZDBmMzc4ZDNlOGMiLCJzaGEyMjQiOiIwMWUzZjJhNWIyZWQzZjExOTlhMDZl
+        NmM0NGFhYzgzOTM1Y2JkNjZmOTU4YTMwYWE3ZDI1YTRmNCIsInNoYTI1NiI6
+        IjgzM2FmNTk0YmMwYmEzMTI1NjA0NWVkMWZiMTdkM2RmMmQ4MzQxYTg5YjBj
+        NWE5YmY2MTBkZDYxMDNjZTRjYzgiLCJzaGEzODQiOiI3NTBhNWI3NGFmZTc3
+        Nzc3NTQyNWRjNTlmNTAwNjIzODUyYmExZGU3ZDhkMWNlNDg3OWZlZTQyNmNi
+        YmZlYTk1OWMxZGIxYzUxMGJjYTRhMGRiYWYwYzg0ZWZjMGUxOWIiLCJzaGE1
+        MTIiOiIzNWJhNjkyYTdhN2IyZDg0MzY2YjAxNTgxNDdlN2VkZTQ2ZjM4MGMw
+        ZTZhY2RmMzkxOGM0YjA5ZThiNzIyMTZkYTE1ODU0NWU4NDhhYjE4ZDc5YWVh
+        MDQwNGYzNDBlNWYyMGFmZjc3NzJkZjZhNDA0NzEwYzcxNGJhZDIyMjc3MyIs
+        ImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9mY2JhYTMyMC00
+        MzE4LTQwOTAtOTlkMy1jNDk5ZmE2YmRiNzEvIiwibmFtZSI6Imthbmdhcm9v
+        IiwiZXBvY2giOiIwIiwidmVyc2lvbiI6IjAuMiIsInJlbGVhc2UiOiIxIiwi
+        YXJjaCI6Im5vYXJjaCIsInBrZ0lkIjoiODMzYWY1OTRiYzBiYTMxMjU2MDQ1
+        ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIs
+        ImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJzdW1tYXJ5IjoiQSBkdW1teSBw
+        YWNrYWdlIG9mIGthbmdhcm9vIiwiZGVzY3JpcHRpb24iOiJBIGR1bW15IHBh
+        Y2thZ2Ugb2Yga2FuZ2Fyb28iLCJ1cmwiOiJodHRwOi8vdHN0cmFjaG90YS5m
+        ZWRvcmFwZW9wbGUub3JnIiwiY2hhbmdlbG9ncyI6W10sImZpbGVzIjpbWyIi
+        LCIvdG1wLyIsImthbmdhcm9vLnR4dCJdXSwicmVxdWlyZXMiOltdLCJwcm92
+        aWRlcyI6W1sia2FuZ2Fyb28iLCJFUSIsIjAiLCIwLjIiLCIxIixmYWxzZV1d
+        LCJjb25mbGljdHMiOltdLCJvYnNvbGV0ZXMiOltdLCJzdWdnZXN0cyI6W10s
+        ImVuaGFuY2VzIjpbXSwicmVjb21tZW5kcyI6W10sInN1cHBsZW1lbnRzIjpb
+        XSwibG9jYXRpb25fYmFzZSI6IiIsImxvY2F0aW9uX2hyZWYiOiJrYW5nYXJv
+        by0wLjItMS5ub2FyY2gucnBtIiwicnBtX2J1aWxkaG9zdCI6InNtcWUtd3Mx
+        NSIsInJwbV9ncm91cCI6IkludGVybmV0L0FwcGxpY2F0aW9ucyIsInJwbV9s
+        aWNlbnNlIjoiR1BMdjIiLCJycG1fcGFja2FnZXIiOiIiLCJycG1fc291cmNl
+        cnBtIjoia2FuZ2Fyb28tMC4yLTEuc3JjLnJwbSIsInJwbV92ZW5kb3IiOiIi
+        LCJycG1faGVhZGVyX3N0YXJ0IjoyODAsInJwbV9oZWFkZXJfZW5kIjoxNzIx
+        LCJpc19tb2R1bGFyIjpmYWxzZSwic2l6ZV9hcmNoaXZlIjozMDAsInNpemVf
+        aW5zdGFsbGVkIjo0Miwic2l6ZV9wYWNrYWdlIjoxODc1LCJ0aW1lX2J1aWxk
+        IjoxMzMxODMxMzc2LCJ0aW1lX2ZpbGUiOjE2NDkzNTE2OTV9
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:03 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/6da9e4a0-c8e1-4478-b574-edd7b8aef6ec/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - '092f740bc982423e89c4ff1feb639493'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '474'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmRhOWU0YTAtYzhl
+        MS00NDc4LWI1NzQtZWRkN2I4YWVmNmVjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTc6MDMuMDQ2NjM0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
+        c2giLCJsb2dnaW5nX2NpZCI6ImZlODU0Zjc2OTc1ODQxMWQ5YjUwY2JhZGQz
+        YTcyMWFkIiwic3RhcnRlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTc6MDMuMDk2
+        MTQ1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNC0wN1QxNzoxNzowMy4zNTAw
+        NDVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzYxMzdkNTdjLWNkNTQtNGM3Ny05MzU3LTRlZTEzZGZmMTU4YS8iLCJw
+        YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
+        IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
+        dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
+        ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
+        OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vODliOGJh
+        YTMtMWJjZC00Y2RlLWE1MzktZDg5YTdmYTgyYTZmLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL3JwbS9ycG0vZmM2ZDRjNjItZDUwNC00Nzc2LTg0ZGEtZWIzYmZi
+        NzllNGEzLyJdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:03 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2abd6b2d2f9c400fa25fbc59ec275c5e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:03 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3Jh
+        XzE3X2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6IkZlZG9y
+        YV8xNyIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9u
+        cy9ycG0vcnBtLzg5YjhiYWEzLTFiY2QtNGNkZS1hNTM5LWQ4OWE3ZmE4MmE2
+        Zi8ifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d1d7c5def2f6451aab2a1d28ab8922e7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBiNDJmZWZmLTIxODktNDEw
+        Yy1iZjY5LWNlOTEwNDhmM2UzOC8ifQ==
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:03 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/tasks/0b42feff-2189-410c-bf69-ce91048f3e38/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.16.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ccfecc937ee14aafb857f5c128d28fe9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '378'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMGI0MmZlZmYtMjE4
+        OS00MTBjLWJmNjktY2U5MTA0OGYzZTM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDQtMDdUMTc6MTc6MDMuNTMyMTQ2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJkMWQ3YzVkZWYyZjY0NTFhYWIyYTFkMjhh
+        Yjg5MjJlNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA0LTA3VDE3OjE3OjAzLjU4
+        ODYzNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDQtMDdUMTc6MTc6MDMuNzkw
+        MDk0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8zNzI3MDBmOC1jYjk1LTQyMzMtOGFkNy04ZDdjZjg1M2YyMWIvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vYWMy
+        OWM2YWYtZjI0Mi00YjdiLWEyNjAtMGZiYmZkMTZmMTBlLyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:03 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.samir.example.com/pulp/api/v3/distributions/rpm/rpm/ac29c6af-f242-4b7b-a260-0fbbfd16f10e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 Apr 2022 17:17:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 807e7db03b07434484a11290af26c9c5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.samir.example.com
+      Content-Length:
+      - '302'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2FjMjljNmFmLWYyNDItNGI3Yi1hMjYwLTBmYmJmZDE2ZjEwZS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA0LTA3VDE3OjE3OjAzLjc2ODM5NFoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3
+        X2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0ZWxsby1k
+        ZXZlbC5zYW1pci5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jw
+        b3JhdGlvbi9saWJyYXJ5L2ZlZG9yYV8xN19sYWJlbC8iLCJjb250ZW50X2d1
+        YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiJGZWRvcmFfMTci
+        LCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92
+        My9wdWJsaWNhdGlvbnMvcnBtL3JwbS84OWI4YmFhMy0xYmNkLTRjZGUtYTUz
+        OS1kODlhN2ZhODJhNmYvIn0=
+    http_version: 
+  recorded_at: Thu, 07 Apr 2022 17:17:03 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Upload additively so as not to delete all existing content on the repo being uploaded to. And make import_all respect mirroring policy.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
A. 
1. Upload content to repositories of type yum and possibly deb if you want to test it.
2. The existing rpms in the repo should not get deleted.

B. 
1. Set mirroring policy to additive on a repo.
2. Sync
3. Upload package.
4. Resync. 
5. Repo should have the uploaded package persist.