### PR TITLE
Fixes #33902 - host registration form should include activation key on the first page

### DIFF
--- a/webpack/components/extensions/RegistrationCommands/index.js
+++ b/webpack/components/extensions/RegistrationCommands/index.js
@@ -7,32 +7,20 @@ import LifecycleEnvironment from './fields/LifecycleEnvironment';
 import IgnoreSubmanErrors from './fields/IgnoreSubmanErrors';
 import Force from './fields/Force';
 
-const RegistrationCommands = ({
+export const RegistrationCommands = ({
   organizationId,
   hostGroupId,
   pluginValues,
   pluginData,
   onChange,
-  handleInvalidField,
   isLoading,
 }) => {
   useEffect(() => {
-    onChange({ activationKeys: [], lifecycleEnvironmentId: '' });
+    onChange({ lifecycleEnvironmentId: '' });
   }, [onChange, organizationId, hostGroupId]);
 
   return (
     <>
-      <ActivationKeys
-        activationKeys={pluginData?.activationKeys}
-        organizationId={organizationId}
-        selectedKeys={(pluginValues?.activationKeys || [])}
-        hostGroupActivationKeys={pluginData?.hostGroupActivationKeys}
-        hostGroupId={hostGroupId}
-        pluginValues={pluginValues}
-        onChange={onChange}
-        handleInvalidField={handleInvalidField}
-        isLoading={isLoading}
-      />
       <LifecycleEnvironment
         pluginValues={pluginValues}
         lifecycleEnvironments={pluginData?.lifecycleEnvironments}
@@ -63,7 +51,6 @@ RegistrationCommands.propTypes = {
   pluginValues: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   pluginData: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   onChange: PropTypes.func,
-  handleInvalidField: PropTypes.func,
   isLoading: PropTypes.bool,
 };
 
@@ -74,7 +61,52 @@ RegistrationCommands.defaultProps = {
   pluginData: {},
   isLoading: false,
   onChange: noop,
-  handleInvalidField: noop,
 };
 
-export default RegistrationCommands;
+export const RegistrationActivationKeys = ({
+  organizationId,
+  hostGroupId,
+  pluginValues,
+  pluginData,
+  onChange,
+  handleInvalidField,
+  isLoading,
+}) => {
+  useEffect(() => {
+    onChange({ activationKeys: [] });
+  }, [onChange, organizationId, hostGroupId]);
+
+  return (
+    <ActivationKeys
+      activationKeys={pluginData?.activationKeys}
+      organizationId={organizationId}
+      selectedKeys={(pluginValues?.activationKeys || [])}
+      hostGroupActivationKeys={pluginData?.hostGroupActivationKeys}
+      hostGroupId={hostGroupId}
+      pluginValues={pluginValues}
+      onChange={onChange}
+      handleInvalidField={handleInvalidField}
+      isLoading={isLoading}
+    />
+  );
+};
+
+RegistrationActivationKeys.propTypes = {
+  organizationId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  hostGroupId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  pluginValues: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  pluginData: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  onChange: PropTypes.func,
+  handleInvalidField: PropTypes.func,
+  isLoading: PropTypes.bool,
+};
+
+RegistrationActivationKeys.defaultProps = {
+  organizationId: undefined,
+  hostGroupId: undefined,
+  pluginValues: {},
+  pluginData: {},
+  isLoading: false,
+  onChange: noop,
+  handleInvalidField: noop,
+};

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -4,7 +4,10 @@ import { registerReducer } from 'foremanReact/common/MountingService';
 import { translate as __ } from 'foremanReact/common/I18n';
 
 import SystemStatuses from './components/extensions/about';
-import RegistrationCommands from './components/extensions/RegistrationCommands';
+import {
+  RegistrationCommands,
+  RegistrationActivationKeys,
+} from './components/extensions/RegistrationCommands';
 import ContentTab from './components/extensions/HostDetails/Tabs/ContentTab';
 import ContentViewDetailsCard from './components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard';
 import ErrataOverviewCard from './components/extensions/HostDetails/Cards/ErrataOverviewCard';
@@ -30,6 +33,7 @@ registerReducer('katello', rootReducer);
 
 addGlobalFill('aboutFooterSlot', '[katello]AboutSystemStatuses', <SystemStatuses key="katello-system-statuses" />, 100);
 addGlobalFill('registrationAdvanced', '[katello]RegistrationCommands', <RegistrationCommands key="katello-reg" />, 100);
+addGlobalFill('registrationGeneral', '[katello]RegistrationActivationKeys', <RegistrationActivationKeys key="katello-reg-ak" />, 100);
 
 // Host details page tabs
 addGlobalFill('host-details-page-tabs', 'Content', <ContentTab key="content" />, 900, { title: __('Content'), hideTab: hostIsNotRegistered });


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Activation keys are required for host registration and should be displayed on the general page of the host registration form.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Hosts - Register Host
Make sure `Activation Keys` selection is listed in `General` and not `Advanced` tab.
Verify Register Host still works.