### PR TITLE
Refs #34754 - add ouiaId prop to EditableTextInput

### DIFF
--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -738,7 +738,7 @@ module Katello
       assert_equal versions.length, 3
       version = @fedora_17_x86_64.published_in_versions.where(content_view_id: view.id).map(&:version)
       cv_name = @fedora_17_x86_64.published_in_versions.where(content_view_id: view.id).first.content_view.name
-      assert_equal version.sort, view.versions.map(&:version)
+      assert_equal_arrays version, view.versions.map(&:version)
       assert_equal cv_name, view.name
     end
 

--- a/webpack/components/EditableTextInput/EditableTextInput.js
+++ b/webpack/components/EditableTextInput/EditableTextInput.js
@@ -86,6 +86,7 @@ const EditableTextInput = ({
       </SplitItem>
       <SplitItem>
         <Button
+          ouiaId={`submit-button-${attribute}`}
           aria-label={`submit ${attribute}`}
           variant="plain"
           onClick={onSubmit}
@@ -94,13 +95,19 @@ const EditableTextInput = ({
         </Button>
       </SplitItem>
       <SplitItem>
-        <Button aria-label={`clear ${attribute}`} variant="plain" onClick={onClear}>
+        <Button ouiaId={`clear-button-${attribute}`} aria-label={`clear ${attribute}`} variant="plain" onClick={onClear}>
           <TimesIcon />
         </Button>
       </SplitItem>
       {isPassword ?
         <SplitItem>
-          <Button aria-label={`show-password ${attribute}`} variant="plain" isDisabled={!inputValue?.length} onClick={toggleShowPassword}>
+          <Button
+            ouiaId={`show-button-${attribute}`}
+            aria-label={`show-password ${attribute}`}
+            variant="plain"
+            isDisabled={!inputValue?.length}
+            onClick={toggleShowPassword}
+          >
             {showPassword ?
               (<EyeSlashIcon />) :
               (<EyeIcon />)}
@@ -128,6 +135,7 @@ const EditableTextInput = ({
           >
             <Button
               className="foreman-edit-icon"
+              ouiaId={`edit-button-${attribute}`}
               aria-label={`edit ${attribute}`}
               variant="plain"
               onClick={onEditClick}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add ouiaId prop to EditableTextInput which is used in CDN Configuration

#### Considerations taken when implementing this change?
Followup of https://github.com/Katello/katello/pull/10058

#### What are the testing steps for this pull request?
1. Go to CDN configuration > Network Sync
2. Inspect element for pencil icon next to password

Expected Result:
Pencil icon, check mark, and cancel buttons all have unique and static data-ouia-component-id.