### PR TITLE
Fixes #34992 - Use content ID to verify if a redhat_repo already exists

### DIFF
--- a/app/services/katello/pulp3/content_view_version/import.rb
+++ b/app/services/katello/pulp3/content_view_version/import.rb
@@ -42,11 +42,10 @@ module Katello
           # In other words if metadata had repos {label:foo, product: bar}
           # this would match it to the repo with the label foo and product bar
           # in the library.
-
           queries = metadata_map.repositories.map do |repo|
-            if repo.redhat && repo.product.cp_id
+            if repo.redhat && repo.product.cp_id && repo.content&.id
               library_repositories.where("#{Katello::Product.table_name}.cp_id": repo.product.cp_id,
-                                         "#{Katello::RootRepository.table_name}.label": repo.label)
+                                         "#{::Katello::RootRepository.table_name}" => { content_id: repo.content.id })
             else
               library_repositories.where("#{Katello::Product.table_name}.label": repo.product.label,
                                          "#{Katello::RootRepository.table_name}.label": repo.label)
@@ -84,9 +83,9 @@ module Katello
           relation = content_view_version.importable_repositories.joins(:root, :product)
 
           metadata_map.repositories.each do |metadata_repo|
-            if metadata_repo.redhat && metadata_repo.product.cp_id
+            if metadata_repo.redhat && metadata_repo.product.cp_id && metadata_repo.content&.id
               repo = relation.where("#{::Katello::Product.table_name}" => {cp_id: metadata_repo.product.cp_id},
-                                        "#{::Katello::RootRepository.table_name}" => {label: metadata_repo.label}).first
+                                      "#{::Katello::RootRepository.table_name}" => {content_id: metadata_repo.content.id}).first
             else
               repo = relation.where("#{::Katello::Product.table_name}" => {label: metadata_repo.product.label},
                                         "#{::Katello::RootRepository.table_name}" => {label: metadata_repo.label}).first

--- a/app/services/katello/pulp3/content_view_version/importable_repositories.rb
+++ b/app/services/katello/pulp3/content_view_version/importable_repositories.rb
@@ -22,12 +22,18 @@ module Katello
             product = product_for_metadata_repo(repo)
             fail _("Unable to find product '%s' in organization '%s'" % [repo.product.label, @organization.name]) if product.blank?
 
-            root = product.root_repositories.find { |r| r.label == repo.label }
+            root = product.root_repositories.find do |r|
+              if repo.content&.id && repo.redhat
+                r.content.cp_content_id == repo.content.id
+              else
+                r.label == repo.label
+              end
+            end
+
             if root
               updatable << { repository: root, options: update_repo_params(repo) }
             elsif repo.redhat
-              content = repo.content
-              product_content = product_content_by_label(content.label)
+              product_content = fetch_product_content(repo.content, product)
               substitutions = {
                 basearch: repo.arch,
                 releasever: repo.minor
@@ -49,8 +55,14 @@ module Katello
           end
         end
 
-        def product_content_by_label(content_label)
-          ::Katello::Content.find_by_label(content_label)
+        def fetch_product_content(content_metadata, product)
+          query = ::Katello::Content.joins(:product_contents).where("#{Katello::ProductContent.table_name}.product_id": product.id)
+          table_name = Katello::Content.table_name
+          if content_metadata&.id
+            query.find_by("#{table_name}.cp_content_id": content_metadata.id)
+          else
+            query.find_by("#{table_name}.label": content_metadata.label)
+          end
         end
 
         def gpg_key_id(metadata_repo)

--- a/test/fixtures/models/katello_root_repositories.yml
+++ b/test/fixtures/models/katello_root_repositories.yml
@@ -127,7 +127,7 @@ fedora_17_no_arch_root:
 
 rhel_7_no_arch_root:
   name:                 RHEL 7 no_arch
-  content_id:           1
+  content_id:           69
   major:                7
   minor:                7Server
   content_type:         yum

--- a/test/services/katello/pulp3/content_view_version/importable_repositories_test.rb
+++ b/test/services/katello/pulp3/content_view_version/importable_repositories_test.rb
@@ -29,7 +29,8 @@ module Katello
                 major: repo.major,
                 minor: repo.minor,
                 download_policy: repo.download_policy,
-                mirroring_policy: repo.mirroring_policy
+                mirroring_policy: repo.mirroring_policy,
+                content: nil
               ),
               stub('new repo 1',
                    name: new_repo_1,
@@ -46,7 +47,8 @@ module Katello
                    major: '7',
                    minor: '1',
                    download_policy: 'immediate',
-                   mirroring_policy: nil
+                   mirroring_policy: nil,
+                   content: nil
                   )
             ]
 
@@ -69,7 +71,7 @@ module Katello
             repo = katello_repositories(:rhel_7_no_arch)
             product_label = repo.product.label
             metadata_product = stub(label: product_label, cp_id: nil)
-            metadata_content = stub(label: repo.content.label)
+            metadata_content = stub(label: repo.content.label, id: nil)
             metadata_repositories = [
               stub(
                 name: repo.name,
@@ -100,7 +102,8 @@ module Katello
           it "Fetches the redhat repos to enable by cp_id" do
             repo = katello_repositories(:rhel_7_no_arch)
             metadata_product = stub(cp_id: repo.product.cp_id)
-            metadata_content = stub(label: repo.content.label)
+            metadata_content = stub(label: repo.content.label, id: repo.content.cp_content_id)
+            ::Katello::Product.any_instance.expects(:root_repositories).returns([])
             metadata_repositories = [
               stub(
                 name: repo.name,


### PR DESCRIPTION
Using labels to verify if a repository already exists create issues when labels differ between exporting and importing servers.

What are the changes introduced in this pull request?
Instead of using repository labels to verify if a repository being import already exists, this PR uses content ID.

What are the testing steps for this pull request?
Simulate a label mismatch between exporting and importing servers
Export content once and import it (this works fine)
Export content again (incremental export or a simple new complete export) and try importing again. Without this PR, the second import fails. With this patch it should work.

Opening this PR because https://github.com/Katello/katello/pull/10139 was closed by mistake.
