### PR TITLE
Refs #34671 - clarify sync error on smart proxy sync

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.controller.js
@@ -109,7 +109,7 @@ angular.module('Bastion.capsule-content').controller('CapsuleContentController',
                         } else if (errorCount > 1) {
                             errorMessage += " " + translate("Plus 1 more error");
                         }
-                        Notification.setErrorMessage(errorMessage);
+                        Notification.setErrorMessage(translate('Last sync failed: ') + errorMessage);
                     }
                 }
                 $scope.syncState.set(stateFromTask(activeOrFailedTask));


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Refs https://github.com/Katello/katello/pull/10030
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Follow steps here: https://github.com/Katello/katello/pull/10030

Note: You need at least 1 successful sync before a failed sync shows error notifications. Not trying to change that behavior as part of this.