### PR TITLE
Fixes #35165 - Jest & Nock JS test improvements

### DIFF
--- a/webpack/components/Search/__tests__/search.test.js
+++ b/webpack/components/Search/__tests__/search.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
-import nock, {
+import {
   nockInstance, assertNockRequest, mockAutocomplete, mockSetting,
 } from '../../../test-utils/nockWrapper';
 import { AUTOSEARCH_WHILE_TYPING, AUTOSEARCH_DELAY } from '../../../scenes/Settings/SettingsConstants.js';
@@ -24,7 +24,6 @@ beforeEach(() => {
 
 afterEach(() => {
   assertNockRequest(searchDelayScope);
-  nock.cleanAll();
 });
 
 jest.mock('../../../utils/useDebounce', () => ({

--- a/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, renderWithRedux } from 'react-testing-lib-wrapper';
 import ErrataOverviewCard from '../ErrataOverviewCard';
-import nock from '../../../../../test-utils/nockWrapper';
 
 const baseHostDetails = {
   id: 2,
@@ -20,10 +19,6 @@ const renderOptions = {
   },
 };
 describe('Without errata', () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   test('shows zero counts when there are 0 installable errata', () => {
     const hostDetails = {
       ...baseHostDetails,
@@ -89,10 +84,6 @@ describe('Without errata', () => {
 });
 
 describe('With errata', () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   test('shows links when there are errata', () => {
     const hostDetails = {
       ...baseHostDetails,

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { renderWithRedux, waitFor, patientlyWaitFor, fireEvent, act } from 'react-testing-lib-wrapper';
-import nock, { nockInstance, assertNockRequest, mockForemanAutocomplete, mockSetting } from '../../../../../test-utils/nockWrapper';
+import { nockInstance, assertNockRequest, mockForemanAutocomplete, mockSetting } from '../../../../../test-utils/nockWrapper';
 import { foremanApi } from '../../../../../services/api';
 import { REX_FEATURES } from '../RemoteExecutionConstants';
 import { HOST_TRACES_KEY, TRACES_SEARCH_QUERY } from '../TracesTab/HostTracesConstants';
@@ -74,7 +74,6 @@ describe('With tracer installed', () => {
     assertNockRequest(searchDelayScope);
     assertNockRequest(autoSearchScope);
     assertNockRequest(bookmarkScope);
-    nock.cleanAll();
   });
 
   test('Can call API for traces and show on screen on page load', async (done) => {
@@ -345,10 +344,6 @@ describe('With tracer installed', () => {
       [firstTrace] = results;
     });
 
-    afterEach(() => {
-      nock.cleanAll();
-    });
-
     test('Does not allow selection of session type traces', async (done) => {
       const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
 
@@ -374,10 +369,6 @@ describe('With tracer installed', () => {
 });
 
 describe('Without tracer installed', () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   test('Shows Enable Tracer empty state', async () => {
     const { queryByText } = renderWithRedux(<TracesTab />, renderOptions(false));
 

--- a/webpack/global_test_setup.js
+++ b/webpack/global_test_setup.js
@@ -24,6 +24,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  nock.restore();
+  nock.cleanAll();
 });
 

--- a/webpack/scenes/AlternateContentSources/Create/__tests__/acsCreate.test.js
+++ b/webpack/scenes/AlternateContentSources/Create/__tests__/acsCreate.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import * as reactRedux from 'react-redux';
 import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
 import api, { foremanApi } from '../../../../services/api';
-import nock, { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../../test-utils/nockWrapper';
+import { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../../test-utils/nockWrapper';
 import ACSTable from '../../MainTable/ACSTable';
 import contentCredentialResult from './contentCredentials.fixtures';
 import smartProxyResult from './smartProxy.fixtures';
@@ -43,7 +43,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  nock.cleanAll();
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
 });

--- a/webpack/scenes/AlternateContentSources/Details/__tests__/ACSExpandableDetails.test.js
+++ b/webpack/scenes/AlternateContentSources/Details/__tests__/ACSExpandableDetails.test.js
@@ -1,17 +1,13 @@
 import React from 'react';
 import { act, renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
 import { Route } from 'react-router-dom';
-import nock, { nockInstance, assertNockRequest } from '../../../../test-utils/nockWrapper';
+import { nockInstance, assertNockRequest } from '../../../../test-utils/nockWrapper';
 import api from '../../../../services/api';
 import ACSExpandableDetails from '../ACSExpandableDetails';
 import acsDetails from './acsDetails.fixtures';
 
 const acsDetailsURL = api.getApiUrl('/alternate_content_sources/1');
 const withACSRoute = component => <Route path="/labs/alternate_content_sources/:id([0-9]+)">{component}</Route>;
-
-afterEach(() => {
-  nock.cleanAll();
-});
 
 test('Can call API and show ACS details expandable sections on page load', async (done) => {
   const renderOptions = {

--- a/webpack/scenes/AlternateContentSources/MainTable/__tests__/acsTable.test.js
+++ b/webpack/scenes/AlternateContentSources/MainTable/__tests__/acsTable.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { renderWithRedux, patientlyWaitFor } from 'react-testing-lib-wrapper';
 
-import nock, { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../../test-utils/nockWrapper';
+import { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../../test-utils/nockWrapper';
 import api from '../../../../services/api';
 import ACSTable from '../ACSTable';
 import acsData from './acsIndex.fixtures.json';
@@ -21,7 +21,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  nock.cleanAll();
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
 });

--- a/webpack/scenes/Content/__tests__/contentTable.test.js
+++ b/webpack/scenes/Content/__tests__/contentTable.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { renderWithRedux, patientlyWaitFor } from 'react-testing-lib-wrapper';
-import nock, { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../test-utils/nockWrapper';
+import { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../test-utils/nockWrapper';
 import api from '../../../services/api';
 import ContentPage from '../ContentPage';
 import ansibleCollectionsResponse from './ansibleCollections.fixtures';
@@ -21,7 +21,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  nock.cleanAll();
   assertNockRequest(autoSearchScope);
   assertNockRequest(searchDelayScope);
 });

--- a/webpack/scenes/ContentViews/Delete/__tests__/contentViewDelete.test.js
+++ b/webpack/scenes/ContentViews/Delete/__tests__/contentViewDelete.test.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { renderWithRedux, patientlyWaitFor, fireEvent, act } from 'react-testing-lib-wrapper';
 import api, { foremanApi } from '../../../../services/api';
-import nock, {
+import {
   nockInstance, assertNockRequest, mockAutocomplete, mockSetting, mockForemanAutocomplete,
 } from '../../../../test-utils/nockWrapper';
 import CONTENT_VIEWS_KEY from '../../ContentViewsConstants';
@@ -53,7 +53,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  nock.cleanAll();
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
 });

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.test.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
-import nock, { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../../../test-utils/nockWrapper';
+import { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../../../test-utils/nockWrapper';
 import api from '../../../../../services/api';
 import CONTENT_VIEWS_KEY from '../../../ContentViewsConstants';
 import ContentViewComponents from '../ContentViewComponents';
@@ -30,7 +30,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  nock.cleanAll();
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
 });

--- a/webpack/scenes/ContentViews/Details/Filters/MatchContentModal/__tests__/CVRpmMatchContentModal.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/MatchContentModal/__tests__/CVRpmMatchContentModal.test.js
@@ -4,7 +4,7 @@ import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-
 
 import api from '../../../../../../services/api';
 import CVRpmMatchContentModal from '../CVRpmMatchContentModal';
-import nock, { nockInstance, assertNockRequest, mockSetting, mockAutocomplete } from '../../../../../../test-utils/nockWrapper';
+import { nockInstance, assertNockRequest, mockSetting, mockAutocomplete } from '../../../../../../test-utils/nockWrapper';
 
 import CVMatchedContent from './CVRpmMatchContent.fixtures.json';
 import CVMatchContentSearch from './CVRpmMatchContentSearch.fixtures.json';
@@ -27,7 +27,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  nock.cleanAll();
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
 });

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/CVContainerImageFilterContent.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/CVContainerImageFilterContent.test.js
@@ -3,7 +3,7 @@ import { renderWithRedux, patientlyWaitFor, fireEvent, act } from 'react-testing
 import { Route } from 'react-router-dom';
 
 import { cvFilterDetailsKey } from '../../../ContentViewsConstants';
-import nock, {
+import {
   nockInstance,
   assertNockRequest,
   mockAutocomplete,
@@ -51,7 +51,6 @@ beforeEach(() => {
 afterEach(() => {
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
-  nock.cleanAll();
 });
 
 test('Can view container image filter rules', async (done) => {

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/ContentViewPackageGroupFilter.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/ContentViewPackageGroupFilter.test.js
@@ -4,7 +4,7 @@ import { Route } from 'react-router-dom';
 
 import ContentViewFilterDetails from '../ContentViewFilterDetails';
 import { ADDED, cvFilterDetailsKey, NOT_ADDED } from '../../../ContentViewsConstants';
-import nock, {
+import {
   nockInstance,
   assertNockRequest,
 } from '../../../../../test-utils/nockWrapper';
@@ -37,10 +37,6 @@ const renderOptions = {
 };
 
 const withCVRoute = component => <Route path="/content_views/:id([0-9]+)#/filters/:filterId([0-9]+)">{component}</Route>;
-
-afterEach(() => {
-  nock.cleanAll();
-});
 
 jest.mock('../../../../../components/Search', () => () => 'mocked!');
 

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilterDetails.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilterDetails.test.js
@@ -4,7 +4,7 @@ import { Route } from 'react-router-dom';
 
 import ContentViewFilterDetails from '../ContentViewFilterDetails';
 import { cvFilterDetailsKey } from '../../../ContentViewsConstants';
-import nock, {
+import {
   nockInstance,
   assertNockRequest,
   mockAutocomplete,
@@ -40,7 +40,6 @@ beforeEach(() => {
 afterEach(() => {
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
-  nock.cleanAll();
 });
 
 test('Can show filter details and package groups on page load', async (done) => {

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilters.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilters.test.js
@@ -3,7 +3,7 @@ import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-
 import { Route } from 'react-router-dom';
 
 import api from '../../../../../services/api';
-import nock, { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../../../test-utils/nockWrapper';
+import { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../../../test-utils/nockWrapper';
 import ContentViewFilters from '../ContentViewFilters';
 import CONTENT_VIEWS_KEY from '../../../ContentViewsConstants';
 import cvFilterFixtures from './contentViewFilters.fixtures.json';
@@ -39,7 +39,6 @@ beforeEach(() => {
 afterEach(() => {
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
-  nock.cleanAll();
 });
 
 test('Can call API and show filters on page load', async (done) => {

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataIDFilter.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataIDFilter.test.js
@@ -4,7 +4,7 @@ import { Route } from 'react-router-dom';
 
 import ContentViewFilterDetails from '../ContentViewFilterDetails';
 import { cvFilterDetailsKey } from '../../../ContentViewsConstants';
-import nock, {
+import {
   nockInstance,
   assertNockRequest,
   mockAutocomplete,
@@ -47,7 +47,6 @@ beforeEach(() => {
 afterEach(() => {
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
-  nock.cleanAll();
 });
 
 test('Can enable and disable add filter button', async (done) => {

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/cvModuleStreamFilter.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/cvModuleStreamFilter.test.js
@@ -4,7 +4,7 @@ import { Route } from 'react-router-dom';
 
 import ContentViewFilterDetails from '../ContentViewFilterDetails';
 import { ADDED, cvFilterDetailsKey, NOT_ADDED } from '../../../ContentViewsConstants';
-import nock, {
+import {
   nockInstance,
   assertNockRequest,
   mockAutocomplete,
@@ -47,7 +47,6 @@ beforeEach(() => {
 afterEach(() => {
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
-  nock.cleanAll();
 });
 
 test('Can enable and disable add filter button', async (done) => {

--- a/webpack/scenes/ContentViews/Details/Histories/__tests__/contentViewHistory.test.js
+++ b/webpack/scenes/ContentViews/Details/Histories/__tests__/contentViewHistory.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { renderWithRedux, patientlyWaitFor } from 'react-testing-lib-wrapper';
 
-import nock, { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../../../test-utils/nockWrapper';
+import { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../../../test-utils/nockWrapper';
 import api from '../../../../../services/api';
 import CONTENT_VIEWS_KEY from '../../../ContentViewsConstants';
 import ContentViewHistories from '../ContentViewHistories';
@@ -23,7 +23,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  nock.cleanAll();
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
 });

--- a/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewAddRemove.test.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewAddRemove.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { renderWithRedux, patientlyWaitFor, act } from 'react-testing-lib-wrapper';
 
-import nock, { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../../../test-utils/nockWrapper';
+import { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../../../test-utils/nockWrapper';
 import api from '../../../../../services/api';
 import CONTENT_VIEWS_KEY from '../../../ContentViewsConstants';
 import ContentViewRepositories from '../ContentViewRepositories';
@@ -33,7 +33,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  nock.cleanAll();
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
 });

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/__tests__/cvVersionRemove.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/__tests__/cvVersionRemove.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
-import nock, { nockInstance, assertNockRequest, mockAutocomplete, mockForemanAutocomplete, mockSetting } from '../../../../../../test-utils/nockWrapper';
+import { nockInstance, assertNockRequest, mockAutocomplete, mockForemanAutocomplete, mockSetting } from '../../../../../../test-utils/nockWrapper';
 import api, { foremanApi } from '../../../../../../services/api';
 import CONTENT_VIEWS_KEY from '../../../../ContentViewsConstants';
 import ContentViewVersions from '../../ContentViewVersions';
@@ -43,7 +43,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  nock.cleanAll();
   assertNockRequest(envScope);
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/__tests__/ContentViewVersionDetails.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/__tests__/ContentViewVersionDetails.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { renderWithRedux, patientlyWaitFor } from 'react-testing-lib-wrapper';
 import { Route } from 'react-router-dom';
 import { head, last } from 'lodash';
-import nock, { nockInstance, assertNockRequest, mockSetting, mockAutocomplete } from '../../../../../../test-utils/nockWrapper';
+import { nockInstance, assertNockRequest, mockSetting, mockAutocomplete } from '../../../../../../test-utils/nockWrapper';
 import api from '../../../../../../services/api';
 import { cvVersionDetailsKey } from '../../../../ContentViewsConstants';
 import ContentViewVersionDetails from '../ContentViewVersionDetails';
@@ -51,7 +51,6 @@ beforeEach(() => {
 
 afterEach(() => {
   assertNockRequest(envScope);
-  nock.cleanAll();
 });
 // This is written separately, as the autocomplete/search scopes are not needed.
 test('Can show versions details - Components Tab', async (done) => {

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/__tests__/ContentViewVersionDetailsEmpty.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/__tests__/ContentViewVersionDetailsEmpty.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { renderWithRedux, patientlyWaitFor, act } from 'react-testing-lib-wrapper';
 import { Route } from 'react-router-dom';
 
-import nock, { nockInstance, assertNockRequest } from '../../../../../../test-utils/nockWrapper';
+import { nockInstance, assertNockRequest } from '../../../../../../test-utils/nockWrapper';
 import api from '../../../../../../services/api';
 import { cvVersionDetailsKey } from '../../../../ContentViewsConstants';
 import ContentViewVersionDetails from '../ContentViewVersionDetails';
@@ -39,7 +39,6 @@ beforeEach(() => {
 afterEach(() => {
   assertNockRequest(envScope);
   assertNockRequest(versionScope);
-  nock.cleanAll();
 });
 
 test('Can show versions detail header', async (done) => {

--- a/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersions.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersions.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act, renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
 import { Route } from 'react-router-dom';
-import nock, { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../../../test-utils/nockWrapper';
+import { nockInstance, assertNockRequest, mockAutocomplete, mockSetting } from '../../../../../test-utils/nockWrapper';
 import api from '../../../../../services/api';
 import CONTENT_VIEWS_KEY from '../../../ContentViewsConstants';
 import ContentViewVersions from '../ContentViewVersions';
@@ -50,7 +50,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  nock.cleanAll();
   assertNockRequest(envScope);
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);

--- a/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
+++ b/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
@@ -5,7 +5,7 @@ import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-
 import CONTENT_VIEWS_KEY from '../ContentViewsConstants';
 import ContentViewsPage from '../../ContentViews';
 import api from '../../../services/api';
-import nock, {
+import {
   nockInstance, assertNockRequest, mockAutocomplete, mockSetting,
 } from '../../../test-utils/nockWrapper';
 import createBasicCVs from './basicContentViews.fixtures';
@@ -31,7 +31,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  nock.cleanAll();
   assertNockRequest(searchDelayScope);
   assertNockRequest(autoSearchScope);
 });

--- a/webpack/test-utils/nockWrapper.js
+++ b/webpack/test-utils/nockWrapper.js
@@ -18,6 +18,13 @@ export const nockInstance = nock('http://localhost');
 // The number of tries dictates the number of attempts assert will make before failing.
 // `tries * interval` is the maximum time that every nock scope will wait before failing if not met.
 export const assertNockRequest = (nockScope, jestDone, tries = 600) => {
+  // First function run of setInterval is not until after interval milliseconds.
+  // So duplicating some code here just in case the scope is already complete.
+  if (nockScope.isDone()) {
+    nockScope.done(); // Assert nock request
+    if (jestDone) jestDone(); // Tell jest test is done
+    return;
+  }
   // 500ms interval * 600 tries = 5 min timeout
   const interval = 500;
   let i = 0;


### PR DESCRIPTION
  #### What are the changes introduced in this pull request?

Some JS test improvements:

1. In global_test.setup.js we call

```js
afterEach(() => {
  nock.restore();
});
```

`restore()` restores the HTTP interceptor to the normal unmocked behaviour, which is not desired or needed after each test. Instead, changed it to

```js
afterEach(() => {
  nock.cleanAll();
});
```

which clears all Nock scopes, and as a side bonus allows us to remove `nock.cleanAll()` from individual test files.

2. In NockWrapper.js there's a `setInterval` which calls the jest `done()` function. The problem is that `setInterval` does not call its passed function until after `delay` milliseconds - see https://developer.mozilla.org/en-US/docs/Web/API/setInterval

So the minimum time before calling jest `done()` will be 500 milliseconds. This means we are wasting countless seconds on our test runs.

Changed `nockWrapper.js` so that Jest `done()` is also checked and called before the first interval.

#### Considerations taken when implementing this change?

With these improvements, __Test run on CI seems to be reduced from >210 to ~160 seconds.__

#### What are the testing steps for this pull request?

see if the tests pass