### PR TITLE
Fixes #34916 - ACS UI - Refresh action from UI and show last refresh …

### DIFF
--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -62,5 +62,10 @@ module Katello
       conditions = sanitize_sql_for_conditions(["? #{operator} ANY (subpaths)", value_to_sql(operator, value)])
       { conditions: conditions }
     end
+
+    def latest_dynflow_refresh_task
+      @latest_dynflow_refresh_task ||= ForemanTasks::Task::DynflowTask.where(:label => Actions::Katello::AlternateContentSource::Refresh.name).
+          for_resource(self).order(:started_at).last
+    end
   end
 end

--- a/app/views/katello/api/v2/alternate_content_sources/base.json.rabl
+++ b/app/views/katello/api/v2/alternate_content_sources/base.json.rabl
@@ -2,7 +2,16 @@ object @resource
 
 extends 'katello/api/v2/common/identifier'
 
-attributes :name, :base_url, :subpaths, :content_type, :alternate_content_source_type, :smart_proxies, :upstream_username
+attributes :name, :base_url, :subpaths, :content_type, :alternate_content_source_type, :smart_proxies, :upstream_username, :last_refreshed
+
+child :latest_dynflow_refresh_task => :last_refresh do |_object|
+  attributes :id, :username, :started_at, :ended_at, :state, :result, :progress
+  node :last_refresh_words do |object|
+    if (object.respond_to?('started_at') && object.started_at)
+      time_ago_in_words(Time.parse(object.started_at.to_s))
+    end
+  end
+end
 
 if params.key?(:include_permissions)
   node :permissions do |alternate_content_source|

--- a/webpack/scenes/AlternateContentSources/ACSActions.js
+++ b/webpack/scenes/AlternateContentSources/ACSActions.js
@@ -1,8 +1,9 @@
 import { API_OPERATIONS, APIActions, get, post } from 'foremanReact/redux/API';
 import { translate as __ } from 'foremanReact/common/I18n';
 import api, { orgId } from '../../services/api';
-import ACS_KEY, { CREATE_ACS_KEY, DELETE_ACS_KEY } from './ACSConstants';
+import ACS_KEY, { acsRefreshKey, CREATE_ACS_KEY, DELETE_ACS_KEY } from './ACSConstants';
 import { getResponseErrorMsgs } from '../../utils/helpers';
+import { renderTaskStartedToast } from '../Tasks/helpers';
 
 const acsSuccessToast = (response) => {
   const { data: { name } } = response;
@@ -47,6 +48,17 @@ export const deleteACS = (acsId, handleSuccess) => APIActions.delete({
   errorToast: error => __(`Something went wrong while deleting this alternate content source! ${getResponseErrorMsgs(error.response)}`),
 });
 
+export const refreshACS = (acsId, handleSuccess) => post({
+  type: API_OPERATIONS.POST,
+  key: acsRefreshKey(acsId),
+  url: api.getApiUrl(`/alternate_content_sources/${acsId}/refresh`),
+  params: { id: acsId },
+  handleSuccess: (response) => {
+    if (handleSuccess) handleSuccess();
+    return renderTaskStartedToast(response.data);
+  },
+  errorToast: error => __(`Something went wrong while refreshing this alternate content source! ${getResponseErrorMsgs(error.response)}`),
+});
 export default getAlternateContentSources;
 
 // acs = Katello::AlternateContentSource.new

--- a/webpack/scenes/AlternateContentSources/ACSConstants.js
+++ b/webpack/scenes/AlternateContentSources/ACSConstants.js
@@ -5,6 +5,7 @@ export const CREATE_ACS_KEY = 'ACS_CREATE';
 export const DELETE_ACS_KEY = 'ACS_DELETE';
 export const SMART_PROXY_KEY = 'SMART_PROXY';
 export const SSL_CERTS = 'SSL_CERTS';
+export const acsRefreshKey = acsId => `${ACS_KEY}_REFRESH_${acsId}`;
 
 export const YUM = __('Yum');
 export const FILE = __('File');

--- a/webpack/scenes/AlternateContentSources/MainTable/ACSTable.js
+++ b/webpack/scenes/AlternateContentSources/MainTable/ACSTable.js
@@ -9,8 +9,9 @@ import {
   selectAlternateContentSourcesStatus,
 } from '../ACSSelectors';
 import { useTableSort } from '../../../components/Table/TableHooks';
-import getAlternateContentSources, { deleteACS } from '../ACSActions';
+import getAlternateContentSources, { deleteACS, refreshACS } from '../ACSActions';
 import ACSCreateWizard from '../Create/ACSCreateWizard';
+import LastSync from '../../ContentViews/Details/Repositories/LastSync';
 
 const ACSTable = () => {
   const response = useSelector(selectAlternateContentSources);
@@ -23,7 +24,7 @@ const ACSTable = () => {
   const columnHeaders = [
     __('Name'),
     __('Type'),
-    __('Id'),
+    __('Last Refresh'),
   ];
 
   const COLUMNS_TO_SORT_PARAMS = {
@@ -54,16 +55,28 @@ const ACSTable = () => {
       dispatch(getAlternateContentSources())));
   };
 
+  const onRefresh = (id) => {
+    dispatch(refreshACS(id, () =>
+      dispatch(getAlternateContentSources())));
+  };
+
   const createButtonOnclick = () => {
     setIsCreateWizardOpen(true);
   };
 
   const rowDropdownItems = ({ id }) => [
     {
-      title: 'Delete',
+      title: __('Delete'),
       ouiaId: `remove-acs-${id}`,
       onClick: () => {
         onDelete(id);
+      },
+    },
+    {
+      title: __('Refresh'),
+      ouiaId: `remove-acs-${id}`,
+      onClick: () => {
+        onRefresh(id);
       },
     },
   ];
@@ -120,15 +133,16 @@ const ACSTable = () => {
       <Tbody>
         {results?.map((acs, index) => {
           const {
-            id,
             name,
             alternate_content_source_type: acsType,
+            last_refresh: lastTask,
           } = acs;
+          const { last_refresh_words: lastRefreshWords, started_at: startedAt } = lastTask ?? {};
           return (
             <Tr key={index}>
               <Td>{name}</Td>
               <Td>{acsType}</Td>
-              <Td>{id}</Td>
+              <Td><LastSync startedAt={startedAt} lastSync={lastTask} lastSyncWords={lastRefreshWords} emptyMessage="N/A" /></Td>
               <Td
                 actions={{
                   items: rowDropdownItems(acs),


### PR DESCRIPTION
…on index

#### What are the changes introduced in this pull request?
Add last refresh task info to the rabl, index and refresh action on the UI
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Under Labs > Alternate content sources > on any acs row actions, hit refresh.