### PR TITLE
Fixes #34788 - render smart_proxies/show also for non-content

### DIFF
--- a/app/views/foreman/smart_proxies/show.html.erb
+++ b/app/views/foreman/smart_proxies/show.html.erb
@@ -6,4 +6,6 @@
   <div ng-controller="PulpPrimaryController">
     <%= render :file => 'smart_proxies/show' %>
   </div>
+<% else -%>
+  <%= render :file => 'smart_proxies/show' %>
 <% end -%>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This adds back the `else` branch that was removed in #9811

#### Considerations taken when implementing this change?

None ;-)

#### What are the testing steps for this pull request?

Deploy a Katello with a non-content proxy, without this patch the info page under "Infrastructure → Smart Proxies" renders empty for that particular proxy, while it works fine for those with content. After the patch, all should render correctly.

See https://community.theforeman.org/t/smart-proxy-page-is-empty/28189 for the original report and discussion.