### PR TITLE
Fixes #35064 - bump pulp_ansible_client to 0.13.1

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "faraday", "< 1.9"
   gem.add_dependency "pulpcore_client", ">= 3.18.0", "< 3.19.0"
   gem.add_dependency "pulp_file_client", ">= 1.10.0", "< 1.11.0"
-  gem.add_dependency "pulp_ansible_client", ">= 0.12.1", "< 0.13"
+  gem.add_dependency "pulp_ansible_client", ">= 0.13.1", "< 0.14"
   gem.add_dependency "pulp_container_client", ">= 2.10.0", "< 2.11.0"
   gem.add_dependency "pulp_deb_client", ">= 2.18.0", "< 2.19.0"
   gem.add_dependency "pulp_rpm_client", ">= 3.17.0", "< 3.18.0"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Bumps pulp_ansible_client up to 0.13.1 or greater

#### Considerations taken when implementing this change?
0.13.0 is busted

#### What are the testing steps for this pull request?
Do the tests all pass?