### PR TITLE
Fixes #34865 - New host detail - Change content source

### DIFF
--- a/webpack/components/extensions/HostDetails/ActionsBar/index.js
+++ b/webpack/components/extensions/HostDetails/ActionsBar/index.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { DropdownItem } from '@patternfly/react-core';
+import { CubeIcon } from '@patternfly/react-icons';
+
+import { translate as __ } from 'foremanReact/common/I18n';
+import { foremanUrl } from 'foremanReact/common/helpers';
+
+import { selectHostDetails } from '../HostDetailsSelectors';
+
+const HostActionsBar = () => {
+  const hostDetails = useSelector(selectHostDetails);
+
+  return (
+    <>
+      <DropdownItem
+        key="katello-change-host-content-source"
+        href={foremanUrl(`/change_host_content_source?host_id=${hostDetails?.id}`)}
+        icon={<CubeIcon />}
+      >
+        {__('Change content source')}
+      </DropdownItem>
+    </>
+  );
+};
+
+export default HostActionsBar;

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -18,6 +18,7 @@ import rootReducer from './redux/reducers';
 import HostCollectionsCard from './components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsCard';
 import { hostIsNotRegistered } from './components/extensions/HostDetails/hostDetailsHelpers';
 import SystemPropertiesCardExtensions from './components/extensions/HostDetails/DetailsTabCards/SystemPropertiesCardExtensions';
+import HostActionsBar from './components/extensions/HostDetails/ActionsBar';
 
 registerReducer('katelloExtends', extendReducer);
 registerReducer('katello', rootReducer);
@@ -49,3 +50,10 @@ addGlobalFill('host-overview-cards', 'Installable errata', <ErrataOverviewCard k
 addGlobalFill('host-tab-details-cards', 'Installed products', <InstalledProductsCard key="installed-products" />, 100);
 addGlobalFill('host-tab-details-cards', 'Registration details', <RegistrationCard key="registration-details" />, 200);
 addGlobalFill('host-details-tab-properties-1', 'Subscription UUID', <SystemPropertiesCardExtensions key="subscription-uuid" />);
+
+addGlobalFill(
+  'host-details-kebab',
+  'katello-host-details-kebab',
+  <HostActionsBar key="katello-host-details-kebab" />,
+  100,
+);

--- a/webpack/scenes/Hosts/ChangeContentSource/helpers.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/helpers.js
@@ -1,6 +1,11 @@
 import { STATUS } from 'foremanReact/constants';
 
 export const getHostIds = () => {
+  const url = new URL(window.location);
+  const hostId = url.searchParams.get('host_id');
+
+  if (hostId) return [hostId];
+
   const cookie = document.cookie.split('; ')
     .find(row => row.startsWith('_ForemanSelectedhosts'));
   const params = new URLSearchParams(cookie);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Allow change of host's content source from the new host detail page
![katello_cs](https://user-images.githubusercontent.com/59385976/166881264-dc15625e-04bb-4c83-bd46-fc575475aeef.png)

#### Considerations taken when implementing this change?
* Only UI change, no changes in logic
* Follow up for https://github.com/Katello/katello/pull/9873

#### What are the testing steps for this pull request?
Go to new host detail page and change the content source