### PR TITLE
Fixes #35073 - Cannot delete record because of dependent library_instances_inverse

### DIFF
--- a/app/models/katello/authorization/repository.rb
+++ b/app/models/katello/authorization/repository.rb
@@ -5,11 +5,13 @@ module Katello
     delegate :editable?, to: :product
 
     def deletable?(remove_from_content_view_versions = true)
-      product.editable? && (remove_from_content_view_versions || !promoted? || !self.content_views.generated_for_none.exists?)
+      return false unless product.editable?
+      remove_from_content_view_versions || !promoted? || (self.content_views.exists? && !self.content_views.generated_for_none.exists?)
     end
 
     def redhat_deletable?(remove_from_content_view_versions = false)
-      (remove_from_content_view_versions || !self.promoted? || !self.content_views.generated_for_none.exists?) && self.product.editable?
+      return false unless product.editable?
+      remove_from_content_view_versions || !self.promoted? || (self.content_views.exists? && !self.content_views.generated_for_none.exists?)
     end
 
     def readable?


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1) Enable a repository and sync it.
2) Create a content view and add the repository to it, and then publish the first version.
3) Remove the repository from the content view.
4) Disable the repository.

On master: You'll see the error: Cannot delete record because of dependent library_instances_inverse
On this branch: You should see: Repository cannot be deleted since it has already been included in a published Content View. Please delete all Content View versions containing this repository before attempting to delete it.

You should be able to delete the repository from products> repository page where we show a modal to confirm version deletion.