### PR TITLE
Fixes #35060 - Uploaded deb packages show up empty

### DIFF
--- a/app/services/katello/pulp3/deb.rb
+++ b/app/services/katello/pulp3/deb.rb
@@ -24,7 +24,8 @@ module Katello
       end
 
       def self.generate_model_row(unit)
-        {
+        unit = unit.try(:with_indifferent_access)
+        return {
           pulp_id: unit[unit_identifier],
           checksum: unit[:sha256],
           filename: unit[:relative_path],


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Allow indifferent access on pulp_data unit for debian content.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Test with https://github.com/Katello/katello/pull/10164 and try uploading debian content. The uploaded content should have valid names and other fields indexed from katello.

