### PR TITLE
Fixes #35197 - Restrict to architecture showed as a label on Repository Sets screen

### DIFF
--- a/app/views/katello/api/v2/repository_sets/show.json.rabl
+++ b/app/views/katello/api/v2/repository_sets/show.json.rabl
@@ -37,6 +37,10 @@ child @resource.repositories => :repositories do
   attributes :minor => :releasever
 end
 
+node :archRestricted do |pc|
+  pc.repositories&.first&.arch
+end
+
 node :osRestricted do |pc|
   pc.repositories&.first&.os_versions&.first
 end

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -111,6 +111,29 @@ EnabledIcon.propTypes = {
   isOverridden: PropTypes.bool.isRequired,
 };
 
+const ArchRestrictedIcon = ({ archRestricted }) => (
+  <Tooltip
+    position="right"
+    content={<FormattedMessage
+      id="arch-restricted-tooltip"
+      defaultMessage={__('Architecture restricted to {archRestricted}. If host architecture does not match, the repository will not be available on this host.')}
+      values={{ archRestricted }}
+    />}
+  >
+    <Label color="orange" className="arch-restricted-label" style={{ marginLeft: '8px' }}>
+      {__(archRestricted)}
+    </Label>
+  </Tooltip>
+);
+
+ArchRestrictedIcon.propTypes = {
+  archRestricted: PropTypes.string,
+};
+
+ArchRestrictedIcon.defaultProps = {
+  archRestricted: null,
+};
+
 const OsRestrictedIcon = ({ osRestricted }) => (
   <Tooltip
     position="right"
@@ -491,9 +514,11 @@ const RepositorySetsTab = () => {
                 contentUrl: repoPath,
                 product: { name: productName, id: productId },
                 osRestricted,
+                archRestricted,
               } = repoSet;
               const { isEnabled, isOverridden } =
                 getEnabledValue({ enabled, enabledContentOverride });
+              const showArchRestricted = archRestricted !== 'noarch';
               return (
                 <Tr key={id}>
                   {canDoContentOverrides ? (
@@ -517,6 +542,9 @@ const RepositorySetsTab = () => {
                   </Td>
                   <Td>
                     <span><EnabledIcon key={`enabled-icon-${id}`} {...{ isEnabled, isOverridden }} /></span>
+                    {showArchRestricted &&
+                      <span><ArchRestrictedIcon key={`arch-restricted-icon-${id}`} {...{ archRestricted }} /></span>
+                    }
                     {osRestricted &&
                       <span><OsRestrictedIcon key={`os-restricted-icon-${id}`} {...{ osRestricted }} /></span>
                     }

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySets.fixtures.json
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySets.fixtures.json
@@ -42,6 +42,7 @@
       "gpgUrl": null,
       "contentUrl": "/custom/ParthaProduct/empty_repo",
       "osRestricted": null,
+      "archRestricted": "noarch",
       "override": "default",
       "overrides": [],
       "enabled_content_override": null
@@ -77,6 +78,7 @@
       "gpgUrl": null,
       "contentUrl": "/custom/ParthaProduct/partha_multi-errata",
       "osRestricted": "rhel-7",
+      "archRestricted": "x86_64",
       "override": "0",
       "overrides": [
         {
@@ -110,6 +112,7 @@
       "gpgUrl": null,
       "contentUrl": "/custom/Pull_Provider/yggdrasil",
       "osRestricted": null,
+      "archRestricted": "noarch",
       "override": "1",
       "overrides": [
         {

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySetsTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySetsTab.test.js
@@ -389,7 +389,7 @@ test('Can filter by status', async (done) => {
   assertNockRequest(scope2, done); // Pass jest callback to confirm test is done
 });
 
-test('Can display osRestricted as a label', async (done) => {
+test('Can display restrictions as labels', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
   const scope = nockInstance
     .get(hostRepositorySets)
@@ -401,6 +401,8 @@ test('Can display osRestricted as a label', async (done) => {
   await patientlyWaitFor(() => expect(getByText(secondRepoSet.contentUrl)).toBeInTheDocument());
   expect(secondRepoSet.osRestricted).not.toBeNull();
   expect(getByText(secondRepoSet.osRestricted)).toBeInTheDocument();
+  expect(secondRepoSet.archRestricted).not.toBeNull();
+  expect(getByText(secondRepoSet.archRestricted)).toBeInTheDocument();
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done); // Pass jest callback to confirm test is done
 });


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add a label in `Status` column for repositories with `Restrict to architecture` set on Repository Sets screen.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1. Set a value to `Restrict to architecture` for a repository
2. All Hosts - select a host - Repository Sets
    Check Status for a label if `Restrict to architecture` is set