### PR TITLE
Fixes #34818 - Fix Upstream authentication autofill issue

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
@@ -89,7 +89,7 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                 return deferred.promise;
             };
 
-            $scope.save = function (repository, saveUpstreamAuth) {
+            $scope.save = function (repository) {
                 var deferred = $q.defer();
                 var fields = ['upstream_password', 'upstream_username', 'upstream_authentication_token', 'ansible_collection_auth_token', 'ansible_collection_auth_url', 'ansible_collection_requirements'];
                 if (repository.content_type === 'yum' && typeof repository.ignore_srpms !== 'undefined') {
@@ -99,13 +99,6 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                         repository['ignorable_content'] = [];
                     }
                 }
-
-                if (!saveUpstreamAuth) {
-                    repository['upstream_username'] = null;
-                    repository['upstream_password'] = null;
-                    repository['upstream_authentication_token'] = null;
-                }
-
                 if ($scope.genericRemoteOptions && $scope.genericRemoteOptions !== []) {
                     $scope.genericRemoteOptions.forEach(function(option) {
                        if (option.type === "Array") {
@@ -141,6 +134,9 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                         repository[field] = null;
                     }
                 });
+                if (!repository['upstream_username']) {
+                    repository['upstream_password'] = null;
+                }
                 repository.os_versions = $scope.osVersionsParam();
                 repository.$update(function (response) {
                     deferred.resolve(response);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -63,7 +63,7 @@
       <dt ng-show="repository.content_type !== 'docker'" translate>Upstream URL</dt>
       <dt ng-show="repository.content_type === 'docker'" translate>Registry URL</dt>
       <dd bst-edit-text="repository.url"
-          on-save="save(repository, true)"
+          on-save="save(repository)"
           readonly="product.redhat || denied('edit_products', product)">
       </dd>
 
@@ -134,7 +134,7 @@
         <dt translate>Ansible Collection Authorization</dt>
         <dd bst-edit-custom="repository.ansible_collection_auth_exists"
             readonly="denied('edit_products', product)"
-            on-save="save(repository, true)"
+            on-save="save(repository)"
             formatter="ansibleAuthFilter"
             formatter-options="repository"
             deletable="repository.ansible_collection_auth_exists"
@@ -165,7 +165,7 @@
         <dt translate>Upstream Authorization</dt>
         <dd bst-edit-custom="repository.upstream_auth_exists"
             readonly="denied('edit_products', product)"
-            on-save="save(repository, true)"
+            on-save="save(repository)"
             formatter="upstreamPasswordFilter"
             formatter-options="repository"
             deletable="repository.upstream_auth_exists"
@@ -174,18 +174,17 @@
           <input id="upstream_username"
                  name="upstream_username"
                  type="name"
-                 autocomplete="off"
                  ng-model="repository.upstream_username"/>
           <div translate>Upstream Password</div>
-          <input id="upstream_password"
+	  <input id="upstream_password"
                  name="upstream_password"
-                 type="password"
-                 autocomplete="off"
+                 type="{{ repository.upstream_password.length < 1 ? 'text': 'password' }}"
+                 autocomplete="{{ (repository.upstream_username==null || repository.upstream_username=='') ? 'new-password' : '' }}"
                  ng-model="repository.upstream_password"/>
           <div translate>Upstream Authentication Token</div>
           <input id="upstream_authentication_token"
                   name="upstream_authentication_token"
-                  type="password"
+                  type="{{ repository.upstream_authentication_token.length < 1 ? 'text': 'password' }}"
                   autocomplete="off"
                   ng-model="repository.upstream_authentication_token"/>
         </dd>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -224,7 +224,8 @@
         <input id="upstream_password"
                name="upstream_password"
                ng-model="repository.upstream_password"
-               type="password"/>
+               type="password"
+               autocomplete="new-password"/>
         <p class="help-block" translate>
           Password of the upstream repository user for authentication. Leave empty if repository does not require authentication.
         </p>

--- a/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
@@ -125,34 +125,6 @@ describe('Controller: RepositoryDetailsInfoController', function() {
         expect(Notification.setSuccessMessage).toHaveBeenCalledWith('Repository Saved.');
     });
 
-    it('should ignore upstream auth on save unless specified', function() {
-        var repo = new Repository({
-            upstream_username: 'autofilled',
-            upstream_password: 'autofilled',
-            upstream_authentication_token: 'autofilled'
-        })
-
-        $scope.save(repo);
-
-        expect(repo.upstream_username).toBe(null);
-        expect(repo.upstream_password).toBe(null);
-        expect(repo.upstream_authentication_token).toBe(null);
-    });
-
-    it('should not ignore upstream auth on save unless specified', function() {
-        var repo = new Repository({
-            upstream_username: 'autofilled',
-            upstream_password: 'autofilled',
-            upstream_authentication_token: 'autofilled'
-        })
-
-        $scope.save(repo, true);
-
-        expect(repo.upstream_username).toBe('autofilled');
-        expect(repo.upstream_password).toBe('autofilled');
-        expect(repo.upstream_authentication_token).toBe('autofilled');
-    });
-
     it('should clear out auth fields on save if blank', function() {
       var repo = new Repository({
         upstream_username: '',
@@ -162,7 +134,7 @@ describe('Controller: RepositoryDetailsInfoController', function() {
         ansible_collection_auth_token: '',
       })
 
-      $scope.save(repo, true);
+      $scope.save(repo);
 
       expect(repo.upstream_username).toBe(null);
       expect(repo.upstream_password).toBe(null);
@@ -180,7 +152,7 @@ describe('Controller: RepositoryDetailsInfoController', function() {
       ansible_collection_auth_token: 'some_token',
     })
 
-    $scope.save(repo, true);
+    $scope.save(repo);
 
     expect(repo.upstream_username).not.toBe(null);
     expect(repo.upstream_password).not.toBe(null);


### PR DESCRIPTION
This PR fixes autofill issue in Katello repository forms caused by some browsers.

Test Cases:
1. Create Katello repository and upstream_username/password shouldn't be auto-filled by browser.
2. Editing Katello repository which doesn't contain upstream_username/password set by user should have empty upstream_authentication fields.
3. Editing Katello repository which contains upstream_username/password set by user should have show upstream_authentication fields as username and hidden password.