### PR TITLE
Fixes #34861 - Syncable yum-format repository exports

### DIFF
--- a/app/controllers/katello/api/v2/content_exports_controller.rb
+++ b/app/controllers/katello/api/v2/content_exports_controller.rb
@@ -34,12 +34,18 @@ module Katello
                                                "no greater than the specified size in gigabytes."), :required => false
     param :fail_on_missing_content, :bool, :desc => N_("Fails if any of the repositories belonging to this version"\
                                                          " are unexportable. False by default."), :required => false
+    param :format, ::Katello::Pulp3::ContentViewVersion::Export::FORMATS,
+                   :desc => N_("Export formats. Choose syncable if content is to be imported via repository sync. "\
+                               "Choose importable if content is to be imported via hammer content-import.
+                                Defaults to importable."),
+                   :required => false
     def version
       tasks = async_task(::Actions::Katello::ContentViewVersion::Export,
                           content_view_version: @version,
                           destination_server: params[:destination_server],
                           chunk_size: params[:chunk_size_gb],
-                          fail_on_missing_content: ::Foreman::Cast.to_bool(params[:fail_on_missing_content]))
+                          fail_on_missing_content: ::Foreman::Cast.to_bool(params[:fail_on_missing_content]),
+                          format: find_export_format)
       respond_for_async :resource => tasks
     end
 
@@ -50,12 +56,18 @@ module Katello
                                                "no greater than the specified size in gigabytes."), :required => false
     param :fail_on_missing_content, :bool, :desc => N_("Fails if any of the repositories belonging to this organization"\
                                                          " are unexportable. False by default."), :required => false
+    param :format, ::Katello::Pulp3::ContentViewVersion::Export::FORMATS,
+                   :desc => N_("Export formats. Choose syncable if content is to be imported via repository sync. "\
+                               "Choose importable if content is to be imported via hammer content-import.
+                                Defaults to importable."),
+                   :required => false
     def library
       tasks = async_task(::Actions::Pulp3::Orchestration::ContentViewVersion::ExportLibrary,
                           @organization,
                           destination_server: params[:destination_server],
                           chunk_size: params[:chunk_size_gb],
-                          fail_on_missing_content: ::Foreman::Cast.to_bool(params[:fail_on_missing_content]))
+                          fail_on_missing_content: ::Foreman::Cast.to_bool(params[:fail_on_missing_content]),
+                          format: find_export_format)
       respond_for_async :resource => tasks
     end
 
@@ -63,10 +75,16 @@ module Katello
     param :id, :number, :desc => N_("Repository identifier"), :required => true
     param :chunk_size_gb, :number, :desc => N_("Split the exported content into archives "\
                                                "no greater than the specified size in gigabytes."), :required => false
+    param :format, ::Katello::Pulp3::ContentViewVersion::Export::FORMATS,
+                   :desc => N_("Export formats. Choose syncable if content is to be imported via repository sync. "\
+                               "Choose importable if content is to be imported via hammer content-import.
+                                Defaults to importable."),
+                   :required => false
     def repository
       tasks = async_task(::Actions::Pulp3::Orchestration::ContentViewVersion::ExportRepository,
                           @repository,
-                          chunk_size: params[:chunk_size_gb])
+                          chunk_size: params[:chunk_size_gb],
+                          format: find_export_format)
       respond_for_async :resource => tasks
     end
 
@@ -88,6 +106,18 @@ module Katello
       find_organization
       unless @organization.can_export_content?
         throw_resource_not_found(name: 'organization', id: params[:organization_id])
+      end
+    end
+
+    def find_export_format
+      if params[:format]
+        unless ::Katello::Pulp3::ContentViewVersion::Export::FORMATS.include?(params[:format])
+          fail HttpErrors::UnprocessableEntity, _('Invalid export format provided. Format must be one of  %s ') %
+                                            ::Katello::Pulp3::ContentViewVersion::Export::FORMATS.join(',')
+        end
+        params[:format]
+      else
+        ::Katello::Pulp3::ContentViewVersion::Export::IMPORTABLE
       end
     end
   end

--- a/app/lib/actions/pulp3/content_view_version/create_exporter.rb
+++ b/app/lib/actions/pulp3/content_view_version/create_exporter.rb
@@ -6,13 +6,20 @@ module Actions
           param :smart_proxy_id, Integer
           param :content_view_version_id, Integer
           param :destination_server, String
+          param :format, String
+          param :base_path, String
+          param :repository_id, Integer
         end
 
         def run
           cvv = ::Katello::ContentViewVersion.find(input[:content_view_version_id])
-          output[:exporter_data] = ::Katello::Pulp3::ContentViewVersion::Export.new(smart_proxy: smart_proxy,
+          repository = ::Katello::Repository.find(input[:repository_id]) unless input[:repository_id].blank?
+          output[:exporter_data] = ::Katello::Pulp3::ContentViewVersion::Export.create(smart_proxy: smart_proxy,
                                                                             content_view_version: cvv,
-                                                                            destination_server: input[:destination_server]).create_exporter
+                                                                            destination_server: input[:destination_server],
+                                                                            format: input[:format],
+                                                                            base_path: input[:base_path],
+                                                                            repository: repository).create_exporter
         end
       end
     end

--- a/app/lib/actions/pulp3/content_view_version/create_syncable_export_history.rb
+++ b/app/lib/actions/pulp3/content_view_version/create_syncable_export_history.rb
@@ -1,57 +1,43 @@
 module Actions
   module Pulp3
     module ContentViewVersion
-      class CreateExportHistory < Actions::EntryAction
+      class CreateSyncableExportHistory < Actions::EntryAction
         input_format do
           param :smart_proxy_id, Integer
-          param :exporter_data, Hash
+          param :base_path, String
           param :content_view_version_id, Integer
-          param :from_content_view_version_id, Integer
           param :destination_server, String
         end
 
         output_format do
           param :export_history_id, Integer
           param :path, String
-          param :exported_file_checksum, String
         end
 
         def run
           smart_proxy = ::SmartProxy.unscoped.find(input[:smart_proxy_id])
-          api = ::Katello::Pulp3::Api::Core.new(smart_proxy)
-          export_data = api.export_api.list(input[:exporter_data][:pulp_href]).results.first
-          output[:exported_file_checksum] = export_data.output_file_info
-          file_name = output[:exported_file_checksum].first&.first
-          path = File.dirname(file_name.to_s)
-          output[:path] = path
+          output[:path] = input[:base_path]
           cvv = ::Katello::ContentViewVersion.find(input[:content_view_version_id])
-          from_cvv = ::Katello::ContentViewVersion.find(input[:from_content_view_version_id]) unless input[:from_content_view_version_id].blank?
-
           export_metadata = ::Katello::Pulp3::ContentViewVersion::Export.create(
                                                      content_view_version: cvv,
                                                      smart_proxy: smart_proxy,
-                                                     format: ::Katello::Pulp3::ContentViewVersion::Export::IMPORTABLE,
-                                                     from_content_view_version: from_cvv).generate_metadata
-
-          toc_path_info = output[:exported_file_checksum].find { |item| item.first.end_with?("toc.json") }
-          export_metadata[:toc] = File.basename(toc_path_info.first)
+                                                     format: input[:format]).generate_metadata
 
           history = ::Katello::ContentViewVersionExportHistory.create!(
             content_view_version_id: input[:content_view_version_id],
             destination_server: input[:destination_server],
-            path: path,
+            path: input[:base_path],
             metadata: export_metadata,
             audit_comment: ::Katello::ContentViewVersionExportHistory.generate_audit_comment(content_view_version: cvv,
                                                                                              user: User.current,
-                                                                                             from_version: from_cvv,
                                                                                              metadata: export_metadata)
           )
           output[:export_history_id] = history.id
-          output[:format] = ::Katello::Pulp3::ContentViewVersion::Export::IMPORTABLE
+          output[:format] = ::Katello::Pulp3::ContentViewVersion::Export::SYNCABLE
         end
 
         def humanized_name
-          _("Create Export History")
+          _("Create Syncable Export History")
         end
       end
     end

--- a/app/lib/actions/pulp3/content_view_version/destroy_exporter.rb
+++ b/app/lib/actions/pulp3/content_view_version/destroy_exporter.rb
@@ -5,10 +5,15 @@ module Actions
         input_format do
           param :smart_proxy_id, Integer
           param :exporter_data, Hash
+          param :format, String
+          param :repository_id, Integer
         end
 
         def invoke_external_task
-          ::Katello::Pulp3::ContentViewVersion::Export.new(smart_proxy: smart_proxy).destroy_exporter(input[:exporter_data][:pulp_href])
+          repository = ::Katello::Repository.find(input[:repository_id]) unless input[:repository_id].blank?
+          ::Katello::Pulp3::ContentViewVersion::Export.create(smart_proxy: smart_proxy,
+                                                              format: input[:format],
+                                                              repository: repository).destroy_exporter(input[:exporter_data])
         end
       end
     end

--- a/app/lib/actions/pulp3/content_view_version/export.rb
+++ b/app/lib/actions/pulp3/content_view_version/export.rb
@@ -7,16 +7,21 @@ module Actions
           param :from_content_view_version_id, Integer
           param :smart_proxy_id, Integer
           param :exporter_data, Hash
+          param :format, String
           param :chunk_size, Integer
+          param :repository_id, Integer
         end
 
         def invoke_external_task
+          repository = ::Katello::Repository.find(input[:repository_id]) unless input[:repository_id].blank?
           cvv = ::Katello::ContentViewVersion.find(input[:content_view_version_id])
           from_cvv = ::Katello::ContentViewVersion.find(input[:from_content_view_version_id]) unless input[:from_content_view_version_id].blank?
-          ::Katello::Pulp3::ContentViewVersion::Export.new(smart_proxy: smart_proxy,
+          ::Katello::Pulp3::ContentViewVersion::Export.create(smart_proxy: smart_proxy,
                                                    content_view_version: cvv,
-                                                   from_content_view_version: from_cvv)
-                                                   .create_export(input[:exporter_data][:pulp_href],
+                                                   from_content_view_version: from_cvv,
+                                                   format: input[:format],
+                                                   repository: repository)
+                                                   .create_export(input[:exporter_data],
                                                                         chunk_size: input[:chunk_size])
         end
       end

--- a/app/lib/actions/pulp3/orchestration/content_view_version/export_library.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/export_library.rb
@@ -6,7 +6,8 @@ module Actions
           def plan(organization, destination_server: nil,
                                  chunk_size: nil,
                                  from_history: nil,
-                                 fail_on_missing_content: false)
+                                 fail_on_missing_content: false,
+                                 format: ::Katello::Pulp3::ContentViewVersion::Export::IMPORTABLE)
             action_subject(organization)
             validate_repositories_immediate!(organization) if fail_on_missing_content
 
@@ -24,7 +25,8 @@ module Actions
                                           chunk_size: chunk_size,
                                           from_history: from_history,
                                           validate_incremental: false,
-                                          fail_on_missing_content: fail_on_missing_content)
+                                          fail_on_missing_content: fail_on_missing_content,
+                                          format: format)
               plan_self(export_action_output: export_action.output)
             end
           end

--- a/app/lib/actions/pulp3/orchestration/content_view_version/export_repository.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/export_repository.rb
@@ -5,7 +5,8 @@ module Actions
         class ExportRepository < Actions::EntryAction
           def plan(repository,
                     chunk_size: nil,
-                    from_history: nil)
+                    from_history: nil,
+                    format: ::Katello::Pulp3::ContentViewVersion::Export::IMPORTABLE)
             action_subject(repository)
             validate_repositories_immediate!(repository)
 
@@ -19,7 +20,8 @@ module Actions
               export_action = plan_action(Actions::Katello::ContentViewVersion::Export,
                                           content_view_version: publish_action.version,
                                           chunk_size: chunk_size,
-                                          from_history: from_history)
+                                          from_history: from_history,
+                                          format: format)
               plan_self(export_action_output: export_action.output)
             end
           end

--- a/app/lib/actions/pulp3/orchestration/content_view_version/syncable_export.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/syncable_export.rb
@@ -1,0 +1,82 @@
+module Actions
+  module Pulp3
+    module Orchestration
+      module ContentViewVersion
+        class SyncableExport < Actions::EntryAction
+          input_format do
+            param :smart_proxy_id, Integer
+            param :content_view_version_id, Integer
+            param :export_history_id, Integer
+            param :export_path, String
+          end
+
+          output_format do
+            param :export_path, String
+            param :export_history_id, Integer
+          end
+
+          def plan(content_view_version:,
+                   smart_proxy:,
+                   fail_on_missing_content: false,
+                   destination_server:)
+            format = ::Katello::Pulp3::ContentViewVersion::Export::SYNCABLE
+            sequence do
+              export_service = ::Katello::Pulp3::ContentViewVersion::Export.create(
+                  smart_proxy: smart_proxy,
+                  content_view_version: content_view_version,
+                  format: format,
+                  destination_server: destination_server)
+              export_service.validate!(fail_on_missing_content: fail_on_missing_content)
+              base_path = export_service.generate_exporter_path
+              export_service.repositories.each do |repository|
+                action_output = plan_action(::Actions::Pulp3::ContentViewVersion::CreateExporter,
+                                            content_view_version_id: content_view_version.id,
+                                            smart_proxy_id: smart_proxy.id,
+                                            format: format,
+                                            base_path: base_path,
+                                            repository_id: repository.id,
+                                            destination_server: destination_server).output
+
+                plan_action(::Actions::Pulp3::ContentViewVersion::Export,
+                            content_view_version_id: content_view_version.id,
+                            smart_proxy_id: smart_proxy.id,
+                            exporter_data: action_output[:exporter_data],
+                            format: format,
+                            repository_id: repository.id)
+
+                plan_action(::Actions::Pulp3::ContentViewVersion::DestroyExporter,
+                          smart_proxy_id: smart_proxy.id,
+                          exporter_data: action_output[:exporter_data],
+                          format: format,
+                          repository_id: repository.id)
+              end
+
+              history_output = plan_action(
+                  ::Actions::Pulp3::ContentViewVersion::CreateSyncableExportHistory,
+                  smart_proxy_id: smart_proxy.id,
+                  content_view_version_id: content_view_version.id,
+                  destination_server: destination_server,
+                  format: format,
+                  base_path: base_path
+              ).output
+
+              plan_self(export_history_id: history_output[:export_history_id],
+                        export_path: base_path)
+            end
+          end
+
+          def run
+            output.update(
+                export_history_id: input[:export_history_id],
+                export_path: input[:export_path]
+            )
+          end
+
+          def rescue_strategy
+            Dynflow::Action::Rescue::Skip
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/api/core.rb
+++ b/app/services/katello/pulp3/api/core.rb
@@ -89,6 +89,10 @@ module Katello
           PulpcoreClient::RepositoriesReclaimSpaceApi.new(core_api_client)
         end
 
+        def yum_exporter_api
+          PulpcoreClient::ExportersFilesystemApi.new(core_api_client)
+        end
+
         def exporter_api
           PulpcoreClient::ExportersPulpApi.new(core_api_client)
         end
@@ -99,6 +103,10 @@ module Katello
 
         def importer_check_api
           PulpcoreClient::ImportersPulpImportCheckApi.new(core_api_client)
+        end
+
+        def yum_export_api
+          PulpcoreClient::ExportersFilesystemExportsApi.new(core_api_client)
         end
 
         def export_api

--- a/app/services/katello/pulp3/content_view_version/metadata_generator.rb
+++ b/app/services/katello/pulp3/content_view_version/metadata_generator.rb
@@ -16,10 +16,12 @@ module Katello
 
         def generate!
           ret = { organization: organization.name,
+                  base_path: Setting['pulpcore_export_destination'],
                   repositories: {},
                   content_view: content_view.slice(:name, :label, :description, :generated_for),
                   content_view_version: content_view_version.slice(:major, :minor, :description),
-                  incremental: from_content_view_version.present?
+                  incremental: from_content_view_version.present?,
+                  format: export_service.format
           }
 
           unless from_content_view_version.blank?

--- a/app/services/katello/pulp3/content_view_version/syncable_format_export.rb
+++ b/app/services/katello/pulp3/content_view_version/syncable_format_export.rb
@@ -1,0 +1,34 @@
+module Katello
+  module Pulp3
+    module ContentViewVersion
+      class SyncableFormatExport < Export
+        def create_exporter
+          api.yum_exporter_api.create(name: "#{generate_id(content_view_version)}-#{repository.id}",
+                                      path: generate_repository_exporter_path,
+                                      method: :hardlink)
+        end
+
+        def create_export(exporter_data, _options = {})
+          [api.yum_export_api.create(exporter_data[:pulp_href], publication: repository.publication_href)]
+        end
+
+        def fetch_export(exporter_href)
+          api.yum_export_api.list(exporter_href).results.first
+        end
+
+        def destroy_exporter(exporter_data)
+          exporter_href = exporter_data[:pulp_href]
+          export_data = fetch_export(exporter_href)
+          api.yum_export_api.delete(export_data.pulp_href)
+          api.yum_exporter_api.delete(exporter_href)
+        end
+
+        def generate_repository_exporter_path
+          _org, _content, content_path = repository.library_instance_or_self.relative_path.split("/", 3)
+          content_path = content_path.sub(%r|^/|, '')
+          "#{generate_exporter_path}/#{content_path}".gsub(/\s/, '_')
+        end
+      end
+    end
+  end
+end

--- a/test/actions/pulp3/orchestration/export_test.rb
+++ b/test/actions/pulp3/orchestration/export_test.rb
@@ -5,6 +5,8 @@ module ::Actions::Katello::ContentViewVersion
     include Katello::Pulp3Support
 
     def setup
