### PR TITLE
Fixes #35295 - Details tab cards - Switch to masonry card layout inst…

### DIFF
--- a/webpack/components/extensions/HostDetails/DetailsTabCards/HwPropertiesCard.js
+++ b/webpack/components/extensions/HostDetails/DetailsTabCards/HwPropertiesCard.js
@@ -46,6 +46,7 @@ const HwPropertiesCard = ({ isExpandedGlobal, hostDetails }) => {
       header={__('HW properties')}
       expandable
       isExpandedGlobal={isExpandedGlobal}
+      masonryLayout
     >
       <DescriptionList isHorizontal>
         <DescriptionListGroup>

--- a/webpack/components/extensions/HostDetails/DetailsTabCards/InstalledProductsCard.js
+++ b/webpack/components/extensions/HostDetails/DetailsTabCards/InstalledProductsCard.js
@@ -11,6 +11,7 @@ const InstalledProductsCard = ({ isExpandedGlobal, hostDetails }) => {
     <CardTemplate
       header={__('Installed products')}
       expandable
+      masonryLayout
       isExpandedGlobal={isExpandedGlobal}
     >
       <List isPlain>

--- a/webpack/components/extensions/HostDetails/DetailsTabCards/RegistrationCard.js
+++ b/webpack/components/extensions/HostDetails/DetailsTabCards/RegistrationCard.js
@@ -62,6 +62,7 @@ const RegistrationCard = ({ isExpandedGlobal, hostDetails }) => {
     <CardTemplate
       header={__('Registration details')}
       expandable
+      masonryLayout
       isExpandedGlobal={isExpandedGlobal}
     >
       <DescriptionList isHorizontal>


### PR DESCRIPTION
…ead of square grid

#### What are the changes introduced in this pull request?

nothin' much, just add some props
Requires https://github.com/theforeman/foreman/pull/9327

#### Considerations taken when implementing this change?
I had to consider whether to spell it "masonary" since that's how a lot of people say it. I decided against it.

#### What are the testing steps for this pull request?
Check out the Foreman PR
Settings > Show Experimental Labs > yes
Go to the new host details page > Details tab
