### PR TITLE
Fixes #35233 - ForeignKeyViolation Error with docker_meta_tags during Pulp migration

### DIFF
--- a/lib/katello/tasks/correct_docker_meta_tags.rake
+++ b/lib/katello/tasks/correct_docker_meta_tags.rake
@@ -1,0 +1,10 @@
+require File.expand_path("../engine", File.dirname(__FILE__))
+
+namespace :katello do
+  desc "Reindex DockerMetaTags in response to Redmine #35233"
+  task :correct_docker_meta_tags => ['check_ping'] do
+    puts 'DockerMetaTag correction running'
+    Katello::Pulp3::MigrationSwitchover.new(SmartProxy.pulp_primary).correct_docker_meta_tags
+    puts 'DockerMetaTag correction complete'
+  end
+end

--- a/test/services/katello/pulp3/migration_switchover_test.rb
+++ b/test/services/katello/pulp3/migration_switchover_test.rb
@@ -166,6 +166,7 @@ module Katello
 
       refute_equal @another_fake_pulp3_href, tag.reload.pulp_id
 
+      ::Katello::Pulp3::MigrationSwitchover.any_instance.expects(:correct_docker_meta_tags).returns(true)
       @switchover.run
       assert_equal @another_fake_pulp3_href, tag.reload.pulp_id
     end
@@ -177,6 +178,7 @@ module Katello
       docker_manifest = tag.docker_taggable
       docker_manifest.update(:migrated_pulp3_href => @another_fake_pulp3_href + docker_manifest.id.to_s)
 
+      ::Katello::Pulp3::MigrationSwitchover.any_instance.expects(:correct_docker_meta_tags).returns(true)
       @switchover.run
 
       refute Katello::DockerTag.find_by(:id => tag.id)
@@ -217,6 +219,7 @@ module Katello
 
     def test_docker_tag_cleanup
       assert_equal 2, Katello::DockerTag.count
+      ::Katello::Pulp3::MigrationSwitchover.any_instance.expects(:correct_docker_meta_tags).returns(true)
       @switchover_service.run
       assert_equal 1, Katello::DockerTag.count
       tag = Katello::DockerTag.first


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Updates DockerMetaTag indexing to handle situations where 3 docker tags exist in a single Pulp repository that have the same name. Usually we expect two: one v1 tag and one v2 tag.  However, if a repository had a v2 tag pointed at a manifest and then updated it to point at a manifest list, Pulp will hold on to the manifest and its tag. So, we need to ignore this old tag.

This bug caused data integrity issues with DockerMetaTags. Due to the bug, some DockerMetaTags may have two v2 tags instead of a v1 tag and a v2 tag. It's random.

To clean this up, I've included a migration script. Let me know if the script should exist somewhere besides a migration. It seems to make sense for everyone getting this fix to run the migration, since it's likely there are data errors with older Docker repos.

#### Considerations taken when implementing this change?

There may be more efficient ways to write the cleanup script, but I tested it on a reproducer and it's slow to retest, so I've left it as-is. I'm up for suggestions on replacing blocks with queries, but we'll have to retest on the reproducer.

Also, this script simply orphans the container image tags that point to the old unused v2 image manifests.  I don't see a reason to delete them since we'd have to remove them from Pulp as well. At this point, since it's right before switchover, it doesn't seem worth removing anything from the Pulp 2 DB.  The orphaned tags don't seem to cause any data issues.

#### What are the testing steps for this pull request?

On a reproducer environment:

1) Run this method to confirm the error: https://github.com/Katello/katello/blob/KATELLO-3.18/app/services/katello/pulp3/migration_switchover.rb#L101

2) Revert the reproducer to ensure the data is back to normal

3) Patch in the change and run the migration

4) Run `combine_duplicate_docker_tags` again and see that it succeeds
  -> If all unmigrated content is deleted, a perhaps better alternative would be to try running the switchover:
```ruby
switchover_service = Katello::Pulp3::MigrationSwitchover.new(SmartProxy.pulp_primary)
switchover_service.run
```