### PR TITLE
Fixes #35118 - add cvv compare button and basic page with Packages

### DIFF
--- a/webpack/scenes/ContentViews/ContentViewsConstants.js
+++ b/webpack/scenes/ContentViews/ContentViewsConstants.js
@@ -2,6 +2,7 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import { toUpper } from 'lodash';
 
 const CONTENT_VIEWS_KEY = 'CONTENT_VIEWS';
+const PACKAGES_KEY = 'PACKAGES';
 export const CREATE_CONTENT_VIEW_KEY = 'CONTENT_VIEW_CREATE';
 export const COPY_CONTENT_VIEW_KEY = 'CONTENT_VIEW_COPY';
 export const CREATE_CONTENT_VIEW_FILTER_KEY = 'CONTENT_VIEW_FILTER_CREATE';
@@ -51,7 +52,7 @@ export const cvVersionPublishKey = (cvId, versionCount) => `${PUBLISH_CONTENT_VI
 export const cvVersionTaskPollingKey = cvId => `CONTENT_VIEW_VERSION_POLLING_${cvId}`;
 export const cvAddComponentKey = cvId => `${CONTENT_VIEWS_KEY}_ADD_COMPONENT_${cvId}`;
 export const cvRemoveComponentKey = cvId => `${CONTENT_VIEWS_KEY}_REMOVE_COMPONENT_${cvId}`;
-
+export const cvPackagesCompareKey = (versionOne, versionTwo) => `${PACKAGES_KEY}_${versionOne}_${versionTwo}`;
 export const removeComponentSuccessMessage = size => (size === 1 ? __('Removed component from content view') : __('Removed components from content view'));
 
 export const addComponentSuccessMessage = component => (component ? __('Updated component details') : __('Added component to content view'));

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
@@ -49,6 +49,7 @@ import {
   generatedContentKey,
   STATUS_TRANSLATIONS_ENUM,
   bulkRemoveVersionKey,
+  cvPackagesCompareKey,
 } from '../ContentViewsConstants';
 import api, { foremanApi, orgId } from '../../../services/api';
 import { getResponseErrorMsgs } from '../../../utils/helpers';
@@ -77,6 +78,18 @@ export const getRPMPackages = params => get({
   params,
   errorToast: error => __(`Something went wrong while fetching rpm packages! ${getResponseErrorMsgs(error.response)}`),
 });
+
+export const getRPMPackagesComparison = (versionOne, versionTwo, params) => {
+  const versions = { content_view_version_ids: [versionOne, versionTwo] };
+  const apiParams = { ...versions, ...params };
+  const apiUrl = '/packages/compare';
+  return get({
+    key: cvPackagesCompareKey(versionOne, versionTwo),
+    params: apiParams,
+    errorToast: error => __(`Something went wrong while retrieving the packages! ${getResponseErrorMsgs(error.response)}`),
+    url: api.getApiUrl(apiUrl),
+  });
+};
 
 export const getFiles = params => get({
   type: API_OPERATIONS.GET,

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
@@ -37,6 +37,7 @@ import {
   REPOSITORY_TYPES,
   RPM_PACKAGE_GROUPS_CONTENT,
   RPM_PACKAGES_CONTENT,
+  cvPackagesCompareKey,
 } from '../ContentViewsConstants';
 
 export const selectCVDetails = (state, cvId) =>
@@ -125,6 +126,15 @@ export const selectCVHistoriesStatus = (state, cvId) =>
 
 export const selectCVHistoriesError = (state, cvId) =>
   selectAPIError(state, cvDetailsHistoryKey(cvId));
+
+export const selectPackagesComparison = (state, versionOne, versionTwo) =>
+  selectAPIResponse(state, cvPackagesCompareKey(versionOne, versionTwo)) || {};
+
+export const selectPackagesComparisonStatus = (state, versionOne, versionTwo) =>
+  selectAPIStatus(state, cvPackagesCompareKey(versionOne, versionTwo)) || STATUS.PENDING;
+
+export const selectPackagesComparisonError = (state, versionOne, versionTwo) =>
+  selectAPIError(state, cvPackagesCompareKey(versionOne, versionTwo));
 
 export const selectCVFilterRules = (state, filterId) =>
   selectAPIResponse(state, cvFilterRulesKey(filterId));

--- a/webpack/scenes/ContentViews/Details/Filters/CVContainerImageFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVContainerImageFilterContent.js
@@ -30,7 +30,7 @@ import AffectedRepositoryTable from './AffectedRepositories/AffectedRepositoryTa
 import { hasPermission } from '../../helpers';
 
 const emptyContentTitle = __('No rules have been added to this filter.');
-const emptyContentBody = __("Add to this filter using the 'Add filter rule' button.");
+const emptyContentBody = __('Filters will appear here when the filter rule is added.');
 const emptySearchTitle = __('No matching filter rules found.');
 const emptySearchBody = __('Try changing your search settings.');
 
@@ -123,6 +123,7 @@ const CVContainerImageFilterContent = ({
       },
     },
   ];
+
   return (
     <Tabs className="margin-0-24" activeKey={activeTabKey} onSelect={(_event, eventKey) => setActiveTabKey(eventKey)}>
       <Tab eventKey={0} title={<TabTitleText>{__('Tags')}</TabTitleText>}>

--- a/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
@@ -106,7 +106,7 @@ const CVRpmFilterContent = ({
   }, [showAffectedRepos, repositories.length]);
 
   const emptyContentTitle = __('No rules have been added to this filter.');
-  const emptyContentBody = __("Add to this filter using the 'Add RPM rule' button.");
+  const emptyContentBody = __('RPM filters will appear here when the RPM rule is added.');
   const emptySearchTitle = __('No matching rules found.');
   const emptySearchBody = __('Try changing your search settings.');
   const tabTitle = (inclusion ? __('Included') : __('Excluded')) + __(' RPMs');

--- a/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompare.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompare.js
@@ -1,0 +1,153 @@
+import React, { useCallback, useState } from 'react';
+import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { Grid } from '@patternfly/react-core';
+import { TableVariant, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { TimesIcon, CheckIcon } from '@patternfly/react-icons';
+import CVVersionCompareHeader from './CVVersionCompareHeader';
+import { selectPackagesComparison, selectPackagesComparisonError, selectPackagesComparisonStatus, selectCVDetails } from '../../ContentViewDetailSelectors';
+import TableWrapper from '../../../../../components/Table/TableWrapper';
+import { getRPMPackagesComparison } from '../../ContentViewDetailActions';
+
+const CVVersionCompare = ({
+  cvId,
+  versionIds,
+}) => {
+  const emptyContentTitle = __("You currently don't have any packages for this content view.");
+  const emptyContentBody = __('Packages will appear here when the content view is published or promoted.');
+  const emptySearchTitle = __('No matching history record found');
+  const emptySearchBody = __('Try changing your search settings.');
+  const [searchQuery, updateSearchQuery] = useState('');
+  const { versionOneId: initialVersionOneId, versionTwoId: initialVersionTwoId } = versionIds;
+  const { versions: cvDetails } = useSelector(state => selectCVDetails(state, cvId));
+  const [versionOne, setVersionOne] = useState(String(cvDetails?.find(version =>
+    Number(version.id) === Number(initialVersionOneId)).version));
+  const [versionTwo, setVersionTwo] = useState(String(cvDetails?.find(version =>
+    Number(version.id) === Number(initialVersionTwoId)).version));
+  const getIdFromVersion = useCallback(version =>
+    String(cvDetails?.find(result => Number(result.version) === Number(version)).id), [cvDetails]);
+
+  const response = useSelector(state =>
+    selectPackagesComparison(state, getIdFromVersion(versionOne), getIdFromVersion(versionTwo)));
+  const status = useSelector(state =>
+    selectPackagesComparisonStatus(
+      state,
+      getIdFromVersion(versionOne),
+      getIdFromVersion(versionTwo),
+    ));
+  const error = useSelector(state =>
+    selectPackagesComparisonError(
+      state,
+      getIdFromVersion(versionOne),
+      getIdFromVersion(versionTwo),
+    ));
+
+  const { results, ...metadata } = response;
+  const columnHeaders = [
+    __('Name'),
+    __(`Version ${versionOne}`),
+    __(`Version ${versionTwo}`),
+  ];
+  return (
+    <Grid>
+      <CVVersionCompareHeader
+        versionOne={versionOne}
+        versionTwo={versionTwo}
+        cvId={cvId}
+        setVersionOne={setVersionOne}
+        setVersionTwo={setVersionTwo}
+      />
+      <TableWrapper
+        {...{
+          metadata,
+          emptyContentTitle,
+          emptyContentBody,
+          emptySearchTitle,
+          emptySearchBody,
+          error,
+          status,
+          searchQuery,
+          updateSearchQuery,
+        }}
+        ouiaId="content-view-history-table"
+        variant={TableVariant.compact}
+        autocompleteEndpoint="/packages/auto_complete_search"
+        additionalListeners={[versionOne, versionTwo]}
+        fetchItems={useCallback(
+          params =>
+            getRPMPackagesComparison(
+              getIdFromVersion(versionOne),
+              getIdFromVersion(versionTwo),
+              params,
+            ),
+          [versionOne, versionTwo, getIdFromVersion],
+        )}
+      >
+        <Thead>
+          <Tr>
+            {columnHeaders.map(col =>
+              <Th key={col}>{col}</Th>)}
+          </Tr>
+        </Thead>
+        <Tbody>
+          {results?.map((data) => {
+            const {
+              id,
+              nvrea,
+              comparison,
+            } = data;
+            if (comparison?.length === 2) {
+              return (
+                <Tr key={id}>
+                  <Td>{nvrea}</Td>
+                  <Th isStickyColumn hasRightBorder modifier="truncate">
+                    <CheckIcon />
+                  </Th>
+                  <Th isStickyColumn modifier="truncate">
+                    <CheckIcon />
+                  </Th>
+                </Tr>
+              );
+            } else if (Number(comparison?.[0]) === Number(versionOne)) {
+              return (
+                <Tr key={id}>
+                  <Td>{nvrea}</Td>
+                  <Th isStickyColumn hasRightBorder modifier="truncate">
+                    <CheckIcon />
+                  </Th>
+                  <Th isStickyColumn hasRightBorder modifier="truncate">
+                    <TimesIcon />
+                  </Th>
+                </Tr>
+              );
+            }
+            return (
+              <Tr key={id}>
+                <Td>{nvrea}</Td>
+                { }
+                <Th isStickyColumn hasRightBorder modifier="truncate">
+                  <TimesIcon />
+                </Th>
+                <Th isStickyColumn hasRightBorder modifier="truncate">
+                  <CheckIcon />
+                </Th>
+              </Tr>
+            );
+          })
+          }
+        </Tbody>
+
+      </TableWrapper>
+    </Grid >
+  );
+};
+CVVersionCompare.propTypes = {
+  cvId: PropTypes.number.isRequired,
+  versionIds: PropTypes.shape({
+    versionOneId: PropTypes.string,
+    versionTwoId: PropTypes.string,
+  }).isRequired,
+};
+
+export default CVVersionCompare;

--- a/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompare.scss
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompare.scss
@@ -1,0 +1,13 @@
+.content-view-header-content {
+  padding-top: 24px;
+
+  .pf-c-content {
+    dl {
+      margin: 0;
+    }
+  }
+
+  .pf-l-flex {
+    padding-top: 24px;
+  }
+}

--- a/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareHeader.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareHeader.js
@@ -1,0 +1,194 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { useSelector } from 'react-redux';
+import {
+  Grid, GridItem, TextContent, Text, TextVariants, Tooltip, Button,
+  Select, SelectOption, SelectVariant, Flex, FlexItem,
+} from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { selectCVDetails } from '../../ContentViewDetailSelectors';
+
+const CVVersionCompareHeader = ({
+  versionOne, versionTwo, cvId, setVersionOne, setVersionTwo,
+}) => {
+  const toolTipContent = 'Comparison of the content types within selected two versions';
+  const response = useSelector(state => selectCVDetails(state, cvId));
+  const { versions } = response;
+  const [isOpenSelectVersionOne, setIsOpenSelectVersionOne] = useState(false);
+  const [isOpenSelectVersionTwo, setIsOpenSelectVersionTwo] = useState(false);
+  const [isOpenSelectViewBy, setIsOpenSelectViewBy] = useState(false);
+
+  const [selectedViewBy, setSelectedViewBy] = useState('Different');
+  const viewBySelectionOptions = ['Different', 'Same'];
+
+  const clearSelectionVersionOne = () => {
+    setVersionOne(null);
+    setIsOpenSelectVersionOne(false);
+  };
+  const clearSelectionVersionTwo = () => {
+    setVersionTwo(null);
+    setIsOpenSelectVersionTwo(false);
+  };
+
+  const clearSelectionViewBy = () => {
+    setSelectedViewBy('');
+    setIsOpenSelectViewBy(false);
+  };
+  const onSelectVersionOne = (_event, selection, isPlaceholder) => {
+    if (isPlaceholder) {
+      clearSelectionVersionOne();
+    } else {
+      setVersionOne(selection);
+      setIsOpenSelectVersionOne(false);
+    }
+  };
+
+  const onSelectVersionTwo = (_event, selection, isPlaceholder) => {
+    if (isPlaceholder) {
+      clearSelectionVersionTwo();
+    } else {
+      setVersionTwo(selection);
+      setIsOpenSelectVersionTwo(false);
+    }
+  };
+
+  const onSelectViewBy = (_event, selection, isPlaceholder) => {
+    if (isPlaceholder) {
+      clearSelectionViewBy();
+    } else {
+      setSelectedViewBy(selection);
+      setIsOpenSelectViewBy(false);
+    }
+  };
+
+  const filteredVersions = selectedVersion =>
+    versions?.filter(result => Number(result.version) !== Number(selectedVersion));
+  const filteredVersionsFirstSelect = versions?.filter(result =>
+    Number(result.version) !== Number(versionTwo));
+  const filteredVersionsSecondSelect = versions?.filter(result =>
+    Number(result.version) !== Number(versionOne));
+  const selectionOptionsViewBy = viewBySelectionOptions.map(option => (
+    <SelectOption
+      key={option}
+      value={option}
+    >
+      {__(`${option}`)}
+    </SelectOption>
+  ));
+  return (
+    <Grid hasGutter style={{ margin: '0 24px' }}>
+      <GridItem span={12} style={{ display: 'flex' }}>
+        <TextContent>
+          <Text component={TextVariants.h2}>{__('Compare')}</Text>
+        </TextContent>
+        <Tooltip aria="none" aria-live="polite" content={toolTipContent} style={{ marginLeft: 'auto' }}>
+          <Button
+            aria-label="Clipboard"
+            variant="plain"
+            id="tt-ref"
+          >
+            <OutlinedQuestionCircleIcon />
+          </Button>
+        </Tooltip>
+      </GridItem>
+      <GridItem span={12}>
+        <Flex className="example-border">
+          <FlexItem>
+            <Flex direction={{ default: 'column' }}>
+              <TextContent>
+                <Text component={TextVariants.h4}>{__('Versions to compare')}</Text>
+              </TextContent>
+              <FlexItem>
+                <Flex className="example-border">
+                  <FlexItem>
+                    <Select
+                      style={{ marginRight: '10px' }}
+                      variant={SelectVariant.single}
+                      placeholderText="Select an option"
+                      aria-label="Select version one"
+                      onToggle={setIsOpenSelectVersionOne}
+                      onSelect={onSelectVersionOne}
+                      selections={versionOne}
+                      isOpen={isOpenSelectVersionOne}
+                      isDisabled={!filteredVersionsFirstSelect?.length}
+                    >
+                      {filteredVersions(versionTwo)?.map(({ version }) => (
+                        <SelectOption
+                          key={version}
+                          value={version}
+                        >
+                          {__('Version ')}{version}
+                        </SelectOption>
+                      ))}
+                    </Select>
+                  </FlexItem>
+                  <FlexItem>
+                    <TextContent style={{ margin: '10px' }}>
+                      <Text component={TextVariants.h4}>{__('to')}</Text>
+                    </TextContent>
+                  </FlexItem>
+                  <FlexItem>
+                    <Select
+                      variant={SelectVariant.single}
+                      placeholderText="Select an option"
+                      aria-label="Select version two"
+                      onToggle={setIsOpenSelectVersionTwo}
+                      onSelect={onSelectVersionTwo}
+                      selections={versionTwo}
+                      isOpen={isOpenSelectVersionTwo}
+                      isDisabled={!filteredVersionsSecondSelect?.length}
+                    >
+                      {filteredVersions(versionOne)?.map(({ version }) => (
+                        <SelectOption
+                          key={version}
+                          value={version}
+                        >
+                          {__('Version ')}{version}
+                        </SelectOption>
+                      ))}
+                    </Select>
+                  </FlexItem>
+                </Flex>
+              </FlexItem>
+            </Flex>
+          </FlexItem >
+          <FlexItem style={{ marginLeft: '60px' }}>
+            <Flex direction={{ default: 'column' }}>
+              <FlexItem>
+                <TextContent>
+                  <Text component={TextVariants.h4}>{__('View by')}</Text>
+                </TextContent>
+              </FlexItem>
+              <FlexItem>
+                <Select
+                  style={{ marginRight: '10px' }}
+                  variant={SelectVariant.single}
+                  placeholderText="Select an option"
+                  aria-label="Select view by"
+                  onToggle={setIsOpenSelectViewBy}
+                  onSelect={onSelectViewBy}
+                  selections={selectedViewBy}
+                  isOpen={isOpenSelectViewBy}
+                  isDisabled={!(filteredVersionsFirstSelect?.length
+                    && filteredVersionsSecondSelect?.length)}
+                >
+                  {selectionOptionsViewBy}
+                </Select>
+              </FlexItem>
+            </Flex>
+          </FlexItem >
+        </Flex >
+      </GridItem>
+    </Grid>
+  );
+};
+
+CVVersionCompareHeader.propTypes = {
+  versionOne: PropTypes.string.isRequired,
+  versionTwo: PropTypes.string.isRequired,
+  cvId: PropTypes.number.isRequired,
+  setVersionOne: PropTypes.func.isRequired,
+  setVersionTwo: PropTypes.func.isRequired,
+};
+export default CVVersionCompareHeader;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
I added the "Compare" button to the ContentViewVersions page. This button directs to the table with selected versions and the  comparison (checks and crosses), showing the common and different packages in two versions
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Select two versions on the ContentViewVersions page
2. Hit "Compare" button
3. The new table needs to be rendered with crosses and checks for each different and common packages respectively
4. Try changing the version in the dropdown and check if the table re-renders