### PR TITLE
Fixes #35004: Drop use of pulp_client_cert and pulp_client_key

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -188,14 +188,12 @@ module Katello
       end
 
       def pulp3_ssl_configuration(config, connection_adapter = Faraday.default_adapter)
-        legacy_pulp_cert = !self.setting(PULP3_FEATURE, 'client_authentication')&.include?('client_certificate')
-
         if connection_adapter == :excon
-          config.ssl_client_cert = ::Cert::Certs.ssl_client_cert_filename(use_admin_as_cn_cert: legacy_pulp_cert)
-          config.ssl_client_key = ::Cert::Certs.ssl_client_key_filename(use_admin_as_cn_cert: legacy_pulp_cert)
+          config.ssl_client_cert = ::Cert::Certs.ssl_client_cert_filename
+          config.ssl_client_key = ::Cert::Certs.ssl_client_key_filename
         elsif connection_adapter == :net_http
-          config.ssl_client_cert = ::Cert::Certs.ssl_client_cert(use_admin_as_cn_cert: legacy_pulp_cert)
-          config.ssl_client_key = ::Cert::Certs.ssl_client_key(use_admin_as_cn_cert: legacy_pulp_cert)
+          config.ssl_client_cert = ::Cert::Certs.ssl_client_cert
+          config.ssl_client_key = ::Cert::Certs.ssl_client_key
         else
           fail "Unexpected connection_adapter #{Faraday.default_adapter}!  Cannot continue, this is likely a bug."
         end

--- a/app/services/cert/certs.rb
+++ b/app/services/cert/certs.rb
@@ -12,28 +12,20 @@ module Cert
       File.read(SETTINGS[:katello][:candlepin][:ca_cert_file])
     end
 
-    def self.ssl_client_cert(use_admin_as_cn_cert: false)
-      @ssl_client_cert ||= OpenSSL::X509::Certificate.new(File.read(ssl_client_cert_filename(use_admin_as_cn_cert: use_admin_as_cn_cert)))
+    def self.ssl_client_cert
+      @ssl_client_cert ||= OpenSSL::X509::Certificate.new(File.read(ssl_client_cert_filename))
     end
 
-    def self.ssl_client_cert_filename(use_admin_as_cn_cert: false)
-      if use_admin_as_cn_cert
-        Setting[:pulp_client_cert]
-      else
-        Setting[:ssl_certificate]
-      end
+    def self.ssl_client_cert_filename
+      Setting[:ssl_certificate]
     end
 
-    def self.ssl_client_key(use_admin_as_cn_cert: false)
-      @ssl_client_key ||= OpenSSL::PKey::RSA.new(File.read(ssl_client_key_filename(use_admin_as_cn_cert: use_admin_as_cn_cert)))
+    def self.ssl_client_key
+      @ssl_client_key ||= OpenSSL::PKey::RSA.new(File.read(ssl_client_key_filename))
     end
 
-    def self.ssl_client_key_filename(use_admin_as_cn_cert: false)
-      if use_admin_as_cn_cert
-        Setting[:pulp_client_key]
-      else
-        Setting[:ssl_priv_key]
-      end
+    def self.ssl_client_key_filename
+      Setting[:ssl_priv_key]
     end
 
     def self.verify_ueber_cert(organization)

--- a/app/services/katello/pulp/server.rb
+++ b/app/services/katello/pulp/server.rb
@@ -17,8 +17,8 @@ module Katello
             :debug => true
           },
           :cert_auth => {
-            :ssl_client_cert => ::Cert::Certs.ssl_client_cert(use_admin_as_cn_pulp_cert: true),
-            :ssl_client_key => ::Cert::Certs.ssl_client_key(use_admin_as_cn_pulp_cert: true)
+            :ssl_client_cert => '/etc/pki/katello/certs/pulp-client.crt',
+            :ssl_client_key => '/etc/pki/katello/private/pulp-client.key'
           }
         }
 

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -517,18 +517,6 @@ Foreman::Plugin.register :katello do
         full_name: N_('Pulp 3 export destination filepath'),
         description: N_("On-disk location for pulp 3 exported repositories")
 
-      setting 'pulp_client_key',
-        type: :string,
-        default: "/etc/pki/katello/private/pulp-client.key",
-        full_name: N_('Pulp client key'),
-        description: N_("Path for ssl key used for pulp server auth")
-
-      setting 'pulp_client_cert',
-        type: :string,
-        default: "/etc/pki/katello/certs/pulp-client.crt",
-        full_name: N_('Pulp client cert'),
-        description: N_("Path for ssl cert used for pulp server auth")
-
       setting 'sync_total_timeout',
         type: :integer,
         default: 3600,


### PR DESCRIPTION
Foreman 3.0 introduced use of Foreman client certificates to talk to
Pulp 3 and therefore the older Pulp 2 based client certificates are
no longer needed.

See also:

 - https://github.com/theforeman/puppet-katello/pull/450
 - https://github.com/theforeman/puppet-certs/pull/399