### PR TITLE
Fixes #33449 - Alternate Content Source refreshing support

### DIFF
--- a/app/controllers/katello/api/v2/alternate_content_sources_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/alternate_content_sources_bulk_actions_controller.rb
@@ -1,0 +1,44 @@
+module Katello
+  class Api::V2::AlternateContentSourcesBulkActionsController < Api::V2::ApiController
+    before_action :find_alternate_content_sources
+
+    api :PUT, '/alternate_content_sources/bulk/destroy', N_('Destroy one or more alternate content sources')
+    param :ids, Array, desc: N_('List of alternate content source IDs'), required: true
+    def destroy_alternate_content_sources
+      deletable_alternate_content_sources = @alternate_content_sources.deletable
+
+      if deletable_alternate_content_sources.empty?
+        msg = _("Unable to delete any alternate content source. You either do not have the permission to"\
+          " delete, or none of the alternate content sources exist.")
+        fail HttpErrors::UnprocessableEntity, msg
+      end
+      task = async_task(::Actions::BulkAction,
+                        ::Actions::Katello::AlternateContentSource::Destroy,
+                        deletable_alternate_content_sources)
+      respond_for_async :resource => task
+    end
+
+    api :POST, '/alternate_content_sources/bulk/refresh', N_('Refresh alternate content sources')
+    param :ids, Array, desc: N_('List of alternate content source IDs'), required: true
+    def refresh_alternate_content_sources
+      refreshable_alternate_content_sources = @alternate_content_sources.editable
+      if refreshable_alternate_content_sources.empty?
+        msg = _("Unable to refresh any alternate content source. You either do not have the permission to"\
+                " refresh, or none of the alternate content sources exist.")
+        fail HttpErrors::UnprocessableEntity, msg
+      else
+        task = async_task(::Actions::BulkAction,
+                          ::Actions::Katello::AlternateContentSource::Refresh,
+                          refreshable_alternate_content_sources)
+        respond_for_async resource: task
+      end
+    end
+
+    private
+
+    def find_alternate_content_sources
+      params.require(:ids)
+      @alternate_content_sources = AlternateContentSource.readable.where(id: params[:ids])
+    end
+  end
+end

--- a/app/lib/actions/katello/alternate_content_source/refresh.rb
+++ b/app/lib/actions/katello/alternate_content_source/refresh.rb
@@ -1,0 +1,27 @@
+module Actions
+  module Katello
+    module AlternateContentSource
+      class Refresh < Actions::EntryAction
+        def plan(acs)
+          action_subject(acs)
+          concurrence do
+            acs.smart_proxies.each do |smart_proxy|
+              plan_action(Pulp3::Orchestration::AlternateContentSource::Refresh,
+                          acs, smart_proxy)
+            end
+          end
+          plan_self(acs_id: acs.id)
+        end
+
+        def finalize
+          acs = ::Katello::AlternateContentSource.find_by(id: input[:acs_id])
+          acs.update(last_refreshed: ::DateTime.now)
+        end
+
+        def humanized_name
+          _("Refresh Alternate Content Source")
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/alternate_content_source/refresh.rb
+++ b/app/lib/actions/pulp3/alternate_content_source/refresh.rb
@@ -1,0 +1,23 @@
+module Actions
+  module Pulp3
+    module AlternateContentSource
+      class Refresh < Pulp3::AbstractAsyncTask
+        def plan(acs, smart_proxy)
+          plan_self(acs_id: acs.id, smart_proxy_id: smart_proxy.id)
+        end
+
+        def invoke_external_task
+          acs = ::Katello::AlternateContentSource.find(input[:acs_id])
+          output[:response] = acs.backend_service(smart_proxy).refresh
+        end
+
+        def rescue_strategy_for_self
+          # There are various reasons why refreshing fails, but not all of them are
+          # fatal. When failing to refresh, we continue with the task ending up
+          # in the warning state, but don't lock further refreshing
+          Dynflow::Action::Rescue::Skip
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/orchestration/alternate_content_source/create.rb
+++ b/app/lib/actions/pulp3/orchestration/alternate_content_source/create.rb
@@ -7,8 +7,6 @@ module Actions
             sequence do
               plan_action(Actions::Pulp3::AlternateContentSource::CreateRemote, acs, smart_proxy)
               plan_action(Actions::Pulp3::AlternateContentSource::Create, acs, smart_proxy)
-              # TODO: Should the hrefs be committed to acs records in a new action? Is it okay to be in the service class methods?
-              #  -> i.e. do we need something like SaveVersions?
             end
           end
         end

--- a/app/lib/actions/pulp3/orchestration/alternate_content_source/refresh.rb
+++ b/app/lib/actions/pulp3/orchestration/alternate_content_source/refresh.rb
@@ -1,0 +1,15 @@
+module Actions
+  module Pulp3
+    module Orchestration
+      module AlternateContentSource
+        class Refresh < Pulp3::Abstract
+          def plan(acs, smart_proxy)
+            sequence do
+              plan_action(Actions::Pulp3::AlternateContentSource::Refresh, acs, smart_proxy)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/orchestration/alternate_content_source/update.rb
+++ b/app/lib/actions/pulp3/orchestration/alternate_content_source/update.rb
@@ -7,8 +7,6 @@ module Actions
             sequence do
               plan_action(Actions::Pulp3::AlternateContentSource::UpdateRemote, acs, smart_proxy)
               plan_action(Actions::Pulp3::AlternateContentSource::Update, acs, smart_proxy)
-              # TODO: Should the hrefs be committed to acs records in a new action? Is it okay to be in the service class methods?
-              #  -> i.e. do we need something like SaveVersions?
             end
           end
         end

--- a/app/services/katello/pulp3/alternate_content_source.rb
+++ b/app/services/katello/pulp3/alternate_content_source.rb
@@ -101,6 +101,12 @@ module Katello
         ignore_404_exception { api.alternate_content_source_api.delete(href) } if href
       end
 
+      def refresh
+        href = smart_proxy_acs.alternate_content_source_href
+        # https://github.com/pulp/pulp_rpm/issues/2504
+        api.alternate_content_source_api.refresh(href, 'placeholder')
+      end
+
       private
 
       def insert_pulp_manifest!(subpaths)

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -14,6 +14,10 @@ Katello::Engine.routes.draw do
         # re-routes alphabetical
         ##############################
 
+        api_resources :alternate_content_sources, :only => [:index, :show, :create, :update, :destroy] do
+          get :auto_complete_search, :on => :collection
+        end
+
         api_resources :capsules, :only => [:index, :show] do
           member do
             resource :content, :only => [], :controller => 'capsule_content' do
@@ -349,6 +353,18 @@ Katello::Engine.routes.draw do
         ##############################
         ##############################
 
+        api_resources :alternate_content_sources, :only => [], :constraints => { :id => /[0-9a-zA-Z\-_.]*/ } do
+          collection do
+            match '/bulk/destroy' => 'alternate_content_sources_bulk_actions#destroy_alternate_content_sources', :via => :put
+            match '/bulk/refresh' => 'alternate_content_sources_bulk_actions#refresh_alternate_content_sources', :via => :post
+            get :auto_complete_search
+          end
+
+          member do
+            post :refresh
+          end
+        end
+
         api_resources :organizations do
           api_resources :sync_plans do
             member do
@@ -468,10 +484,6 @@ Katello::Engine.routes.draw do
         api_resources :sync_plans, :only => [:index, :show, :update, :destroy] do
           get :auto_complete_search, :on => :collection
           put :sync
-        end
-
-        api_resources :alternate_content_sources, :only => [:index, :show, :create, :update, :destroy] do
-          get :auto_complete_search, :on => :collection
         end
       end # module v2
     end # '/api' namespace

--- a/db/migrate/20220428203334_add_last_refreshed_to_katello_alternate_content_sources.rb
+++ b/db/migrate/20220428203334_add_last_refreshed_to_katello_alternate_content_sources.rb
@@ -1,0 +1,5 @@
+class AddLastRefreshedToKatelloAlternateContentSources < ActiveRecord::Migration[6.0]
+  def change
+    add_column :katello_alternate_content_sources, :last_refreshed, :datetime
+  end
+end

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -404,13 +404,15 @@ module Katello
                          :finder_scope => :editable
       @plugin.permission :edit_alternate_content_sources,
                          {
-                           'katello/api/v2/alternate_content_sources' => [:update]
+                           'katello/api/v2/alternate_content_sources' => [:update, :refresh],
+                           'katello/api/v2/alternate_content_sources_bulk_actions' => [:refresh_alternate_content_sources]
                          },
                          :resource_type => 'Katello::AlternateContentSource',
                          :finder_scope => :editable
       @plugin.permission :destroy_alternate_content_sources,
                          {
-                           'katello/api/v2/alternate_content_sources' => [:destroy]
+                           'katello/api/v2/alternate_content_sources' => [:destroy],
+                           'katello/api/v2/alternate_content_sources_bulk_actions' => [:destroy_alternate_content_sources]
                          },
                          :resource_type => 'Katello::AlternateContentSource',
                          :finder_scope => :deletable

