### PR TITLE
Fixes #35082 - Add same/different flags to content compare endpoint

### DIFF
--- a/app/models/katello/concerns/pulp_database_unit.rb
+++ b/app/models/katello/concerns/pulp_database_unit.rb
@@ -156,8 +156,8 @@ module Katello
         end
 
         self.joins(repository_association_units).
-            where(repository_association_class.table_name => {:repository_id => facet_repos,
-                                                              content_unit_association_id => facet_content_units}).distinct
+          where(repository_association_class.table_name => { :repository_id => facet_repos,
+                                                             content_unit_association_id => facet_content_units }).distinct
       end
 
       def with_identifiers(ids)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Add params[:content_view_version_ids] = [13,14,15] to def compare in katello/app/controllers/katello/concerns/api/v2/repository_content_controller.rb for example or pass param content_view_version_ids

Errata compare, scoped to repo: https://centos7-katello-devel-stable.example.com/katello/api/v2/errata/compare?organization_id=1&page=1&paged=true&per_page=20&repository_id=7&search=
Errata compare all scoped by version Ids: https://centos7-katello-devel-stable.example.com/katello/api/v2/errata/compare/ 

https://centos7-katello-devel-stable.example.com/katello/api/v2/packages/compare?organization_id=1&page=1&paged=true&per_page=20&repository_id=7&search=

To test compare by different/same/all:

Add restrict_comparision=same , restrict_comparision = different to the API call above and verify the results.