### PR TITLE
Refs #32726 - Suppress all Candlepin stack traces for Api::Rhsm::CandlepinDynflowProxyController

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_dynflow_proxy_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_dynflow_proxy_controller.rb
@@ -59,6 +59,16 @@ module Katello
       @host = facet.host
     end
 
+    rescue_from RestClient::Exception do |e|
+      Rails.logger.error(pp_exception(e, with_backtrace: false))
+      Rails.logger.error(e.backtrace.detect { |line| line.match("katello.*controller") })
+      if request_from_katello_cli?
+        render :json => { :errors => [e.http_body] }, :status => e.http_code
+      else
+        render :plain => e.http_body, :status => e.http_code
+      end
+    end
+
     def authorize_client_or_user
       client_authorized? || authorize
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Suppress  the backtrace log for each RestClient exception since the error happened outside the scope of our app.

#### Considerations taken when implementing this change?
Followup of https://github.com/Katello/katello/pull/9392

#### What are the testing steps for this pull request?
1. Register a host to Satellite.
2. Delete the host using a bulk action on the Hosts > All Hosts page of the Satellite webUI.
3. Attempt to install a package on the host using yum while tailing /var/log/foreman/production.log on the Satellite.

Expected Results:
No large tracebacks follow the log entries reporting HTTP 410 Gone responses.