### PR TITLE
Fixes #34829 - Update pulp_deb to 2.18

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -58,7 +58,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "pulp_file_client", ">= 1.10.0", "< 1.11.0"
   gem.add_dependency "pulp_ansible_client", ">= 0.12.1", "< 0.13"
   gem.add_dependency "pulp_container_client", ">= 2.10.0", "< 2.11.0"
-  gem.add_dependency "pulp_deb_client", ">= 2.17.1", "< 2.18.0"
+  gem.add_dependency "pulp_deb_client", ">= 2.18.0", "< 2.19.0"
   gem.add_dependency "pulp_rpm_client", ">= 3.17.0", "< 3.18.0"
   gem.add_dependency "pulp_certguard_client", "< 2.0"
   gem.add_dependency "pulp_python_client", ">= 3.6.0", "< 3.7.0"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The pulp_deb_client range is adjusted for use with pulp_deb 2.18

#### Considerations taken when implementing this change?

* Must be coordinated with: https://github.com/theforeman/foreman-packaging/pull/7836
* pulp_deb 2.18.0 is already available in: https://yum.theforeman.org/pulpcore/3.17/