### PR TITLE
Fixes #34872 - Search for errata tasks by scoped search

### DIFF
--- a/app/lib/katello/concerns/base_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/base_template_scope_extensions.rb
@@ -4,6 +4,8 @@ module Katello
       extend ActiveSupport::Concern
       extend ApipieDSL::Module
 
+      ERRATA_SEARCH_QUERY_INPUT = 'Errata search query'
+
       apipie :class, 'Base macros related to content hosts to use within a template' do
         name 'Base Content'
         sections only: %w[all reports provisioning jobs partition_tables]
@@ -322,13 +324,27 @@ module Katello
 
       def parse_errata(task)
         task_input = get_task_input(task)
-        agent_input = task_input['errata'] || task_input['content']
+        agent_input = errata_ids_from_task_input(task_input)
         # Pick katello agent errata if present
         # Otherwise pick rex errata. There are multiple template inputs, such as errata, pre_script and post_script we only need the
         # errata input here.
-        @_tasks_errata_cache[task.id] ||= agent_input.presence || TemplateInvocationInputValue.joins(:template_input)
-                                            .where("template_invocation_id = ? AND template_inputs.name = ?", task.template_invocation_id, 'errata')
-                                            .first.value.split(',')
+        @_tasks_errata_cache[task.id] ||= agent_input.presence || errata_ids_from_template_invocation(task, task_input)
+      end
+
+      def errata_ids_from_task_input(task)
+        return task_input['errata'] || task_input['content'] unless task_input.has_key? 'job_features'
+      end
+
+      def errata_ids_from_template_invocation(task, task_input)
+        scope = TemplateInvocationInputValue.joins(:template_input)
+        if task_input.has_key? 'job_features' && task_input['job_features'].include? 'katello_errata_install_by_search'
+          query = scope.where("template_invocation_id = ? AND template_inputs.name = ?", task.template_invocation_id, ERRATA_SEARCH_QUERY_INPUT)
+                    .first.value
+          ::Katello::Erratum.search_for(query).pluck(:id)
+        else
+          scope.where("template_invocation_id = ? AND template_inputs.name = ?", task.template_invocation_id, 'errata')
+            .first.value.split(',')
+        end
       end
     end
   end

--- a/app/lib/katello/concerns/base_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/base_template_scope_extensions.rb
@@ -210,7 +210,7 @@ module Katello
         select = 'foreman_tasks_tasks.*'
 
         if Katello.with_remote_execution?
-          new_labels = 'label = Actions::RemoteExecution::RunHostJob AND remote_execution_feature.label = katello_errata_install'
+          new_labels = 'label = Actions::RemoteExecution::RunHostJob AND remote_execution_feature.label ^ (katello_errata_install, katello_errata_install_by_search)'
           labels = [labels, new_labels].map { |label| "(#{label})" }.join(' OR ')
           select += ',template_invocations.id AS template_invocation_id'
         else

--- a/app/lib/katello/concerns/base_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/base_template_scope_extensions.rb
@@ -336,7 +336,7 @@ module Katello
           #   resolved ids in the template
           script = task.execution_plan.actions[1].try(:input).try(:[], 'script') || ''
           found = script.lines.find { |line| line.start_with? '# RESOLVED_ERRATA_IDS=' } || ''
-          (found.split('=').last || '').split(',')
+          (found.chomp.split('=', 2).last || '').split(',')
         else
           TemplateInvocationInputValue.joins(:template_input).where("template_invocation_id = ? AND template_inputs.name = ?", task.template_invocation_id, 'errata')
             .first.value.split(',')

--- a/app/views/foreman/job_templates/install_errata_by_search_query.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query.erb
@@ -16,7 +16,7 @@ foreign_input_sets:
 %>
 
 <% advisory_ids = @host.advisory_ids(search: input("Errata search query")) %>
-# RESOLVED_ERRATA_IDS=<%= @advisory_ids.join(',') %>
+# RESOLVED_ERRATA_IDS=<%= advisory_ids.join(',') %>
 
 <% if @host.operatingsystem.family == 'Suse' -%>
     <%= render_template('Package Action - Script Default', :action => 'install -n -t patch', :package => advisory_ids.join(' ')) %>

--- a/app/views/foreman/job_templates/install_errata_by_search_query.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query.erb
@@ -15,11 +15,12 @@ foreign_input_sets:
   exclude: action,package
 %>
 
+<% advisory_ids = @host.advisory_ids(search: input("Errata search query")) %>
+# RESOLVED_ERRATA_IDS=<%= @advisory_ids.join(',') %>
+
 <% if @host.operatingsystem.family == 'Suse' -%>
-    <% advisories = @host.advisory_ids(search: input("Errata search query")).join(' ') %>
-    <%= render_template('Package Action - Script Default', :action => 'install -n -t patch', :package => advisories) %>
+    <%= render_template('Package Action - Script Default', :action => 'install -n -t patch', :package => advisory_ids.join(' ')) %>
 <% else %>
-    <% advisory_ids = @host.advisory_ids(search: input("Errata search query")) %>
     <% raise "No errata matching given search query" if !input("Errata search query").blank? && advisory_ids.empty? %>
 
     <% advisories = advisory_ids.map { |e| "--advisory=#{e}" }.join(' ') %>

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "rabl"
   gem.add_dependency "foreman-tasks", ">= 5.0"
-  gem.add_dependency "foreman_remote_execution", ">= 3.0"
+  gem.add_dependency "foreman_remote_execution", ">= 7.1.0"
   gem.add_dependency "dynflow", ">= 1.6.1"
   gem.add_dependency "activerecord-import"
   gem.add_dependency "qpid_proton"


### PR DESCRIPTION
Requires:
- https://github.com/theforeman/foreman_remote_execution/pull/719

#### What are the changes introduced in this pull request?
When looking up tasks to use as data sources when generating errata application report, Katello had to implement quite a lot of the logic to match the right tasks. Recently, REX has added support for searching on tasks using a REX feature, which can be reused here to drop the all the custom code.

#### Considerations taken when implementing this change?
Primary drive here was removal of custom code while making sure thing still work the same way

#### What are the testing steps for this pull request?
- Apply this patch and the patch in REX
- try generating an errata application report.