### PR TITLE
Fixes #35102 - Add SCA status endpoint

### DIFF
--- a/app/controllers/katello/api/v2/simple_content_access_controller.rb
+++ b/app/controllers/katello/api/v2/simple_content_access_controller.rb
@@ -15,6 +15,14 @@ module Katello
       render json: { simple_content_access_eligible: eligible }
     end
 
+    api :GET, "/organizations/:organization_id/simple_content_access/status",
+      N_("Check if the specified organization has Simple Content Access enabled")
+    param :organization_id, :number, :desc => N_("Organization ID"), :required => true
+    def status
+      status = @organization.simple_content_access?
+      render json: { simple_content_access: status }
+    end
+
     api :PUT, "/organizations/:organization_id/simple_content_access/enable",
       N_("Enable simple content access for a manifest")
     param :organization_id, :number, :desc => N_("Organization ID"), :required => true

--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -154,7 +154,7 @@ module Katello
 
     class NoManifestImported < StandardError
       def message
-        _("Current organization has no manifest imported.")
+        _("Current organization does not have a manifest imported.")
       end
     end
 

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -392,6 +392,7 @@ Katello::Engine.routes.draw do
               put :enable
               put :disable
               get :eligible
+              get :status
             end
           end
 
@@ -403,6 +404,7 @@ Katello::Engine.routes.draw do
               match '/simple_content_access/enable', :to => 'upstream_subscriptions#enable_simple_content_access', :via => :put
               match '/simple_content_access/disable', :to => 'upstream_subscriptions#disable_simple_content_access', :via => :put
               match '/simple_content_access/eligible', :to => 'upstream_subscriptions#simple_content_access_eligible', :via => :get
+              match '/simple_content_access/status', :to => 'upstream_subscriptions#simple_content_access_status', :via => :get
             end
           end
         end

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -350,8 +350,8 @@ module Katello
                          :resource_type => 'Katello::Subscription'
       @plugin.permission :manage_subscription_allocations,
                          {
-                           'katello/api/v2/upstream_subscriptions' => [:index, :create, :destroy, :update, :ping, :enable_simple_content_access, :disable_simple_content_access, :simple_content_access_eligible],
-                           'katello/api/v2/simple_content_access' => [:enable, :disable, :eligible]
+                           'katello/api/v2/upstream_subscriptions' => [:index, :create, :destroy, :update, :ping, :enable_simple_content_access, :disable_simple_content_access, :simple_content_access_eligible, :simple_content_access_status],
+                           'katello/api/v2/simple_content_access' => [:enable, :disable, :eligible, :status]
                          },
                          :resource_type => 'Katello::Subscription'
     end

--- a/test/controllers/api/v2/simple_content_access_controller_test.rb
+++ b/test/controllers/api/v2/simple_content_access_controller_test.rb
@@ -74,6 +74,26 @@ module Katello
       end
     end
 
+    def test_status_true
+      Organization.any_instance.stubs(:simple_content_access?).returns(true)
+
+      get :status, params: { organization_id: @organization.id }
+      body = JSON.parse(response.body)
+
+      assert_response :success
+      assert(body['simple_content_access'])
+    end
+
+    def test_status_false
+      Organization.any_instance.stubs(:simple_content_access?).returns(false)
+
+      get :status, params: { organization_id: @organization.id }
+      body = JSON.parse(response.body)
+
+      assert_response :success
+      refute(body['simple_content_access'])
+    end
+
     def test_eligible
       Katello::Candlepin::UpstreamConsumer.any_instance.expects(:simple_content_access_eligible?).returns(true)
 

--- a/test/controllers/api/v2/simple_content_access_controller_test.rb
+++ b/test/controllers/api/v2/simple_content_access_controller_test.rb
@@ -101,7 +101,7 @@ module Katello
       assert_protected_action(:status, allowed_perms, denied_perms, [@organization]) do
         get :status, params: { organization_id: @organization.id }
       end
-    end    
+    end
 
     def test_eligible
       Katello::Candlepin::UpstreamConsumer.any_instance.expects(:simple_content_access_eligible?).returns(true)

--- a/test/controllers/api/v2/simple_content_access_controller_test.rb
+++ b/test/controllers/api/v2/simple_content_access_controller_test.rb
@@ -93,6 +93,7 @@ module Katello
       assert_response :success
       refute(body['simple_content_access'])
     end
+
     def test_status_protected
       allowed_perms = [permission]
       denied_perms = []

--- a/test/controllers/api/v2/simple_content_access_controller_test.rb
+++ b/test/controllers/api/v2/simple_content_access_controller_test.rb
@@ -93,7 +93,6 @@ module Katello
       assert_response :success
       refute(body['simple_content_access'])
     end
-    
     def test_status_protected
       allowed_perms = [permission]
       denied_perms = []

--- a/test/controllers/api/v2/simple_content_access_controller_test.rb
+++ b/test/controllers/api/v2/simple_content_access_controller_test.rb
@@ -93,6 +93,15 @@ module Katello
       assert_response :success
       refute(body['simple_content_access'])
     end
+    
+    def test_status_protected
+      allowed_perms = [permission]
+      denied_perms = []
+
+      assert_protected_action(:status, allowed_perms, denied_perms, [@organization]) do
+        get :status, params: { organization_id: @organization.id }
+      end
+    end    
 
     def test_eligible
       Katello::Candlepin::UpstreamConsumer.any_instance.expects(:simple_content_access_eligible?).returns(true)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Added an API to check if SCA is enabled for an org.

#### Considerations taken when implementing this change?
* Updated the manifest not imported message to be more grammatically correct

#### What are the testing steps for this pull request?
* Check out PR
* Import a manifest
* Use the [hammer pr](https://github.com/Katello/hammer-cli-katello/pull/855) or hit the api with postman and verify we see values coming back with sca on/off and that we get an error without a manifest imported.