### PR TITLE
Fixes #34804 - Fix upload debian package with invalid relative_path error

### DIFF
--- a/app/services/katello/pulp3/deb.rb
+++ b/app/services/katello/pulp3/deb.rb
@@ -9,6 +9,7 @@ module Katello
       end
 
       def self.content_api_create(opts = {})
+        opts.delete(:relative_path) if opts.key?(:relative_path)
         self.content_api.create(opts)
       end
 

--- a/app/services/katello/pulp3/pulp_content_unit.rb
+++ b/app/services/katello/pulp3/pulp_content_unit.rb
@@ -146,6 +146,8 @@ module Katello
         elsif repository.generic?
           duplicate_sha_path_content_list = content_backend_service.content_api(repository.repository_type, unit_type_id).list(
             filter_label => checksum)
+        elsif unit_type_id == 'deb'
+          duplicate_sha_path_content_list = content_backend_service.content_api.list(filter_label => checksum)
         else
           duplicate_sha_path_content_list = content_backend_service.content_api.list(
             filter_label => checksum,


### PR DESCRIPTION
Fixes following error when uploading certain debian packages:
``Error during upload: Katello::Errors::Pulp3Error: {'non_field_errors': [ErrorDetail(string='Invalid relative_path provided, filename does not match.', code='invalid')]} ``