### PR TITLE
Refs #34923 - fix CloneToVersion generate_metadata

### DIFF
--- a/app/lib/actions/katello/repository/clone_to_version.rb
+++ b/app/lib/actions/katello/repository/clone_to_version.rb
@@ -23,7 +23,7 @@ module Actions
                         rpm_filenames: rpm_filenames,
                         copy_contents: copy_contents,
                         solve_dependencies: content_view.solve_dependencies,
-                        metadata_generate: !incremental)
+                        generate_metadata: true)
           end
         end
 

--- a/app/lib/actions/katello/repository/multi_clone_to_version.rb
+++ b/app/lib/actions/katello/repository/multi_clone_to_version.rb
@@ -10,7 +10,7 @@ module Actions
             plan_action(::Actions::Katello::Repository::MultiCloneContents, extended_repo_map,
                         copy_contents: true,
                         solve_dependencies: true,
-                        metadata_generate: !incremental)
+                        generate_metadata: true)
           end
         end
 

--- a/test/actions/katello/repository/clone_to_version_test.rb
+++ b/test/actions/katello/repository/clone_to_version_test.rb
@@ -42,7 +42,7 @@ module Actions
 
       assert_action_planned_with(action, Actions::Katello::Repository::CloneContents, [yum_repo], cloned_repo,
                                 :purge_empty_contents => true, :filters => [], :rpm_filenames => nil,
-                                :copy_contents => true, :metadata_generate => true,
+                                :copy_contents => true, :generate_metadata => true,
                                 :solve_dependencies => false)
     end
 
@@ -58,7 +58,7 @@ module Actions
 
       assert_action_planned_with(action, Actions::Katello::Repository::CloneContents, [yum_repo], cloned_repo,
                                 :purge_empty_contents => true, :filters => [], :rpm_filenames => nil,
-                                :copy_contents => true, :metadata_generate => true,
+                                :copy_contents => true, :generate_metadata => true,
                                 :solve_dependencies => true)
     end
 
@@ -73,7 +73,7 @@ module Actions
 
       assert_action_planned_with(action, Actions::Katello::Repository::CloneContents, [yum_repo], cloned_repo,
                                 :purge_empty_contents => true, :filters => [], :rpm_filenames => nil,
-                                :copy_contents => true, :metadata_generate => true,
+                                :copy_contents => true, :generate_metadata => true,
                                 :solve_dependencies => false)
     end
 
@@ -88,7 +88,7 @@ module Actions
 
       assert_action_planned_with(action, Actions::Katello::Repository::CloneContents, [docker_repo], cloned_repo,
                                 :purge_empty_contents => true, :filters => [], :rpm_filenames => nil,
-                                :copy_contents => true, :metadata_generate => true,
+                                :copy_contents => true, :generate_metadata => true,
                                 :solve_dependencies => false)
     end
 
@@ -102,7 +102,7 @@ module Actions
 
       assert_action_planned_with(action, Actions::Katello::Repository::CloneContents, [file_repo], cloned_repo,
                                 :purge_empty_contents => true, :filters => [], :rpm_filenames => nil, :copy_contents => true,
-                                :metadata_generate => true, :solve_dependencies => false)
+                                :generate_metadata => true, :solve_dependencies => false)
     end
 
     it 'fully plans out a clone with pulp3' do


### PR DESCRIPTION
This fix ensures that the code does, what originally was intended.

I do not know, whether this really is what should be done, since no one seems to have been complaining about this, yet.
Please verify, if setting `generate_metadata=false` for incremental updates should be done (unfortunately, I lack knowledge on how this is all supposed to work :wink: )

This might not be the only occurrence of `generate_metadata` vs. `metadata_generate`, therefore, I used 'Refs' instead of 'Fixes'.
