### PR TITLE
Fixes #35170 - Add RHEL 9 appstream and baseos as recommended repos

### DIFF
--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -10,6 +10,8 @@ const repoTypeSearchQueryMap = {
 };
 
 const recommendedRepositoriesRHEL = [
+  'rhel-9-for-x86_64-baseos-rpms',
+  'rhel-9-for-x86_64-appstream-rpms',
   'rhel-8-for-x86_64-baseos-rpms',
   'rhel-8-for-x86_64-baseos-kickstart',
   'rhel-8-for-x86_64-appstream-rpms',


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add rhel-9-for-x86_64-appstream-rpms and rhel-9-for-x86_64-baseos-rpms as recommended repositories.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

- Red Hat Enterprise Linux 9 for x86_64 - AppStream (RPMs)

- Red Hat Enterprise Linux 9 for x86_64 - BaseOS (RPMs)

should be included in the recommended repositories list when searching for RHEL 9 content.