### PR TITLE
Fixes #35246 - Default cv creation error during seed

### DIFF
--- a/app/services/katello/organization_creator.rb
+++ b/app/services/katello/organization_creator.rb
@@ -101,12 +101,23 @@ module Katello
     end
 
     def create_library_view
-      @library_view = Katello::ContentView.where(
+      cv_wrong_label = Katello::ContentView.where(
         default: true,
         name: DEFAULT_CONTENT_VIEW_NAME,
-        label: DEFAULT_CONTENT_VIEW_LABEL,
         organization: @organization
-      ).first_or_create!
+      ).where.not(label: DEFAULT_CONTENT_VIEW_LABEL)&.first
+
+      if cv_wrong_label
+        cv_wrong_label.update_attribute(:label, DEFAULT_CONTENT_VIEW_LABEL)
+        @library_view = cv_wrong_label
+      else
+        @library_view = Katello::ContentView.where(
+          default: true,
+          name: DEFAULT_CONTENT_VIEW_NAME,
+          label: DEFAULT_CONTENT_VIEW_LABEL,
+          organization: @organization
+        ).first_or_create!
+      end
     end
 
     def create_library_cvv

--- a/test/actions/pulp3/orchestration/rpm_remove_units_test.rb
+++ b/test/actions/pulp3/orchestration/rpm_remove_units_test.rb
@@ -8,7 +8,7 @@ module ::Actions::Pulp3
       @primary = SmartProxy.pulp_primary
       @repo = katello_repositories(:fedora_17_x86_64_dev)
       @repo.root.update(url: 'https://fixtures.pulpproject.org/rpm-unsigned/')
-      @repo.content_view.update(default: true)
+      @repo.content_view.update_attribute(:default, true)
 
       create_and_sync_repo(@repo, @primary)
       @repo.reload
@@ -21,7 +21,7 @@ module ::Actions::Pulp3
       ForemanTasks.sync_task(
         ::Actions::Katello::Repository::MetadataGenerate, repo)
 
-      sync_args = {:smart_proxy_id => proxy.id, :repo_id => repo.id, :full_index => true}
+      sync_args = { :smart_proxy_id => proxy.id, :repo_id => repo.id, :full_index => true }
       sync_action = ForemanTasks.sync_task(
         ::Actions::Pulp3::Orchestration::Repository::Sync, repo, proxy, sync_args)
 
@@ -36,7 +36,7 @@ module ::Actions::Pulp3
     def test_remove_rpm
       content_unit = @rpm
 
-      remove_content_args = {contents: [content_unit.id], content_unit_type: 'rpm'}
+      remove_content_args = { contents: [content_unit.id], content_unit_type: 'rpm' }
       remove_action = ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::RemoveUnits, @repo, @primary, remove_content_args)
       assert_equal "success", remove_action.result
     end
@@ -45,27 +45,27 @@ module ::Actions::Pulp3
       content_unit = @rpm
 
       version_href = @repo.version_href
-      remove_content_args = {contents: [content_unit.id], content_unit_type: 'rpm'}
+      remove_content_args = { contents: [content_unit.id], content_unit_type: 'rpm' }
       ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::RemoveUnits, @repo, @primary, remove_content_args)
       refute_equal version_href, @repo.reload.version_href
     end
 
     def test_empty_content_args_doesnt_update_version_href
       version_href = @repo.reload.version_href
-      remove_content_args = {contents: [], content_unit_type: 'rpm'}
+      remove_content_args = { contents: [], content_unit_type: 'rpm' }
       ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::RemoveUnits, @repo, @primary, remove_content_args)
       assert_equal version_href, @repo.reload.version_href
     end
 
     def test_empty_content_args
-      remove_content_args = {contents: [], content_unit_type: 'rpm'}
+      remove_content_args = { contents: [], content_unit_type: 'rpm' }
       remove_action = ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::RemoveUnits, @repo, @primary, remove_content_args)
       assert_equal "success", remove_action.result
     end
 
     def test_incorrect_content_units_doesnt_update_version_href
       version_href = @repo.reload.version_href
-      remove_content_args = {contents: [ "not an id"], content_unit_type: 'rpm'}
+      remove_content_args = { contents: ["not an id"], content_unit_type: 'rpm' }
       ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::RemoveUnits, @repo, @primary, remove_content_args)
       assert_equal version_href, @repo.reload.version_href
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
1. Adds a validation to ensure default CVs have Default Content View as name and Default_content_view as label.
2. Ensure db:seed doesn't fail for default CVs with wrong label and corrects the label.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a test org
4. In your console: 
cv = Katello::ContentView.where(default: true, organization_id: 4)&.first
cv.update_attribute(:label, "abc")
5. org.update_attribute(:created_in_katello, false) 
6. Run bundle exec rails db:seed
7. Without this change, it should fail.