### PR TITLE
Fixes #32830 - docker-ce fails to pull docker images

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -177,6 +177,9 @@ module Katello
                        end
         end
         response.headers['Content-Type'] = media_type
+        length = manifest_response.try(:body).try(:size)
+        length ||= 0
+        response.header['Content-Length'] = "#{length}"
         render json: manifest_response
       end
     end

--- a/test/controllers/api/registry/registry_proxies_controller_test.rb
+++ b/test/controllers/api/registry/registry_proxies_controller_test.rb
@@ -409,6 +409,7 @@ module Katello
         get :pull_manifest, params: { repository: @docker_repo.name, tag: @tag.name }
         assert_response 200
         assert_equal(manifest, response.body)
+        assert_equal response.header['Content-Length'], '0'
         assert response.header['Content-Type'] =~ /MEDIATYPE/
         assert_equal @digest, response.header['Docker-Content-Digest']
       end
@@ -435,6 +436,7 @@ module Katello
         get :pull_manifest, params: { repository: @docker_repo.name, tag: @tag.name }
         assert_response 200
         assert_equal(manifest, response.body)
+        assert_equal response.header['Content-Length'], '0'
         assert response.header['Content-Type'] =~ /MEDIATYPE/
         assert_equal @digest, response.header['Docker-Content-Digest']
       end
@@ -453,6 +455,7 @@ module Katello
         assert_response 200
         assert_equal(manifest, response.body)
         assert_includes response.header['Content-Type'], 'application/vnd.docker.distribution.manifest.v1+json'
+        assert_equal response.header['Content-Length'], '0'
         assert_equal @digest, response.header['Docker-Content-Digest']
       end
 
@@ -469,6 +472,7 @@ module Katello
         get :pull_manifest, params: { repository: @docker_repo.name, tag: @tag.name }
         assert_response 200
         assert_equal(manifest, response.body)
+        assert_equal response.header['Content-Length'], '0'
         assert_includes response.header['Content-Type'], 'application/vnd.docker.distribution.manifest.v1+prettyjws'
         assert_equal @digest, response.header['Docker-Content-Digest']
       end
@@ -487,6 +491,7 @@ module Katello
         get :pull_manifest, params: { repository: @docker_repo.name, tag: @tag.name }
         assert_response 200
         assert_equal(manifest, response.body)
+        assert_equal response.header['Content-Length'], '0'
         assert response.header['Content-Type'] =~ /MEDIATYPE/
         assert_equal @digest, response.header['Docker-Content-Digest']
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
`Content-Length` was not being returned in the container manifest response. Newer versions of Docker require this.

#### Considerations taken when implementing this change?
I kept the `Content-Length` as a string to be consistent with the other instances of it being set. I don't think it's necessary, but I'm not positive.

#### What are the testing steps for this pull request?
1) Install `docker-ce`: https://docs.docker.com/engine/install/centos/
2) Sync a container repository and ensure that it has manifests
3) `docker pull hostname/image`
  -> `docker login hostname` first and then `docker search hostname/` to see the images
4) Try the above steps with podman to ensure compatibility was not broken