### PR TITLE
Fixes #34770 - Pin pulp_rpm_client to <3.17.5

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "pulp_ansible_client", ">= 0.10", "< 0.11"
   gem.add_dependency "pulp_container_client", ">= 2.9.0", "< 2.10.0"
   gem.add_dependency "pulp_deb_client", ">= 2.16.0", "< 2.17.0"
-  gem.add_dependency "pulp_rpm_client", ">=3.17.0", "< 3.18.0"
+  gem.add_dependency "pulp_rpm_client", ">=3.17.0", "< 3.17.5"
   gem.add_dependency "pulp_certguard_client", "< 2.0"
   gem.add_dependency "pulp_python_client", ">= 3.5.0", "< 3.6.0"
   gem.add_dependency "pulp_ostree_client"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Pin pulp_rpm_client to <3.17.5
#### Considerations taken when implementing this change?
https://github.com/pulp/pulp_rpm/issues/2490
#### What are the testing steps for this pull request?
Tests should be green!