### PR TITLE
Fixes #35053 - User no longer receive errata email notification

### DIFF
--- a/app/lib/actions/katello/repository/errata_mail.rb
+++ b/app/lib/actions/katello/repository/errata_mail.rb
@@ -5,15 +5,15 @@ module Actions
         middleware.use Actions::Middleware::ExecuteIfContentsChanged
 
         def plan(repo, contents_changed = nil)
-          plan_self(:repo => repo.id, :contents_changed => contents_changed)
+          last_updated = repo.repository_errata.order('updated_at ASC').last.try(:updated_at) || Time.now
+          plan_self(:repo => repo.id, :contents_changed => contents_changed, :last_updated => last_updated.to_s)
         end
 
         def run
           ::User.current = ::User.anonymous_admin
           repo = ::Katello::Repository.find(input[:repo])
-          last_updated = repo.repository_errata.order('updated_at ASC').last.try(:updated_at) || Time.now
           users = ::User.select { |user| user.receives?(:sync_errata) && user.organization_ids.include?(repo.organization.id) && user.can?(:view_products, repo.product) }.compact
-          errata = ::Katello::Erratum.where(:id => repo.repository_errata.where('katello_repository_errata.updated_at > ?', last_updated).pluck(:erratum_id))
+          errata = ::Katello::Erratum.where(:id => repo.repository_errata.where('katello_repository_errata.updated_at > ?', input['last_updated'].to_datetime).pluck(:erratum_id))
 
           begin
             MailNotification[:sync_errata].deliver(:users => users, :repo => repo, :errata => errata) unless (users.blank? || errata.blank?)

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -747,7 +747,10 @@ module ::Actions::Katello::Repository
     it 'plans' do
       action = create_action action_class
       planned_action = plan_action action, repository, true
-      assert_equal planned_action.execution_plan.planned_run_steps.first.input, "repo" => repository.id, "contents_changed" => true
+      last_updated = repository.repository_errata.order("updated_at desc").first.updated_at.to_s
+      new_errata = ::Katello::Erratum.where.not(:id => repository.repository_errata.pluck(:erratum_id)).first
+      repository.errata << new_errata
+      assert_equal planned_action.execution_plan.planned_run_steps.first.input, "repo" => repository.id, "contents_changed" => true, "last_updated" => last_updated
     end
   end
 


### PR DESCRIPTION
Use "repository_errata.updated_at" before the repository sync is
started to retrieve all new errata created in the repository
sync.