### PR TITLE
Fixes #35296 - New Custom CDN type

### DIFF
--- a/app/lib/actions/katello/cdn_configuration/update.rb
+++ b/app/lib/actions/katello/cdn_configuration/update.rb
@@ -18,7 +18,7 @@ module Actions
           org = cdn_configuration.organization
           roots = ::Katello::RootRepository.redhat.in_organization(org)
           roots.each do |root|
-            full_path = if cdn_configuration.redhat_cdn?
+            full_path = if cdn_configuration.redhat_cdn? || cdn_configuration.custom_cdn?
                           root.product.repo_url(root.library_instance.generate_content_path)
                         elsif cdn_configuration.network_sync?
                           resource.repository_url(content_label: root.content.label, arch: root.arch, major: root.major, minor: root.minor)

--- a/app/models/katello/cdn_configuration.rb
+++ b/app/models/katello/cdn_configuration.rb
@@ -32,6 +32,10 @@ module Katello
       type == CDN_TYPE
     end
 
+    def redhat_cdn_url?
+      Katello::Resources::CDN::CdnResource.redhat_cdn?(url)
+    end
+
     def export_sync?
       type == EXPORT_SYNC
     end

--- a/app/models/katello/cdn_configuration.rb
+++ b/app/models/katello/cdn_configuration.rb
@@ -5,8 +5,9 @@ module Katello
     CDN_TYPE = 'redhat_cdn'.freeze
     NETWORK_SYNC = 'network_sync'.freeze
     EXPORT_SYNC = 'export_sync'.freeze
+    CUSTOM_CDN_TYPE = 'custom_cdn'.freeze
 
-    TYPES = [CDN_TYPE, NETWORK_SYNC, EXPORT_SYNC].freeze
+    TYPES = [CDN_TYPE, NETWORK_SYNC, EXPORT_SYNC, CUSTOM_CDN_TYPE].freeze
 
     belongs_to :organization, :inverse_of => :cdn_configuration
 
@@ -32,6 +33,10 @@ module Katello
       type == CDN_TYPE
     end
 
+    def custom_cdn?
+      type == CUSTOM_CDN_TYPE
+    end
+
     def redhat_cdn_url?
       Katello::Resources::CDN::CdnResource.redhat_cdn?(url)
     end
@@ -50,11 +55,11 @@ module Katello
       return if network_sync?
 
       self.url = nil if export_sync?
-      self.url ||= SETTINGS[:katello][:redhat_repository_url] if redhat_cdn?
+      self.url = SETTINGS[:katello][:redhat_repository_url] if redhat_cdn?
       self.username = nil
       self.password = nil
       self.upstream_organization_label = nil
-      self.ssl_ca_credential_id = nil
+      self.ssl_ca_credential_id = nil unless custom_cdn?
       self.upstream_content_view_label = nil
       self.upstream_lifecycle_environment_label = nil
       self.ssl_cert = nil

--- a/db/migrate/20220730033504_update_custom_cdn.rb
+++ b/db/migrate/20220730033504_update_custom_cdn.rb
@@ -1,0 +1,13 @@
+class UpdateCustomCdn < ActiveRecord::Migration[6.1]
+  class FakeCdnConfiguration < Katello::Model
+    self.table_name = 'katello_cdn_configurations'
+    self.inheritance_column = nil
+  end
+
+  def change
+    FakeCdnConfiguration.reset_column_information
+    FakeCdnConfiguration.where(type: 'redhat_cdn').each do |config|
+      config.update!(type: 'custom_cdn') unless Katello::Resources::CDN::CdnResource.redhat_cdn?(config.url)
+    end
+  end
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -14,6 +14,7 @@ module Katello
         @organization = get_organization
       end
 
+      OpenSSL::X509::Store.any_instance.stubs(:add_file)
       @provider = Provider.where(:name => "customprovider", :organization => @organization, :provider_type => Provider::CUSTOM).first_or_create
       @cdn_mock = Resources::CDN::CdnResource.new("https://cdn.redhat.com", :ssl_client_cert => "456", :ssl_ca_file => "fake-ca.pem", :ssl_client_key => "123")
       @substitutor_mock = Util::CdnVarSubstitutor.new(@cdn_mock)

