### PR TITLE
Fixes #32104 - Retain tasks used for errata reporting for longer time

### DIFF
--- a/app/lib/actions/katello/extensions/rex_jobs_extensions.rb
+++ b/app/lib/actions/katello/extensions/rex_jobs_extensions.rb
@@ -1,0 +1,11 @@
+module Actions
+  module Katello
+    module Extensions
+      module RexJobsExtensions
+        def cleanup_rules
+          ::ForemanTasks::ActionRule.new(self, '90d', 'remote_execution_feature.label = katello_errata_install')
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/host/erratum/applicable_errata_install.rb
+++ b/app/lib/actions/katello/host/erratum/applicable_errata_install.rb
@@ -37,6 +37,10 @@ module Actions
           def presenter
             Helpers::Presenter::Delegated.new(self, planned_actions(Katello::Host::Erratum::Install))
           end
+
+          def self.cleanup_after
+            '90d'
+          end
         end
       end
     end

--- a/app/lib/actions/katello/host/erratum/install.rb
+++ b/app/lib/actions/katello/host/erratum/install.rb
@@ -31,6 +31,10 @@ module Actions
             host = ::Host.find_by(:id => input[:host_id])
             host.update(audit_comment: (_("Installation of errata requested: %{errata}") % {errata: input[:content].join(", ")}).truncate(255))
           end
+
+          def self.cleanup_after
+            '90d'
+          end
         end
       end
     end

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rest-client"
 
   gem.add_dependency "rabl"
-  gem.add_dependency "foreman-tasks", ">= 5.0"
+  gem.add_dependency "foreman-tasks", ">= 7.0"
   gem.add_dependency "foreman_remote_execution", ">= 7.1.0"
   gem.add_dependency "dynflow", ">= 1.6.1"
   gem.add_dependency "activerecord-import"

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -222,6 +222,8 @@ module Katello
 
       if ::Katello.with_remote_execution?
         ::RemoteExecutionProxySelector.prepend Katello::Concerns::RemoteExecutionProxySelectorExtensions
+        ::Actions::RemoteExecution::RunHostJob.extend Actions::Katello::Extensions::RexJobsExtensions
+        ::Actions::RemoteExecution::RunHostsJob.extend Actions::Katello::Extensions::RexJobsExtensions
       end
 
       load 'katello/repository_types.rb'


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Erratum::ApplicableErrataInstall and Erratum::Install tasks are kept around for 90 days instead of 30.

#### Considerations taken when implementing this change?
This is a workaround and as such has a few hairy bits:

Foreman-tasks has a configuration file where this can be configured, however currently the configuration file comes straight from the packages (no installer involved), in packaging we take the example config file without making any changes to it. On update people would (maybe) still need to deal with .rpmnew files. 

If we changed the defaults in the config file, we would shipping configuration for other plugins, which may not be enabled. This would cause warnings to appear in output when running the cleanup rake task without katello or remote_execution.

Alternatively we could make the installer manage that configuration file, but that could get out of hand really quickly.

Of course the right solution would be to consider tasks ephemeral and store the important bits elsewhere, but here we are.

#### What are the testing steps for this pull request?
1) Have errata applications older than 1 month but younger than 3 months
2) Run rake foreman_tasks:cleanup

Alternatively just run rake foreman_tasks:cleanup with SQL logging enabled and watch the queries it does.
