### PR TITLE
Fixes #34808 - Repository Sets status tab

### DIFF
--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -31,13 +31,18 @@ module Katello
     param :host_id, :number, :desc => N_("Id of the host"), :required => false
     param :content_access_mode_all, :bool, :desc => N_("Get all content available, not just that provided by subscriptions.")
     param :content_access_mode_env, :bool, :desc => N_("Limit content to just that available in the host's or activation key's content view version and lifecycle environment.")
+    param :status, [:enabled, :disabled, :overridden],
+                                  :desc => N_("Limit content to enabled / disabled / overridden"),
+                                  :required => false
+
     param_group :search, Api::V2::ApiController
     add_scoped_search_description_for(Katello::ProductContent)
     def index
       collection = scoped_search(index_relation, :name, :asc, :resource_class => Katello::ProductContent)
       pcf = ProductContentFinder.wrap_with_overrides(
         product_contents: collection[:results],
-        overrides: @consumable&.content_overrides)
+        overrides: @consumable&.content_overrides,
+        status: params[:status])
       collection[:results] = custom_sort_results(pcf)
       respond(:collection => collection)
     end

--- a/app/presenters/katello/product_content_presenter.rb
+++ b/app/presenters/katello/product_content_presenter.rb
@@ -23,5 +23,20 @@ module Katello
       return [] if overrides.blank?
       overrides.select { |pc| pc.content_label == content.label }
     end
+
+    def status
+      overidden_value = enabled_content_override&.computed_value
+      if overidden_value.nil?
+        {
+          status: enabled ? "enabled" : "disabled",
+          overridden: false
+        }
+      else
+        {
+          status: overidden_value ? "enabled" : "disabled",
+          overridden: true
+        }
+      end
+    end
   end
 end

--- a/app/services/katello/product_content_finder.rb
+++ b/app/services/katello/product_content_finder.rb
@@ -30,8 +30,18 @@ module Katello
       consumable.organization.enabled_product_content_for(roots)
     end
 
-    def self.wrap_with_overrides(product_contents:, overrides:)
-      product_contents.map { |pc| ProductContentPresenter.new(pc, overrides) }
+    def self.wrap_with_overrides(product_contents:, overrides:, status: nil)
+      pc_with_overrides = product_contents.map { |pc| ProductContentPresenter.new(pc, overrides) }
+      if status
+        pc_with_overrides.keep_if do |pc|
+          if status == "overridden"
+            pc.status[:overridden]
+          else
+            pc.status[:status] == status
+          end
+        end
+      end
+      pc_with_overrides
     end
 
     def presenter_with_overrides(overrides)

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsConstants.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsConstants.js
@@ -1,2 +1,22 @@
+import { translate as __ } from 'foremanReact/common/I18n';
+
 export const REPOSITORY_SETS_KEY = 'HOST_DETAIL_REPOSITORY_SETS';
 export const CONTENT_OVERRIDES_KEY = 'HOST_DETAIL_CONTENT_OVERRIDES';
+
+export const STATUSES = {
+  ENABLED: __('Enabled'),
+  DISABLED: __('Disabled'),
+  OVERRIDDEN: __('Overridden'),
+};
+
+export const STATUS_TO_PARAM = {
+  [STATUSES.ENABLED]: 'enabled',
+  [STATUSES.DISABLED]: 'disabled',
+  [STATUSES.OVERRIDDEN]: 'overridden',
+};
+
+export const PARAM_TO_FRIENDLY_NAME = {
+  enabled: __('Enabled'),
+  disabled: __('Disabled'),
+  overridden: __('Overridden'),
+};


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
- Adds a status tab to repository sets tab where you can filter based on `Enabled/Disabed/Overridden`
#### Considerations taken when implementing this change?
- Had to tweak backend controller to make this work. 
#### What are the testing steps for this pull request?
Have a host pointing to a few repositories
Click on hosts -> host -> Repository Sets tab
Mess with the status dropdown.
