### PR TITLE
Fixes #35329 - useTableSort should translate params

### DIFF
--- a/webpack/components/Table/TableHooks.js
+++ b/webpack/components/Table/TableHooks.js
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { isEmpty } from 'lodash';
 import { useLocation } from 'react-router-dom';
+import { translate as __ } from 'foremanReact/common/I18n';
 import { friendlySearchParam } from '../../utils/helpers';
 
 class ReactConnectedSet extends Set {
@@ -268,12 +269,15 @@ export const useUrlParams = () => {
 export const useTableSort = ({
   allColumns,
   columnsToSortParams,
-  initialSortColumnName = allColumns[0],
+  initialSortColumnName,
 }) => {
-  if (!Object.keys(columnsToSortParams).includes(initialSortColumnName)) {
-    throw new Error(`initialSortColumnName '${initialSortColumnName}' must also be defined in columnsToSortParams`);
+  const translatedInitialSortColumnName = initialSortColumnName
+    ? __(initialSortColumnName)
+    : allColumns[0];
+  if (!Object.keys(columnsToSortParams).includes(translatedInitialSortColumnName)) {
+    throw new Error(`translatedInitialSortColumnName '${translatedInitialSortColumnName}' must also be defined in columnsToSortParams`);
   }
-  const [activeSortColumn, setActiveSortColumn] = useState(initialSortColumnName);
+  const [activeSortColumn, setActiveSortColumn] = useState(translatedInitialSortColumnName);
   const [activeSortDirection, setActiveSortDirection] = useState('asc');
 
   // Patternfly sort function


### PR DESCRIPTION
It receives the untranlsated value which is not a part of the columnsToSortParams object.
Because of this users cant open Katello tabs in the new host details
Error:
`TableHooks.js:275 Uncaught Error: initialSortColumnName 'Name' must also be defined in columnsToSortParams`

#### What are the changes introduced in this pull request?
Translating the value of `initialSortColumnName` in `useTableSort`

#### Considerations taken when implementing this change?
Thought it would be better to translate at the function declaration instead of in each function call so if someone wrote a new call to `useTableSort` they won't accidentally re-do this bug.
`allColumns[0]` is already translated and it might cause issues to translate it twice.

#### What are the testing steps for this pull request?
set locale=cs_cz and open Errate - Module streams tab
