### PR TITLE
Refs #34617 - Remove publish via https

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -255,9 +255,6 @@
         </dd>
       </span>
 
-      <dt translate>Publish via HTTPS</dt>
-      <dd translate>Yes</dd>
-
       <span ng-hide="repository.content_type === 'docker' || repository.content_type === 'ansible_collection'">
         <dt translate>Unprotected</dt>
         <dd bst-edit-checkbox="repository.unprotected"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* When working on 34617 I forgot to remove `Publish via HTTPS` from the repo page
* This does not do anything and was left over from the nutupane conversion Walden did, you can verify by git grep as it only appears in the AngularJS code and if you look at the json from the repos, we don't store that anywhere. I am guessing it had something to do with Pulp2.

#### Considerations taken when implementing this change?

None

#### What are the testing steps for this pull request?

* Check out the PR
* Create a repo
* View the repo details and make sure 'Publish via HTTPS' is removed