### PR TITLE
Fixes #35079 - Pulp 3 migration stats timing is too low for very large deployments

### DIFF
--- a/lib/katello/tasks/pulp3_migration_stats.rake
+++ b/lib/katello/tasks/pulp3_migration_stats.rake
@@ -24,7 +24,7 @@ namespace :katello do
     migration_minutes = (0.000646 * on_demand_unmigrated_rpm_count - 3.22 +
                          0.000943 * immediate_unmigrated_deb_count - 3 + # copied from RPM, no scientific analysis has been done ;-)
                          0.000943 * immediate_unmigrated_rpm_count - 3 +
-                         0.0746 * migratable_repo_count).to_i
+                         0.0746 * migratable_repo_count).round
 
     puts "============Migration Summary================"
     puts "Migrated/Total DEBs: #{migrated_deb_count}/#{::Katello::Deb.count}"
@@ -34,9 +34,9 @@ namespace :katello do
 
     # The timing formulas go negative if the amount of content is negligibly small
     if migration_minutes >= 5
-      fast_hours = (migration_minutes / 60) % 60
+      fast_hours = migration_minutes / 60
       fast_minutes = migration_minutes % 60
-      slow_hours = ((migration_minutes * 4) / 60) % 60
+      slow_hours = (migration_minutes * 4) / 60
       slow_minutes = (migration_minutes * 4) % 60
       puts "Estimated migration time based on yum/apt content, fast hardware, and low server load: #{fast_hours} hours, #{fast_minutes} minutes"
       puts "Estimated migration time based on yum/apt content, slow hardware, and high server load: #{slow_hours} hours, #{slow_minutes} minutes"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
There was an extra `% 60` in the timing estimate for the hours calculation. This PR removes that.

This isn't noticeable if the calculated migration hours are under 60. However, since the "slow" migration calculation multiplies it by 4, the calculation error will be more noticeable there.

#### Considerations taken when implementing this change?
None really.

#### What are the testing steps for this pull request?
1) Either create enough dummy RPM / repository records to get the `migration_minutes` up above 3600, or copy and paste the relevant code into a method and hack in the RPM and repository values.

2) Try varying values below 3600 just to make sure everything makes sense.  Compare the results with an online minutes to hours:minutes calculator online.