### PR TITLE
Fixes #34816 - Add Installed Products card

### DIFF
--- a/webpack/components/extensions/HostDetails/DetailsTabCards/InstalledProductsCard.js
+++ b/webpack/components/extensions/HostDetails/DetailsTabCards/InstalledProductsCard.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { List, ListItem } from '@patternfly/react-core';
+import CardTemplate from 'foremanReact/components/HostDetails/Templates/CardItem/CardTemplate';
+
+const InstalledProductsCard = ({ isExpandedGlobal, hostDetails }) => {
+  const installedProducts = hostDetails?.subscription_facet_attributes?.installed_products;
+  if (!installedProducts?.length) return null;
+  return (
+    <CardTemplate
+      overrideGridProps={{ rowSpan: 2 }}
+      header={__('Installed products')}
+      expandable
+      isExpandedGlobal={isExpandedGlobal}
+    >
+      <List isPlain>
+        {installedProducts.map(product => (
+          <ListItem key={product.productId}>
+            {product.productName}
+          </ListItem>
+        ))}
+      </List>
+    </CardTemplate>
+  );
+};
+
+InstalledProductsCard.propTypes = {
+  isExpandedGlobal: PropTypes.bool,
+  hostDetails: PropTypes.shape({
+    subscription_facet_attributes: PropTypes.shape({
+      installed_products: PropTypes.arrayOf(PropTypes.shape({
+        productId: PropTypes.string,
+        productName: PropTypes.string,
+      })),
+    }),
+  }),
+};
+
+InstalledProductsCard.defaultProps = {
+  isExpandedGlobal: false,
+  hostDetails: {},
+};
+
+export default InstalledProductsCard;

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -8,6 +8,7 @@ import RegistrationCommands from './components/extensions/RegistrationCommands';
 import ContentTab from './components/extensions/HostDetails/Tabs/ContentTab';
 import ContentViewDetailsCard from './components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard';
 import ErrataOverviewCard from './components/extensions/HostDetails/Cards/ErrataOverviewCard';
+import InstalledProductsCard from './components/extensions/HostDetails/DetailsTabCards/InstalledProductsCard';
 
 // import SubscriptionTab from './components/extensions/HostDetails/Tabs/SubscriptionTab';
 import RepositorySetsTab from './components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab';
@@ -41,3 +42,4 @@ addGlobalFill(
   700,
 );
 addGlobalFill('details-cards', 'Installable errata', <ErrataOverviewCard key="errata-overview" />, 1900);
+addGlobalFill('host-tab-details-cards', 'Installed products', <InstalledProductsCard key="installed-products" />, 100);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add an Installed products card to the new Details tab.
![installed_products_card](https://user-images.githubusercontent.com/22042343/165180212-58cfd858-a405-447b-a936-2d9c3537eb10.png)

#### Considerations taken when implementing this change?

The mockup had the products as links. But I don't know what they would link to. And the old content host page doesn't have links.

Right now there seems to be a bug where if a card is not expanded, it hides its data but still takes the height of the tallest card. (this may be a PF issue or a Foreman issue..)

#### What are the testing steps for this pull request?

* Settings > Show experimental labs - Yes
* View the new host details page > Details tab
