### PR TITLE
Fixes #35000 - API endpoint to return host's enabled repositories

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -187,6 +187,13 @@ module Katello
       respond_for_index :collection => full_result_response(releases)
     end
 
+    api :GET, "/hosts/:host_id/subscriptions/enabled_repositories", N_("Show repositories enabled on the host that are known to Katello")
+    param :host_id, String, :desc => N_("id of host"), :required => true
+    def enabled_repositories
+      repositories = @host.content_facet.try(:bound_repositories) || []
+      respond_with_template_collection "index", 'repositories', :collection => full_result_response(repositories)
+    end
+
     private
 
     def fetch_product_content
@@ -216,7 +223,7 @@ module Katello
     def action_permission
       if ['add_subscriptions', 'destroy', 'remove_subscriptions', 'auto_attach', 'content_override'].include?(params[:action])
         :edit
-      elsif ['index', 'events', 'product_content', 'available_release_versions'].include?(params[:action])
+      elsif ['index', 'events', 'product_content', 'available_release_versions', 'enabled_repositories'].include?(params[:action])
         :view
       else
         fail ::Foreman::Exception.new(N_("unknown permission for %s"), "#{params[:controller]}##{params[:action]}")

--- a/app/views/katello/api/v2/repository_sets/show.json.rabl
+++ b/app/views/katello/api/v2/repository_sets/show.json.rabl
@@ -59,3 +59,21 @@ node :enabled_content_override do |pc|
     override&.computed_value
   end
 end
+
+# ISSUE: this doesn't take into account the repo's arch or OS version restrictions
+# It may be better to just make a new "bound repositories" API endpoint...
+# REMOVE ME
+if params[:host_id].present?
+  node :enabled_for_host do |pc|
+    if pc.enabled_content_override.present?
+      pc.enabled_content_override.computed_value
+    else
+      host = ::Host.find(params[:host_id].to_i)
+      if host.organization.simple_content_access?
+        true
+      else
+        ::Katello::ProductContentFinder.new(consumable: host.subscription_facet, match_subscription: true).product_content.find { |host_pc| host_pc.attributes == pc.attributes }.present?
+      end
+    end
+  end
+end

--- a/app/views/katello/api/v2/repository_sets/show.json.rabl
+++ b/app/views/katello/api/v2/repository_sets/show.json.rabl
@@ -59,21 +59,3 @@ node :enabled_content_override do |pc|
     override&.computed_value
   end
 end
-
-# ISSUE: this doesn't take into account the repo's arch or OS version restrictions
-# It may be better to just make a new "bound repositories" API endpoint...
-# REMOVE ME
-if params[:host_id].present?
-  node :enabled_for_host do |pc|
-    if pc.enabled_content_override.present?
-      pc.enabled_content_override.computed_value
-    else
-      host = ::Host.find(params[:host_id].to_i)
-      if host.organization.simple_content_access?
-        true
-      else
-        ::Katello::ProductContentFinder.new(consumable: host.subscription_facet, match_subscription: true).product_content.find { |host_pc| host_pc.attributes == pc.attributes }.present?
-      end
-    end
-  end
-end

--- a/config/routes/overrides.rb
+++ b/config/routes/overrides.rb
@@ -110,6 +110,7 @@ Foreman::Application.routes.draw do
               put :auto_attach
               match '/product_content' => 'repository_sets#index', :via => :get, :entity => :host
               get :available_release_versions
+              get :enabled_repositories
               put :content_override
               put :remove_subscriptions
               put :add_subscriptions

--- a/lib/katello/permissions/host_permissions.rb
+++ b/lib/katello/permissions/host_permissions.rb
@@ -52,6 +52,7 @@ Foreman::AccessControl.permission(:view_hosts).actions.concat [
   'katello/api/v2/host_subscriptions/index',
   'katello/api/v2/host_subscriptions/events',
   'katello/api/v2/host_subscriptions/product_content',
+  'katello/api/v2/host_subscriptions/enabled_repositories',
   'katello/api/v2/hosts_bulk_actions/applicable_errata',
   'katello/api/v2/hosts_bulk_actions/installable_errata',
   'katello/api/v2/hosts_bulk_actions/available_incremental_updates',

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -285,6 +285,14 @@ module Katello
       assert_response :success
     end
 
+    def test_enabled_repositories
+      @host.content_facet = ::Katello::Host::ContentFacet.find_by(uuid: 'abcdefghi')
+
+      get :enabled_repositories, params: { :host_id => @host.id }
+
+      assert_response :success
+    end
+
     def test_destroy
       ::Katello::RegistrationManager.expects(:unregister_host).with(@host, :unregistering => true)
 

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -289,7 +289,10 @@ module Katello
       @host.content_facet = ::Katello::Host::ContentFacet.find_by(uuid: 'abcdefghi')
 
       get :enabled_repositories, params: { :host_id => @host.id }
+      response_body_hash = JSON.parse(response.body)
 
+      assert_equal 1, response_body_hash['results'].count
+      assert_equal 'ACME_Corporation/dev/fedora_17_dev_label', response_body_hash['results'].first['relative_path']
       assert_response :success
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Introduces a new API endpoint, `/hosts/:host_id/subscriptions/enabled_repositories`, that lists the repositories known to Katello that are enabled on the machine.

#### Considerations taken when implementing this change?
The original issue was in regards to the `/api/hosts/:host_id/subscriptions/product_content` endpoint.  I've left my own attempt (starts with the comment `# ISSUE: ...`) at adding a new boolean value on that endpoint that would show if the ProductContent was available to the host. I'll delete it, but I wanted to show what I was thinking before moving on.

I moved on from this attempt because ProductContents aren't intrinsically attached to any host, so it's complicated to correctly say whether or not it applies to the host with `:host_id`.  OS and Arch restrictions on repos is one place where this gets complicated. A `::Katello::Content` can have more than one repo, say RHEL 9 BaseOS 9.0 and RHEL 9 BaseOS 9.  One of those could be arch restricted and the other not, but since the API is only talking at the `::Katello::Content` level, differentiating between the two repos isn't possible.

So, I thought a simpler approach would be to just make an enpoint that uses `bound_repositories`. It would be helpful too for users to check if a host's `bound_repositories` are up to date.  Plus, it directly addresses the original RFE request.

#### What are the testing steps for this pull request?
Create a content host and try to query the new endpoint, `/hosts/:host_id/subscriptions/enabled_repositories`. Ensure the returned repositories make sense. Try disabling some repo sets, enabling them, using OS/Arch restrictions on repositories, etc.  The returned repositories should always match the return of `subscription-manager repos`.

TODO:
- [x] Tests