### PR TITLE
Fixes #35231 - Add testing support for ouiaIds

### DIFF
--- a/webpack/components/Loading.js
+++ b/webpack/components/Loading.js
@@ -14,7 +14,7 @@ const Loading = ({ size, showText, loadingText }) => (
     <EmptyState>
       <EmptyStateIcon size={size} variant="container" component={Spinner} />
       {showText && (
-        <Title size={size} headingLevel="h4">
+        <Title size={size} headingLevel="h4" ouiaId="loading-title">
           {loadingText || __('Loading')}
         </Title>)}
     </EmptyState>

--- a/webpack/components/SelectAllCheckbox/index.js
+++ b/webpack/components/SelectAllCheckbox/index.js
@@ -68,16 +68,16 @@ const SelectAllCheckbox = ({
   }, [selectedCount, areAllRowsSelected]);
 
   const selectAllDropdownItems = [
-    <DropdownItem key="select-none" component="button" isDisabled={selectedCount === 0} onClick={handleSelectNone} >
+    <DropdownItem key="select-none" ouiaId="select-none" component="button" isDisabled={selectedCount === 0} onClick={handleSelectNone} >
       {`${__('Select none')} (0)`}
     </DropdownItem>,
-    <DropdownItem key="select-page" component="button" isDisabled={pageRowCount === 0 || areAllRowsOnPageSelected} onClick={handleSelectPage}>
+    <DropdownItem key="select-page" ouiaId="select-page" component="button" isDisabled={pageRowCount === 0 || areAllRowsOnPageSelected} onClick={handleSelectPage}>
       {`${__('Select page')} (${pageRowCount})`}
     </DropdownItem>,
   ];
   if (canSelectAll) {
     selectAllDropdownItems.push((
-      <DropdownItem key="select-all" id="all" component="button" isDisabled={totalCount === 0 || areAllRowsSelected} onClick={handleSelectAll}>
+      <DropdownItem key="select-all" id="all" ouiaId="select-all" component="button" isDisabled={totalCount === 0 || areAllRowsSelected} onClick={handleSelectAll}>
         {`${__('Select all')} (${totalCount})`}
       </DropdownItem>));
   }
@@ -87,11 +87,13 @@ const SelectAllCheckbox = ({
       toggle={
         <DropdownToggle
           onToggle={onSelectAllDropdownToggle}
-          id="toggle-id-8"
+          id="select-all-checkbox-dropdown-toggle"
+          ouiaId="select-all-checkbox-dropdown-toggle"
           splitButtonItems={[
             <DropdownToggleCheckbox
               className="tablewrapper-select-all-checkbox"
               key="tablewrapper-select-all-checkbox"
+              ouiaId="select-all-checkbox-dropdown-toggle-checkbox"
               aria-label="Select all"
               onChange={checked => onSelectAllCheckboxChange(checked)}
               isChecked={selectionToggle}
@@ -105,6 +107,7 @@ const SelectAllCheckbox = ({
       isOpen={isSelectAllDropdownOpen}
       dropdownItems={selectAllDropdownItems}
       id="selection-checkbox"
+      ouiaId="selection-checkbox"
     />
   );
 };

--- a/webpack/components/SelectableDropdown/SelectableDropdown.js
+++ b/webpack/components/SelectableDropdown/SelectableDropdown.js
@@ -33,6 +33,7 @@ const SelectableDropdown = ({
       <LevelItem aria-label={`select ${title} container`}>
         <Select
           id={`select ${title}`}
+          ouiaId={`select ${title}`}
           aria-label={`select ${title}`}
           key="type-dropdown"
           variant={SelectVariant.single}

--- a/webpack/components/Table/EmptyStateMessage.js
+++ b/webpack/components/Table/EmptyStateMessage.js
@@ -80,7 +80,7 @@ const EmptyStateMessage = ({
           customIcon={customIcon}
           happyIcon={happy}
         />
-        <Title headingLevel="h2" size="lg">
+        <Title headingLevel="h2" size="lg" ouiaId="empty-state-title">
           {emptyStateTitle}
         </Title>
         <EmptyStateBody>

--- a/webpack/components/TypeAhead/pf3Search/TypeAheadItems.js
+++ b/webpack/components/TypeAhead/pf3Search/TypeAheadItems.js
@@ -6,7 +6,7 @@ import { commonItemPropTypes } from '../helpers/commonPropTypes';
 const TypeAheadItems = ({
   items, activeItems, getItemProps, highlightedIndex,
 }) => (
-  <Dropdown.Menu className="typeahead-dropdown">
+  <Dropdown.Menu className="typeahead-dropdown" ouiaId="typeahead-dropdown">
     {items.map(({ text, type, disabled = false }, index) => {
       if (type === 'header') {
         return (

--- a/webpack/components/TypeAhead/pf4Search/TypeAheadInput.js
+++ b/webpack/components/TypeAhead/pf4Search/TypeAheadInput.js
@@ -30,6 +30,7 @@ const TypeAheadInput = ({
         ref={inputRef}
         onFocus={onInputFocus}
         aria-label="text input for search"
+        ouiaId="type-ahead-input"
         onChange={onChangeWrapper}
         type="text"
         iconVariant={autoSearchEnabled && !isTextInput ? 'search' : undefined}

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -316,13 +316,13 @@ const RepositorySetsTab = () => {
   cannot(createBookmarks, userPermissionsFromHostDetails({ hostDetails }));
 
   const dropdownItems = [
-    <DropdownItem aria-label="bulk_enable" key="bulk_enable" component="button" onClick={enableRepoSets} isDisabled={selectedCount === 0}>
+    <DropdownItem aria-label="bulk_enable" key="bulk_enable" ouiaId="bulk_enable" component="button" onClick={enableRepoSets} isDisabled={selectedCount === 0}>
       {__('Override to enabled')}
     </DropdownItem>,
-    <DropdownItem aria-label="bulk_disable" key="bulk_disable" component="button" onClick={disableRepoSets} isDisabled={selectedCount === 0}>
+    <DropdownItem aria-label="bulk_disable" key="bulk_disable" ouiaId="bulk_disable" component="button" onClick={disableRepoSets} isDisabled={selectedCount === 0}>
       {__('Override to disabled')}
     </DropdownItem>,
-    <DropdownItem aria-label="bulk_reset_default" key="bulk_reset_default" component="button" onClick={resetToDefaultRepoSets} isDisabled={selectedCount === 0}>
+    <DropdownItem aria-label="bulk_reset_default" key="bulk_reset_default" ouiaId="bulk_reset_default" component="button" onClick={resetToDefaultRepoSets} isDisabled={selectedCount === 0}>
       {__('Reset to default')}
     </DropdownItem>,
   ];
@@ -352,6 +352,7 @@ const RepositorySetsTab = () => {
       <SplitItem>
         <SelectableDropdown
           id="status-dropdown"
+          ouiaId="status-dropdown"
           title={STATUS_LABEL}
           showTitle={false}
           items={Object.values(STATUSES)}
@@ -372,6 +373,7 @@ const RepositorySetsTab = () => {
               isOpen={isBulkActionOpen}
               isPlain
               dropdownItems={dropdownItems}
+              ouiaId="repository-sets-bulk-actions"
             />
           </ActionListItem>
         </ActionList>
@@ -413,6 +415,7 @@ const RepositorySetsTab = () => {
             <Alert
               variant="info"
               className="repo-sets-alert"
+              ouiaId="repo-sets-alert"
               isInline
               title={
                 <FormattedMessage
@@ -425,7 +428,7 @@ const RepositorySetsTab = () => {
                   }}
                 />
               }
-              actionClose={<AlertActionCloseButton onClose={() => setAlertShowing(false)} />}
+              actionClose={<AlertActionCloseButton ouiaId="alert-close-button" onClose={() => setAlertShowing(false)} />}
             />
           }
         </div>
@@ -470,7 +473,7 @@ const RepositorySetsTab = () => {
           displaySelectAllCheckbox={canDoContentOverrides}
         >
           <Thead>
-            <Tr>
+            <Tr ouiaId="header-tr">
               <Th key="select-all" />
               <SortableColumnHeaders
                 columnHeaders={columnHeaders}
@@ -495,7 +498,7 @@ const RepositorySetsTab = () => {
               const { isEnabled, isOverridden } =
                 getEnabledValue({ enabled, enabledContentOverride });
               return (
-                <Tr key={id}>
+                <Tr key={id} ouiaId={`tr-${rowIndex}`}>
                   {canDoContentOverrides ? (
                     <Td select={{
                       disable: !isSelectable(id),

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySetsTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySetsTab.test.js
@@ -8,6 +8,7 @@ import mockRepoSetData from './repositorySets.fixtures.json';
 import mockBookmarkData from './bookmarks.fixtures.json';
 import mockContentOverride from './contentOverrides.fixtures.json';
 
+
 jest.mock('../../hostDetailsHelpers', () => ({
   ...jest.requireActual('../../hostDetailsHelpers'),
   userPermissionsFromHostDetails: () => ({

--- a/webpack/global_test_setup.js
+++ b/webpack/global_test_setup.js
@@ -1,4 +1,5 @@
 import nock from 'nock';
+// import checkForOuiaIds from './ouia_id_check';
 
 // runs before each test to make sure console.error output will
 // fail a test (i.e. default PropType missing). Check the error
@@ -8,7 +9,8 @@ global.console.error = (error, stack) => {
   originalConsoleError(error); // ensure error is printed to console
   /* eslint-disable-next-line no-console */
   if (stack) console.log(stack); // Prints out original stack trace
-  throw new Error(error);
+  throw new Error(error); // comment this and uncomment the next line when checking for ouia ids
+  // if (!error.includes('Failed prop type')) throw new Error(error);
 };
 
 // Increase jest timeout as some tests using multiple http mocks can time out on CI systems.
@@ -27,6 +29,11 @@ afterAll(() => {
 beforeEach(() => {
   if (!nock.isActive()) { nock.activate(); }
 });
+
+// To see where you need to add ouiaIds:
+// 1. uncomment this and the import above
+// checkForOuiaIds();
+// 2. (optional) uncomment the line in global.console.error function above
 
 afterEach(() => {
   nock.cleanAll();

--- a/webpack/ouia_id_check.js
+++ b/webpack/ouia_id_check.js
@@ -1,0 +1,95 @@
+import PropTypes from 'prop-types';
+import {
+  Alert,
+  Breadcrumb,
+  Button,
+  Card,
+  Checkbox,
+  Chip,
+  ChipGroup,
+  ContextSelector,
+  Dropdown,
+  DropdownItem,
+  DropdownSeparator,
+  DropdownToggle,
+  DropdownToggleCheckbox,
+  FormSelect,
+  Menu,
+  Modal,
+  ModalContent,
+  Nav,
+  NavExpandable,
+  NavItem,
+  OptionsMenu,
+  Pagination,
+  Radio,
+  Select,
+  Switch,
+  TabButton,
+  TabContent,
+  Tabs,
+  Text,
+  TextInput,
+  Title,
+  Toolbar,
+} from '@patternfly/react-core';
+import {
+  RowWrapper,
+  Table,
+  TableComposable,
+  Tr,
+} from '@patternfly/react-table';
+
+const checkForOuiaIds = () => {
+  const ouiaSupportedPFComponents = [
+    Alert,
+    Breadcrumb,
+    Button,
+    Card,
+    Checkbox,
+    Chip,
+    ChipGroup,
+    ContextSelector,
+    Dropdown,
+    DropdownItem,
+    DropdownSeparator,
+    DropdownToggle,
+    DropdownToggleCheckbox,
+    FormSelect,
+    Menu,
+    Modal,
+    ModalContent,
+    Nav,
+    NavExpandable,
+    NavItem,
+    OptionsMenu,
+    Pagination,
+    Radio,
+    Select,
+    Switch,
+    TabButton,
+    TabContent,
+    Tabs,
+    Text,
+    TextInput,
+    Title,
+    Toolbar,
+    RowWrapper,
+    Table,
+    TableComposable,
+    Tr,
+  ];
+  beforeEach(() => {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const Component of ouiaSupportedPFComponents) {
+      // eslint-disable-next-line no-continue
+      if (!Component) continue;
+      Component.propTypes = {
+        ...Component.propTypes,
+        ouiaId: PropTypes.string.isRequired,
+      };
+    }
+  });
+};
+
+export default checkForOuiaIds;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

1. Adds a `checkforOuiaIds` function in `global_test_setup.js`. When this is uncommented properly, your tests will still pass but will alert you of any PF components where you forgot to add an `ouiaId` prop.

```
[vagrant@centos8-katello-devel katello]$ npx jest webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySetsTab.test.js
  console.error webpack/global_test_setup.js:9
    Warning: Failed prop type: The prop `ouiaId` is marked as required in `Dropdown`, but its value is `undefined`.
        in Dropdown (created by TypeAheadItems)
        in TypeAheadItems (created by TypeAheadSearch)
        in TypeAheadSearch (created by Downshift)
        in div (created by Downshift)
        in Downshift (created by TypeAhead)
        in TypeAhead (created by Search)
        in div (created by Search)
        in Search (created by Connect(Search))
        in Connect(Search) (created by TableWrapper)
        in div (created by FlexItem)
        in FlexItem (created by TableWrapper)
        in div (created by Flex)
        in Flex (created by TableWrapper)
        in TableWrapper (created by RepositorySetsTab)
        in div (created by RepositorySetsTab)
        in div (created by RepositorySetsTab)
        in RepositorySetsTab
        in Router (created by MemoryRouter)
        in MemoryRouter
        in Provider

  console.error webpack/global_test_setup.js:9
    Warning: Failed prop type: The prop `ouiaId` is marked as required in `Pagination`, but its value is `undefined`.
        in Pagination (created by Pagination)
        in Pagination (created by PageControls)
        in div (created by FlexItem)
        in FlexItem (created by PageControls)
        in PageControls (created by TableWrapper)
        in div (created by Flex)
        in Flex (created by TableWrapper)
        in TableWrapper (created by RepositorySetsTab)
        in div (created by RepositorySetsTab)
        in div (created by RepositorySetsTab)
        in RepositorySetsTab
        in Router (created by MemoryRouter)
        in MemoryRouter
        in Provider

  console.error webpack/global_test_setup.js:9
    Warning: Failed prop type: The prop `ouiaId` is marked as required in `DropdownItem`, but its value is `undefined`.
        in DropdownItem (created by PaginationOptionsMenu)
        in PaginationOptionsMenu (created by Pagination)
        in div (created by Pagination)
        in Pagination (created by Pagination)
        in Pagination (created by PageControls)
        in div (created by FlexItem)
        in FlexItem (created by PageControls)
        in PageControls (created by TableWrapper)
        in div (created by Flex)
        in Flex (created by TableWrapper)
        in TableWrapper (created by RepositorySetsTab)
        in div (created by RepositorySetsTab)
        in div (created by RepositorySetsTab)
        in RepositorySetsTab
        in Router (created by MemoryRouter)
        in MemoryRouter
        in Provider

  console.error webpack/global_test_setup.js:9
    Warning: Failed prop type: The prop `ouiaId` is marked as required in `DropdownToggle`, but its value is `undefined`.
        in DropdownToggle (created by OptionsToggle)
        in OptionsToggle (created by PaginationOptionsMenu)
        in div (created by Context.Consumer)
        in DropdownWithContext (created by PaginationOptionsMenu)
        in PaginationOptionsMenu (created by Pagination)
        in div (created by Pagination)
        in Pagination (created by Pagination)
        in Pagination (created by PageControls)
        in div (created by FlexItem)
        in FlexItem (created by PageControls)
        in PageControls (created by TableWrapper)
        in div (created by Flex)
        in Flex (created by TableWrapper)
        in TableWrapper (created by RepositorySetsTab)
        in div (created by RepositorySetsTab)
        in div (created by RepositorySetsTab)
        in RepositorySetsTab
        in Router (created by MemoryRouter)
        in MemoryRouter
        in Provider

  console.error webpack/global_test_setup.js:9
    Warning: Failed prop type: The prop `ouiaId` is marked as required in `Button`, but its value is `undefined`.
        in Button (created by Navigation)
        in Navigation (created by Pagination)
        in div (created by Pagination)
        in Pagination (created by Pagination)
        in Pagination (created by PageControls)
        in div (created by FlexItem)
        in FlexItem (created by PageControls)
        in PageControls (created by TableWrapper)
        in div (created by Flex)
        in Flex (created by TableWrapper)
        in TableWrapper (created by RepositorySetsTab)
        in div (created by RepositorySetsTab)
        in div (created by RepositorySetsTab)
        in RepositorySetsTab
        in Router (created by MemoryRouter)
        in MemoryRouter
        in Provider

 PASS  webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySetsTab.test.js (6.956s, 216 MB heap size)
  ✓ Can call API for repository sets and show basic table (245ms)
  ✓ Can handle no repository sets being present (75ms)
  ✓ Toggle Group shows if it's not the default content view or library enviroment (116ms)
  ✓ Toggle Group shows if it's the default content view but non-library environment (105ms)
  ✓ Toggle Group shows if it's the library environment but a non-default content view (109ms)
  ✓ Toggle Group does not show if it's the library environment and default content view (85ms)
  ✓ Can toggle with the Toggle Group  (216ms)
  ✓ Can override to disabled (198ms)
  ✓ Can override to enabled (174ms)
  ✓ Can reset to default (159ms)
  ✓ Can override in bulk (682ms)
  ✓ Can filter by status (237ms)
  ✓ Can display osRestricted as a label (88ms)

Test Suites: 1 passed, 1 total
Tests:       13 passed, 13 total
```

Note that each error displays the React component tree, so it should be easy to find the correct JS file and add the prop.
3. Adds `ouiaId`s in `RepositorySetsTab.js`.

#### Considerations taken when implementing this change?

If a component is imported from `foremanReact`, it will still flag it if the ouiaId is missing. So you may not be able to eliminate all ouiaId issues in the Katello code base alone.

#### What are the testing steps for this pull request?

* Follow the instructions I added to `global_test_setup.js`
* Run any test file: `npx jest <path_to_file>.js`


