### PR TITLE
Fixes #32282 - Repository restricted to an OS showed in a label on Repository Sets screen

### DIFF
--- a/app/views/katello/api/v2/repository_sets/show.json.rabl
+++ b/app/views/katello/api/v2/repository_sets/show.json.rabl
@@ -37,6 +37,10 @@ child @resource.repositories => :repositories do
   attributes :minor => :releasever
 end
 
+node :osRestricted do |pc|
+  pc.repositories&.first&.os_versions&.first
+end
+
 node :override do |pc|
   pc.override if pc.respond_to? :override
 end

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -96,6 +96,29 @@ EnabledIcon.propTypes = {
   isOverridden: PropTypes.bool.isRequired,
 };
 
+const OsRestrictedIcon = ({ osRestricted }) => (
+  <Tooltip
+    position="right"
+    content={<FormattedMessage
+      id="os-restricted-tooltip"
+      defaultMessage={__('OS restricted to {osRestricted}. If host OS does not match, the repository will not be available on this host.')}
+      values={{ osRestricted }}
+    />}
+  >
+    <Label color="blue" className="os-restricted-label" style={{ marginLeft: '8px' }}>
+      {__(osRestricted)}
+    </Label>
+  </Tooltip>
+);
+
+OsRestrictedIcon.propTypes = {
+  osRestricted: PropTypes.string,
+};
+
+OsRestrictedIcon.defaultProps = {
+  osRestricted: null,
+};
+
 const RepositorySetsTab = () => {
   const hostDetails = useSelector(state => selectAPIResponse(state, 'HOST_DETAILS'));
   const {
@@ -426,6 +449,7 @@ const RepositorySetsTab = () => {
                 enabled_content_override: enabledContentOverride,
                 contentUrl: repoPath,
                 product: { name: productName, id: productId },
+                osRestricted,
               } = repoSet;
               const { isEnabled, isOverridden } =
                 getEnabledValue({ enabled, enabledContentOverride });
@@ -450,6 +474,9 @@ const RepositorySetsTab = () => {
                   </Td>
                   <Td>
                     <span><EnabledIcon key={`enabled-icon-${id}`} {...{ isEnabled, isOverridden }} /></span>
+                    {osRestricted &&
+                      <span><OsRestrictedIcon key={`os-restricted-icon-${id}`} {...{ osRestricted }} /></span>
+                    }
                   </Td>
                   <Td
                     key={`rowActions-${id}`}

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySets.fixtures.json
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySets.fixtures.json
@@ -41,6 +41,7 @@
       "type": "yum",
       "gpgUrl": null,
       "contentUrl": "/custom/ParthaProduct/empty_repo",
+      "osRestricted": null,
       "override": "default",
       "overrides": [],
       "enabled_content_override": null
@@ -75,6 +76,7 @@
       "type": "yum",
       "gpgUrl": null,
       "contentUrl": "/custom/ParthaProduct/partha_multi-errata",
+      "osRestricted": "rhel-7",
       "override": "0",
       "overrides": [
         {
@@ -107,6 +109,7 @@
       "type": "yum",
       "gpgUrl": null,
       "contentUrl": "/custom/Pull_Provider/yggdrasil",
+      "osRestricted": null,
       "override": "1",
       "overrides": [
         {

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySetsTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySetsTab.test.js
@@ -378,3 +378,19 @@ test('Can filter by status', async (done) => {
   assertNockRequest(autoSearchScope);
   assertNockRequest(scope2, done); // Pass jest callback to confirm test is done
 });
+
+test('Can display osRestricted as a label', async (done) => {
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
+  const scope = nockInstance
+    .get(hostRepositorySets)
+    .query(defaultQuery)
+    .reply(200, mockRepoSetData);
+
+  const { getByText } = renderWithRedux(<RepositorySetsTab />, renderOptions());
+
+  await patientlyWaitFor(() => expect(getByText(secondRepoSet.contentUrl)).toBeInTheDocument());
+  expect(secondRepoSet.osRestricted).not.toBeNull();
+  expect(getByText(secondRepoSet.osRestricted)).toBeInTheDocument();
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(scope, done); // Pass jest callback to confirm test is done
+});


### PR DESCRIPTION

#### What are the changes introduced in this pull request?
Add a label in `Status` column for repositories with `Restrict to OS version` set on Repository Sets screen.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Set a value to `Restrict to OS version` for a repository
2. All Hosts - pick your host - Repository Sets 
    Check Status for a label if `Restrict to OS version` is set
