### PR TITLE
Fixes #35276 - Add LCE controller to AngularJS so bookmarks work

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment-content.controller.js
@@ -11,6 +11,8 @@
     function EnvironmentContentController($scope, ContentService, ContentView, Repository, translate, $location) {
         var nutupane, allRepositories, nutupaneParams;
 
+        $scope.controllerName = 'katello_environments';
+
         function fetchContentViews(environmentId) {
             ContentView.queryUnpaged({'environment_id': environmentId}, function (data) {
                 $scope.contentViews = [$scope.contentView].concat(data.results);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment.controller.js
@@ -16,6 +16,8 @@
             loading: true
         };
 
+        $scope.controllerName = 'katello_environments';
+
         $scope.repositoryTypeEnabled = RepositoryTypesService.repositoryTypeEnabled;
         $scope.environment = Environment.get({id: $scope.$stateParams.environmentId}, function () {
             $scope.panel.loading = false;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environments.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environments.controller.js
@@ -26,6 +26,7 @@ angular.module('Bastion.environments').controller('EnvironmentsController',
             };
 
             var nutupane = new Nutupane(Environment, params);
+            $scope.controllerName = 'katello_environments';
             $scope.table = nutupane.table;
             $scope.loading = true;
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

In AngularJS we are missing the `$scope.controllerName` which allows bookmarks to be saved/created.

#### Considerations taken when implementing this change?

N/A

#### What are the testing steps for this pull request?

* Apply PR
* Try to create a bookmark under any of the tabs except details.
* Verify it saved and we get a success response from the Foreman bookmarks controller. 