### PR TITLE
Fixes #35193 - Manifest Refresh should ensure environment-content

### DIFF
--- a/app/lib/actions/katello/organization/environment_contents_refresh.rb
+++ b/app/lib/actions/katello/organization/environment_contents_refresh.rb
@@ -1,0 +1,20 @@
+module Actions
+  module Katello
+    module Organization
+      class EnvironmentContentsRefresh < Actions::AbstractAsyncTask
+        middleware.use Actions::Middleware::PropagateCandlepinErrors
+
+        def plan(organization)
+          organization.content_view_environments.each do |cve|
+            plan_action(
+              Actions::Candlepin::Environment::SetContent,
+              cve.content_view,
+              cve.owner,
+              cve
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/organization/manifest_refresh.rb
+++ b/app/lib/actions/katello/organization/manifest_refresh.rb
@@ -29,6 +29,8 @@ module Actions
             import_products = plan_action(Candlepin::Owner::ImportProducts,
               :organization_id => organization.id,
               :dependency => owner_import.output)
+            plan_action(Katello::Organization::EnvironmentContentsRefresh,
+              organization)
             if manifest_update
               plan_refresh_repos(import_products, organization)
             end


### PR DESCRIPTION
Candlepin may delete products if entitlements are removed from the
manifest (c.f. https://github.com/candlepin/candlepin/pull/3341 ). This
leads to an issue in Katello once the entitlements are restored to the
manifest; contents get recreated in Candlepin but Katello needs to tell it
once again which environments should have access to which contents.

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Steps to Test:
1. Upload a manifest with some subscriptions
2. Create a lifecycle path and content view, publish and promote some CV versions
3. Register the client in some LCE and CV
4. Enable repos on the client, try to install some package
5. Remove all subscriptions from the manifest and refresh it
6. Refresh the manifest a 2nd time (to produce the conditions of https://bugzilla.redhat.com/show_bug.cgi?id=2064979 )
6. Add subscriptions back to the manifest
7. Refresh the manifest again, one or more times
8. Sub-man refresh and re-subscribe the client, try to enable repos and install the same package as before
9. Alternatively, register some new client in same CV and LCE, try to enable repos and install the same package as before

Expected Results:
1. With this PR, the task in step 6 should have a Warning (without this PR, no Warning)
2. With this PR, clients in the CV/LCE with a new subscription attached will still be able to enable repositories and download packages (without this PR, the entitlement certificate will not provide any repositories outside of Library environment, requiring re-promotion to resolve)