### PR TITLE
Fixes #35247 - Can Import/Export docker content

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -31,7 +31,7 @@ module Katello
     ANSIBLE_COLLECTION_TYPE = 'ansible_collection'.freeze
     GENERIC_TYPE = 'generic'.freeze
 
-    EXPORTABLE_TYPES = [YUM_TYPE, FILE_TYPE, ANSIBLE_COLLECTION_TYPE].freeze
+    EXPORTABLE_TYPES = [YUM_TYPE, FILE_TYPE, ANSIBLE_COLLECTION_TYPE, DOCKER_TYPE].freeze
 
     define_model_callbacks :sync, :only => :after
 

--- a/app/services/katello/pulp3/api/generic.rb
+++ b/app/services/katello/pulp3/api/generic.rb
@@ -15,10 +15,6 @@ module Katello
         def self.repository_sync_url_class(repository_type)
           repository_type.repo_sync_url_class
         end
-
-        def self.add_remove_content_class
-          fail NotImplementedError
-        end
       end
     end
   end

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -299,7 +299,7 @@ module Katello
           tasks << api.repositories_api.modify(repository_reference.repository_href, remove_content_units: ['*'])
         end
 
-        if options[:mirror]
+        if options[:mirror] && api.class.respond_to?(:add_remove_content_class)
           data = api.class.add_remove_content_class.new(
                     base_version: source_repository.version_href)
 

--- a/test/models/content_view_repository_test.rb
+++ b/test/models/content_view_repository_test.rb
@@ -17,7 +17,7 @@ module Katello
       cv = katello_content_views(:import_only_view)
 
       assert_raises(ActiveRecord::RecordInvalid) do
-        cv.repositories << katello_repositories(:busybox)
+        cv.repositories << katello_repositories(:pulp3_ostree_1)
       end
     end
   end

--- a/test/services/katello/pulp3/content_view_version/export_test.rb
+++ b/test/services/katello/pulp3/content_view_version/export_test.rb
@@ -77,9 +77,9 @@ module Katello
                                      destination_server: destination_server,
                                      from_content_view_version: from_version)
             ::Katello::Pulp3::ContentViewVersion::Export.any_instance.expects(:validate_repositories_immediate!)
-            ::Katello::Pulp3::ContentViewVersion::Export.any_instance.expects(:version_href_to_repository_href).with(nil).returns(nil).twice
             ::Katello::Pulp3::ContentViewVersion::Export.any_instance.expects(:version_href_to_repository_href).with("0").returns("0")
             ::Katello::Pulp3::ContentViewVersion::Export.any_instance.expects(:version_href_to_repository_href).with("1").returns("1")
+            ::Katello::Pulp3::ContentViewVersion::Export.any_instance.expects(:version_href_to_repository_href).with(nil).returns(nil).at_least_once
 
             exception = assert_raises(RuntimeError) do
               export.validate!(fail_on_missing_content: true, validate_incremental: true)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This PR makes use of pulp import/export bindings for docker and adds that as an exportable type.

#### What are the testing steps for this pull request?

- Create a custom product 
- Create and Sync a docker repo
- Try any of the following commands
`hammer content-export complete repository --id=<repo-id>`
`hammer content-export complete version --id= <cvv-id>`
`hammer content-export complete library --id= <organization-id>`

Try importing those.
- `hammer organization create --name=bar`
- `hammer content-import  repository --organization=bar --path=<...> --metadata-file=<....>`
- `hammer content-import version  --organization=bar --path=<...> --metadata-file=<....>`
- `hammer content-import  library  --organization=bar --path=<...> --metadata-file=<....>`

Try the same for incremental variants
`hammer content-export incremental repository --id=<repo-id>`
`hammer content-export incremental version --id= <cvv-id>`
`hammer content-export incremental library --id= <organization-id>`

