### PR TITLE
Fixes #34760 - Hide profiles for module streams

### DIFF
--- a/app/views/katello/api/v2/module_streams/show.json.rabl
+++ b/app/views/katello/api/v2/module_streams/show.json.rabl
@@ -6,13 +6,6 @@ child :artifacts => :artifacts do
   attributes :id, :name
 end
 
-child :profiles => :profiles do
-  attributes :id, :name
-  child :rpms => :rpms do
-    attributes :id, :name
-  end
-end
-
 child :library_repositories => :repositories do
   attributes :id, :name
   glue :product do

--- a/webpack/scenes/ModuleStreams/Details/ModuleDetailsSchema.js
+++ b/webpack/scenes/ModuleStreams/Details/ModuleDetailsSchema.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
 import ModuleStreamDetailArtifacts from './ModuleStreamDetailArtifacts';
-import ModuleStreamDetailProfiles from './Profiles/ModuleStreamDetailProfiles';
 import ContentDetailInfo from '../../../components/Content/Details/ContentDetailInfo';
 import ContentDetailRepositories from '../../../components/Content/Details/ContentDetailRepositories';
 
@@ -17,7 +16,7 @@ export const displayMap = new Map([
 ]);
 
 export default (detailInfo) => {
-  const { repositories, profiles, artifacts } = detailInfo;
+  const { repositories, artifacts } = detailInfo;
 
   return [
     {
@@ -37,14 +36,6 @@ export default (detailInfo) => {
     },
     {
       key: 3,
-      tabHeader: __('Profiles'),
-      tabContent: (profiles && profiles.length ?
-        <ModuleStreamDetailProfiles profiles={profiles} /> :
-        __('No profiles to show')
-      ),
-    },
-    {
-      key: 4,
       tabHeader: __('Artifacts'),
       tabContent: (artifacts && artifacts.length ?
         <ModuleStreamDetailArtifacts artifacts={artifacts} /> :

--- a/webpack/scenes/ModuleStreams/Details/ModuleStreamDetails.js
+++ b/webpack/scenes/ModuleStreams/Details/ModuleStreamDetails.js
@@ -44,21 +44,20 @@ class ModuleStreamDetails extends Component {
     return (
       <div>
         {!loading && <BreadcrumbsBar
+          isLoadingResources={loading}
           onSwitcherItemClick={(e, url) => this.handleBreadcrumbSwitcherItem(e, url)}
-          data={{
-            isSwitchable: true,
-            breadcrumbItems: [
-              {
-                caption: __('Module Streams'),
-                onClick: () =>
-                  this.props.history.push('/module_streams'),
-              },
-              {
-                caption: `${name} ${stream}`,
-              },
-            ],
-            resource,
-          }}
+          isSwitchable
+          breadcrumbItems={[
+            {
+              caption: __('Module Streams'),
+              onClick: () =>
+                this.props.history.push('/module_streams'),
+            },
+            {
+              caption: `${name} ${stream}`,
+            },
+          ]}
+          resource={resource}
         />}
         <ContentDetails
           contentDetails={moduleStreamDetails}

--- a/webpack/scenes/ModuleStreams/Details/__tests__/__snapshots__/ModuleStreamDetails.test.js.snap
+++ b/webpack/scenes/ModuleStreams/Details/__tests__/__snapshots__/ModuleStreamDetails.test.js.snap
@@ -76,11 +76,6 @@ exports[`Module stream details page rendering renders with loading state 1`] = `
         },
         Object {
           "key": 3,
-          "tabContent": "No profiles to show",
-          "tabHeader": "Profiles",
-        },
-        Object {
-          "key": 4,
           "tabContent": "No artifacts to show",
           "tabHeader": "Artifacts",
         },
@@ -93,26 +88,26 @@ exports[`Module stream details page rendering renders with loading state 1`] = `
 exports[`Module stream details page rendering renders with module stream provided 1`] = `
 <div>
   <BreadcrumbsBar
-    data={
-      Object {
-        "breadcrumbItems": Array [
-          Object {
-            "caption": "Module Streams",
-            "onClick": [Function],
-          },
-          Object {
-            "caption": "avocado latest",
-          },
-        ],
-        "isSwitchable": true,
-        "resource": Object {
-          "nameField": "name",
-          "resourceUrl": "/katello/api/v2/module_streams",
-          "switcherItemUrl": "/module_streams/:id",
+    breadcrumbItems={
+      Array [
+        Object {
+          "caption": "Module Streams",
+          "onClick": [Function],
         },
+        Object {
+          "caption": "avocado latest",
+        },
+      ]
+    }
+    isSwitchable={true}
+    onSwitcherItemClick={[Function]}
+    resource={
+      Object {
+        "nameField": "name",
+        "resourceUrl": "/katello/api/v2/module_streams",
+        "switcherItemUrl": "/module_streams/:id",
       }
     }
-    onSwitcherItemClick={[Function]}
   />
   <ContentDetails
     contentDetails={
@@ -397,84 +392,6 @@ exports[`Module stream details page rendering renders with module stream provide
         },
         Object {
           "key": 3,
-          "tabContent": <ModuleStreamDetailProfiles
-            profiles={
-              Array [
-                Object {
-                  "id": 37,
-                  "name": "default",
-                  "rpms": Array [
-                    Object {
-                      "id": 108,
-                      "name": "perl",
-                    },
-                    Object {
-                      "id": 110,
-                      "name": "foo",
-                    },
-                    Object {
-                      "id": 111,
-                      "name": "rpm_0",
-                    },
-                    Object {
-                      "id": 112,
-                      "name": "rpm_1",
-                    },
-                    Object {
-                      "id": 113,
-                      "name": "rpm_2",
-                    },
-                    Object {
-                      "id": 114,
-                      "name": "rpm_3",
-                    },
-                    Object {
-                      "id": 115,
-                      "name": "rpm_4",
-                    },
-                    Object {
-                      "id": 116,
-                      "name": "rpm_5",
-                    },
-                    Object {
-                      "id": 117,
-                      "name": "rpm_6",
-                    },
-                    Object {
-                      "id": 118,
-                      "name": "rpm_7",
-                    },
-                    Object {
-                      "id": 119,
-                      "name": "rpm_8",
-                    },
-                    Object {
-                      "id": 120,
-                      "name": "rpm_9",
-                    },
-                    Object {
-                      "id": 121,
-                      "name": "rpm_10",
-                    },
-                  ],
-                },
-                Object {
-                  "id": 38,
-                  "name": "minimal",
-                  "rpms": Array [
-                    Object {
-                      "id": 84,
-                      "name": "python2-avocado",
-                    },
-                  ],
-                },
-              ]
-            }
-          />,
-          "tabHeader": "Profiles",
-        },
-        Object {
-          "key": 4,
           "tabContent": <ModuleStreamDetailArtifacts
             artifacts={
               Array [


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Hide Module Stream profiles from UI/Hammer/API since we don't have that data anymore.
#### Considerations taken when implementing this change?
Pulp no longer provides the profile information for module streams for katello to index.
We have an issue open for pulp to consider adding it https://github.com/pulp/pulp_rpm/issues/2456
In the meantime, we should hide user-facing profile details since it's empty.
#### What are the testing steps for this pull request?
On UI:

Sync a repo with modules.
Go to > Content > Module Streams > module_stream_record
You shouldn't see the profiles tab.
Also check the breadcrumb bar. Due to some changes in foreman, the breadcrumb on the module stream page had stopped working.

In hammer
hammer -r module-stream info --id 1
should not show profile section anymore.
