### PR TITLE
Fixes #35277 - make severity N/A filter work for empty severity

### DIFF
--- a/app/controllers/katello/api/v2/host_errata_controller.rb
+++ b/app/controllers/katello/api/v2/host_errata_controller.rb
@@ -104,6 +104,7 @@ module Katello
         relation = relation.where(:errata_type => TYPES_FROM_PARAMS[params[:type].to_sym])
       end
       if params[:severity].present?
+        params[:severity] = ['None', ''] if params[:severity] == 'None'
         relation = relation.where(:severity => params[:severity])
       end
       relation


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Severity N/A is stored as `'None'` in DB for a normal errata. 
However it's stored as `''` in DB for some of our testing repos like `https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/`.
Improve severity N/A filter so that it would work for empty severity in DB.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. add a repo that has errata with empty severity in DB
2. SCA enabled
3. new host UI, content tab, errata sub tab 
    Make sure the errata with empty severity is displayed. 
4. choose severity filter N/A 
    Verify the errata with empty severity is displayed. 