--- a/test/actions/katello/cdn_configuration/update_test.rb
+++ b/test/actions/katello/cdn_configuration/update_test.rb
@@ -75,8 +75,27 @@ module ::Actions::Katello::CdnConfiguration
 
     def test_plans_redhat_cdn
       attrs = {
-        type: ::Katello::CdnConfiguration::CDN_TYPE,
-        url: 'http://cdn.redhat.com'
+        type: ::Katello::CdnConfiguration::CDN_TYPE
+      }
+
+      plan_action(@action, @cdn_configuration, attrs)
+
+      @cdn_configuration.reload
+
+      assert_equal ::Katello::Resources::CDN::CdnResource.redhat_cdn_url, @cdn_configuration.url
+      assert_nil @cdn_configuration.ssl_cert
+      assert_nil @cdn_configuration.ssl_key
+      assert_nil @cdn_configuration.ssl_ca_credential_id
+      assert_nil @cdn_configuration.username
+      assert_nil @cdn_configuration.password
+      assert_nil @cdn_configuration.upstream_organization_label
+    end
+
+    def test_plans_custom_cdn
+      attrs = {
+        type: ::Katello::CdnConfiguration::CUSTOM_CDN_TYPE,
+        url: 'http://newcdn.example.com',
+        ssl_ca_credential_id: @credential.id
       }
 
       plan_action(@action, @cdn_configuration, attrs)
@@ -84,9 +103,7 @@ module ::Actions::Katello::CdnConfiguration
       @cdn_configuration.reload
 
       assert_equal attrs[:url], @cdn_configuration.url
-      assert_nil @cdn_configuration.ssl_cert
-      assert_nil @cdn_configuration.ssl_key
-      assert_nil @cdn_configuration.ssl_ca_credential_id
+      assert_equal @credential.id, @cdn_configuration.ssl_ca_credential_id
       assert_nil @cdn_configuration.username
       assert_nil @cdn_configuration.password
       assert_nil @cdn_configuration.upstream_organization_label

--- a/test/factories/cdn_configuration_factory.rb
+++ b/test/factories/cdn_configuration_factory.rb
@@ -12,5 +12,9 @@ FactoryBot.define do
     trait :redhat_cdn do
       type { ::Katello::CdnConfiguration::CDN_TYPE }
     end
+
+    trait :custom_cdn do
+      type { ::Katello::CdnConfiguration::CUSTOM_CDN_TYPE }
+    end
   end
 end

--- a/test/models/cdn_configuration_test.rb
+++ b/test/models/cdn_configuration_test.rb
@@ -15,6 +15,14 @@ module Katello
       assert config.valid?
     end
 
+    def test_custom_cdn
+      config = FactoryBot.build(:katello_cdn_configuration, :custom_cdn)
+      assert config.custom_cdn?
+      assert config.valid?
+      config.assign_attributes(url: nil)
+      refute config.valid?
+    end
+
     def test_non_redhat_configuration
       NON_REDHAT_FIELDS.each do |field|
         config = FactoryBot.build(:katello_cdn_configuration, :upstream_server)
@@ -41,6 +49,14 @@ module Katello
                      ssl_ca_credential_id: content_credential.id)
 
       assert config.network_sync?
+
+      # Now update to custom cdn
+      config.update!(type: ::Katello::CdnConfiguration::CUSTOM_CDN_TYPE)
+      assert config.custom_cdn?
+      assert_empty config.username
+      assert_empty config.password
+      assert_empty config.upstream_organization_label
+      assert_equal content_credential.id, config.ssl_ca_credential_id
 
       # Now update back to airgapped
       config.update!(type: ::Katello::CdnConfiguration::EXPORT_SYNC)

--- a/webpack/scenes/Organizations/OrganizationSelectors.js
+++ b/webpack/scenes/Organizations/OrganizationSelectors.js
@@ -9,6 +9,7 @@ import {
 } from './OrganizationConstants';
 
 export const selectOrganizationState = state => state.katello.organization;
+export const selectOrgLoading = state => state.katello.organization.loading;
 
 export const selectManifestName = state =>
   selectOrganizationState(state).owner_details?.upstreamConsumer?.name;

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/CdnConfigurationConstants.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/CdnConfigurationConstants.js
@@ -2,9 +2,10 @@ import { translate as __ } from 'foremanReact/common/I18n';
 
 export const CDN_URL = 'https://cdn.redhat.com';
 
-export const [CDN, NETWORK_SYNC, EXPORT_SYNC] = ['redhat_cdn', 'network_sync', 'export_sync'];
+export const [CDN, NETWORK_SYNC, EXPORT_SYNC, CUSTOM_CDN] = ['redhat_cdn', 'network_sync', 'export_sync', 'custom_cdn'];
 export const CDN_CONFIGURATION_TYPES = {
   redhat_cdn: __('Red Hat CDN'),
+  custom_cdn: __('Custom CDN'),
   network_sync: __('Network Sync'),
   export_sync: __('Export Sync'),
 };

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/CdnTypeForm.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/CdnTypeForm.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
@@ -16,16 +16,16 @@ import { noop } from 'foremanReact/common/helpers';
 import { CDN_URL, CDN } from './CdnConfigurationConstants';
 import { updateCdnConfiguration } from '../../../Organizations/OrganizationActions';
 import {
+  selectOrgLoading,
   selectUpdatingCdnConfiguration,
 } from '../../../Organizations/OrganizationSelectors';
 import './CdnConfigurationForm.scss';
 