--- a/lib/katello/tasks/refresh_alternate_content_sources.rake
+++ b/lib/katello/tasks/refresh_alternate_content_sources.rake
@@ -1,0 +1,10 @@
+namespace :katello do
+  desc 'Refresh all alternate content sources'
+  task :refresh_alternate_content_sources => ["dynflow:client"] do
+    User.current = User.anonymous_admin
+    ::ForemanTasks.async_task(::Actions::BulkAction,
+                              ::Actions::Katello::AlternateContentSource::Refresh,
+                              ::Katello::AlternateContentSource.all)
+    puts _("Alternate content source refreshing started in the background.")
+  end
+end

--- a/test/actions/pulp3/orchestration/alternate_content_source_refresh_test.rb
+++ b/test/actions/pulp3/orchestration/alternate_content_source_refresh_test.rb
@@ -1,0 +1,53 @@
+require 'katello_test_helper'
+
+module ::Actions::Pulp3
+  class AlternateContentSourceRefreshTest < ActiveSupport::TestCase
+    include Katello::Pulp3Support
+
+    def setup
+      @primary = SmartProxy.pulp_primary
+      @yum_acs = katello_alternate_content_sources(:yum_alternate_content_source)
+      @yum_acs.subpaths = ['rpm-zchunk/', 'rpm-with-modules/']
+      @yum_acs.ssl_ca_cert_id = nil
+      @yum_acs.ssl_client_cert_id = nil
+      @yum_acs.ssl_client_key_id = nil
+      @yum_acs.upstream_username = nil
+      @yum_acs.upstream_password = nil
+      @file_acs = katello_alternate_content_sources(:file_alternate_content_source)
+      @file_acs.subpaths = ['file/', 'file-many/', 'file-mixed/']
+      @file_acs.ssl_ca_cert_id = nil
+      @file_acs.ssl_client_cert_id = nil
+      @file_acs.ssl_client_key_id = nil
+      @file_acs.upstream_username = nil
+      @file_acs.upstream_password = nil
+      @yum_acs.save!
+      @file_acs.save!
+      ::Katello::SmartProxyAlternateContentSource.create(alternate_content_source_id: @yum_acs.id, smart_proxy_id: @primary.id)
+      ::Katello::SmartProxyAlternateContentSource.create(alternate_content_source_id: @file_acs.id, smart_proxy_id: @primary.id)
+    end
+
+    def teardown
+      @yum_acs.smart_proxies.each do |proxy|
+        ForemanTasks.sync_task(
+            ::Actions::Pulp3::Orchestration::AlternateContentSource::Delete, @yum_acs, proxy)
+      end
+
+      @file_acs.smart_proxies.each do |proxy|
+        ForemanTasks.sync_task(
+            ::Actions::Pulp3::Orchestration::AlternateContentSource::Delete, @file_acs, proxy)
+      end
+    end
+
+    def test_yum_refresh
+      ::Katello::Pulp3::AlternateContentSource.any_instance.stubs(:generate_backend_object_name).returns(@yum_acs.name)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::AlternateContentSource::Create, @yum_acs, @primary)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::AlternateContentSource::Refresh, @yum_acs, @primary)
+    end
+
+    def test_file_create
+      ::Katello::Pulp3::AlternateContentSource.any_instance.stubs(:generate_backend_object_name).returns(@file_acs.name)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::AlternateContentSource::Create, @file_acs, @primary)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::AlternateContentSource::Refresh, @file_acs, @primary)
+    end
+  end
+end

--- a/test/controllers/api/v2/alternate_content_sources_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/alternate_content_sources_bulk_actions_controller_test.rb
@@ -1,0 +1,37 @@
+require "katello_test_helper"
+
+module Katello
+  class Api::V2::AlternateContentSourcesBulkActionsControllerTest < ActionController::TestCase
+    include Support::ForemanTasks::Task
+
+    def setup
+      setup_controller_defaults_api
+      login_user(User.find(users(:admin).id))
+      User.current = User.find(users(:admin).id)
+      @acss = katello_alternate_content_sources(:yum_alternate_content_source, :file_alternate_content_source)
+      @acss.first.save
+      @acss.second.save
+    end
+
+    def test_destroy_alternate_content_sources
+      assert_async_task(::Actions::BulkAction) do |action_class|
+        assert_equal action_class, ::Actions::Katello::AlternateContentSource::Destroy
+      end
+
+      put :destroy_alternate_content_sources, params: { ids: @acss.collect(&:id) }
+
+      assert_response :success
+    end
+
+    def test_refresh
+      assert_async_task(::Actions::BulkAction) do |action_class, acss|
+        assert_equal action_class, ::Actions::Katello::AlternateContentSource::Refresh
+        assert_equal @acss.map(&:id).sort, acss.map(&:id).sort
+      end
+
+      post :refresh_alternate_content_sources, params: { ids: @acss.collect(&:id) }
+
+      assert_response :success
+    end
+  end
+end

--- a/test/controllers/api/v2/alternate_content_sources_controller_test.rb
+++ b/test/controllers/api/v2/alternate_content_sources_controller_test.rb
@@ -24,17 +24,9 @@ module Katello
       @acs.save!
     end
 
-    def permissions
-      @read_permission = :view_alternate_content_sources
-      @create_permission = :create_alternate_content_sources
-      @update_permission = :edit_alternate_content_sources
-      @destroy_permission = :destroy_alternate_content_sources
-    end
-
     def setup
       setup_controller_defaults_api
       models
-      permissions
     end
 
     def test_index
@@ -198,6 +190,16 @@ module Katello
       end
 
       delete :destroy, params: { :id => @acs.id }
+
+      assert_response :success
+    end
+
+    def test_refresh
+      assert_async_task(::Actions::Katello::AlternateContentSource::Refresh) do |acs|
+        assert_equal acs.attributes.except('id', 'label'), @acs.attributes.except('id', 'label')
+      end
+
+      post :refresh, params: { :id => @acs.id }
 
       assert_response :success
     end

