### PR TITLE
Fixes #34999 - retrieve the software vendor package from the installed package

### DIFF
--- a/app/models/katello/installed_package.rb
+++ b/app/models/katello/installed_package.rb
@@ -23,5 +23,6 @@ module Katello
     scoped_search :on => :version
     scoped_search :on => :release
     scoped_search :on => :arch
+    scoped_search :on => :vendor
   end
 end

--- a/db/migrate/20220601163911_add_vendor_to_katello_installed_packages.rb
+++ b/db/migrate/20220601163911_add_vendor_to_katello_installed_packages.rb
@@ -1,0 +1,5 @@
+class AddVendorToKatelloInstalledPackages < ActiveRecord::Migration[6.1]
+  def change
+    add_column :katello_installed_packages, :vendor, :string
+  end
+end

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -232,7 +232,7 @@ module Katello
     def setup
       super
       package_json = {:name => "foo", :version => "1", :release => "1.el7", :arch => "x86_64", :epoch => "1",
-                      :nvra => "foo-1-1.el7.x86_64"}
+                      :nvra => "foo-1-1.el7.x86_64", :vendor => "Fedora"}
       @foreman_host.import_package_profile([::Katello::Pulp::SimplePackage.new(package_json)])
       @nvra = 'foo-1-1.el7.x86_64'
       @foreman_host.reload
@@ -242,6 +242,7 @@ module Katello
       assert_equal 1, @foreman_host.installed_packages.count
       assert_equal 'foo', @foreman_host.installed_packages.first.name
       assert_equal @nvra, @foreman_host.installed_packages.first.nvra
+      assert_equal 'Fedora', @foreman_host.installed_packages.first.vendor
     end
 
     def test_import_package_profile_adds_removes_bulk


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Indexes vendor for installed packages
#### Considerations taken when implementing this change?
Added logic to update installed packages with nil vendor as part of importing package profile upload
#### What are the testing steps for this pull request?
How I tested this:
1. On master, register a host
2. In console check: Katello::InstalledPackage.where(vendor: nil).count
3. Switch to this branch, run db:migrate
4. Unregister host and register again. (Or do a package profile upload)
5. Check in console: Katello::InstalledPackage.where(vendor: nil).count
6. Should be 0.