### PR TITLE
Refs #34877 - fix slot's id

### DIFF
--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -32,18 +32,18 @@ addGlobalFill('host-details-page-tabs', 'Repository sets', <RepositorySetsTab ke
 
 // Overview tab cards
 addGlobalFill(
-  'details-cards',
+  'host-overview-cards',
   'Content view details',
   <ContentViewDetailsCard key="content-view-details" />,
   2000,
 );
 addGlobalFill(
-  'details-cards',
+  'host-overview-cards',
   'Host collections',
   <HostCollectionsCard key="host-collections-details" />,
   700,
 );
-addGlobalFill('details-cards', 'Installable errata', <ErrataOverviewCard key="errata-overview" />, 1900);
+addGlobalFill('host-overview-cards', 'Installable errata', <ErrataOverviewCard key="errata-overview" />, 1900);
 
 // Details tab cards & card extensions
 addGlobalFill('host-tab-details-cards', 'Installed products', <InstalledProductsCard key="installed-products" />, 100);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

stop use of deprecated slot id. Taking over from https://github.com/Katello/katello/pull/9973

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

If all your plugins are updated, you should no longer see the slot deprecation warning in the JS console when visiting the Overview tab of the new host details page.

also, if your cards were out of order, this should fix it