### PR TITLE
Fixes #34904 - Add Details tab - HW properties card

### DIFF
--- a/webpack/components/extensions/HostDetails/DetailsTabCards/HwPropertiesCard.js
+++ b/webpack/components/extensions/HostDetails/DetailsTabCards/HwPropertiesCard.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { propsToCamelCase } from 'foremanReact/common/helpers';
+import { translate as __ } from 'foremanReact/common/I18n';
+import {
+  DescriptionList,
+  DescriptionListTerm,
+  DescriptionListGroup,
+  DescriptionListDescription,
+  Text,
+  TextVariants,
+} from '@patternfly/react-core';
+import CardTemplate from 'foremanReact/components/HostDetails/Templates/CardItem/CardTemplate';
+import { TranslatedPlural } from '../../../Table/components/TranslatedPlural';
+
+const HostDisks = ({ totalDisks }) => {
+  if (!totalDisks) return null;
+  return (
+    <>
+      <DescriptionListTerm>{__('Storage')}</DescriptionListTerm>
+      <Text component={TextVariants.h4}><TranslatedPlural count={totalDisks} singular={__('disk')} id="total-disks" /></Text>
+    </>
+  );
+};
+
+HostDisks.propTypes = {
+  totalDisks: PropTypes.number,
+};
+
+HostDisks.defaultProps = {
+  totalDisks: null,
+};
+
+const HwPropertiesCard = ({ isExpandedGlobal, hostDetails }) => {
+  const { facts } = hostDetails || {};
+  const model = facts?.['virt::host_type'];
+  const cpuCount = facts?.['cpu::cpu(s)'];
+  const cpuSockets = facts?.['cpu::cpu_socket(s)'];
+  const coreSocket = facts?.['cpu::core(s)_per_socket'];
+  const reportedFacts = propsToCamelCase(hostDetails?.reported_data || {});
+  const totalDisks = reportedFacts?.disksTotal;
+  const memory = facts?.['dmi::memory::maximum_capacity'];
+
+  return (
+    <CardTemplate
+      header={__('HW properties')}
+      expandable
+      isExpandedGlobal={isExpandedGlobal}
+    >
+      <DescriptionList isHorizontal>
+        <DescriptionListGroup>
+          <DescriptionListTerm>{__('Model')}</DescriptionListTerm>
+          <DescriptionListDescription>{model}</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>{__('Number of CPU(s)')}</DescriptionListTerm>
+          <DescriptionListDescription>{cpuCount}</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>{__('Sockets')}</DescriptionListTerm>
+          <DescriptionListDescription>{cpuSockets}</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>{__('Cores per socket')}</DescriptionListTerm>
+          <DescriptionListDescription>{coreSocket}</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>{__('RAM')}</DescriptionListTerm>
+          <DescriptionListDescription>{memory}</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <HostDisks totalDisks={totalDisks} />
+        </DescriptionListGroup>
+      </DescriptionList>
+    </CardTemplate>
+  );
+};
+
+HwPropertiesCard.propTypes = {
+  isExpandedGlobal: PropTypes.bool,
+  hostDetails: PropTypes.shape({
+    facts: PropTypes.shape({
+      model: PropTypes.string,
+      cpuCount: PropTypes.number,
+      cpuSockets: PropTypes.number,
+      coreSocket: PropTypes.number,
+      memory: PropTypes.string,
+    }),
+    reported_data: PropTypes.shape({
+      totalDisks: PropTypes.number,
+    }),
+  }),
+};
+
+HwPropertiesCard.defaultProps = {
+  isExpandedGlobal: false,
+  hostDetails: {},
+};
+
+export default HwPropertiesCard;

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -10,6 +10,7 @@ import ContentViewDetailsCard from './components/extensions/HostDetails/Cards/Co
 import ErrataOverviewCard from './components/extensions/HostDetails/Cards/ErrataOverviewCard';
 import InstalledProductsCard from './components/extensions/HostDetails/DetailsTabCards/InstalledProductsCard';
 import RegistrationCard from './components/extensions/HostDetails/DetailsTabCards/RegistrationCard';
+import HwPropertiesCard from './components/extensions/HostDetails/DetailsTabCards/HwPropertiesCard';
 
 import RepositorySetsTab from './components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab';
 import TracesTab from './components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js';
@@ -57,3 +58,4 @@ addGlobalFill(
   <HostActionsBar key="katello-host-details-kebab" />,
   100,
 );
+addGlobalFill('host-tab-details-cards', 'HW properties', <HwPropertiesCard key="hw-properties" />, 200);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Adding info on hardware such as model, ram/cpu and storage

#### Considerations taken when implementing this change?

* Making sure all data is reported correctly from the facts and reported data object
* Moved storage to bottom since it was 4th on the mockup so that way incase the value is `null` we hide it, it does not mess up the layout of the rest of the card. 

#### What are the testing steps for this pull request?

* Checkout PR
* Settings > Show experimental labs - Yes
* Register a content host with subscription manager
* Verify there are no console errors and check to see if the card is correct.
* Storage field is hidden unless `totalDisks` comes back with a value, to test to make sure that works you can edit the following value `disks_total` in the `host_facets_reported_data_facets` table to 1 or 2 and you can see the singluar/plural disks value populate the filed correctly.