### PR TITLE
Fixes #34792 - Add module version to db and show in UI

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -257,7 +257,8 @@ module Katello
         module_streams.each do |module_stream|
           stream = AvailableModuleStream.where(name: module_stream["name"],
                                                context: module_stream["context"],
-                                               stream: module_stream["stream"]).first_or_create!
+                                               stream: module_stream["stream"],
+                                               version: module_stream["version"]).first_or_create!
           streams[stream.id] = module_stream
         end
         sync_available_module_stream_associations(streams)

--- a/app/models/katello/host_available_module_stream.rb
+++ b/app/models/katello/host_available_module_stream.rb
@@ -27,6 +27,7 @@ module Katello
 
     scoped_search :on => :name, :relation => :available_module_stream, :complete_value => true
     scoped_search :on => :stream, :relation => :available_module_stream, :complete_value => false
+    scoped_search :on => :version, :relation => :available_module_stream, :complete_value => false
     scoped_search :on => :installed_profiles
     scoped_search :on => :status, :complete_value => STATUS
 

--- a/app/views/katello/api/v2/host_module_streams/base.json.rabl
+++ b/app/views/katello/api/v2/host_module_streams/base.json.rabl
@@ -5,5 +5,5 @@ attributes :upgradable? => :upgradable
 attributes :install_status => :install_status
 
 glue(@object.available_module_stream) do
-  attributes :id, :name, :stream, :module_spec
+  attributes :id, :name, :stream, :version, :module_spec
 end

--- a/db/migrate/20220602153341_add_version_to_available_module_streams.rb
+++ b/db/migrate/20220602153341_add_version_to_available_module_streams.rb
@@ -1,0 +1,7 @@
+class AddVersionToAvailableModuleStreams < ActiveRecord::Migration[6.1]
+  def change
+    add_column :katello_available_module_streams, :version, :string
+    remove_index :katello_available_module_streams, name: 'katello_available_module_streams_name_stream_context'
+    add_index :katello_available_module_streams, [:name, :stream, :context, :version], :unique => false, :name => :katello_available_module_streams_name_stream
+  end
+end

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -233,7 +233,7 @@ export const ModuleStreamsTab = () => {
   const columnHeaders = [
     __('Name'),
     __('State'),
-    __('Stream'),
+    __('Version'),
     __('Installation status'),
     __('Installed profile'),
   ];
@@ -398,7 +398,7 @@ export const ModuleStreamsTab = () => {
               id,
               status: moduleStreamStatus,
               name,
-              stream,
+              version,
               installed_profiles: installedProfiles,
               upgradable,
               install_status: installedStatus,
@@ -591,7 +591,7 @@ export const ModuleStreamsTab = () => {
                   <Td>
                     <StreamState moduleStreamStatus={moduleStreamStatus} />
                   </Td>
-                  <Td>{stream}</Td>
+                  <Td>{version}</Td>
                   <Td>
                     <EnabledIcon
                       streamText={moduleStreamStatus}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Added a db migration to add `version` to the `katello_available_module_streams` table
* Remove the index `katello_available_module_streams_name_stream_contex` so we can lay ours down
* Added an index https://github.com/Katello/katello/compare/master...chris1984:streams?expand=1#diff-f4d99100291d8b178a9143f229b31fee9dd0a1565161a34b17d30f34654f5c64R5

#### Considerations taken when implementing this change?
* Made sure Module stream applicabilty was not affected
* Made sure there was not any performance hits by adding an index on version

#### What are the testing steps for this pull request?
* Apply patch and run db migration
* Sync CentOS8 stream repo from anywhere or this mirror (https://mirror.steadfast.net/centos/8-stream/BaseOS/x86_64/os/)
* Register a CentOS 8 stream machine to your Katello server
* Verify you see Module streams in the new ui and now see versions instead of duplicated streams