### PR TITLE
Fixes #35136 - Fix docker escaping in LCE table

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/views/environments.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/views/environments.html
@@ -34,10 +34,10 @@
                 OSTree Repositories <div>{{ library.counts.ostree_repositories || 0 }}</div>
               </td>
               <td class="info-block" ng-show="library.counts.docker_repositories > 0" translate>
-	      <td class="info-block" ng-show="library.counts.deb_repositories > 0" translate>
-                Deb Repositories <div>{{ library.counts.deb_repositories || 0 }}</div>
-              </td>
                 Docker Repositories <div>{{ library.counts.docker_repositories || 0 }}</div>
+                </td>
+	            <td class="info-block" ng-show="library.counts.deb_repositories > 0" translate>
+                Deb Repositories <div>{{ library.counts.deb_repositories || 0 }}</div>
               </td>
               <td class="info-block" ng-show="library.counts.packages > 0" translate>
                 Packages <div>{{ library.counts.packages || 0 }}</div>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* When adding the deb repos, we forgot a `<td>` not sure why the linting didn't catch it but w/e :shrug: 

#### Considerations taken when implementing this change?

* N/A

#### What are the testing steps for this pull request?

* Check out PR
* If you don't have any docker repos, verify you do not see docker repos listed in LCE page.
* Create a docker repo
* Verify that Docker repos are showing in the table instead of the top of the page.
