### PR TITLE
Fixes #34863 - No virt-who-hypervisor entry for libvert

### DIFF
--- a/app/lib/actions/katello/host/hypervisors_update.rb
+++ b/app/lib/actions/katello/host/hypervisors_update.rb
@@ -132,7 +132,11 @@ module Actions
 
         def name_for_host(organization, consumer)
           sanitized_name = ::Katello::Host::SubscriptionFacet.sanitize_name(consumer[:hypervisorId][:hypervisorId])
-          "virt-who-#{sanitized_name}-#{organization.id}"
+          rhel_host?(consumer) ? sanitized_name : "virt-who-#{sanitized_name}-#{organization.id}"
+        end
+
+        def rhel_host?(consumer)
+          consumer[:facts]["hypervisor.type"] == 'QEMU'
         end
 
         def duplicate_name(hypervisor, consumer)

--- a/test/actions/katello/host/hypervisors_update_test.rb
+++ b/test/actions/katello/host/hypervisors_update_test.rb
@@ -100,6 +100,7 @@ module Katello::Host
         "entitlementStatus" => nil,
         "entitlementCount" => 0,
         "hypervisorId" => {"hypervisorId" => "hypervisor1.example.com"},
+        "facts" => {"hypervisor.type" => "VMware ESXi"},
         "type" => {"id" => "1004", "label" => "hypervisor", "manifest" => false}
       }
       Katello::Resources::Candlepin::Consumer.expects(:get_all_with_facts).returns([consumer.with_indifferent_access])


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Virt-who always create a host entry named like `virt-who-<hypervisor_id>-<org_id>` for the hypervisor.
So two entries are created for one RHEV hypervisor.

A single entry would be created for RHEV hypervisor when `hostname` is set as `Hypervisor ID` with this commit.

#### Considerations taken when implementing this change?
Change is made only to RHEV hypervisor not others.

#### What are the testing steps for this pull request?
1. Register the hypervisor to satellite
2. Install virt-who on the hypervisor
3. Check in Satellite webUI

Before
Two entries: hypervisor and virt-who-hypervisor-1

After
Only one entry: hypervisor