### PR TITLE
Fixes #35265 - When toggling SCA, change the owner and don't refresh manifest

### DIFF
--- a/app/lib/actions/katello/organization/simple_content_access/toggle.rb
+++ b/app/lib/actions/katello/organization/simple_content_access/toggle.rb
@@ -14,15 +14,7 @@ module Actions
           def plan(organization_id)
             @organization = ::Organization.find(organization_id)
             action_subject organization
-            ::Katello::Resources::Candlepin::UpstreamConsumer.update(
-              "#{consumer['apiUrl']}#{consumer['uuid']}",
-              consumer['idCert']['cert'],
-              consumer['idCert']['key'],
-              nil,
-              {contentAccessMode: content_access_mode_value}
-            )
-
-            plan_action(::Actions::Katello::Organization::ManifestRefresh, organization)
+            ::Katello::Resources::Candlepin::Owner.update(@organization.label, contentAccessMode: content_access_mode_value)
           end
 
           def failure_notification(plan)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
1. Don't refresh manifest when toggling SCA on the Organization edit page
2. To toggle SCA on an org, hit the /candlepin/owners endpoint and not the consumers/:uuid.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Verify simple content access toggling on organization works.

To upgrate environment to 4.2 candlepin for simple content access change                                                                                              
```   
systemctl stop tomcat
yum install -y http://download.eng.bos.redhat.com/brewroot/vol/rhel-7/packages/candlepin/4.2.3/1.el7sat/noarch/candlepin-4.2.3-1.el7sat.noarch.rpm
yum install -y http://download.eng.bos.redhat.com/brewroot/vol/rhel-7/packages/candlepin/4.2.3/1.el7sat/noarch/candlepin-selinux-4.2.3-1.el7sat.noarch.rpm
/usr/share/candlepin/cpdb --update
systemctl start tomcat
```
EL8 packages: http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/candlepin/4.2.3/1.el8sat/noarch/