### PR TITLE
Fixes #34805 - Add happy empty states

### DIFF
--- a/webpack/components/SelectAllCheckbox/index.js
+++ b/webpack/components/SelectAllCheckbox/index.js
@@ -95,6 +95,7 @@ const SelectAllCheckbox = ({
               aria-label="Select all"
               onChange={checked => onSelectAllCheckboxChange(checked)}
               isChecked={selectionToggle}
+              isDisabled={totalCount === 0 && selectedCount === 0}
             >
               {selectedCount > 0 && `${selectedCount} selected`}
             </DropdownToggleCheckbox>,

--- a/webpack/components/SelectableDropdown/SelectableDropdown.js
+++ b/webpack/components/SelectableDropdown/SelectableDropdown.js
@@ -5,7 +5,7 @@ import { ErrorCircleOIcon } from '@patternfly/react-icons';
 
 
 const SelectableDropdown = ({
-  items, title, showTitle, selected, setSelected, loading, error,
+  items, title, showTitle, selected, setSelected, loading, error, isDisabled,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const icon = () => {
@@ -40,7 +40,7 @@ const SelectableDropdown = ({
           onSelect={onSelect}
           selections={selected}
           isOpen={isOpen}
-          isDisabled={loading || error}
+          isDisabled={loading || error || isDisabled}
           toggleIcon={icon()}
         >
           {selectItems}
@@ -59,12 +59,14 @@ SelectableDropdown.propTypes = {
   // If the items are loaded dynamically, you can pass in loading or error states
   loading: PropTypes.bool,
   error: PropTypes.bool,
+  isDisabled: PropTypes.bool,
 };
 
 SelectableDropdown.defaultProps = {
   loading: false,
   error: false,
   showTitle: true,
+  isDisabled: false,
 };
 
 

--- a/webpack/components/Table/EmptyStateMessage.js
+++ b/webpack/components/Table/EmptyStateMessage.js
@@ -9,18 +9,19 @@ import {
 } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { CubeIcon, ExclamationCircleIcon, SearchIcon } from '@patternfly/react-icons';
-import { global_danger_color_200 as dangerColor } from '@patternfly/react-tokens';
+import { CubeIcon, ExclamationCircleIcon, SearchIcon, CheckCircleIcon } from '@patternfly/react-icons';
+import { global_danger_color_200 as dangerColor, global_success_color_100 as successColor } from '@patternfly/react-tokens';
 
-const KatelloEmptyStateIcon = ({ error, search, customIcon }) => {
+const KatelloEmptyStateIcon = ({ error, search, customIcon, happyIcon }) => {
   if (error) return <EmptyStateIcon icon={ExclamationCircleIcon} color={dangerColor.value} />;
   if (search) return <EmptyStateIcon icon={SearchIcon} />;
+  if (happyIcon) return <EmptyStateIcon icon={CheckCircleIcon} color={successColor.value} />;
   if (customIcon) return <EmptyStateIcon icon={customIcon} />;
   return <EmptyStateIcon icon={CubeIcon} />;
 };
 
 const EmptyStateMessage = ({
-  title, body, error, search, customIcon,
+  title, body, error, search, customIcon, happy,
 }) => {
   let emptyStateTitle = title;
   let emptyStateBody = body;
@@ -37,8 +38,8 @@ const EmptyStateMessage = ({
   }
   return (
     <Bullseye>
-      <EmptyState variant={EmptyStateVariant.small}>
-        <KatelloEmptyStateIcon error={!!error} search={search} customIcon={customIcon} />
+      <EmptyState variant={happy ? EmptyStateVariant.large : EmptyStateVariant.small}>
+        <KatelloEmptyStateIcon error={!!error} search={search} customIcon={customIcon} happyIcon={happy} />
         <Title headingLevel="h2" size="lg">
           {emptyStateTitle}
         </Title>
@@ -54,12 +55,14 @@ KatelloEmptyStateIcon.propTypes = {
   error: PropTypes.bool,
   search: PropTypes.bool,
   customIcon: PropTypes.elementType,
+  happyIcon: PropTypes.bool,
 };
 
 KatelloEmptyStateIcon.defaultProps = {
   error: false,
   search: false,
   customIcon: undefined,
+  happyIcon: undefined,
 };
 
 EmptyStateMessage.propTypes = {

--- a/webpack/components/Table/EmptyStateMessage.js
+++ b/webpack/components/Table/EmptyStateMessage.js
@@ -67,13 +67,14 @@ KatelloEmptyStateIcon.defaultProps = {
 
 EmptyStateMessage.propTypes = {
   title: PropTypes.string,
-  body: PropTypes.string,
+  body: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({})]),
   error: PropTypes.oneOfType([
     PropTypes.shape({}),
     PropTypes.string,
   ]),
   search: PropTypes.bool,
   customIcon: PropTypes.elementType,
+  happy: PropTypes.bool,
 };
 
 EmptyStateMessage.defaultProps = {
@@ -82,6 +83,7 @@ EmptyStateMessage.defaultProps = {
   error: undefined,
   search: false,
   customIcon: undefined,
+  happy: false,
 };
 
 export default EmptyStateMessage;

--- a/webpack/components/Table/EmptyStateMessage.js
+++ b/webpack/components/Table/EmptyStateMessage.js
@@ -12,7 +12,9 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import { CubeIcon, ExclamationCircleIcon, SearchIcon, CheckCircleIcon } from '@patternfly/react-icons';
 import { global_danger_color_200 as dangerColor, global_success_color_100 as successColor } from '@patternfly/react-tokens';
 
-const KatelloEmptyStateIcon = ({ error, search, customIcon, happyIcon }) => {
+const KatelloEmptyStateIcon = ({
+  error, search, customIcon, happyIcon,
+}) => {
   if (error) return <EmptyStateIcon icon={ExclamationCircleIcon} color={dangerColor.value} />;
   if (search) return <EmptyStateIcon icon={SearchIcon} />;
   if (happyIcon) return <EmptyStateIcon icon={CheckCircleIcon} color={successColor.value} />;
@@ -38,8 +40,15 @@ const EmptyStateMessage = ({
   }
   return (
     <Bullseye>
-      <EmptyState variant={happy ? EmptyStateVariant.large : EmptyStateVariant.small}>
-        <KatelloEmptyStateIcon error={!!error} search={search} customIcon={customIcon} happyIcon={happy} />
+      <EmptyState
+        variant={happy ? EmptyStateVariant.large : EmptyStateVariant.small}
+      >
+        <KatelloEmptyStateIcon
+          error={!!error}
+          search={search}
+          customIcon={customIcon}
+          happyIcon={happy}
+        />
         <Title headingLevel="h2" size="lg">
           {emptyStateTitle}
         </Title>

--- a/webpack/components/Table/MainTable.js
+++ b/webpack/components/Table/MainTable.js
@@ -93,7 +93,7 @@ MainTable.propTypes = {
     PropTypes.string,
   ]),
   emptyContentTitle: PropTypes.string.isRequired,
-  emptyContentBody: PropTypes.string.isRequired,
+  emptyContentBody: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({})]).isRequired,
   emptySearchTitle: PropTypes.string.isRequired,
   emptySearchBody: PropTypes.string.isRequired,
   errorSearchTitle: PropTypes.string,

--- a/webpack/components/Table/MainTable.js
+++ b/webpack/components/Table/MainTable.js
@@ -113,6 +113,7 @@ MainTable.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
+  happyEmptyContent: PropTypes.bool,
 };
 
 MainTable.defaultProps = {
@@ -127,6 +128,7 @@ MainTable.defaultProps = {
   cells: undefined,
   rows: undefined,
   rowsCount: undefined,
+  happyEmptyContent: false,
 };
 
 export default MainTable;

--- a/webpack/components/Table/MainTable.js
+++ b/webpack/components/Table/MainTable.js
@@ -17,7 +17,7 @@ import Loading from '../../components/Loading';
 const MainTable = ({
   status, cells, rows, error, emptyContentTitle, emptyContentBody,
   emptySearchTitle, emptySearchBody, errorSearchTitle, errorSearchBody,
-  searchIsActive, activeFilters, defaultFilters, actionButtons, rowsCount,
+  happyEmptyContent, searchIsActive, activeFilters, defaultFilters, actionButtons, rowsCount,
   children, ...extraTableProps
 }) => {
   const tableHasNoRows = () => {
@@ -48,7 +48,14 @@ const MainTable = ({
     />);
   }
   if (status === STATUS.RESOLVED && tableHasNoRows()) {
-    return (<EmptyStateMessage title={emptyContentTitle} body={emptyContentBody} search />);
+    return (
+      <EmptyStateMessage
+        title={emptyContentTitle}
+        body={emptyContentBody}
+        happy={happyEmptyContent}
+        search={!happyEmptyContent}
+      />
+    );
   }
 
   const tableProps = { cells, rows, ...extraTableProps };

--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -50,6 +50,7 @@ const TableWrapper = ({
   const perPage = Number(metadata?.per_page ?? foremanPerPage);
   const page = Number(metadata?.page ?? 1);
   const total = Number(metadata?.subtotal ?? 0);
+  const totalSelectableCount = Number(metadata?.selectable ?? total);
   const { pageRowCount } = getPageStats({ total, page, perPage });
   const unresolvedStatus = !!allTableProps?.status && allTableProps.status !== STATUS.RESOLVED;
   const unresolvedStatusOrNoRows = unresolvedStatus || pageRowCount === 0;
@@ -174,7 +175,7 @@ const TableWrapper = ({
                 pageRowCount,
               }
               }
-              totalCount={Number(metadata?.selectable ?? total)}
+              totalCount={totalSelectableCount}
               areAllRowsOnPageSelected={areAllRowsOnPageSelected()}
               areAllRowsSelected={areAllRowsSelected()}
             />

--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
@@ -15,9 +15,11 @@ import { ChartPie } from '@patternfly/react-charts';
 import { ErrataMapper } from '../../../../components/Errata';
 import { hostIsRegistered } from '../hostDetailsHelpers';
 import { TranslatedAnchor } from '../../../Table/components/TranslatedPlural';
+import EmptyStateMessage from '../../../Table/EmptyStateMessage';
+import './ErrataOverviewCard.scss';
 
 function HostInstallableErrata({
-  id, errataCounts,
+  id, errataCounts, errataStatus,
 }) {
   const errataTotal = errataCounts.total;
   const errataSecurity = errataCounts.security;
@@ -37,43 +39,52 @@ function HostInstallableErrata({
           <CardTitle>{__('Installable errata')}</CardTitle>
         </CardHeader>
         <CardBody>
-          <Flex direction="column">
-            <FlexItem>
-              <TranslatedAnchor
-                id="errata-card-total-count"
-                href="#/Content/errata"
-                count={errataTotal}
-                plural="errata"
-                singular="erratum"
-                ariaLabel={`${errataTotal} total errata`}
-              />
-            </FlexItem>
-            <Flex flexWrap={{ xl: 'nowrap' }} direction="row" alignItems={{ default: 'alignItemsCenter' }}>
-              <div className="piechart-overflow" style={{ overflow: 'visible', minWidth: '140px', maxHeight: '155px' }}>
-                <div className="erratachart" style={{ minWidth: '300px', minHeight: '300px' }}>
-                  <ChartPie
-                    ariaDesc="errataChart"
-                    data={chartData}
-                    constrainToVisibleArea
-                    labels={({ datum }) => `${datum.y} ${datum.w}`}
-                    padding={{
-                      bottom: 20,
-                      left: 20,
-                      right: 140,
-                      top: 20,
-                    }}
-                    width={250}
-                    height={130}
-                  />
+          {errataStatus === 0 &&
+            <EmptyStateMessage
+              title={__('All errata up-to-date')}
+              body={__('No action required')}
+              happy
+            />
+          }
+          {errataStatus !== 0 &&
+            <Flex direction="column">
+              <FlexItem>
+                <TranslatedAnchor
+                  id="errata-card-total-count"
+                  href="#/Content/errata"
+                  count={errataTotal}
+                  plural="errata"
+                  singular="erratum"
+                  ariaLabel={`${errataTotal} total errata`}
+                />
+              </FlexItem>
+              <Flex flexWrap={{ xl: 'nowrap' }} direction="row" alignItems={{ default: 'alignItemsCenter' }}>
+                <div className="piechart-overflow" style={{ overflow: 'visible', minWidth: '140px', maxHeight: '155px' }}>
+                  <div className="erratachart" style={{ minWidth: '300px', minHeight: '300px' }}>
+                    <ChartPie
+                      ariaDesc="errataChart"
+                      data={chartData}
+                      constrainToVisibleArea
+                      labels={({ datum }) => `${datum.y} ${datum.w}`}
+                      padding={{
+                        bottom: 20,
+                        left: 20,
+                        right: 140,
+                        top: 20,
+                      }}
+                      width={250}
+                      height={130}
+                    />
+                  </div>
                 </div>
-              </div>
-              <div className="erratalegend" style={{ minWidth: '140px' }}>
-                <FlexItem>
-                  <ErrataMapper data={chartData} id={id} />
-                </FlexItem>
-              </div>
+                <div className="erratalegend" style={{ minWidth: '140px' }}>
+                  <FlexItem>
+                    <ErrataMapper data={chartData} id={id} />
+                  </FlexItem>
+                </div>
+              </Flex>
             </Flex>
-          </Flex>
+          }
         </CardBody>
       </Card>
     </GridItem>
@@ -82,10 +93,11 @@ function HostInstallableErrata({
 
 const ErrataOverviewCard = ({ hostDetails }) => {
   if (hostIsRegistered({ hostDetails }) && hostDetails.content_facet_attributes) {
-    const { id: hostId } = hostDetails;
+    const { id: hostId, errata_status: errataStatus } = hostDetails;
     return (<HostInstallableErrata
       {...propsToCamelCase(hostDetails.content_facet_attributes)}
       id={hostId}
+      errataStatus={errataStatus}
     />);
   }
   return null;
@@ -99,12 +111,18 @@ HostInstallableErrata.propTypes = {
     security: PropTypes.number,
     total: PropTypes.number,
   }).isRequired,
+  errataStatus: PropTypes.number,
+};
+
+HostInstallableErrata.defaultProps = {
+  errataStatus: undefined,
 };
 
 ErrataOverviewCard.propTypes = {
   hostDetails: PropTypes.shape({
     content_facet_attributes: PropTypes.shape({}),
     id: PropTypes.number,
+    errata_status: PropTypes.number,
   }),
 };
 

--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.scss
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.scss
@@ -1,0 +1,3 @@
+.pf-c-empty-state {
+  margin-top: 0;
+}

--- a/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
@@ -15,9 +15,10 @@ describe('Without errata', () => {
     nock.cleanAll();
   });
 
-  test('shows zero counts when there are 0 errata', () => {
+  test('shows zero counts when there are 0 installable errata', () => {
     const hostDetails = {
       ...baseHostDetails,
+      errata_status: 1,
       content_facet_attributes: {
         errata_counts: {
           bugfix: 0,
@@ -35,6 +36,26 @@ describe('Without errata', () => {
     expect(getByLabelText('0 security advisories')).toBeInTheDocument();
     expect(getByLabelText('0 bug fixes')).toBeInTheDocument();
     expect(getByLabelText('0 enhancements')).toBeInTheDocument();
+  });
+
+  test('shows empty state when there are 0 errata', () => {
+    const hostDetails = {
+      ...baseHostDetails,
+      errata_status: 0,
+      content_facet_attributes: {
+        errata_counts: {
+          bugfix: 0,
+          enhancement: 0,
+          security: 0,
+          total: 0,
+        },
+      },
+    };
+    /* eslint-disable max-len */
+    const { queryByLabelText, getByText } = render(<ErrataOverviewCard hostDetails={hostDetails} />);
+    /* eslint-enable max-len */
+    expect(queryByLabelText('errataChart')).not.toBeInTheDocument();
+    expect(getByText('All errata up-to-date')).toBeInTheDocument();
   });
 
   test('does not show errata card when host not registered', () => {

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -42,6 +42,7 @@ export const ErrataTab = () => {
     id: hostId,
     name: hostname,
     content_facet_attributes: contentFacetAttributes,
+    errata_status: errataStatus,
   } = hostDetails;
   const contentFacet = propsToCamelCase(contentFacetAttributes ?? {});
   const dispatch = useDispatch();
@@ -66,9 +67,9 @@ export const ErrataTab = () => {
     = useState(PARAM_TO_FRIENDLY_NAME[initialSeverity] ?? ERRATA_SEVERITY);
   const activeFilters = [errataTypeSelected, errataSeveritySelected];
   const defaultFilters = [ERRATA_TYPE, ERRATA_SEVERITY];
-
-  const emptyContentTitle = __('This host does not have any installable errata.');
-  const emptyContentBody = __('Installable errata will appear here when available.');
+  const allUpToDate = errataStatus === 0;
+  const emptyContentTitle = allUpToDate ? __('All errata up-to-date') : __('This host has errata that are applicable, but not installable.');
+  const emptyContentBody = allUpToDate ? __('No action is needed because there are no applicable errata for this host.') : __("You may want to check the host's content view and lifecycle environment.");
   const emptySearchTitle = __('No matching errata found');
   const emptySearchBody = __('Try changing your search settings.');
   const errorSearchTitle = __('Problem searching errata');
@@ -345,6 +346,7 @@ export const ErrataTab = () => {
             toggleGroup,
           }
           }
+          happyEmptyContent={allUpToDate}
           ouiaId="host-errata-table"
           additionalListeners={[
             hostId, toggleGroupState, errataTypeSelected,

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -288,6 +288,7 @@ export const ErrataTab = () => {
           items={Object.values(ERRATA_TYPES)}
           selected={errataTypeSelected}
           setSelected={handleErrataTypeSelected}
+          isDisabled={!results?.length}
         />
       </SplitItem>
       <SplitItem>
@@ -298,6 +299,7 @@ export const ErrataTab = () => {
           items={Object.values(ERRATA_SEVERITIES)}
           selected={errataSeveritySelected}
           setSelected={handleErrataSeveritySelected}
+          isDisabled={!results?.length}
         />
       </SplitItem>
       {hostIsNonLibrary &&

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -47,10 +47,10 @@ export const PackagesTab = () => {
     name: hostname,
   } = hostDetails;
 
-  const { searchParam } = useUrlParams();
+  const { searchParam, status: statusParam } = useUrlParams();
   const dispatch = useDispatch();
   const PACKAGE_STATUS = __('Status');
-  const [packageStatusSelected, setPackageStatusSelected] = useState(PACKAGE_STATUS);
+  const [packageStatusSelected, setPackageStatusSelected] = useState(statusParam ?? PACKAGE_STATUS);
   const activeFilters = [packageStatusSelected];
   const defaultFilters = [PACKAGE_STATUS];
   const [isBulkActionOpen, setIsBulkActionOpen] = useState(false);

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
@@ -34,7 +34,7 @@ const TracesTab = () => {
     values={{
       pkgLink: <a href="#/Content/packages?status=Upgradable">{__('installing or updating packages')}</a>,
     }}
-    defaultMessage={__('To see suitable applications, update your host by {pkgLink}.')}
+    defaultMessage={__('Traces may be listed here after {pkgLink}.')}
   />);
   const emptySearchTitle = __('No matching traces found');
   const emptySearchBody = __('Try changing your search settings.');

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import { FormattedMessage } from 'react-intl';
 import {
   Skeleton, Button, Split, SplitItem, ActionList, ActionListItem, Dropdown,
   DropdownItem, KebabToggle,
@@ -27,8 +28,14 @@ const TracesTab = () => {
     content_facet_attributes: contentFacetAttributes,
   } = hostDetails;
   const showEnableTracer = (contentFacetAttributes?.katello_tracer_installed === false);
-  const emptyContentTitle = __('This host currently does not have traces.');
-  const emptyContentBody = __('Add traces by applying updates on this host.');
+  const emptyContentTitle = __('No applications to restart');
+  const emptyContentBody = (<FormattedMessage
+    id="traces-happy-empty"
+    values={{
+      pkgLink: <a href="#/Content/packages?status=Upgradable">{__('installing or updating packages')}</a>,
+    }}
+    defaultMessage={__('To see suitable applications, update your host by {pkgLink}.')}
+  />);
   const emptySearchTitle = __('No matching traces found');
   const emptySearchBody = __('Try changing your search settings.');
   const errorSearchTitle = __('Problem searching traces');
@@ -152,6 +159,7 @@ const TracesTab = () => {
           actionButtons,
         }
         }
+        happyEmptyContent
         ouiaId="host-traces-table"
         metadata={meta}
         bookmarkController="katello_host_tracers"

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
@@ -140,7 +140,7 @@ test('Can handle no errata being present', async (done) => {
   const { queryByText } = renderWithRedux(<ErrataTab />, renderOptions());
 
   // Assert that there are not any errata showing on the screen.
-  await patientlyWaitFor(() => expect(queryByText('This host does not have any installable errata.')).toBeInTheDocument());
+  await patientlyWaitFor(() => expect(queryByText('This host has errata that are applicable, but not installable.')).toBeInTheDocument());
   // Assert request was made and completed, see helper function
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done); // Pass jest callback to confirm test is done

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
@@ -104,7 +104,7 @@ describe('With tracer installed', () => {
     const { queryByText } = renderWithRedux(<TracesTab />, renderOptions(true));
 
     // Assert that there are not any traces showing on the screen.
-    await patientlyWaitFor(() => expect(queryByText('This host currently does not have traces.')).toBeInTheDocument());
+    await patientlyWaitFor(() => expect(queryByText('No applications to restart')).toBeInTheDocument());
     // Assert request was made and completed, see helper function
     assertNockRequest(autocompleteScope);
     assertNockRequest(scope, done);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add "happy" empty states for

* Installable Errata overview card
* Errata
* Traces

![happy_errata_overview](https://user-images.githubusercontent.com/22042343/165159456-30496c4f-8c54-4b63-bfa6-c80f7ddca047.png)
![errata_happy](https://user-images.githubusercontent.com/22042343/165159459-ba64d4be-8914-4d14-98f9-4add582667bc.png)
![traces_happy](https://user-images.githubusercontent.com/22042343/165159461-a09a134f-53da-44d9-ad88-10b2f983d6e8.png)



Also, change some wording on existing Errata empty state
![applicable_errata_host](https://user-images.githubusercontent.com/22042343/165159416-272b74f8-2dc8-4e4b-9aac-8f6a9943e2d0.png)


#### Considerations taken when implementing this change?

For Errata, the happy empty state will not show if you have errata that are applicable but not installable. (see above)

#### What are the testing steps for this pull request?

Register a host
### Traces
* Set up REX or install `katello-host-tools-tracer` on the host by some other method
* Reboot the host; this will probably clear all the traces

### Errata & Errata overview card
* Apply all errata to the host
* View overview card and Errata tab empty states
* Get another host of the same operating system and assign it to an empty CV
* Note absence of happy empty state on both card and tab
