### PR TITLE
Fixes #35039 - use correct slot for recent communication card item

### DIFF
--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -45,7 +45,7 @@ addGlobalFill(
   700,
 );
 addGlobalFill('host-overview-cards', 'Installable errata', <ErrataOverviewCard key="errata-overview" />, 1900);
-addGlobalFill('host-overview-cards', 'Recent communication', <RecentCommunicationCardExtensions key="recent-communication" />, 3000);
+addGlobalFill('recent-communication-card-item', 'Recent communication', <RecentCommunicationCardExtensions key="recent-communication" />, 3000);
 
 // Details tab cards & card extensions
 addGlobalFill('host-tab-details-cards', 'Installed products', <InstalledProductsCard key="installed-products" />, 100);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The 'Last check-in' card extension was using the slot `host-overview-cards` when it should have been using `recent-communication-card-item`. This causes text to be displayed outside any card.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

make sure the Recent communication card is present and shows last checkin
