### PR TITLE
Fixes #35074 - Hide table toolbar / filter dropdowns for empty states

### DIFF
--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -18,6 +18,7 @@ import { orgId } from '../../services/api';
 /* Patternfly 4 table wrapper */
 const TableWrapper = ({
   actionButtons,
+  alwaysShowActionButtons,
   toggleGroup,
   children,
   metadata,
@@ -55,11 +56,13 @@ const TableWrapper = ({
   const { pageRowCount } = getPageStats({ total, page, perPage });
   const unresolvedStatus = !!allTableProps?.status && allTableProps.status !== STATUS.RESOLVED;
   const unresolvedStatusOrNoRows = unresolvedStatus || pageRowCount === 0;
-  const resolvedStatusNoContent =
-    !searchQuery && allTableProps.status === STATUS.RESOLVED && pageRowCount === 0;
   const showPagination = !unresolvedStatusOrNoRows;
-  const showActionButtons = actionButtons && !unresolvedStatus;
-  const showToggleGroup = toggleGroup && !unresolvedStatus;
+  const filtersAreActive = activeFilters?.length &&
+    !isEqual(new Set(activeFilters), new Set(allTableProps.defaultFilters));
+  const hideToolbar = !searchQuery && !filtersAreActive &&
+    allTableProps.status === STATUS.RESOLVED && total === 0;
+  const showActionButtons = actionButtons && (alwaysShowActionButtons || !hideToolbar);
+  const showToggleGroup = toggleGroup && !hideToolbar;
   const paginationParams = useCallback(() =>
     ({ per_page: perPage, page }), [perPage, page]);
   const prevRequest = useRef({});
@@ -163,7 +166,7 @@ const TableWrapper = ({
   return (
     <>
       <Flex style={{ alignItems: 'center' }} className="margin-16-24">
-        {displaySelectAllCheckbox &&
+        {displaySelectAllCheckbox && !hideToolbar &&
           <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
             <SelectAllCheckbox
               {...{
@@ -180,7 +183,7 @@ const TableWrapper = ({
             />
           </FlexItem>
         }
-        {!disableSearch && !resolvedStatusNoContent &&
+        {!disableSearch && !hideToolbar &&
           <FlexItem>
             <Search
               isDisabled={unresolvedStatusOrNoRows && !searchQuery}
@@ -271,6 +274,7 @@ TableWrapper.propTypes = {
   foremanApiAutoComplete: PropTypes.bool,
   searchPlaceholderText: PropTypes.string,
   actionButtons: PropTypes.node,
+  alwaysShowActionButtons: PropTypes.bool,
   toggleGroup: PropTypes.node,
   children: PropTypes.node,
   // additionalListeners are anything that should trigger another API call, e.g. a filter
@@ -314,6 +318,7 @@ TableWrapper.defaultProps = {
   foremanApiAutoComplete: false,
   searchPlaceholderText: undefined,
   actionButtons: null,
+  alwaysShowActionButtons: true,
   toggleGroup: null,
   displaySelectAllCheckbox: false,
   selectedCount: 0,

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -430,6 +430,7 @@ export const ErrataTab = () => {
           {...selectAll}
           displaySelectAllCheckbox={showActions}
           requestKey={HOST_ERRATA_KEY}
+          alwaysShowActionButtons={false}
         >
           <Thead>
             <Tr>

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -373,6 +373,7 @@ export const ModuleStreamsTab = () => {
           rowsCount={results?.length}
           variant={TableVariant.compact}
           requestKey={MODULE_STREAMS_KEY}
+          alwaysShowActionButtons={false}
           actionButtons={
             <Split hasGutter>
               <SplitItem>

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -426,6 +426,7 @@ export const PackagesTab = () => {
           {...selectAll}
           displaySelectAllCheckbox={showActions}
           requestKey={HOST_PACKAGES_KEY}
+          alwaysShowActionButtons={false}
         >
           <Thead>
             <Tr>

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -468,6 +468,7 @@ const RepositorySetsTab = () => {
           {...selectAll}
           requestKey={REPOSITORY_SETS_KEY}
           displaySelectAllCheckbox={canDoContentOverrides}
+          alwaysShowActionButtons={false}
         >
           <Thead>
             <Tr>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Hide table toolbar / filter dropdowns for empty states.
Add `alwaysShowActionButtons` to always display the `actionButtons`.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
All Hosts - host - Content 
Make sure no toolbar (select all, search, action buttons and toggle groups) displayed when there is no data for Errata, Module streams and Repository sets.
Verify the action buttons work well for content view, content view filter and alternate content source even with empty state.