### PR TITLE
Fixes #34721 - Use dropdown for Traces & Errata REX actions

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -1,8 +1,9 @@
 import React, { useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
-  Button, Split, SplitItem, ActionList, ActionListItem, Dropdown,
+  Split, SplitItem, ActionList, ActionListItem, Dropdown,
   DropdownItem, KebabToggle, Skeleton, Tooltip, ToggleGroup, ToggleGroupItem,
+  DropdownToggle, DropdownToggleAction,
 } from '@patternfly/react-core';
 import { TimesIcon, CheckIcon } from '@patternfly/react-icons';
 import {
@@ -67,6 +68,12 @@ export const ErrataTab = () => {
     = useState(PARAM_TO_FRIENDLY_NAME[initialSeverity] ?? ERRATA_SEVERITY);
   const activeFilters = [errataTypeSelected, errataSeveritySelected];
   const defaultFilters = [ERRATA_TYPE, ERRATA_SEVERITY];
+
+  const [isActionOpen, setIsActionOpen] = useState(false);
+  const onActionToggle = () => {
+    setIsActionOpen(prev => !prev);
+  };
+
   const allUpToDate = errataStatus === 0;
   const emptyContentTitle = allUpToDate ? __('All errata up-to-date') : __('This host has errata that are applicable, but not installable.');
   const emptyContentBody = allUpToDate ? __('No action is needed because there are no applicable errata for this host.') : __("You may want to check the host's content view and lifecycle environment.");
@@ -193,7 +200,7 @@ export const ErrataTab = () => {
     }
   };
 
-  const dropdownItems = [
+  const dropdownKebabItems = [
     <DropdownItem
       aria-label="bulk_add"
       key="bulk_add"
@@ -204,8 +211,29 @@ export const ErrataTab = () => {
     </DropdownItem>,
   ];
 
+  const dropdownItems = [
+    <DropdownItem
+      aria-label="apply_via_remote_execution"
+      key="apply_via_remote_execution"
+      component="button"
+      onClick={applyViaRemoteExecution}
+      isDisabled={selectedCount === 0}
+    >
+      {__('Apply via remote execution')}
+    </DropdownItem>,
+    <DropdownItem
+      aria-label="apply_via_customized_remote_execution"
+      key="apply_via_customized_remote_execution"
+      component="a"
+      href={bulkCustomizedRexUrl()}
+      isDisabled={selectedCount === 0}
+    >
+      {__('Apply via customized remote execution')}
+    </DropdownItem>,
+  ];
+
   if (defaultRemoteAction === KATELLO_AGENT) {
-    dropdownItems.push((
+    dropdownItems.unshift((
       <DropdownItem
         aria-label="apply_via_katello_agent"
         key="apply_via_katello_agent"
@@ -216,28 +244,6 @@ export const ErrataTab = () => {
         {__('Apply via Katello agent')}
       </DropdownItem>));
   }
-
-  dropdownItems.push((
-    <DropdownItem
-      aria-label="apply_via_remote_execution"
-      key="apply_via_remote_execution"
-      component="button"
-      onClick={applyViaRemoteExecution}
-      isDisabled={selectedCount === 0}
-    >
-      {__('Apply via remote execution')}
-    </DropdownItem>));
-
-  dropdownItems.push((
-    <DropdownItem
-      aria-label="apply_via_customized_remote_execution"
-      key="apply_via_customized_remote_execution"
-      component="a"
-      href={bulkCustomizedRexUrl()}
-      isDisabled={selectedCount === 0}
-    >
-      {__('Apply via customized remote execution')}
-    </DropdownItem>));
 
   const handleErrataTypeSelected = newType => setErrataTypeSelected((prevType) => {
     if (prevType === newType) {
@@ -259,14 +265,31 @@ export const ErrataTab = () => {
         <SplitItem>
           <ActionList isIconList>
             <ActionListItem>
-              <Button isDisabled={selectedCount === 0} onClick={apply}> {__('Apply')} </Button>
+              <Dropdown
+                aria-label="errata_dropdown"
+                toggle={
+                  <DropdownToggle
+                    aria-label="expand_errata_toggle"
+                    splitButtonItems={[
+                      <DropdownToggleAction key="action" aria-label="bulk_actions" onClick={apply}>
+                        {__('Apply')}
+                      </DropdownToggleAction>,
+                    ]}
+                    splitButtonVariant="action"
+                    toggleVariant="primary"
+                    onToggle={onActionToggle}
+                  />
+              }
+                isOpen={isActionOpen}
+                dropdownItems={dropdownItems}
+              />
             </ActionListItem>
             <ActionListItem>
               <Dropdown
-                toggle={<KebabToggle aria-label="bulk_actions" onToggle={toggleBulkAction} />}
+                toggle={<KebabToggle aria-label="bulk_actions_kebab" onToggle={toggleBulkAction} />}
                 isOpen={isBulkActionOpen}
                 isPlain
-                dropdownItems={dropdownItems}
+                dropdownItems={dropdownKebabItems}
               />
             </ActionListItem>
           </ActionList>

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
@@ -1,8 +1,8 @@
 import React, { useState, useCallback } from 'react';
 import { FormattedMessage } from 'react-intl';
 import {
-  Skeleton, Button, Split, SplitItem, ActionList, ActionListItem, Dropdown,
-  DropdownItem, KebabToggle,
+  Skeleton, Split, SplitItem, ActionList, ActionListItem, Dropdown,
+  DropdownItem, DropdownToggle, DropdownToggleAction,
 } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { TableVariant, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
@@ -112,19 +112,22 @@ const TracesTab = () => {
       <SplitItem>
         <ActionList isIconList>
           <ActionListItem>
-            <Button
-              variant="secondary"
-              isDisabled={selectedCount === 0}
-              onClick={onBulkRestartApp}
-            >
-              {__('Restart app')}
-            </Button>
-          </ActionListItem>
-          <ActionListItem>
             <Dropdown
-              toggle={<KebabToggle aria-label="bulk_actions" onToggle={toggleBulkAction} />}
+              aria-label="bulk_actions_dropdown"
+              toggle={
+                <DropdownToggle
+                  aria-label="bulk_actions"
+                  splitButtonItems={[
+                    <DropdownToggleAction key="action" onClick={onBulkRestartApp}>
+                      {__('Restart app')}
+                    </DropdownToggleAction>,
+                  ]}
+                  splitButtonVariant="action"
+                  toggleVariant="primary"
+                  onToggle={toggleBulkAction}
+                />
+              }
               isOpen={isBulkActionOpen}
-              isPlain
               dropdownItems={dropdownItems}
             />
           </ActionListItem>

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
@@ -875,7 +875,7 @@ test('Can bulk apply via katello agent', async (done) => {
   getByLabelText('Select row 0').click();
   getByLabelText('Select row 1').click();
 
-  const actionMenu = getByLabelText('bulk_actions');
+  const actionMenu = getByLabelText('expand_errata_toggle');
   actionMenu.click();
   const viaAction = queryByText('Apply via Katello agent');
   expect(viaAction).toBeInTheDocument();
@@ -923,7 +923,7 @@ test('Can select all, exclude and bulk apply via katello agent', async (done) =>
 
   getByLabelText('Select row 0').click(); // deselect
 
-  const actionMenu = getByLabelText('bulk_actions');
+  const actionMenu = getByLabelText('expand_errata_toggle');
   actionMenu.click();
   const viaAction = queryByText('Apply via Katello agent');
   expect(viaAction).toBeInTheDocument();
@@ -1013,7 +1013,7 @@ test('Can bulk apply via remote execution', async (done) => {
   getByLabelText('Select row 0').click();
   getByLabelText('Select row 1').click();
 
-  const actionMenu = getByLabelText('bulk_actions');
+  const actionMenu = getByLabelText('expand_errata_toggle');
   actionMenu.click();
   const viaRexAction = queryByText('Apply via remote execution');
   expect(viaRexAction).toBeInTheDocument();
@@ -1059,7 +1059,7 @@ test('Can select all, exclude and bulk apply via remote execution', async (done)
 
   getByLabelText('Select row 0').click(); // de select
 
-  const actionMenu = getByLabelText('bulk_actions');
+  const actionMenu = getByLabelText('expand_errata_toggle');
   actionMenu.click();
   const viaRexAction = queryByText('Apply via remote execution');
   expect(viaRexAction).toBeInTheDocument();
@@ -1091,7 +1091,7 @@ test('Can apply errata in bulk via customized remote execution', async (done) =>
   getByLabelText('Select row 1').click();
   const errata = `${results[0].errata_id},${results[1].errata_id}`;
   const feature = REX_FEATURES.KATELLO_HOST_ERRATA_INSTALL_BY_SEARCH;
-  const actionMenu = getByLabelText('bulk_actions');
+  const actionMenu = getByLabelText('expand_errata_toggle');
   actionMenu.click();
   const viaRexAction = queryByText('Apply via customized remote execution');
   expect(viaRexAction).toBeInTheDocument();


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Changed the button to a dropdown with the actions that are in the kebab to make it like we have it on the packages page

#### Considerations taken when implementing this change?

* Made sure all tests run and the REX actions function like before. 

#### What are the testing steps for this pull request?

* Click the drop-down on the restart app button and make sure the actions work
* Verify there are not any console errors
