### PR TITLE
Fixes #35038 - remove spinner from PackagesTab & ModuleStreamsTab

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -7,7 +7,6 @@ import { Skeleton,
   Button,
   Split,
   SplitItem,
-  Spinner,
   Checkbox,
   Dropdown,
   Text,
@@ -376,11 +375,6 @@ export const ModuleStreamsTab = () => {
                   setSelected={handleModuleStreamInstallationStatusSelected}
                 />
               </SplitItem>
-              {actionInProgress && (
-                <SplitItem style={{ alignSelf: 'center' }}>
-                  <Spinner size="lg" style={{ marginTop: '2px' }} />
-                </SplitItem>
-              )}
             </Split>
           }
         >

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -12,7 +12,6 @@ import {
   Skeleton,
   Split,
   SplitItem,
-  Spinner,
 } from '@patternfly/react-core';
 import { TableVariant, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -358,14 +357,12 @@ export const PackagesTab = () => {
             />
           </ActionListItem>
           <ActionListItem>
-            {actionInProgress ? <Spinner size="lg" style={{ marginLeft: '1em', marginTop: '4px' }} /> : (
-              <Dropdown
-                toggle={<KebabToggle aria-label="bulk_actions" onToggle={toggleBulkAction} />}
-                isOpen={isBulkActionOpen}
-                isPlain
-                dropdownItems={dropdownRemoveItems}
-              />
-            )}
+            <Dropdown
+              toggle={<KebabToggle aria-label="bulk_actions" onToggle={toggleBulkAction} />}
+              isOpen={isBulkActionOpen}
+              isPlain
+              dropdownItems={dropdownRemoveItems}
+            />
           </ActionListItem>
         </ActionList>
       </SplitItem>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Removes the spinner from PackagesTab that showed during package actions (install, remove, upgrade).
Removes the spinner from ModuleStreamsTab that showed during module actions.

#### Considerations taken when implementing this change?

The spinner was left over from a previous design iteration and should not be there.

#### What are the testing steps for this pull request?

note: If you're using foreman_remote_execution from source, it currently requires checkout of https://github.com/theforeman/foreman_remote_execution/pull/692

Perform a REX package action and module actions on the new host details page

* verify that no spinner appears
* verify that previous behavior is still there
  - toast notifications on job start and job success/failure
  - checkboxes disabled while job is in progress

