### PR TITLE
Fixes #35284 - Unhide SCA checkbox in org settings for edit

### DIFF
--- a/app/views/overrides/organizations/_edit_override.html.erb
+++ b/app/views/overrides/organizations/_edit_override.html.erb
@@ -12,13 +12,10 @@
                'data-url' => "/katello/api/v2/organizations/#{@taxonomy.id}/download_debug_certificate"
   end %>
 
-  <% if @can_toggle_sca %>
-    <%= field(f, _('Simple Content Access'),
-              :help_inline => _('Toggling Simple Content Access will refresh your manifest.')) do
-      tag1 = hidden_field_tag 'simple_content_access', '0'
-      tag2 = check_box_tag 'simple_content_access', '1', @taxonomy.simple_content_access?
-      tag1 + tag2
-    end %>
-  <% end %>
+  <%= field(f, _('Simple Content Access')) do
+    tag1 = hidden_field_tag 'simple_content_access', '0'
+    tag2 = check_box_tag 'simple_content_access', '1', @taxonomy.simple_content_access?(cached: false)
+    tag1 + tag2
+  end %>
 
 <% end %>

--- a/app/views/overrides/organizations/_index_row_override.html.erb
+++ b/app/views/overrides/organizations/_index_row_override.html.erb
@@ -1,3 +1,3 @@
 <% if taxonomy.is_a?(Organization) %>
-  <td><%= checked_icon taxonomy.simple_content_access? %></td>
+  <td><%= checked_icon taxonomy.simple_content_access?(cached: false) %></td>
 <% end %>

--- a/test/controllers/foreman/organizations_controller_test.rb
+++ b/test/controllers/foreman/organizations_controller_test.rb
@@ -28,7 +28,7 @@ class OrganizationsControllerTest < ActionController::TestCase
     org = get_organization(:organization2)
     Organization.any_instance.stubs(:simple_content_access?).returns true
     # assert correct task will be started
-    @controller.expects(:async_task).with(::Actions::Katello::Organization::SimpleContentAccess::Disable, org.id.to_s)
+    @controller.expects(:sync_task).with(::Actions::Katello::Organization::SimpleContentAccess::Disable, org.id.to_s)
     # send request to disable SCA
     put :update, params: { id: org.id, simple_content_access: false }
     assert_response :found
@@ -39,7 +39,7 @@ class OrganizationsControllerTest < ActionController::TestCase
     org = get_organization(:organization2)
     Organization.any_instance.stubs(:simple_content_access?).returns false
     # assert correct task will be started
-    @controller.expects(:async_task).with(::Actions::Katello::Organization::SimpleContentAccess::Enable, org.id.to_s)
+    @controller.expects(:sync_task).with(::Actions::Katello::Organization::SimpleContentAccess::Enable, org.id.to_s)
     # send request to enable SCA
     put :update, params: { id: org.id, simple_content_access: true }
     assert_response :found
@@ -60,8 +60,6 @@ class OrganizationsControllerTest < ActionController::TestCase
     org = get_organization(:organization2)
     Organization.any_instance.stubs(:service_level)
     Organization.any_instance.stubs(:service_levels).returns []
-    Katello::UpstreamConnectionChecker.any_instance.expects(:can_connect?).returns true
-    Katello::Candlepin::UpstreamConsumer.any_instance.expects(:simple_content_access_eligible?).returns(true)
     Organization.any_instance.expects(:simple_content_access?).returns true
     get :edit, params: { id: org.id }
     assert_response :success


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Removed the logic that hides the sca checkbox in org settings, so it can be used as part of the new SCA work.

#### Considerations taken when implementing this change?

* Making sure the org edit page, did not break

#### What are the testing steps for this pull request?

* Apply PR
* Don't import a manifest
* Try to edit an org without a manifest and see if you see the checkbox
* Create an org and when you get to the edit org page in the wizard, make sure checkbox is present