-const CdnTypeForm = ({ showUpdate, onUpdate }) => {
+const CdnTypeForm = ({ typeChangeInProgress, onUpdate }) => {
   const dispatch = useDispatch();
-  const [updateEnabled, setUpdateEnabled] = useState(showUpdate);
   const updatingCdnConfiguration = useSelector(state => selectUpdatingCdnConfiguration(state));
+  const orgIsLoading = useSelector(state => selectOrgLoading(state));
   const performUpdate = () => {
-    setUpdateEnabled(false);
     dispatch(updateCdnConfiguration({
       type: CDN,
     }, onUpdate));
@@ -43,7 +43,7 @@ const CdnTypeForm = ({ showUpdate, onUpdate }) => {
             }}
           />
           <br />
-          {showUpdate &&
+          {typeChangeInProgress &&
           <FormattedMessage
             id="cdn-configuration-type-cdn"
             defaultMessage={__('Click {update} below to save changes.')}
@@ -70,7 +70,7 @@ const CdnTypeForm = ({ showUpdate, onUpdate }) => {
           aria-label="update-cdn-configuration"
           variant="secondary"
           onClick={performUpdate}
-          isDisabled={updatingCdnConfiguration || !updateEnabled}
+          isDisabled={updatingCdnConfiguration || orgIsLoading || !typeChangeInProgress}
           isLoading={updatingCdnConfiguration}
         >
           {__('Update')}
@@ -82,7 +82,7 @@ const CdnTypeForm = ({ showUpdate, onUpdate }) => {
 };
 
 CdnTypeForm.propTypes = {
-  showUpdate: PropTypes.bool.isRequired,
+  typeChangeInProgress: PropTypes.bool.isRequired,
   onUpdate: PropTypes.func,
 };
 

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/CdnTypeForm.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/CdnTypeForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
@@ -20,26 +20,14 @@ import {
 } from '../../../Organizations/OrganizationSelectors';
 import './CdnConfigurationForm.scss';
 
-const CdnTypeForm = ({ showUpdate, onUpdate, url }) => {
+const CdnTypeForm = ({ showUpdate, onUpdate }) => {
   const dispatch = useDispatch();
-  const [cdnUrl, setCdnUrl] = useState(url);
   const [updateEnabled, setUpdateEnabled] = useState(showUpdate);
   const updatingCdnConfiguration = useSelector(state => selectUpdatingCdnConfiguration(state));
-  const firstUpdate = useRef(true);
-
-  useEffect(() => {
-    if (firstUpdate.current) {
-      firstUpdate.current = false;
-      return;
-    }
-    setUpdateEnabled(true);
-  }, [cdnUrl]);
-
   const performUpdate = () => {
     setUpdateEnabled(false);
     dispatch(updateCdnConfiguration({
       type: CDN,
-      url: cdnUrl,
     }, onUpdate));
   };
 
@@ -69,11 +57,10 @@ const CdnTypeForm = ({ showUpdate, onUpdate, url }) => {
       <FormGroup label={__('URL')} isRequired>
         <TextInput
           ouiaId="cdn-configuration-url-input"
-          aria-label="cdn-url"
+          aria-label="redhat-cdn-url"
           type="text"
-          value={cdnUrl}
-          onChange={setCdnUrl}
-          isDisabled={updatingCdnConfiguration}
+          value={CDN_URL}
+          isDisabled
         />
       </FormGroup>
 
@@ -83,7 +70,7 @@ const CdnTypeForm = ({ showUpdate, onUpdate, url }) => {
           aria-label="update-cdn-configuration"
           variant="secondary"
           onClick={performUpdate}
-          isDisabled={updatingCdnConfiguration || !updateEnabled || !cdnUrl}
+          isDisabled={updatingCdnConfiguration || !updateEnabled}
           isLoading={updatingCdnConfiguration}
         >
           {__('Update')}
@@ -97,11 +84,9 @@ const CdnTypeForm = ({ showUpdate, onUpdate, url }) => {
 CdnTypeForm.propTypes = {
   showUpdate: PropTypes.bool.isRequired,
   onUpdate: PropTypes.func,
-  url: PropTypes.string,
 };
 
 CdnTypeForm.defaultProps = {
-  url: CDN_URL,
   onUpdate: noop,
 };
 

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/CustomCdnTypeForm.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/CustomCdnTypeForm.js
@@ -1,0 +1,148 @@
+import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
+import { FormattedMessage } from 'react-intl';
+import {
+  ActionGroup,
+  Button,
+  Form,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  TextInput,
+  Text,
+} from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { noop } from 'foremanReact/common/helpers';
+
+import { CUSTOM_CDN } from './CdnConfigurationConstants';
+import { updateCdnConfiguration } from '../../../Organizations/OrganizationActions';
+import {
+  selectUpdatingCdnConfiguration,
+} from '../../../Organizations/OrganizationSelectors';
+import './CdnConfigurationForm.scss';
+
+const CustomCdnTypeForm = ({
+  showUpdate, onUpdate, contentCredentials, cdnConfiguration,
+}) => {
+  const dispatch = useDispatch();
+  const urlValue = cdnConfiguration.type === CUSTOM_CDN ? cdnConfiguration.url : '';
+  const [url, setUrl] = useState(urlValue);
+  const [updateEnabled, setUpdateEnabled] = useState(showUpdate);
+  const updatingCdnConfiguration = useSelector(state => selectUpdatingCdnConfiguration(state));
+  const firstUpdate = useRef(true);
+  const [sslCaCredentialId, setSslCaCredentialId] = useState(cdnConfiguration.ssl_ca_credential_id);
+
+  useEffect(() => {
+    if (firstUpdate.current) {
+      firstUpdate.current = false;
+      return;
+    }
+    setUpdateEnabled(true);
+  }, [sslCaCredentialId, cdnConfiguration]);
+
+  const onError = () => setUpdateEnabled(true);
+
+  const performUpdate = () => {
+    setUpdateEnabled(false);
+    dispatch(updateCdnConfiguration({
+      url,
+      ssl_ca_credential_id: sslCaCredentialId,
+      type: CUSTOM_CDN,
+    }, onUpdate, onError));
+  };
+
+
+  return (
+    <Form isHorizontal>
+      <div id="update-hint-cdn" className="margin-top-16">
+        <Text>
+          <FormattedMessage
+            id="cdn-configuration-type"
+            defaultMessage={__('Red Hat content will be consumed from the {type}.')}
+            values={{
+              type: <strong>{__('Custom CDN Url')}</strong>,
+            }}
+          />
+          <br />
+          {showUpdate &&
+          <FormattedMessage
+            id="cdn-configuration-type-cdn"
+            defaultMessage={__('Click {update} below to save changes.')}
+            values={{
+              update: <strong>{__('Update')}</strong>,
+            }}
+          />
+          }
+        </Text>
+      </div>
+
+      <FormGroup
+        label={__('URL')}
+        isRequired
+      >
+        <TextInput
+          ouiaId="custom-cdn-url-input"
+          aria-label="cdn-url"
+          type="text"
+          value={url || ''}
+          onChange={value => setUrl(value)}
+          isDisabled={updatingCdnConfiguration}
+        />
+      </FormGroup>
+
+      <FormGroup
+        label={__('SSL CA Content Credential')}
+      >
+        <FormSelect
+          ouiaId="custom-cdn-ca-content-credential-input"
+          aria-label="cdn-ssl-ca-content-credential"
+          value={sslCaCredentialId || ''}
+          isDisabled={updatingCdnConfiguration}
+          onChange={value => setSslCaCredentialId(value)}
+        >
+          <FormSelectOption label={__('N/A')} />
+          {contentCredentials.map(cred =>
+            <FormSelectOption data-testid="ssl-ca-content-credential-option" key={cred.id} value={cred.id} label={cred.name} />)}
+        </FormSelect>
+      </FormGroup>
+
+      <ActionGroup>
+        <Button
+          ouiaId="custom-cdn-type-configuration-update-button"
+          aria-label="update-custom-cdn-configuration"
+          variant="secondary"
+          onClick={performUpdate}
+          isDisabled={updatingCdnConfiguration || !updateEnabled || !url}
+          isLoading={updatingCdnConfiguration}
+        >
+          {__('Update')}
+        </Button>
+      </ActionGroup>
+    </Form>
+
+  );
+};
+
+CustomCdnTypeForm.propTypes = {
+  showUpdate: PropTypes.bool.isRequired,
+  onUpdate: PropTypes.func,
+  contentCredentials: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+  })),
+  cdnConfiguration: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+    url: PropTypes.string,
+    ssl_ca_credential_id: PropTypes.number,
+  }),
+
+};
+
+CustomCdnTypeForm.defaultProps = {
+  onUpdate: noop,
+  contentCredentials: [],
+  cdnConfiguration: {},
+};
+
+export default CustomCdnTypeForm;

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/ExportSyncForm.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/ExportSyncForm.js
@@ -18,8 +18,8 @@ import {
 
 import './CdnConfigurationForm.scss';
 
-const ExportSyncForm = ({ showUpdate, onUpdate }) => {
-  const [updateEnabled, setUpdateEnabled] = useState(showUpdate);
+const ExportSyncForm = ({ typeChangeInProgress, onUpdate }) => {
+  const [updateEnabled, setUpdateEnabled] = useState(typeChangeInProgress);
   const updatingCdnConfiguration = useSelector(state => selectUpdatingCdnConfiguration(state));
   const dispatch = useDispatch();
   const performUpdate = () => {
@@ -41,7 +41,7 @@ const ExportSyncForm = ({ showUpdate, onUpdate }) => {
             }}
           />
           <br />
-          {showUpdate &&
+          {typeChangeInProgress &&
             <FormattedMessage
               id="cdn-configuration-type-cdn"
               defaultMessage={__('Click {update} below to save changes.')}
@@ -71,7 +71,7 @@ const ExportSyncForm = ({ showUpdate, onUpdate }) => {
 
 
 ExportSyncForm.propTypes = {
-  showUpdate: PropTypes.bool.isRequired,
+  typeChangeInProgress: PropTypes.bool.isRequired,
   onUpdate: PropTypes.func,
 };
 

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/NetworkSyncForm.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/NetworkSyncForm.js
@@ -72,7 +72,7 @@ const NetworkSyncForm = ({
   const hasPassword = (cdnConfiguration.password_exists && !password)
       || password?.length > 0;
 
-  const requiredFields = [username, organizationLabel, sslCaCredentialId];
+  const requiredFields = [username, organizationLabel, sslCaCredentialId, url];
 
   if (!hasPassword) {
     requiredFields.push(password);

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/__tests__/CdnTypeForm.test.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/__tests__/CdnTypeForm.test.js
@@ -24,7 +24,7 @@ const initialState = {
 
 test('Can update to cdn type', async (done) => {
   const { getByLabelText } = renderWithRedux(<CdnTypeForm
-    showUpdate
+    typeChangeInProgress
   />, { initialState });
 
   const updateCdnConfigurationRequest = nockInstance

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/__tests__/CdnTypeForm.test.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/__tests__/CdnTypeForm.test.js
@@ -4,7 +4,7 @@ import { renderWithRedux, fireEvent } from 'react-testing-lib-wrapper';
 import CdnTypeForm from '../CdnTypeForm';
 import { nockInstance, assertNockRequest } from '../../../../../test-utils/nockWrapper';
 import { updateCdnConfigurationSuccessResponse } from '../../../../Organizations/__tests__/organizations.fixtures';
-import { CDN, CDN_URL } from '../CdnConfigurationConstants';
+import { CDN } from '../CdnConfigurationConstants';
 
 import api from '../../../../../services/api';
 
@@ -25,43 +25,18 @@ const initialState = {
 test('Can update to cdn type', async (done) => {
   const { getByLabelText } = renderWithRedux(<CdnTypeForm
     showUpdate
-    url={CDN_URL}
   />, { initialState });
 
   const updateCdnConfigurationRequest = nockInstance
     .put(updateCdnConfigurationPath, {
-      url: CDN_URL,
       type: CDN,
     })
     .reply(200, updateCdnConfigurationSuccessResponse);
 
   expect(getByLabelText(updateButtonName)).toHaveAttribute('aria-disabled', 'false');
+  expect(getByLabelText('redhat-cdn-url')).toHaveAttribute('disabled');
 
   const updateButton = getByLabelText(updateButtonName);
-  fireEvent.click(updateButton);
-  assertNockRequest(updateCdnConfigurationRequest, done);
-});
-
-test('Can update the cdn url', async (done) => {
-  const { getByLabelText } = renderWithRedux(<CdnTypeForm
-    showUpdate={false}
-    url={CDN_URL}
-  />, { initialState });
-
-  const updateCdnConfigurationRequest = nockInstance
-    .put(updateCdnConfigurationPath, {
-      url: 'http://cdn.example.com',
-      type: CDN,
-    })
-    .reply(200, updateCdnConfigurationSuccessResponse);
-
-  expect(getByLabelText(updateButtonName)).toHaveAttribute('aria-disabled', 'true');
-
-  const url = getByLabelText('cdn-url');
-  fireEvent.change(url, { target: { value: 'http://cdn.example.com' } });
-
-  const updateButton = getByLabelText(updateButtonName);
-  expect(updateButton).toHaveAttribute('aria-disabled', 'false');
   fireEvent.click(updateButton);
   assertNockRequest(updateCdnConfigurationRequest, done);
 });

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/__tests__/CustomCdnTypeForm.test.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/__tests__/CustomCdnTypeForm.test.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import { cleanup } from '@testing-library/react';
+import { renderWithRedux, fireEvent } from 'react-testing-lib-wrapper';
+import userEvent from '@testing-library/user-event';
+import CustomCdnTypeForm from '../CustomCdnTypeForm';
+import { nockInstance, assertNockRequest } from '../../../../../test-utils/nockWrapper';
+import { updateCdnConfigurationSuccessResponse } from '../../../../Organizations/__tests__/organizations.fixtures';
+import { CUSTOM_CDN } from '../CdnConfigurationConstants';
+
+import api from '../../../../../services/api';
+
+afterEach(cleanup);
+const updateCdnConfigurationPath = api.getApiUrl('/organizations/1/cdn_configuration');
+
+const updateButtonName = 'update-custom-cdn-configuration';
+const organization = {
+  id: 1,
+};
+
+const initialState = {
+  katello: {
+    organization,
+  },
+};
+
+const cdnConfiguration = {
+  url: 'http://currentcdn.example.com',
+  ssl_ca_credential_id: 2,
+  type: CUSTOM_CDN,
+};
+
+const contentCredentials = [
+  {
+    name: 'Credential1',
+    id: 1,
+  },
+  {
+    name: 'Credential2',
+    id: 2,
+  },
+];
+
+test('Can update the custom cdn server configuration', async (done) => {
+  const { getByLabelText } = renderWithRedux(<CustomCdnTypeForm
+    showUpdate
+    cdnConfiguration={cdnConfiguration}
+    contentCredentials={contentCredentials}
+  />, { initialState });
+
+  const updateCdnConfigurationRequest = nockInstance
+    .put(updateCdnConfigurationPath, {
+      url: 'http://cdn.example.com',
+      ssl_ca_credential_id: '1',
+      type: CUSTOM_CDN,
+    })
+    .reply(200, updateCdnConfigurationSuccessResponse);
+
+  const url = getByLabelText('cdn-url');
+  fireEvent.change(url, { target: { value: 'http://cdn.example.com' } });
+
+  userEvent.selectOptions(
+    getByLabelText('cdn-ssl-ca-content-credential'),
+    '1',
+  );
+
+  const updateButton = getByLabelText(updateButtonName);
+  fireEvent.click(updateButton);
+
+  assertNockRequest(updateCdnConfigurationRequest, done);
+});
+
+test('the form shall reflect the given cdnConfiguration', () => {
+  const { getAllByTestId } = renderWithRedux(<CustomCdnTypeForm
+    showUpdate
+    cdnConfiguration={cdnConfiguration}
+    contentCredentials={contentCredentials}
+  />, { initialState });
+
+  const options = getAllByTestId('ssl-ca-content-credential-option');
+
+  expect(options).toHaveLength(contentCredentials.length);
+  expect(options[0].selected).toBeFalsy();
+  expect(options[1].selected).toBeTruthy();
+});
+
+test('update button disabled on incomplete information', async (done) => {
+  const { getByLabelText } = renderWithRedux(<CustomCdnTypeForm
+    showUpdate
+    cdnConfiguration={{ ...cdnConfiguration, url: '' }}
+    contentCredentials={contentCredentials}
+  />, { initialState });
+
+  expect(getByLabelText(updateButtonName)).toHaveAttribute('aria-disabled', 'true');
+  fireEvent.change(getByLabelText('cdn-url'), { target: { value: 'http://example.com' } });
+  expect(getByLabelText(updateButtonName)).toHaveAttribute('aria-disabled', 'false');
+  done();
+});

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/__tests__/CustomCdnTypeForm.test.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/__tests__/CustomCdnTypeForm.test.js
@@ -42,7 +42,7 @@ const contentCredentials = [
 
 test('Can update the custom cdn server configuration', async (done) => {
   const { getByLabelText } = renderWithRedux(<CustomCdnTypeForm
-    showUpdate
+    typeChangeInProgress
     cdnConfiguration={cdnConfiguration}
     contentCredentials={contentCredentials}
   />, { initialState });
@@ -71,7 +71,7 @@ test('Can update the custom cdn server configuration', async (done) => {
 
 test('the form shall reflect the given cdnConfiguration', () => {
   const { getAllByTestId } = renderWithRedux(<CustomCdnTypeForm
-    showUpdate
+    typeChangeInProgress
     cdnConfiguration={cdnConfiguration}
     contentCredentials={contentCredentials}
   />, { initialState });
@@ -85,7 +85,7 @@ test('the form shall reflect the given cdnConfiguration', () => {
 
 test('update button disabled on incomplete information', async (done) => {
   const { getByLabelText } = renderWithRedux(<CustomCdnTypeForm
-    showUpdate
+    typeChangeInProgress
     cdnConfiguration={{ ...cdnConfiguration, url: '' }}
     contentCredentials={contentCredentials}
   />, { initialState });

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/__tests__/ExportSyncForm.test.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/__tests__/ExportSyncForm.test.js
@@ -26,7 +26,7 @@ const initialState = {
 
 test('Can update to Airgapped type', async (done) => {
   const { getByLabelText } = renderWithRedux(<ExportSyncForm
-    showUpdate
+    typeChangeInProgress
   />, { initialState });
 
   const updateCdnConfigurationRequest = nockInstance

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/__tests__/NetworkSyncForm.test.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/__tests__/NetworkSyncForm.test.js
@@ -48,7 +48,7 @@ const contentCredentials = [
 
 test('Can update the upstream server configuration', async (done) => {
   const { getByLabelText } = renderWithRedux(<NetworkSyncForm
-    showUpdate
+    typeChangeInProgress
     cdnConfiguration={cdnConfiguration}
     contentCredentials={contentCredentials}
   />, { initialState });
@@ -93,7 +93,7 @@ test('Can update the upstream server configuration', async (done) => {
 
 test('the form shall reflect the given cdnConfiguration', () => {
   const { getAllByTestId, getByLabelText } = renderWithRedux(<NetworkSyncForm
-    showUpdate
+    typeChangeInProgress
     cdnConfiguration={cdnConfiguration}
     contentCredentials={contentCredentials}
   />, { initialState });
@@ -110,7 +110,7 @@ test('the form shall reflect the given cdnConfiguration', () => {
 
 test('resetting the password enables/disables appropriately', async (done) => {
   const { getByLabelText } = renderWithRedux(<NetworkSyncForm
-    showUpdate
+    typeChangeInProgress
     cdnConfiguration={{ ...cdnConfiguration, password_exists: true }}
   />, { initialState });
 
@@ -131,7 +131,7 @@ test('resetting the password enables/disables appropriately', async (done) => {
 
 test('update button disabled on incomplete information', async (done) => {
   const { getByLabelText } = renderWithRedux(<NetworkSyncForm
-    showUpdate
+    typeChangeInProgress
     cdnConfiguration={{ ...cdnConfiguration, password_exists: true }}
     contentCredentials={contentCredentials}
   />, { initialState });

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/index.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/index.js
@@ -54,13 +54,13 @@ const CdnConfigurationForm = (props) => {
           cdnConfiguration={cdnConfiguration}
           contentCredentials={contentCredentials}
           onUpdate={onUpdate}
-          showUpdate={type !== cdnConfiguration.type}
+          typeChangeInProgress={type !== cdnConfiguration.type}
         />
       }
 
       { type === CDN &&
         <CdnTypeForm
-          showUpdate={type !== cdnConfiguration.type}
+          typeChangeInProgress={type !== cdnConfiguration.type}
           onUpdate={onUpdate}
         />
       }
@@ -68,14 +68,14 @@ const CdnConfigurationForm = (props) => {
         <CustomCdnTypeForm
           cdnConfiguration={cdnConfiguration}
           contentCredentials={contentCredentials}
-          showUpdate={type !== cdnConfiguration.type}
+          typeChangeInProgress={type !== cdnConfiguration.type}
           onUpdate={onUpdate}
         />
       }
 
       { type === EXPORT_SYNC &&
         <ExportSyncForm
-          showUpdate={type !== cdnConfiguration.type}
+          typeChangeInProgress={type !== cdnConfiguration.type}
           onUpdate={onUpdate}
         />
       }

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/index.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/index.js
@@ -9,9 +9,9 @@ import { noop } from 'foremanReact/common/helpers';
 import CdnTypeForm from './CdnTypeForm';
 import ExportSyncForm from './ExportSyncForm';
 import NetworkSyncForm from './NetworkSyncForm';
-
+import CustomCdnTypeForm from './CustomCdnTypeForm';
 import './CdnConfigurationForm.scss';
-import { CDN_URL, CDN, EXPORT_SYNC, NETWORK_SYNC, CDN_CONFIGURATION_TYPES } from './CdnConfigurationConstants';
+import { CDN, EXPORT_SYNC, CUSTOM_CDN, NETWORK_SYNC, CDN_CONFIGURATION_TYPES } from './CdnConfigurationConstants';
 
 const CdnConfigurationForm = (props) => {
   const {
@@ -28,20 +28,25 @@ const CdnConfigurationForm = (props) => {
     }
   };
 
-  const cdnUrl = type !== cdnConfiguration.type ? CDN_URL : cdnConfiguration.url;
-
   return (
     <div id="cdn-configuration">
       <ToggleGroup aria-label="Default with multiple selectable">
         <ToggleGroupItem text={CDN_CONFIGURATION_TYPES[CDN]} key={0} buttonId="cdn" isSelected={type === CDN} onChange={() => updateType(CDN)} />
         <ToggleGroupItem
-          text={CDN_CONFIGURATION_TYPES[NETWORK_SYNC]}
+          text={CDN_CONFIGURATION_TYPES[CUSTOM_CDN]}
           key={1}
+          buttonId="customCdn"
+          isSelected={type === CUSTOM_CDN}
+          onChange={() => updateType(CUSTOM_CDN)}
+        />
+        <ToggleGroupItem
+          text={CDN_CONFIGURATION_TYPES[NETWORK_SYNC]}
+          key={2}
           buttonId="usptream_server"
           isSelected={type === NETWORK_SYNC}
           onChange={() => updateType(NETWORK_SYNC)}
         />
-        <ToggleGroupItem text={CDN_CONFIGURATION_TYPES[EXPORT_SYNC]} key={2} buttonId="airgapped" isSelected={type === EXPORT_SYNC} onChange={() => updateType(EXPORT_SYNC)} />
+        <ToggleGroupItem text={CDN_CONFIGURATION_TYPES[EXPORT_SYNC]} key={3} buttonId="airgapped" isSelected={type === EXPORT_SYNC} onChange={() => updateType(EXPORT_SYNC)} />
       </ToggleGroup>
 
       { type === NETWORK_SYNC &&
@@ -57,9 +62,17 @@ const CdnConfigurationForm = (props) => {
         <CdnTypeForm
           showUpdate={type !== cdnConfiguration.type}
           onUpdate={onUpdate}
-          url={cdnUrl}
         />
       }
+      { type === CUSTOM_CDN &&
+        <CustomCdnTypeForm
+          cdnConfiguration={cdnConfiguration}
+          contentCredentials={contentCredentials}
+          showUpdate={type !== cdnConfiguration.type}
+          onUpdate={onUpdate}
+        />
+      }
+
       { type === EXPORT_SYNC &&
         <ExportSyncForm
           showUpdate={type !== cdnConfiguration.type}


### PR DESCRIPTION

Now that we have the syncable yum exports available, we need the ability to pull in the exported content.
One should be able to enable via http / https to a custom cdn location.

However while enabling a repo via https we hit an SSL verifcation issue. This is because we only pass redhat ca cert while talking to cdn. So the connection is not able to verify the custom cdn url.
This commit adds a new 'custom_cdn'  type configuration where you specify both your custom cdn url and ssl cert.
 
#### What are the changes introduced in this pull request?
- New Custom CDN configuration type. API + UI Changes
- Updated the RedHat CDN type and set its url as read only.

#### Considerations taken when implementing this change?
Initially thought of just using the default trust store to accept custom cert. However from a security perspective we probably shouldn't be making use of those.

#### What are the testing steps for this pull request?
Feel free to ping me for the dump url or do the following 7 steps to generate one.
- Enable a RH Repo like `rhel-7-server-ansible-2.9-rpms`
- Go to products -> repo details of this repo and mark the download policy  immediate
- Sync repo
- On your dev env you may need to run sudo setfacl --recursive --modify u:vagrant:rwX,d:u:vagrant:rwX /var/lib/pulp/exports so that listing files can be generate when hammer is running as a vagrant user.
- `hammer content-export complete repository --id=<repo-id> --format=syncable` -> This should generate a dump
- `mv <dump-dir>  /var/www/html/pub/repos`
- make sure `https://<...>/pub/repos` is browsable.

Now in a new Katello instance which will be the importing sat
- create new org
- import manifest
- Goto Subscriptions => Manage Manifest => CDN Configuration => Redhat CDN
-  Change the URL to https://<...>/pub/repos
- Click updateb
- Now go to Redhat Repos page and try enabling the ansible repo

Before this PR - 
You should see an error like 
```
2022-07-28T18:01:33 [I|app|37e3cb19] CDN: Requesting path https://<webserver>:443/pub/repos/content/dist/rhel/server/7/listing
/opt/rh/rh-ruby27/root/usr/share/ruby/net/protocol.rb:44: warning: exception in verify_callback is ignored
2022-07-28T18:01:33 [E|app|37e3cb19] Failed at scanning for repository: SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate in certificate chain)
```

After PR
- `bundle exec rake db:migrate`
- Go to `Content->Content Credentials`
- Create a new cert with contents of -> `https://<...>/pub/katello-server-ca.crt`
- Go to Subscriptions => Manage Manifest => CDN Configuration => Custom CDN
- Update the url to `https://<...>/pub/repos`  and content credentials to the one you created above
- Now try enabling and syncing the desired repo.