### PR TITLE
Update reset rake script to remove missing redis service error

### DIFF
--- a/lib/katello/tasks/reset.rake
+++ b/lib/katello/tasks/reset.rake
@@ -5,7 +5,7 @@ namespace :katello do
     service_start = "sudo /usr/bin/systemctl start %s"
 
     task :pulp do
-      SERVICES = %w(rh-redis5-redis pulpcore-api pulpcore-content).freeze
+      SERVICES = %w(pulpcore-api pulpcore-content).freeze
 
       puts "\e[33mStarting Pulp3 Reset\e[0m\n\n"
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* We don't use redis anymore since pulp changed their tasking system, so if you run the reset rake task it complains with `Unit rh-redis5-redis.service could not be found.`

#### Considerations taken when implementing this change?

* N/A

#### What are the testing steps for this pull request?

* Apply PR
* Run reset rake task and make sure you don't see the redis error message anymore. - This will blow away your db, so maybe spin up a fresh stable box or something if you can't part with your data
