### PR TITLE
Fixes #34859 - only allow label when creating an organization

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -29,7 +29,6 @@ module Katello
         param :hostgroup_ids, Array, N_("Host group IDs"), :required => false
         param :environment_ids, Array, N_("Environment IDs"), :required => false
         param :subnet_ids, Array, N_("Subnet IDs"), :required => false
-        param :label, String, :required => false
         param :location_ids, Array, N_("Associated location IDs"), :required => false
       end
     end
@@ -66,6 +65,9 @@ module Katello
 
     api :POST, '/organizations', N_('Create organization')
     param_group :resource
+    param :organization, Hash do
+      param :label, String, :required => false
+    end
     def create
       @organization = Organization.new(resource_params)
       creator = ::Katello::OrganizationCreator.new(@organization)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

We forbid updating the label of an org, so we also should not expose it in the apidoc.

#### Considerations taken when implementing this change?

The apidoc should match reality.

#### What are the testing steps for this pull request?

Before this patch, the apidoc contains `organization[label]` for both `PUT /organizations/:id` and `POST /organizations`. After it, only for `POST`