### PR TITLE
Fixes #34836 - Add registration card to new host ui details page

### DIFF
--- a/webpack/components/extensions/HostDetails/DetailsTabCards/InstalledProductsCard.js
+++ b/webpack/components/extensions/HostDetails/DetailsTabCards/InstalledProductsCard.js
@@ -9,7 +9,6 @@ const InstalledProductsCard = ({ isExpandedGlobal, hostDetails }) => {
   if (!installedProducts?.length) return null;
   return (
     <CardTemplate
-      overrideGridProps={{ rowSpan: 2 }}
       header={__('Installed products')}
       expandable
       isExpandedGlobal={isExpandedGlobal}

--- a/webpack/components/extensions/HostDetails/DetailsTabCards/RegistrationCard.js
+++ b/webpack/components/extensions/HostDetails/DetailsTabCards/RegistrationCard.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
+import {
+  DescriptionList,
+  DescriptionListTerm,
+  DescriptionListGroup,
+  DescriptionListDescription,
+  List,
+  ListItem,
+  Text,
+  TextVariants,
+} from '@patternfly/react-core';
+import { urlBuilder } from 'foremanReact/common/urlHelpers';
+import { propsToCamelCase } from 'foremanReact/common/helpers';
+import IsoDate from 'foremanReact/components/common/dates/IsoDate';
+import CardTemplate from 'foremanReact/components/HostDetails/Templates/CardItem/CardTemplate';
+
+export const RegisteredBy = ({ user, activationKeys }) => {
+  if (user) {
+    return (
+      <DescriptionListDescription>{user}</DescriptionListDescription>
+    );
+  }
+  return (
+    <>
+      <List isPlain>
+        <Text component={TextVariants.h4}>{activationKeys.length > 1 ? __('Activation keys') : __('Activation key')}</Text>
+        {activationKeys.map(key => (
+          <ListItem key={key.id}>
+            <a href={urlBuilder(`activation_keys/${key.id}`, '')}>{key.name}</a>
+          </ListItem>
+        ))}
+      </List>
+    </>
+  );
+};
+
+RegisteredBy.propTypes = {
+  user: PropTypes.string,
+  activationKeys: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+  })),
+};
+
+RegisteredBy.defaultProps = {
+  user: '',
+  activationKeys: {},
+};
+
+const RegistrationCard = ({ isExpandedGlobal, hostDetails }) => {
+  const subscriptionFacetAttributes
+    = propsToCamelCase(hostDetails?.subscription_facet_attributes || {});
+  const {
+    registeredAt, registeredThrough, activationKeys, user,
+  }
+    = subscriptionFacetAttributes;
+  const login = user?.login;
+  if (!registeredAt) return null;
+  return (
+    <CardTemplate
+      header={__('Registration details')}
+      expandable
+      isExpandedGlobal={isExpandedGlobal}
+    >
+      <DescriptionList isHorizontal>
+        <DescriptionListGroup>
+          <DescriptionListTerm>{__('Registered on')}</DescriptionListTerm>
+          <DescriptionListDescription><IsoDate date={registeredAt} /></DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>{__('Registered by')}</DescriptionListTerm>
+          <RegisteredBy user={login} activationKeys={activationKeys} />
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>{__('Registered through')}</DescriptionListTerm>
+          <DescriptionListDescription>{registeredThrough}</DescriptionListDescription>
+        </DescriptionListGroup>
+      </DescriptionList>
+    </CardTemplate>
+  );
+};
+
+RegistrationCard.propTypes = {
+  isExpandedGlobal: PropTypes.bool,
+  hostDetails: PropTypes.shape({
+    subscription_facet_attributes: PropTypes.shape({
+      user: PropTypes.shape({
+        login: PropTypes.string,
+      }),
+      registered_at: PropTypes.string,
+      registered_through: PropTypes.string,
+      activation_keys: PropTypes.arrayOf(PropTypes.shape({
+        id: PropTypes.number,
+        name: PropTypes.string,
+      })),
+    }),
+  }),
+};
+
+RegistrationCard.defaultProps = {
+  isExpandedGlobal: false,
+  hostDetails: {},
+};
+
+export default RegistrationCard;

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -9,6 +9,7 @@ import ContentTab from './components/extensions/HostDetails/Tabs/ContentTab';
 import ContentViewDetailsCard from './components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard';
 import ErrataOverviewCard from './components/extensions/HostDetails/Cards/ErrataOverviewCard';
 import InstalledProductsCard from './components/extensions/HostDetails/DetailsTabCards/InstalledProductsCard';
+import RegistrationCard from './components/extensions/HostDetails/DetailsTabCards/RegistrationCard';
 
 // import SubscriptionTab from './components/extensions/HostDetails/Tabs/SubscriptionTab';
 import RepositorySetsTab from './components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab';
@@ -43,3 +44,4 @@ addGlobalFill(
 );
 addGlobalFill('details-cards', 'Installable errata', <ErrataOverviewCard key="errata-overview" />, 1900);
 addGlobalFill('host-tab-details-cards', 'Installed products', <InstalledProductsCard key="installed-products" />, 100);
+addGlobalFill('host-tab-details-cards', 'Registration details', <RegistrationCard key="registration-details" />, 200);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Created a new card in the Host Details New UI Details page for registration info

#### Considerations taken when implementing this change?

Followed the mockup steps and stayed consistent with the old AngularJS page

#### What are the testing steps for this pull request?

* Settings > Show experimental labs - Yes

* Register a content host with a user/pass, check and see if it shows the user info and all the other details such as registered on/through

* Unregister the host and make sure the tab does not show up

* Register with an activation key and see if instead of the username it shows Activation Key and the name with a link to the old activation key page

* Verify there are not any console errors on the page.
