### PR TITLE
use a normal version of grunt-bower-task, not a git checkout

### DIFF
--- a/engines/bastion/package.json
+++ b/engines/bastion/package.json
@@ -7,7 +7,7 @@
     "generator-bastion": "~0.1.2",
     "grunt": "~0.4.5",
     "grunt-angular-gettext": "~0.2.15",
-    "grunt-bower-task": "yatskevich/grunt-bower-task#v0.5.0",
+    "grunt-bower-task": "0.5.0",
     "grunt-concurrent": "~1.0.0",
     "grunt-eslint": "~6.0.0",
     "grunt-htmlhint": "~0.9.13",

--- a/engines/bastion_katello/package.json
+++ b/engines/bastion_katello/package.json
@@ -8,7 +8,7 @@
     "generator-bastion": "~0.1.2",
     "grunt": "~0.4.5",
     "grunt-angular-gettext": "~0.2.15",
-    "grunt-bower-task": "yatskevich/grunt-bower-task#v0.5.0",
+    "grunt-bower-task": "0.5.0",
     "grunt-concurrent": "~1.0.0",
     "grunt-eslint": "~6.0.0",
     "grunt-htmlhint": "~0.9.13",


### PR DESCRIPTION
the git checkout takes ~6 minutes to fetch and inspect on our CI nodes
and has exactly zero benefit.

This was introduced in
https://github.com/Katello/bastion/commit/db728a7cd1cf53572e06b5c53f2855742b350117

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
