### PR TITLE
Fixes #34856 - Add TracerEnabler progress indicator and poll Rex jobs

### DIFF
--- a/webpack/components/Table/MainTable.scss
+++ b/webpack/components/Table/MainTable.scss
@@ -15,3 +15,7 @@
 .pf-c-table tbody tr td {
   vertical-align: inherit;
 }
+
+input[type="checkbox"][disabled] {
+  cursor: initial;
+}

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -9,7 +9,6 @@ import {
 import { translate as __ } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
-import { HOST_DETAILS_KEY } from 'foremanReact/components/HostDetails/consts';
 import { selectAPIStatus } from 'foremanReact/redux/API/APISelectors';
 import EnvironmentPaths from '../../../../../scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths';
 import { ENVIRONMENT_PATHS_KEY } from '../../../../../scenes/ContentViews/components/EnvironmentPaths/EnvironmentPathConstants';
@@ -20,6 +19,7 @@ import { uniq } from '../../../../../utils/helpers';
 import ContentViewIcon from '../../../../../scenes/ContentViews/components/ContentViewIcon';
 import updateHostContentViewAndEnvironment from './HostContentViewActions';
 import HOST_CV_AND_ENV_KEY from './HostContentViewConstants';
+import { getHostDetails } from '../../HostDetailsActions';
 
 const ENV_PATH_OPTIONS = { key: ENVIRONMENT_PATHS_KEY };
 
@@ -110,13 +110,7 @@ const ChangeHostCVModal = ({
 
   const refreshHostDetails = () => {
     handleModalClose();
-    return dispatch({
-      type: 'API_GET',
-      payload: {
-        key: HOST_DETAILS_KEY,
-        url: `/api/hosts/${hostName}`,
-      },
-    });
+    return dispatch(getHostDetails({ hostname: hostName }));
   };
 
   const handleSave = () => {

--- a/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsActions.js
+++ b/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsActions.js
@@ -24,7 +24,7 @@ export const alterHostCollections = (hostId, params, refreshHostDetails) => put(
   url: foremanApi.getApiUrl(`/hosts/${hostId}/host_collections`),
   params,
   successToast: () => __('Host collections updated'),
-  errorToast: error => errorToast(error),
-  handleSuccess: () => refreshHostDetails(),
+  errorToast,
+  handleSuccess: refreshHostDetails,
 });
 

--- a/webpack/components/extensions/HostDetails/HostDetailsActions.js
+++ b/webpack/components/extensions/HostDetails/HostDetailsActions.js
@@ -2,11 +2,11 @@ import HOST_DETAILS_KEY from './HostDetailsConstants';
 
 const hostIdNotReady = { type: 'NOOP_HOST_ID_NOT_READY' };
 
-export const refreshHostDetails = ({ hostName }) => ({
+export const refreshHostDetails = ({ hostname }) => ({
   type: 'API_GET',
   payload: {
     key: HOST_DETAILS_KEY,
-    url: `/api/hosts/${hostName}`,
+    url: `/api/hosts/${hostname}`,
   },
 });
 

--- a/webpack/components/extensions/HostDetails/HostDetailsActions.js
+++ b/webpack/components/extensions/HostDetails/HostDetailsActions.js
@@ -2,7 +2,7 @@ import HOST_DETAILS_KEY from './HostDetailsConstants';
 
 const hostIdNotReady = { type: 'NOOP_HOST_ID_NOT_READY' };
 
-export const refreshHostDetails = ({ hostname }) => ({
+export const getHostDetails = ({ hostname }) => ({
   type: 'API_GET',
   payload: {
     key: HOST_DETAILS_KEY,

--- a/webpack/components/extensions/HostDetails/HostDetailsActions.js
+++ b/webpack/components/extensions/HostDetails/HostDetailsActions.js
@@ -1,2 +1,13 @@
+import HOST_DETAILS_KEY from './HostDetailsConstants';
+
 const hostIdNotReady = { type: 'NOOP_HOST_ID_NOT_READY' };
+
+export const refreshHostDetails = ({ hostName }) => ({
+  type: 'API_GET',
+  payload: {
+    key: HOST_DETAILS_KEY,
+    url: `/api/hosts/${hostName}`,
+  },
+});
+
 export default hostIdNotReady;

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -290,6 +290,7 @@ export const ErrataTab = () => {
                     splitButtonVariant="action"
                     toggleVariant="primary"
                     onToggle={onActionToggle}
+                    isDisabled={selectedCount === 0}
                   />
               }
                 isOpen={isActionOpen}

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -3,7 +3,11 @@ import { useSelector, useDispatch } from 'react-redux';
 import {
   Split, SplitItem, ActionList, ActionListItem, Dropdown,
   DropdownItem, KebabToggle, Skeleton, Tooltip, ToggleGroup, ToggleGroupItem,
+<<<<<<< HEAD
   DropdownToggle, DropdownToggleAction,
+=======
+  Spinner,
+>>>>>>> 33b221d6c5 (Refs #34856 - add loader to Errata)
 } from '@patternfly/react-core';
 import { TimesIcon, CheckIcon } from '@patternfly/react-icons';
 import {
@@ -147,19 +151,26 @@ export const ErrataTab = () => {
   const installErrataAction = () => installErrata({
     hostname, search: fetchBulkParams(),
   });
-  const { triggerJobStart: triggerBulkApply, lastCompletedJob: lastCompletedBulkApply }
-    = useRexJobPolling(installErrataAction);
+  const {
+    triggerJobStart: triggerBulkApply, lastCompletedJob: lastCompletedBulkApply,
+    isPolling: isBulkApplyInProgress,
+  } = useRexJobPolling(installErrataAction);
 
   const installErratumAction = id => installErrata({
     hostname,
     search: errataSearchQuery(id),
   });
 
-  const { triggerJobStart: triggerApply, lastCompletedJob: lastCompletedApply }
-    = useRexJobPolling(installErratumAction);
+  const {
+    triggerJobStart: triggerApply, lastCompletedJob: lastCompletedApply,
+    isPolling: isApplyInProgress,
+  } = useRexJobPolling(installErratumAction);
 
-  const tdSelect = useCallback((errataId, rowIndex) => ({
-    disable: !isSelectable(errataId),
+  const actionInProgress = (isApplyInProgress || isBulkApplyInProgress);
+  const disabledReason = __('A remote execution job is in progress');
+
+  const tdSelect = useCallback((errataId, rowIndex, rexJobInProgress) => ({
+    disable: rexJobInProgress || !isSelectable(errataId),
     isSelected: isSelected(errataId),
     onSelect: (event, selected) => selectOne(selected, errataId),
     rowIndex,
@@ -420,6 +431,7 @@ export const ErrataTab = () => {
                   {
                     title: __('Apply via remote execution'),
                     onClick: () => applyErratumViaRemoteExecution(errataId),
+                    isDisabled: actionInProgress,
                   },
                   {
                     title: __('Apply via customized remote execution'),
@@ -454,7 +466,10 @@ export const ErrataTab = () => {
                         onToggle: (_event, _rInx, isOpen) => expandedErrata.onToggle(isOpen, id),
                       }}
                     />
-                    <Td select={tdSelect(errataId, rowIndex)} />
+                    <Td
+                      select={tdSelect(errataId, rowIndex, actionInProgress)}
+                      title={actionInProgress && disabledReason}
+                    />
                     <Td>
                       <a href={urlBuilder(`errata/${id}`, '')}>{errataId}</a>
                     </Td>

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -3,11 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import {
   Split, SplitItem, ActionList, ActionListItem, Dropdown,
   DropdownItem, KebabToggle, Skeleton, Tooltip, ToggleGroup, ToggleGroupItem,
-<<<<<<< HEAD
   DropdownToggle, DropdownToggleAction,
-=======
-  Spinner,
->>>>>>> 33b221d6c5 (Refs #34856 - add loader to Errata)
 } from '@patternfly/react-core';
 import { TimesIcon, CheckIcon } from '@patternfly/react-icons';
 import {

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -36,7 +36,7 @@ import './ErrataTab.scss';
 import hostIdNotReady from '../../HostDetailsActions';
 import { defaultRemoteActionMethod, KATELLO_AGENT } from '../../hostDetailsHelpers';
 import SortableColumnHeaders from '../../../../Table/components/SortableColumnHeaders';
-import useRexJobPolling from '../RemoteExecutionHooks';
+import { useRexJobPolling } from '../RemoteExecutionHooks';
 
 export const ErrataTab = () => {
   const hostDetails = useSelector(state => selectAPIResponse(state, 'HOST_DETAILS'));
@@ -147,20 +147,16 @@ export const ErrataTab = () => {
   const installErrataAction = () => installErrata({
     hostname, search: fetchBulkParams(),
   });
-  const refreshErrataAction = () => getInstallableErrata(
-    hostId,
-    { include_applicable: toggleGroupState === ALL },
-  );
-  const { triggerJobStart: triggerBulkApply }
-    = useRexJobPolling(installErrataAction, refreshErrataAction);
+  const { triggerJobStart: triggerBulkApply, lastCompletedJob: lastCompletedBulkApply }
+    = useRexJobPolling(installErrataAction);
 
   const installErratumAction = id => installErrata({
     hostname,
     search: errataSearchQuery(id),
   });
 
-  const { triggerJobStart: triggerApply }
-    = useRexJobPolling(installErratumAction, refreshErrataAction);
+  const { triggerJobStart: triggerApply, lastCompletedJob: lastCompletedApply }
+    = useRexJobPolling(installErratumAction);
 
   const tdSelect = useCallback((errataId, rowIndex) => ({
     disable: !isSelectable(errataId),
@@ -384,7 +380,8 @@ export const ErrataTab = () => {
           ouiaId="host-errata-table"
           additionalListeners={[
             hostId, toggleGroupState, errataTypeSelected,
-            errataSeveritySelected, activeSortColumn, activeSortDirection]}
+            errataSeveritySelected, activeSortColumn, activeSortDirection,
+            lastCompletedApply, lastCompletedBulkApply]}
           fetchItems={fetchItems}
           bookmarkController="katello_errata"
           autocompleteEndpoint={`/hosts/${hostId}/errata/auto_complete_search`}

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -240,10 +240,10 @@ export const ModuleStreamsTab = () => {
     initialSortColumnName: 'Name',
   });
 
-  const { triggerJobStart: triggerModuleStreamAction, pollingComplete: tablePollingComplete }
+  const { triggerJobStart: triggerModuleStreamAction, lastCompletedJob: tableJobCompleted }
     = useRexJobPolling(moduleStreamAction);
 
-  const { triggerJobStart: triggerConfirmModalAction, pollingComplete: confirmModalPollingComplete }
+  const { triggerJobStart: triggerConfirmModalAction, lastCompletedJob: confirmModalJobCompleted }
     = useRexJobPolling(moduleStreamAction);
 
   const fetchItems = useCallback(
@@ -324,8 +324,8 @@ export const ModuleStreamsTab = () => {
           }}
           ouiaId="host-module-stream-table"
           additionalListeners={[hostId, activeSortColumn, activeSortDirection,
-            statusSelected, installStatusSelected, confirmModalPollingComplete,
-            tablePollingComplete]}
+            statusSelected, installStatusSelected, confirmModalJobCompleted,
+            tableJobCompleted]}
           fetchItems={fetchItems}
           bookmarkController="katello_host_available_module_streams"
           autocompleteEndpoint={`/hosts/${hostId}/module_streams/auto_complete_search`}

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -7,6 +7,7 @@ import { Skeleton,
   Button,
   Split,
   SplitItem,
+  Spinner,
   Checkbox,
   Dropdown,
   Text,
@@ -240,11 +241,17 @@ export const ModuleStreamsTab = () => {
     initialSortColumnName: 'Name',
   });
 
-  const { triggerJobStart: triggerModuleStreamAction, lastCompletedJob: tableJobCompleted }
-    = useRexJobPolling(moduleStreamAction);
+  const {
+    triggerJobStart: triggerModuleStreamAction, lastCompletedJob: tableJobCompleted,
+    isPolling: isModuleStreamActionInProgress,
+  } = useRexJobPolling(moduleStreamAction);
 
-  const { triggerJobStart: triggerConfirmModalAction, lastCompletedJob: confirmModalJobCompleted }
-    = useRexJobPolling(moduleStreamAction);
+  const {
+    triggerJobStart: triggerConfirmModalAction, lastCompletedJob: confirmModalJobCompleted,
+    isPolling: isConfirmModalActionInProgress,
+  } = useRexJobPolling(moduleStreamAction);
+
+  const actionInProgress = (isModuleStreamActionInProgress || isConfirmModalActionInProgress);
 
   const fetchItems = useCallback(
     (params) => {
@@ -354,6 +361,11 @@ export const ModuleStreamsTab = () => {
                   setSelected={handleModuleStreamInstallationStatusSelected}
                 />
               </SplitItem>
+              {actionInProgress && (
+                <SplitItem style={{ alignSelf: 'center' }}>
+                  <Spinner size="lg" style={{ marginTop: '2px' }} />
+                </SplitItem>
+              )}
             </Split>
           }
         >
@@ -466,7 +478,7 @@ export const ModuleStreamsTab = () => {
                       setUseCustomizedRex('');
                       setDropdownOpen('');
                     }}
-                    isDisabled={stateText(moduleStreamStatus) ===
+                    isDisabled={actionInProgress || stateText(moduleStreamStatus) ===
                     HOST_MODULE_STREAM_STATUSES.ENABLED}
                   >
                     {__('Enable')}
@@ -482,7 +494,7 @@ export const ModuleStreamsTab = () => {
                       setUseCustomizedRex('');
                       setDropdownOpen('');
                     }}
-                    isDisabled={stateText(moduleStreamStatus) !==
+                    isDisabled={actionInProgress || stateText(moduleStreamStatus) !==
                     HOST_MODULE_STREAM_STATUSES.ENABLED}
                   >
                     {__('Disable')}
@@ -497,7 +509,7 @@ export const ModuleStreamsTab = () => {
                       setUseCustomizedRex('');
                       setDropdownOpen('');
                     }}
-                    isDisabled={(upgradable ||
+                    isDisabled={(actionInProgress || upgradable ||
                       (installedStatus !== INSTALLED_STATE.NOTINSTALLED) ||
                       !(stateText(moduleStreamStatus) === HOST_MODULE_STREAM_STATUSES.ENABLED ||
                         stateText(moduleStreamStatus) === HOST_MODULE_STREAM_STATUSES.DISABLED)
@@ -514,7 +526,7 @@ export const ModuleStreamsTab = () => {
                       setUseCustomizedRex('');
                       setDropdownOpen('');
                     }}
-                    isDisabled={!upgradable}
+                    isDisabled={actionInProgress || !upgradable}
                   >
                     {__('Update')}
                   </DropdownItem>,
@@ -529,6 +541,7 @@ export const ModuleStreamsTab = () => {
                       setUseCustomizedRex('');
                       setDropdownOpen('');
                     }}
+                    isDisabled={actionInProgress}
                   >
                     {__('Reset')}
                     <InactiveText style={{ marginBottom: '1px' }} text={__('Reset to the default state')} />
@@ -544,6 +557,7 @@ export const ModuleStreamsTab = () => {
                       setUseCustomizedRex('');
                       setDropdownOpen('');
                     }}
+                    isDisabled={actionInProgress}
                   >
                     {__('Remove')}
                     <InactiveText style={{ marginBottom: '1px' }} text={__('Uninstall and reset')} />

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.js
@@ -15,11 +15,9 @@ import { HOST_YUM_INSTALLABLE_PACKAGES_KEY } from './YumInstallablePackagesConst
 import { selectHostYumInstallablePackagesStatus } from './YumInstallablePackagesSelectors';
 import { getHostYumInstallablePackages } from './YumInstallablePackagesActions';
 import './PackageInstallModal.scss';
-import { installPackageBySearch } from '../RemoteExecutionActions';
 import { katelloPackageInstallBySearchUrl, katelloPackageInstallUrl } from '../customizedRexUrlHelpers';
 import hostIdNotReady from '../../HostDetailsActions';
 import { installPackageViaKatelloAgent } from './HostPackagesActions';
-import { useRexJobPolling } from '../RemoteExecutionHooks';
 
 const InstallDropdown = ({
   isDisabled, installViaRex, installViaKatelloAgent,
@@ -102,7 +100,7 @@ InstallDropdown.defaultProps = {
 };
 
 const PackageInstallModal = ({
-  isOpen, closeModal, hostId, hostName, showKatelloAgent,
+  isOpen, closeModal, hostId, hostName, showKatelloAgent, triggerPackageInstall,
 }) => {
   const emptyContentTitle = __('No packages available to install');
   const emptyContentBody = __('No packages available to install on this host. Please check the host\'s content view and lifecycle environment.');
@@ -128,12 +126,6 @@ const PackageInstallModal = ({
     selectedResults,
     ...selectAll
   } = useBulkSelect({ results, metadata });
-
-  const packageInstallAction
-    = bulkParams => installPackageBySearch({ hostname: hostName, search: bulkParams });
-
-  const { triggerJobStart: triggerPackageInstall, lastCompletedJob: lastCompletedPackageInstall }
-   = useRexJobPolling(packageInstallAction);
 
   const fetchItems = (params) => {
     if (!hostId) return hostIdNotReady;
@@ -219,7 +211,7 @@ const PackageInstallModal = ({
         }
         }
         ouiaId="host-package-install-table"
-        additionalListeners={[hostId, lastCompletedPackageInstall]}
+        additionalListeners={[hostId]}
         fetchItems={fetchItems}
         searchPlaceholderText={__('Search available packages')}
         autocompleteEndpoint={`/hosts/${hostId}/packages/auto_complete_search`}
@@ -279,6 +271,7 @@ PackageInstallModal.propTypes = {
   hostId: PropTypes.number.isRequired,
   hostName: PropTypes.string.isRequired,
   showKatelloAgent: PropTypes.bool,
+  triggerPackageInstall: PropTypes.func.isRequired,
 };
 
 PackageInstallModal.defaultProps = {

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.js
@@ -19,6 +19,7 @@ import { installPackageBySearch } from '../RemoteExecutionActions';
 import { katelloPackageInstallBySearchUrl, katelloPackageInstallUrl } from '../customizedRexUrlHelpers';
 import hostIdNotReady from '../../HostDetailsActions';
 import { installPackageViaKatelloAgent } from './HostPackagesActions';
+import useRexJobPolling from '../RemoteExecutionHooks';
 
 const InstallDropdown = ({
   isDisabled, installViaRex, installViaKatelloAgent,
@@ -127,6 +128,13 @@ const PackageInstallModal = ({
     selectedResults,
     ...selectAll
   } = useBulkSelect({ results, metadata });
+
+  const packageInstallAction
+    = bulkParams => installPackageBySearch({ hostname: hostName, search: bulkParams });
+
+  const { triggerJobStart: triggerPackageInstall }
+   = useRexJobPolling(packageInstallAction);
+
   const fetchItems = (params) => {
     if (!hostId) return hostIdNotReady;
 
@@ -141,7 +149,7 @@ const PackageInstallModal = ({
   const selectedPackageNames = () => selectedResults.map(({ name }) => name);
 
   const installViaRex = () => {
-    dispatch(installPackageBySearch({ hostname: hostName, search: fetchBulkParams() }));
+    triggerPackageInstall(fetchBulkParams());
     selectNone();
     closeModal();
   };

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.js
@@ -19,7 +19,7 @@ import { installPackageBySearch } from '../RemoteExecutionActions';
 import { katelloPackageInstallBySearchUrl, katelloPackageInstallUrl } from '../customizedRexUrlHelpers';
 import hostIdNotReady from '../../HostDetailsActions';
 import { installPackageViaKatelloAgent } from './HostPackagesActions';
-import useRexJobPolling from '../RemoteExecutionHooks';
+import { useRexJobPolling } from '../RemoteExecutionHooks';
 
 const InstallDropdown = ({
   isDisabled, installViaRex, installViaKatelloAgent,
@@ -132,7 +132,7 @@ const PackageInstallModal = ({
   const packageInstallAction
     = bulkParams => installPackageBySearch({ hostname: hostName, search: bulkParams });
 
-  const { triggerJobStart: triggerPackageInstall }
+  const { triggerJobStart: triggerPackageInstall, lastCompletedJob: lastCompletedPackageInstall }
    = useRexJobPolling(packageInstallAction);
 
   const fetchItems = (params) => {
@@ -219,7 +219,7 @@ const PackageInstallModal = ({
         }
         }
         ouiaId="host-package-install-table"
-        additionalListeners={[hostId]}
+        additionalListeners={[hostId, lastCompletedPackageInstall]}
         fetchItems={fetchItems}
         searchPlaceholderText={__('Search available packages')}
         autocompleteEndpoint={`/hosts/${hostId}/packages/auto_complete_search`}

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -33,7 +33,7 @@ import { selectHostPackagesStatus } from './HostPackagesSelectors';
 import {
   HOST_PACKAGES_KEY, PACKAGES_VERSION_STATUSES, VERSION_STATUSES_TO_PARAM,
 } from './HostPackagesConstants';
-import { removePackage, updatePackage, removePackages, updatePackages } from '../RemoteExecutionActions';
+import { removePackage, updatePackage, removePackages, updatePackages, installPackageBySearch } from '../RemoteExecutionActions';
 import { katelloPackageUpdateUrl, packagesUpdateUrl } from '../customizedRexUrlHelpers';
 import './PackagesTab.scss';
 import hostIdNotReady from '../../HostDetailsActions';
@@ -173,8 +173,17 @@ export const PackagesTab = () => {
     isPolling: isBulkUpgradeInProgress,
   } = useRexJobPolling(packageBulkUpgradeAction);
 
+  const packageInstallAction
+    = bulkParams => installPackageBySearch({ hostname, search: bulkParams });
+
+  const {
+    triggerJobStart: triggerPackageInstall,
+    lastCompletedJob: lastCompletedPackageInstall,
+    isPolling: isInstallInProgress,
+  } = useRexJobPolling(packageInstallAction);
+
   const actionInProgress = (isRemoveInProgress || isUpgradeInProgress
-    || isBulkRemoveInProgress || isBulkUpgradeInProgress);
+    || isBulkRemoveInProgress || isBulkUpgradeInProgress || isInstallInProgress);
   const disabledReason = __('A remote execution job is in progress.');
 
   if (!hostId) return <Skeleton />;
@@ -392,7 +401,7 @@ export const PackagesTab = () => {
           additionalListeners={[hostId, packageStatusSelected,
             activeSortDirection, activeSortColumn, lastCompletedPackageUpgrade,
             lastCompletedPackageRemove, lastCompletedBulkPackageRemove,
-            lastCompletedBulkPackageUpgrade]}
+            lastCompletedBulkPackageUpgrade, lastCompletedPackageInstall]}
           fetchItems={fetchItems}
           bookmarkController="katello_host_installed_packages"
           autocompleteEndpoint={`/hosts/${hostId}/packages/auto_complete_search`}
@@ -488,6 +497,7 @@ export const PackagesTab = () => {
           key={hostId}
           hostName={hostname}
           showKatelloAgent={showKatelloAgent}
+          triggerPackageInstall={triggerPackageInstall}
         />
       }
     </div>

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -335,7 +335,7 @@ export const PackagesTab = () => {
             />
           </ActionListItem>
           <ActionListItem>
-            {actionInProgress ? <Spinner size="lg" style={{marginLeft: '1em', marginTop: '4px' }} /> : (
+            {actionInProgress ? <Spinner size="lg" style={{ marginLeft: '1em', marginTop: '4px' }} /> : (
               <Dropdown
                 toggle={<KebabToggle aria-label="bulk_actions" onToggle={toggleBulkAction} />}
                 isOpen={isBulkActionOpen}

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -134,7 +134,7 @@ export const PackagesTab = () => {
     packageName,
   });
 
-  const { triggerJobStart: triggerPackageRemove }
+  const { triggerJobStart: triggerPackageRemove, lastCompletedJob: lastCompletedPackageRemove }
     = useRexJobPolling(packageRemoveAction);
 
   const packageBulkRemoveAction = bulkParams => removePackages({
@@ -142,24 +142,30 @@ export const PackagesTab = () => {
     search: bulkParams,
   });
 
-  const { triggerJobStart: triggerBulkPackageRemove }
-    = useRexJobPolling(packageBulkRemoveAction);
+  const {
+    triggerJobStart: triggerBulkPackageRemove,
+    lastCompletedJob: lastCompletedBulkPackageRemove,
+  } = useRexJobPolling(packageBulkRemoveAction);
 
   const packageUpgradeAction = packageName => updatePackage({
     hostname,
     packageName,
   });
 
-  const { triggerJobStart: triggerPackageUpgrade }
-    = useRexJobPolling(packageUpgradeAction);
+  const {
+    triggerJobStart: triggerPackageUpgrade,
+    lastCompletedJob: lastCompletedPackageUpgrade,
+  } = useRexJobPolling(packageUpgradeAction);
 
   const packageBulkUpgradeAction = bulkParams => updatePackages({
     hostname,
     search: bulkParams,
   });
 
-  const { triggerJobStart: triggerBulkPackageUpgrade }
-    = useRexJobPolling(packageBulkUpgradeAction);
+  const {
+    triggerJobStart: triggerBulkPackageUpgrade,
+    lastCompletedJob: lastCompletedBulkPackageUpgrade,
+  } = useRexJobPolling(packageBulkUpgradeAction);
 
   if (!hostId) return <Skeleton />;
 
@@ -372,7 +378,9 @@ export const PackagesTab = () => {
           }
           ouiaId="host-packages-table"
           additionalListeners={[hostId, packageStatusSelected,
-            activeSortDirection, activeSortColumn]}
+            activeSortDirection, activeSortColumn, lastCompletedPackageUpgrade,
+            lastCompletedPackageRemove, lastCompletedBulkPackageRemove,
+            lastCompletedBulkPackageUpgrade]}
           fetchItems={fetchItems}
           bookmarkController="katello_host_installed_packages"
           autocompleteEndpoint={`/hosts/${hostId}/packages/auto_complete_search`}

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -465,7 +465,7 @@ export const PackagesTab = () => {
                       rowIndex,
                       variant: 'checkbox',
                     }}
-                    title={actionInProgress && disabledReason}
+                    title={actionInProgress ? disabledReason : undefined}
                   />
                   <Td>
                     {rpmId

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -39,7 +39,7 @@ import hostIdNotReady from '../../HostDetailsActions';
 import PackageInstallModal from './PackageInstallModal';
 import { defaultRemoteActionMethod, KATELLO_AGENT } from '../../hostDetailsHelpers';
 import SortableColumnHeaders from '../../../../Table/components/SortableColumnHeaders';
-import useRexJobPolling from '../RemoteExecutionHooks';
+import { useRexJobPolling } from '../RemoteExecutionHooks';
 
 export const PackagesTab = () => {
   const hostDetails = useSelector(state => selectAPIResponse(state, 'HOST_DETAILS'));

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionHooks.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionHooks.js
@@ -10,7 +10,13 @@ export const useRexJobPolling = (initialAction, successAction = null, failureAct
   const [rexJobId, setRexJobId] = useState(null);
   const dispatch = useDispatch();
 
-  const stopRexJobPolling = useCallback(({ jobId }) => {
+  const stopRexJobPolling = useCallback(({ jobId, statusLabel }) => {
+    setIsPolling(false);
+    if (statusLabel === 'succeeded') {
+      setSucceeded(true);
+    } else {
+      setSucceeded(false);
+    }
     dispatch(stopPollingJob({ key: `REX_JOB_POLLING_${jobId}` }));
   }, [dispatch]);
 
@@ -19,14 +25,13 @@ export const useRexJobPolling = (initialAction, successAction = null, failureAct
     const { statusLabel, id, description } = propsToCamelCase(data);
     setRexJobId(id);
     if (statusLabel !== 'running') {
-      setIsPolling(false);
-      stopRexJobPolling({ jobId: id });
+      stopRexJobPolling({ jobId: id, statusLabel });
       if (statusLabel === 'succeeded') {
-        setSucceeded(true);
+        // setSucceeded(true);
         renderRexJobSucceededToast({ id, description });
         if (successAction) dispatch(typeof successAction === 'function' ? successAction() : successAction);
       } else {
-        setSucceeded(false);
+        // setSucceeded(false);
         renderRexJobFailedToast({ id, description });
         if (failureAction) dispatch(typeof failureAction === 'function' ? failureAction() : failureAction);
       }
@@ -62,7 +67,6 @@ export const useRexJobPolling = (initialAction, successAction = null, failureAct
       if (rexJobId) stopRexJobPolling({ jobId: rexJobId });
     };
   }, [rexJobId, stopRexJobPolling]);
-
   return ({
     pollingStarted,
     pollingComplete: succeeded,

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionHooks.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionHooks.js
@@ -59,7 +59,7 @@ export const useRexJobPolling = (initialAction, successAction = null, failureAct
   useEffect(() => {
     // clean up polling when component unmounts
     return function cleanupRexPolling() {
-      stopRexJobPolling({ jobId: rexJobId });
+      if (rexJobId) stopRexJobPolling({ jobId: rexJobId });
     };
   }, [rexJobId, stopRexJobPolling]);
 

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionHooks.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionHooks.js
@@ -1,0 +1,70 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import { propsToCamelCase } from 'foremanReact/common/helpers';
+import { startPollingJob, stopPollingJob } from './RemoteExecutionActions';
+import { refreshHostDetails } from '../HostDetailsActions';
+
+export const useRexJobPolling = (initialAction) => {
+  const [isPolling, setIsPolling] = useState(null);
+  const [pollingComplete, setPollingComplete] = useState(false);
+  const [rexJobId, setRexJobId] = useState(null);
+  const dispatch = useDispatch();
+
+  const stopRexJobPolling = useCallback(({ jobId }) => {
+    dispatch(stopPollingJob({ key: `INSTALL_TRACER_${jobId}` }));
+  }, [dispatch]);
+
+  const handleSuccess = (resp) => {
+    const { data } = resp;
+    const { statusLabel, id } = propsToCamelCase(data);
+    const hostName = data.targeting.hosts[0].name;
+    setRexJobId(id);
+    if (statusLabel !== 'running') {
+      setPollingComplete(true);
+      setIsPolling(false);
+      stopRexJobPolling({ jobId: id });
+    }
+    if (statusLabel === 'succeeded') {
+      dispatch(refreshHostDetails({ hostName }));
+    }
+  };
+  const startRexJobPolling = ({ jobId }) => {
+    setIsPolling(true);
+    dispatch(startPollingJob({ key: `INSTALL_TRACER_${jobId}`, jobId, handleSuccess }));
+  };
+  const pollingStarted = (isPolling || pollingComplete);
+
+  const dispatchInitialAction = () => {
+    const modifiedAction = {
+      ...initialAction,
+      payload: {
+        ...initialAction.payload,
+        handleSuccess: (resp) => {
+          const jobId = resp?.data?.id;
+          if (!jobId) return;
+          startRexJobPolling({ jobId });
+        },
+      },
+    };
+    dispatch(modifiedAction);
+  };
+
+  // eslint-disable-next-line arrow-body-style
+  useEffect(() => {
+    // clean up polling when component unmounts
+    return function cleanupRexPolling() {
+      stopRexJobPolling({ jobId: rexJobId });
+    };
+  }, [rexJobId, stopRexJobPolling]);
+
+  return ({
+    pollingStarted,
+    pollingComplete,
+    isPolling,
+    startRexJobPolling,
+    rexJobId,
+    triggerJobStart: dispatchInitialAction,
+  });
+};
+
+export default useRexJobPolling;

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionHooks.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionHooks.js
@@ -8,12 +8,16 @@ export const useRexJobPolling = (initialAction, successAction = null, failureAct
   const [isPolling, setIsPolling] = useState(null);
   const [succeeded, setSucceeded] = useState(null);
   const [rexJobId, setRexJobId] = useState(null);
+  // A value that only changes when the job succeeds. Pass to TableWrapper as an additionalListener
+  // to reload results.
+  const [lastCompletedJob, setLastCompletedJob] = useState(null);
   const dispatch = useDispatch();
 
   const stopRexJobPolling = useCallback(({ jobId, statusLabel }) => {
     setIsPolling(false);
     if (statusLabel === 'succeeded') {
       setSucceeded(true);
+      setLastCompletedJob(jobId);
     } else {
       setSucceeded(false);
     }
@@ -69,10 +73,10 @@ export const useRexJobPolling = (initialAction, successAction = null, failureAct
   }, [rexJobId, stopRexJobPolling]);
   return ({
     pollingStarted,
-    pollingComplete: succeeded,
     isPolling,
-    startRexJobPolling,
+    succeeded,
     rexJobId,
+    lastCompletedJob,
     triggerJobStart: dispatchInitialAction,
   });
 };

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionHooks.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionHooks.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
+import { deleteToast } from 'foremanReact/components/ToastsList/slice';
 import { startPollingJob, stopPollingJob } from './RemoteExecutionActions';
 import { renderRexJobFailedToast, renderRexJobStartedToast, renderRexJobSucceededToast } from '../../../../scenes/Tasks/helpers';
 
@@ -22,6 +23,7 @@ export const useRexJobPolling = (initialAction, successAction = null, failureAct
       setSucceeded(false);
     }
     dispatch(stopPollingJob({ key: `REX_JOB_POLLING_${jobId}` }));
+    dispatch(deleteToast(`REX_TOAST_${jobId}`));
   }, [dispatch]);
 
   const tick = (resp) => {
@@ -53,7 +55,7 @@ export const useRexJobPolling = (initialAction, successAction = null, failureAct
         handleSuccess: (resp) => {
           const jobId = resp?.data?.id;
           if (!jobId) return;
-          renderRexJobStartedToast(resp.data);
+          renderRexJobStartedToast({ key: `REX_TOAST_${jobId}`, ...resp.data });
           startRexJobPolling({ jobId });
         },
       },

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionHooks.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionHooks.js
@@ -75,6 +75,7 @@ export const useRexJobPolling = (initialAction, successAction = null, failureAct
     succeeded,
     rexJobId,
     lastCompletedJob,
+    startRexJobPolling,
     triggerJobStart: dispatchInitialAction,
   });
 };

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionHooks.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionHooks.js
@@ -14,7 +14,7 @@ export const useRexJobPolling = (initialAction, successAction = null, failureAct
   const dispatch = useDispatch();
 
   const stopRexJobPolling = useCallback(({ jobId, statusLabel }) => {
-    setIsPolling(false);
+    if (statusLabel) setIsPolling(false);
     if (statusLabel === 'succeeded') {
       setSucceeded(true);
       setLastCompletedJob(jobId);
@@ -28,21 +28,18 @@ export const useRexJobPolling = (initialAction, successAction = null, failureAct
     const { data } = resp;
     const { statusLabel, id, description } = propsToCamelCase(data);
     setRexJobId(id);
-    if (statusLabel !== 'running') {
+    if (statusLabel && statusLabel !== 'running') {
       stopRexJobPolling({ jobId: id, statusLabel });
       if (statusLabel === 'succeeded') {
-        // setSucceeded(true);
         renderRexJobSucceededToast({ id, description });
         if (successAction) dispatch(typeof successAction === 'function' ? successAction() : successAction);
       } else {
-        // setSucceeded(false);
         renderRexJobFailedToast({ id, description });
         if (failureAction) dispatch(typeof failureAction === 'function' ? failureAction() : failureAction);
       }
     }
   };
   const startRexJobPolling = ({ jobId }) => {
-    setIsPolling(true);
     dispatch(startPollingJob({ key: `REX_JOB_POLLING_${jobId}`, jobId, handleSuccess: tick }));
   };
   const pollingStarted = !!(isPolling || succeeded);
@@ -61,6 +58,7 @@ export const useRexJobPolling = (initialAction, successAction = null, failureAct
         },
       },
     };
+    setIsPolling(true);
     dispatch(modifiedAction);
   };
 

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerEmptyState.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerEmptyState.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
 import {
   EmptyState,
   EmptyStateIcon,
@@ -11,12 +12,40 @@ import {
 } from '@patternfly/react-core';
 import { WrenchIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
+import { propsToCamelCase } from 'foremanReact/common/helpers';
 import EnableTracerModal from './EnableTracerModal';
+import { startPollingJob, stopPollingJob } from '../RemoteExecutionActions';
+import { refreshHostDetails } from '../../HostDetailsActions';
 
 const EnableTracerEmptyState = () => {
   const title = __('Traces are not enabled');
   const body = __('Traces help administrators identify applications that need to be restarted after a system is patched.');
   const [enableTracerModalOpen, setEnableTracerModalOpen] = useState(false);
+  const [isPolling, setIsPolling] = useState(null);
+  const [pollingComplete, setPollingComplete] = useState(false);
+  const dispatch = useDispatch();
+
+  const stopRexJobPolling = ({ jobId }) => {
+    dispatch(stopPollingJob({ key: `INSTALL_TRACER_${jobId}` }));
+  };
+  const handleSuccess = (resp) => {
+    const { data } = resp;
+    const { statusLabel, id } = propsToCamelCase(data);
+    const hostName = data.targeting.hosts[0].name;
+    if (statusLabel !== 'running') {
+      setPollingComplete(true);
+      setIsPolling(false);
+      stopRexJobPolling({ jobId: id });
+    }
+    if (statusLabel === 'succeeded') {
+      dispatch(refreshHostDetails({ hostName }));
+    }
+  };
+  const startRexJobPolling = ({ jobId }) => {
+    setIsPolling(true);
+    setEnableTracerModalOpen(false);
+    dispatch(startPollingJob({ key: `INSTALL_TRACER_${jobId}`, jobId, handleSuccess }));
+  };
 
   return (
     <EmptyState variant={EmptyStateVariant.small}>
@@ -28,13 +57,20 @@ const EnableTracerEmptyState = () => {
         <Flex direction={{ default: 'column' }}>
           <FlexItem>{body}</FlexItem>
           <FlexItem>
-            <Button onClick={() => setEnableTracerModalOpen(true)}>
+            <Button
+              onClick={() => setEnableTracerModalOpen(true)}
+              isDisabled={isPolling || pollingComplete}
+            >
               {__('Enable Traces')}
             </Button>
           </FlexItem>
         </Flex>
       </EmptyStateBody>
-      <EnableTracerModal isOpen={enableTracerModalOpen} setIsOpen={setEnableTracerModalOpen} />
+      <EnableTracerModal
+        isOpen={enableTracerModalOpen}
+        setIsOpen={setEnableTracerModalOpen}
+        startRexJobPolling={startRexJobPolling}
+      />
     </EmptyState>
   );
 };

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.js
@@ -12,13 +12,12 @@ import {
 } from '@patternfly/react-core';
 import { CaretDownIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { selectAPIResponse } from 'foremanReact/redux/API/APISelectors';
-import { installTracerPackage } from './HostTracesActions';
 import { katelloPackageInstallUrl } from '../customizedRexUrlHelpers';
 import { KATELLO_TRACER_PACKAGE } from './HostTracesConstants';
 
-const EnableTracerModal = ({ isOpen, setIsOpen, startRexJobPolling }) => {
+const EnableTracerModal = ({ isOpen, setIsOpen, triggerJobStart }) => {
   const title = __('Enable Tracer');
   const body = __('Enabling will install the katello-host-tools-tracer package on the host.');
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -29,26 +28,18 @@ const EnableTracerModal = ({ isOpen, setIsOpen, startRexJobPolling }) => {
     __('via customized remote execution'),
   ];
   const [selectedOption, setSelectedOption] = useState(dropdownOptions[0]);
-  const dispatch = useDispatch();
   const hostDetails = useSelector(state => selectAPIResponse(state, 'HOST_DETAILS'));
   const { name: hostname } = hostDetails;
   const handleSelect = () => {
     setIsDropdownOpen(false);
   };
-  const enableTracer = () => {
-    setButtonLoading(true);
-    dispatch(installTracerPackage({
-      hostname,
-      handleSuccess: (resp) => {
-        const jobId = resp?.data?.id;
-        if (!jobId) return;
-        startRexJobPolling({ jobId });
-      },
-    }));
-  };
   const handleClose = () => {
     setIsOpen(false);
-    setButtonLoading(false);
+  };
+  const enableTracer = () => {
+    setButtonLoading(true);
+    triggerJobStart();
+    handleClose();
   };
 
   const dropdownItems = dropdownOptions.map(text => (
@@ -129,7 +120,7 @@ const EnableTracerModal = ({ isOpen, setIsOpen, startRexJobPolling }) => {
 EnableTracerModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   setIsOpen: PropTypes.func.isRequired,
-  startRexJobPolling: PropTypes.func.isRequired,
+  triggerJobStart: PropTypes.func.isRequired,
 };
 
 export default EnableTracerModal;

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/HostTracesActions.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/HostTracesActions.js
@@ -13,7 +13,8 @@ export const getHostTraces = (hostId, params) => get({
   params,
 });
 
-export const installTracerPackage = ({ hostname }) => installPackage({
+export const installTracerPackage = ({ hostname, handleSuccess }) => installPackage({
   hostname,
   packageName: KATELLO_TRACER_PACKAGE,
+  handleSuccess,
 });

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesEnabler.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesEnabler.js
@@ -17,7 +17,7 @@ import { urlBuilder } from 'foremanReact/common/urlHelpers';
 import EnableTracerModal from './EnableTracerModal';
 import { useRexJobPolling } from '../RemoteExecutionHooks';
 import { installTracerPackage } from './HostTracesActions';
-import { refreshHostDetails } from '../../HostDetailsActions';
+import { getHostDetails } from '../../HostDetailsActions';
 
 const EnableTracerButton = ({ setEnableTracerModalOpen, pollingStarted }) => (
   <Button
@@ -57,7 +57,7 @@ const TracesEnabler = ({ hostname }) => {
   const body = __('Traces help administrators identify applications that need to be restarted after a system is patched.');
   const [enableTracerModalOpen, setEnableTracerModalOpen] = useState(false);
   const initialAction = installTracerPackage({ hostname });
-  const successAction = refreshHostDetails({ hostname });
+  const successAction = getHostDetails({ hostname });
   const {
     pollingStarted,
     rexJobId,

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesEnabler.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesEnabler.js
@@ -17,6 +17,7 @@ import { urlBuilder } from 'foremanReact/common/urlHelpers';
 import EnableTracerModal from './EnableTracerModal';
 import { useRexJobPolling } from '../RemoteExecutionHooks';
 import { installTracerPackage } from './HostTracesActions';
+import { refreshHostDetails } from '../../HostDetailsActions';
 
 const EnableTracerButton = ({ setEnableTracerModalOpen, pollingStarted }) => (
   <Button
@@ -55,11 +56,13 @@ const TracesEnabler = ({ hostname }) => {
   const enablingTitle = __('Traces are being enabled');
   const body = __('Traces help administrators identify applications that need to be restarted after a system is patched.');
   const [enableTracerModalOpen, setEnableTracerModalOpen] = useState(false);
+  const initialAction = installTracerPackage({ hostname });
+  const successAction = refreshHostDetails({ hostname });
   const {
     pollingStarted,
     rexJobId,
     triggerJobStart,
-  } = useRexJobPolling(installTracerPackage({ hostname }));
+  } = useRexJobPolling(initialAction, successAction);
 
   return (
     <EmptyState variant={EmptyStateVariant.small}>

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
@@ -208,15 +208,6 @@ const TracesTab = () => {
               helper,
               app_type: appType,
             } = result;
-            // if (actionInProgress) {
-            //   return (
-            //     <Tr>
-            //       <Td key={id} colSpan={5}>
-            //         <Skeleton />
-            //       </Td>
-            //     </Tr>
-            //   );
-            // }
             const resolveDisabled = !isSelectable(id);
             let disabledReason;
             if (resolveDisabled) disabledReason = __('Traces that require logout cannot be restarted remotely');

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
@@ -8,7 +8,7 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import { TableVariant, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import { useSelector, useDispatch } from 'react-redux';
 import { selectAPIResponse } from 'foremanReact/redux/API/APISelectors';
-import EnableTracerEmptyState from './EnableTracerEmptyState';
+import TracesEnabler from './TracesEnabler';
 import TableWrapper from '../../../../Table/TableWrapper';
 import { useBulkSelect, useTableSort, useUrlParams } from '../../../../Table/TableHooks';
 import { getHostTraces } from './HostTracesActions';
@@ -137,7 +137,7 @@ const TracesTab = () => {
 
   );
   const status = useSelector(state => selectHostTracesStatus(state));
-  if (showEnableTracer) return <EnableTracerEmptyState />;
+  if (showEnableTracer) return <TracesEnabler />;
 
   if (!hostId) return <Skeleton />;
 

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
@@ -208,6 +208,15 @@ const TracesTab = () => {
               helper,
               app_type: appType,
             } = result;
+            // if (actionInProgress) {
+            //   return (
+            //     <Tr>
+            //       <Td key={id} colSpan={5}>
+            //         <Skeleton />
+            //       </Td>
+            //     </Tr>
+            //   );
+            // }
             const resolveDisabled = !isSelectable(id);
             let disabledReason;
             if (resolveDisabled) disabledReason = __('Traces that require logout cannot be restarted remotely');

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
@@ -135,6 +135,7 @@ const TracesTab = () => {
                       {__('Restart app')}
                     </DropdownToggleAction>,
                   ]}
+                  isDisabled={selectedCount === 0}
                   splitButtonVariant="action"
                   toggleVariant="primary"
                   onToggle={toggleBulkAction}

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
@@ -1,13 +1,8 @@
 import React, { useState, useCallback } from 'react';
 import { FormattedMessage } from 'react-intl';
 import {
-<<<<<<< HEAD
   Skeleton, Split, SplitItem, ActionList, ActionListItem, Dropdown,
   DropdownItem, DropdownToggle, DropdownToggleAction,
-=======
-  Skeleton, Button, Split, SplitItem, ActionList, ActionListItem, Dropdown,
-  DropdownItem, KebabToggle, Spinner,
->>>>>>> e7c816ca85 (Refs #34856 - standardize spinner in Traces)
 } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { TableVariant, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
@@ -137,7 +137,7 @@ const TracesTab = () => {
 
   );
   const status = useSelector(state => selectHostTracesStatus(state));
-  if (showEnableTracer) return <TracesEnabler />;
+  if (showEnableTracer) return <TracesEnabler hostname={hostname} />;
 
   if (!hostId) return <Skeleton />;
 

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
@@ -6,7 +6,7 @@ import {
 } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { TableVariant, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { selectAPIResponse } from 'foremanReact/redux/API/APISelectors';
 import TracesEnabler from './TracesEnabler';
 import TableWrapper from '../../../../Table/TableWrapper';
@@ -18,11 +18,10 @@ import { resolveTraceUrl } from '../customizedRexUrlHelpers';
 import './TracesTab.scss';
 import hostIdNotReady from '../../HostDetailsActions';
 import SortableColumnHeaders from '../../../../Table/components/SortableColumnHeaders';
-import useRexJobPolling from '../RemoteExecutionHooks';
+import { useRexJobPolling } from '../RemoteExecutionHooks';
 
 const TracesTab = () => {
   const hostDetails = useSelector(state => selectAPIResponse(state, 'HOST_DETAILS'));
-  const dispatch = useDispatch();
   const {
     id: hostId,
     name: hostname,
@@ -78,17 +77,16 @@ const TracesTab = () => {
   const BulkRestartTracesAction = () => resolveTraces({
     hostname, search: fetchBulkParams(),
   });
-  const refreshTracesAction = getHostTraces(hostId);
-  const { triggerJobStart: triggerBulkRestart }
-    = useRexJobPolling(BulkRestartTracesAction, refreshTracesAction);
+  const { triggerJobStart: triggerBulkRestart, lastCompletedJob: lastCompletedBulkRestart }
+    = useRexJobPolling(BulkRestartTracesAction);
 
   const restartTraceAction = id => resolveTraces({
     hostname,
     search: tracesSearchQuery(id),
   });
 
-  const { triggerJobStart: triggerAppRestart }
-    = useRexJobPolling(restartTraceAction, refreshTracesAction);
+  const { triggerJobStart: triggerAppRestart, lastCompletedJob: lastCompletedAppRestart }
+    = useRexJobPolling(restartTraceAction);
 
   const fetchItems = useCallback(
     params =>
@@ -180,7 +178,8 @@ const TracesTab = () => {
         rowsCount={results?.length}
         variant={TableVariant.compact}
         displaySelectAllCheckbox
-        additionalListeners={[activeSortColumn, activeSortDirection]}
+        additionalListeners={[activeSortColumn, activeSortDirection,
+          lastCompletedAppRestart, lastCompletedBulkRestart]}
         {...selectAll}
       >
         <Thead>

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
@@ -1,8 +1,13 @@
 import React, { useState, useCallback } from 'react';
 import { FormattedMessage } from 'react-intl';
 import {
+<<<<<<< HEAD
   Skeleton, Split, SplitItem, ActionList, ActionListItem, Dropdown,
   DropdownItem, DropdownToggle, DropdownToggleAction,
+=======
+  Skeleton, Button, Split, SplitItem, ActionList, ActionListItem, Dropdown,
+  DropdownItem, KebabToggle, Spinner,
+>>>>>>> e7c816ca85 (Refs #34856 - standardize spinner in Traces)
 } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { TableVariant, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
@@ -949,11 +949,6 @@ test('Apply button chooses remote execution', async (done) => {
     .query(defaultQuery)
     .reply(200, mockErrata);
 
-  const scope1 = nockInstance
-    .get(hostErrata)
-    .query(baseQuery)
-    .reply(200, mockErrata);
-
   const resolveErrataScope = nockInstance
     .post(jobInvocations)
     .reply(201, mockResolveErrataTask);
@@ -974,7 +969,6 @@ test('Apply button chooses remote execution', async (done) => {
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(resolveErrataScope);
-  assertNockRequest(scope1);
   assertNockRequest(scope, done);
 });
 
@@ -985,11 +979,6 @@ test('Can bulk apply via remote execution', async (done) => {
   const scope = nockInstance
     .get(hostErrata)
     .query(defaultQuery)
-    .reply(200, mockErrata);
-
-  const scope1 = nockInstance
-    .get(hostErrata)
-    .query(baseQuery)
     .reply(200, mockErrata);
 
   // eslint-disable-next-line camelcase
@@ -1021,7 +1010,6 @@ test('Can bulk apply via remote execution', async (done) => {
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(resolveErrataScope);
-  assertNockRequest(scope1);
   assertNockRequest(scope, done);
 });
 
@@ -1034,11 +1022,6 @@ test('Can select all, exclude and bulk apply via remote execution', async (done)
   const scope = nockInstance
     .get(hostErrata)
     .query(defaultQuery)
-    .reply(200, mockErrata);
-
-  const scope1 = nockInstance
-    .get(hostErrata)
-    .query(baseQuery)
     .reply(200, mockErrata);
 
   const jobInvocationBody = ({ job_invocation: { inputs } }) =>
@@ -1067,7 +1050,6 @@ test('Can select all, exclude and bulk apply via remote execution', async (done)
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(resolveErrataScope);
-  assertNockRequest(scope1);
   assertNockRequest(scope, done);
 });
 

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
@@ -117,7 +117,6 @@ describe('With tracer installed', () => {
     const scope = nockInstance
       .get(hostTraces)
       .query(true)
-      .times(2)
       .reply(200, mockTraceData);
     const resolveTracesScope = nockInstance
       .post(jobInvocations)
@@ -140,7 +139,7 @@ describe('With tracer installed', () => {
     const restartAppButton = getByText('Restart app');
     // wait 50ms so that the button is enabled
     await waitFor(() => {
-      expect(getByText('Restart app')).not.toBeDisabled();
+      expect(getByText('Restart app')).toHaveAttribute('aria-disabled', 'false');
       restartAppButton.click();
     });
 
@@ -157,7 +156,6 @@ describe('With tracer installed', () => {
     const scope = nockInstance
       .get(hostTraces)
       .query(true)
-      .times(2)
       .reply(200, mockTraceData);
     const resolveTracesScope = nockInstance
       .post(jobInvocations)
@@ -195,7 +193,6 @@ describe('With tracer installed', () => {
     const scope = nockInstance
       .get(hostTraces)
       .query(true)
-      .times(2)
       .reply(200, mockTraceData);
     const jobInvocationBody = ({ job_invocation: { inputs } }) =>
       inputs[TRACES_SEARCH_QUERY] === `id !^ (${firstTrace.id},${thirdTrace.id})`;

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
@@ -139,7 +139,7 @@ describe('With tracer installed', () => {
     const restartAppButton = getByText('Restart app');
     // wait 50ms so that the button is enabled
     await waitFor(() => {
-      expect(getByText('Restart app')).toHaveAttribute('aria-disabled', 'false');
+      expect(restartAppButton.parentElement).not.toHaveClass('pf-m-disabled');
       restartAppButton.click();
     });
 

--- a/webpack/scenes/Tasks/helpers.js
+++ b/webpack/scenes/Tasks/helpers.js
@@ -63,7 +63,7 @@ export const renderRexJobFailedToast = ({ id, description }) => {
 
   window.tfm.toastNotifications.notify({
     message,
-    type: 'error',
+    type: 'danger',
     link: rexJobLink(id),
   });
 };

--- a/webpack/scenes/Tasks/helpers.js
+++ b/webpack/scenes/Tasks/helpers.js
@@ -56,6 +56,30 @@ export const renderRexJobStartedToast = ({ id, description }) => {
   });
 };
 
+export const renderRexJobFailedToast = ({ id, description }) => {
+  if (!id) return;
+
+  const message = (__(`Remote execution job '${description}' failed.`));
+
+  window.tfm.toastNotifications.notify({
+    message,
+    type: 'error',
+    link: rexJobLink(id),
+  });
+};
+
+export const renderRexJobSucceededToast = ({ id, description }) => {
+  if (!id) return;
+
+  const message = (__(`Job '${description}' completed`));
+
+  window.tfm.toastNotifications.notify({
+    message,
+    type: 'success',
+    link: rexJobLink(id),
+  });
+};
+
 export const taskFinishedToast = (task) => {
   const message = __(`Task ${task.humanized.action} completed with a result of ${task.result}.
   ${task.errors ? getErrors(task) : ''}`);

--- a/webpack/scenes/Tasks/helpers.js
+++ b/webpack/scenes/Tasks/helpers.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
+import store from 'foremanReact/redux';
 import { urlBuilder } from 'foremanReact/common/urlHelpers';
+import { addToast } from 'foremanReact/components/ToastsList/slice.js';
 import { getResponseErrorMsgs } from '../../utils/helpers';
 
 export const bulkSearchKey = key => `${key}_TASK_SEARCH`;
@@ -44,17 +46,17 @@ export const renderTaskStartedToast = (task) => {
   });
 };
 
-export const renderRexJobStartedToast = ({ id, description }) => {
+export const renderRexJobStartedToast = ({ id, description, key }) => {
   if (!id) return;
+  const message = (__(`Job '${description}' has started.`));
 
-  const message = (__(`Job ${description} has started.`));
-
-  window.tfm.toastNotifications.notify({
+  store.dispatch(addToast({
     message,
     type: 'info',
     link: rexJobLink(id),
     sticky: true,
-  });
+    key,
+  }));
 };
 
 export const renderRexJobFailedToast = ({ id, description }) => {

--- a/webpack/scenes/Tasks/helpers.js
+++ b/webpack/scenes/Tasks/helpers.js
@@ -53,6 +53,7 @@ export const renderRexJobStartedToast = ({ id, description }) => {
     message,
     type: 'info',
     link: rexJobLink(id),
+    sticky: true,
   });
 };
 


### PR DESCRIPTION
- [x] rebase
- [x] fix button enablement bug
- [x] add sticky toast
- [x] un-stick toast after job succeed or fail
- [x] remove cursor that happens when mousing over disabled checkboxes

#### What are the changes introduced in this pull request?
![traces_enable](https://user-images.githubusercontent.com/22042343/166828669-22bff50e-b0ab-4480-9ef1-01ac2ab43217.png)

1. Add a loading screen for enabling Traces:

Succeed:
https://www.awesomescreenshot.com/video/8739856?key=9654f43a18a51c1da28a013fa47d4333

Fail:
https://www.awesomescreenshot.com/video/8739884?key=3e443826b2dab30f6b460dfa1f647be9

2. On all host details tabs, poll Rex jobs. While in progress, display a spinner. When they succeed, display a success toast and reload results. When they fail, display an error toast.

Package remove with results reload:
https://www.awesomescreenshot.com/video/8774035?key=6b9e8e0b8d1cf1edca62e39c91fbfb40

All this is achieved via a new `useRexJobPolling` hook.

#### Considerations taken when implementing this change?

After adding the loading indicator to Traces, I couldn't resist spreading the love!

Sadly, I was unable to use the `isLoading` prop of `<Button>` because of upcoming changes in https://github.com/Katello/katello/pull/10046. So I just added a standard spinner instead, which will allow consistency across all tabs.

#### What are the testing steps for this pull request?

* Get a working REX setup
* Enable the Satellite Tools repo so you can install Tracer (you'll probably have to override to enabled in Repo sets as well)
* New host detail page > Traces > Enable Tracer
* Make sure everything works ok and you get toasts as in the videos
* Try it again with a different host which is not running and view the failure mode

Also test the following pages and confirm that

1. you get toasts for starting, success, and failure of the job
2. results are reloaded ONLY on success (not on starting the job and not on failure)
3. Polling stops if you navigate away from the tab
4. When results are reloaded, the current search and pagination options are remembered
5. checkboxes are disabled while job is in progress, with small tooltip on mouse hover explaining the reason
6. immediate remote execution actions are disabled while job is in progress (this is to prevent users from trying the same job twice in a row, etc.)
7. customized remote execution actions remain unchanged

* Errata application
* Package remove
* Package upgrade
* Package install
* Traces restart
* Module stream actions