### PR TITLE
Fixes #34889 - host collection update correctly handles unlimited-host

### DIFF
--- a/app/controllers/katello/api/v2/host_collections_controller.rb
+++ b/app/controllers/katello/api/v2/host_collections_controller.rb
@@ -194,7 +194,11 @@ module Katello
 
     def host_collection_params_with_host_ids
       result = host_collection_params
-      result[:max_hosts] = nil if params[:unlimited_hosts]
+      if params[:unlimited_hosts]
+        result[:max_hosts] = nil
+      elsif params[:max_hosts]
+        result[:unlimited_hosts] = false
+      end
       result
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The host collection update call was not updating the `unlimited_hosts` attribute to false if `max_hosts` param was provided.

This PR fixes that and works in conjunction with -> https://github.com/Katello/hammer-cli-katello/pull/846 

#### What are the testing steps for this pull request?

- Checkout https://github.com/Katello/hammer-cli-katello/pull/846
- Keep katello at master
- Try the following commands
```
$ hammer host-collection create --name=great --organization-id=1  --unlimited-hosts
$ hammer host-collection info --name=great --organization-id=1 | grep Limit
Limit:       None

$ hammer  host-collection update --name=great --max-hosts=100 --organization-id=1
Host collection updated.

$ hammer host-collection info --name=great --organization-id=1 |grep Limit
Limit:       None
```
- No change in the Limit even though we set Max hosts param.
- Checkout the PR
- Try
```
$ hammer  host-collection update --name=great --max-hosts=100 --organization-id=1
Host collection updated.

$ hammer host-collection info --name=great --organization-id=1 |grep Limit
Limit:       100
```
