### PR TITLE
Fixes #34862 - Rails 6.1 updates

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -7,7 +7,7 @@ module Katello
       generic_repo_wrap_params << option.name
     end
 
-    repo_wrap_params = RootRepository.attribute_names.concat([:ignore_global_proxy, :mirror_on_sync]) + generic_repo_wrap_params
+    repo_wrap_params = RootRepository.attribute_names + [:mirror_on_sync] + generic_repo_wrap_params
 
     wrap_parameters :repository, :include => repo_wrap_params
 


### PR DESCRIPTION
In rails 6.1 the following line in repository controller was causing a
'Frozen' error.

RootRepository.attribute_names.concat(....) + generic_repo_wrap_params

In 6.1 looks like RootRepository.attribute_names is frozen so tweaked
this method a little. Also rremoved the unused ignore_global_proxy
attribute from the wrap params

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
