### PR TITLE
Fixes #35012 - add call-to-action empty states

### DIFF
--- a/webpack/components/Table/EmptyStateMessage.js
+++ b/webpack/components/Table/EmptyStateMessage.js
@@ -4,8 +4,10 @@ import {
   EmptyStateBody,
   EmptyStateIcon,
   EmptyStateVariant,
+  EmptyStateSecondaryActions,
   Bullseye,
   Title,
+  Button,
 } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -23,10 +25,14 @@ const KatelloEmptyStateIcon = ({
 };
 
 const EmptyStateMessage = ({
-  title, body, error, search, customIcon, happy,
+  title, body, error, search, customIcon, happy, ...extraTableProps
 }) => {
   let emptyStateTitle = title;
   let emptyStateBody = body;
+  const {
+    primaryActionTitle, showPrimaryAction, showSecondaryAction,
+    secondaryActionTitle, primaryActionLink, secondaryActionLink,
+  } = extraTableProps;
   if (error) {
     if (error?.response?.data?.error) {
       const { response: { data: { error: { message, details } } } } = error;
@@ -55,10 +61,23 @@ const EmptyStateMessage = ({
         <EmptyStateBody>
           {emptyStateBody}
         </EmptyStateBody>
+        {showPrimaryAction &&
+          <Button>
+            <a href={primaryActionLink} style={{ color: 'white', textDecoration: 'none' }}>{primaryActionTitle}</a>
+          </Button>}
+        {showSecondaryAction &&
+          <EmptyStateSecondaryActions>
+            <Button variant="link">
+              <a href={secondaryActionLink} style={{ textDecoration: 'none' }}>{secondaryActionTitle}</a>
+            </Button>
+          </EmptyStateSecondaryActions>
+        }
+
       </EmptyState>
     </Bullseye>
   );
 };
+
 
 KatelloEmptyStateIcon.propTypes = {
   error: PropTypes.bool,
@@ -84,6 +103,8 @@ EmptyStateMessage.propTypes = {
   search: PropTypes.bool,
   customIcon: PropTypes.elementType,
   happy: PropTypes.bool,
+  showPrimaryAction: PropTypes.bool,
+  showSecondaryAction: PropTypes.bool,
 };
 
 EmptyStateMessage.defaultProps = {
@@ -93,6 +114,8 @@ EmptyStateMessage.defaultProps = {
   search: false,
   customIcon: undefined,
   happy: false,
+  showPrimaryAction: false,
+  showSecondaryAction: false,
 };
 
 export default EmptyStateMessage;

--- a/webpack/components/Table/MainTable.js
+++ b/webpack/components/Table/MainTable.js
@@ -18,11 +18,20 @@ const MainTable = ({
   status, cells, rows, error, emptyContentTitle, emptyContentBody,
   emptySearchTitle, emptySearchBody, errorSearchTitle, errorSearchBody,
   happyEmptyContent, searchIsActive, activeFilters, defaultFilters, actionButtons, rowsCount,
-  children, ...extraTableProps
+  children, showPrimaryAction, showSecondaryAction, primaryActionLink,
+  secondaryActionLink, primaryActionTitle, secondaryActionTitle, ...extraTableProps
 }) => {
   const tableHasNoRows = () => {
     if (children) return rowsCount === 0;
     return rows.length === 0;
+  };
+  const callToActionProps = {
+    showPrimaryAction,
+    showSecondaryAction,
+    primaryActionLink,
+    primaryActionTitle,
+    secondaryActionLink,
+    secondaryActionTitle,
   };
   const filtersAreActive = activeFilters?.length &&
     !isEqual(new Set(activeFilters), new Set(defaultFilters));
@@ -54,6 +63,7 @@ const MainTable = ({
         body={emptyContentBody}
         happy={happyEmptyContent}
         search={!happyEmptyContent}
+        {...callToActionProps}
       />
     );
   }
@@ -85,11 +95,11 @@ const MainTable = ({
 MainTable.propTypes = {
   status: PropTypes.string.isRequired,
   cells: PropTypes.arrayOf(PropTypes.oneOfType([
-    PropTypes.shape({ }),
+    PropTypes.shape({}),
     PropTypes.string])),
-  rows: PropTypes.arrayOf(PropTypes.shape({ })),
+  rows: PropTypes.arrayOf(PropTypes.shape({})),
   error: PropTypes.oneOfType([
-    PropTypes.shape({ }),
+    PropTypes.shape({}),
     PropTypes.string,
   ]),
   emptyContentTitle: PropTypes.string.isRequired,
@@ -114,6 +124,12 @@ MainTable.propTypes = {
     PropTypes.node,
   ]),
   happyEmptyContent: PropTypes.bool,
+  showPrimaryAction: PropTypes.bool,
+  showSecondaryAction: PropTypes.bool,
+  primaryActionLink: PropTypes.string,
+  secondaryActionLink: PropTypes.string,
+  secondaryActionTitle: PropTypes.string,
+  primaryActionTitle: PropTypes.string,
 };
 
 MainTable.defaultProps = {
@@ -129,6 +145,13 @@ MainTable.defaultProps = {
   rows: undefined,
   rowsCount: undefined,
   happyEmptyContent: false,
+  showPrimaryAction: false,
+  showSecondaryAction: false,
+  primaryActionLink: '',
+  secondaryActionLink: '',
+  primaryActionTitle: '',
+  secondaryActionTitle: '',
+
 };
 
 export default MainTable;

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -168,7 +168,8 @@ const ChangeHostCVModal = ({
           title={__('No content views available for the selected environment')}
           style={{ marginBottom: '1rem' }}
         >
-          {__('View the Content Views page to manage and promote content views, or select a different environment.')}
+          <a href="/content_views">{__('View the Content Views page')}</a>
+          {__(' to manage and promote content views, or select a different environment.')}
         </Alert>
       }
       <EnvironmentPaths

--- a/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsModal.js
@@ -29,7 +29,9 @@ export const HostCollectionsModal = ({
   const emptySearchTitle = __('No matching host collections found');
   const emptySearchBody = __('Try changing your search settings.');
   const errorSearchTitle = __('Problem searching host collections');
-
+  const primaryActionTitle = __('Create host collection');
+  const showPrimaryAction = true;
+  const primaryActionLink = '/host_collections/new';
   const columnHeaders = ['', __('Host collection'), __('Capacity'), __('Description')];
   const adding = (modalType === MODAL_TYPES.ADD);
 
@@ -158,6 +160,9 @@ export const HostCollectionsModal = ({
           updateSearchQuery,
           selectedCount,
           selectNone,
+          showPrimaryAction,
+          primaryActionTitle,
+          primaryActionLink,
         }
         }
         ouiaId="host-collections-table"

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -213,9 +213,15 @@ export const ModuleStreamsTab = () => {
   const [hostModuleStreamAction, setHostModuleStreamAction] = useState(null);
 
   const emptyContentTitle = __('This host does not have any Module streams.');
-  const emptyContentBody = __('Module streams will appear here when available.');
+  const emptyContentBody = __('Module streams will appear here after enabling Red Hat repositories or creating custom products.');
   const emptySearchTitle = __('Your search returned no matching Module streams.');
   const emptySearchBody = __('Try changing your search criteria.');
+  const showPrimaryAction = true;
+  const showSecondaryAction = true;
+  const primaryActionTitle = __('Enable Red Hat repositories');
+  const secondaryActionTitle = __('Create a custom product');
+  const primaryActionLink = '/redhat_repositories';
+  const secondaryActionLink = '/products/new';
   const errorSearchTitle = __('Problem searching module streams');
   const {
     status: initialStatus,
@@ -342,6 +348,12 @@ export const ModuleStreamsTab = () => {
             activeFilters,
             defaultFilters,
             status,
+            showPrimaryAction,
+            showSecondaryAction,
+            primaryActionTitle,
+            secondaryActionTitle,
+            primaryActionLink,
+            secondaryActionLink,
           }}
           ouiaId="host-module-stream-table"
           additionalListeners={[hostId, activeSortColumn, activeSortDirection,

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -153,9 +153,15 @@ const RepositorySetsTab = () => {
 
   const [alertShowing, setAlertShowing] = useState(false);
   const emptyContentTitle = __('No repository sets to show.');
-  const emptyContentBody = __('Repository sets will appear here when available.');
+  const emptyContentBody = __('Repository sets will appear here after enabling Red Hat repositories or creating custom products.');
   const emptySearchTitle = __('No matching repository sets found');
   const emptySearchBody = __('Try changing your search query.');
+  const showPrimaryAction = true;
+  const showSecondaryAction = true;
+  const primaryActionTitle = __('Enable Red Hat repositories');
+  const secondaryActionTitle = __('Create a custom product');
+  const primaryActionLink = '/redhat_repositories';
+  const secondaryActionLink = '/products/new';
   const errorSearchTitle = __('Problem searching repository sets');
   const columnHeaders = useMemo(() => [
     __('Repository'),
@@ -414,6 +420,12 @@ const RepositorySetsTab = () => {
             emptySearchBody,
             activeFilters,
             defaultFilters,
+            showPrimaryAction,
+            showSecondaryAction,
+            primaryActionLink,
+            secondaryActionLink,
+            primaryActionTitle,
+            secondaryActionTitle,
           }
           }
           ouiaId="host-repository-sets-table"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Added call-to-actions for empty state on Host collections (under Host Overview Tab), Module Streams (under Content Tab), Repository sets, and Host content view selection (under Host Overview Tab -> Content View Details) pages/tabs

#### Considerations taken when implementing this change?
I believe that adding call-to-actions will increase user experience whenever they are no existing/available items/products/repos to show

#### What are the testing steps for this pull request?
For all the corresponding tabs:
1. Navigate to the corresponding tab/page 
2. Assuming that you do not have available/existing items to show, you should see action button(s) (the number of action buttons depends on different number of the ways you can create a specific item/product/repo), which should direct you to the creation page
3. Try adding some items and searching for non-existing item. You should see a message indicating that such item does not exist without call-to-action button(s) 

Note: there is a separate card created for the last action item (empty search)