+      Setting[:ssl_certificate] = '/etc/foreman/client_cert.pem'
+      Setting[:ssl_priv_key] = '/etc/foreman/client_key.pem'
       @primary = SmartProxy.pulp_primary
       @repo = katello_repositories(:fedora_17_x86_64_duplicate)
       @repo.root.update!(url: 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/')

--- a/test/fixtures/vcr_cassettes/actions/katello/content_view_version/export/create_exporter.yml
+++ b/test/fixtures/vcr_cassettes/actions/katello/content_view_version/export/create_exporter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:48 GMT
+      - Tue, 19 Jul 2022 18:46:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -41,21 +41,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0405b6b86f404f5d9f37ce3426d092cd
+      - c4a9345cbd6f47c996c731379b2aae4f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:48 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -76,7 +76,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:48 GMT
+      - Tue, 19 Jul 2022 18:46:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -94,21 +94,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 90af15d26c7a4172b799b368396cd747
+      - 3def58222852483ebff90e0dbfa66d51
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:48 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -116,7 +116,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -129,7 +129,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:48 GMT
+      - Tue, 19 Jul 2022 18:46:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -147,21 +147,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 70079ea0d2294d17a3f2f0319e1c5d38
+      - 45510cd41949431e980c8387192e8434
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:48 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:32 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -169,7 +169,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -182,7 +182,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:48 GMT
+      - Tue, 19 Jul 2022 18:46:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -200,21 +200,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c9c759fd27b04998bfec9dd390e05192
+      - b00e3d11334c4162b0e3b94c07fa191d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:48 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -231,7 +231,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -244,13 +244,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:49 GMT
+      - Tue, 19 Jul 2022 18:46:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/981d178a-53df-495c-a976-cb015e7885d6/"
+      - "/pulp/api/v3/remotes/rpm/rpm/d9c75e34-c60b-4096-b7f8-57a9f22f3baf/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -264,32 +264,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1b0e67f4055a4a0eb9b8c7a03c5ca1a9
+      - c7d9911bd10745beb454acaa114cff8d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk4
-        MWQxNzhhLTUzZGYtNDk1Yy1hOTc2LWNiMDE1ZTc4ODVkNi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI4OjQ5LjAzMDc4NloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q5
+        Yzc1ZTM0LWM2MGItNDA5Ni1iN2Y4LTU3YTlmMjJmM2JhZi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjMyLjc3MTcyNloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI4OjQ5LjAzMDgwNVoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjMyLjc3MTc1MloiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:49 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:32 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -299,7 +299,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -312,13 +312,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:49 GMT
+      - Tue, 19 Jul 2022 18:46:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/13218c8e-2543-4566-8767-addb620163a0/"
+      - "/pulp/api/v3/repositories/rpm/rpm/8a9b6a9a-207d-429b-812a-d80d0d69b0cf/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -332,22 +332,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2ca985d956054b5abb245be018d10c35
+      - a772ee99c33c471599edeb5c384e082d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMTMyMThjOGUtMjU0My00NTY2LTg3NjctYWRkYjYyMDE2M2EwLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6NDkuMTYzNDU0WiIsInZl
+        cG0vOGE5YjZhOWEtMjA3ZC00MjliLTgxMmEtZDgwZDBkNjliMGNmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6MzMuMDUzNzA1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMTMyMThjOGUtMjU0My00NTY2LTg3NjctYWRkYjYyMDE2M2EwL3ZlcnNp
+        cG0vOGE5YjZhOWEtMjA3ZC00MjliLTgxMmEtZDgwZDBkNjliMGNmL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xMzIxOGM4ZS0y
-        NTQzLTQ1NjYtODc2Ny1hZGRiNjIwMTYzYTAvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84YTliNmE5YS0y
+        MDdkLTQyOWItODEyYS1kODBkMGQ2OWIwY2YvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -356,21 +356,21 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:49 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:33 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMTMyMThjOGUtMjU0My00NTY2LTg3NjctYWRkYjYyMDE2
-        M2EwL3ZlcnNpb25zLzAvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vOGE5YjZhOWEtMjA3ZC00MjliLTgxMmEtZDgwZDBkNjli
+        MGNmL3ZlcnNpb25zLzAvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -383,7 +383,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:49 GMT
+      - Tue, 19 Jul 2022 18:46:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -401,21 +401,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8ab5f2d268ee428b81405a75d931bc2c
+      - 2540ca921ea74b83be4c617909995858
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFlYmE3ODZmLTIxZGUtNGJk
-        OC05Njg5LWNmNmUwNmUxZTg2ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlhOWM0YTE5LTgxNjItNGJj
+        OS05OTljLTIyOTVmOTU2MTkxYi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:49 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/1eba786f-21de-4bd8-9689-cf6e06e1e86d/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/9a9c4a19-8162-4bc9-999c-2295f956191b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -436,7 +436,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:49 GMT
+      - Tue, 19 Jul 2022 18:46:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -452,40 +452,40 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b08f637805714856a697a404d3521eaa
+      - 988dc2a9cc8444cab6292f967d5716f0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '476'
+      - '477'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWViYTc4NmYtMjFk
-        ZS00YmQ4LTk2ODktY2Y2ZTA2ZTFlODZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NDkuNTgzNjA1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWE5YzRhMTktODE2
+        Mi00YmM5LTk5OWMtMjI5NWY5NTYxOTFiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6MzMuNTY3NDE3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjhhYjVmMmQyNjhlZTQyOGI4MTQwNWE3NWQ5
-        MzFiYzJjIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NDkuNjEz
-        NTk1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyODo0OS44NTk2
-        ODZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjI1NDBjYTkyMWVhNzRiODNiZTRjNjE3OTA5
+        OTk1ODU4Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6MzMuNjI4
+        MDc2WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0xOVQxODo0NjozMy43OTg3
+        MThaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzc0YzQwNzJhLTM2MjMtNDg0Mi04ZmFlLWU0YzQyMDA4OTliMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZmYyNmM1
-        NzItNDNmMC00OGYxLWE0ZjgtZmFlNDZiMThhMzE5LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vN2FlMzc4
+        ZGEtMGU5Ni00OWJlLWI2OGEtMTA0OTA3MDNiZmE0LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMTMyMThjOGUtMjU0My00NTY2LTg3NjctYWRkYjYy
-        MDE2M2EwLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vOGE5YjZhOWEtMjA3ZC00MjliLTgxMmEtZDgwZDBk
+        NjliMGNmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:49 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -493,7 +493,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -506,7 +506,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:49 GMT
+      - Tue, 19 Jul 2022 18:46:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -524,21 +524,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 84c119a496314b58a3cd221cc3555539
+      - e8baa79fae8d4ea1b052bed352e51e90
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:49 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:33 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/ff26c572-43f0-48f1-a4f8-fae46b18a319/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/7ae378da-0e96-49be-b68a-10490703bfa4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -546,7 +546,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -559,7 +559,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:50 GMT
+      - Tue, 19 Jul 2022 18:46:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -575,44 +575,44 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - babe333792fa45b8ba9b603c4cb36ad6
+      - d4fdcb857cba4c94a55df5b508b9eb8f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
       - '249'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vZmYyNmM1NzItNDNmMC00OGYxLWE0ZjgtZmFlNDZiMThhMzE5LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6NDkuNjM2MzgxWiIsInJl
+        cG0vN2FlMzc4ZGEtMGU5Ni00OWJlLWI2OGEtMTA0OTA3MDNiZmE0LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6MzMuNjUzODg2WiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xMzIxOGM4ZS0yNTQzLTQ1NjYtODc2Ny1hZGRiNjIwMTYzYTAv
+        cnBtL3JwbS84YTliNmE5YS0yMDdkLTQyOWItODEyYS1kODBkMGQ2OWIwY2Yv
         dmVyc2lvbnMvMC8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzEzMjE4YzhlLTI1NDMtNDU2Ni04NzY3LWFkZGI2
-        MjAxNjNhMC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtLzhhOWI2YTlhLTIwN2QtNDI5Yi04MTJhLWQ4MGQw
+        ZDY5YjBjZi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:50 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:33 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vZmYyNmM1NzItNDNmMC00OGYxLWE0ZjgtZmFl
-        NDZiMThhMzE5LyJ9
+        bGljYXRpb25zL3JwbS9ycG0vN2FlMzc4ZGEtMGU5Ni00OWJlLWI2OGEtMTA0
+        OTA3MDNiZmE0LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -625,7 +625,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:50 GMT
+      - Tue, 19 Jul 2022 18:46:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -643,21 +643,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e462e7276b604dfbb98902903dca2ff7
+      - 44648c9bc020483ea6c42833562d630a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MxZTg0ZjhjLTQyMzAtNGQ2
-        Ny05Nzc2LWNjYWIzZjk2NjQwZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA5ZTViNzIxLTU2NTAtNDZk
+        NS05NzMyLTkyMDdjMTMxYzBiNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:50 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c1e84f8c-4230-4d67-9776-ccab3f96640f/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/09e5b721-5650-46d5-9732-9207c131c0b5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -678,7 +678,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:50 GMT
+      - Tue, 19 Jul 2022 18:46:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -694,36 +694,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a56f3d9aa2da4bb2affe1256ecf9f2a7
+      - 5be57bd833664d129fd48317f12ae0b9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '381'
+      - '378'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzFlODRmOGMtNDIz
-        MC00ZDY3LTk3NzYtY2NhYjNmOTY2NDBmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NTAuMDcwNTcyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDllNWI3MjEtNTY1
+        MC00NmQ1LTk3MzItOTIwN2MxMzFjMGI1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6MzQuMDA1MTc5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwibG9nZ2luZ19jaWQiOiJlNDYyZTcyNzZiNjA0ZGZiYjk4OTAyOTAz
-        ZGNhMmZmNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjUwLjEy
-        NTgwM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NTAuMzc2
-        ODcwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI0NDY0OGM5YmMwMjA0ODNlYTZjNDI4MzM1
+        NjJkNjMwYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM0LjA0
+        NzU3MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6MzQuMTc5
+        Nzc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8zNjAxYmE4OC1hYzM2LTQwNzctYjhhNC04YTA3ODlmYzJkOGMvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vZmNl
-        ZjE1NDctMTFhMy00MTUzLWFmNTYtNGQyNWMxM2E5MzNhLyJdLCJyZXNlcnZl
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vYzg0
+        NzJlMzUtOGFjZi00MTQ2LWIzN2ItODc5MTU5Njk5ZTBiLyJdLCJyZXNlcnZl
         ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
         XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:50 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/fcef1547-11a3-4153-af56-4d25c13a933a/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/c8472e35-8acf-4146-b37b-879159699e0b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -731,7 +731,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -744,7 +744,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:50 GMT
+      - Tue, 19 Jul 2022 18:46:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -760,32 +760,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5cb19dd3b034462d96fd43a1587acec1
+      - 758b0d954dc249cdb9c6ef75b1e0d773
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '308'
+      - '300'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtL2ZjZWYxNTQ3LTExYTMtNDE1My1hZjU2LTRkMjVjMTNhOTMzYS8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI4OjUwLjM2MjI0OVoiLCJi
+        cnBtL2M4NDcyZTM1LThhY2YtNDE0Ni1iMzdiLTg3OTE1OTY5OWUwYi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM0LjE2Mjk5M1oiLCJi
         YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
-        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
-        ZWxsby1kZXZlbC5tYW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50
-        L0FDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFi
-        ZWwvIiwiY29udGVudF9ndWFyZCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJu
-        YW1lIjoiMl9kdXBsaWNhdGUiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNh
-        dGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS9mZjI2
-        YzU3Mi00M2YwLTQ4ZjEtYTRmOC1mYWU0NmIxOGEzMTkvIn0=
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL3phbnppYmFyLmxh
+        Z3JhbmdlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01FX0NvcnBvcmF0
+        aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIsImNvbnRlbnRf
+        Z3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGlj
+        YXRlIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9h
+        cGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vN2FlMzc4ZGEtMGU5Ni00OWJl
+        LWI2OGEtMTA0OTA3MDNiZmE0LyJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:50 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:34 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/981d178a-53df-495c-a976-cb015e7885d6/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/d9c75e34-c60b-4096-b7f8-57a9f22f3baf/
     body:
       encoding: UTF-8
       base64_string: |
@@ -802,7 +802,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -815,7 +815,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:50 GMT
+      - Tue, 19 Jul 2022 18:46:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -833,21 +833,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1b180627e8824791975afdca2c5d1190
+      - 5a60bd0c2b404e648cf3e8cfd3884c53
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc5YzQ1YjQ1LTE2YWMtNDAz
-        Mi1hNmY1LTk1OWMzZTk3NmJhZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I4ZWM4YjIxLTAyNzMtNGRk
+        MC04YTFkLTFjMjYxZjNlMjgzZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:50 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/79c45b45-16ac-4032-a6f5-959c3e976bae/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/b8ec8b21-0273-4dd0-8a1d-1c261f3e283f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -868,7 +868,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:50 GMT
+      - Tue, 19 Jul 2022 18:46:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -884,47 +884,47 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b85a7fae2c754426baeede49ee224499
+      - 6abc6bf3adc140c481b0d3eefa0ce07d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '373'
+      - '371'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzljNDViNDUtMTZh
-        Yy00MDMyLWE2ZjUtOTU5YzNlOTc2YmFlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NTAuODIwMzIzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjhlYzhiMjEtMDI3
+        My00ZGQwLThhMWQtMWMyNjFmM2UyODNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6MzQuNjYyMDg2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIxYjE4MDYyN2U4ODI0NzkxOTc1YWZkY2Ey
-        YzVkMTE5MCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjUwLjg1
-        MDE3OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NTAuODc0
-        ODU0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI1YTYwYmQwYzJiNDA0ZTY0OGNmM2U4Y2Zk
+        Mzg4NGM1MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM0Ljcw
+        ODU0MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6MzQuNzQz
+        ODg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81MWI3NmQzNS1hYTBhLTQ0OTMtYmVlNS0xZTdlZTJmZmVjMTQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk4MWQxNzhhLTUzZGYtNDk1Yy1hOTc2
-        LWNiMDE1ZTc4ODVkNi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q5Yzc1ZTM0LWM2MGItNDA5Ni1iN2Y4
+        LTU3YTlmMjJmM2JhZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:50 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:34 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/13218c8e-2543-4566-8767-addb620163a0/sync/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/8a9b6a9a-207d-429b-812a-d80d0d69b0cf/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk4MWQx
-        NzhhLTUzZGYtNDk1Yy1hOTc2LWNiMDE1ZTc4ODVkNi8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q5Yzc1
+        ZTM0LWM2MGItNDA5Ni1iN2Y4LTU3YTlmMjJmM2JhZi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -937,7 +937,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:51 GMT
+      - Tue, 19 Jul 2022 18:46:34 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -955,21 +955,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 218481349ed94fe9b40a1ac5c13b3e92
+      - 361862ffa31d4871bb268013e74376cd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MwMjc3ZTRjLWZhMWMtNDBl
-        OS04NTk4LWU2NmUzZmRjNGE2ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY4ZWMxOGVjLTQwNWYtNDVk
+        Ny1iZDYwLWZjZjEyODA5YWEzNy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:51 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:34 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c0277e4c-fa1c-40e9-8598-e66e3fdc4a6d/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/68ec18ec-405f-45d7-bd60-fcf12809aa37/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -990,7 +990,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:52 GMT
+      - Tue, 19 Jul 2022 18:46:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1006,66 +1006,66 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b6d206055b774641872e7bd579d5f15a
+      - 23cd266e725d460db923ed7c7026b353
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '600'
+      - '606'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzAyNzdlNGMtZmEx
-        Yy00MGU5LTg1OTgtZTY2ZTNmZGM0YTZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NTAuOTk1OTAwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjhlYzE4ZWMtNDA1
+        Zi00NWQ3LWJkNjAtZmNmMTI4MDlhYTM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6MzQuODQzMTUwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIyMTg0ODEzNDllZDk0ZmU5YjQw
-        YTFhYzVjMTNiM2U5MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjUxLjAzNzQ4N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        NTIuNjE4NDE3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIzNjE4NjJmZmEzMWQ0ODcxYmIy
+        NjgwMTNlNzQzNzZjZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2
+        OjM0Ljg4MzM0N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6
+        MzYuODY3ODEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8zNjAxYmE4OC1hYzM2LTQwNzctYjhhNC04YTA3ODlmYzJk
+        OGMvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
-        IjpudWxsLCJkb25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
-        d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
-        LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
-        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
-        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
-        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
-        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
-        InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMTMyMThjOGUtMjU0My00NTY2LTg3Njct
-        YWRkYjYyMDE2M2EwL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        LzEzMjE4YzhlLTI1NDMtNDU2Ni04NzY3LWFkZGI2MjAxNjNhMC8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS85ODFkMTc4YS01M2Rm
-        LTQ5NWMtYTk3Ni1jYjAxNWU3ODg1ZDYvIl19
+        IjpudWxsLCJkb25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
+        cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozMiwiZG9uZSI6MzIsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIEFkdmlzb3JpZXMiLCJj
+        b2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3JpZXMiLCJzdGF0ZSI6ImNvbXBs
+        ZXRlZCIsInRvdGFsIjo0LCJkb25lIjo0LCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRv
+        d25sb2FkaW5nLmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
+        IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGlu
+        Zy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwi
+        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGlu
+        ZyBDb250ZW50IiwiY29kZSI6ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjozNiwic3VmZml4
+        IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvcnBtL3JwbS84YTliNmE5YS0yMDdkLTQyOWItODEyYS1k
+        ODBkMGQ2OWIwY2YvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
+        X3JlY29yZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0v
+        OGE5YjZhOWEtMjA3ZC00MjliLTgxMmEtZDgwZDBkNjliMGNmLyIsInNoYXJl
+        ZDovcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q5Yzc1ZTM0LWM2MGIt
+        NDA5Ni1iN2Y4LTU3YTlmMjJmM2JhZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:52 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:36 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMTMyMThjOGUtMjU0My00NTY2LTg3NjctYWRkYjYyMDE2
-        M2EwL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vOGE5YjZhOWEtMjA3ZC00MjliLTgxMmEtZDgwZDBkNjli
+        MGNmL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1078,7 +1078,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:52 GMT
+      - Tue, 19 Jul 2022 18:46:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1096,21 +1096,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e19f227ad4b140f38d2c206fc961e925
+      - f38c46343c2444968b5dfadee8e6eae5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M2MmRjNmQwLTQ1NmEtNDhj
-        Zi04MDFhLTExMTAwMGYwOGQwZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I4M2EyMTAxLTAzZDItNDJl
+        MC04MzNhLTc2Y2M2ZmNhYmY0ZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:52 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c62dc6d0-456a-48cf-801a-111000f08d0e/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/b83a2101-03d2-42e0-833a-76cc6fcabf4e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:53 GMT
+      - Tue, 19 Jul 2022 18:46:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1147,40 +1147,40 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 76787e613e354a1aa7e9f9fac07b4fc7
+      - 16808aaecb704737bc0dc49a91a69969
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '475'
+      - '476'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzYyZGM2ZDAtNDU2
-        YS00OGNmLTgwMWEtMTExMDAwZjA4ZDBlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NTIuNzYwODk1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjgzYTIxMDEtMDNk
+        Mi00MmUwLTgzM2EtNzZjYzZmY2FiZjRlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6MzcuMDQ2NjA3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImUxOWYyMjdhZDRiMTQwZjM4ZDJjMjA2ZmM5
-        NjFlOTI1Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NTIuNzk1
-        NDUwWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyODo1My4wNzgw
-        NjRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2I3NjM4MThmLTAzOTItNGZlMS1hZWRhLTY1M2ZkMWExMWNkOS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImYzOGM0NjM0M2MyNDQ0OTY4YjVkZmFkZWU4
+        ZTZlYWU1Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6MzcuMDg1
+        MTg2WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0xOVQxODo0NjozNy4yNzU5
+        OThaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzUxYjc2ZDM1LWFhMGEtNDQ5My1iZWU1LTFlN2VlMmZmZWMxNC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOGVmZDA5
-        ZWQtZDNmYS00YTNlLWEzMjgtZWY2YTlkMTFjMjBlLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYTAxZWM4
+        MjktMmQyMy00OTViLWIzOTEtZGRjMDc2ZGQ1MzBlLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vMTMyMThjOGUtMjU0My00NTY2LTg3NjctYWRkYjYy
-        MDE2M2EwLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vOGE5YjZhOWEtMjA3ZC00MjliLTgxMmEtZDgwZDBk
+        NjliMGNmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:53 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1188,7 +1188,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1201,7 +1201,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:53 GMT
+      - Tue, 19 Jul 2022 18:46:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1217,33 +1217,33 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9b9a0d8f8b3d429dbe4cca787a16d951
+      - 859982da86884680ace8bf2e7b91a2fe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '338'
+      - '330'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vZmNlZjE1NDctMTFhMy00MTUzLWFmNTYtNGQyNWMxM2E5MzNh
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6NTAuMzYyMjQ5
+        L3JwbS9ycG0vYzg0NzJlMzUtOGFjZi00MTQ2LWIzN2ItODc5MTU5Njk5ZTBi
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6MzQuMTYyOTkz
         WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
-        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
-        OC1rYXRlbGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9wdWxwL2Nv
-        bnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0
-        ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6
-        e30sIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInJlcG9zaXRvcnkiOm51bGwsInB1
-        YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBt
-        L2ZmMjZjNTcyLTQzZjAtNDhmMS1hNGY4LWZhZTQ2YjE4YTMxOS8ifV19
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vemFuemli
+        YXIubGFncmFuZ2UuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0FDTUVfQ29y
+        cG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwvIiwiY29u
+        dGVudF9ndWFyZCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJuYW1lIjoiMl9k
+        dXBsaWNhdGUiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6Ii9w
+        dWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS83YWUzNzhkYS0wZTk2
+        LTQ5YmUtYjY4YS0xMDQ5MDcwM2JmYTQvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:53 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/8efd09ed-d3fa-4a3e-a328-ef6a9d11c20e/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/a01ec829-2d23-495b-b391-ddc076dd530e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1251,7 +1251,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1264,7 +1264,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:53 GMT
+      - Tue, 19 Jul 2022 18:46:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1280,43 +1280,43 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c36488d586eb48e9b8df3535b679e993
+      - ce9e4fa7350649b18278d1724b67a261
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
       - '249'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vOGVmZDA5ZWQtZDNmYS00YTNlLWEzMjgtZWY2YTlkMTFjMjBlLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6NTIuODE0MjU5WiIsInJl
+        cG0vYTAxZWM4MjktMmQyMy00OTViLWIzOTEtZGRjMDc2ZGQ1MzBlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6MzcuMTA1MzczWiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xMzIxOGM4ZS0yNTQzLTQ1NjYtODc2Ny1hZGRiNjIwMTYzYTAv
+        cnBtL3JwbS84YTliNmE5YS0yMDdkLTQyOWItODEyYS1kODBkMGQ2OWIwY2Yv
         dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzEzMjE4YzhlLTI1NDMtNDU2Ni04NzY3LWFkZGI2
-        MjAxNjNhMC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtLzhhOWI2YTlhLTIwN2QtNDI5Yi04MTJhLWQ4MGQw
+        ZDY5YjBjZi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:53 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:37 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/fcef1547-11a3-4153-af56-4d25c13a933a/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/c8472e35-8acf-4146-b37b-879159699e0b/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
-        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOGVm
-        ZDA5ZWQtZDNmYS00YTNlLWEzMjgtZWY2YTlkMTFjMjBlLyJ9
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYTAx
+        ZWM4MjktMmQyMy00OTViLWIzOTEtZGRjMDc2ZGQ1MzBlLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1329,7 +1329,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:53 GMT
+      - Tue, 19 Jul 2022 18:46:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1347,21 +1347,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 495336b80150430cb7c93a3a1a22d820
+      - 3cf9803999c64252b82640567e9ca37d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE1Mjg5NmY4LTZlNTMtNGNh
-        NS05ODZhLTFhNDczMWQyZGM3Yy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM1MjQ3YzAyLWU5YzItNDE3
+        Zi1hZTg1LWNjMzY2YWRlZjlmOC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:53 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/152896f8-6e53-4ca5-986a-1a4731d2dc7c/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/35247c02-e9c2-417f-ae85-cc366adef9f8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1382,7 +1382,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:53 GMT
+      - Tue, 19 Jul 2022 18:46:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1398,34 +1398,34 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d0fd4f07c2d7418ab464cdc2f15a8d42
+      - f9ff355ae0614f78b5622199ac771230
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '347'
+      - '346'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTUyODk2ZjgtNmU1
-        My00Y2E1LTk4NmEtMWE0NzMxZDJkYzdjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NTMuMjk3MjUxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzUyNDdjMDItZTlj
+        Mi00MTdmLWFlODUtY2MzNjZhZGVmOWY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6MzcuNTIzMDM1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI0OTUzMzZiODAxNTA0MzBjYjdjOTNhM2Ex
-        YTIyZDgyMCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjUzLjMy
-        NzgyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NTMuNTYw
-        ODkwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIzY2Y5ODAzOTk5YzY0MjUyYjgyNjQwNTY3
+        ZTljYTM3ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM3LjU1
+        OTU3OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6MzcuNjc2
+        MTA0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81MWI3NmQzNS1hYTBhLTQ0OTMtYmVlNS0xZTdlZTJmZmVjMTQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
         L2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:53 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:37 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/8efd09ed-d3fa-4a3e-a328-ef6a9d11c20e/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/a01ec829-2d23-495b-b391-ddc076dd530e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1433,7 +1433,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1446,7 +1446,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:53 GMT
+      - Tue, 19 Jul 2022 18:46:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1462,43 +1462,43 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cd6489fb52f24e8fb409052338f8968d
+      - c03b889da9474bf896f8636269016be5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
       - '249'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vOGVmZDA5ZWQtZDNmYS00YTNlLWEzMjgtZWY2YTlkMTFjMjBlLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6NTIuODE0MjU5WiIsInJl
+        cG0vYTAxZWM4MjktMmQyMy00OTViLWIzOTEtZGRjMDc2ZGQ1MzBlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6MzcuMTA1MzczWiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8xMzIxOGM4ZS0yNTQzLTQ1NjYtODc2Ny1hZGRiNjIwMTYzYTAv
+        cnBtL3JwbS84YTliNmE5YS0yMDdkLTQyOWItODEyYS1kODBkMGQ2OWIwY2Yv
         dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzEzMjE4YzhlLTI1NDMtNDU2Ni04NzY3LWFkZGI2
-        MjAxNjNhMC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtLzhhOWI2YTlhLTIwN2QtNDI5Yi04MTJhLWQ4MGQw
+        ZDY5YjBjZi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:53 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:37 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/fcef1547-11a3-4153-af56-4d25c13a933a/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/c8472e35-8acf-4146-b37b-879159699e0b/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
-        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOGVm
-        ZDA5ZWQtZDNmYS00YTNlLWEzMjgtZWY2YTlkMTFjMjBlLyJ9
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYTAx
+        ZWM4MjktMmQyMy00OTViLWIzOTEtZGRjMDc2ZGQ1MzBlLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1511,7 +1511,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:53 GMT
+      - Tue, 19 Jul 2022 18:46:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1529,30 +1529,30 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c0b03742e6224c17835906c90d7ff0eb
+      - 2c24633c5252466fb4b9ce7a097b498e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhkZmZhYTAxLWVlMWUtNGRm
-        Zi05YzdiLWFlOGEzY2I5Yzk0MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MwZmFlYTY5LWJlODMtNGJm
+        MS04OWE5LTRkMThjN2I2ZDY5ZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:53 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:37 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/exporters/core/pulp/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/
     body:
       encoding: UTF-8
       base64_string: |
         eyJuYW1lIjoiRW1wdHlfT3JnYW5pemF0aW9uX0FDTUVfRGVmYXVsdF9Db250
         ZW50Vmlld18xLjAiLCJwYXRoIjoiL3Zhci9saWIvcHVscC9leHBvcnRzL0Vt
-        cHR5X09yZ2FuaXphdGlvbi9BQ01FX0RlZmF1bHRfQ29udGVudFZpZXcvMS4w
+        cHR5X09yZ2FuaXphdGlvbi9BQ01FIERlZmF1bHQgQ29udGVudFZpZXcvMS4w
         L2RyZWFtLWRlc3RpbmF0aW9uL2RhdGVfZGlyIiwicmVwb3NpdG9yaWVzIjpb
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8xMzIxOGM4ZS0y
-        NTQzLTQ1NjYtODc2Ny1hZGRiNjIwMTYzYTAvIl19
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84YTliNmE5YS0y
+        MDdkLTQyOWItODEyYS1kODBkMGQ2OWIwY2YvIl19
     headers:
       Content-Type:
       - application/json
@@ -1570,13 +1570,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:53 GMT
+      - Tue, 19 Jul 2022 18:46:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/exporters/core/pulp/d0993cbc-cdc1-4b2f-b34d-ce4f30c85add/"
+      - "/pulp/api/v3/exporters/core/pulp/f7e17d0b-69eb-4fcc-841c-c73644f9052a/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1590,28 +1590,28 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3b02fcccc6824d8cb7c49931ffc55f3b
+      - 4561345e503c49cdac687cebff3f090f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
-        cC9kMDk5M2NiYy1jZGMxLTRiMmYtYjM0ZC1jZTRmMzBjODVhZGQvIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyODo1My44NzQ0MDNaIiwibmFt
+        cC9mN2UxN2QwYi02OWViLTRmY2MtODQxYy1jNzM2NDRmOTA1MmEvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMi0wNy0xOVQxODo0NjozOC4wMDAzODFaIiwibmFt
         ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
         ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
-        cmdhbml6YXRpb24vQUNNRV9EZWZhdWx0X0NvbnRlbnRWaWV3LzEuMC9kcmVh
+        cmdhbml6YXRpb24vQUNNRSBEZWZhdWx0IENvbnRlbnRWaWV3LzEuMC9kcmVh
         bS1kZXN0aW5hdGlvbi9kYXRlX2RpciIsInJlcG9zaXRvcmllcyI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTMyMThjOGUtMjU0My00
-        NTY2LTg3NjctYWRkYjYyMDE2M2EwLyJdLCJsYXN0X2V4cG9ydCI6bnVsbH0=
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOGE5YjZhOWEtMjA3ZC00
+        MjliLTgxMmEtZDgwZDBkNjliMGNmLyJdLCJsYXN0X2V4cG9ydCI6bnVsbH0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:53 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/exporters/core/pulp/d0993cbc-cdc1-4b2f-b34d-ce4f30c85add/exports/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/f7e17d0b-69eb-4fcc-841c-c73644f9052a/exports/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1632,7 +1632,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:54 GMT
+      - Tue, 19 Jul 2022 18:46:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1650,21 +1650,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a97c76d6d3f245819afddfacce6efb06
+      - 8baf9ccd05d54747b10ea321ee5461cd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:54 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/exporters/core/pulp/d0993cbc-cdc1-4b2f-b34d-ce4f30c85add/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/f7e17d0b-69eb-4fcc-841c-c73644f9052a/
     body:
       encoding: UTF-8
       base64_string: 'eyJsYXN0X2V4cG9ydCI6bnVsbH0=
@@ -1687,7 +1687,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:54 GMT
+      - Tue, 19 Jul 2022 18:46:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1705,21 +1705,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e5f940c5fbd34573bf9391c4fe3da181
+      - 25b2c2da63c049cab49b7c6b3f7e1006
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJhZDAxYTZhLThmMWItNDk2
-        NC1iNmJmLWFmYjk1YWM2NjRjNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmMDc1ZGM5LTYyNDMtNGJh
+        ZS1hYzk0LTk4OTE1ZTc4MTAxYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:54 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/exporters/core/pulp/d0993cbc-cdc1-4b2f-b34d-ce4f30c85add/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/f7e17d0b-69eb-4fcc-841c-c73644f9052a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1740,7 +1740,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:54 GMT
+      - Tue, 19 Jul 2022 18:46:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1758,21 +1758,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fe06df608d9c45ae99faadd1bd5f40a6
+      - 71e0d82dfcd14fc9bac4e80800cee143
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM4NzExOTMwLWM0NjItNDBl
-        Ny05MmE1LWQwZDkzM2JjMzU3NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E2NWYwOWNiLTk1ZWQtNDNh
+        OC1hMzRlLWY5MzY5MTJjYmZkZi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:54 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/38711930-c462-40e7-92a5-d0d933bc3575/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/a65f09cb-95ed-43a8-a34e-f936912cbfdf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1793,7 +1793,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:54 GMT
+      - Tue, 19 Jul 2022 18:46:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1809,35 +1809,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a29e96fe28b84e04b4f4cf8aa2db2c3c
+      - ab239fc66dfe4d4bb2bf224f13a0d067
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '371'
+      - '370'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzg3MTE5MzAtYzQ2
-        Mi00MGU3LTkyYTUtZDBkOTMzYmMzNTc1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NTQuMDk0MTk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTY1ZjA5Y2ItOTVl
+        ZC00M2E4LWEzNGUtZjkzNjkxMmNiZmRmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6MzguMjcxNDU2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJmZTA2ZGY2MDhkOWM0NWFlOTlmYWFkZDFi
-        ZDVmNDBhNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjU0LjEy
-        NjUwN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NTQuMTU1
-        NTAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI3MWUwZDgyZGZjZDE0ZmM5YmFjNGU4MDgw
+        MGNlZTE0MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM4LjMy
+        Mjg0N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6MzguMzUw
+        NjEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy83NGM0MDcyYS0zNjIzLTQ4NDItOGZhZS1lNGM0MjAwODk5YjAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVscC9kMDk5M2NiYy1jZGMxLTRiMmYt
-        YjM0ZC1jZTRmMzBjODVhZGQvIl19
+        cGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVscC9mN2UxN2QwYi02OWViLTRmY2Mt
+        ODQxYy1jNzM2NDRmOTA1MmEvIl19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:54 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/981d178a-53df-495c-a976-cb015e7885d6/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/d9c75e34-c60b-4096-b7f8-57a9f22f3baf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1845,7 +1845,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1858,7 +1858,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:54 GMT
+      - Tue, 19 Jul 2022 18:46:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1876,21 +1876,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0d73a94bcfc74cf7a0100e4cc7cf51a7
+      - 5dda6d3013f44dbeb38dcc45d6082c7e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMzODdmZmNjLTAxZDUtNGY3
-        Ni1hM2ZlLTBiYTJjZDFlNThkMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwZTM2MzllLWQ1NzEtNDBk
+        OS1iYzlhLWM4M2QzOWQ3YzM0Yi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:54 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/3387ffcc-01d5-4f76-a3fe-0ba2cd1e58d1/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/90e3639e-d571-40d9-bc9a-c83d39d7c34b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1911,7 +1911,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:54 GMT
+      - Tue, 19 Jul 2022 18:46:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1927,35 +1927,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6089e72f48fc44248846008751d28f99
+      - 918cc0f839564890b3d416d4efe4b20d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '371'
+      - '372'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzM4N2ZmY2MtMDFk
-        NS00Zjc2LWEzZmUtMGJhMmNkMWU1OGQxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NTQuMzc2OTIwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTBlMzYzOWUtZDU3
+        MS00MGQ5LWJjOWEtYzgzZDM5ZDdjMzRiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6MzguNjM1MzE4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIwZDczYTk0YmNmYzc0Y2Y3YTAxMDBlNGNj
-        N2NmNTFhNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjU0LjQw
-        ODc1M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NTQuNDUw
-        NjQ0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1ZGRhNmQzMDEzZjQ0ZGJlYjM4ZGNjNDVk
+        NjA4MmM3ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM4LjY3
+        Njc1M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6MzguNzE2
+        MzU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81MWI3NmQzNS1hYTBhLTQ0OTMtYmVlNS0xZTdlZTJmZmVjMTQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzk4MWQxNzhhLTUzZGYtNDk1Yy1hOTc2
-        LWNiMDE1ZTc4ODVkNi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q5Yzc1ZTM0LWM2MGItNDA5Ni1iN2Y4
+        LTU3YTlmMjJmM2JhZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:54 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/fcef1547-11a3-4153-af56-4d25c13a933a/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/c8472e35-8acf-4146-b37b-879159699e0b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1963,7 +1963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1976,7 +1976,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:54 GMT
+      - Tue, 19 Jul 2022 18:46:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1994,21 +1994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 21177bfc4fda42de89196bb392d1ae8e
+      - 8008c477d64148658e03f5b1b636a4e3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI4ODY1YTYyLWFhZGMtNDcz
-        Mi1hYWZkLTNjMWNiZmU3MjdjYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk3OWU4MTc4LTMyYTMtNDkz
+        YS1hOGQzLTdmNWUwODY0ZDkyZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:54 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/13218c8e-2543-4566-8767-addb620163a0/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/8a9b6a9a-207d-429b-812a-d80d0d69b0cf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2016,7 +2016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2029,7 +2029,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:54 GMT
+      - Tue, 19 Jul 2022 18:46:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2047,21 +2047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 65aacee0bcaf4822a20050e86a57edcd
+      - 6825933e0b794973af954428e3fd3679
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzExYTg1M2EyLTFhMGEtNGU0
-        NC1iOWJhLWExZjc2ZDFlNjJkYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFiMzAwOWFkLTBlYmUtNGZl
+        Zi1hYTQxLWE0ZWIwMTc2ZTlhMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:54 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/11a853a2-1a0a-4e44-b9ba-a1f76d1e62db/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/1b3009ad-0ebe-4fef-aa41-a4eb0176e9a2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2082,7 +2082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:54 GMT
+      - Tue, 19 Jul 2022 18:46:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2098,30 +2098,30 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 83c63d58159a445284d13f3c725f189f
+      - 3d441dd88ff2488db2ff2922397da5dd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '373'
+      - '375'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTFhODUzYTItMWEw
-        YS00ZTQ0LWI5YmEtYTFmNzZkMWU2MmRiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NTQuNjIwMzU1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWIzMDA5YWQtMGVi
+        ZS00ZmVmLWFhNDEtYTRlYjAxNzZlOWEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6MzguODg0Nzk3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2NWFhY2VlMGJjYWY0ODIyYTIwMDUwZTg2
-        YTU3ZWRjZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjU0LjY2
-        MDI0M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NTQuOTAy
-        ODM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI2ODI1OTMzZTBiNzk0OTczYWY5NTQ0Mjhl
+        M2ZkMzY3OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM4Ljky
+        NTQyNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6MzkuMDU1
+        NjcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81MWI3NmQzNS1hYTBhLTQ0OTMtYmVlNS0xZTdlZTJmZmVjMTQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMTMyMThjOGUtMjU0My00NTY2
-        LTg3NjctYWRkYjYyMDE2M2EwLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOGE5YjZhOWEtMjA3ZC00Mjli
+        LTgxMmEtZDgwZDBkNjliMGNmLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:54 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:39 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/katello/content_view_version/export/destroy_exporter.yml
+++ b/test/fixtures/vcr_cassettes/actions/katello/content_view_version/export/destroy_exporter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,127 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:41 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - d3073345a21741a0b0ffcde741a82887
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '315'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iNWM5YjdkNi0xZGVlLTQ3NDctYmNkNi0xZTVhZGViZmM3OGYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyODoyMC4wMjA1Mzla
-        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9iNWM5YjdkNi0xZGVlLTQ3NDctYmNkNi0xZTVhZGViZmM3OGYv
-        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2I1Yzli
-        N2Q2LTFkZWUtNDc0Ny1iY2Q2LTFlNWFkZWJmYzc4Zi92ZXJzaW9ucy8xLyIs
-        Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
-        aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
-        bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
-        cmV0YWluX3BhY2thZ2VfdmVyc2lvbnMiOjAsIm1ldGFkYXRhX2NoZWNrc3Vt
-        X3R5cGUiOm51bGwsInBhY2thZ2VfY2hlY2tzdW1fdHlwZSI6bnVsbCwiZ3Bn
-        Y2hlY2siOjAsInJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6
-        ZmFsc2V9XX0=
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:41 GMT
-- request:
-    method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/b5c9b7d6-1dee-4747-bcd6-1e5adebfc78f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:28:41 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - f879048a9f7847ecb8106eb5437d9d65
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MyYzU0M2RjLTcwMDQtNGUw
-        Ni05YjBiLTZhNzJiZDBkYzQ3ZC8ifQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:41 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:28:41 GMT
+      - Tue, 19 Jul 2022 18:46:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -161,21 +41,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - af561b91b0524bc2b0a0676e6b87b7f1
+      - a375aee550524352a5678c22fc4ff7fd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:41 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c2c543dc-7004-4e06-9b0b-6a72bd0dc47d/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -183,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -196,72 +76,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:41 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Correlation-Id:
-      - 49a5a998f7434371af030df4246c492e
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
-      Content-Length:
-      - '374'
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzJjNTQzZGMtNzAw
-        NC00ZTA2LTliMGItNmE3MmJkMGRjNDdkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NDEuMjUzNjA0WiIsInN0YXRlIjoiY29tcGxldGVk
-        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJmODc5MDQ4YTlmNzg0N2VjYjgxMDZlYjU0
-        MzdkOWQ2NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjQxLjI4
-        NjA3OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NDEuNTE2
-        NTkxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYjVjOWI3ZDYtMWRlZS00NzQ3
-        LWJjZDYtMWU1YWRlYmZjNzhmLyJdfQ==
-    http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:41 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 23 May 2022 23:28:41 GMT
+      - Tue, 19 Jul 2022 18:46:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -279,21 +94,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 211b4384f6e043d8a4e96a74f6f63d05
+      - a45839203efb45e8a06a37eb5c5ade1a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:41 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:39 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,7 +116,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -314,7 +129,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:41 GMT
+      - Tue, 19 Jul 2022 18:46:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -332,21 +147,74 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 556f407b36a846baac84c53d071af1b5
+      - 9903e684b6a449b890e539520cdce3c8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:41 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:39 GMT
+- request:
+    method: get
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.17.7/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 19 Jul 2022 18:46:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6412d1dc305341e0a8021fa8fbef9f77
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 zanzibar.lagrange.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 19 Jul 2022 18:46:39 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -363,7 +231,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -376,13 +244,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:41 GMT
+      - Tue, 19 Jul 2022 18:46:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/a0535d82-0ff4-4619-8485-ab17c881b84f/"
+      - "/pulp/api/v3/remotes/rpm/rpm/4db5798c-e6fb-446b-8f76-bb4d4a008b0c/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -396,32 +264,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e193b668e88740ebbc4a1bf5407573fb
+      - feb95e18a4fd45d8b42649311e653b54
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Ew
-        NTM1ZDgyLTBmZjQtNDYxOS04NDg1LWFiMTdjODgxYjg0Zi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI4OjQxLjg0MzExMVoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRk
+        YjU3OThjLWU2ZmItNDQ2Yi04Zjc2LWJiNGQ0YTAwOGIwYy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM5LjczOTU0N1oiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI4OjQxLjg0MzEzMFoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM5LjczOTU2MloiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:41 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:39 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -431,7 +299,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -444,13 +312,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:41 GMT
+      - Tue, 19 Jul 2022 18:46:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/a79c65b8-b812-41dd-b9e1-7a9b46dfbcbb/"
+      - "/pulp/api/v3/repositories/rpm/rpm/de0f7ea0-c0ff-4ce7-8556-79a297392853/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -464,22 +332,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - db738bbd1c7d4b339cf1b0d20be10d8b
+      - 5010307d8aac406c9ec4ea28159c3b86
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYTc5YzY1YjgtYjgxMi00MWRkLWI5ZTEtN2E5YjQ2ZGZiY2JiLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6NDEuOTg3MzU0WiIsInZl
+        cG0vZGUwZjdlYTAtYzBmZi00Y2U3LTg1NTYtNzlhMjk3MzkyODUzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6MzkuODkxNDk2WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYTc5YzY1YjgtYjgxMi00MWRkLWI5ZTEtN2E5YjQ2ZGZiY2JiL3ZlcnNp
+        cG0vZGUwZjdlYTAtYzBmZi00Y2U3LTg1NTYtNzlhMjk3MzkyODUzL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hNzljNjViOC1i
-        ODEyLTQxZGQtYjllMS03YTliNDZkZmJjYmIvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kZTBmN2VhMC1j
+        MGZmLTRjZTctODU1Ni03OWEyOTczOTI4NTMvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -488,21 +356,21 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:41 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:39 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vYTc5YzY1YjgtYjgxMi00MWRkLWI5ZTEtN2E5YjQ2ZGZi
-        Y2JiL3ZlcnNpb25zLzAvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vZGUwZjdlYTAtYzBmZi00Y2U3LTg1NTYtNzlhMjk3Mzky
+        ODUzL3ZlcnNpb25zLzAvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -515,7 +383,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:42 GMT
+      - Tue, 19 Jul 2022 18:46:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -533,21 +401,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a22a8ea98347418d94227adb6e1543f6
+      - 5ed5aace6adb4f48aa94b67c2508bead
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VmOTVhMzRjLWVhMWYtNDM5
-        OS05N2E5LWEwZmZlZWI1OWU2YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMzODU3NGE1LWRkNDUtNDEx
+        OS1hNTYzLTQ4M2U3OWZiYWU1Zi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:42 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/ef95a34c-ea1f-4399-97a9-a0ffeeb59e6a/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/338574a5-dd45-4119-a563-483e79fbae5f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -568,7 +436,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:42 GMT
+      - Tue, 19 Jul 2022 18:46:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -584,40 +452,40 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fd5eb6eb17804ea2a9b3403b580f4e9e
+      - 54349dd0896b458d838f646e5b480377
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '474'
+      - '477'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWY5NWEzNGMtZWEx
-        Zi00Mzk5LTk3YTktYTBmZmVlYjU5ZTZhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NDIuMjQyMzI5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzM4NTc0YTUtZGQ0
+        NS00MTE5LWE1NjMtNDgzZTc5ZmJhZTVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NDAuMjc1NTM1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImEyMmE4ZWE5ODM0NzQxOGQ5NDIyN2FkYjZl
-        MTU0M2Y2Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NDIuMjcz
-        NzA1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyODo0Mi41MDg1
-        MDlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjVlZDVhYWNlNmFkYjRmNDhhYTk0YjY3YzI1
+        MDhiZWFkIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDAuMzIw
+        NDIxWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0xOVQxODo0Njo0MC40Njk3
+        OTlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzBmMjMwNTg2LWIwNzUtNGE5NC1hY2QyLWFmNWE2NzMyOTQ1MS8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDdkMTU1
-        MjEtNWE3MC00OGEyLTk4MTItZjcyMGQ2OGI1NmFiLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNDUxNWFh
+        MTYtMjYwMS00YWM4LWIxNWYtYjIzZjc5MWI5ZGZlLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vYTc5YzY1YjgtYjgxMi00MWRkLWI5ZTEtN2E5YjQ2
-        ZGZiY2JiLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vZGUwZjdlYTAtYzBmZi00Y2U3LTg1NTYtNzlhMjk3
+        MzkyODUzLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:42 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -625,7 +493,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -638,7 +506,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:42 GMT
+      - Tue, 19 Jul 2022 18:46:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -656,21 +524,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9b0097bde4a7405fb415e9b32a3d4349
+      - f9c235a7352c4afbaf96ec8e0ef361b3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:42 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/07d15521-5a70-48a2-9812-f720d68b56ab/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/4515aa16-2601-4ac8-b15f-b23f791b9dfe/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -678,7 +546,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -691,7 +559,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:42 GMT
+      - Tue, 19 Jul 2022 18:46:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -707,44 +575,44 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6da466b486974b77aa9e26b6b7184948
+      - bfc8f34c980943bbbbfe505651c1621e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '249'
+      - '250'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDdkMTU1MjEtNWE3MC00OGEyLTk4MTItZjcyMGQ2OGI1NmFiLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6NDIuMjkyNDE0WiIsInJl
+        cG0vNDUxNWFhMTYtMjYwMS00YWM4LWIxNWYtYjIzZjc5MWI5ZGZlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDAuMzQzNTU0WiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9hNzljNjViOC1iODEyLTQxZGQtYjllMS03YTliNDZkZmJjYmIv
+        cnBtL3JwbS9kZTBmN2VhMC1jMGZmLTRjZTctODU1Ni03OWEyOTczOTI4NTMv
         dmVyc2lvbnMvMC8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2E3OWM2NWI4LWI4MTItNDFkZC1iOWUxLTdhOWI0
-        NmRmYmNiYi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtL2RlMGY3ZWEwLWMwZmYtNGNlNy04NTU2LTc5YTI5
+        NzM5Mjg1My8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:42 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:40 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vMDdkMTU1MjEtNWE3MC00OGEyLTk4MTItZjcy
-        MGQ2OGI1NmFiLyJ9
+        bGljYXRpb25zL3JwbS9ycG0vNDUxNWFhMTYtMjYwMS00YWM4LWIxNWYtYjIz
+        Zjc5MWI5ZGZlLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -757,7 +625,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:42 GMT
+      - Tue, 19 Jul 2022 18:46:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -775,21 +643,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f5b304b8e32f429591fcb66bd6ae3b27
+      - fa3693b073334d9eb566199147d7ae4e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M5YTRhZDFiLTJkYTMtNGZl
-        Mi1iZjdlLWQyNzRhZDc5ZDY5ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkZjQwNjA0LWQ2MGYtNGQy
+        Mi1hOTVjLWY0ZTdhODNkYmUwNS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:42 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c9a4ad1b-2da3-4fe2-bf7e-d274ad79d69d/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/2df40604-d60f-4d22-a95c-f4e7a83dbe05/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -810,7 +678,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:43 GMT
+      - Tue, 19 Jul 2022 18:46:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -826,36 +694,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 43b330f361a64b7f99e0f1ffde70a14f
+      - ec55dc713b254e4eaf6973d615506907
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '380'
+      - '378'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzlhNGFkMWItMmRh
-        My00ZmUyLWJmN2UtZDI3NGFkNzlkNjlkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NDIuNzM5MzEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmRmNDA2MDQtZDYw
+        Zi00ZDIyLWE5NWMtZjRlN2E4M2RiZTA1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NDAuNjkxMDM2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwibG9nZ2luZ19jaWQiOiJmNWIzMDRiOGUzMmY0Mjk1OTFmY2I2NmJk
-        NmFlM2IyNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjQyLjc5
-        NjI3NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NDMuMDM4
-        NzU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJmYTM2OTNiMDczMzM0ZDllYjU2NjE5OTE0
+        N2Q3YWU0ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQwLjcz
+        MjM4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDAuODU5
+        NjE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy83NGM0MDcyYS0zNjIzLTQ4NDItOGZhZS1lNGM0MjAwODk5YjAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vYjhi
-        MGFmNzUtZTIyYS00M2M2LThjNDUtNzRiNzlmYjRmZjM0LyJdLCJyZXNlcnZl
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMzdl
+        YjAxZDItZDMyNi00NjE5LTg2NzQtZDZhMjZmOWNlNGM2LyJdLCJyZXNlcnZl
         ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
         XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:43 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:40 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/b8b0af75-e22a-43c6-8c45-74b79fb4ff34/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/37eb01d2-d326-4619-8674-d6a26f9ce4c6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -863,7 +731,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -876,7 +744,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:43 GMT
+      - Tue, 19 Jul 2022 18:46:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -892,32 +760,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7b58df4e51f04fc993b237383e641468
+      - 2f8b4aa2c38f44429e37f98a4a7e3f49
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '309'
+      - '301'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtL2I4YjBhZjc1LWUyMmEtNDNjNi04YzQ1LTc0Yjc5ZmI0ZmYzNC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI4OjQzLjAyNDIyOFoiLCJi
+        cnBtLzM3ZWIwMWQyLWQzMjYtNDYxOS04Njc0LWQ2YTI2ZjljZTRjNi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQwLjg0NTczM1oiLCJi
         YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
-        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
-        ZWxsby1kZXZlbC5tYW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50
-        L0FDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFi
-        ZWwvIiwiY29udGVudF9ndWFyZCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJu
-        YW1lIjoiMl9kdXBsaWNhdGUiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNh
-        dGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wN2Qx
-        NTUyMS01YTcwLTQ4YTItOTgxMi1mNzIwZDY4YjU2YWIvIn0=
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL3phbnppYmFyLmxh
+        Z3JhbmdlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01FX0NvcnBvcmF0
+        aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIsImNvbnRlbnRf
+        Z3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGlj
+        YXRlIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9h
+        cGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNDUxNWFhMTYtMjYwMS00YWM4
+        LWIxNWYtYjIzZjc5MWI5ZGZlLyJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:43 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:40 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/a0535d82-0ff4-4619-8485-ab17c881b84f/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/4db5798c-e6fb-446b-8f76-bb4d4a008b0c/
     body:
       encoding: UTF-8
       base64_string: |
@@ -934,7 +802,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -947,7 +815,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:43 GMT
+      - Tue, 19 Jul 2022 18:46:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -965,21 +833,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9245232546284d65901f3158146579c8
+      - 00eee17411114703b33e16c8d8150e97
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUwNzZiZjkwLTA2YzUtNDJm
-        ZS05ZDZjLWIwMTA3NjY4M2RmNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc0YmRiMGYxLWU5MDEtNDQ5
+        OC1hMGZlLWRkYzBlZDhmMzJhOS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:43 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/5076bf90-06c5-42fe-9d6c-b01076683df7/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/74bdb0f1-e901-4498-a0fe-ddc0ed8f32a9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1000,7 +868,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:43 GMT
+      - Tue, 19 Jul 2022 18:46:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1016,47 +884,47 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a646d64c28e7469dbf03345f355cc7cb
+      - 8b0ac0cd138540af91880f14b4967021
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '372'
+      - '369'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTA3NmJmOTAtMDZj
-        NS00MmZlLTlkNmMtYjAxMDc2NjgzZGY3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NDMuNDY2OTg0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzRiZGIwZjEtZTkw
+        MS00NDk4LWEwZmUtZGRjMGVkOGYzMmE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NDEuNDM0NzE2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI5MjQ1MjMyNTQ2Mjg0ZDY1OTAxZjMxNTgx
-        NDY1NzljOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjQzLjQ5
-        ODE5OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NDMuNTIy
-        MzU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwMGVlZTE3NDExMTE0NzAzYjMzZTE2Yzhk
+        ODE1MGU5NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQxLjQ3
+        Nzk5NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDEuNTA3
+        NTY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy83NGM0MDcyYS0zNjIzLTQ4NDItOGZhZS1lNGM0MjAwODk5YjAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2EwNTM1ZDgyLTBmZjQtNDYxOS04NDg1
-        LWFiMTdjODgxYjg0Zi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRkYjU3OThjLWU2ZmItNDQ2Yi04Zjc2
+        LWJiNGQ0YTAwOGIwYy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:43 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:41 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/a79c65b8-b812-41dd-b9e1-7a9b46dfbcbb/sync/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/de0f7ea0-c0ff-4ce7-8556-79a297392853/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2EwNTM1
-        ZDgyLTBmZjQtNDYxOS04NDg1LWFiMTdjODgxYjg0Zi8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRkYjU3
+        OThjLWU2ZmItNDQ2Yi04Zjc2LWJiNGQ0YTAwOGIwYy8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1069,7 +937,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:43 GMT
+      - Tue, 19 Jul 2022 18:46:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1087,21 +955,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 456e00d075ed44efac03bb1eadb83ff7
+      - 145dea17e3fd4b64b9a49369fcf62e06
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U1ZWY3OWZlLTA3Y2ItNGYw
-        Zi04NDgwLTA5NjkxNTg3ODU5ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JlZDE2NTI5LTA3MDEtNGM4
+        Yi04OThhLWYzZjEyZDhkZWU3ZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:43 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:41 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e5ef79fe-07cb-4f0f-8480-09691587859e/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/bed16529-0701-4c8b-898a-f3f12d8dee7e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1122,7 +990,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:45 GMT
+      - Tue, 19 Jul 2022 18:46:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1138,66 +1006,66 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b52b60af050542dd906a0207d3fffa76
+      - 71e9f57e47024a66a3a2ceffdbb566dd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '600'
+      - '607'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTVlZjc5ZmUtMDdj
-        Yi00ZjBmLTg0ODAtMDk2OTE1ODc4NTllLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NDMuNjc5MjI1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmVkMTY1MjktMDcw
+        MS00YzhiLTg5OGEtZjNmMTJkOGRlZTdlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NDEuNjI1MDk5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiI0NTZlMDBkMDc1ZWQ0NGVmYWMw
-        M2JiMWVhZGI4M2ZmNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjQzLjcxMjI4NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        NDUuNTE4MzIwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFj
-        ZDkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIxNDVkZWExN2UzZmQ0YjY0Yjlh
+        NDkzNjlmY2Y2MmUwNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2
+        OjQxLjY3Mjc1OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6
+        NDIuODI2MjEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8zNjAxYmE4OC1hYzM2LTQwNzctYjhhNC04YTA3ODlmYzJk
+        OGMvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
-        IjpudWxsLCJkb25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
-        d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
-        LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
-        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
-        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
-        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
-        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
-        InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vYTc5YzY1YjgtYjgxMi00MWRkLWI5ZTEt
-        N2E5YjQ2ZGZiY2JiL3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        L2E3OWM2NWI4LWI4MTItNDFkZC1iOWUxLTdhOWI0NmRmYmNiYi8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS9hMDUzNWQ4Mi0wZmY0
-        LTQ2MTktODQ4NS1hYjE3Yzg4MWI4NGYvIl19
+        IjpudWxsLCJkb25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
+        cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozMiwiZG9uZSI6MzIsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIEFkdmlzb3JpZXMiLCJj
+        b2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3JpZXMiLCJzdGF0ZSI6ImNvbXBs
+        ZXRlZCIsInRvdGFsIjo0LCJkb25lIjo0LCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRv
+        d25sb2FkaW5nLmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        QXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MzYsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtL2RlMGY3ZWEwLWMwZmYtNGNlNy04NTU2LTc5
+        YTI5NzM5Mjg1My92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9k
+        ZTBmN2VhMC1jMGZmLTRjZTctODU1Ni03OWEyOTczOTI4NTMvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vNGRiNTc5OGMtZTZmYi00
+        NDZiLThmNzYtYmI0ZDRhMDA4YjBjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:45 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:42 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vYTc5YzY1YjgtYjgxMi00MWRkLWI5ZTEtN2E5YjQ2ZGZi
-        Y2JiL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vZGUwZjdlYTAtYzBmZi00Y2U3LTg1NTYtNzlhMjk3Mzky
+        ODUzL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1210,7 +1078,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:45 GMT
+      - Tue, 19 Jul 2022 18:46:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1228,21 +1096,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 38e6f157c2784ad2b186677a600bfc94
+      - 72b3cf8d68f74432beef70615b8e194d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJiNTk4NjNmLTRmZDQtNGVi
-        MC1hMDE4LWNhZjA0ZWFkZWM0Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EwYmNhZTFmLThiZDctNDhm
+        OC04ZDRkLTE3NzI4ODJhOGE2NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:45 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2b59863f-4fd4-4eb0-a018-caf04eadec4b/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/a0bcae1f-8bd7-48f8-8d4d-1772882a8a65/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1263,7 +1131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:46 GMT
+      - Tue, 19 Jul 2022 18:46:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1279,40 +1147,40 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7e1c3530e3e2478dbe778879380be6de
+      - f6039bd98a5c4f52bc4da4396e32a632
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '476'
+      - '478'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmI1OTg2M2YtNGZk
-        NC00ZWIwLWEwMTgtY2FmMDRlYWRlYzRiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NDUuNjYxMjM1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTBiY2FlMWYtOGJk
+        Ny00OGY4LThkNGQtMTc3Mjg4MmE4YTY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NDIuOTkxNDMxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjM4ZTZmMTU3YzI3ODRhZDJiMTg2Njc3YTYw
-        MGJmYzk0Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NDUuNjky
-        MDI5WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyODo0NS45Nzc0
-        NTNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2U4NDc1N2FiLTgyNGMtNGJhNC1hNWFmLWVmODc4MGQyOTA1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjcyYjNjZjhkNjhmNzQ0MzJiZWVmNzA2MTVi
+        OGUxOTRkIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDMuMDMw
+        NTAxWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0xOVQxODo0Njo0My4yMzI2
+        OTdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzBmMjMwNTg2LWIwNzUtNGE5NC1hY2QyLWFmNWE2NzMyOTQ1MS8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vM2RjOGI0
-        Y2ItM2M3Zi00YTJlLTljNzMtMzc2MjU3OWQ2NTE4LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMTExMzA3
+        ZTMtNDQ2MS00MjllLTg5OGQtYjZmZDBiOTVjNjE2LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vYTc5YzY1YjgtYjgxMi00MWRkLWI5ZTEtN2E5YjQ2
-        ZGZiY2JiLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vZGUwZjdlYTAtYzBmZi00Y2U3LTg1NTYtNzlhMjk3
+        MzkyODUzLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:46 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1320,7 +1188,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1333,7 +1201,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:46 GMT
+      - Tue, 19 Jul 2022 18:46:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1349,33 +1217,33 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2ae394128531449e959c2a6e81d7e321
+      - b74690db0e514aeba3eb2b19d2e0d285
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '339'
+      - '330'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vYjhiMGFmNzUtZTIyYS00M2M2LThjNDUtNzRiNzlmYjRmZjM0
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6NDMuMDI0MjI4
+        L3JwbS9ycG0vMzdlYjAxZDItZDMyNi00NjE5LTg2NzQtZDZhMjZmOWNlNGM2
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDAuODQ1NzMz
         WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
-        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
-        OC1rYXRlbGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9wdWxwL2Nv
-        bnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0
-        ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6
-        e30sIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInJlcG9zaXRvcnkiOm51bGwsInB1
-        YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBt
-        LzA3ZDE1NTIxLTVhNzAtNDhhMi05ODEyLWY3MjBkNjhiNTZhYi8ifV19
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vemFuemli
+        YXIubGFncmFuZ2UuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0FDTUVfQ29y
+        cG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwvIiwiY29u
+        dGVudF9ndWFyZCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJuYW1lIjoiMl9k
+        dXBsaWNhdGUiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6Ii9w
+        dWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS80NTE1YWExNi0yNjAx
+        LTRhYzgtYjE1Zi1iMjNmNzkxYjlkZmUvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:46 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/3dc8b4cb-3c7f-4a2e-9c73-3762579d6518/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/111307e3-4461-429e-898d-b6fd0b95c616/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1383,7 +1251,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1396,7 +1264,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:46 GMT
+      - Tue, 19 Jul 2022 18:46:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1412,43 +1280,43 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d58373158ee7417091c1444a8cc5ccf5
+      - 2ef3ed454b344ecba01706132c5bdc7f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '251'
+      - '249'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vM2RjOGI0Y2ItM2M3Zi00YTJlLTljNzMtMzc2MjU3OWQ2NTE4LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6NDUuNzEwODg4WiIsInJl
+        cG0vMTExMzA3ZTMtNDQ2MS00MjllLTg5OGQtYjZmZDBiOTVjNjE2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDMuMDUwODU1WiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9hNzljNjViOC1iODEyLTQxZGQtYjllMS03YTliNDZkZmJjYmIv
+        cnBtL3JwbS9kZTBmN2VhMC1jMGZmLTRjZTctODU1Ni03OWEyOTczOTI4NTMv
         dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2E3OWM2NWI4LWI4MTItNDFkZC1iOWUxLTdhOWI0
-        NmRmYmNiYi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtL2RlMGY3ZWEwLWMwZmYtNGNlNy04NTU2LTc5YTI5
+        NzM5Mjg1My8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:46 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/b8b0af75-e22a-43c6-8c45-74b79fb4ff34/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/37eb01d2-d326-4619-8674-d6a26f9ce4c6/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
-        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vM2Rj
-        OGI0Y2ItM2M3Zi00YTJlLTljNzMtMzc2MjU3OWQ2NTE4LyJ9
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMTEx
+        MzA3ZTMtNDQ2MS00MjllLTg5OGQtYjZmZDBiOTVjNjE2LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1461,7 +1329,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:46 GMT
+      - Tue, 19 Jul 2022 18:46:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1479,21 +1347,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '08de06b8e2db44acb1df4d807d70c40c'
+      - 057446ad0ac4429fa0246322e13f541f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU3Y2Q4NWQyLWIwOGUtNDRi
-        My1hNmQwLTVlY2UyZmFkMzZiMS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzViMTk5YzcwLTA5ZmEtNDcx
+        MS1hNzg5LTcwMDI0NDg2NzhmNi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:46 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/57cd85d2-b08e-44b3-a6d0-5ece2fad36b1/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/5b199c70-09fa-4711-a789-7002448678f6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1514,7 +1382,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:46 GMT
+      - Tue, 19 Jul 2022 18:46:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1530,34 +1398,34 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2ea327c77cf9490e8223c3e87781fae1
+      - d8b9ae5b80f64881a7fd00b69dba7768
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
       - '345'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTdjZDg1ZDItYjA4
-        ZS00NGIzLWE2ZDAtNWVjZTJmYWQzNmIxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NDYuMjMwMjE1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWIxOTljNzAtMDlm
+        YS00NzExLWE3ODktNzAwMjQ0ODY3OGY2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NDMuNDA1MTgwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIwOGRlMDZiOGUyZGI0NGFjYjFkZjRkODA3
-        ZDcwYzQwYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjQ2LjI4
-        MjI2MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NDYuNTIy
-        NzE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwNTc0NDZhZDBhYzQ0MjlmYTAyNDYzMjJl
+        MTNmNTQxZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQzLjQ0
+        NTAwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDMuNTYz
+        MDEyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81MWI3NmQzNS1hYTBhLTQ0OTMtYmVlNS0xZTdlZTJmZmVjMTQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
         L2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:46 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/3dc8b4cb-3c7f-4a2e-9c73-3762579d6518/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/111307e3-4461-429e-898d-b6fd0b95c616/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1565,7 +1433,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1578,7 +1446,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:46 GMT
+      - Tue, 19 Jul 2022 18:46:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1594,43 +1462,43 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 585313668df843ba8f449910dd0fa5b3
+      - 226afad64c834e4c950f3ce3591ee3f4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '251'
+      - '249'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vM2RjOGI0Y2ItM2M3Zi00YTJlLTljNzMtMzc2MjU3OWQ2NTE4LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6NDUuNzEwODg4WiIsInJl
+        cG0vMTExMzA3ZTMtNDQ2MS00MjllLTg5OGQtYjZmZDBiOTVjNjE2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDMuMDUwODU1WiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9hNzljNjViOC1iODEyLTQxZGQtYjllMS03YTliNDZkZmJjYmIv
+        cnBtL3JwbS9kZTBmN2VhMC1jMGZmLTRjZTctODU1Ni03OWEyOTczOTI4NTMv
         dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2E3OWM2NWI4LWI4MTItNDFkZC1iOWUxLTdhOWI0
-        NmRmYmNiYi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtL2RlMGY3ZWEwLWMwZmYtNGNlNy04NTU2LTc5YTI5
+        NzM5Mjg1My8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:46 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/b8b0af75-e22a-43c6-8c45-74b79fb4ff34/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/37eb01d2-d326-4619-8674-d6a26f9ce4c6/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
-        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vM2Rj
-        OGI0Y2ItM2M3Zi00YTJlLTljNzMtMzc2MjU3OWQ2NTE4LyJ9
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMTEx
+        MzA3ZTMtNDQ2MS00MjllLTg5OGQtYjZmZDBiOTVjNjE2LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1643,7 +1511,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:46 GMT
+      - Tue, 19 Jul 2022 18:46:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1661,30 +1529,30 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 25f9ef8b2c234380b4cf0698c617d01e
+      - 38ebc076f6ab49ee8db834f9b6139ea8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EyY2I2Yzk4LWVkNDEtNGJi
-        YS04MDAzLWU1NjRjNjcxZDJkNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VlMjgxNjBhLTczMjQtNGU5
+        YS1iMmQ1LTY0MjNiMmM0MDg5YS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:46 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/exporters/core/pulp/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/
     body:
       encoding: UTF-8
       base64_string: |
         eyJuYW1lIjoiRW1wdHlfT3JnYW5pemF0aW9uX0FDTUVfRGVmYXVsdF9Db250
         ZW50Vmlld18xLjAiLCJwYXRoIjoiL3Zhci9saWIvcHVscC9leHBvcnRzL0Vt
-        cHR5X09yZ2FuaXphdGlvbi9BQ01FX0RlZmF1bHRfQ29udGVudFZpZXcvMS4w
+        cHR5X09yZ2FuaXphdGlvbi9BQ01FIERlZmF1bHQgQ29udGVudFZpZXcvMS4w
         L2RyZWFtLWRlc3RpbmF0aW9uL2RhdGVfZGlyIiwicmVwb3NpdG9yaWVzIjpb
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hNzljNjViOC1i
-        ODEyLTQxZGQtYjllMS03YTliNDZkZmJjYmIvIl19
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kZTBmN2VhMC1j
+        MGZmLTRjZTctODU1Ni03OWEyOTczOTI4NTMvIl19
     headers:
       Content-Type:
       - application/json
@@ -1702,13 +1570,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:46 GMT
+      - Tue, 19 Jul 2022 18:46:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/exporters/core/pulp/df8fb0ca-a1e8-4c99-8656-0601957669cc/"
+      - "/pulp/api/v3/exporters/core/pulp/7168f696-e39e-487a-9833-6c3beca73e15/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1722,28 +1590,28 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5ab01fabfb2a47919e823ede0389ed7a
+      - 76e683c5c4634e048cca2058763e5380
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
-        cC9kZjhmYjBjYS1hMWU4LTRjOTktODY1Ni0wNjAxOTU3NjY5Y2MvIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyODo0Ni44NDc3MzJaIiwibmFt
+        cC83MTY4ZjY5Ni1lMzllLTQ4N2EtOTgzMy02YzNiZWNhNzNlMTUvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMi0wNy0xOVQxODo0Njo0My45MTAxMjNaIiwibmFt
         ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
         ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
-        cmdhbml6YXRpb24vQUNNRV9EZWZhdWx0X0NvbnRlbnRWaWV3LzEuMC9kcmVh
+        cmdhbml6YXRpb24vQUNNRSBEZWZhdWx0IENvbnRlbnRWaWV3LzEuMC9kcmVh
         bS1kZXN0aW5hdGlvbi9kYXRlX2RpciIsInJlcG9zaXRvcmllcyI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTc5YzY1YjgtYjgxMi00
-        MWRkLWI5ZTEtN2E5YjQ2ZGZiY2JiLyJdLCJsYXN0X2V4cG9ydCI6bnVsbH0=
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGUwZjdlYTAtYzBmZi00
+        Y2U3LTg1NTYtNzlhMjk3MzkyODUzLyJdLCJsYXN0X2V4cG9ydCI6bnVsbH0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:46 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/exporters/core/pulp/df8fb0ca-a1e8-4c99-8656-0601957669cc/exports/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/7168f696-e39e-487a-9833-6c3beca73e15/exports/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1764,7 +1632,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:46 GMT
+      - Tue, 19 Jul 2022 18:46:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1782,21 +1650,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2312d04f18cd4bb2b96d0d5f21e02f0c
+      - 5e582416b09e4b5894eda1507c91c551
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:46 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/exporters/core/pulp/df8fb0ca-a1e8-4c99-8656-0601957669cc/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/7168f696-e39e-487a-9833-6c3beca73e15/
     body:
       encoding: UTF-8
       base64_string: 'eyJsYXN0X2V4cG9ydCI6bnVsbH0=
@@ -1819,7 +1687,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:47 GMT
+      - Tue, 19 Jul 2022 18:46:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1837,21 +1705,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 85dd8ec0870d4704b99e064778c83b8f
+      - d38dbb6f5a044004b1ee77aea9af6f46
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzExMzVhZmNhLWY0NDMtNDVh
-        NC04MTU5LTE5N2IzYjNmZWNjNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmYTUxN2MyLTc5YzAtNDIz
+        Yi1iMDcxLTBiNDBkZTc2MzI2NS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:47 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/exporters/core/pulp/df8fb0ca-a1e8-4c99-8656-0601957669cc/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/7168f696-e39e-487a-9833-6c3beca73e15/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1872,7 +1740,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:47 GMT
+      - Tue, 19 Jul 2022 18:46:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1890,21 +1758,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6744c22f6dd448fa8d7210ccc4d76a24
+      - 221149f5db2d48c0822a85ea0d2e43c8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FmNzViZDE2LTczYjEtNDBl
-        MC1hNzJiLTViNTY4Njk3MWM0ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM4NTRkMjIwLTlmMGUtNGE3
+        ZC1iYmFlLTc3ZjljM2E3NTViZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:47 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/af75bd16-73b1-40e0-a72b-5b5686971c4e/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/3854d220-9f0e-4a7d-bbae-77f9c3a755be/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1925,7 +1793,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:47 GMT
+      - Tue, 19 Jul 2022 18:46:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1941,35 +1809,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 56fd92b5dfbc44eeb677c1668e4e0789
+      - 873125a59e2b4679a0eb31d422585430
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
       - '371'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWY3NWJkMTYtNzNi
-        MS00MGUwLWE3MmItNWI1Njg2OTcxYzRlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NDcuMDkwNzUwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzg1NGQyMjAtOWYw
+        ZS00YTdkLWJiYWUtNzdmOWMzYTc1NWJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NDQuMjEzNDg4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2NzQ0YzIyZjZkZDQ0OGZhOGQ3MjEwY2Nj
-        NGQ3NmEyNCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjQ3LjEy
-        NjI2OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NDcuMTUz
-        MjM5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZGYxOGFmZi02NGI4LTRjNmEtOTQxYi00YjQ5ODBjZjgwM2EvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyMjExNDlmNWRiMmQ0OGMwODIyYTg1ZWEw
+        ZDJlNDNjOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ0LjI1
+        NTMwNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDQuMjg1
+        NTc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8zNjAxYmE4OC1hYzM2LTQwNzctYjhhNC04YTA3ODlmYzJkOGMvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVscC9kZjhmYjBjYS1hMWU4LTRjOTkt
-        ODY1Ni0wNjAxOTU3NjY5Y2MvIl19
+        cGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVscC83MTY4ZjY5Ni1lMzllLTQ4N2Et
+        OTgzMy02YzNiZWNhNzNlMTUvIl19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:47 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/exporters/core/pulp/df8fb0ca-a1e8-4c99-8656-0601957669cc/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/7168f696-e39e-487a-9833-6c3beca73e15/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1990,7 +1858,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:47 GMT
+      - Tue, 19 Jul 2022 18:46:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2008,21 +1876,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 272018590d264596bc6265f3ab0e0e95
+      - 6039063992a64cb58770838d8adc1f4c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
 
 '
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:47 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/exporters/core/pulp/df8fb0ca-a1e8-4c99-8656-0601957669cc/exports/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/7168f696-e39e-487a-9833-6c3beca73e15/exports/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2043,7 +1911,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:47 GMT
+      - Tue, 19 Jul 2022 18:46:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2061,21 +1929,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8dd969ebf47e42688bb1626bc7b49d78
+      - b99c720f8a0e4b48b65246e3876226bd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
 
 '
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:47 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/a0535d82-0ff4-4619-8485-ab17c881b84f/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/4db5798c-e6fb-446b-8f76-bb4d4a008b0c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2083,7 +1951,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2096,7 +1964,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:47 GMT
+      - Tue, 19 Jul 2022 18:46:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2114,21 +1982,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 526c5a3b6ad44d049afed0118e2ddd9c
+      - e75a2498f4d748acaea7fabd7318476f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI2OTNjYWQ0LTRjYmQtNGY1
-        NS05M2ZiLWEwYTE1YzM3NmM0Yy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY5ODVjZGNiLTdjZGUtNGYy
+        Ny1iNDdmLWQzNThmMDNkMGU1NC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:47 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2693cad4-4cbd-4f55-93fb-a0a15c376c4c/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/6985cdcb-7cde-4f27-b47f-d358f03d0e54/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2149,7 +2017,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:47 GMT
+      - Tue, 19 Jul 2022 18:46:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2165,35 +2033,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dc774100bf724a7eafa516fe66011119
+      - 2bc04ccb0b6e4d358cefb3668c8f0c9c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '373'
+      - '371'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjY5M2NhZDQtNGNi
-        ZC00ZjU1LTkzZmItYTBhMTVjMzc2YzRjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NDcuNDM4OTgwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjk4NWNkY2ItN2Nk
+        ZS00ZjI3LWI0N2YtZDM1OGYwM2QwZTU0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NDQuNzgwODAzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI1MjZjNWEzYjZhZDQ0ZDA0OWFmZWQwMTE4
-        ZTJkZGQ5YyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjQ3LjQ2
-        ODc2NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NDcuNTEz
-        MDU5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJlNzVhMjQ5OGY0ZDc0OGFjYWVhN2ZhYmQ3
+        MzE4NDc2ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ0Ljgy
+        OTgyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDQuODY5
+        OTM0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy83NGM0MDcyYS0zNjIzLTQ4NDItOGZhZS1lNGM0MjAwODk5YjAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2EwNTM1ZDgyLTBmZjQtNDYxOS04NDg1
-        LWFiMTdjODgxYjg0Zi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRkYjU3OThjLWU2ZmItNDQ2Yi04Zjc2
+        LWJiNGQ0YTAwOGIwYy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:47 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/b8b0af75-e22a-43c6-8c45-74b79fb4ff34/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/37eb01d2-d326-4619-8674-d6a26f9ce4c6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2201,7 +2069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2214,7 +2082,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:47 GMT
+      - Tue, 19 Jul 2022 18:46:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2232,21 +2100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7bbd895d285c41a693ea02671f1633d6
+      - 56a765c3b7b04a1ca335eeb0d40b5077
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA5Zjk1MmFiLTUyYmYtNDNj
-        Yy1iNTBhLTc5Yjg3OTA4YThhZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNmYjI0YjhlLTA0ODEtNDdm
+        My04ZDAyLTU0ODljMzYyN2IyZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:47 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/a79c65b8-b812-41dd-b9e1-7a9b46dfbcbb/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/de0f7ea0-c0ff-4ce7-8556-79a297392853/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2254,7 +2122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2267,7 +2135,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:47 GMT
+      - Tue, 19 Jul 2022 18:46:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2285,21 +2153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dcf05db9d99a42ddb2ab3d21f106981c
+      - c1d395932ed941c6a3eae4316582ab45
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U3OTAzYmZjLThhYjMtNDVm
-        ZC04ZmZkLTkyMzM3NzMwMDU5ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EyMzg3NjcwLWM1OWMtNGNl
+        ZC04NzY2LTk1YmQyMzFhZTM5ZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:47 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/e7903bfc-8ab3-45fd-8ffd-92337730059e/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/a2387670-c59c-4ced-8766-95bd231ae39e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2320,7 +2188,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:47 GMT
+      - Tue, 19 Jul 2022 18:46:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2336,30 +2204,30 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6f1159cfce894b159293b4ba5675be31
+      - 7d2cdc020cb94dde873468ebdd714fa8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '374'
+      - '375'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZTc5MDNiZmMtOGFi
-        My00NWZkLThmZmQtOTIzMzc3MzAwNTllLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NDcuNjkyNTY1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTIzODc2NzAtYzU5
+        Yy00Y2VkLTg3NjYtOTViZDIzMWFlMzllLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NDUuMDYxNzAyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJkY2YwNWRiOWQ5OWE0MmRkYjJhYjNkMjFm
-        MTA2OTgxYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjQ3Ljcy
-        NTk1NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NDcuOTY5
-        OTYyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjMWQzOTU5MzJlZDk0MWM2YTNlYWU0MzE2
+        NTgyYWI0NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ1LjEw
+        NzgyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDUuMjIw
+        ODA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8zNjAxYmE4OC1hYzM2LTQwNzctYjhhNC04YTA3ODlmYzJkOGMvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTc5YzY1YjgtYjgxMi00MWRk
-        LWI5ZTEtN2E5YjQ2ZGZiY2JiLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGUwZjdlYTAtYzBmZi00Y2U3
+        LTg1NTYtNzlhMjk3MzkyODUzLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:47 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:45 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/katello/content_view_version/export/export.yml
+++ b/test/fixtures/vcr_cassettes/actions/katello/content_view_version/export/export.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:55 GMT
+      - Tue, 19 Jul 2022 18:46:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -41,21 +41,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2835d690bedf4712b7847ab7db12ea70
+      - 61c62976839640eebb9e13a263292a92
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:55 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -76,7 +76,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:55 GMT
+      - Tue, 19 Jul 2022 18:46:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -94,21 +94,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1ce7cac65171406a8cd38848a57d3905
+      - e751be181b62424ba6caaa31be4031eb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:55 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -116,7 +116,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -129,7 +129,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:55 GMT
+      - Tue, 19 Jul 2022 18:46:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -147,21 +147,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 732d63989c28462688f3a28288740830
+      - 5481e93fe03c425f83f54a07b6965207
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:55 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:45 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -169,7 +169,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -182,7 +182,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:55 GMT
+      - Tue, 19 Jul 2022 18:46:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -200,21 +200,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ce42fd5c96fd4e558a2da4e68ac87d9b
+      - 8dcb95eb0b0a47afadf87a868921b682
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:55 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:45 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -231,7 +231,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -244,13 +244,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:55 GMT
+      - Tue, 19 Jul 2022 18:46:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/042624ef-6354-450b-84a8-5159647b2c2a/"
+      - "/pulp/api/v3/remotes/rpm/rpm/d63541bf-e3d9-47a1-98aa-a4ee71ab120c/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -264,32 +264,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bd75e94cce3e4bbeb066dc9d5aa6fbec
+      - 5d88727bf00044238a6afcdda59fe456
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA0
-        MjYyNGVmLTYzNTQtNDUwYi04NGE4LTUxNTk2NDdiMmMyYS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI4OjU1Ljk2MDc0OFoiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q2
+        MzU0MWJmLWUzZDktNDdhMS05OGFhLWE0ZWU3MWFiMTIwYy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ1Ljg2NTIwM1oiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI4OjU1Ljk2MDc2N1oiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ1Ljg2NTIxOFoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:55 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:45 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -299,7 +299,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -312,13 +312,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:56 GMT
+      - Tue, 19 Jul 2022 18:46:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/c38d8f55-2aa0-463f-912a-c7f40769cea4/"
+      - "/pulp/api/v3/repositories/rpm/rpm/c3d0fe0e-9f92-479d-b3c5-fa1105d2f43b/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -332,22 +332,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c132c2eda4614a4eb20bf001c1cbd6b2
+      - b4586556c6fb4e1988351f64d6a03d3d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYzM4ZDhmNTUtMmFhMC00NjNmLTkxMmEtYzdmNDA3NjljZWE0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6NTYuMDk1MTA4WiIsInZl
+        cG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1ZDJmNDNiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDYuMDAwMjk1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYzM4ZDhmNTUtMmFhMC00NjNmLTkxMmEtYzdmNDA3NjljZWE0L3ZlcnNp
+        cG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1ZDJmNDNiL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jMzhkOGY1NS0y
-        YWEwLTQ2M2YtOTEyYS1jN2Y0MDc2OWNlYTQvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jM2QwZmUwZS05
+        ZjkyLTQ3OWQtYjNjNS1mYTExMDVkMmY0M2IvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -356,21 +356,21 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:56 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:46 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vYzM4ZDhmNTUtMmFhMC00NjNmLTkxMmEtYzdmNDA3Njlj
-        ZWE0L3ZlcnNpb25zLzAvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1ZDJm
+        NDNiL3ZlcnNpb25zLzAvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -383,7 +383,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:56 GMT
+      - Tue, 19 Jul 2022 18:46:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -401,21 +401,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 32444911a52b4f2a999782f33f290276
+      - 90001392f7ad4e87a661d8cd9c14d42c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRlOWQxYWFjLTQ1YjctNDVk
-        My05MzQ2LTdjMmRiM2IxNjY2Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QxZmM4OWZjLTk2MjMtNDJi
+        MS1hYzY4LWJlNmVkMWRlNDZiMi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:56 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/4e9d1aac-45b7-45d3-9346-7c2db3b1666b/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/d1fc89fc-9623-42b1-ac68-be6ed1de46b2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -436,7 +436,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:56 GMT
+      - Tue, 19 Jul 2022 18:46:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -452,40 +452,40 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 389dacfa306e4e15988e3e8fb42d226c
+      - 0fd725902b8048a696a29fd0fa485a15
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '476'
+      - '475'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGU5ZDFhYWMtNDVi
-        Ny00NWQzLTkzNDYtN2MyZGIzYjE2NjZiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NTYuNDk3MjAxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDFmYzg5ZmMtOTYy
+        My00MmIxLWFjNjgtYmU2ZWQxZGU0NmIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NDYuMzE4ODM2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjMyNDQ0OTExYTUyYjRmMmE5OTk3ODJmMzNm
-        MjkwMjc2Iiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NTYuNTI4
-        Mjk3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyODo1Ni43OTIz
-        MzVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBkZjE4YWZmLTY0YjgtNGM2YS05NDFiLTRiNDk4MGNmODAzYS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjkwMDAxMzkyZjdhZDRlODdhNjYxZDhjZDlj
+        MTRkNDJjIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDYuMzY1
+        ODQzWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0xOVQxODo0Njo0Ni41MTM1
+        MjdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzBmMjMwNTg2LWIwNzUtNGE5NC1hY2QyLWFmNWE2NzMyOTQ1MS8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZDI4OTBk
-        ZmUtNGZlNi00MGJlLTg2ODItYmU4NGI0ODMyYzNmLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOWM4NWE4
+        OTMtYmYyNC00ZDZkLWE2YWEtZDNkN2EyMWEyZDBiLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vYzM4ZDhmNTUtMmFhMC00NjNmLTkxMmEtYzdmNDA3
-        NjljZWE0LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1
+        ZDJmNDNiLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:56 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -493,7 +493,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -506,7 +506,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:56 GMT
+      - Tue, 19 Jul 2022 18:46:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -524,21 +524,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 73b8abe2a941467e885d1c98706180f3
+      - daded6bb98fe4efda4cd7e600a6f6834
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:56 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/d2890dfe-4fe6-40be-8682-be84b4832c3f/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/9c85a893-bf24-4d6d-a6aa-d3d7a21a2d0b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -546,7 +546,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -559,7 +559,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:56 GMT
+      - Tue, 19 Jul 2022 18:46:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -575,44 +575,44 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a40e51c27e304297a5db82acbe2e69e8
+      - 94f4e4eae1e547c782dd3daeb730b7ec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '248'
+      - '249'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vZDI4OTBkZmUtNGZlNi00MGJlLTg2ODItYmU4NGI0ODMyYzNmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6NTYuNTQ3NDk4WiIsInJl
+        cG0vOWM4NWE4OTMtYmYyNC00ZDZkLWE2YWEtZDNkN2EyMWEyZDBiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDYuMzg2MzA0WiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jMzhkOGY1NS0yYWEwLTQ2M2YtOTEyYS1jN2Y0MDc2OWNlYTQv
+        cnBtL3JwbS9jM2QwZmUwZS05ZjkyLTQ3OWQtYjNjNS1mYTExMDVkMmY0M2Iv
         dmVyc2lvbnMvMC8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2MzOGQ4ZjU1LTJhYTAtNDYzZi05MTJhLWM3ZjQw
-        NzY5Y2VhNC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtL2MzZDBmZTBlLTlmOTItNDc5ZC1iM2M1LWZhMTEw
+        NWQyZjQzYi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:56 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:46 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vZDI4OTBkZmUtNGZlNi00MGJlLTg2ODItYmU4
-        NGI0ODMyYzNmLyJ9
+        bGljYXRpb25zL3JwbS9ycG0vOWM4NWE4OTMtYmYyNC00ZDZkLWE2YWEtZDNk
+        N2EyMWEyZDBiLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -625,7 +625,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:57 GMT
+      - Tue, 19 Jul 2022 18:46:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -643,21 +643,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a4f8f25204e14113b60c19e4acf942c1
+      - bb0c6d1c22ab40a2bf01e321d90c420e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE2MTg3ZTI1LTA4ZDQtNDgz
-        NS04MDkwLTMxNTU5Y2E4NDI3Ni8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRhMGU1MjE3LWFjMTMtNDY1
+        My1iZjY0LWE5ZGZkN2ZmYTkyMC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:57 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:46 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/16187e25-08d4-4835-8090-31559ca84276/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/4a0e5217-ac13-4653-bf64-a9dfd7ffa920/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -678,7 +678,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:57 GMT
+      - Tue, 19 Jul 2022 18:46:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -694,36 +694,36 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0ef61704e2b54b45a4ee70a2668f9ee9
+      - 72772c8a1b0b435eb95e7ccc4c0ade5e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '380'
+      - '376'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTYxODdlMjUtMDhk
-        NC00ODM1LTgwOTAtMzE1NTljYTg0Mjc2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NTYuOTk5NDcxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGEwZTUyMTctYWMx
+        My00NjUzLWJmNjQtYTlkZmQ3ZmZhOTIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NDYuNzQ5MDczWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwibG9nZ2luZ19jaWQiOiJhNGY4ZjI1MjA0ZTE0MTEzYjYwYzE5ZTRh
-        Y2Y5NDJjMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjU3LjA0
-        ODQyM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NTcuMzMw
-        MTI2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJiYjBjNmQxYzIyYWI0MGEyYmYwMWUzMjFk
+        OTBjNDIwZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ2Ljc5
+        NTg0N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDYuOTIx
+        NDg4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy83NGM0MDcyYS0zNjIzLTQ4NDItOGZhZS1lNGM0MjAwODk5YjAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vYmNh
-        MjBjMTItZDM4Ny00NDBmLTg3NjAtYWYxMDNlN2E4ZmRkLyJdLCJyZXNlcnZl
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vYTZl
+        Y2RhYTAtZmUxZi00MjUwLTgyOWYtNjc5NGM4OTI4MGM2LyJdLCJyZXNlcnZl
         ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
         XX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:57 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/bca20c12-d387-440f-8760-af103e7a8fdd/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/a6ecdaa0-fe1f-4250-829f-6794c89280c6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -731,7 +731,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -744,7 +744,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:57 GMT
+      - Tue, 19 Jul 2022 18:46:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -760,32 +760,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - cf6a7c22a0674feda3b7b7ea62d32c56
+      - e55b109588034eb98693655b926ff5c7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '308'
+      - '299'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtL2JjYTIwYzEyLWQzODctNDQwZi04NzYwLWFmMTAzZTdhOGZkZC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI4OjU3LjMxMzU3NVoiLCJi
+        cnBtL2E2ZWNkYWEwLWZlMWYtNDI1MC04MjlmLTY3OTRjODkyODBjNi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ2LjkwNzMxOVoiLCJi
         YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
-        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0
-        ZWxsby1kZXZlbC5tYW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50
-        L0FDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFi
-        ZWwvIiwiY29udGVudF9ndWFyZCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJu
-        YW1lIjoiMl9kdXBsaWNhdGUiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNh
-        dGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS9kMjg5
-        MGRmZS00ZmU2LTQwYmUtODY4Mi1iZTg0YjQ4MzJjM2YvIn0=
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL3phbnppYmFyLmxh
+        Z3JhbmdlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01FX0NvcnBvcmF0
+        aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIsImNvbnRlbnRf
+        Z3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGlj
+        YXRlIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9h
+        cGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOWM4NWE4OTMtYmYyNC00ZDZk
+        LWE2YWEtZDNkN2EyMWEyZDBiLyJ9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:57 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:47 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/042624ef-6354-450b-84a8-5159647b2c2a/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/d63541bf-e3d9-47a1-98aa-a4ee71ab120c/
     body:
       encoding: UTF-8
       base64_string: |
@@ -802,7 +802,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -815,7 +815,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:57 GMT
+      - Tue, 19 Jul 2022 18:46:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -833,21 +833,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 762b2423c522462497836eb34efff6cd
+      - 0f20356daae64ce4961cee7645acc551
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ExZmZjN2E5LTk0ZGEtNDlh
-        Yy05MGM1LTRiYjExZDYyZGVlMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNkYjliMmExLTBkOGItNGZk
+        MC1iNGJiLTVjYTY2M2M5NWQ1Mi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:57 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a1ffc7a9-94da-49ac-90c5-4bb11d62dee3/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/3db9b2a1-0d8b-4fd0-b4bb-5ca663c95d52/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -868,7 +868,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:57 GMT
+      - Tue, 19 Jul 2022 18:46:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -884,47 +884,47 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - '028a1731b2054c9eae3e264707600f4d'
+      - d06c3aa5949c48e7b6e852eafc03afda
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '373'
+      - '372'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTFmZmM3YTktOTRk
-        YS00OWFjLTkwYzUtNGJiMTFkNjJkZWUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NTcuNjcxMDI5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2RiOWIyYTEtMGQ4
+        Yi00ZmQwLWI0YmItNWNhNjYzYzk1ZDUyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NDcuNDU5NDUzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI3NjJiMjQyM2M1MjI0NjI0OTc4MzZlYjM0
-        ZWZmZjZjZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4OjU3Ljcx
-        MjcwNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NTcuNzM3
-        MjAxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwZjIwMzU2ZGFhZTY0Y2U0OTYxY2VlNzY0
+        NWFjYzU1MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ3LjUw
+        MzA1NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDcuNTMw
+        NzkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8wZjIzMDU4Ni1iMDc1LTRhOTQtYWNkMi1hZjVhNjczMjk0NTEvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA0MjYyNGVmLTYzNTQtNDUwYi04NGE4
-        LTUxNTk2NDdiMmMyYS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q2MzU0MWJmLWUzZDktNDdhMS05OGFh
+        LWE0ZWU3MWFiMTIwYy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:57 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:47 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/c38d8f55-2aa0-463f-912a-c7f40769cea4/sync/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/c3d0fe0e-9f92-479d-b3c5-fa1105d2f43b/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA0MjYy
-        NGVmLTYzNTQtNDUwYi04NGE4LTUxNTk2NDdiMmMyYS8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q2MzU0
+        MWJmLWUzZDktNDdhMS05OGFhLWE0ZWU3MWFiMTIwYy8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -937,7 +937,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:57 GMT
+      - Tue, 19 Jul 2022 18:46:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -955,21 +955,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - acd2e1fde7cc401c9155de6e56adea3d
+      - 33f504a0e2584e4b92fe02ffb37734aa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M4ZTE0ODllLTQwNDctNDYw
-        MS1iN2E5LTUzZjE1ZWM2YjBhMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JkYjU0MzgyLTExNTctNDYw
+        MS1hZWY4LTY5OTA1YjlkMGYyOS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:57 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/c8e1489e-4047-4601-b7a9-53f15ec6b0a3/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/bdb54382-1157-4601-aef8-69905b9d0f29/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -990,7 +990,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:59 GMT
+      - Tue, 19 Jul 2022 18:46:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1006,66 +1006,66 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e9bd17d6ba9f43e59fcec7beb442359d
+      - d7a67081715b469bb1138ee6983d5886
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '599'
+      - '602'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzhlMTQ4OWUtNDA0
-        Ny00NjAxLWI3YTktNTNmMTVlYzZiMGEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NTcuODYxMjMzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmRiNTQzODItMTE1
+        Ny00NjAxLWFlZjgtNjk5MDViOWQwZjI5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NDcuNjU2OTkwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJhY2QyZTFmZGU3Y2M0MDFjOTE1
-        NWRlNmU1NmFkZWEzZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI4
-        OjU3LjkwNzY2MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6
-        NTkuNTI5MDgzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcy
-        ZTUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIzM2Y1MDRhMGUyNTg0ZTRiOTJm
+        ZTAyZmZiMzc3MzRhYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2
+        OjQ3LjcwODIyOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6
+        NDguOTY3OTg4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy83NGM0MDcyYS0zNjIzLTQ4NDItOGZhZS1lNGM0MjAwODk5
+        YjAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
-        IjpudWxsLCJkb25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
-        d25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
-        LmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
-        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
-        bmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3Rh
-        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MzYsInN1ZmZp
-        eCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6
-        InN5bmMucGFyc2luZy5wYWNrYWdlcyIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNlZCBBZHZpc29yaWVzIiwiY29kZSI6InN5bmMucGFyc2luZy5h
-        ZHZpc29yaWVzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9u
-        ZSI6NCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0
-        YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vYzM4ZDhmNTUtMmFhMC00NjNmLTkxMmEt
-        YzdmNDA3NjljZWE0L3ZlcnNpb25zLzEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBt
-        L2MzOGQ4ZjU1LTJhYTAtNDYzZi05MTJhLWM3ZjQwNzY5Y2VhNC8iLCJzaGFy
-        ZWQ6L3B1bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS8wNDI2MjRlZi02MzU0
-        LTQ1MGItODRhOC01MTU5NjQ3YjJjMmEvIl19
+        IjpudWxsLCJkb25lIjo1LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
+        cnNlZCBQYWNrYWdlcyIsImNvZGUiOiJzeW5jLnBhcnNpbmcucGFja2FnZXMi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozMiwiZG9uZSI6MzIsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2VkIEFkdmlzb3JpZXMiLCJj
+        b2RlIjoic3luYy5wYXJzaW5nLmFkdmlzb3JpZXMiLCJzdGF0ZSI6ImNvbXBs
+        ZXRlZCIsInRvdGFsIjo0LCJkb25lIjo0LCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRv
+        d25sb2FkaW5nLmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        VW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5n
+        LmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJk
+        b25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5n
+        IENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRl
+        IjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjM2LCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtL2MzZDBmZTBlLTlmOTItNDc5ZC1iM2M1LWZh
+        MTEwNWQyZjQzYi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9j
+        M2QwZmUwZS05ZjkyLTQ3OWQtYjNjNS1mYTExMDVkMmY0M2IvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vZDYzNTQxYmYtZTNkOS00
+        N2ExLTk4YWEtYTRlZTcxYWIxMjBjLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:59 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vYzM4ZDhmNTUtMmFhMC00NjNmLTkxMmEtYzdmNDA3Njlj
-        ZWE0L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1ZDJm
+        NDNiL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1078,7 +1078,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:28:59 GMT
+      - Tue, 19 Jul 2022 18:46:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1096,21 +1096,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8898bc39bd4a4db49d2e50d025bb8583
+      - b1b896fecc8f46b3acc2bc0ae07badbd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E0M2MyMzhkLWM4MmQtNGM3
-        Ny05Njc0LWE4MTJhM2Y2ZjY4Mi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JmMmM0ZTk4LThlOGItNGVh
+        My05OTg5LWI2NGEzMTY1NzgzNi8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:28:59 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/a43c238d-c82d-4c77-9674-a812a3f6f682/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/bf2c4e98-8e8b-4ea3-9989-b64a31657836/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1131,7 +1131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:00 GMT
+      - Tue, 19 Jul 2022 18:46:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1147,40 +1147,40 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 766b71379932406abc90c12a9af9c9f9
+      - bd8e66b57587462d96330dc42d12b5eb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '477'
+      - '475'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTQzYzIzOGQtYzgy
-        ZC00Yzc3LTk2NzQtYTgxMmEzZjZmNjgyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjg6NTkuNzM0MjY1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmYyYzRlOTgtOGU4
+        Yi00ZWEzLTk5ODktYjY0YTMxNjU3ODM2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NDkuMjE1OTkyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6Ijg4OThiYzM5YmQ0YTRkYjQ5ZDJlNTBkMDI1
-        YmI4NTgzIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjg6NTkuNzY3
-        NTUxWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyOTowMC4wNzgw
-        MDJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzNmYTZkMDgyLTk2ODMtNGVmZi1hYTZkLTFlZDM0NTEwNzJlNS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImIxYjg5NmZlY2M4ZjQ2YjNhY2MyYmMwYWUw
+        N2JhZGJkIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDkuMjY0
+        MzQ0WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0xOVQxODo0Njo0OS40ODY4
+        ODlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzUxYjc2ZDM1LWFhMGEtNDQ5My1iZWU1LTFlN2VlMmZmZWMxNC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOGY4NzI2
-        ZDktODQ0My00MTY4LWJhODYtY2U1MGNlNTE4MzI3LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYWI0OWI4
+        YzUtY2FjNy00ZjBkLTliOTgtNGVmNWI3ZDU4MDcwLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vYzM4ZDhmNTUtMmFhMC00NjNmLTkxMmEtYzdmNDA3
-        NjljZWE0LyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1
+        ZDJmNDNiLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:00 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1188,7 +1188,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1201,7 +1201,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:00 GMT
+      - Tue, 19 Jul 2022 18:46:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1217,33 +1217,33 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 62a6414ed8c34078ae8a1a55dc42461a
+      - 297ee6b79e524a8787eb56a96052f51d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '337'
+      - '330'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vYmNhMjBjMTItZDM4Ny00NDBmLTg3NjAtYWYxMDNlN2E4ZmRk
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6NTcuMzEzNTc1
+        L3JwbS9ycG0vYTZlY2RhYTAtZmUxZi00MjUwLTgyOWYtNjc5NGM4OTI4MGM2
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDYuOTA3MzE5
         WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
-        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
-        OC1rYXRlbGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9wdWxwL2Nv
-        bnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0
-        ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6
-        e30sIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInJlcG9zaXRvcnkiOm51bGwsInB1
-        YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBt
-        L2QyODkwZGZlLTRmZTYtNDBiZS04NjgyLWJlODRiNDgzMmMzZi8ifV19
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vemFuemli
+        YXIubGFncmFuZ2UuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0FDTUVfQ29y
+        cG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwvIiwiY29u
+        dGVudF9ndWFyZCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJuYW1lIjoiMl9k
+        dXBsaWNhdGUiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6Ii9w
+        dWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS85Yzg1YTg5My1iZjI0
+        LTRkNmQtYTZhYS1kM2Q3YTIxYTJkMGIvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:00 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/8f8726d9-8443-4168-ba86-ce50ce518327/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/ab49b8c5-cac7-4f0d-9b98-4ef5b7d58070/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1251,7 +1251,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1264,7 +1264,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:00 GMT
+      - Tue, 19 Jul 2022 18:46:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1280,43 +1280,43 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 286f05bc42844a6d8b6de14b9d4c1694
+      - 94197545d942442ca42a1b54428134c9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '248'
+      - '250'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vOGY4NzI2ZDktODQ0My00MTY4LWJhODYtY2U1MGNlNTE4MzI3LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6NTkuNzkyODMzWiIsInJl
+        cG0vYWI0OWI4YzUtY2FjNy00ZjBkLTliOTgtNGVmNWI3ZDU4MDcwLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDkuMjg4NzA4WiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jMzhkOGY1NS0yYWEwLTQ2M2YtOTEyYS1jN2Y0MDc2OWNlYTQv
+        cnBtL3JwbS9jM2QwZmUwZS05ZjkyLTQ3OWQtYjNjNS1mYTExMDVkMmY0M2Iv
         dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2MzOGQ4ZjU1LTJhYTAtNDYzZi05MTJhLWM3ZjQw
-        NzY5Y2VhNC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtL2MzZDBmZTBlLTlmOTItNDc5ZC1iM2M1LWZhMTEw
+        NWQyZjQzYi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:00 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/bca20c12-d387-440f-8760-af103e7a8fdd/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/a6ecdaa0-fe1f-4250-829f-6794c89280c6/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
-        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOGY4
-        NzI2ZDktODQ0My00MTY4LWJhODYtY2U1MGNlNTE4MzI3LyJ9
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYWI0
+        OWI4YzUtY2FjNy00ZjBkLTliOTgtNGVmNWI3ZDU4MDcwLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1329,7 +1329,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:00 GMT
+      - Tue, 19 Jul 2022 18:46:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1347,21 +1347,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3838cc5bb1884d1abc4af97c3e7202ac
+      - 587578b1e46f425bb218212a4ce5e719
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI1MjQ0MDlhLTNkZTUtNDJi
-        Zi05OGQwLTJiNGY2ODlkM2Y1MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRhZTIwMDUyLWQ4OGItNDFi
+        Ny1iM2U4LWIzYjMwMDZjMzk5OS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:00 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2524409a-3de5-42bf-98d0-2b4f689d3f50/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/4ae20052-d88b-41b7-b3e8-b3b3006c3999/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1382,7 +1382,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:00 GMT
+      - Tue, 19 Jul 2022 18:46:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1398,34 +1398,34 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1f14185e168f44adb5a481bc6a690621
+      - d999a9fac1f84e21b45a58504dd93e88
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '347'
+      - '346'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjUyNDQwOWEtM2Rl
-        NS00MmJmLTk4ZDAtMmI0ZjY4OWQzZjUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MDAuMzI3MTkwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGFlMjAwNTItZDg4
+        Yi00MWI3LWIzZTgtYjNiMzAwNmMzOTk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NDkuNjg2MzI2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIzODM4Y2M1YmIxODg0ZDFhYmM0YWY5N2Mz
-        ZTcyMDJhYyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjAwLjM1
-        OTM4NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MDAuNjE1
-        MjQ0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9lODQ3NTdhYi04MjRjLTRiYTQtYTVhZi1lZjg3ODBkMjkwNTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI1ODc1NzhiMWU0NmY0MjViYjIxODIxMmE0
+        Y2U1ZTcxOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ5Ljcz
+        NjI0M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDkuODU2
+        MTcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy83NGM0MDcyYS0zNjIzLTQ4NDItOGZhZS1lNGM0MjAwODk5YjAvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
         L2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:00 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/8f8726d9-8443-4168-ba86-ce50ce518327/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/ab49b8c5-cac7-4f0d-9b98-4ef5b7d58070/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1433,7 +1433,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1446,7 +1446,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:00 GMT
+      - Tue, 19 Jul 2022 18:46:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1462,43 +1462,43 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5e4e343a93004c34bf1fb680143bd207
+      - e54036e0c3404f80bef4a7dd8bb3f20a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '248'
+      - '250'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vOGY4NzI2ZDktODQ0My00MTY4LWJhODYtY2U1MGNlNTE4MzI3LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6NTkuNzkyODMzWiIsInJl
+        cG0vYWI0OWI4YzUtY2FjNy00ZjBkLTliOTgtNGVmNWI3ZDU4MDcwLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDkuMjg4NzA4WiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jMzhkOGY1NS0yYWEwLTQ2M2YtOTEyYS1jN2Y0MDc2OWNlYTQv
+        cnBtL3JwbS9jM2QwZmUwZS05ZjkyLTQ3OWQtYjNjNS1mYTExMDVkMmY0M2Iv
         dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2MzOGQ4ZjU1LTJhYTAtNDYzZi05MTJhLWM3ZjQw
-        NzY5Y2VhNC8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtL2MzZDBmZTBlLTlmOTItNDc5ZC1iM2M1LWZhMTEw
+        NWQyZjQzYi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:00 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/bca20c12-d387-440f-8760-af103e7a8fdd/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/a6ecdaa0-fe1f-4250-829f-6794c89280c6/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
-        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOGY4
-        NzI2ZDktODQ0My00MTY4LWJhODYtY2U1MGNlNTE4MzI3LyJ9
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYWI0
+        OWI4YzUtY2FjNy00ZjBkLTliOTgtNGVmNWI3ZDU4MDcwLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1511,7 +1511,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:00 GMT
+      - Tue, 19 Jul 2022 18:46:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1529,30 +1529,30 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7be8e336f42444178dc60eeabdbbd074
+      - 9e0644574e2041d7a98269405116e047
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwMzU4MTRhLWEyYWYtNGFl
-        MS04MzgwLTRiY2ZiNDZhYmRkYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc5YTVlYTNkLTVkMzEtNDE1
+        ZC1iNzk0LWVhNDY2MjBjNDVlZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:00 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/exporters/core/pulp/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/
     body:
       encoding: UTF-8
       base64_string: |
         eyJuYW1lIjoiRW1wdHlfT3JnYW5pemF0aW9uX0FDTUVfRGVmYXVsdF9Db250
         ZW50Vmlld18xLjAiLCJwYXRoIjoiL3Zhci9saWIvcHVscC9leHBvcnRzL0Vt
-        cHR5X09yZ2FuaXphdGlvbi9BQ01FX0RlZmF1bHRfQ29udGVudFZpZXcvMS4w
+        cHR5X09yZ2FuaXphdGlvbi9BQ01FIERlZmF1bHQgQ29udGVudFZpZXcvMS4w
         L2Zvby9kYXRlX2RpciIsInJlcG9zaXRvcmllcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vYzM4ZDhmNTUtMmFhMC00NjNmLTkxMmEt
-        YzdmNDA3NjljZWE0LyJdfQ==
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUt
+        ZmExMTA1ZDJmNDNiLyJdfQ==
     headers:
       Content-Type:
       - application/json
@@ -1570,13 +1570,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:01 GMT
+      - Tue, 19 Jul 2022 18:46:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/exporters/core/pulp/460b2576-e151-4f90-a12b-dafc52b8336e/"
+      - "/pulp/api/v3/exporters/core/pulp/a069771f-3479-4915-a304-f7d94768761f/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1590,33 +1590,33 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 48c0317d095d4a5ba759d45105db8903
+      - 392d729d588b48f7b8bdb6a974fde5e7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
-        cC80NjBiMjU3Ni1lMTUxLTRmOTAtYTEyYi1kYWZjNTJiODMzNmUvIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyMi0wNS0yM1QyMzoyOTowMS4wMDIzMTZaIiwibmFt
+        cC9hMDY5NzcxZi0zNDc5LTQ5MTUtYTMwNC1mN2Q5NDc2ODc2MWYvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMi0wNy0xOVQxODo0Njo1MC4zNjIxNDRaIiwibmFt
         ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
         ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
-        cmdhbml6YXRpb24vQUNNRV9EZWZhdWx0X0NvbnRlbnRWaWV3LzEuMC9mb28v
+        cmdhbml6YXRpb24vQUNNRSBEZWZhdWx0IENvbnRlbnRWaWV3LzEuMC9mb28v
         ZGF0ZV9kaXIiLCJyZXBvc2l0b3JpZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2MzOGQ4ZjU1LTJhYTAtNDYzZi05MTJhLWM3ZjQw
-        NzY5Y2VhNC8iXSwibGFzdF9leHBvcnQiOm51bGx9
+        aXRvcmllcy9ycG0vcnBtL2MzZDBmZTBlLTlmOTItNDc5ZC1iM2M1LWZhMTEw
+        NWQyZjQzYi8iXSwibGFzdF9leHBvcnQiOm51bGx9
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:01 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:50 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/exporters/core/pulp/460b2576-e151-4f90-a12b-dafc52b8336e/exports/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/a069771f-3479-4915-a304-f7d94768761f/exports/
     body:
       encoding: UTF-8
       base64_string: |
         eyJ2ZXJzaW9ucyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYzM4ZDhmNTUtMmFhMC00NjNmLTkxMmEtYzdmNDA3NjljZWE0L3ZlcnNp
+        cG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1ZDJmNDNiL3ZlcnNp
         b25zLzEvIl0sImNodW5rX3NpemUiOiIwLjFHQiJ9
     headers:
       Content-Type:
@@ -1635,7 +1635,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:01 GMT
+      - Tue, 19 Jul 2022 18:46:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1653,21 +1653,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 1d8bfe06bda643bf9f37e246a6fed1dc
+      - f14f8c6f40d14c43aa5fd03eda6bcb91
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YxYjZhODNhLWFiZjAtNGQ4
-        Zi1iYTFiLWI1MGM0MDc4YzljMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YzYjRjNmE5LTc0YTctNDFj
+        My04NGJhLTVmMDZhOTA1ZTUwYy8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:01 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/f1b6a83a-abf0-4d8f-ba1b-b50c4078c9c0/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/f3b4c6a9-74a7-41c3-84ba-5f06a905e50c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1688,7 +1688,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:01 GMT
+      - Tue, 19 Jul 2022 18:46:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1704,25 +1704,25 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e79c7650209b42c5af1f720dc21c5899
+      - 555a52fbb3e846ce9d98c1949b2653fa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '510'
+      - '509'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjFiNmE4M2EtYWJm
-        MC00ZDhmLWJhMWItYjUwYzQwNzhjOWMwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MDEuMDc1NTEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjNiNGM2YTktNzRh
+        Ny00MWMzLTg0YmEtNWYwNmE5MDVlNTBjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NTAuNDQ2NDMxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5leHBvcnQucHVscF9leHBv
-        cnQiLCJsb2dnaW5nX2NpZCI6IjFkOGJmZTA2YmRhNjQzYmY5ZjM3ZTI0NmE2
-        ZmVkMWRjIiwic3RhcnRlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MDEuMTE3
-        NDM3WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNS0yM1QyMzoyOTowMS43MDMw
-        NzFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzL2I3NjM4MThmLTAzOTItNGZlMS1hZWRhLTY1M2ZkMWExMWNkOS8iLCJw
+        cnQiLCJsb2dnaW5nX2NpZCI6ImYxNGY4YzZmNDBkMTRjNDNhYTVmZDAzZWRh
+        NmJjYjkxIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NTAuNDk0
+        OTE1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0xOVQxODo0Njo1MC45Njky
+        OTdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzBmMjMwNTg2LWIwNzUtNGE5NC1hY2QyLWFmNWE2NzMyOTQ1MS8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRXhwb3J0
         aW5nIEFydGlmYWN0cyIsImNvZGUiOiJleHBvcnQuYXJ0aWZhY3RzIiwic3Rh
@@ -1732,16 +1732,16 @@ http_interactions:
         b3J0LnJlcG8udmVyc2lvbi5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQi
         LCJ0b3RhbCI6MzYsImRvbmUiOjM2LCJzdWZmaXgiOm51bGx9XSwiY3JlYXRl
         ZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2V4cG9ydGVycy9jb3JlL3B1
-        bHAvNDYwYjI1NzYtZTE1MS00ZjkwLWExMmItZGFmYzUyYjgzMzZlL2V4cG9y
-        dHMvM2UwMTc5NjktMzlhNi00NDFjLWEwYjEtOTFlODNjYTRlODBhLyJdLCJy
+        bHAvYTA2OTc3MWYtMzQ3OS00OTE1LWEzMDQtZjdkOTQ3Njg3NjFmL2V4cG9y
+        dHMvYzRhYWVkZTItNzQ3YS00ZjA4LWI5YzEtYzI3MWI5ZTk4MWYwLyJdLCJy
         ZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9leHBv
-        cnRlcnMvY29yZS9wdWxwLzQ2MGIyNTc2LWUxNTEtNGY5MC1hMTJiLWRhZmM1
-        MmI4MzM2ZS8iXX0=
+        cnRlcnMvY29yZS9wdWxwL2EwNjk3NzFmLTM0NzktNDkxNS1hMzA0LWY3ZDk0
+        NzY4NzYxZi8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:01 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/exporters/core/pulp/460b2576-e151-4f90-a12b-dafc52b8336e/exports/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/a069771f-3479-4915-a304-f7d94768761f/exports/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1762,7 +1762,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:01 GMT
+      - Tue, 19 Jul 2022 18:46:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1778,49 +1778,49 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b4ab666ba8f7452392e1c3a742fbb9e2
+      - ddb3bcfc994747de8464bbf70cce5b4a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '543'
+      - '546'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9leHBvcnRlcnMvY29y
-        ZS9wdWxwLzQ2MGIyNTc2LWUxNTEtNGY5MC1hMTJiLWRhZmM1MmI4MzM2ZS9l
-        eHBvcnRzLzNlMDE3OTY5LTM5YTYtNDQxYy1hMGIxLTkxZTgzY2E0ZTgwYS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI5OjAxLjM0ODY0OFoi
-        LCJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YxYjZhODNhLWFiZjAtNGQ4
-        Zi1iYTFiLWI1MGM0MDc4YzljMC8iLCJleHBvcnRlZF9yZXNvdXJjZXMiOlsi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2MzOGQ4ZjU1LTJh
-        YTAtNDYzZi05MTJhLWM3ZjQwNzY5Y2VhNC92ZXJzaW9ucy8xLyJdLCJwYXJh
+        ZS9wdWxwL2EwNjk3NzFmLTM0NzktNDkxNS1hMzA0LWY3ZDk0NzY4NzYxZi9l
+        eHBvcnRzL2M0YWFlZGUyLTc0N2EtNGYwOC1iOWMxLWMyNzFiOWU5ODFmMC8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjUwLjYyMDE4NFoi
+        LCJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YzYjRjNmE5LTc0YTctNDFj
+        My04NGJhLTVmMDZhOTA1ZTUwYy8iLCJleHBvcnRlZF9yZXNvdXJjZXMiOlsi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2MzZDBmZTBlLTlm
+        OTItNDc5ZC1iM2M1LWZhMTEwNWQyZjQzYi92ZXJzaW9ucy8xLyJdLCJwYXJh
         bXMiOnsidmVyc2lvbnMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
-        cG0vcnBtL2MzOGQ4ZjU1LTJhYTAtNDYzZi05MTJhLWM3ZjQwNzY5Y2VhNC92
+        cG0vcnBtL2MzZDBmZTBlLTlmOTItNDc5ZC1iM2M1LWZhMTEwNWQyZjQzYi92
         ZXJzaW9ucy8xLyJdLCJjaHVua19zaXplIjoiMC4xR0IifSwib3V0cHV0X2Zp
         bGVfaW5mbyI6eyIvdmFyL2xpYi9wdWxwL2V4cG9ydHMvRW1wdHlfT3JnYW5p
-        emF0aW9uL0FDTUVfRGVmYXVsdF9Db250ZW50Vmlldy8xLjAvZm9vL2RhdGVf
-        ZGlyL2V4cG9ydC0zZTAxNzk2OS0zOWE2LTQ0MWMtYTBiMS05MWU4M2NhNGU4
-        MGEtMjAyMjA1MjNfMjMyOS10b2MuanNvbiI6ImUwY2UzMmQ1NmI5ZDVhNGVk
-        Y2UwMDUyZTg5ZDc3NTI2NmE4YjM2Y2M0MDNjYWQ1YTNiNTk4NDIyMzA3MDM5
-        ZDIiLCIvdmFyL2xpYi9wdWxwL2V4cG9ydHMvRW1wdHlfT3JnYW5pemF0aW9u
-        L0FDTUVfRGVmYXVsdF9Db250ZW50Vmlldy8xLjAvZm9vL2RhdGVfZGlyL2V4
-        cG9ydC0zZTAxNzk2OS0zOWE2LTQ0MWMtYTBiMS05MWU4M2NhNGU4MGEtMjAy
-        MjA1MjNfMjMyOS50YXIuZ3ouMDAwMCI6IjEzOWI3NTg3NjQ5MjEzYzA2ZmUy
-        OTI5NDljNGFkMDZkMjNmMWMyNTg4NjIzNDkzY2NlYmFkZDBlNTg5Y2RkYTEi
+        emF0aW9uL0FDTUUgRGVmYXVsdCBDb250ZW50Vmlldy8xLjAvZm9vL2RhdGVf
+        ZGlyL2V4cG9ydC1jNGFhZWRlMi03NDdhLTRmMDgtYjljMS1jMjcxYjllOTgx
+        ZjAtMjAyMjA3MTlfMTg0Ni10b2MuanNvbiI6IjAzZmY0MzZjN2JkMGZjNDhh
+        ODFmMTYxYmQxZDA1NjZjZjg4MDUxMDY4MzFjZTcyOGJmZjc2ZGIwYjAzZTRl
+        MjIiLCIvdmFyL2xpYi9wdWxwL2V4cG9ydHMvRW1wdHlfT3JnYW5pemF0aW9u
+        L0FDTUUgRGVmYXVsdCBDb250ZW50Vmlldy8xLjAvZm9vL2RhdGVfZGlyL2V4
+        cG9ydC1jNGFhZWRlMi03NDdhLTRmMDgtYjljMS1jMjcxYjllOTgxZjAtMjAy
+        MjA3MTlfMTg0Ni50YXIuZ3ouMDAwMCI6ImEwNmUzNDJjM2RmMGRiMDlhYzE1
+        MTc4MGVmNmM0MzZiMjE1NzViZGVkNGFiMjI5YmM3OTJjNzJhM2VmY2ZiMGQi
         fSwidG9jX2luZm8iOnsiZmlsZSI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9F
-        bXB0eV9Pcmdhbml6YXRpb24vQUNNRV9EZWZhdWx0X0NvbnRlbnRWaWV3LzEu
-        MC9mb28vZGF0ZV9kaXIvZXhwb3J0LTNlMDE3OTY5LTM5YTYtNDQxYy1hMGIx
-        LTkxZTgzY2E0ZTgwYS0yMDIyMDUyM18yMzI5LXRvYy5qc29uIiwic2hhMjU2
-        IjoiZTBjZTMyZDU2YjlkNWE0ZWRjZTAwNTJlODlkNzc1MjY2YThiMzZjYzQw
-        M2NhZDVhM2I1OTg0MjIzMDcwMzlkMiJ9fV19
+        bXB0eV9Pcmdhbml6YXRpb24vQUNNRSBEZWZhdWx0IENvbnRlbnRWaWV3LzEu
+        MC9mb28vZGF0ZV9kaXIvZXhwb3J0LWM0YWFlZGUyLTc0N2EtNGYwOC1iOWMx
+        LWMyNzFiOWU5ODFmMC0yMDIyMDcxOV8xODQ2LXRvYy5qc29uIiwic2hhMjU2
+        IjoiMDNmZjQzNmM3YmQwZmM0OGE4MWYxNjFiZDFkMDU2NmNmODgwNTEwNjgz
+        MWNlNzI4YmZmNzZkYjBiMDNlNGUyMiJ9fV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:01 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/c38d8f55-2aa0-463f-912a-c7f40769cea4/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/c3d0fe0e-9f92-479d-b3c5-fa1105d2f43b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1828,7 +1828,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1841,7 +1841,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:01 GMT
+      - Tue, 19 Jul 2022 18:46:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1857,24 +1857,24 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4e924583e18f4547bb2326d67a623061
+      - 83f06e481eb048ecb92dbe699b031a39
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '289'
+      - '287'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYzM4ZDhmNTUtMmFhMC00NjNmLTkxMmEtYzdmNDA3NjljZWE0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDUtMjNUMjM6Mjg6NTYuMDk1MTA4WiIsInZl
+        cG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1ZDJmNDNiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDYuMDAwMjk1WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYzM4ZDhmNTUtMmFhMC00NjNmLTkxMmEtYzdmNDA3NjljZWE0L3ZlcnNp
+        cG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1ZDJmNDNiL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jMzhkOGY1NS0y
-        YWEwLTQ2M2YtOTEyYS1jN2Y0MDc2OWNlYTQvdmVyc2lvbnMvMS8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jM2QwZmUwZS05
+        ZjkyLTQ3OWQtYjNjNS1mYTExMDVkMmY0M2IvdmVyc2lvbnMvMS8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -1883,10 +1883,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:01 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/exporters/core/pulp/460b2576-e151-4f90-a12b-dafc52b8336e/exports/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/a069771f-3479-4915-a304-f7d94768761f/exports/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1907,7 +1907,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:02 GMT
+      - Tue, 19 Jul 2022 18:46:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1923,49 +1923,49 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9e575be711524421bf45b300439427d0
+      - 67dcc91bfb444cd89f0d27a4a95c8902
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '543'
+      - '546'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9leHBvcnRlcnMvY29y
-        ZS9wdWxwLzQ2MGIyNTc2LWUxNTEtNGY5MC1hMTJiLWRhZmM1MmI4MzM2ZS9l
-        eHBvcnRzLzNlMDE3OTY5LTM5YTYtNDQxYy1hMGIxLTkxZTgzY2E0ZTgwYS8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA1LTIzVDIzOjI5OjAxLjM0ODY0OFoi
-        LCJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YxYjZhODNhLWFiZjAtNGQ4
-        Zi1iYTFiLWI1MGM0MDc4YzljMC8iLCJleHBvcnRlZF9yZXNvdXJjZXMiOlsi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2MzOGQ4ZjU1LTJh
-        YTAtNDYzZi05MTJhLWM3ZjQwNzY5Y2VhNC92ZXJzaW9ucy8xLyJdLCJwYXJh
+        ZS9wdWxwL2EwNjk3NzFmLTM0NzktNDkxNS1hMzA0LWY3ZDk0NzY4NzYxZi9l
+        eHBvcnRzL2M0YWFlZGUyLTc0N2EtNGYwOC1iOWMxLWMyNzFiOWU5ODFmMC8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjUwLjYyMDE4NFoi
+        LCJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YzYjRjNmE5LTc0YTctNDFj
+        My04NGJhLTVmMDZhOTA1ZTUwYy8iLCJleHBvcnRlZF9yZXNvdXJjZXMiOlsi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2MzZDBmZTBlLTlm
+        OTItNDc5ZC1iM2M1LWZhMTEwNWQyZjQzYi92ZXJzaW9ucy8xLyJdLCJwYXJh
         bXMiOnsidmVyc2lvbnMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
-        cG0vcnBtL2MzOGQ4ZjU1LTJhYTAtNDYzZi05MTJhLWM3ZjQwNzY5Y2VhNC92
+        cG0vcnBtL2MzZDBmZTBlLTlmOTItNDc5ZC1iM2M1LWZhMTEwNWQyZjQzYi92
         ZXJzaW9ucy8xLyJdLCJjaHVua19zaXplIjoiMC4xR0IifSwib3V0cHV0X2Zp
         bGVfaW5mbyI6eyIvdmFyL2xpYi9wdWxwL2V4cG9ydHMvRW1wdHlfT3JnYW5p
-        emF0aW9uL0FDTUVfRGVmYXVsdF9Db250ZW50Vmlldy8xLjAvZm9vL2RhdGVf
-        ZGlyL2V4cG9ydC0zZTAxNzk2OS0zOWE2LTQ0MWMtYTBiMS05MWU4M2NhNGU4
-        MGEtMjAyMjA1MjNfMjMyOS10b2MuanNvbiI6ImUwY2UzMmQ1NmI5ZDVhNGVk
-        Y2UwMDUyZTg5ZDc3NTI2NmE4YjM2Y2M0MDNjYWQ1YTNiNTk4NDIyMzA3MDM5
-        ZDIiLCIvdmFyL2xpYi9wdWxwL2V4cG9ydHMvRW1wdHlfT3JnYW5pemF0aW9u
-        L0FDTUVfRGVmYXVsdF9Db250ZW50Vmlldy8xLjAvZm9vL2RhdGVfZGlyL2V4
-        cG9ydC0zZTAxNzk2OS0zOWE2LTQ0MWMtYTBiMS05MWU4M2NhNGU4MGEtMjAy
-        MjA1MjNfMjMyOS50YXIuZ3ouMDAwMCI6IjEzOWI3NTg3NjQ5MjEzYzA2ZmUy
-        OTI5NDljNGFkMDZkMjNmMWMyNTg4NjIzNDkzY2NlYmFkZDBlNTg5Y2RkYTEi
+        emF0aW9uL0FDTUUgRGVmYXVsdCBDb250ZW50Vmlldy8xLjAvZm9vL2RhdGVf
+        ZGlyL2V4cG9ydC1jNGFhZWRlMi03NDdhLTRmMDgtYjljMS1jMjcxYjllOTgx
+        ZjAtMjAyMjA3MTlfMTg0Ni10b2MuanNvbiI6IjAzZmY0MzZjN2JkMGZjNDhh
+        ODFmMTYxYmQxZDA1NjZjZjg4MDUxMDY4MzFjZTcyOGJmZjc2ZGIwYjAzZTRl
+        MjIiLCIvdmFyL2xpYi9wdWxwL2V4cG9ydHMvRW1wdHlfT3JnYW5pemF0aW9u
+        L0FDTUUgRGVmYXVsdCBDb250ZW50Vmlldy8xLjAvZm9vL2RhdGVfZGlyL2V4
+        cG9ydC1jNGFhZWRlMi03NDdhLTRmMDgtYjljMS1jMjcxYjllOTgxZjAtMjAy
+        MjA3MTlfMTg0Ni50YXIuZ3ouMDAwMCI6ImEwNmUzNDJjM2RmMGRiMDlhYzE1
+        MTc4MGVmNmM0MzZiMjE1NzViZGVkNGFiMjI5YmM3OTJjNzJhM2VmY2ZiMGQi
         fSwidG9jX2luZm8iOnsiZmlsZSI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9F
-        bXB0eV9Pcmdhbml6YXRpb24vQUNNRV9EZWZhdWx0X0NvbnRlbnRWaWV3LzEu
-        MC9mb28vZGF0ZV9kaXIvZXhwb3J0LTNlMDE3OTY5LTM5YTYtNDQxYy1hMGIx
-        LTkxZTgzY2E0ZTgwYS0yMDIyMDUyM18yMzI5LXRvYy5qc29uIiwic2hhMjU2
-        IjoiZTBjZTMyZDU2YjlkNWE0ZWRjZTAwNTJlODlkNzc1MjY2YThiMzZjYzQw
-        M2NhZDVhM2I1OTg0MjIzMDcwMzlkMiJ9fV19
+        bXB0eV9Pcmdhbml6YXRpb24vQUNNRSBEZWZhdWx0IENvbnRlbnRWaWV3LzEu
+        MC9mb28vZGF0ZV9kaXIvZXhwb3J0LWM0YWFlZGUyLTc0N2EtNGYwOC1iOWMx
+        LWMyNzFiOWU5ODFmMC0yMDIyMDcxOV8xODQ2LXRvYy5qc29uIiwic2hhMjU2
+        IjoiMDNmZjQzNmM3YmQwZmM0OGE4MWYxNjFiZDFkMDU2NmNmODgwNTEwNjgz
+        MWNlNzI4YmZmNzZkYjBiMDNlNGUyMiJ9fV19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:02 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/exporters/core/pulp/460b2576-e151-4f90-a12b-dafc52b8336e/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/a069771f-3479-4915-a304-f7d94768761f/
     body:
       encoding: UTF-8
       base64_string: 'eyJsYXN0X2V4cG9ydCI6bnVsbH0=
@@ -1988,7 +1988,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:02 GMT
+      - Tue, 19 Jul 2022 18:46:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2006,21 +2006,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4babe5305e3640aab3274e73f91fb5bc
+      - d322adf0125d4fa0aa8ca37577c0008f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZmZTZjMTY3LWYxNDgtNDdm
-        Yi05ZmRlLTJhM2JkMmRkOTIwYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkMmEwNDRlLWExZDUtNDg5
+        MC04ZTcyLWMxMzg0ODY3ODNiYS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:02 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/exporters/core/pulp/460b2576-e151-4f90-a12b-dafc52b8336e/exports/3e017969-39a6-441c-a0b1-91e83ca4e80a/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/a069771f-3479-4915-a304-f7d94768761f/exports/c4aaede2-747a-4f08-b9c1-c271b9e981f0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2041,7 +2041,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:02 GMT
+      - Tue, 19 Jul 2022 18:46:51 GMT
       Server:
       - gunicorn
       Vary:
@@ -2055,19 +2055,19 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b91bb58b334c407e835125b6b49de1e7
+      - 31c55e0003f1451293c1c7ca3235d5ec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:02 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/exporters/core/pulp/460b2576-e151-4f90-a12b-dafc52b8336e/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/a069771f-3479-4915-a304-f7d94768761f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2088,7 +2088,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:02 GMT
+      - Tue, 19 Jul 2022 18:46:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2106,21 +2106,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6f9df44c024d48e1a904009989fffa79
+      - 04a864a8b58842f8ae7e447aeac5d786
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU3M2EzN2RlLWY3MzYtNDJl
-        Yi1iNzhiLTcxZjQyOTQ0NDRlZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZlMzhmODgzLWQ1OGQtNGRi
+        Ni1hNTNlLTUwMDc4MDM0ODQ4OC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:02 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/573a37de-f736-42eb-b78b-71f4294444ef/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/6e38f883-d58d-4db6-a53e-500780348488/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2141,7 +2141,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:02 GMT
+      - Tue, 19 Jul 2022 18:46:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2157,35 +2157,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b8907a04d9ba40ea982771062cb94347
+      - 2b2cf937cbd94707b39f40738fe6d66f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
       - '369'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTczYTM3ZGUtZjcz
-        Ni00MmViLWI3OGItNzFmNDI5NDQ0NGVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MDIuMjg1NTg0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmUzOGY4ODMtZDU4
+        ZC00ZGI2LWE1M2UtNTAwNzgwMzQ4NDg4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NTEuNDUwMzcwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2ZjlkZjQ0YzAyNGQ0OGUxYTkwNDAwOTk4
-        OWZmZmE3OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjAyLjMy
-        MDM2M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MDIuMzUy
-        MDk5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zZmE2ZDA4Mi05NjgzLTRlZmYtYWE2ZC0xZWQzNDUxMDcyZTUvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwNGE4NjRhOGI1ODg0MmY4YWU3ZTQ0N2Fl
+        YWM1ZDc4NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjUxLjQ5
+        MzEwOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NTEuNTIy
+        NDM4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81MWI3NmQzNS1hYTBhLTQ0OTMtYmVlNS0xZTdlZTJmZmVjMTQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVscC80NjBiMjU3Ni1lMTUxLTRmOTAt
-        YTEyYi1kYWZjNTJiODMzNmUvIl19
+        cGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVscC9hMDY5NzcxZi0zNDc5LTQ5MTUt
+        YTMwNC1mN2Q5NDc2ODc2MWYvIl19
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:02 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/042624ef-6354-450b-84a8-5159647b2c2a/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/d63541bf-e3d9-47a1-98aa-a4ee71ab120c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2193,7 +2193,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2206,7 +2206,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:02 GMT
+      - Tue, 19 Jul 2022 18:46:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2224,21 +2224,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 281dcbfe4c854265be0eef08ce8301f6
+      - 362c8d713ff7468aae2edeee3bc29f05
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhiMDBkMDRiLTQ2Y2UtNGNj
-        Mi1hOGY4LWU3ZTE1MWQ2MmU0MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FmZTk1Yjg3LWYxOTAtNDc2
+        Ny05NzlkLWU3Y2U4ZTE1ZWRiZS8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:02 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/8b00d04b-46ce-4cc2-a8f8-e7e151d62e40/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/afe95b87-f190-4767-979d-e7ce8e15edbe/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2259,7 +2259,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:02 GMT
+      - Tue, 19 Jul 2022 18:46:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2275,35 +2275,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 50f69ec4b76c411881e9693519320ec3
+      - 9c1382b0cad34d23ae0b145614e61648
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '370'
+      - '372'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGIwMGQwNGItNDZj
-        ZS00Y2MyLWE4ZjgtZTdlMTUxZDYyZTQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MDIuNjA0NzM5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWZlOTViODctZjE5
+        MC00NzY3LTk3OWQtZTdjZThlMTVlZGJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NTEuODU1NjI4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIyODFkY2JmZTRjODU0MjY1YmUwZWVmMDhj
-        ZTgzMDFmNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjAyLjYz
-        NTk3MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MDIuNjc5
-        NTg1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIzNjJjOGQ3MTNmZjc0NjhhYWUyZWRlZWUz
+        YmMyOWYwNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjUxLjkw
+        NDE2OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NTEuOTUy
+        MTQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8zNjAxYmE4OC1hYzM2LTQwNzctYjhhNC04YTA3ODlmYzJkOGMvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA0MjYyNGVmLTYzNTQtNDUwYi04NGE4
-        LTUxNTk2NDdiMmMyYS8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q2MzU0MWJmLWUzZDktNDdhMS05OGFh
+        LWE0ZWU3MWFiMTIwYy8iXX0=
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:02 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/bca20c12-d387-440f-8760-af103e7a8fdd/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/a6ecdaa0-fe1f-4250-829f-6794c89280c6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2311,7 +2311,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2324,7 +2324,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:02 GMT
+      - Tue, 19 Jul 2022 18:46:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2342,21 +2342,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - dd303b2c0dad4b5ca3dddd4f49eef7b1
+      - e1eee041624f43ac86487b5f2ffabf7c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNhOTJiYzIxLWVjNDAtNDM4
-        NS1hNzA3LTQ5OTNmYmJiYTg3MC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UyMzE3NmNmLTY1ODgtNDc0
+        Ni1hMjMyLTlkY2QwMmJkNjM0NC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:02 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:52 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/c38d8f55-2aa0-463f-912a-c7f40769cea4/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/c3d0fe0e-9f92-479d-b3c5-fa1105d2f43b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2364,7 +2364,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.5/ruby
+      - OpenAPI-Generator/3.17.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2377,7 +2377,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:02 GMT
+      - Tue, 19 Jul 2022 18:46:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2395,21 +2395,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 98c9bd6d81ab4d0195c34d05a35c99e1
+      - f09b5ab842c04410a12b2a9bf843e472
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI1NzJjNGI2LTE5ZmUtNDMx
-        OC1iMzgxLTQxMDEwOThjOGZkMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ViOTdmODdkLWU4NmYtNDYy
+        OS1hYjdkLTYxZjI4NzZlNWMxZC8ifQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:02 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel.manicotto.example.com/pulp/api/v3/tasks/2572c4b6-19fe-4318-b381-4101098c8fd0/
+    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/eb97f87d-e86f-4629-ab7d-61f2876e5c1d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2430,7 +2430,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 23 May 2022 23:29:03 GMT
+      - Tue, 19 Jul 2022 18:46:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2446,30 +2446,30 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9d01b60dfe02454189b78d658bc2f489
+      - a1244afedacd4dda99dce716398c9a7d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.manicotto.example.com
+      - 1.1 zanzibar.lagrange.example.com
       Content-Length:
-      - '374'
+      - '373'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjU3MmM0YjYtMTlm
-        ZS00MzE4LWIzODEtNDEwMTA5OGM4ZmQwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDUtMjNUMjM6Mjk6MDIuODU0NzUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWI5N2Y4N2QtZTg2
+        Zi00NjI5LWFiN2QtNjFmMjg3NmU1YzFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDctMTlUMTg6NDY6NTIuMTQyNDU0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI5OGM5YmQ2ZDgxYWI0ZDAxOTVjMzRkMDVh
-        MzVjOTllMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA1LTIzVDIzOjI5OjAyLjg4
-        ODExNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDUtMjNUMjM6Mjk6MDMuMTE2
-        NDE1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy9iNzYzODE4Zi0wMzkyLTRmZTEtYWVkYS02NTNmZDFhMTFjZDkvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJmMDliNWFiODQyYzA0NDEwYTEyYjJhOWJm
+        ODQzZTQ3MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjUyLjE5
+        MTcyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NTIuMzEy
+        MDIxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy81MWI3NmQzNS1hYTBhLTQ0OTMtYmVlNS0xZTdlZTJmZmVjMTQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzM4ZDhmNTUtMmFhMC00NjNm
-        LTkxMmEtYzdmNDA3NjljZWE0LyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzNkMGZlMGUtOWY5Mi00Nzlk
+        LWIzYzUtZmExMTA1ZDJmNDNiLyJdfQ==
     http_version: 
-  recorded_at: Mon, 23 May 2022 23:29:03 GMT
+  recorded_at: Tue, 19 Jul 2022 18:46:52 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This commit adds the concept of `syncable` exports. 

```
$ hammer content-export complete version --format=syncable --id=81
[....................................................................................................................................................................] [100%]
Generated /var/lib/pulp/exports/Default_Organization/sample-content-view/4.0/2022-06-30T22-19-34-00-00
```

The files are exported in a different format. cd into `/var/lib/pulp/exports/Default_Organization/sample-content-view/4.0/2022-06-30T22-19-34-00-00` and you should see a directory structure that looks like the following. 
```
$ ls -l /var/lib/pulp/exports/Default_Organization/sample-content-view/4.0/2022-06-30T22-27-11-00-00/content/dist/rhel/server/7/7.5/x86_64/openstack-tools/10/os
total 24300
-rw-rw-rw-+ 1 pulp pulp   19484 Jun 30 22:27 babel-2.3.4-1.el7ost.noarch.rpm
-rw-rw-rw-+ 1 pulp pulp   71976 Jun 30 22:27 openshift-heat-templates-0.9.9-2.el7ost.noarch.rpm
-rw-rw-rw-+ 1 pulp pulp   72448 Jun 30 22:27 openshift-heat-templates-0.9.9-5.el7ost.noarch.rpm
.....
drwxrwxrwx+ 2 pulp pulp    4096 Jun 30 22:27 repodata

$ 
```

The export directory should also display generated listing files (note you need to run hammer as root for this part.)
```
$ find /var/lib/pulp/exports/Default_Organization/sample-content-view/4.0/2022-06-30T22-27-11-00-00/content/ -name listing
....
/var/lib/pulp/exports/Default_Organization/sample-content-view/4.0/2022-06-30T22-27-11-00-00/content/dist/rhel/server/7/listing
/var/lib/pulp/exports/Default_Organization/sample-content-view/4.0/2022-06-30T22-27-11-00-00/content/dist/rhel/server/listing
/var/lib/pulp/exports/Default_Organization/sample-content-view/4.0/2022-06-30T22-27-11-00-00/content/dist/rhel/listing
/var/lib/pulp/exports/Default_Organization/sample-content-view/4.0/2022-06-30T22-27-11-00-00/content/dist/listing
/var/lib/pulp/exports/Default_Organization/sample-content-view/4.0/2022-06-30T22-27-11-00-00/content/listing
....
```

This is similar to the cdn structure. The typical user would
1. Copy the contents of  `/var/lib/pulp/exports/Default_Organization/sample-content-view/4.0/2022-06-30T22-19-34-00-00` to a disconnected server 
2. Update the other server's cdn to `file:///var/lib/pulp/exports/Default_Organization/sample-content-view/4.0/2022-06-30T22-19-34-00-00`
3. Enable and Sync repos available in this archive

#### Constraints
- No `metadata.json` is generated.
- No import command available here. The disconnected user is responsible for the consistency of data.
- No incremental exports. Only complete for starts.

This will be ideally used in environments where one wants to share the exports to the world and the downstream server may be old and not having pulp3 installed. 

#### Considerations taken when implementing this change?
Pulp 3.14 and above had facilities to do a regular complete and incremental exports. However it expects the importer to match versions. In many disconnected environments user may not know what part the downstream may use. They just want a dump of the data like iso's that could then be hand delivered to the disconnected environment.

Pulp 3.16 and later added a new filesystem exports => https://docs.pulpproject.org/pulpcore/restapi.html#tag/Exporters:-Filesystem-Exports
Katello is taking advantage of this feature implement `syncable` exports.

Initially started the PR making this available for repository exports only. However in the current state all three content-export options are available to be extracted in syncable format.
- `hammer content-export complete version --format=syncable ....`
- `hammer content-export complete library --format=syncable ....`
- `hammer content-export complete repository --format=syncable ....`

The export rpm files are generated as hardlinks to the actual file on disk. This there by avoids the 2X space we may need for regular importable exports.  

There are couple of downsides as stated above
- No import command available here. The disconnected user is responsible for the consistency of data.
- No incremental exports. Only complete for starts.

#### What are the testing steps for this pull request?
- Make sure you have https://github.com/Katello/hammer-cli-katello/pull/856 checked out along with this pr.
- On your dev env you may need to run `sudo setfacl --recursive --modify u:vagrant:rwX,d:u:vagrant:rwX /var/lib/pulp/exports` so that listing files can be generate when hammer is running as a vagrant user.
- On your katello instance `Administer -> Settings -> Content`. 
- set both `Default Custom Repository download policy` and `Default Red Hat Repository download policy` to immediate
- Create an org
- Add/Enable + sync few repos (recommend Ansible/Openstack as they tend to be smaller.) 
- Create a content view with these repos an publish.

Try any of the 3 hammer commands listed here
- `hammer content-export complete version --format=syncable ....`
- `hammer content-export complete library --format=syncable ....`
- `hammer content-export complete repository --format=syncable ....`

- Check if the listing files generated ok
