### PR TITLE
Fixes #34817 - name/checksum are not required on repo upload

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -420,8 +420,8 @@ module Katello
       param 'id', String, :required => true
       param 'content_unit_id', String
       param 'size', String
-      param 'checksum', String, :required => true
-      param 'name', String, :required => true, :desc => N_("Needs to only be set for file repositories or docker tags")
+      param 'checksum', String
+      param 'name', String, :desc => N_("Needs to only be set for file repositories or docker tags")
       param 'digest', String, :desc => N_("Needs to only be set for docker tags")
     end
     Katello::RepositoryTypeManager.generic_repository_types.each_pair do |_, repo_type|
@@ -439,12 +439,6 @@ module Katello
       end
 
       uploads = (params[:uploads] || []).map do |upload|
-        if upload[:checksum].nil?
-          fail HttpErrors::BadRequest, _('Checksum is a required parameter.')
-        end
-        if upload[:name].nil?
-          fail HttpErrors::BadRequest, _('Name is a required parameter.')
-        end
         upload.permit(:id, :content_unit_id, :size, :checksum, :name, :digest).to_h
       end
 

--- a/app/lib/actions/pulp3/repository/save_artifact.rb
+++ b/app/lib/actions/pulp3/repository/save_artifact.rb
@@ -5,7 +5,7 @@ module Actions
         #This task creates a content unit and may or may not create a new repository version in the process
         def plan(file, repository, smart_proxy, tasks, unit_type_id, options = {})
           options[:file_name] = file[:filename]
-          options[:sha256] = file[:sha256] || Digest::SHA256.hexdigest(File.read(file[:path]))
+          options[:sha256] = file[:sha256] || (Digest::SHA256.hexdigest(File.read(file[:path])) if file[:path].present?)
           plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id, :tasks => tasks, :unit_type_id => unit_type_id, :options => options)
         end
 

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -943,24 +943,26 @@ module Katello
 
     def test_import_uploads_without_checksum
       uploads = [{'id' => '1', 'size' => '12333', 'name' => 'test'}]
+      @controller.expects(:sync_task)
+        .with(::Actions::Katello::Repository::ImportUpload, @repository, uploads,
+              generate_metadata: true, content_type: nil, sync_capsule: true)
+        .returns(build_task_stub)
 
       put :import_uploads, params: { id: @repository.id, uploads: uploads }
 
-      response = JSON.parse(@response.body)
-      assert response.key?('displayMessage')
-      assert_equal 'Checksum is a required parameter.', response['displayMessage']
-      assert_response :bad_request
+      assert_response :success
     end
 
     def test_import_uploads_without_name
       uploads = [{'id' => '1', 'size' => '12333', 'checksum' => 'asf23421324'}]
+      @controller.expects(:sync_task)
+        .with(::Actions::Katello::Repository::ImportUpload, @repository, uploads,
+              generate_metadata: true, content_type: nil, sync_capsule: true)
+        .returns(build_task_stub)
 
       put :import_uploads, params: { id: @repository.id, uploads: uploads }
 
-      response = JSON.parse(@response.body)
-      assert response.key?('displayMessage')
-      assert_equal 'Name is a required parameter.', response['displayMessage']
-      assert_response :bad_request
+      assert_response :success
     end
 
     def test_import_uploads_file


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
`name` and `checksum` are not required attributes for `import_uploads`.
Fix the code that throws error `no implicit conversion of nil into String` when `checksum` is not specified.

#### Considerations taken when implementing this change?
This PR reverts https://github.com/Katello/katello/pull/10049.

#### What are the testing steps for this pull request?

1. hammer command like the following should work
    `hammer repository update --id=<docker_repo_id> --docker-tag=bar --docker-digest=sha256:c04ad6bf4cd7871b4919bf9bb9085726bb0a1d445de32512be7b44e1fd54e2c7`
2. Download an rpm from https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/
Create a product and repo
Grab the script from the [redmine](https://projects.theforeman.org/issues/34729) and update the credentials to match your box
Try to upload and make sure it goes through without name/checksum specified in the script

