### PR TITLE
Fixes #34905 - override_components don't make it to composite CV publ…

### DIFF
--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -41,7 +41,7 @@ module Actions
                                                           :triggered_by => options[:triggered_by]
                                                          )
           source_repositories = []
-          content_view.publish_repositories(options[:override_cvvs]) do |repositories|
+          content_view.publish_repositories(options[:override_components]) do |repositories|
             source_repositories += [repositories]
           end
 

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -36,6 +36,14 @@ module ::Actions::Katello::ContentView
       end
     end
 
+    it 'uses override_components properly' do
+      action.stubs(:task).returns(success_task)
+      action.expects(:include_other_components).with('mock', content_view).returns('mock')
+      content_view.expects(:publish_repositories).with.returns([])
+      content_view.expects(:publish_repositories).with('mock').returns([])
+      plan_action action, content_view, nil, override_components: 'mock', importing: false
+    end
+
     context 'run phase' do
       it 'creates auto-publish events for non-composite views' do
         composite_view = katello_content_views(:composite_view)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Override components weren't being sent properly to the publish task during incremental update with `--propagate-all-composites=true`.  This was due to a simple typo!

#### Considerations taken when implementing this change?
It's a simple typo!

~I need to figure out a test that'll cover this.~

#### What are the testing steps for this pull request?
Follow these reproducer steps here: https://bugzilla.redhat.com/show_bug.cgi?id=2049799#c0