### PR TITLE
Refs #34749 - ouia-id to ouiaId

### DIFF
--- a/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
+++ b/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
@@ -170,7 +170,7 @@ const CreateContentViewForm = ({ setModalOpen }) => {
         </FormGroup>}
       <ActionGroup>
         <Button
-          ouia-id="create-content-view-form-submit"
+          ouiaId="create-content-view-form-submit"
           aria-label="create_content_view"
           variant="primary"
           isDisabled={submitDisabled}
@@ -178,7 +178,7 @@ const CreateContentViewForm = ({ setModalOpen }) => {
         >
           {__('Create content view')}
         </Button>
-        <Button ouia-id="create-content-view-form-cancel" variant="link" onClick={() => setModalOpen(false)}>
+        <Button ouiaId="create-content-view-form-cancel" variant="link" onClick={() => setModalOpen(false)}>
           {__('Cancel')}
         </Button>
       </ActionGroup>

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewBulkAddModal.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewBulkAddModal.js
@@ -112,8 +112,8 @@ const ComponentContentViewBulkAddModal = ({ cvId, rowsToAdd, onClose }) => {
           </Card>
         ))}
         <ActionGroup>
-          <Button ouia-id="add-components-modal-add" aria-label="add_components" variant="primary" type="submit">{__('Add')}</Button>
-          <Button ouia-id="add-components-modal-cancel" variant="link" onClick={onClose}>{__('Cancel')}</Button>
+          <Button ouiaId="add-components-modal-add" aria-label="add_components" variant="primary" type="submit">{__('Add')}</Button>
+          <Button ouiaId="add-components-modal-cancel" variant="link" onClick={onClose}>{__('Cancel')}</Button>
         </ActionGroup>
       </Form>
     </Modal >);

--- a/webpack/scenes/ContentViews/Details/Filters/Rules/ContainerTag/AddEditContainerTagRuleModal.js
+++ b/webpack/scenes/ContentViews/Details/Filters/Rules/ContainerTag/AddEditContainerTagRuleModal.js
@@ -71,7 +71,7 @@ const AddEditContainerTagRuleModal = ({
         </FormGroup>
         <ActionGroup>
           <Button
-            ouia-id="add-edit-container-tag-filter-rule-submit"
+            ouiaId="add-edit-container-tag-filter-rule-submit"
             aria-label="add_edit_filter_rule"
             variant="primary"
             isDisabled={saving || tagName.length === 0}
@@ -79,7 +79,7 @@ const AddEditContainerTagRuleModal = ({
           >
             {isEditing ? __('Edit rule') : __('Add rule')}
           </Button>
-          <Button ouia-id="add-edit-container-tag-filter-rule-cancel" variant="link" onClick={onClose}>
+          <Button ouiaId="add-edit-container-tag-filter-rule-cancel" variant="link" onClick={onClose}>
             {__('Cancel')}
           </Button>
         </ActionGroup>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fixes snake case vs hyphenated ouiaId typos in CV UI.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Go to CV UI.
Click on create CV > Right click -> Inspect element on Create content view button.
You should see data-ouia-component-id being set for the button.
Same for Cancel button on the form.