### PR TITLE
Fixes #34814 - Add Subscription UUID to System Properties card

### DIFF
--- a/webpack/components/extensions/HostDetails/DetailsTabCards/SystemPropertiesCardExtensions.js
+++ b/webpack/components/extensions/HostDetails/DetailsTabCards/SystemPropertiesCardExtensions.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  ClipboardCopy,
+} from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+const SystemPropertiesCardExtensions = ({ hostDetails }) => {
+  const subscriptionUuid = hostDetails?.subscription_facet_attributes?.uuid;
+  if (!subscriptionUuid) return null;
+  return (
+    <DescriptionListGroup>
+      <DescriptionListTerm>{__('Subscription UUID')}</DescriptionListTerm>
+      <DescriptionListDescription>
+        <ClipboardCopy isBlock variant="inline-compact" clickTip={__('Copied to clipboard')}>
+          {subscriptionUuid}
+        </ClipboardCopy>
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
+
+SystemPropertiesCardExtensions.propTypes = {
+  hostDetails: PropTypes.shape({
+    subscription_facet_attributes: PropTypes.shape({
+      uuid: PropTypes.string,
+    }),
+  }),
+};
+
+SystemPropertiesCardExtensions.defaultProps = {
+  hostDetails: {},
+};
+
+export default SystemPropertiesCardExtensions;

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -11,25 +11,26 @@ import ErrataOverviewCard from './components/extensions/HostDetails/Cards/Errata
 import InstalledProductsCard from './components/extensions/HostDetails/DetailsTabCards/InstalledProductsCard';
 import RegistrationCard from './components/extensions/HostDetails/DetailsTabCards/RegistrationCard';
 
-// import SubscriptionTab from './components/extensions/HostDetails/Tabs/SubscriptionTab';
 import RepositorySetsTab from './components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab';
 import TracesTab from './components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js';
 import extendReducer from './components/extensions/reducers';
 import rootReducer from './redux/reducers';
 import HostCollectionsCard from './components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsCard';
 import { hostIsNotRegistered } from './components/extensions/HostDetails/hostDetailsHelpers';
+import SystemPropertiesCardExtensions from './components/extensions/HostDetails/DetailsTabCards/SystemPropertiesCardExtensions';
 
 registerReducer('katelloExtends', extendReducer);
 registerReducer('katello', rootReducer);
 
 addGlobalFill('aboutFooterSlot', '[katello]AboutSystemStatuses', <SystemStatuses key="katello-system-statuses" />, 100);
 addGlobalFill('registrationAdvanced', '[katello]RegistrationCommands', <RegistrationCommands key="katello-reg" />, 100);
+
+// Host details page tabs
 addGlobalFill('host-details-page-tabs', 'Content', <ContentTab key="content" />, 900, { title: __('Content'), hideTab: hostIsNotRegistered });
-/* eslint-disable max-len */
-// addGlobalFill('host-details-page-tabs', 'Subscription', <SubscriptionTab key="subscription" />, 100, { title: __('Subscription') });
 addGlobalFill('host-details-page-tabs', 'Traces', <TracesTab key="traces" />, 800, { title: __('Traces'), hideTab: hostIsNotRegistered });
 addGlobalFill('host-details-page-tabs', 'Repository sets', <RepositorySetsTab key="repository-sets" />, 700, { title: __('Repository sets'), hideTab: hostIsNotRegistered });
 
+// Overview tab cards
 addGlobalFill(
   'details-cards',
   'Content view details',
@@ -43,5 +44,8 @@ addGlobalFill(
   700,
 );
 addGlobalFill('details-cards', 'Installable errata', <ErrataOverviewCard key="errata-overview" />, 1900);
+
+// Details tab cards & card extensions
 addGlobalFill('host-tab-details-cards', 'Installed products', <InstalledProductsCard key="installed-products" />, 100);
 addGlobalFill('host-tab-details-cards', 'Registration details', <RegistrationCard key="registration-details" />, 200);
+addGlobalFill('host-details-tab-properties-1', 'Subscription UUID', <SystemPropertiesCardExtensions key="subscription-uuid" />);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* minor cleanup of comments in `global_index.js`
* Add "Subscription UUID" to the System Properties card on the new host detail page.
![sub_uuid](https://user-images.githubusercontent.com/22042343/165174132-a1f30196-b4e9-486f-9ae1-ea37237a5190.png)

#### Considerations taken when implementing this change?

~~I had to add some minor functionality to the slots; therefore this requires https://github.com/theforeman/foreman/pull/9200~~
I added a `clickTip` so it says "Copied to clipboard" instead of "Successfully copied to clipboard". We're not supposed to use "successfully".

#### What are the testing steps for this pull request?

* Set "Show experimental labs" setting to Yes
* ~~Check out the Foreman PR~~ Pull latest Foreman `develop`
* Check out the Katello PR - you should now have a Details tab on the new host detail page
* Ensure that Subscription UUID shows on the System Properties card

