### PR TITLE
Fixes #35031 - Delete ModuleProfile and ModuleProfileRpms before ModuleStreams

### DIFF
--- a/test/migrations/20211220185935_clean_duplicate_content_units_test.rb
+++ b/test/migrations/20211220185935_clean_duplicate_content_units_test.rb
@@ -46,7 +46,7 @@ module Katello
       assert_equal 1, Katello::ModuleStream.where(:pulp_id => original_stream.pulp_id).count
     end
 
-    def test_duplicates_module_profile
+    def test_delete_all_module_profiles
       stream = katello_module_streams(:river)
 
       dup_profile = Katello::ModuleProfile.create!(module_stream_id: stream.id, name: stream.profiles.first.name)
@@ -54,16 +54,16 @@ module Katello
 
       assert_equal 2, Katello::ModuleProfile.where(module_stream_id: stream.id, name: stream.profiles.first.name).count
       migrate_up
-      assert_equal 1, Katello::ModuleProfile.where(module_stream_id: stream.id, name: stream.profiles.first.name).count
+      assert_equal 0, Katello::ModuleProfile.all.count
     end
 
-    def test_module_profile_rpm
+    def test_delete_all_module_profile_rpms
       profile_rpm = Katello::ModuleProfileRpm.first
       Katello::ModuleProfileRpm.create!(name: profile_rpm.name, module_profile_id: profile_rpm.module_profile_id)
 
       assert_equal 2, Katello::ModuleProfileRpm.where(name: profile_rpm.name, module_profile_id: profile_rpm.module_profile_id).count
       migrate_up
-      assert_equal 1, Katello::ModuleProfileRpm.where(name: profile_rpm.name, module_profile_id: profile_rpm.module_profile_id).count
+      assert_equal 0, Katello::ModuleProfileRpm.all.count
     end
 
     def test_ansible_tag


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Move deletion of child records before parent in migration.
#### Considerations taken when implementing this change?
I have a feeling destroy_all instead of delete_all for child records will resolve this too but it will be a costlier operation.
#### What are the testing steps for this pull request?
