### PR TITLE
Fixes #34797 - Host detail page sentence case fixes

### DIFF
--- a/app/models/katello/purpose_sla_status.rb
+++ b/app/models/katello/purpose_sla_status.rb
@@ -2,7 +2,7 @@ module Katello
   class PurposeSlaStatus < HostStatus::Status
     UNKNOWN = Katello::PurposeStatus::UNKNOWN
     def self.status_name
-      N_('Service Level')
+      N_('Service level')
     end
 
     def self.humanized_name

--- a/app/models/katello/purpose_status.rb
+++ b/app/models/katello/purpose_status.rb
@@ -17,7 +17,7 @@ module Katello
     end
 
     def self.status_name
-      N_('System Purpose')
+      N_('System purpose')
     end
 
     def self.humanized_name
@@ -31,7 +31,7 @@ module Katello
       when MISMATCHED
         N_('Mismatched')
       when NOT_SPECIFIED
-        N_('Not Specified')
+        N_('Not specified')
       else
         N_('Unknown')
       end

--- a/test/models/purpose_status_test.rb
+++ b/test/models/purpose_status_test.rb
@@ -25,7 +25,7 @@ module Katello
       status.status = status.to_status
 
       assert_equal Katello::PurposeStatus::NOT_SPECIFIED, status.status
-      assert_equal 'Not Specified', status.to_label
+      assert_equal 'Not specified', status.to_label
     end
 
     def test_status_matched

--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
@@ -34,7 +34,7 @@ function HostInstallableErrata({
     <GridItem rowSpan={1} md={6} lg={4} xl2={3} >
       <Card isHoverable>
         <CardHeader>
-          <CardTitle>{__('Installable Errata')}</CardTitle>
+          <CardTitle>{__('Installable errata')}</CardTitle>
         </CardHeader>
         <CardBody>
           <Flex direction="column">


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

change some uppercase letters to lowercase on the new host detail page:
Manage all statuses - modal (from status card)
“Service level”
“System purpose”

Errata card
"Installable errata"

#### Considerations taken when implementing this change?

Only for the new Host detail page (we don't care about the old UI)

#### What are the testing steps for this pull request?

Restart the server and view the new host detail page
