### PR TITLE
Fixes #34932 - Prevent reclaim_space task in the absence of downloade…

### DIFF
--- a/app/lib/actions/pulp3/capsule_content/reclaim_space.rb
+++ b/app/lib/actions/pulp3/capsule_content/reclaim_space.rb
@@ -12,6 +12,7 @@ module Actions
             end
             repository_hrefs = ::Katello::Pulp3::Api::Core.new(smart_proxy).core_repositories_list_all(fields: 'pulp_href').map(&:pulp_href)
           end
+          fail _('There is no downloaded content to clean.') if repository_hrefs.empty?
           plan_self(repository_hrefs: repository_hrefs, smart_proxy_id: smart_proxy.id)
         end
 


### PR DESCRIPTION
…d content

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1. Setup a fresh environment (reset data and checkout branch)
2. WebUI -> Infrastructure -> Smart Proxies -> $KATELLO_FQDN -> Reclaim Space
3. See a message "There is no downloaded content to clean"
4. No task is created