### PR TITLE
Fixes #34736 - Show added filter rule content even if repository is removed

### DIFF
--- a/app/controllers/katello/api/v2/errata_controller.rb
+++ b/app/controllers/katello/api/v2/errata_controller.rb
@@ -35,7 +35,9 @@ module Katello
     end
 
     def all_for_content_view_filter(filter, _collection)
-      Erratum.joins(:repositories).merge(filter.applicable_repos)
+      available_ids = Erratum.joins(:repositories).merge(filter.applicable_repos)&.pluck(:errata_id) || []
+      added_ids = filter&.erratum_rules&.pluck(:errata_id) || []
+      Erratum.where(errata_id: available_ids + added_ids)
     end
 
     def custom_index_relation(collection)

--- a/app/controllers/katello/api/v2/module_streams_controller.rb
+++ b/app/controllers/katello/api/v2/module_streams_controller.rb
@@ -36,7 +36,9 @@ module Katello
     end
 
     def all_for_content_view_filter(filter, _collection)
-      ModuleStream.joins(:repositories).merge(filter.applicable_repos)
+      available_ids = ModuleStream.joins(:repositories).merge(filter.applicable_repos)&.pluck(:id) || []
+      added_ids = filter&.module_stream_rules&.pluck(:module_stream_id) || []
+      ModuleStream.where(id: available_ids + added_ids)
     end
 
     def available_for_content_view_filter(filter, _collection)

--- a/app/controllers/katello/api/v2/package_groups_controller.rb
+++ b/app/controllers/katello/api/v2/package_groups_controller.rb
@@ -67,7 +67,9 @@ module Katello
     end
 
     def all_for_content_view_filter(filter, _collection)
-      PackageGroup.joins(:repositories).merge(filter.applicable_repos)
+      available_ids = PackageGroup.joins(:repositories).merge(filter.applicable_repos)&.pluck(:pulp_id) || []
+      added_ids = filter&.package_group_rules&.pluck(:uuid) || []
+      PackageGroup.where(pulp_id: available_ids + added_ids)
     end
 
     def default_sort


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add all added content to filter rules irrespective of repository being in CV or not.
#### Considerations taken when implementing this change?
Only 3 content type rules are impacted:
1. Module Stream
2. Errata by Id
3. Package groups
These rules add actual content unit records to the filter rule and not conditions like date & type or nvra to filter. 
#### What are the testing steps for this pull request?
Steps to reproduce for errata.
1. Sync a repo with errata.
2. Create a CV and add the repo to it.
3. Create an errata filter, add any errata from the synced repo to the filter.
4. Remove repo from CV.
5. The Errata filter does not show the added errata from the repo although it is still applied in the backend.

Repeat the steps for module streams, package groups.
Verify that everything works properly.