### PR TITLE
Fixes #34984 - ActionController::BadRequest when uploading RPMs via Hammer

### DIFF
--- a/app/controllers/katello/api/v2/content_uploads_controller.rb
+++ b/app/controllers/katello/api/v2/content_uploads_controller.rb
@@ -2,6 +2,8 @@ module Katello
   class Api::V2::ContentUploadsController < Api::V2::ApiController
     before_action :find_repository
     skip_before_action :check_media_type, :only => [:update]
+    # https://github.com/rails/rails/issues/42278#issuecomment-918079123
+    skip_parameter_encoding :update
 
     include ::Foreman::Controller::FilterParameters
     filter_parameters :content


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Stops parameter encoding when uploading binary content (RPMs).

#### Considerations taken when implementing this change?
We're not sure of the change that occurred to cause this, but the issue is blocking nightly so this seems like the safest option.

#### What are the testing steps for this pull request?
Upload an RPM to a repository via Hammer.