### PR TITLE
Fixes #34920 - Rename Component content view to content view (#10111)

### DIFF
--- a/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
+++ b/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
@@ -114,7 +114,7 @@ const CreateContentViewForm = ({ setModalOpen }) => {
               aria-label="component_tile"
               icon={<ContentViewIcon composite={false} />}
               id="component"
-              title={__('Component content view')}
+              title={__('Content view')}
               onClick={() => { setComponent(true); setComposite(false); }}
               isSelected={component}
             >
@@ -132,7 +132,7 @@ const CreateContentViewForm = ({ setModalOpen }) => {
               onClick={() => { setComposite(true); setComponent(false); }}
               isSelected={composite}
             >
-              {__('Consisting of multiple component content views')}
+              {__('Consisting of multiple content views')}
             </Tile>
           </GridItem>
         </Grid>

--- a/webpack/scenes/ContentViews/Create/__tests__/createContentView.test.js
+++ b/webpack/scenes/ContentViews/Create/__tests__/createContentView.test.js
@@ -68,7 +68,7 @@ test('Displays dependent fields correctly', () => {
   expect(getByText('Name')).toBeInTheDocument();
   expect(getByText('Label')).toBeInTheDocument();
   expect(getByText('Composite content view')).toBeInTheDocument();
-  expect(getByText('Component content view')).toBeInTheDocument();
+  expect(getByText('Content view')).toBeInTheDocument();
   expect(getByText('Solve dependencies')).toBeInTheDocument();
   expect(queryByText('Auto publish')).not.toBeInTheDocument();
   expect(getByText('Import only')).toBeInTheDocument();

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewAddModal.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewAddModal.js
@@ -87,7 +87,7 @@ const ComponentContentViewAddModal = ({
 
   return (
     <Modal
-      title={componentId ? __('Update version') : __('Add component')}
+      title={componentId ? __('Update version') : __('Add content view')}
       variant={ModalVariant.small}
       isOpen={show}
       description={__(`Select available version of ${cvName} to use`)}

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewBulkAddModal.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewBulkAddModal.js
@@ -51,10 +51,10 @@ const ComponentContentViewBulkAddModal = ({ cvId, rowsToAdd, onClose }) => {
 
   return (
     <Modal
-      title={__('Add component content views')}
+      title={__('Add content views')}
       variant={ModalVariant.large}
       isOpen
-      description={__('Select available version of components to use')}
+      description={__('Select available version of content views to use')}
       onClose={onClose}
       appendTo={document.body}
     >

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.test.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.test.js
@@ -212,7 +212,7 @@ test('Can add published component views to content view with modal', async (done
   });
   fireEvent.click(getByText('Add'));
   await patientlyWaitFor(() => {
-    expect(getByText('Add component')).toBeInTheDocument();
+    expect(getByText('Add content view')).toBeInTheDocument();
   });
   fireEvent.click(getByLabelText('add_component'));
   await patientlyWaitFor(() => {
@@ -317,7 +317,7 @@ test('Can bulk add component views to content view with modal', async (done) => 
     .reply(200, {});
 
   const {
-    getByText, getByLabelText, queryByText,
+    getAllByText, getByLabelText, queryByText,
   } = renderWithRedux(
     <ContentViewComponents cvId={4} details={cvDetails} />,
     renderOptions,
@@ -333,14 +333,14 @@ test('Can bulk add component views to content view with modal', async (done) => 
   });
   fireEvent.click(getByLabelText('bulk_add_components'));
   await patientlyWaitFor(() => {
-    expect(getByText('Add component content views')).toBeInTheDocument();
+    expect(getAllByText('Add content views')[1]).toBeInTheDocument();
   });
   fireEvent.click(getByLabelText('version-select-cv-10'));
   fireEvent.click(getByLabelText('cv-10-3.0'));
 
   fireEvent.click(getByLabelText('add_components'));
   await patientlyWaitFor(() => {
-    expect(queryByText('Add component content views')).not.toBeInTheDocument();
+    expect(queryByText('Select available version of content views to use')).not.toBeInTheDocument();
     expect(getByLabelText('bulk_add_components')).toHaveAttribute('aria-disabled', 'false');
   });
 

--- a/webpack/scenes/ContentViews/Details/ContentViewInfo.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewInfo.js
@@ -71,7 +71,7 @@ const ContentViewInfo = ({ cvId, details }) => {
         <TextListItem component={TextListItemVariants.dd} className="foreman-spaced-list">
           <Flex>
             <FlexItem spacer={{ default: 'spacerXs' }}>
-              <ContentViewIcon composite={composite} description={composite ? __('Composite') : __('Component')} />
+              <ContentViewIcon composite={composite} description={composite ? __('Composite') : __('Content view')} />
             </FlexItem>
           </Flex>
         </TextListItem>

--- a/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
+++ b/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
@@ -43,14 +43,14 @@ test('Can call API for CVs and show on screen on page load', async (done) => {
     .query(true)
     .reply(200, cvIndexData);
 
-  const { queryByText } = renderWithRedux(<ContentViewsPage />, renderOptions);
+  const { queryByText, queryAllByText } = renderWithRedux(<ContentViewsPage />, renderOptions);
 
   expect(queryByText(firstCV.name)).toBeNull();
 
   // Assert that the CV name is now showing on the screen, but wait for it to appear.
   await patientlyWaitFor(() => {
     expect(queryByText(firstCV.name)).toBeInTheDocument();
-    expect(queryByText('Component content views')).toBeInTheDocument();
+    expect(queryAllByText('Content views')[0]).toBeInTheDocument();
     expect(queryByText('Composite content views')).toBeInTheDocument();
   });
 
@@ -354,7 +354,7 @@ test('Displays Create Content View and opens modal with Form', async () => {
   expect(queryByText('Name')).not.toBeInTheDocument();
   expect(queryByText('Label')).not.toBeInTheDocument();
   expect(queryByText('Composite content view')).not.toBeInTheDocument();
-  expect(queryByText('Component content view')).not.toBeInTheDocument();
+  expect(queryByText('Content view')).not.toBeInTheDocument();
   expect(queryByText('Solve dependencies')).not.toBeInTheDocument();
   expect(queryByText('Auto publish')).not.toBeInTheDocument();
   expect(queryByText('Import only')).not.toBeInTheDocument();
@@ -365,7 +365,7 @@ test('Displays Create Content View and opens modal with Form', async () => {
   expect(getByText('Name')).toBeInTheDocument();
   expect(getByText('Label')).toBeInTheDocument();
   expect(getByText('Composite content view')).toBeInTheDocument();
-  expect(getByText('Component content view')).toBeInTheDocument();
+  expect(getByText('Content view')).toBeInTheDocument();
   expect(getByText('Solve dependencies')).toBeInTheDocument();
   expect(queryByText('Auto publish')).not.toBeInTheDocument();
   expect(getByText('Import only')).toBeInTheDocument();

--- a/webpack/scenes/ContentViews/components/ContentViewsCounter.js
+++ b/webpack/scenes/ContentViews/components/ContentViewsCounter.js
@@ -18,7 +18,7 @@ const ContentViewsCounter = () => {
         <b>
           <Flex>
             <FlexItem spacer={{ default: 'spacerXs' }}>
-              <ContentViewIcon composite={false} description={__('Component content views')} count={(component || component === 0) ? component : <InProgressIcon />} />
+              <ContentViewIcon composite={false} description={__('Content views')} count={(component || component === 0) ? component : <InProgressIcon />} />
             </FlexItem>
             <FlexItem>
               <Tooltip

--- a/webpack/scenes/ContentViews/expansions/DetailsExpansion.js
+++ b/webpack/scenes/ContentViews/expansions/DetailsExpansion.js
@@ -14,14 +14,14 @@ const DetailsExpansion = ({
     if (cvComposite) {
       return (
         <>
-          {__('Related component cvs: ')}
+          {__('Related content views: ')}
           <RelatedContentViewComponentsModal key="cvId" {...{ cvName, cvId, relatedCVCount }} />
         </>
       );
     }
     return (
       <>
-        {__('Related composite cvs: ')}
+        {__('Related composite content views: ')}
         <RelatedCompositeContentViewsModal
           key={cvId}
           {...{

--- a/webpack/scenes/ContentViews/expansions/RelatedContentViewComponentsModal.js
+++ b/webpack/scenes/ContentViews/expansions/RelatedContentViewComponentsModal.js
@@ -29,7 +29,7 @@ const RelatedContentViewsModal = ({ cvName, cvId, relatedCVCount }) => {
       <FlexItem>
         <RegistryIcon />
         <b>{` ${cvName}`}</b>
-        {__(' content view is used in listed component content views. For more information, ')}
+        {__(' content view is used in listed content views. For more information, ')}
         <Link to={urlBuilder(`content_views/${cvId}#/contentviews`, '')}>
           {__('view content view tabs.')}
         </Link>
@@ -49,7 +49,7 @@ const RelatedContentViewsModal = ({ cvName, cvId, relatedCVCount }) => {
       <Grid>
         <GridItem span={12}>
           <Modal
-            title={__('Related component content views')}
+            title={__('Related content views')}
             variant={ModalVariant.medium}
             isOpen={isOpen}
             description={description()}

--- a/webpack/scenes/ContentViews/expansions/__tests__/contentViewComponentsModal.test.js
+++ b/webpack/scenes/ContentViews/expansions/__tests__/contentViewComponentsModal.test.js
@@ -30,7 +30,7 @@ test('Can call API and show Related Content Views Components Modal', async (done
 
   await patientlyWaitFor(() => expect(getByLabelText(`button_${cvId}`)).toBeInTheDocument());
   fireEvent.click(getByLabelText(`button_${cvId}`));
-  await patientlyWaitFor(() => expect(getByText('Related component content views')).toBeInTheDocument());
+  await patientlyWaitFor(() => expect(getByText('Related content views')).toBeInTheDocument());
 
   assertNockRequest(scope, done);
 });


### PR DESCRIPTION
(cherry picked from commit 0a69189eb5272f851e101d6792593cbb3f201f0c)

Original PR: https://github.com/Katello/katello/pull/10111 (merged to master and cherry-picked by @ianballou  to 4.4).
Discussion in foreman_documentation: https://github.com/theforeman/foreman-documentation/pull/1206#discussion_r853151310

#### What are the changes introduced in this pull request?
Rename "composite content view" to "content view" which is the old terminology.

#### Considerations taken when implementing this change?
I think it's easier for everyone, esp. community users, to _not_ introduce a new term for one version of Katello only.

#### What are the testing steps for this pull request?
I resolved one cherry-pick conflict in `webpack/scenes/ContentViews/components/ContentViewIcon.js`. Other than that, see original PR.