### PR TITLE
Fixes #34890 - move repository sets tab to content tab

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/ContentTab/SecondaryTabsRoutes.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ContentTab/SecondaryTabsRoutes.js
@@ -1,37 +1,27 @@
 import React from 'react';
-import { Route, Switch, Redirect, useLocation } from 'react-router-dom';
+import { Route, Switch, Redirect } from 'react-router-dom';
 import { PackagesTab } from '../PackagesTab/PackagesTab.js';
 import { ErrataTab } from '../ErrataTab/ErrataTab.js';
 import { ModuleStreamsTab } from '../ModuleStreamsTab/ModuleStreamsTab';
-import  RepositorySetsTab  from '../RepositorySetsTab/RepositorySetsTab';
+import RepositorySetsTab from '../RepositorySetsTab/RepositorySetsTab';
 import { route } from './helpers';
 
-const SecondaryTabRoutes = () => {
-  console.log(route('Repository%20sets'));
-  console.log(useLocation());
-  return (
-    <Switch>
-      <Route path={route('packages')}>
-        <PackagesTab />
-      </Route>
-
-      <Route path={route('errata')}>
-        <ErrataTab />
-      </Route>
-
-      <Route path={route('module-streams')}>
-        <ModuleStreamsTab />
-      </Route>
-
-      <Route path={route('Repository sets')}>
-
-        <RepositorySetsTab />
-      </Route>
-
-      <Redirect to={route('errata')} />
-
-    </Switch>
-  );
-};
+const SecondaryTabRoutes = () => (
+  <Switch>
+    <Route path={route('packages')}>
+      <PackagesTab />
+    </Route>
+    <Route path={route('errata')}>
+      <ErrataTab />
+    </Route>
+    <Route path={route('module-streams')}>
+      <ModuleStreamsTab />
+    </Route>
+    <Route path={route('Repository sets')}>
+      <RepositorySetsTab />
+    </Route>
+    <Redirect to={route('errata')} />
+  </Switch>
+);
 
 export default SecondaryTabRoutes;

--- a/webpack/components/extensions/HostDetails/Tabs/ContentTab/SecondaryTabsRoutes.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ContentTab/SecondaryTabsRoutes.js
@@ -1,23 +1,37 @@
 import React from 'react';
-import { Route, Switch, Redirect } from 'react-router-dom';
+import { Route, Switch, Redirect, useLocation } from 'react-router-dom';
 import { PackagesTab } from '../PackagesTab/PackagesTab.js';
 import { ErrataTab } from '../ErrataTab/ErrataTab.js';
 import { ModuleStreamsTab } from '../ModuleStreamsTab/ModuleStreamsTab';
+import  RepositorySetsTab  from '../RepositorySetsTab/RepositorySetsTab';
 import { route } from './helpers';
 
-const SecondaryTabRoutes = () => (
-  <Switch>
-    <Route path={route('packages')}>
-      <PackagesTab />
-    </Route>
-    <Route path={route('errata')}>
-      <ErrataTab />
-    </Route>
-    <Route path={route('module-streams')}>
-      <ModuleStreamsTab />
-    </Route>
-    <Redirect to={route('errata')} />
-  </Switch>
-);
+const SecondaryTabRoutes = () => {
+  console.log(route('Repository%20sets'));
+  console.log(useLocation());
+  return (
+    <Switch>
+      <Route path={route('packages')}>
+        <PackagesTab />
+      </Route>
+
+      <Route path={route('errata')}>
+        <ErrataTab />
+      </Route>
+
+      <Route path={route('module-streams')}>
+        <ModuleStreamsTab />
+      </Route>
+
+      <Route path={route('Repository sets')}>
+
+        <RepositorySetsTab />
+      </Route>
+
+      <Redirect to={route('errata')} />
+
+    </Switch>
+  );
+};
 
 export default SecondaryTabRoutes;

--- a/webpack/components/extensions/HostDetails/Tabs/ContentTab/constants.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ContentTab/constants.js
@@ -1,10 +1,11 @@
 import { translate as __ } from 'foremanReact/common/I18n';
+import { hideRepoSetsTab } from '../RepositorySetsTab/RepositorySetsTab';
 
 const SECONDARY_TABS = [
   { key: 'packages', title: __('Packages') },
   { key: 'errata', title: __('Errata') },
   { key: 'module-streams', title: __('Module streams') },
-  { key: 'Repository sets', title: __('Repository sets') },
+  { key: 'Repository sets', hideTab: hideRepoSetsTab, title: __('Repository sets') },
 ];
 
 export default SECONDARY_TABS;

