### PR TITLE
Fixes #34934 - activation key overriding broke parameters table

### DIFF
--- a/app/assets/javascripts/katello/hosts/activation_key_edit.js
+++ b/app/assets/javascripts/katello/hosts/activation_key_edit.js
@@ -75,8 +75,15 @@ function ktSetParam(name, value) {
     var paramContainer = ktFindParamContainer(name);
     if(value) {
         if(! paramContainer) { // we create the param for kt_activation_keys
-            $("div#parameters a[target~='#global_parameters_table']").click();
-            paramContainer = $("div#parameters .fields").last();
+            var addParameterButton = $('#parameters').find('.btn-primary');
+            addParameterButton.click();
+            var directionOfAddedItems = addParameterButton.attr('direction');
+            var paramContainer = $('#parameters').find('.fields');
+            if(directionOfAddedItems === 'append'){
+                paramContainer = paramContainer.last();
+            } else {
+                paramContainer = paramContainer.first();
+            }
             paramContainer.find("input[name*='name']").val(name);
         }
         paramContainer.find("textarea").val(value);


### PR DESCRIPTION
after a change was added to the hostgroup parameters addition order,
the direction of addition should be also considered when overriding / setting params.
