### PR TITLE
Fixes #35045 - fixed the issue that all errata are applied when only certain errata selected

### DIFF
--- a/webpack/components/Table/TableHooks.js
+++ b/webpack/components/Table/TableHooks.js
@@ -144,6 +144,7 @@ export const useBulkSelect = ({
   initialArry = [],
   initialSearchQuery = '',
   idColumn = 'id',
+  filtersQuery = '',
   isSelectable,
 }) => {
   const { selectionSet: inclusionSet, ...selectOptions } =
@@ -207,7 +208,7 @@ export const useBulkSelect = ({
 
   const fetchBulkParams = (idColumnName = idColumn) => {
     const searchQueryWithExclusionSet = () => {
-      const query = [searchQuery,
+      const query = [searchQuery, filtersQuery,
         !isEmpty(exclusionSet) && `${idColumnName} !^ (${[...exclusionSet].join(',')})`];
       return query.filter(item => item).join(' and ');
     };

--- a/webpack/components/Table/__test__/useBulkSelect.test.js
+++ b/webpack/components/Table/__test__/useBulkSelect.test.js
@@ -1,0 +1,99 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useBulkSelect } from '../TableHooks';
+
+const isSelectable = () => true;
+const idColumn = 'errata_id';
+const metadata = {
+  error: null, selectable: 2, subtotal: 2, total: 2,
+};
+const results = [
+  {
+    errata_id: 'RHSA-2022:2031',
+    id: 311,
+    severity: 'Low',
+    type: 'security',
+  },
+  {
+    errata_id: 'RHSA-2022:2110',
+    id: 17,
+    severity: 'Low',
+    type: 'security',
+  },
+];
+
+it('returns a scoped search string based on inclusionSet', () => {
+  const { result } = renderHook(() => useBulkSelect({
+    results,
+    metadata,
+    idColumn,
+    isSelectable,
+  }));
+
+  act(() => {
+    result.current.selectOne(true, 'RHSA-2022:2031');
+  });
+
+  expect(result.current.fetchBulkParams()).toBe('errata_id ^ (RHSA-2022:2031)');
+});
+
+it('returns a scoped search string based on exclusionSet', () => {
+  const { result } = renderHook(() => useBulkSelect({
+    results,
+    metadata,
+    idColumn,
+    isSelectable,
+  }));
+
+  act(() => {
+    result.current.selectAll(true);
+  });
+
+  act(() => {
+    result.current.selectOne(false, 'RHSA-2022:2031');
+  });
+
+  expect(result.current.fetchBulkParams()).toBe('errata_id !^ (RHSA-2022:2031)');
+});
+
+it('adds search query to scoped search string based on exclusionSet', () => {
+  const { result } = renderHook(() => useBulkSelect({
+    results,
+    metadata,
+    idColumn,
+    isSelectable,
+  }));
+
+  act(() => {
+    result.current.updateSearchQuery('type=security');
+  });
+
+  act(() => {
+    result.current.selectAll(true);
+  });
+
+  act(() => {
+    result.current.selectOne(false, 'RHSA-2022:2031');
+  });
+
+  expect(result.current.fetchBulkParams()).toBe('type=security and errata_id !^ (RHSA-2022:2031)');
+});
+
+it('adds filter dropdown query to scoped search string', () => {
+  const { result } = renderHook(() => useBulkSelect({
+    results,
+    metadata,
+    idColumn,
+    isSelectable,
+    filtersQuery: 'severity=Low',
+  }));
+
+  act(() => {
+    result.current.selectAll(true);
+  });
+
+  act(() => {
+    result.current.selectOne(false, 'RHSA-2022:2031');
+  });
+
+  expect(result.current.fetchBulkParams()).toBe('severity=Low and errata_id !^ (RHSA-2022:2031)');
+});

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -120,6 +120,17 @@ export const ErrataTab = () => {
     initialSortColumnName: 'Errata',
   });
 
+  const filtersQuery = () => {
+    const query = [];
+    if (errataTypeSelected !== ERRATA_TYPE) {
+      query.push(`type=${TYPES_TO_PARAM[errataTypeSelected]}`);
+    }
+    if (errataSeveritySelected !== ERRATA_SEVERITY) {
+      query.push(`severity=${SEVERITIES_TO_PARAM[errataSeveritySelected]}`);
+    }
+    return query.join(' and ');
+  };
+
   const fetchItems = useCallback(
     (params) => {
       if (!hostId) return hostIdNotReady;
@@ -155,6 +166,7 @@ export const ErrataTab = () => {
     results,
     metadata,
     idColumn: 'errata_id',
+    filtersQuery: filtersQuery(),
     isSelectable: result => result.installable,
     initialSearchQuery: searchParam || '',
   });


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add `fetchItemsQuery` to `useBulkSelect` for dropdown filters.

#### Considerations taken when implementing this change?
@jeremylenz has done an excellent job to explain the issue. I'd like to save it here for the record. Thanks @jeremylenz.

`fetchBulkParams` returns a scoped search query that matches whatever items are selected.

If you're in regular mode and have ids 1 and 3 selected, it will return `"id ^ (1, 3)"`.
if you're in `selectAll` mode, it uses `exclusionSet` instead. 

Let's say you select all, the front end hasn't downloaded all the IDs yet from all the pages so it doesn't know what they are. 
but then lets say you go to page 4 of 99 and deselect a couple items. It knows you deselected those.  So `searchQueryWithExclusionSet` will return a query like "id !^ (396, 398)" which means "id is not equal to those two that the user deselected". So that search would match all IDs _except_ those.

Now, it gets more complicated when the user has already entered a search in the search box. That's why you see it joined with `searchQuery` [there](https://github.com/Katello/katello/blob/a9e44e26abb667ed474fc562b97172a62ea98a2a/webpack/components/Table/TableHooks.js#L210). It actually joins that `id !^ (396, 398)` with the search query so you'll get something like `id !^ (396, 398) AND name ~ panda` or whatever your search was.

The bug is that it should _also_ do that with whatever filter dropdowns you have selected. Right now it ignores them.
But it should translate those dropdowns into a scoped search query and add that to `searchQueryWithExclusionSet` similar to the way `searchQuery` is now.

#### What are the testing steps for this pull request?
Get a host with multiple types of errata
On the new host detail page, filter the errata to only a single type (e.g. Bugfix)
Click the Select All checkbox
Click Apply

Expected: Only the selected errata type will be applied instead of all errata are applied.

