### PR TITLE
Fixes #35119 - acs refresh rake task fails with no ACSs

### DIFF
--- a/lib/katello/tasks/refresh_alternate_content_sources.rake
+++ b/lib/katello/tasks/refresh_alternate_content_sources.rake
@@ -2,9 +2,14 @@ namespace :katello do
   desc 'Refresh all alternate content sources'
   task :refresh_alternate_content_sources => ["dynflow:client"] do
     User.current = User.anonymous_admin
-    ::ForemanTasks.async_task(::Actions::BulkAction,
-                              ::Actions::Katello::AlternateContentSource::Refresh,
-                              ::Katello::AlternateContentSource.all)
-    puts _("Alternate content source refreshing started in the background.")
+    alternate_content_sources = ::Katello::AlternateContentSource.all
+    if alternate_content_sources.present?
+      ::ForemanTasks.async_task(::Actions::BulkAction,
+                                ::Actions::Katello::AlternateContentSource::Refresh,
+                                alternate_content_sources)
+      puts _("Alternate content source refreshing started in the background.")
+    else
+      puts _("No alternate content sources to refresh.")
+    end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds a check for existing ACSs in the refresh ACS rake task.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Run `rake katello:refresh_alternate_content_sources` with and without ACSs in the DB.