### PR TITLE
Fixes #34766 - Show sync progress for never synced repos

### DIFF
--- a/app/views/katello/sync_management/_repo.html.erb
+++ b/app/views/katello/sync_management/_repo.html.erb
@@ -14,40 +14,19 @@
   <td class="size" data-size="<%= @repo_status[repo.id][:size] %>">
     <%= @repo_status[repo.id][:sync_id] ? @repo_status[repo.id][:display_size]  : _('N/A')%>
   </td>
-  <% if @repo_status[repo.id][:sync_id] %>
-    <td class="result">
+  <td class="result">
       <span class="result-info">
+        <% if @repo_status[repo.id][:sync_id] %>
           <a href="/foreman_tasks/tasks/<%= @repo_status[repo.id][:sync_id] %>">
             <%= @repo_status[repo.id][:state] %>
           </a>
+        <% elsif repo&.latest_sync_audit&.created_at %>
+          <%= _("Synced ") + time_ago_in_words(repo&.latest_sync_audit&.created_at) + _(" ago.") %>
+        <% else%>
+          <%= @repo_status[repo.id][:state] %>
+        <% end %>
       </span>
-      <a class="info-tipsy clickable fa fa-warning <%= 'hidden' if @repo_status[repo.id][:raw_state] != 'error' %>"
-         href="/foreman_tasks/tasks/<%= @repo_status[repo.id][:sync_id] %>">
-        <span class="hidden-text hidden">
-          <div class="la error-tipsy">
-            <ul>
-              <% if @repo_status[repo.id][:error_details].present? && error_state?(@repo_status[repo.id]) %>
-                <% @repo_status[repo.id][:error_details][:messages].each do |error| %>
-                  <li>
-                    <%= error %>
-                  </li>
-                <% end %>
-              <% end %>
-            </ul>
-          </div>
-        </span>
-      </a>
-    </td>
-  <% elsif repo&.latest_sync_audit&.created_at %>
-    <td>
-      <%= _("Synced ") + time_ago_in_words(repo&.latest_sync_audit&.created_at) + _(" ago.") %>
-    </td>
-  <% else%>
-    <td>
-      <%= @repo_status[repo.id][:state] %>
-    </td>
-  <% end %>
-
+  </td>
   <% if @show_org %>
     <td></td>
   <% end %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
For some reason, the page doesn't update with changing data if we use the if/else to render the td.
What happens because of that is if @repo_status[repo.id][:sync_id] is not present(In case of never synced repos. If a repo has been synced atleast once, this is true and hence we do see status updates reflect for synced repos.)
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a new repo/ Enable a redhat repo
2. Go to sync status page
3. Select new repo (should say "never synced") and synchronize on the page.
4. With this PR, you should see a progress bar for the sync.
5. It should behave similarly for already synced repos for a resync.
