### PR TITLE
Fixes #34944 - Don't run update if erratum_package doesn't exist

### DIFF
--- a/db/migrate/20220303160220_remove_duplicate_errata.rb
+++ b/db/migrate/20220303160220_remove_duplicate_errata.rb
@@ -43,7 +43,7 @@ class RemoveDuplicateErrata < ActiveRecord::Migration[6.0]
         ::Katello::ModuleStreamErratumPackage.where(erratum_package_id: dup_err_package).each do |dup_mod_errata_package|
           if ::Katello::ModuleStreamErratumPackage.find_by(module_stream_id: dup_mod_errata_package.module_stream_id, erratum_package_id: erratum_package_to_keep&.id)
             dup_mod_errata_package.delete
-          else
+          elsif erratum_package_to_keep&.id
             begin
               dup_mod_errata_package.update(erratum_package_id: erratum_package_to_keep&.id)
             rescue


### PR DESCRIPTION
#### What are the testing steps for this pull request?

To test:
Sync
Red Hat Enterprise Linux 8 for x86_64 - AppStream RPMs 8
Confirm you have errata, modulestreams and in console, check if you have `::Katello::ModuleStreamErratumPackage.count > 0`

Create a bunch of duplicate errata:
```ruby
::Katello::Erratum.all.each do |errata|
   errata.pulp_id = errata.errata_id + 'random'
   errata.save!
end
```
Do a complete sync on the repo above.
Check `::Katello::ModuleStreamErratumPackage.count` again and see if it increased.

If not:
Run the below to force re-index content

```ruby
repo = Katello.find(repo_id)
repo.index_content

::Katello::ModuleStreamErratumPackage.first
=> #<Katello::ModuleStreamErratumPackage:0x0000000010fcb308 id: 1, module_stream_id: 115, **erratum_package_id: 16970**, created_at: nil, updated_at: nil>

Katello::ErratumPackage.where(id: **16970**)
=> [#<Katello::ErratumPackage:0x000000000aa26ea8
  id: 16970,
  **erratum_id: 1655,**
  nvrea: "jss-4.8.1-2.module+el8.4.0+10451+3e5b5448.x86_64",
  name: "jss",
  filename: "jss-4.8.1-2.module+el8.4.0+10451+3e5b5448.x86_64.rpm">]

[10] pry(main)> Katello::Erratum.find(**1655**)
=> #<Katello::Erratum:0x000000000a0611e8
 id: 1655,
 pulp_id: "RHSA-2021:1775random",
 **errata_id: "RHSA-2021:1775",**
 created_at: Thu, 26 May 2022 14:47:50 UTC +00:00,
 updated_at: Thu, 26 May 2022 14:55:58 UTC +00:00,
 issued: Tue, 18 May 2021,
 updated: Tue, 18 May 2021,
...]

Katello::Erratum.where(**errata_id: "RHSA-2021:1775"**)

[#<Katello::Erratum:0x000000000ed3ea10
  id: 1655,
  pulp_id: "RHSA-2021:1775random",
  errata_id: "RHSA-2021:1775",
  created_at: Thu, 26 May 2022 14:47:50 UTC +00:00,
  updated_at: Thu, 26 May 2022 14:55:58 UTC +00:00,
  issued: Tue, 18 May 2021,
  updated: Tue, 18 May 2021,...>,
#<Katello::Erratum:0x000000000ed3e7b8
  id: **10066**,
  **pulp_id: "RHSA-2021:1775",
  errata_id: "RHSA-2021:1775",**
  created_at: Thu, 26 May 2022 15:11:52 UTC +00:00,
  updated_at: Thu, 26 May 2022 15:11:52 UTC +00:00,
  issued: Tue, 18 May 2021,
  updated: Tue, 18 May 2021,..]
```
Pick the one where `errata_id == pulp_id`.

Delete all module stream errata packages tied to the original errata:
```ruby
::Katello::ModuleStreamErratumPackage.where(erratum_package_id: Katello::ErratumPackage.where(erratum_id: **10066**).pluck(:id)).each do |e_p_m|
  e_p_m.delete
end
```
Now delete all ErratumPackages
```ruby
Katello::ErratumPackage.where(erratum_id: **10066**).each do |ep|
   ep.delete
end
```
Run migration:
bundle exec rails db:migrate:down VERSION=20220303160220
bundle exec rails db:migrate:up VERSION=20220303160220

Run migration on master. It should fail.
Run migration on branch. It should succeed.