### PR TITLE
Fixes #34769 - Add tooltips for errata type icons

### DIFF
--- a/webpack/components/Errata/index.js
+++ b/webpack/components/Errata/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { TableText } from '@patternfly/react-table';
+import { Tooltip } from '@patternfly/react-core';
 import {
   chart_color_black_500 as pfBlack,
   chart_color_gold_400 as pfGold,
@@ -86,7 +87,9 @@ export const ErrataSummary = ({ type, count }) => {
       <TableText>
         <SquareIcon size="sm" color={color} />
         <span style={{ marginLeft: '8px' }}>
-          <ErrataIcon title={label} />
+          <Tooltip content={label} >
+            <ErrataIcon />
+          </Tooltip>
           {url}
         </span>
       </TableText>
@@ -124,7 +127,10 @@ export const ErrataType = ({ type }) => {
 
   return (
     <TableText wrapModifier="nowrap">
-      <ErrataIcon title={label} /> {label}
+      <Tooltip content={label} >
+        <ErrataIcon style={{ marginRight: '4px' }} />
+      </Tooltip>
+      {label}
     </TableText>
   );
 };
@@ -157,7 +163,16 @@ export const ErrataSeverity = ({ severity }) => {
   default:
     label = __('N/A');
   }
-  return <TableText wrapModifier="nowrap">{color && <SecurityIcon color={color} title={label} />} {label} </TableText>;
+  return (
+    <TableText wrapModifier="nowrap">
+      {color &&
+        <Tooltip content={label} >
+          <SecurityIcon color={color} />
+        </Tooltip>
+      }
+      {label}
+    </TableText>
+  );
 };
 
 ErrataSeverity.propTypes = {

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
@@ -9,6 +9,7 @@ import {
   SecurityIcon,
   EnhancementIcon,
 } from '@patternfly/react-icons';
+import { Tooltip } from '@patternfly/react-core';
 import {
   getContentViewVersions,
   getDebPackages,
@@ -217,8 +218,9 @@ export default ({ cvId, versionId }) => [
             enhancements: EnhancementIcon,
           };
           const ErrataIcon = errataIcons[item?.type];
-          if (!ErrataIcon) return startCase(item?.type);
-          return <><ErrataIcon />{' '}{startCase(item?.type)}{item?.severity && ` - ${item.severity}`}</>;
+          const itemType = startCase(item?.type);
+          if (!ErrataIcon) return itemType;
+          return <><Tooltip content={itemType} ><ErrataIcon style={{ marginRight: '4px' }} /></Tooltip>{itemType}{item?.severity !== 'None' && ` - ${item.severity}`}</>;
         },
       },
       {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add tooltips for errata type icons to Errata overview card, new host content errata table and content view details version tab. 
Fix a bug on content view details version tab where `severity` is showed as `None` for Bugfix or Enhancement errata.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Check the tooltip for those icons displayed
1. All Hosts - select a host - Overview - Installable errata
2.  All Hosts - select a host - Content 
3. Content Views - select a CV - select version - Errata 