### PR TITLE
Fixes #35041 - Small fixes for ACS UI and vendor field autocomplete

### DIFF
--- a/app/models/katello/installed_package.rb
+++ b/app/models/katello/installed_package.rb
@@ -23,6 +23,6 @@ module Katello
     scoped_search :on => :version
     scoped_search :on => :release
     scoped_search :on => :arch
-    scoped_search :on => :vendor
+    scoped_search :on => :vendor, :complete_value => true
   end
 end

--- a/webpack/scenes/AlternateContentSources/Create/Steps/ACSSmartProxies.js
+++ b/webpack/scenes/AlternateContentSources/Create/Steps/ACSSmartProxies.js
@@ -21,8 +21,8 @@ const ACSSmartProxies = () => {
   return (
     <>
       <WizardHeader
-        title={__('Name source')}
-        description={__('Enter a name for your source.')}
+        title={__('Select smart proxy')}
+        description={__('Select smart proxies to be used with this source.')}
       />
       <DualListSelector
         isSearchable


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Small fixes for ACS UI and vendor field autocomplete
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
A)
1. Go to Lab features > Alternate content sources > Create
2. The wizard > Add smart proxy step header and description should be right. 

B)
1. Go to new host UI > host> content > packages
2. Autocomplete in search sshould have autocomplete enabled for vendor.