### PR TITLE
Fixes #34957 - Put manifest into a shared temp directory

### DIFF
--- a/app/lib/actions/katello/organization/manifest_refresh.rb
+++ b/app/lib/actions/katello/organization/manifest_refresh.rb
@@ -9,7 +9,7 @@ module Actions
         def plan(organization)
           action_subject organization
           manifest_update = organization.products.redhat.any?
-          path = "/tmp/#{rand}.zip"
+          path = File.join(::Rails.root, "tmp", "#{rand}.zip")
           details = organization.owner_details
           upstream = details['upstreamConsumer'].blank? ? {} : details['upstreamConsumer']
 

--- a/test/actions/katello/organization_test.rb
+++ b/test/actions/katello/organization_test.rb
@@ -86,6 +86,7 @@ module ::Actions::Katello::Organization
       acme_org.stubs(:owner_details).returns({})
       action.stubs(:action_subject).with(acme_org)
       action.stubs(:rand).returns('1234')
+      path = File.join(::Rails.root, 'tmp', '1234.zip')
       plan_action(action, acme_org)
 
       found = assert_action_planned_with(action,
@@ -97,13 +98,13 @@ module ::Actions::Katello::Organization
                                  ::Actions::Candlepin::Owner::UpstreamExport,
                                  organization_id: acme_org.id,
                                  upstream: upstream,
-                                 path: "/tmp/1234.zip",
+                                 path: path,
                                  dependency: found.first.output
                                         )
       found = assert_action_planned_with(action,
                                  ::Actions::Candlepin::Owner::Import,
                                  label: acme_org.label,
-                                 path: "/tmp/1234.zip",
+                                 path: path,
                                  dependency: found.first.output
                                         )
       found = assert_action_planned_with(action,


### PR DESCRIPTION
On production deployments, dynflow workers have private tmp directories,
meaning they cannot use /tmp as a place for shared data. This could lead
to manifest refresh failing on scaled-up deployments.

#### What are the changes introduced in this pull request?
Manifest refresh actions now place the exported manifest into Rails.root/tmp (~foreman/tmp on production deployments) instead of /tmp, which may be private to each worker.

#### Considerations taken when implementing this change?
Alternatively we could make all the workers share /tmp, private from the rest of the system, but the approach take here felt more correct.

#### What are the testing steps for this pull request?
Steps to reproduce are described in the redmine issue.