### PR TITLE
Fixes #34952 - address render issues after Rails 6.1 upgrade

### DIFF
--- a/app/views/foreman/smart_proxies/show.html.erb
+++ b/app/views/foreman/smart_proxies/show.html.erb
@@ -1,11 +1,11 @@
 <% if @smart_proxy.pulp_mirror? -%>
   <div ng-controller="CapsuleContentController">
-    <%= render :file => 'smart_proxies/show' %>
+    <%= render :template => 'smart_proxies/show' %>
   </div>
 <% elsif @smart_proxy.pulp_primary? -%>
   <div ng-controller="PulpPrimaryController">
-    <%= render :file => 'smart_proxies/show' %>
+    <%= render :template => 'smart_proxies/show' %>
   </div>
 <% else -%>
-  <%= render :file => 'smart_proxies/show' %>
+  <%= render :template => 'smart_proxies/show' %>
 <% end -%>

--- a/app/views/katello/layouts/foreman_with_bastion.html.erb
+++ b/app/views/katello/layouts/foreman_with_bastion.html.erb
@@ -2,4 +2,4 @@
   <%= render :partial => 'layouts/application_content' %>
 <% end %>
 
-<%= render :file => 'bastion/layouts/assets' %>
+<%= render :template => 'bastion/layouts/assets' %>

--- a/app/views/katello/layouts/react.html.erb
+++ b/app/views/katello/layouts/react.html.erb
@@ -13,4 +13,4 @@
       <%= react_component('katello') %>
     </div>
 <% end %>
-<%= render file: "layouts/base" %>
+<%= render template: "layouts/base" %>

--- a/engines/bastion/app/views/bastion/layouts/application.html.erb
+++ b/engines/bastion/app/views/bastion/layouts/application.html.erb
@@ -7,4 +7,4 @@
   </div>
 <% end %>
 
-<%= render file: "bastion/layouts/assets" %>
+<%= render template: "bastion/layouts/assets" %>

--- a/engines/bastion/app/views/bastion/layouts/application_ie.html.erb
+++ b/engines/bastion/app/views/bastion/layouts/application_ie.html.erb
@@ -1,1 +1,1 @@
-<%= render file: "bastion/layouts/application" %>
+<%= render template: "bastion/layouts/application" %>

--- a/engines/bastion/app/views/bastion/layouts/assets.html.erb
+++ b/engines/bastion/app/views/bastion/layouts/assets.html.erb
@@ -38,4 +38,4 @@
   <% end %>
 <% end %>
 
-<%= render file: "layouts/base" %>
+<%= render template: "layouts/base" %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Changes the template rendering to match up with what Rails 6.1 expects.

#### Considerations taken when implementing this change?
I made this PR because pages will not load using `render file: ...` after upgrading to Rails 6.1.

#### What are the testing steps for this pull request?
1) `git pull`, `bundle update`, etc
2) Try loading varying Katello pages, like the subscriptions page or the products page.