--- a/test/fixtures/vcr_cassettes/actions/pulp3/alternate_content_source_refresh/file_create.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/alternate_content_source_refresh/file_create.yml
@@ -1,0 +1,2644 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRmlsZSBBQ1MiLCJ1cmwiOiJodHRwczovL2ZpeHR1cmVzLnB1
+        bHBwcm9qZWN0Lm9yZy8iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6
+        bnVsbCwiY2xpZW50X2tleSI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUs
+        InByb3h5X3VybCI6bnVsbCwicHJveHlfdXNlcm5hbWUiOm51bGwsInByb3h5
+        X3Bhc3N3b3JkIjpudWxsLCJ1c2VybmFtZSI6bnVsbCwicGFzc3dvcmQiOm51
+        bGwsInBvbGljeSI6Im9uX2RlbWFuZCIsInRvdGFsX3RpbWVvdXQiOm51bGx9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/file/file/ce9d030e-cc1d-4750-954f-606596d3dd37/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '527'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 719f2a49f28d42c386525f8273ff548d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
+        Y2U5ZDAzMGUtY2MxZC00NzUwLTk1NGYtNjA2NTk2ZDNkZDM3LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuNDk2NzQ5WiIsIm5hbWUi
+        OiJGaWxlIEFDUyIsInVybCI6Imh0dHBzOi8vZml4dHVyZXMucHVscHByb2pl
+        Y3Qub3JnLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0
+        bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xh
+        YmVscyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyMi0wNS0wMlQyMTox
+        ODozMy40OTY3OTRaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOm51bGwsIm1h
+        eF9yZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJvbl9kZW1hbmQiLCJ0b3RhbF90
+        aW1lb3V0IjpudWxsLCJjb25uZWN0X3RpbWVvdXQiOm51bGwsInNvY2tfY29u
+        bmVjdF90aW1lb3V0IjpudWxsLCJzb2NrX3JlYWRfdGltZW91dCI6bnVsbCwi
+        aGVhZGVycyI6bnVsbCwicmF0ZV9saW1pdCI6bnVsbH0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:33 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/acs/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRmlsZSBBQ1MiLCJwYXRocyI6WyJmaWxlLy9QVUxQX01BTklG
+        RVNUIiwiZmlsZS1tYW55Ly9QVUxQX01BTklGRVNUIiwiZmlsZS1taXhlZC8v
+        UFVMUF9NQU5JRkVTVCJdLCJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rl
+        cy9maWxlL2ZpbGUvY2U5ZDAzMGUtY2MxZC00NzUwLTk1NGYtNjA2NTk2ZDNk
+        ZDM3LyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/acs/file/file/6cb1927e-a954-4d90-97ea-513284fcc9d5/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '332'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0e0ef3751fa04ac792e30b9e8c31d9cc
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvYWNzL2ZpbGUvZmlsZS82Y2Ix
+        OTI3ZS1hOTU0LTRkOTAtOTdlYS01MTMyODRmY2M5ZDUvIiwicHVscF9jcmVh
+        dGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy42MDgxNjlaIiwibmFtZSI6IkZp
+        bGUgQUNTIiwibGFzdF9yZWZyZXNoZWQiOm51bGwsInBhdGhzIjpbImZpbGUt
+        bWl4ZWQvL1BVTFBfTUFOSUZFU1QiLCJmaWxlLW1hbnkvL1BVTFBfTUFOSUZF
+        U1QiLCJmaWxlLy9QVUxQX01BTklGRVNUIl0sInJlbW90ZSI6Ii9wdWxwL2Fw
+        aS92My9yZW1vdGVzL2ZpbGUvZmlsZS9jZTlkMDMwZS1jYzFkLTQ3NTAtOTU0
+        Zi02MDY1OTZkM2RkMzcvIn0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:33 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/acs/file/file/6cb1927e-a954-4d90-97ea-513284fcc9d5/refresh/
+    body:
+      encoding: UTF-8
+      base64_string: 'cGxhY2Vob2xkZXI=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '79'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 21132afd04a641a79ba9a1bdf54e9a5f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrX2dyb3VwIjoiL3B1bHAvYXBpL3YzL3Rhc2stZ3JvdXBzLzkwMzAx
+        YmY0LTliZmQtNDEwYy1hNDMwLTZiMTBhOGI1NDcxYS8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:33 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 04026571df5f4eadabd97fb5207cb9d0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '522'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MywiY29tcGxldGVkIjowLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJydW5uaW5nIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTEzNjg2WiIsImZpbmlzaGVkX2F0Ijpu
+        dWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0y
+        MGI5LTRmZTgtOGNkNC1lYTE5YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvdGFza3MvYzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5
+        ZTBjOTAwYTY2LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6
+        MzMuODk1MTg4WiIsIm5hbWUiOiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozMy45NDYzODVaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQt
+        YTliMy01YmI2NWY4MzU5M2IvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45MTgyOTFaIiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFz
+        a3Muc3luY2hyb25pemluZy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmlu
+        ZyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjk1OTcwM1oi
+        LCJmaW5pc2hlZF9hdCI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dv
+        cmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYzOTEzZmQ2LyJ9
+        XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:33 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 522da45c65ea41939b51dcb76f5be495
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '522'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MywiY29tcGxldGVkIjowLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJydW5uaW5nIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTEzNjg2WiIsImZpbmlzaGVkX2F0Ijpu
+        dWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0y
+        MGI5LTRmZTgtOGNkNC1lYTE5YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvdGFza3MvYzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5
+        ZTBjOTAwYTY2LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6
+        MzMuODk1MTg4WiIsIm5hbWUiOiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozMy45NDYzODVaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQt
+        YTliMy01YmI2NWY4MzU5M2IvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45MTgyOTFaIiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFz
+        a3Muc3luY2hyb25pemluZy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmlu
+        ZyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjk1OTcwM1oi
+        LCJmaW5pc2hlZF9hdCI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dv
+        cmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYzOTEzZmQ2LyJ9
+        XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:34 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 44f54f56a0eb448c995381d10f15ad90
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '522'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MywiY29tcGxldGVkIjowLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJydW5uaW5nIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTEzNjg2WiIsImZpbmlzaGVkX2F0Ijpu
+        dWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0y
+        MGI5LTRmZTgtOGNkNC1lYTE5YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvdGFza3MvYzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5
+        ZTBjOTAwYTY2LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6
+        MzMuODk1MTg4WiIsIm5hbWUiOiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozMy45NDYzODVaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQt
+        YTliMy01YmI2NWY4MzU5M2IvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45MTgyOTFaIiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFz
+        a3Muc3luY2hyb25pemluZy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmlu
+        ZyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjk1OTcwM1oi
+        LCJmaW5pc2hlZF9hdCI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dv
+        cmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYzOTEzZmQ2LyJ9
+        XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:34 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 98fced7e4d4b48b59f4f4532f585320b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '522'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MywiY29tcGxldGVkIjowLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJydW5uaW5nIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTEzNjg2WiIsImZpbmlzaGVkX2F0Ijpu
+        dWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0y
+        MGI5LTRmZTgtOGNkNC1lYTE5YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvdGFza3MvYzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5
+        ZTBjOTAwYTY2LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6
+        MzMuODk1MTg4WiIsIm5hbWUiOiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozMy45NDYzODVaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQt
+        YTliMy01YmI2NWY4MzU5M2IvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45MTgyOTFaIiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFz
+        a3Muc3luY2hyb25pemluZy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmlu
+        ZyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjk1OTcwM1oi
+        LCJmaW5pc2hlZF9hdCI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dv
+        cmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYzOTEzZmQ2LyJ9
+        XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:34 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8eacb0cf886942eaaba8135ac28c07ab
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '522'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MywiY29tcGxldGVkIjowLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJydW5uaW5nIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTEzNjg2WiIsImZpbmlzaGVkX2F0Ijpu
+        dWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0y
+        MGI5LTRmZTgtOGNkNC1lYTE5YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvdGFza3MvYzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5
+        ZTBjOTAwYTY2LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6
+        MzMuODk1MTg4WiIsIm5hbWUiOiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozMy45NDYzODVaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQt
+        YTliMy01YmI2NWY4MzU5M2IvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45MTgyOTFaIiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFz
+        a3Muc3luY2hyb25pemluZy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmlu
+        ZyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjk1OTcwM1oi
+        LCJmaW5pc2hlZF9hdCI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dv
+        cmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYzOTEzZmQ2LyJ9
+        XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:34 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 654735b996d6477fb0d1ad905e7875fe
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '522'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MywiY29tcGxldGVkIjowLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJydW5uaW5nIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTEzNjg2WiIsImZpbmlzaGVkX2F0Ijpu
+        dWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0y
+        MGI5LTRmZTgtOGNkNC1lYTE5YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvdGFza3MvYzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5
+        ZTBjOTAwYTY2LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6
+        MzMuODk1MTg4WiIsIm5hbWUiOiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozMy45NDYzODVaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBf
+        aHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQt
+        YTliMy01YmI2NWY4MzU5M2IvIiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45MTgyOTFaIiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFz
+        a3Muc3luY2hyb25pemluZy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmlu
+        ZyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjk1OTcwM1oi
+        LCJmaW5pc2hlZF9hdCI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dv
+        cmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYzOTEzZmQ2LyJ9
+        XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:34 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 67cc77de64624ad8ae4adbfe66c7a02a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:34 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6c9d944586264dcb8972f0666033a93b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:34 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0b50d7f65fae4982920a83313dae7ac0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:34 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1eecc8b316d444c7832822b953cec710
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:34 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 420a9ef51b5240dc8786e93c8f7a6e35
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:34 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:34 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 953280f846ef498bbd7b08a22235dac5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:34 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3446a672062744948dc02525faa26259
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5512118968de43d69968ebab7707946a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d016d4dd14344711943125e965ba0cab
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b297185ebb204c049a182b9d3e388951
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e8550223ee4a4a7ca84c98735e8e1986
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - de1601c6f0a64b82a4263b15fc3f8485
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d06ae6d60cca49eabc8742f6b29559e1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e52d9ff67dca48989091cdbb3081a618
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - af9a5d51d5614ce6a302d69c11e3bdc2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3a9e89cdf5aa4ce7a6ce0734b31cb19d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7ee44fad98fa4bdf823e7f32bd8096ff
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4ed4dde77bc742d68e99adcde128c8c4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fdd28c0844ea4bc88f663589b80f0498
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:35 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:36 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 77261ce35e6142bf80e75da1037a2748
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:36 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:36 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 86d8d5609eb7475f844b9c9831078afd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:36 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:36 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 290ac85d08dd4d15b11feb4c0a93d799
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '543'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MSwiY29tcGxldGVkIjoyLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozMy45NDYzODVaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My90YXNrcy84NWNiYTc3Zi01YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2Iv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFa
+        IiwibmFtZSI6InB1bHBfZmlsZS5hcHAudGFza3Muc3luY2hyb25pemluZy5z
+        eW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6
+        IjIwMjItMDUtMDJUMjE6MTg6MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0Ijoi
+        MjAyMi0wNS0wMlQyMToxODozNC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvNGY1Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYz
+        OTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:36 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/90301bf4-9bfd-410c-a430-6b10a8b5471a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:36 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c73592f48f84458fa33176cfb73d91a4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '537'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvOTAzMDFi
+        ZjQtOWJmZC00MTBjLWE0MzAtNmIxMGE4YjU0NzFhLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAzIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        cy4iLCJhbGxfdGFza3NfZGlzcGF0Y2hlZCI6dHJ1ZSwid2FpdGluZyI6MCwi
+        c2tpcHBlZCI6MCwicnVubmluZyI6MCwiY29tcGxldGVkIjozLCJjYW5jZWxl
+        ZCI6MCwiZmFpbGVkIjowLCJjYW5jZWxpbmciOjAsImdyb3VwX3Byb2dyZXNz
+        X3JlcG9ydHMiOltdLCJ0YXNrcyI6W3sicHVscF9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3Rhc2tzLzQwZTNiYTUzLWJiNjAtNGQzMi1hYWI2LTIwNzQ5MmRmZTM0
+        MC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjMzLjg1NTE1
+        N1oiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6aW5n
+        LnN5bmNocm9uaXplIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJzdGFydGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODozMy45MTM2ODZaIiwiZmluaXNoZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM0LjQ0NzUwNFoiLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5
+        YTA5NmUzMjcvIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3Mv
+        Yzg2NGM2NmEtZTQxMi00NWUzLWI3MTctMDk5ZTBjOTAwYTY2LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzMuODk1MTg4WiIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1
+        LTAyVDIxOjE4OjMzLjk0NjM4NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUt
+        MDJUMjE6MTg6MzYuMTc3MzA5WiIsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8i
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84NWNiYTc3Zi01
+        YTIxLTRhZWQtYTliMy01YmI2NWY4MzU5M2IvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyMi0wNS0wMlQyMToxODozMy45MTgyOTFaIiwibmFtZSI6InB1bHBfZmls
+        ZS5hcHAudGFza3Muc3luY2hyb25pemluZy5zeW5jaHJvbml6ZSIsInN0YXRl
+        IjoiY29tcGxldGVkIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMDJUMjE6MTg6
+        MzMuOTU5NzAzWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODoz
+        NC40NzU0NjJaIiwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNGY1
+        Yjc4YTgtN2VlOS00Yjc5LWIwYTEtZGZkMzYzOTEzZmQ2LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:36 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/acs/file/file/6cb1927e-a954-4d90-97ea-513284fcc9d5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:36 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5bc08b4c464f48b2b417f5c8c63ad08d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YyNTczYTA0LTk2MmQtNDQ2
+        YS05OGI1LWNjMGFkYTVmNzYwNS8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:36 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/file/file/ce9d030e-cc1d-4750-954f-606596d3dd37/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.10.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:36 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 820a3aaca4d74df6a0fa5281d30772fa
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNjYTRjYTViLWFjN2ItNDM5
+        Zi05NTJjLTVmMTYzNWFmODhlMS8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:36 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/alternate_content_source_refresh/yum_refresh.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/alternate_content_source_refresh/yum_refresh.yml
@@ -1,0 +1,2612 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiWXVtIEFDUyIsInVybCI6Imh0dHBzOi8vZml4dHVyZXMucHVs
+        cHByb2plY3Qub3JnLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0Ijpu
+        dWxsLCJjbGllbnRfa2V5IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwi
+        cHJveHlfdXJsIjpudWxsLCJwcm94eV91c2VybmFtZSI6bnVsbCwicHJveHlf
+        cGFzc3dvcmQiOm51bGwsInVzZXJuYW1lIjpudWxsLCJwYXNzd29yZCI6bnVs
+        bCwicG9saWN5Ijoib25fZGVtYW5kIiwidG90YWxfdGltZW91dCI6bnVsbH0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:37 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/rpm/rpm/5f5b7386-a9fd-46b9-861e-79cab8d4e9d7/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '547'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3d86c982ca254d379ee2f13d7373576e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzVm
+        NWI3Mzg2LWE5ZmQtNDZiOS04NjFlLTc5Y2FiOGQ0ZTlkNy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjM3LjY3MDgwOVoiLCJuYW1lIjoi
+        WXVtIEFDUyIsInVybCI6Imh0dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qu
+        b3JnLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNf
+        dmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVs
+        cyI6e30sInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyMi0wNS0wMlQyMToxODoz
+        Ny42NzA4NTFaIiwiZG93bmxvYWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9y
+        ZXRyaWVzIjpudWxsLCJwb2xpY3kiOiJvbl9kZW1hbmQiLCJ0b3RhbF90aW1l
+        b3V0IjpudWxsLCJjb25uZWN0X3RpbWVvdXQiOm51bGwsInNvY2tfY29ubmVj
+        dF90aW1lb3V0IjpudWxsLCJzb2NrX3JlYWRfdGltZW91dCI6bnVsbCwiaGVh
+        ZGVycyI6bnVsbCwicmF0ZV9saW1pdCI6bnVsbCwic2xlc19hdXRoX3Rva2Vu
+        IjpudWxsfQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:37 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/acs/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiWXVtIEFDUyIsInBhdGhzIjpbInJwbS16Y2h1bmsvIiwicnBt
+        LXdpdGgtbW9kdWxlcy8iXSwicmVtb3RlIjoiL3B1bHAvYXBpL3YzL3JlbW90
+        ZXMvcnBtL3JwbS81ZjViNzM4Ni1hOWZkLTQ2YjktODYxZS03OWNhYjhkNGU5
+        ZDcvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:37 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/acs/rpm/rpm/e2bcacb0-06d0-4a49-b8e2-709211b8bc3d/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '284'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - df815438031d47fb951a124f52f765f8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvYWNzL3JwbS9ycG0vZTJiY2Fj
+        YjAtMDZkMC00YTQ5LWI4ZTItNzA5MjExYjhiYzNkLyIsInB1bHBfY3JlYXRl
+        ZCI6IjIwMjItMDUtMDJUMjE6MTg6MzcuNzUwNTY0WiIsIm5hbWUiOiJZdW0g
+        QUNTIiwibGFzdF9yZWZyZXNoZWQiOm51bGwsInBhdGhzIjpbInJwbS16Y2h1
+        bmsvIiwicnBtLXdpdGgtbW9kdWxlcy8iXSwicmVtb3RlIjoiL3B1bHAvYXBp
+        L3YzL3JlbW90ZXMvcnBtL3JwbS81ZjViNzM4Ni1hOWZkLTQ2YjktODYxZS03
+        OWNhYjhkNGU5ZDcvIn0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:37 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/acs/rpm/rpm/e2bcacb0-06d0-4a49-b8e2-709211b8bc3d/refresh/
+    body:
+      encoding: UTF-8
+      base64_string: 'cGxhY2Vob2xkZXI=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '79'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d5d6b3eabb634426b73bbf56da97c5a8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrX2dyb3VwIjoiL3B1bHAvYXBpL3YzL3Rhc2stZ3JvdXBzLzExMjlj
+        ODFjLTVhMTItNGFhMy05OTUzLTExODJmNmQ0ZWU3OC8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 33a85b2eb55b41a6be818f67fc4d03e0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 74887bfe48634d27800f9c7bcfbb880f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 215ece4d7b284e549a012ddfbeeea0d5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f1a4089bcb4f42919ed91f2b1c8f7f89
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e9fc695535e84b5ea8151a8e4c0401d1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b657fa47dd3549d6858d619e37710bc4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 95ebc34d4b03450b856f706073994d9b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 77ddac4c846c48f39ad7b5fd4df078d5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e2f851bfd09742ec826716cf6b047b88
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fd8da65011cd4a45a038834e04e8056f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a11231c094f5448fb03dd9a00510b5b4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4b88b1c091134087b34a796e6bd58f41
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a2c85cc586dd4b2d91424d963ab832a8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d14e9ac482134dcf920da7f1a0b7cb32
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 68fce6d955f4435aad4b1932a4dc883e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 862b3e64de394649b2cfaf13c527144c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 76a371f0d9e340a1ab0b7fe23a8f3f46
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d97114eddf574240ac034b8e2ec021ee
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7d3d029a215248d98d1da6d07b36253d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 71394ed22abd40a480cd47abe19b3214
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 32bcbb72aeb04871a89244e68d632712
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ffd5a29dd2f44b9b8f445715a3b7517d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 43010b153ad54b06bd56cccc7c58e7e9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 268fe0fa498345809d57aa4dce55a98d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4db43c30e295470c89467caa30ff60f0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '458'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA2NjIyMFoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0
+        MzI5ZGE5OTI3Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4
+        OjM4LjA0Nzg5NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMToxODozOC4wODQwNDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAy
+        ODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 31b08650101b44d89f151642ebc3b1f3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '474'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoxLCJjb21wbGV0ZWQiOjEsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9h
+        dCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDY2MjIwWiIsImZpbmlzaGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODo0MC4zMTQ1NzNaIiwid29ya2VyIjoiL3B1
+        bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQtMjBiOS00ZmU4LThjZDQtZWEx
+        OWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3Rhc2tz
+        LzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0MzI5ZGE5OTI3Mi8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA0Nzg5NloiLCJuYW1l
+        IjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozOC4wODQwNDNaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0e9c6a8b7bd64751a816df07e9a9de40
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '474'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoxLCJjb21wbGV0ZWQiOjEsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9h
+        dCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDY2MjIwWiIsImZpbmlzaGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODo0MC4zMTQ1NzNaIiwid29ya2VyIjoiL3B1
+        bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQtMjBiOS00ZmU4LThjZDQtZWEx
+        OWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3Rhc2tz
+        LzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0MzI5ZGE5OTI3Mi8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA0Nzg5NloiLCJuYW1l
+        IjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozOC4wODQwNDNaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6208617680524615af025c7114766211
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '474'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoxLCJjb21wbGV0ZWQiOjEsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9h
+        dCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDY2MjIwWiIsImZpbmlzaGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODo0MC4zMTQ1NzNaIiwid29ya2VyIjoiL3B1
+        bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQtMjBiOS00ZmU4LThjZDQtZWEx
+        OWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3Rhc2tz
+        LzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0MzI5ZGE5OTI3Mi8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA0Nzg5NloiLCJuYW1l
+        IjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozOC4wODQwNDNaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9852726a90264f23b32f7b97f1e1c881
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '474'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoxLCJjb21wbGV0ZWQiOjEsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9h
+        dCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDY2MjIwWiIsImZpbmlzaGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODo0MC4zMTQ1NzNaIiwid29ya2VyIjoiL3B1
+        bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQtMjBiOS00ZmU4LThjZDQtZWEx
+        OWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3Rhc2tz
+        LzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0MzI5ZGE5OTI3Mi8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA0Nzg5NloiLCJuYW1l
+        IjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozOC4wODQwNDNaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8cb88cad4dd144eb93b6ccb769af04c8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '474'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoxLCJjb21wbGV0ZWQiOjEsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9h
+        dCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDY2MjIwWiIsImZpbmlzaGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODo0MC4zMTQ1NzNaIiwid29ya2VyIjoiL3B1
+        bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQtMjBiOS00ZmU4LThjZDQtZWEx
+        OWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3Rhc2tz
+        LzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0MzI5ZGE5OTI3Mi8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA0Nzg5NloiLCJuYW1l
+        IjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozOC4wODQwNDNaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9dbf8c0cdb9449618b2d3554080a9746
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '474'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoxLCJjb21wbGV0ZWQiOjEsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9h
+        dCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDY2MjIwWiIsImZpbmlzaGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODo0MC4zMTQ1NzNaIiwid29ya2VyIjoiL3B1
+        bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQtMjBiOS00ZmU4LThjZDQtZWEx
+        OWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3Rhc2tz
+        LzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0MzI5ZGE5OTI3Mi8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA0Nzg5NloiLCJuYW1l
+        IjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMToxODozOC4wODQwNDNaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05
+        MWRlLTY4Y2RiYTc4OTA1MC8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:40 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/1129c81c-5a12-4aa3-9953-1182f6d4ee78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e00126bf49ea4f638a3e772cdc494e8c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '470'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvMTEyOWM4
+        MWMtNWExMi00YWEzLTk5NTMtMTE4MmY2ZDRlZTc4LyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjowLCJjb21wbGV0ZWQiOjIsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvNDdjZTNjMjUtNDRhNC00YTRhLTk5NjItZWEyNWIwNDMx
+        NDQxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDI0
+        MDA5WiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9h
+        dCI6IjIwMjItMDUtMDJUMjE6MTg6MzguMDY2MjIwWiIsImZpbmlzaGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMToxODo0MC4zMTQ1NzNaIiwid29ya2VyIjoiL3B1
+        bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQtMjBiOS00ZmU4LThjZDQtZWEx
+        OWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3Rhc2tz
+        LzllYWZiYmQyLTAyZDAtNDFmOC1hZWVmLTU0MzI5ZGE5OTI3Mi8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjE4OjM4LjA0Nzg5NloiLCJuYW1l
+        IjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1
+        LTAyVDIxOjE4OjM4LjA4NDA0M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUt
+        MDJUMjE6MTg6NDAuNzY5MDc4WiIsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzAyODU1ZDNhLTBkZDMtNDljMC05MWRlLTY4Y2RiYTc4OTA1MC8i
+        fV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:40 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/acs/rpm/rpm/e2bcacb0-06d0-4a49-b8e2-709211b8bc3d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:40 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e08a16fb0404461589430cf610dbf4ce
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E1ZmFkNDFjLTc1MDctNDE5
+        Ny04NTllLTdkMDRhZTRkZGRlMi8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:40 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/5f5b7386-a9fd-46b9-861e-79cab8d4e9d7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:18:41 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4b8b28ec96054e91b718076527bbc5be
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QyZDVhNjA5LWI1YTItNDEy
+        Yi1hZGRjLWFjZDI2MDkzMGU0Ny8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:18:41 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/yum_sync/sync_with_acs.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/yum_sync/sync_with_acs.yml
@@ -1,0 +1,3518 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5d06252ba22543759253a6598be3018d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:46 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - abbb91bc66044f1c8e03cc5bb140f9de
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:46 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2959681fa52e47c2a06b7e0920ffdb1a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:46 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1706871ca7634f6ebd7c5dd5b5bba2d7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:46 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiMl9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJp
+        bGwuZmVkb3JhcGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEv
+        IiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9r
+        ZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51
+        bGwsInByb3h5X3VzZXJuYW1lIjpudWxsLCJwcm94eV9wYXNzd29yZCI6bnVs
+        bCwidXNlcm5hbWUiOm51bGwsInBhc3N3b3JkIjpudWxsLCJwb2xpY3kiOiJp
+        bW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLCJjb25uZWN0X3RpbWVv
+        dXQiOjYwLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAsInNvY2tfcmVhZF90
+        aW1lb3V0IjozNjAwLCJyYXRlX2xpbWl0IjowfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:47 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/rpm/rpm/efe4c1cb-f527-4511-a09c-0aa39872c983/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '580'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 981a6704c82c4201918231fcd4f82c9f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Vm
+        ZTRjMWNiLWY1MjctNDUxMS1hMDljLTBhYTM5ODcyYzk4My8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQwOjQ3LjAyMTM5N1oiLCJuYW1lIjoi
+        Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
+        cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
+        dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
+        cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQwOjQ3LjAyMTQyN1oiLCJk
+        b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
+        InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
+        Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
+        NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
+        bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:47 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiMl9kdXBsaWNhdGUiLCJyZXRhaW5fcGFja2FnZV92ZXJzaW9u
+        cyI6MH0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:47 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/rpm/rpm/340b05cb-5310-4bd4-a861-483ec0d3a0f2/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '631'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5ebb404c7fce4d9093902a8e3dfba0b2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vMzQwYjA1Y2ItNTMxMC00YmQ0LWE4NjEtNDgzZWMwZDNhMGYyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDcuMjI1OTI4WiIsInZl
+        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vMzQwYjA1Y2ItNTMxMC00YmQ0LWE4NjEtNDgzZWMwZDNhMGYyL3ZlcnNp
+        b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8zNDBiMDVjYi01
+        MzEwLTRiZDQtYTg2MS00ODNlYzBkM2EwZjIvdmVyc2lvbnMvMC8iLCJuYW1l
+        IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
+        cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
+        OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
+        bl9wYWNrYWdlX3ZlcnNpb25zIjowLCJtZXRhZGF0YV9jaGVja3N1bV90eXBl
+        IjpudWxsLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOm51bGwsImdwZ2NoZWNr
+        IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
+        fQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:47 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/publications/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL3JwbS9ycG0vMzQwYjA1Y2ItNTMxMC00YmQ0LWE4NjEtNDgzZWMwZDNh
+        MGYyL3ZlcnNpb25zLzAvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:47 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 68b17883150145938a648634e0b00644
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NkNmE2Mjk5LWFkZTEtNDEy
+        Ni1hNzhlLWU0NzM5OTU0MjcwOS8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:47 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/tasks/cd6a6299-ade1-4126-a78e-e47399542709/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:47 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a39b90a471f045edb4a5917e35eb669a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '476'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvY2Q2YTYyOTktYWRl
+        MS00MTI2LWE3OGUtZTQ3Mzk5NTQyNzA5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDUtMDJUMjE6NDA6NDcuNjA2OTEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
+        c2giLCJsb2dnaW5nX2NpZCI6IjY4YjE3ODgzMTUwMTQ1OTM4YTY0ODYzNGUw
+        YjAwNjQ0Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMDJUMjE6NDA6NDcuNjY0
+        MzgzWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo0Ny44MjE5
+        MjJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzRmNWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8iLCJw
+        YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
+        IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
+        dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
+        ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
+        OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOGQyZmJj
+        M2UtZDc3OS00YzAyLTg1MWUtZGU0ZTIwYjU2YWU5LyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL3JwbS9ycG0vMzQwYjA1Y2ItNTMxMC00YmQ0LWE4NjEtNDgzZWMw
+        ZDNhMGYyLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:47 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 987188da126242eb996e067cfd212f4d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:48 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
+        IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
+        bGljYXRpb25zL3JwbS9ycG0vOGQyZmJjM2UtZDc3OS00YzAyLTg1MWUtZGU0
+        ZTIwYjU2YWU5LyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a07c7dc3945247bcb73b02d39e6e9cd2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E3ZGEzMDU2LTAyMDEtNDQ2
+        My1iYTBjLTAzYzNhMjQ2MGJlZi8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:48 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/tasks/a7da3056-0201-4463-ba0c-03c3a2460bef/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2e823ab8fac4492da0ccb4ea7cb1649d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '379'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTdkYTMwNTYtMDIw
+        MS00NDYzLWJhMGMtMDNjM2EyNDYwYmVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDUtMDJUMjE6NDA6NDguMDg4Mzk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwibG9nZ2luZ19jaWQiOiJhMDdjN2RjMzk0NTI0N2JjYjczYjAyZDM5
+        ZTZlOWNkMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTAyVDIxOjQwOjQ4LjE1
+        MTU3NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMDJUMjE6NDA6NDguMjkz
+        MTk4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5YTA5NmUzMjcvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNDlh
+        M2Q5ZjgtMWQ1Ny00OTk5LWEzNTUtZDE1YjJlMGZlMmM0LyJdLCJyZXNlcnZl
+        ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
+        XX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:48 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/49a3d9f8-1d57-4999-a355-d15b2e0fe2c4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 292896f633d24efa884948f62f1b8852
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '306'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtLzQ5YTNkOWY4LTFkNTctNDk5OS1hMzU1LWQxNWIyZTBmZTJjNC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQwOjQ4LjI4MjQ4NVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
+        ZWxsby1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9B
+        Q01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVs
+        LyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFt
+        ZSI6IjJfZHVwbGljYXRlIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRp
+        b24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOGQyZmJj
+        M2UtZDc3OS00YzAyLTg1MWUtZGU0ZTIwYjU2YWU5LyJ9
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:48 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiWXVtIEFDUyIsInVybCI6Imh0dHBzOi8vamxzaGVycmlsbC5m
+        ZWRvcmFwZW9wbGUub3JnL2Zha2UtcmVwb3MvIiwiY2FfY2VydCI6bnVsbCwi
+        Y2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9rZXkiOm51bGwsInRsc192YWxp
+        ZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInByb3h5X3VzZXJuYW1l
+        IjpudWxsLCJwcm94eV9wYXNzd29yZCI6bnVsbCwidXNlcm5hbWUiOm51bGws
+        InBhc3N3b3JkIjpudWxsLCJwb2xpY3kiOiJvbl9kZW1hbmQiLCJ0b3RhbF90
+        aW1lb3V0IjpudWxsfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/rpm/rpm/1690e21b-782c-4f57-afc6-7678e935b35c/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '561'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b4d0d74531944dc5b7b3b247091c5c90
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE2
+        OTBlMjFiLTc4MmMtNGY1Ny1hZmM2LTc2NzhlOTM1YjM1Yy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQwOjQ4LjcxMDU2MloiLCJuYW1lIjoi
+        WXVtIEFDUyIsInVybCI6Imh0dHBzOi8vamxzaGVycmlsbC5mZWRvcmFwZW9w
+        bGUub3JnL2Zha2UtcmVwb3MvIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2Nl
+        cnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51
+        bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDIy
+        LTA1LTAyVDIxOjQwOjQ4LjcxMDU5NFoiLCJkb3dubG9hZF9jb25jdXJyZW5j
+        eSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Im9uX2RlbWFu
+        ZCIsInRvdGFsX3RpbWVvdXQiOm51bGwsImNvbm5lY3RfdGltZW91dCI6bnVs
+        bCwic29ja19jb25uZWN0X3RpbWVvdXQiOm51bGwsInNvY2tfcmVhZF90aW1l
+        b3V0IjpudWxsLCJoZWFkZXJzIjpudWxsLCJyYXRlX2xpbWl0IjpudWxsLCJz
+        bGVzX2F1dGhfdG9rZW4iOm51bGx9
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:48 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/acs/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiWXVtIEFDUyIsInBhdGhzIjpbIm5lZWRlZC1lcnJhdGEvIiwi
+        ZW1wdHkvIl0sInJlbW90ZSI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
+        cG0vMTY5MGUyMWItNzgyYy00ZjU3LWFmYzYtNzY3OGU5MzViMzVjLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/acs/rpm/rpm/a1f053d8-cca1-4b61-8c70-560ff972c960/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '276'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 03d24b947fd649d681aeb5abfa310ba6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvYWNzL3JwbS9ycG0vYTFmMDUz
+        ZDgtY2NhMS00YjYxLThjNzAtNTYwZmY5NzJjOTYwLyIsInB1bHBfY3JlYXRl
+        ZCI6IjIwMjItMDUtMDJUMjE6NDA6NDguODI2MzEwWiIsIm5hbWUiOiJZdW0g
+        QUNTIiwibGFzdF9yZWZyZXNoZWQiOm51bGwsInBhdGhzIjpbImVtcHR5LyIs
+        Im5lZWRlZC1lcnJhdGEvIl0sInJlbW90ZSI6Ii9wdWxwL2FwaS92My9yZW1v
+        dGVzL3JwbS9ycG0vMTY5MGUyMWItNzgyYy00ZjU3LWFmYzYtNzY3OGU5MzVi
+        MzVjLyJ9
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:48 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/acs/rpm/rpm/a1f053d8-cca1-4b61-8c70-560ff972c960/refresh/
+    body:
+      encoding: UTF-8
+      base64_string: 'cGxhY2Vob2xkZXI=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '79'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5966316ff1064cfdad38a88f3f55f7d2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrX2dyb3VwIjoiL3B1bHAvYXBpL3YzL3Rhc2stZ3JvdXBzL2ExYjUz
+        MTk1LWQyMzctNGEyNC1hMTQzLTJiNzc3NDVlNjdkMC8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f51ee3c92592403bb2191ec6c58c8c10
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '459'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA4MzYwMVoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3
+        MzlkMmRlODU0NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQw
+        OjQ5LjA3Mjk3NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRm
+        NWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b536fd01525241eaa3e6187522d6f545
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '459'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA4MzYwMVoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3
+        MzlkMmRlODU0NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQw
+        OjQ5LjA3Mjk3NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRm
+        NWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c9a8eabef97d45b6b8f8f3209cc8fd1b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '459'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA4MzYwMVoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3
+        MzlkMmRlODU0NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQw
+        OjQ5LjA3Mjk3NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRm
+        NWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0d93ade7e3584d8abc0b75ac62f4244e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '459'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA4MzYwMVoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3
+        MzlkMmRlODU0NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQw
+        OjQ5LjA3Mjk3NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRm
+        NWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1421cf195bf7418fbef8ada938f69404
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '459'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA4MzYwMVoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3
+        MzlkMmRlODU0NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQw
+        OjQ5LjA3Mjk3NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRm
+        NWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b4cbf21d491b449d84b4d22a9e54f610
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '459'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA4MzYwMVoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3
+        MzlkMmRlODU0NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQw
+        OjQ5LjA3Mjk3NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRm
+        NWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f98185fcd02a44e2914243a8f132ec78
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '459'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA4MzYwMVoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3
+        MzlkMmRlODU0NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQw
+        OjQ5LjA3Mjk3NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRm
+        NWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - bc08b9045f8d4b6e9e52b925ee899624
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '459'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA4MzYwMVoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3
+        MzlkMmRlODU0NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQw
+        OjQ5LjA3Mjk3NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRm
+        NWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 70cf48e8556d4b58887df64677cfab98
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '459'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA4MzYwMVoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3
+        MzlkMmRlODU0NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQw
+        OjQ5LjA3Mjk3NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRm
+        NWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:49 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ca91d882cc734e08ba20171100dcd2d2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '459'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA4MzYwMVoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3
+        MzlkMmRlODU0NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQw
+        OjQ5LjA3Mjk3NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRm
+        NWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:49 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2add7e1a24b64896b142425c072ce8a7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '459'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA4MzYwMVoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3
+        MzlkMmRlODU0NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQw
+        OjQ5LjA3Mjk3NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRm
+        NWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - bfa053e6d5a74083b9f75eb6194fd742
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '459'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA4MzYwMVoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3
+        MzlkMmRlODU0NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQw
+        OjQ5LjA3Mjk3NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRm
+        NWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - '097ac545be3344b092ff735149536643'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '459'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA4MzYwMVoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3
+        MzlkMmRlODU0NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQw
+        OjQ5LjA3Mjk3NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRm
+        NWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7c4fddb6cdcb450ab3d6064b8d2573bf
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '459'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA4MzYwMVoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3
+        MzlkMmRlODU0NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQw
+        OjQ5LjA3Mjk3NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRm
+        NWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 84cb83b4a4674c0eb8d5a27f5e258c17
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '459'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA4MzYwMVoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3
+        MzlkMmRlODU0NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQw
+        OjQ5LjA3Mjk3NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRm
+        NWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fc174b61945d44a58bd95c0e34d3f304
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '459'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoyLCJjb21wbGV0ZWQiOjAsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoicnVubmluZyIsInN0YXJ0ZWRfYXQi
+        OiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA4MzYwMVoiLCJmaW5pc2hlZF9hdCI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQt
+        MjBiOS00ZmU4LThjZDQtZWExOWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3Rhc2tzLzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3
+        MzlkMmRlODU0NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQw
+        OjQ5LjA3Mjk3NloiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNo
+        cm9uaXppbmcuc3luY2hyb25pemUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFy
+        dGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRm
+        NWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4637a3e8f01c43cda40955756875eb4b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '474'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoxLCJjb21wbGV0ZWQiOjEsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9h
+        dCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDgzNjAxWiIsImZpbmlzaGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMTo0MDo1MC40NDIxODJaIiwid29ya2VyIjoiL3B1
+        bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQtMjBiOS00ZmU4LThjZDQtZWEx
+        OWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3Rhc2tz
+        LzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3MzlkMmRlODU0NC8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA3Mjk3NloiLCJuYW1l
+        IjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRmNWI3OGE4LTdlZTktNGI3OS1i
+        MGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 382634aa44a24fc8968ddac755200b8b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '474'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoxLCJjb21wbGV0ZWQiOjEsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9h
+        dCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDgzNjAxWiIsImZpbmlzaGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMTo0MDo1MC40NDIxODJaIiwid29ya2VyIjoiL3B1
+        bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQtMjBiOS00ZmU4LThjZDQtZWEx
+        OWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3Rhc2tz
+        LzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3MzlkMmRlODU0NC8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA3Mjk3NloiLCJuYW1l
+        IjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRmNWI3OGE4LTdlZTktNGI3OS1i
+        MGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 91411895d6ee444aa9663ddd97a6faa9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '474'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoxLCJjb21wbGV0ZWQiOjEsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9h
+        dCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDgzNjAxWiIsImZpbmlzaGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMTo0MDo1MC40NDIxODJaIiwid29ya2VyIjoiL3B1
+        bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQtMjBiOS00ZmU4LThjZDQtZWEx
+        OWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3Rhc2tz
+        LzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3MzlkMmRlODU0NC8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA3Mjk3NloiLCJuYW1l
+        IjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRmNWI3OGE4LTdlZTktNGI3OS1i
+        MGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 697a444c57d44eff96e07e06bf6a6401
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '474'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjoxLCJjb21wbGV0ZWQiOjEsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9h
+        dCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDgzNjAxWiIsImZpbmlzaGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMTo0MDo1MC40NDIxODJaIiwid29ya2VyIjoiL3B1
+        bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQtMjBiOS00ZmU4LThjZDQtZWEx
+        OWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3Rhc2tz
+        LzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3MzlkMmRlODU0NC8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA3Mjk3NloiLCJuYW1l
+        IjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6InJ1bm5pbmciLCJzdGFydGVkX2F0IjoiMjAyMi0wNS0w
+        MlQyMTo0MDo0OS4xMjA4NzZaIiwiZmluaXNoZWRfYXQiOm51bGwsIndvcmtl
+        ciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzRmNWI3OGE4LTdlZTktNGI3OS1i
+        MGExLWRmZDM2MzkxM2ZkNi8ifV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:50 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/task-groups/a1b53195-d237-4a24-a143-2b77745e67d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:50 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8f71e6761d6b4c958f4fc4baad88346a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '469'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFzay1ncm91cHMvYTFiNTMx
+        OTUtZDIzNy00YTI0LWExNDMtMmI3Nzc0NWU2N2QwLyIsImRlc2NyaXB0aW9u
+        IjoiUmVmcmVzaGluZyAyIGFsdGVybmF0ZSBjb250ZW50IHNvdXJjZSBwYXRo
+        KHMpLiIsImFsbF90YXNrc19kaXNwYXRjaGVkIjp0cnVlLCJ3YWl0aW5nIjow
+        LCJza2lwcGVkIjowLCJydW5uaW5nIjowLCJjb21wbGV0ZWQiOjIsImNhbmNl
+        bGVkIjowLCJmYWlsZWQiOjAsImNhbmNlbGluZyI6MCwiZ3JvdXBfcHJvZ3Jl
+        c3NfcmVwb3J0cyI6W10sInRhc2tzIjpbeyJwdWxwX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvdGFza3MvOWFjM2Q0ODgtMTUzNS00NmEwLWExYTQtMGQzYzRiZWVl
+        ODcxLyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDM1
+        MTgxWiIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFza3Muc3luY2hyb25pemlu
+        Zy5zeW5jaHJvbml6ZSIsInN0YXRlIjoiY29tcGxldGVkIiwic3RhcnRlZF9h
+        dCI6IjIwMjItMDUtMDJUMjE6NDA6NDkuMDgzNjAxWiIsImZpbmlzaGVkX2F0
+        IjoiMjAyMi0wNS0wMlQyMTo0MDo1MC40NDIxODJaIiwid29ya2VyIjoiL3B1
+        bHAvYXBpL3YzL3dvcmtlcnMvNDBjMTgwNGQtMjBiOS00ZmU4LThjZDQtZWEx
+        OWEwOTZlMzI3LyJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL3Rhc2tz
+        LzAzZDU4ZjU4LTFiZTgtNGU4YS04NzVjLWM3MzlkMmRlODU0NC8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDIyLTA1LTAyVDIxOjQwOjQ5LjA3Mjk3NloiLCJuYW1l
+        IjoicHVscF9ycG0uYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1
+        LTAyVDIxOjQwOjQ5LjEyMDg3NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUt
+        MDJUMjE6NDA6NTAuODIzMjYyWiIsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzLzRmNWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8i
+        fV19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:50 GMT
+- request:
+    method: patch
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/efe4c1cb-f527-4511-a09c-0aa39872c983/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IjJfZHVwbGljYXRlIiwi
+        dXJsIjoiaHR0cHM6Ly9qbHNoZXJyaWxsLmZlZG9yYXBlb3BsZS5vcmcvZmFr
+        ZS1yZXBvcy9uZWVkZWQtZXJyYXRhLyIsInByb3h5X3VybCI6bnVsbCwicHJv
+        eHlfdXNlcm5hbWUiOm51bGwsInByb3h5X3Bhc3N3b3JkIjpudWxsLCJ0b3Rh
+        bF90aW1lb3V0IjozNjAwLCJjb25uZWN0X3RpbWVvdXQiOjYwLCJzb2NrX2Nv
+        bm5lY3RfdGltZW91dCI6NjAsInNvY2tfcmVhZF90aW1lb3V0IjozNjAwLCJy
+        YXRlX2xpbWl0IjowLCJ1c2VybmFtZSI6bnVsbCwicGFzc3dvcmQiOm51bGws
+        ImNsaWVudF9jZXJ0IjpudWxsLCJjbGllbnRfa2V5IjpudWxsLCJjYV9jZXJ0
+        IjpudWxsLCJwb2xpY3kiOiJpbW1lZGlhdGUifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5c8b872ad23140de9255277afd99c239
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ1NWY4ZTcwLTRjMzktNDI4
+        ZS1hMWZlLTU4MDljZWJkYTQwNC8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:51 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/tasks/455f8e70-4c39-428e-a1fe-5809cebda404/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 35573d72731b4b26887d8e98893b8d2d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '370'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDU1ZjhlNzAtNGMz
+        OS00MjhlLWExZmUtNTgwOWNlYmRhNDA0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDUtMDJUMjE6NDA6NTEuMTY3ODUwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
+        YXRlIiwibG9nZ2luZ19jaWQiOiI1YzhiODcyYWQyMzE0MGRlOTI1NTI3N2Fm
+        ZDk5YzIzOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTAyVDIxOjQwOjUxLjIy
+        ODMzMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMDJUMjE6NDA6NTEuMjUy
+        ODE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5YTA5NmUzMjcvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2VmZTRjMWNiLWY1MjctNDUxMS1hMDlj
+        LTBhYTM5ODcyYzk4My8iXX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:51 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/340b05cb-5310-4bd4-a861-483ec0d3a0f2/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2VmZTRj
+        MWNiLWY1MjctNDUxMS1hMDljLTBhYTM5ODcyYzk4My8iLCJzeW5jX3BvbGlj
+        eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
+        aW1pemUiOnRydWV9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 368e24c586a14db2b650e521234bce04
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VkNmFhYmJiLWVmOGEtNGQy
+        NS1hMzIyLTBlY2ExMjZhODljMy8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:51 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/tasks/ed6aabbb-ef8a-4d25-a322-0eca126a89c3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3adc1cbfe6924432be42b5db8f5f6b93
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '597'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWQ2YWFiYmItZWY4
+        YS00ZDI1LWEzMjItMGVjYTEyNmE4OWMzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDUtMDJUMjE6NDA6NTEuNDQzMDM3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIzNjhlMjRjNTg2YTE0ZGIyYjY1
+        MGU1MjEyMzRiY2UwNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTAyVDIxOjQw
+        OjUxLjQ3NjYwMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMDJUMjE6NDA6
+        NTMuMTMwOTUxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5YTA5NmUz
+        MjcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
+        IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
+        bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        IjpudWxsLCJkb25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
+        d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
+        LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
+        InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
+        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
+        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
+        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
+        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
+        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
+        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMzQwYjA1Y2ItNTMxMC00YmQ0LWE4NjEt
+        NDgzZWMwZDNhMGYyL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
+        LzM0MGIwNWNiLTUzMTAtNGJkNC1hODYxLTQ4M2VjMGQzYTBmMi8iLCJzaGFy
+        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS9lZmU0YzFjYi1mNTI3
+        LTQ1MTEtYTA5Yy0wYWEzOTg3MmM5ODMvIl19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:53 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/publications/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL3JwbS9ycG0vMzQwYjA1Y2ItNTMxMC00YmQ0LWE4NjEtNDgzZWMwZDNh
+        MGYyL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9cfb57e499a64357b5e3f3b400f4628b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNiZGZkZmZlLTQyNjEtNDkw
+        NS1hOGZlLTVmMjMxNzI0MzA5ZC8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:53 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/tasks/3bdfdffe-4261-4905-a8fe-5f231724309d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3985ca53b3bf4c62972c7c3def3de4fd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '474'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2JkZmRmZmUtNDI2
+        MS00OTA1LWE4ZmUtNWYyMzE3MjQzMDlkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDUtMDJUMjE6NDA6NTMuNDIzMjI1WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
+        c2giLCJsb2dnaW5nX2NpZCI6IjljZmI1N2U0OTlhNjQzNTdiNWUzZjNiNDAw
+        ZjQ2MjhiIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMDJUMjE6NDA6NTMuNDc1
+        MDM3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0wMlQyMTo0MDo1My43OTU1
+        OTdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzRmNWI3OGE4LTdlZTktNGI3OS1iMGExLWRmZDM2MzkxM2ZkNi8iLCJw
+        YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
+        IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
+        dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
+        ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
+        OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNWY2ZWM0
+        YTMtNzkyMC00YzIxLTlhZWUtMTE1YWVjNmVkZmM4LyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL3JwbS9ycG0vMzQwYjA1Y2ItNTMxMC00YmQ0LWE4NjEtNDgzZWMw
+        ZDNhMGYyLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:53 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d064727ccb4049599376f094634889b6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '335'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vNDlhM2Q5ZjgtMWQ1Ny00OTk5LWEzNTUtZDE1YjJlMGZlMmM0
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMDJUMjE6NDA6NDguMjgyNDg1
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        OC1rYXRlbGxvLWRldmVsLmNhbm5vbG8uZXhhbXBsZS5jb20vcHVscC9jb250
+        ZW50L0FDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVf
+        bGFiZWwvIiwiY29udGVudF9ndWFyZCI6bnVsbCwicHVscF9sYWJlbHMiOnt9
+        LCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJs
+        aWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS84
+        ZDJmYmMzZS1kNzc5LTRjMDItODUxZS1kZTRlMjBiNTZhZTkvIn1dfQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:54 GMT
+- request:
+    method: patch
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/49a3d9f8-1d57-4999-a355-d15b2e0fe2c4/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
+        cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNWY2
+        ZWM0YTMtNzkyMC00YzIxLTlhZWUtMTE1YWVjNmVkZmM4LyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 11e647df44874de8b9d626a7e186736c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZmY2ViODRkLWYwZGUtNGNm
+        Yy05ZmQzLTg1NWI0MjY2YzA5MC8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:54 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/tasks/6fceb84d-f0de-4cfc-9fd3-855b4266c090/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b94103dd4cda4f759daef9fb6e3f1c82
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '346'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmZjZWI4NGQtZjBk
+        ZS00Y2ZjLTlmZDMtODU1YjQyNjZjMDkwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDUtMDJUMjE6NDA6NTQuMDk0ODgxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
+        YXRlIiwibG9nZ2luZ19jaWQiOiIxMWU2NDdkZjQ0ODc0ZGU4YjlkNjI2YTdl
+        MTg2NzM2YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTAyVDIxOjQwOjU0LjE0
+        MzA4NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMDJUMjE6NDA6NTQuMjcw
+        MDY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5YTA5NmUzMjcvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
+        L2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:54 GMT
+- request:
+    method: patch
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/49a3d9f8-1d57-4999-a355-d15b2e0fe2c4/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
+        cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNWY2
+        ZWM0YTMtNzkyMC00YzIxLTlhZWUtMTE1YWVjNmVkZmM4LyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:40:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - db32a02adf50469a99ef4246279d2817
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ3MDMyMTEwLWRkNzAtNDky
+        Mi1iMDExLTljYWFiNWQ2MTIzOC8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:40:54 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/acs/rpm/rpm/a1f053d8-cca1-4b61-8c70-560ff972c960/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:41:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 13c3708c21c2401dbcee11bb2c555411
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EzMTk0NWJlLTk4OTQtNDNl
+        OS05NDBhLWQ4OGQzOGVkZTc4NC8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:41:08 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/acs/rpm/rpm/a1f053d8-cca1-4b61-8c70-560ff972c960/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:41:16 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '23'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - acf75bee3bbd4e7baa5a13fae46bc6b5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:41:16 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/1690e21b-782c-4f57-afc6-7678e935b35c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:41:16 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b6c2cfe8395745c3bcc9a3ecffd15e6a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA1NWM1YzI1LTcyZWItNGE2
+        MC05ZWIzLThjNGUxMTkyN2FkOC8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:41:16 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/efe4c1cb-f527-4511-a09c-0aa39872c983/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:41:16 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f23c893dcf3f4ac18b1356d89f702665
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM2OTAzMTY5LWFjZWUtNGFh
+        Yi1iMjI4LTAwNDFkZDA1NDc3MS8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:41:16 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/tasks/36903169-acee-4aab-b228-0041dd054771/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:41:16 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - a4ac15ebaecf49a288c7beee5d175001
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '371'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzY5MDMxNjktYWNl
+        ZS00YWFiLWIyMjgtMDA0MWRkMDU0NzcxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDUtMDJUMjE6NDE6MTYuNjI4NjY0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJmMjNjODkzZGNmM2Y0YWMxOGIxMzU2ZDg5
+        ZjcwMjY2NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTAyVDIxOjQxOjE2LjY4
+        ODI0OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMDJUMjE6NDE6MTYuNzMz
+        MzU5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8wMjg1NWQzYS0wZGQzLTQ5YzAtOTFkZS02OGNkYmE3ODkwNTAvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2VmZTRjMWNiLWY1MjctNDUxMS1hMDlj
+        LTBhYTM5ODcyYzk4My8iXX0=
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:41:16 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/49a3d9f8-1d57-4999-a355-d15b2e0fe2c4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:41:16 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 97bfbdabb8124e7f89a18484ee66fd14
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFmOTFlNTgxLTQxOTMtNDhi
+        Yy1iYjBjLWQ5M2JhM2VmNDZkYy8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:41:16 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/340b05cb-5310-4bd4-a861-483ec0d3a0f2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:41:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8475788f09684293866975b756f37cdb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIyMjIyNWIyLTIxZTUtNDRi
+        My04ZWI3LTYzZDdiZTA1OWViNi8ifQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:41:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/tasks/222225b2-21e5-44b3-8eb7-63d7be059eb6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 May 2022 21:41:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9aa12b19cf22433da79d02f088920722
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Content-Length:
+      - '372'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjIyMjI1YjItMjFl
+        NS00NGIzLThlYjctNjNkN2JlMDU5ZWI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDUtMDJUMjE6NDE6MTcuMDIyOTcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4NDc1Nzg4ZjA5Njg0MjkzODY2OTc1Yjc1
+        NmYzN2NkYiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTAyVDIxOjQxOjE3LjA2
+        OTM3OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMDJUMjE6NDE6MTcuMTg5
+        NTI5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy80MGMxODA0ZC0yMGI5LTRmZTgtOGNkNC1lYTE5YTA5NmUzMjcvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMzQwYjA1Y2ItNTMxMC00YmQ0
+        LWE4NjEtNDgzZWMwZDNhMGYyLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 02 May 2022 21:41:17 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds support for refreshing alternate content sources.

Also adds a rake task to refresh all alternate content sources.  This is to be used by the future cron job.

#### Considerations taken when implementing this change?

Alternate content sources are refreshed in two cases: when a user requests it, and when the cron job (to be done) calls the rake task to refresh all ACSs.

We don't want ACS refresh failures to pause a task, since that would block other ACSs from refreshing. So, we just skip the bad ones.

#### What are the testing steps for this pull request?
1) Try refreshing yum and file ACSs and then syncing repositories that point to the same content

To really test refresh: 
- Host a Katello test repo locally and then create an ACS that points to it.
- Create an immediate upstream repo with the same RPMs (like https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/).
- Refresh the ACS and sync the repository (with an immediate download policy).  The sync should download RPMs from your local server since the ACS will be preferred.  You can see this in your local web server logs.

2) Try bulk refreshing ACSs
3) Try the ACS rake task
4) Try bulk destroying ACSs (something unrelated I added since I was already making bulk actions)