### PR TITLE
Fixes #34743 - Allow RPM updateAll package action

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages.controller.js
@@ -45,7 +45,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesControlle
 
         $scope.updateAll = function () {
             $scope.working = true;
-            HostPackage.updateAll({id: $scope.host.id}, $scope.openEventInfo, $scope.errorHandler);
+            $scope.performPackageAction('packageUpdate', '');
         };
 
         $scope.performPackageAction = function (actionType, term) {
@@ -57,9 +57,14 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesControlle
         };
 
         $scope.performViaKatelloAgent = function (actionType, term) {
-            var terms = term.split(/ *, */);
+            var terms = [];
+            if (term === '') {
+                packageActions.updateAll();
+            } else {
+                terms = term.split(/ *, */);
+                packageActions[actionType](terms);
+            }
             $scope.working = true;
-            packageActions[actionType](terms);
         };
 
         $scope.performViaRemoteExecution = function(actionType, term, customize) {
@@ -76,6 +81,9 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesControlle
         };
 
         packageActions = {
+            updateAll: function () {
+                HostPackage.updateAll({id: $scope.host.id}, $scope.openEventInfo, $scope.errorHandler);
+            },
             packageInstall: function (termList) {
                 HostPackage.install({id: $scope.host.id, packages: termList}, $scope.openEventInfo, $scope.errorHandler);
             },

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
@@ -60,7 +60,7 @@
         <div class="form-group">
           <button class="btn btn-default" type="button"
                   translate
-                  ng-disabled="remoteExecutionByDefault || !katelloAgentPresent || working"
+                  ng-disabled="working || (!remoteExecutionPresent && !katelloAgentPresent)"
                   ng-click="updateAll()">
             Update All Packages
           </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
@@ -49,7 +49,7 @@
         <button class="btn btn-default"
                 type="button"
                 translate
-                ng-disabled="remoteExecutionByDefault || working || !katelloAgentPresent"
+                ng-disabled="working || (!remoteExecutionPresent && !katelloAgentPresent)"
                 ng-click="updateAll()">
           Update All Packages
         </button>

--- a/engines/bastion_katello/test/content-hosts/content/content-host-packages.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-packages.controller.test.js
@@ -82,10 +82,25 @@ describe('Controller: ContentHostPackagesController', function() {
     });
 
     it("provides a way to upgrade all packages", function() {
+        $scope.katelloAgentPresent = true;
+        $scope.remoteExecutionPresent = false;
+        $scope.remoteExecutionByDefault = false;
         spyOn(HostPackage, "updateAll");
         $scope.updateAll();
         expect(HostPackage.updateAll).toHaveBeenCalledWith({id: mockHost.id}, jasmine.any(Function),
             jasmine.any(Function));
+        expect($scope.working).toBe(true);
+    });
+
+    it("provides a way to upgrade all packages via remoteExecution", function() {
+        $scope.remoteExecutionPresent = true;
+        $scope.remoteExecutionByDefault = true;
+        spyOn(HostPackage, "updateAll");
+        $scope.updateAll();
+        expect(HostPackage.updateAll).not.toHaveBeenCalled();
+        expect($scope.packageActionFormValues.package).toEqual('');
+        expect($scope.packageActionFormValues.remoteAction).toEqual('packageUpdate');
+        expect($scope.packageActionFormValues.bulkHostIds).toEqual('{"included":{"ids":[' + mockHost.id + ']}}');
         expect($scope.working).toBe(true);
     });
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Instead of disabling the 'Update all packages' button if katello-agent is not present, use REX to update packages.

#### Considerations taken when implementing this change?
REX is nice and standard use case for new hosts.

#### What are the testing steps for this pull request?
Try to update all packages on a host
a) only having katello-agent (should work)
b) only having REX (should work, too)