### PR TITLE
Fixes #34753 - add ouiaId prop to update buttons in CDN configuration

### DIFF
--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/AirGappedTypeForm.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/AirGappedTypeForm.js
@@ -55,6 +55,7 @@ const AirGappedTypeForm = ({ showUpdate, onUpdate }) => {
 
       <ActionGroup>
         <Button
+          ouiaId="export-sync-configuration-update-button"
           aria-label="update-airgapped-configuration"
           variant="secondary"
           onClick={performUpdate}

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/CdnTypeForm.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/CdnTypeForm.js
@@ -78,6 +78,7 @@ const CdnTypeForm = ({ showUpdate, onUpdate, url }) => {
 
       <ActionGroup>
         <Button
+          ouiaId="cdn-configuration-update-button"
           aria-label="update-cdn-configuration"
           variant="secondary"
           onClick={performUpdate}

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/UpstreamServerTypeForm.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/UpstreamServerTypeForm.js
@@ -220,6 +220,7 @@ const UpstreamServerTypeForm = ({
 
         <ActionGroup>
           <Button
+            ouiaId="network-sync-configuration-update-button"
             aria-label="update-upstream-configuration"
             variant="secondary"
             onClick={performUpdate}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add `ouiaId` prop to `Update` buttons in `CDN Configuration`

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Content -> Subscriptions -> Manage Manifest -> CDN Configuration
Go to each one of  the following: 
  `Red Hat CDN`, `Upstream Foreman server`, and `Air-gapped`
Inspect `Update` button to ensure that the `data-ouia-component-id` prop is now static.
