### PR TITLE
Fixes #35114 - Show toggle groups for non-default environment OR content view

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -341,7 +341,7 @@ export const ErrataTab = () => {
   ) : null;
 
   const hostIsNonLibrary = (
-    contentFacet?.contentViewDefault === false && contentFacet.lifecycleEnvironmentLibrary === false
+    contentFacet?.contentViewDefault === false || contentFacet.lifecycleEnvironmentLibrary === false
   );
   const toggleGroup = (
     <Split hasGutter>

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -154,7 +154,7 @@ const RepositorySetsTab = () => {
     contentViewName,
     lifecycleEnvironmentName,
   } = contentFacet;
-  const nonLibraryHost = contentViewDefault === false &&
+  const nonLibraryHost = contentViewDefault === false ||
     lifecycleEnvironmentLibrary === false;
   const simpleContentAccess = (Number(subscriptionStatus) === 5);
   const [isBulkActionOpen, setIsBulkActionOpen] = useState(false);

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
@@ -577,7 +577,7 @@ test('Toggle Group shows if it\'s not the default content view or library enviro
   assertNockRequest(scope, done); // Pass jest callback to confirm test is done
 });
 
-test('Toggle Group does not show if it\'s the default content view ', async (done) => {
+test('Toggle Group shows if it\'s the default content view but non-library environment', async (done) => {
   const options = renderOptions({
     ...contentFacetAttributes,
     content_view_default: true,
@@ -598,14 +598,41 @@ test('Toggle Group does not show if it\'s the default content view ', async (don
 
   // Assert that the errata are now showing on the screen, but wait for them to appear.
   await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
-  expect(queryByLabelText('Installable Errata')).not.toBeInTheDocument();
+  expect(queryByLabelText('Installable Errata')).toBeInTheDocument();
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done); // Pass jest callback to confirm test is done
 });
 
-test('Toggle Group does not show if it\'s the  library environment', async (done) => {
+test('Toggle Group shows if it\'s the library environment but non-default content view', async (done) => {
   const options = renderOptions({
     ...contentFacetAttributes,
+    lifecycle_environment_library: true,
+  });
+  // Setup autocomplete with mockForemanAutoComplete since we aren't adding /katello
+  const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
+  const mockErrata = makeMockErrata({});
+  // return errata data results when we look for errata
+  const scope = nockInstance
+    .get(hostErrata)
+    .query(defaultQuery)
+    .reply(200, mockErrata);
+
+  const {
+    queryByLabelText,
+    getAllByText,
+  } = renderWithRedux(<ErrataTab />, options);
+
+  // Assert that the errata are now showing on the screen, but wait for them to appear.
+  await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
+  expect(queryByLabelText('Installable Errata')).toBeInTheDocument();
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(scope, done); // Pass jest callback to confirm test is done
+});
+
+test('Toggle Group does not show if it\'s the default content view and library environment', async (done) => {
+  const options = renderOptions({
+    ...contentFacetAttributes,
+    content_view_default: true,
     lifecycle_environment_library: true,
   });
   // Setup autocomplete with mockForemanAutoComplete since we aren't adding /katello

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySetsTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySetsTab.test.js
@@ -46,7 +46,7 @@ const autocompleteUrl = '/repository_sets/auto_complete_search';
 const repositorySetBookmarks = foremanApi.getApiUrl('/bookmarks?search=controller%3Dkatello_product_contents');
 const contentOverride = foremanApi.getApiUrl('/hosts/1/subscriptions/content_override');
 
-const defaultQuery = {
+const limitToEnvQuery = {
   content_access_mode_env: true,
   content_access_mode_all: true,
   host_id: 1,
@@ -56,8 +56,8 @@ const defaultQuery = {
   sort_by: 'name',
   sort_order: 'asc',
 };
-const libraryQuery = {
-  ...defaultQuery,
+const showAllQuery = {
+  ...limitToEnvQuery,
   content_access_mode_env: false,
 };
 
@@ -86,7 +86,7 @@ test('Can call API for repository sets and show basic table', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
   const scope = nockInstance
     .get(hostRepositorySets)
-    .query(defaultQuery)
+    .query(limitToEnvQuery)
     .reply(200, mockRepoSetData);
 
   const { getByText } = renderWithRedux(<RepositorySetsTab />, renderOptions());
@@ -110,7 +110,7 @@ test('Can handle no repository sets being present', async (done) => {
 
   const scope = nockInstance
     .get(hostRepositorySets)
-    .query(defaultQuery)
+    .query(limitToEnvQuery)
     .reply(200, noResults);
 
   const { queryByText } = renderWithRedux(<RepositorySetsTab />, renderOptions());
@@ -126,7 +126,7 @@ test('Toggle Group shows if it\'s not the default content view or library enviro
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
   const scope = nockInstance
     .get(hostRepositorySets)
-    .query(defaultQuery)
+    .query(limitToEnvQuery)
     .reply(200, mockRepoSetData);
 
   const {
@@ -141,7 +141,7 @@ test('Toggle Group shows if it\'s not the default content view or library enviro
   assertNockRequest(scope, done); // Pass jest callback to confirm test is done
 });
 
-test('Toggle Group does not show if it\'s the default content view ', async (done) => {
+test('Toggle Group shows if it\'s the default content view but non-library environment', async (done) => {
   const options = renderOptions({
     ...contentFacetAttributes,
     content_view_default: true,
@@ -150,7 +150,7 @@ test('Toggle Group does not show if it\'s the default content view ', async (don
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
   const scope = nockInstance
     .get(hostRepositorySets)
-    .query(libraryQuery)
+    .query(limitToEnvQuery)
     .reply(200, mockRepoSetData);
 
   const {
@@ -160,12 +160,12 @@ test('Toggle Group does not show if it\'s the default content view ', async (don
 
   // Assert that the errata are now showing on the screen, but wait for them to appear.
   await patientlyWaitFor(() => expect(getByText(firstRepoSet.contentUrl)).toBeInTheDocument());
-  expect(queryByLabelText('Limit to environment')).not.toBeInTheDocument();
+  expect(queryByLabelText('Limit to environment')).toBeInTheDocument();
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done); // Pass jest callback to confirm test is done
 });
 
-test('Toggle Group does not show if it\'s the library environment', async (done) => {
+test('Toggle Group shows if it\'s the library environment but a non-default content view', async (done) => {
   const options = renderOptions({
     ...contentFacetAttributes,
     lifecycle_environment_library: true,
@@ -174,7 +174,32 @@ test('Toggle Group does not show if it\'s the library environment', async (done)
   // return errata data results when we look for errata
   const scope = nockInstance
     .get(hostRepositorySets)
-    .query(libraryQuery)
+    .query(limitToEnvQuery)
+    .reply(200, mockRepoSetData);
+
+  const {
+    queryByLabelText,
+    getByText,
+  } = renderWithRedux(<RepositorySetsTab />, options);
+
+  // Assert that the errata are now showing on the screen, but wait for them to appear.
+  await patientlyWaitFor(() => expect(getByText(firstRepoSet.contentUrl)).toBeInTheDocument());
+  expect(queryByLabelText('Limit to environment')).toBeInTheDocument();
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(scope, done); // Pass jest callback to confirm test is done
+});
+
+test('Toggle Group does not show if it\'s the library environment and default content view', async (done) => {
+  const options = renderOptions({
+    ...contentFacetAttributes,
+    lifecycle_environment_library: true,
+    content_view_default: true,
+  });
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
+  // return errata data results when we look for errata
+  const scope = nockInstance
+    .get(hostRepositorySets)
+    .query(showAllQuery)
     .reply(200, mockRepoSetData);
 
   const {
@@ -195,7 +220,7 @@ test('Can toggle with the Toggle Group ', async (done) => {
   // return errata data results when we look for errata
   const scope = nockInstance
     .get(hostRepositorySets)
-    .query(defaultQuery)
+    .query(limitToEnvQuery)
     .reply(200, mockRepoSetData);
 
   const {
@@ -215,7 +240,7 @@ test('Can override to disabled', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
   const scope = nockInstance
     .get(hostRepositorySets)
-    .query(defaultQuery)
+    .query(limitToEnvQuery)
     .reply(200, mockRepoSetData);
   const overrides = JSON.parse(JSON.stringify(mockContentOverride));
   overrides.results[0].enabled_content_override = false;
@@ -253,7 +278,7 @@ test('Can override to enabled', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
   const scope = nockInstance
     .get(hostRepositorySets)
-    .query(defaultQuery)
+    .query(limitToEnvQuery)
     .reply(200, mockRepoSetData);
   const overrides = JSON.parse(JSON.stringify(mockContentOverride));
   overrides.results[1].enabled_content_override = true;
@@ -292,7 +317,7 @@ test('Can reset to default', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
   const scope = nockInstance
     .get(hostRepositorySets)
-    .query(defaultQuery)
+    .query(limitToEnvQuery)
     .reply(200, mockRepoSetData);
   const overrides = JSON.parse(JSON.stringify(mockContentOverride));
   overrides.results[1].enabled_content_override = null;
@@ -331,7 +356,7 @@ test('Can override in bulk', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
   const scope = nockInstance
     .get(hostRepositorySets)
-    .query(defaultQuery)
+    .query(limitToEnvQuery)
     .reply(200, mockRepoSetData);
   const contentOverrideScope = nockInstance
     .put(contentOverride)
@@ -359,12 +384,12 @@ test('Can filter by status', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
   const scope = nockInstance
     .get(hostRepositorySets)
-    .query(defaultQuery)
+    .query(limitToEnvQuery)
     .reply(200, mockRepoSetData);
 
   const scope2 = nockInstance
     .get(hostRepositorySets)
-    .query({ ...defaultQuery, status: 'overridden' })
+    .query({ ...limitToEnvQuery, status: 'overridden' })
     .reply(200, { ...mockRepoSetData, results: [secondRepoSet] });
 
   const {
@@ -393,7 +418,7 @@ test('Can display osRestricted as a label', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
   const scope = nockInstance
     .get(hostRepositorySets)
-    .query(defaultQuery)
+    .query(limitToEnvQuery)
     .reply(200, mockRepoSetData);
 
   const { getByText } = renderWithRedux(<RepositorySetsTab />, renderOptions());


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

On the Repository sets and Errata tabs, a toggle group "Show all / Limit to environment" shows when the host is a "non-library" host.

This was previously defined as

```js
const nonLibraryHost = contentViewDefault === false &&
lifecycleEnvironmentLibrary === false;
```

However, if only one of the two are non-default, `nonLibraryHost` ends up as false. This is incorrect. The toggle group should show if one of the two is non-default, not require both. It should be

```js
const nonLibraryHost = contentViewDefault === false ||
lifecycleEnvironmentLibrary === false;
```

#### Considerations taken when implementing this change?

If you have a non-default content view but default environment, or vice versa, you'd still want to limit your views to only what's available on your host.

#### What are the testing steps for this pull request?

Create a content view (it doesn't need to have anything in it)
Create a lifecycle environment.

Get a host in 

1. default CV and default environment
2. non-default CV and default environment
3. default CV and non-default environment
4. non-default CV and non-default environment

On the Repository sets and Errata tabs, the "Show all / Limit to environment" toggle group should show for hosts 2, 3, and 4. Previously it would only show for host 4.
