### PR TITLE
Fixes #35040 - wrong latest kernel version in Registered Content Hosts report

### DIFF
--- a/app/lib/katello/concerns/base_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/base_template_scope_extensions.rb
@@ -161,7 +161,7 @@ module Katello
         returns String, desc: 'Package version'
       end
       def host_latest_applicable_rpm_version(host, package)
-        host.applicable_rpms.where(name: package).order(:version_sortable).limit(1).pluck(:nvra).first
+        ::Katello::Rpm.latest(host.applicable_rpms.where(name: package)).first.nvra
       end
 
       apipie :method, 'Loads Pool objects' do


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fixes `host_latest_applicable_rpm_version` to actually calculate the latest RPM version correctly.

```ruby
Host.find(1).applicable_rpms.where(name: 'kernel').order(:name).order(:epoch).order(:version_sortable).order(:release_sortable)
```
Also works, but the method I found seems cleaner.  Plus, the `:packages_restrict_latest` argument uses it as well in the packages controller.

#### Considerations taken when implementing this change?
None!

#### What are the testing steps for this pull request?
From the redmine:

1. Register a RHEL 7 host
2. Sync the RHEL 7 RPMs repo
3. Check that there are multiple applicable kernel versions
  - If there are none, try to obtain an older RHEL 7 host if possible. Otherwise, we may need to discuss an alternative testing method.
5. Generate the Host - Registered Content Hosts report
6. See that the latest kernel is not actually the latest one