### PR TITLE
Fixes #34982 - Add last checkin to 'Recent communication' card

### DIFF
--- a/webpack/components/extensions/HostDetails/DetailsTabCards/RecentCommunicationCardExtensions.js
+++ b/webpack/components/extensions/HostDetails/DetailsTabCards/RecentCommunicationCardExtensions.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import RelativeDateTime from 'foremanReact/components/common/dates/RelativeDateTime';
+import {
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+} from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+const RecentCommunicationCardExtensions = ({ hostDetails }) => {
+  const { subscription_facet_attributes: subscriptionFacetAttributes } = hostDetails;
+  if (!Object.keys(subscriptionFacetAttributes ?? {}).includes('last_checkin')) return null;
+  const lastCheckin = subscriptionFacetAttributes?.last_checkin;
+  return (
+    <DescriptionListGroup>
+      <DescriptionListTerm>{__('Last check-in:')}</DescriptionListTerm>
+      <DescriptionListDescription>
+        <RelativeDateTime date={lastCheckin} defaultValue={__('Never')} />
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
+
+RecentCommunicationCardExtensions.propTypes = {
+  hostDetails: PropTypes.shape({
+    subscription_facet_attributes: PropTypes.shape({
+      last_checkin: PropTypes.string,
+    }),
+  }),
+};
+
+RecentCommunicationCardExtensions.defaultProps = {
+  hostDetails: {},
+};
+
+export default RecentCommunicationCardExtensions;

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -20,6 +20,7 @@ import HostCollectionsCard from './components/extensions/HostDetails/Cards/HostC
 import { hostIsNotRegistered } from './components/extensions/HostDetails/hostDetailsHelpers';
 import SystemPropertiesCardExtensions from './components/extensions/HostDetails/DetailsTabCards/SystemPropertiesCardExtensions';
 import HostActionsBar from './components/extensions/HostDetails/ActionsBar';
+import RecentCommunicationCardExtensions from './components/extensions/HostDetails/DetailsTabCards/RecentCommunicationCardExtensions';
 
 registerReducer('katelloExtends', extendReducer);
 registerReducer('katello', rootReducer);
@@ -46,6 +47,7 @@ addGlobalFill(
   700,
 );
 addGlobalFill('host-overview-cards', 'Installable errata', <ErrataOverviewCard key="errata-overview" />, 1900);
+addGlobalFill('host-overview-cards', 'Recent communication', <RecentCommunicationCardExtensions key="recent-communication" />, 3000);
 
 // Details tab cards & card extensions
 addGlobalFill('host-tab-details-cards', 'Installed products', <InstalledProductsCard key="installed-products" />, 100);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add 'Last check-in' to the new 'Recent communication' card.

![new-card-order](https://user-images.githubusercontent.com/22042343/170776317-56b190f2-ddd0-42c8-88c3-5f1ac381b7fc.png)


#### Considerations taken when implementing this change?

Requires https://github.com/theforeman/foreman/pull/9239
The mockup had the wording "Last subscription-manager check-in" but I found that looked terrible and took up too much space, so I shortened it.

#### What are the testing steps for this pull request?

Check out both the Foreman PR and this PR
View a registered host on the new host details page.