--- a/webpack/components/extensions/HostDetails/Tabs/ContentTab/constants.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ContentTab/constants.js
@@ -4,7 +4,7 @@ const SECONDARY_TABS = [
   { key: 'packages', title: __('Packages') },
   { key: 'errata', title: __('Errata') },
   { key: 'module-streams', title: __('Module streams') },
-  { key: 'Repository sets', title: __ ('Repository sets')},
+  { key: 'Repository sets', title: __('Repository sets') },
 ];
 
 export default SECONDARY_TABS;

--- a/webpack/components/extensions/HostDetails/Tabs/ContentTab/constants.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ContentTab/constants.js
@@ -4,6 +4,7 @@ const SECONDARY_TABS = [
   { key: 'packages', title: __('Packages') },
   { key: 'errata', title: __('Errata') },
   { key: 'module-streams', title: __('Module streams') },
+  { key: 'Repository sets', title: __ ('Repository sets')},
 ];
 
 export default SECONDARY_TABS;

--- a/webpack/components/extensions/HostDetails/Tabs/ContentTab/index.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ContentTab/index.js
@@ -2,12 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
 import { Tabs, Tab, TabTitleText } from '@patternfly/react-core';
+import { useSelector } from 'react-redux';
+import { selectAPIResponse } from 'foremanReact/redux/API/APISelectors';
 import SecondaryTabRoutes from './SecondaryTabsRoutes';
 import { activeTab } from './helpers';
 import SECONDARY_TABS from './constants';
 
 const ContentTab = ({ location: { pathname } }) => {
   const hashHistory = useHistory();
+  const hostDetails = useSelector(state => selectAPIResponse(state, 'HOST_DETAILS'));
+  const filteredTabs =
+    SECONDARY_TABS?.filter(tab => !tab.hideTab?.({ hostDetails })) ?? [];
   return (
     <>
       <Tabs
@@ -16,7 +21,7 @@ const ContentTab = ({ location: { pathname } }) => {
         isSecondary
         activeKey={activeTab(pathname)}
       >
-        {SECONDARY_TABS.map(({ key, title }) => (
+        {filteredTabs.map(({ key, title }) => (
           <Tab
             key={key}
             eventKey={key}

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -61,7 +61,6 @@ import SortableColumnHeaders from '../../../../Table/components/SortableColumnHe
 import SelectableDropdown from '../../../../SelectableDropdown';
 import { hasRequiredPermissions as can,
   missingRequiredPermissions as cannot,
-  hostIsNotRegistered,
   userPermissionsFromHostDetails } from '../../hostDetailsHelpers';
 
 const viewRepoSets = [
@@ -70,11 +69,10 @@ const viewRepoSets = [
 const createBookmarks = ['create_bookmarks'];
 
 export const hideRepoSetsTab = ({ hostDetails }) =>
-  hostIsNotRegistered({ hostDetails }) ||
-    cannot(
-      viewRepoSets,
-      userPermissionsFromHostDetails({ hostDetails }),
-    );
+  cannot(
+    viewRepoSets,
+    userPermissionsFromHostDetails({ hostDetails }),
+  );
 
 const editHosts = ['edit_hosts'];
 const getEnabledValue = ({ enabled, enabledContentOverride }) => {

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -12,7 +12,6 @@ import InstalledProductsCard from './components/extensions/HostDetails/DetailsTa
 import RegistrationCard from './components/extensions/HostDetails/DetailsTabCards/RegistrationCard';
 import HwPropertiesCard from './components/extensions/HostDetails/DetailsTabCards/HwPropertiesCard';
 
-import RepositorySetsTab, { hideRepoSetsTab } from './components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab';
 import TracesTab from './components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js';
 import extendReducer from './components/extensions/reducers';
 import rootReducer from './redux/reducers';
@@ -30,7 +29,6 @@ addGlobalFill('registrationAdvanced', '[katello]RegistrationCommands', <Registra
 // Host details page tabs
 addGlobalFill('host-details-page-tabs', 'Content', <ContentTab key="content" />, 900, { title: __('Content'), hideTab: hostIsNotRegistered });
 addGlobalFill('host-details-page-tabs', 'Traces', <TracesTab key="traces" />, 800, { title: __('Traces'), hideTab: hostIsNotRegistered });
-addGlobalFill('host-details-page-tabs', 'Repository sets', <RepositorySetsTab key="repository-sets" />, 700, { title: __('Repository sets'), hideTab: hideRepoSetsTab });
 
 // Overview tab cards
 addGlobalFill(


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Moved the Repository Sets Tab to be under the Content Tab

#### Considerations taken when implementing this change?
In the usability study, 3 out of 5 users expected repository sets to be under Content.

#### What are the testing steps for this pull request?
Note: This is for the Hosts-> All hosts -> New Host detail page
Step1: Check that Repository Sets Tab is under the Content Tab
Step2: Making sure that Repository Sets tab is not in its original place anymore (as a main tab)
Step3: Checking that the functionality of the Repository Sets Tab works well 