### PR TITLE
Fixes #34756 - Add scope for epoch_to_date method

### DIFF
--- a/app/services/katello/pulp3/erratum.rb
+++ b/app/services/katello/pulp3/erratum.rb
@@ -119,7 +119,7 @@ module Katello
         date.to_i.to_s == date ? epoch_to_date(date) : date
       end
 
-      def epoch_to_date(epoch)
+      def self.epoch_to_date(epoch)
         Time.at(epoch.to_i).to_s
       end
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fixes a small bug introduced in this PR: https://github.com/Katello/katello/commit/215b0401dcdda07ecf300d1751b43c2062f461e3

When Syncing SUSE repos, the epoch_to_date could not be found, anymore. 
