### PR TITLE
Fixes #35063 - Allow copying activation keys with create_activation_keys permissions

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-keys.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-keys.routes.js
@@ -115,7 +115,7 @@ angular.module('Bastion.activation-keys').config(['$stateProvider', function ($s
     })
     .state('activation-key.copy', {
         url: '/copy',
-        permission: 'create_activation_key',
+        permission: 'create_activation_keys',
         controller: 'ActivationKeyCopyController',
         templateUrl: 'activation-keys/details/views/activation-key-copy.html',
         ncyBreadcrumb: {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-details.html
@@ -8,7 +8,7 @@
   <div data-block="item-actions" bst-feature-flag="custom_products">
     <span select-action-dropdown>
       <ul class="dropdown-menu dropdown-menu-right" uib-dropdown-menu role="menu">
-        <li role="menuitem" ng-hide="denied('create_activation_key')">
+        <li role="menuitem" ng-hide="denied('create_activation_keys')">
           <a ui-sref="activation-key.copy" translate>
             Copy Activation Key
           </a>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Create a user with view and create activation keys permissions.
Go to Activation key > your activation_key > 
1. You should be able to see a copy action in the action dropdown
2. You should be able to successfully copy the key without any permissions issues.