### PR TITLE
Fixes #35290 - Katello rpm search via nvra also

### DIFF
--- a/app/models/katello/rpm.rb
+++ b/app/models/katello/rpm.rb
@@ -17,6 +17,7 @@ module Katello
     scoped_search :on => :evr, :ext_method => :scoped_search_evr, :only_explicit => true
     scoped_search :on => :filename, :complete_value => true
     scoped_search :on => :sourcerpm, :complete_value => true
+    scoped_search :on => :nvra, :complete_value => true
     scoped_search :on => :modular, :complete_value => true, :only_explicit => true
     scoped_search :on => :checksum
 


### PR DESCRIPTION
Add scoped_search on nvra. This helps user experience when filename does
not follow NVRA pattern.

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>

#### What are the changes introduced in this pull request?
Added scoped search on nvra over rpm objects.

#### Considerations taken when implementing this change?
??

#### What are the testing steps for this pull request?
Import a package with filename not following NVRA pattern (e.g. google-chrome-stable_current_x86_64.rpm) to a custo repo. Then search the repo by NVRA.