### PR TITLE
Fixes #34862 - Rails 6.1 unit tests

### DIFF
--- a/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
+++ b/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
@@ -2,7 +2,7 @@ module Katello
   class Api::V2::AlternateContentSourcesController < Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
 
-    acs_wrap_params = AlternateContentSource.attribute_names.concat([:smart_proxy_ids, :smart_proxy_names])
+    acs_wrap_params = AlternateContentSource.attribute_names + [:smart_proxy_ids, :smart_proxy_names]
     wrap_parameters :alternate_content_source, include: acs_wrap_params
 
     before_action :find_authorized_katello_resource, only: [:show, :update, :destroy, :refresh]

--- a/app/controllers/katello/api/v2/content_view_components_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_components_controller.rb
@@ -57,7 +57,7 @@ module Katello
               else
                 query
               end
-      custom_sort = ->(sort_query) { sort_query.joins(join_query).order(order_query) }
+      custom_sort = ->(sort_query) { sort_query.joins(join_query).order(Arel.sql(order_query)) }
       options = { resource_class: Katello::ContentView, custom_sort: custom_sort }
       collection = scoped_search(query, nil, nil, options)
       collection[:results] = ComponentViewPresenter.component_presenter(@view, params[:status], views: collection[:results])

--- a/app/controllers/katello/api/v2/content_view_repositories_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_repositories_controller.rb
@@ -28,7 +28,7 @@ module Katello
       query = query.with_type(params[:content_type]) if params[:content_type]
       # Use custom sort to perform the join and order since we need to order by specific content_view
       # and the ORDER BY query needs access to the katello_content_view_repositories table
-      custom_sort = ->(sort_query) { sort_query.joins(:root).joins(join_query).order(order_query) }
+      custom_sort = ->(sort_query) { sort_query.joins(:root).joins(join_query).order(Arel.sql(order_query)) }
       options = { resource_class: Katello::Repository, custom_sort: custom_sort }
       repos = scoped_search(query, nil, nil, options)
 

--- a/test/actions/katello/repository/index_content_test.rb
+++ b/test/actions/katello/repository/index_content_test.rb
@@ -18,7 +18,7 @@ module ::Actions::Katello::Repository
       task = ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, id: @repo.id)
 
       @repo.reload
-      assert_equal indexed_time.inspect, @repo.last_indexed.inspect
+      assert_equal indexed_time.strftime("%D-%T"), @repo.last_indexed.strftime("%D-%T")
       assert task.output[:index_skipped]
     end
 

--- a/test/actions/pulp3/orchestration/apt_update_test.rb
+++ b/test/actions/pulp3/orchestration/apt_update_test.rb
@@ -24,7 +24,7 @@ module ::Actions::Pulp3
     def test_update_http_proxy_with_no_url
       @repo.root.update(url: nil)
       @repo.root.update(http_proxy_policy: ::Katello::RootRepository::USE_SELECTED_HTTP_PROXY)
-      @repo.root.update(http_proxy_id: ::HttpProxy.find_by(name: 'myhttpproxy'))
+      @repo.root.update(http_proxy_id: ::HttpProxy.find_by(name: 'myhttpproxy').id)
 
       ForemanTasks.sync_task(
         ::Actions::Pulp3::Orchestration::Repository::Update,

--- a/test/actions/pulp3/orchestration/yum_update_test.rb
+++ b/test/actions/pulp3/orchestration/yum_update_test.rb
@@ -26,7 +26,7 @@ module ::Actions::Pulp3
     def test_update_http_proxy_with_no_url
       @repo.root.update(url: nil)
       @repo.root.update(http_proxy_policy: ::Katello::RootRepository::USE_SELECTED_HTTP_PROXY)
-      @repo.root.update(http_proxy_id: ::HttpProxy.find_by(name: 'myhttpproxy'))
+      @repo.root.update(http_proxy_id: ::HttpProxy.find_by(name: 'myhttpproxy').id)
 
       ForemanTasks.sync_task(
         ::Actions::Pulp3::Orchestration::Repository::Update,

--- a/test/migrations/20211220185935_clean_duplicate_content_units_test.rb
+++ b/test/migrations/20211220185935_clean_duplicate_content_units_test.rb
@@ -32,7 +32,7 @@ module Katello
       stream = Katello::ModuleStream.create!(:pulp_id => original_stream.pulp_id) #associated_to_repo
       Katello::ModuleStream.create!(:pulp_id => original_stream.pulp_id) #not associated to repo
 
-      Katello::ContentViewModuleStreamFilterRule.create!(module_stream_id: stream.id, content_view_filter_id: katello_content_view_filters(:populated_module_stream_filter))
+      Katello::ContentViewModuleStreamFilterRule.create!(module_stream_id: stream.id, content_view_filter_id: katello_content_view_filters(:populated_module_stream_filter).id)
       Katello::ContentFacetApplicableModuleStream.create!(module_stream_id: stream.id, content_facet_id: katello_content_facets(:content_facet_one).id)
       Katello::ModuleProfile.create!(module_stream_id: stream.id, name: 'foobar')
       Katello::ModuleStreamArtifact.create!(module_stream_id: stream.id, name: 'the one artifact')
@@ -71,8 +71,8 @@ module Katello
       collection = Katello::AnsibleCollection.create!(:pulp_id => 'my_pulp_id')
       tag1 = Katello::AnsibleTag.create(name: name)
       tag2 = Katello::AnsibleTag.create(name: name)
-      Katello::AnsibleCollectionTag.create!(ansible_collection_id: collection.id, ansible_tag_id: tag1)
-      Katello::AnsibleCollectionTag.create!(ansible_collection_id: collection.id, ansible_tag_id: tag2)
+      Katello::AnsibleCollectionTag.create!(ansible_collection_id: collection.id, ansible_tag_id: tag1.id)
+      Katello::AnsibleCollectionTag.create!(ansible_collection_id: collection.id, ansible_tag_id: tag2.id)
 
       assert_equal 2, Katello::AnsibleTag.where(name: name).count
       migrate_up


### PR DESCRIPTION
Based of
https://community.theforeman.org/t/upgrading-rails-to-6-1-and-plugins/27558/3
Given 
Rails 6.1 and https://github.com/theforeman/foreman/pull/9117 this commit fixes unit tests and other controller changes that got missed with -> https://github.com/Katello/katello/pull/10087

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
- Checkout https://github.com/theforeman/foreman/pull/9117
- Checkout latest master
- bundle update rails
- Assuming 6.1 got installed, start the server
Error along the lines of
```
/home/vagrant/katello/app/controllers/katello/api/v2/alternate_content_sources_controller.rb:5:in `concat': can't modify frozen Array: ["id", "name", "label", "description", "ssl_ca_cert_id", "ssl_client_cert_id", "ssl_client_key_id", "http_proxy_id", "base_url", "subpaths", "content_type", "alternate_content_source_type", "verify_ssl", "upstream_username", "upstream_password", "last_refreshed"] (FrozenError)

```
- Check out this PR
- Should work well - No error 
- Also hopefully clears all the tests on 9117