### PR TITLE
Fixes #35410 - Fix a pathing issue on exports

### DIFF
--- a/app/services/katello/pulp3/content_view_version/export.rb
+++ b/app/services/katello/pulp3/content_view_version/export.rb
@@ -53,9 +53,9 @@ module Katello
 
         def generate_exporter_path
           return base_path if base_path
-          export_path = "#{content_view_version.content_view}/#{content_view_version.version}/"
-          export_path += "#{destination_server}/" unless destination_server.blank?
-          export_path += "#{date_dir}".gsub(/\s/, '_')
+          export_path = "#{content_view_version.content_view.label}/#{content_view_version.version}/"
+          export_path += "#{destination_server}/".gsub(/\s/, '_') unless destination_server.blank?
+          export_path += "#{date_dir}"
           @base_path = "#{Setting['pulpcore_export_destination']}/#{content_view_version.organization.label}/#{export_path}"
         end
 

--- a/test/fixtures/vcr_cassettes/actions/katello/content_view_version/export/create_exporter.yml
+++ b/test/fixtures/vcr_cassettes/actions/katello/content_view_version/export/create_exporter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:32 GMT
+      - Mon, 22 Aug 2022 21:48:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -41,21 +41,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c4a9345cbd6f47c996c731379b2aae4f
+      - bea46ac833a04ed8bd19697486b89736
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:32 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:44 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -76,7 +76,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:32 GMT
+      - Mon, 22 Aug 2022 21:48:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -94,21 +94,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3def58222852483ebff90e0dbfa66d51
+      - ac8dae9115e64629afba09aa3aa0cac0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:32 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:44 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -116,7 +116,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -129,7 +129,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:32 GMT
+      - Mon, 22 Aug 2022 21:48:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -147,21 +147,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 45510cd41949431e980c8387192e8434
+      - 4ee1e5afaee64d0e9dbf669a5570a195
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:32 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:44 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -169,7 +169,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -182,7 +182,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:32 GMT
+      - Mon, 22 Aug 2022 21:48:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -200,21 +200,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b00e3d11334c4162b0e3b94c07fa191d
+      - 86ad3c41bd014ec2b437744e965d2911
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:32 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:44 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -231,7 +231,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -244,13 +244,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:32 GMT
+      - Mon, 22 Aug 2022 21:48:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/d9c75e34-c60b-4096-b7f8-57a9f22f3baf/"
+      - "/pulp/api/v3/remotes/rpm/rpm/a9d6f1f3-df5d-4daa-9ad5-ff300a433392/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -264,32 +264,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c7d9911bd10745beb454acaa114cff8d
+      - 0a80d510708146d3859c9a4a4b6ef265
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q5
-        Yzc1ZTM0LWM2MGItNDA5Ni1iN2Y4LTU3YTlmMjJmM2JhZi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjMyLjc3MTcyNloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E5
+        ZDZmMWYzLWRmNWQtNGRhYS05YWQ1LWZmMzAwYTQzMzM5Mi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA4LTIyVDIxOjQ4OjQ0LjkwNTM1OVoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjMyLjc3MTc1MloiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA4LTIyVDIxOjQ4OjQ0LjkwNTM5MVoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:32 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:45 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -299,7 +299,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -312,13 +312,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:33 GMT
+      - Mon, 22 Aug 2022 21:48:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/8a9b6a9a-207d-429b-812a-d80d0d69b0cf/"
+      - "/pulp/api/v3/repositories/rpm/rpm/8fb7874f-4b2e-4a6e-a2db-e9939f15a00b/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -332,22 +332,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a772ee99c33c471599edeb5c384e082d
+      - 5b016ac3d4cc4c1092f9456936fe32b9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOGE5YjZhOWEtMjA3ZC00MjliLTgxMmEtZDgwZDBkNjliMGNmLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6MzMuMDUzNzA1WiIsInZl
+        cG0vOGZiNzg3NGYtNGIyZS00YTZlLWEyZGItZTk5MzlmMTVhMDBiLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDgtMjJUMjE6NDg6NDUuMjk0MDIxWiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vOGE5YjZhOWEtMjA3ZC00MjliLTgxMmEtZDgwZDBkNjliMGNmL3ZlcnNp
+        cG0vOGZiNzg3NGYtNGIyZS00YTZlLWEyZGItZTk5MzlmMTVhMDBiL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84YTliNmE5YS0y
-        MDdkLTQyOWItODEyYS1kODBkMGQ2OWIwY2YvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84ZmI3ODc0Zi00
+        YjJlLTRhNmUtYTJkYi1lOTkzOWYxNWEwMGIvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -356,21 +356,21 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:33 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:45 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vOGE5YjZhOWEtMjA3ZC00MjliLTgxMmEtZDgwZDBkNjli
-        MGNmL3ZlcnNpb25zLzAvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vOGZiNzg3NGYtNGIyZS00YTZlLWEyZGItZTk5MzlmMTVh
+        MDBiL3ZlcnNpb25zLzAvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -383,7 +383,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:33 GMT
+      - Mon, 22 Aug 2022 21:48:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -401,21 +401,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2540ca921ea74b83be4c617909995858
+      - fd238dc5f2804394b432a167796e6660
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlhOWM0YTE5LTgxNjItNGJj
-        OS05OTljLTIyOTVmOTU2MTkxYi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI4YWU0NWUwLTdjMDUtNGE1
+        NC05NmVhLTM0ZTI3ODY4ZjFmMS8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:33 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:46 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/9a9c4a19-8162-4bc9-999c-2295f956191b/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/28ae45e0-7c05-4a54-96ea-34e27868f1f1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -423,7 +423,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -436,56 +436,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:33 GMT
+      - Mon, 22 Aug 2022 21:48:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 988dc2a9cc8444cab6292f967d5716f0
+      - 548f7f684dc543c9b4defbd10a56cce0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '477'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWE5YzRhMTktODE2
-        Mi00YmM5LTk5OWMtMjI5NWY5NTYxOTFiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6MzMuNTY3NDE3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMjhhZTQ1ZTAtN2Mw
+        NS00YTU0LTk2ZWEtMzRlMjc4NjhmMWYxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NDYuMTgyODc0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjI1NDBjYTkyMWVhNzRiODNiZTRjNjE3OTA5
-        OTk1ODU4Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6MzMuNjI4
-        MDc2WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0xOVQxODo0NjozMy43OTg3
-        MThaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzc0YzQwNzJhLTM2MjMtNDg0Mi04ZmFlLWU0YzQyMDA4OTliMC8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6ImZkMjM4ZGM1ZjI4MDQzOTRiNDMyYTE2Nzc5
+        NmU2NjYwIiwic3RhcnRlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6NDYuMjQw
+        NDU2WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wOC0yMlQyMTo0ODo0Ni40MTA1
+        NTlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzQ3Zjg4YWRjLWZhYzUtNGViNi1hMWM2LTY1OWQzZjgzOTc3ZC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vN2FlMzc4
-        ZGEtMGU5Ni00OWJlLWI2OGEtMTA0OTA3MDNiZmE0LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMGYzODg1
+        NWYtMDAyOC00MWYwLWJlZjMtMDliNjE3YTZhZjdjLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vOGE5YjZhOWEtMjA3ZC00MjliLTgxMmEtZDgwZDBk
-        NjliMGNmLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vOGZiNzg3NGYtNGIyZS00YTZlLWEyZGItZTk5Mzlm
+        MTVhMDBiLyJdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:33 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:46 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -493,7 +493,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -506,7 +506,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:33 GMT
+      - Mon, 22 Aug 2022 21:48:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -524,21 +524,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e8baa79fae8d4ea1b052bed352e51e90
+      - af202be19a7c483faa36713a33947b94
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:33 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:46 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/7ae378da-0e96-49be-b68a-10490703bfa4/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0f38855f-0028-41f0-bef3-09b617a6af7c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -546,7 +546,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -559,60 +559,60 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:33 GMT
+      - Mon, 22 Aug 2022 21:48:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d4fdcb857cba4c94a55df5b508b9eb8f
+      - daaf0c89393548c28ac065ff93f01772
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '249'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vN2FlMzc4ZGEtMGU5Ni00OWJlLWI2OGEtMTA0OTA3MDNiZmE0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6MzMuNjUzODg2WiIsInJl
+        cG0vMGYzODg1NWYtMDAyOC00MWYwLWJlZjMtMDliNjE3YTZhZjdjLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDgtMjJUMjE6NDg6NDYuMjU3MzM5WiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS84YTliNmE5YS0yMDdkLTQyOWItODEyYS1kODBkMGQ2OWIwY2Yv
+        cnBtL3JwbS84ZmI3ODc0Zi00YjJlLTRhNmUtYTJkYi1lOTkzOWYxNWEwMGIv
         dmVyc2lvbnMvMC8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzhhOWI2YTlhLTIwN2QtNDI5Yi04MTJhLWQ4MGQw
-        ZDY5YjBjZi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtLzhmYjc4NzRmLTRiMmUtNGE2ZS1hMmRiLWU5OTM5
+        ZjE1YTAwYi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:33 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:46 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vN2FlMzc4ZGEtMGU5Ni00OWJlLWI2OGEtMTA0
-        OTA3MDNiZmE0LyJ9
+        bGljYXRpb25zL3JwbS9ycG0vMGYzODg1NWYtMDAyOC00MWYwLWJlZjMtMDli
+        NjE3YTZhZjdjLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -625,7 +625,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:34 GMT
+      - Mon, 22 Aug 2022 21:48:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -643,21 +643,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 44648c9bc020483ea6c42833562d630a
+      - 0e0a890627164216a1c40930cf42409e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA5ZTViNzIxLTU2NTAtNDZk
-        NS05NzMyLTkyMDdjMTMxYzBiNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk1MTdlM2E0LTVlOGItNDJi
+        Zi04ZTk5LTJkMDcxMWYxZTkyMy8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:34 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:46 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/09e5b721-5650-46d5-9732-9207c131c0b5/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/9517e3a4-5e8b-42bf-8e99-2d0711f1e923/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -665,7 +665,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -678,52 +678,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:34 GMT
+      - Mon, 22 Aug 2022 21:48:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '632'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5be57bd833664d129fd48317f12ae0b9
+      - aafab3df4d4f4872a956c4e90bab0e6a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDllNWI3MjEtNTY1
-        MC00NmQ1LTk3MzItOTIwN2MxMzFjMGI1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6MzQuMDA1MTc5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTUxN2UzYTQtNWU4
+        Yi00MmJmLThlOTktMmQwNzExZjFlOTIzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NDYuNzYxNDE3WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwibG9nZ2luZ19jaWQiOiI0NDY0OGM5YmMwMjA0ODNlYTZjNDI4MzM1
-        NjJkNjMwYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM0LjA0
-        NzU3MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6MzQuMTc5
-        Nzc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zNjAxYmE4OC1hYzM2LTQwNzctYjhhNC04YTA3ODlmYzJkOGMvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIwZTBhODkwNjI3MTY0MjE2YTFjNDA5MzBj
+        ZjQyNDA5ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ4OjQ2Ljgx
+        NjE1NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6NDYuOTYy
+        OTk3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9kODc1ODBiOC0wNTg2LTRjYmMtYmFjZS0zMTc1Y2YwZmQ3MjcvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vYzg0
-        NzJlMzUtOGFjZi00MTQ2LWIzN2ItODc5MTU5Njk5ZTBiLyJdLCJyZXNlcnZl
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vYjVj
+        OGZlMzAtZDIzNi00ZGE3LThmYzEtNmQxMzNkNDk1MmI0LyJdLCJyZXNlcnZl
         ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
         XX0=
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:34 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:47 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/c8472e35-8acf-4146-b37b-879159699e0b/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/b5c8fe30-d236-4da7-8fc1-6d133d4952b4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -731,7 +731,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -744,48 +744,48 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:34 GMT
+      - Mon, 22 Aug 2022 21:48:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '482'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 758b0d954dc249cdb9c6ef75b1e0d773
+      - 418177f3f5224b5fa3bfd1afbe12bd36
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '300'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtL2M4NDcyZTM1LThhY2YtNDE0Ni1iMzdiLTg3OTE1OTY5OWUwYi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM0LjE2Mjk5M1oiLCJi
+        cnBtL2I1YzhmZTMwLWQyMzYtNGRhNy04ZmMxLTZkMTMzZDQ5NTJiNC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA4LTIyVDIxOjQ4OjQ2Ljk0MTM0NFoiLCJi
         YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
-        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL3phbnppYmFyLmxh
-        Z3JhbmdlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01FX0NvcnBvcmF0
-        aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIsImNvbnRlbnRf
-        Z3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGlj
-        YXRlIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9h
-        cGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vN2FlMzc4ZGEtMGU5Ni00OWJl
-        LWI2OGEtMTA0OTA3MDNiZmE0LyJ9
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczcta2F0
+        ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0FD
+        TUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwv
+        IiwiY29udGVudF9ndWFyZCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJuYW1l
+        IjoiMl9kdXBsaWNhdGUiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlv
+        biI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wZjM4ODU1
+        Zi0wMDI4LTQxZjAtYmVmMy0wOWI2MTdhNmFmN2MvIn0=
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:34 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:47 GMT
 - request:
     method: patch
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/d9c75e34-c60b-4096-b7f8-57a9f22f3baf/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/a9d6f1f3-df5d-4daa-9ad5-ff300a433392/
     body:
       encoding: UTF-8
       base64_string: |
@@ -802,7 +802,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -815,7 +815,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:34 GMT
+      - Mon, 22 Aug 2022 21:48:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -833,21 +833,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5a60bd0c2b404e648cf3e8cfd3884c53
+      - 218f86c576ee439384e9644aa09ebf71
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I4ZWM4YjIxLTAyNzMtNGRk
-        MC04YTFkLTFjMjYxZjNlMjgzZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q4N2ViYmQ4LWY0YjMtNDcx
+        ZC1iNmQxLTJmZDMwMDNjMDg5MC8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:34 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:47 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/b8ec8b21-0273-4dd0-8a1d-1c261f3e283f/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/d87ebbd8-f4b3-471d-b6d1-2fd3003c0890/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -855,7 +855,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -868,63 +868,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:34 GMT
+      - Mon, 22 Aug 2022 21:48:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6abc6bf3adc140c481b0d3eefa0ce07d
+      - 5cb9f72382a844bea9f7d8f2c0222be4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjhlYzhiMjEtMDI3
-        My00ZGQwLThhMWQtMWMyNjFmM2UyODNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6MzQuNjYyMDg2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDg3ZWJiZDgtZjRi
+        My00NzFkLWI2ZDEtMmZkMzAwM2MwODkwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NDcuNjkyOTQ0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI1YTYwYmQwYzJiNDA0ZTY0OGNmM2U4Y2Zk
-        Mzg4NGM1MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM0Ljcw
-        ODU0MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6MzQuNzQz
-        ODg3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy81MWI3NmQzNS1hYTBhLTQ0OTMtYmVlNS0xZTdlZTJmZmVjMTQvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiIyMThmODZjNTc2ZWU0MzkzODRlOTY0NGFh
+        MDllYmY3MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ4OjQ3Ljcy
+        MTA1MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6NDcuNzQ1
+        NTQ0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9kODc1ODBiOC0wNTg2LTRjYmMtYmFjZS0zMTc1Y2YwZmQ3MjcvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q5Yzc1ZTM0LWM2MGItNDA5Ni1iN2Y4
-        LTU3YTlmMjJmM2JhZi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E5ZDZmMWYzLWRmNWQtNGRhYS05YWQ1
+        LWZmMzAwYTQzMzM5Mi8iXX0=
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:34 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:47 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/8a9b6a9a-207d-429b-812a-d80d0d69b0cf/sync/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/8fb7874f-4b2e-4a6e-a2db-e9939f15a00b/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q5Yzc1
-        ZTM0LWM2MGItNDA5Ni1iN2Y4LTU3YTlmMjJmM2JhZi8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E5ZDZm
+        MWYzLWRmNWQtNGRhYS05YWQ1LWZmMzAwYTQzMzM5Mi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -937,7 +937,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:34 GMT
+      - Mon, 22 Aug 2022 21:48:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -955,21 +955,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 361862ffa31d4871bb268013e74376cd
+      - ed097183c91d4a308751fa126f353b99
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY4ZWMxOGVjLTQwNWYtNDVk
-        Ny1iZDYwLWZjZjEyODA5YWEzNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q2MTUzMTkwLWMwMDEtNDA5
+        OS1iZjc3LThkNmZkMzg1ZmU4NS8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:34 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:47 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/68ec18ec-405f-45d7-bd60-fcf12809aa37/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/d6153190-c001-4099-bf77-8d6fd385fe85/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -977,7 +977,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -990,42 +990,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:36 GMT
+      - Mon, 22 Aug 2022 21:48:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 23cd266e725d460db923ed7c7026b353
+      - 8000f3468ff942189b2ca2b2174bf9fa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '606'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjhlYzE4ZWMtNDA1
-        Zi00NWQ3LWJkNjAtZmNmMTI4MDlhYTM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6MzQuODQzMTUwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDYxNTMxOTAtYzAw
+        MS00MDk5LWJmNzctOGQ2ZmQzODVmZTg1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NDcuODY0ODY2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIzNjE4NjJmZmEzMWQ0ODcxYmIy
-        NjgwMTNlNzQzNzZjZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2
-        OjM0Ljg4MzM0N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6
-        MzYuODY3ODEwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zNjAxYmE4OC1hYzM2LTQwNzctYjhhNC04YTA3ODlmYzJk
-        OGMvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJlZDA5NzE4M2M5MWQ0YTMwODc1
+        MWZhMTI2ZjM1M2I5OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ4
+        OjQ3LjkxNjcwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6
+        NDkuNjM4MTAyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9kODc1ODBiOC0wNTg2LTRjYmMtYmFjZS0zMTc1Y2YwZmQ3
+        MjcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1037,35 +1037,35 @@ http_interactions:
         ZXRlZCIsInRvdGFsIjo0LCJkb25lIjo0LCJzdWZmaXgiOm51bGx9LHsibWVz
         c2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRv
         d25sb2FkaW5nLmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
-        YWwiOm51bGwsImRvbmUiOjMyLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6
-        IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGlu
-        Zy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwi
-        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGlu
-        ZyBDb250ZW50IiwiY29kZSI6ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
-        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjozNiwic3VmZml4
-        IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvcnBtL3JwbS84YTliNmE5YS0yMDdkLTQyOWItODEyYS1k
-        ODBkMGQ2OWIwY2YvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
-        X3JlY29yZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0v
-        OGE5YjZhOWEtMjA3ZC00MjliLTgxMmEtZDgwZDBkNjliMGNmLyIsInNoYXJl
-        ZDovcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q5Yzc1ZTM0LWM2MGIt
-        NDA5Ni1iN2Y4LTU3YTlmMjJmM2JhZi8iXX0=
+        YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        VW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5n
+        LmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJk
+        b25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5n
+        IENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRl
+        IjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjM2LCJzdWZmaXgi
+        Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9ycG0vcnBtLzhmYjc4NzRmLTRiMmUtNGE2ZS1hMmRiLWU5
+        OTM5ZjE1YTAwYi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84
+        ZmI3ODc0Zi00YjJlLTRhNmUtYTJkYi1lOTkzOWYxNWEwMGIvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vYTlkNmYxZjMtZGY1ZC00
+        ZGFhLTlhZDUtZmYzMDBhNDMzMzkyLyJdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:36 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:49 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vOGE5YjZhOWEtMjA3ZC00MjliLTgxMmEtZDgwZDBkNjli
-        MGNmL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vOGZiNzg3NGYtNGIyZS00YTZlLWEyZGItZTk5MzlmMTVh
+        MDBiL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1078,7 +1078,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:37 GMT
+      - Mon, 22 Aug 2022 21:48:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1096,21 +1096,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f38c46343c2444968b5dfadee8e6eae5
+      - 7cddf3836d4f4875b6a18856ab880c5d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I4M2EyMTAxLTAzZDItNDJl
-        MC04MzNhLTc2Y2M2ZmNhYmY0ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE5YWZjZDM2LTFhOWMtNDll
+        OS04MzI3LTcyZjFkMzYzNjZmZC8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:37 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:49 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/b83a2101-03d2-42e0-833a-76cc6fcabf4e/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/19afcd36-1a9c-49e9-8327-72f1d36366fd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1118,7 +1118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1131,56 +1131,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:37 GMT
+      - Mon, 22 Aug 2022 21:48:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 16808aaecb704737bc0dc49a91a69969
+      - 5b523b7d6a4a4d2a9411003bf57f3e7e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '476'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjgzYTIxMDEtMDNk
-        Mi00MmUwLTgzM2EtNzZjYzZmY2FiZjRlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6MzcuMDQ2NjA3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTlhZmNkMzYtMWE5
+        Yy00OWU5LTgzMjctNzJmMWQzNjM2NmZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NDkuOTI1MTI1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImYzOGM0NjM0M2MyNDQ0OTY4YjVkZmFkZWU4
-        ZTZlYWU1Iiwic3RhcnRlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6MzcuMDg1
-        MTg2WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0xOVQxODo0NjozNy4yNzU5
-        OThaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzUxYjc2ZDM1LWFhMGEtNDQ5My1iZWU1LTFlN2VlMmZmZWMxNC8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjdjZGRmMzgzNmQ0ZjQ4NzViNmExODg1NmFi
+        ODgwYzVkIiwic3RhcnRlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6NDkuOTg3
+        ODc0WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wOC0yMlQyMTo0ODo1MC4xOTI2
+        OTlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzL2Q4NzU4MGI4LTA1ODYtNGNiYy1iYWNlLTMxNzVjZjBmZDcyNy8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYTAxZWM4
-        MjktMmQyMy00OTViLWIzOTEtZGRjMDc2ZGQ1MzBlLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOTU0ODk4
+        MzUtYmE3Zi00NzA2LTlhMzItM2FhZjNjZjEzMzNmLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vOGE5YjZhOWEtMjA3ZC00MjliLTgxMmEtZDgwZDBk
-        NjliMGNmLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vOGZiNzg3NGYtNGIyZS00YTZlLWEyZGItZTk5Mzlm
+        MTVhMDBiLyJdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:37 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:50 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1188,7 +1188,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1201,49 +1201,49 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:37 GMT
+      - Mon, 22 Aug 2022 21:48:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '534'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 859982da86884680ace8bf2e7b91a2fe
+      - e86d0205e8434e6783ae3a523e156c82
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '330'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vYzg0NzJlMzUtOGFjZi00MTQ2LWIzN2ItODc5MTU5Njk5ZTBi
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6MzQuMTYyOTkz
+        L3JwbS9ycG0vYjVjOGZlMzAtZDIzNi00ZGE3LThmYzEtNmQxMzNkNDk1MmI0
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDgtMjJUMjE6NDg6NDYuOTQxMzQ0
         WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
-        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vemFuemli
-        YXIubGFncmFuZ2UuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0FDTUVfQ29y
-        cG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwvIiwiY29u
-        dGVudF9ndWFyZCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJuYW1lIjoiMl9k
-        dXBsaWNhdGUiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6Ii9w
-        dWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS83YWUzNzhkYS0wZTk2
-        LTQ5YmUtYjY4YS0xMDQ5MDcwM2JmYTQvIn1dfQ==
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        Ny1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbS9wdWxwL2NvbnRl
+        bnQvQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9s
+        YWJlbC8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30s
+        Im5hbWUiOiIyX2R1cGxpY2F0ZSIsInJlcG9zaXRvcnkiOm51bGwsInB1Ymxp
+        Y2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBtLzBm
+        Mzg4NTVmLTAwMjgtNDFmMC1iZWYzLTA5YjYxN2E2YWY3Yy8ifV19
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:37 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:50 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/a01ec829-2d23-495b-b391-ddc076dd530e/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/95489835-ba7f-4706-9a32-3aaf3cf1333f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1251,7 +1251,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1264,59 +1264,59 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:37 GMT
+      - Mon, 22 Aug 2022 21:48:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ce9e4fa7350649b18278d1724b67a261
+      - c33726d6b1764783be25c80d2ce7a82e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '249'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vYTAxZWM4MjktMmQyMy00OTViLWIzOTEtZGRjMDc2ZGQ1MzBlLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6MzcuMTA1MzczWiIsInJl
+        cG0vOTU0ODk4MzUtYmE3Zi00NzA2LTlhMzItM2FhZjNjZjEzMzNmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDgtMjJUMjE6NDg6NTAuMDA1MTk5WiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS84YTliNmE5YS0yMDdkLTQyOWItODEyYS1kODBkMGQ2OWIwY2Yv
+        cnBtL3JwbS84ZmI3ODc0Zi00YjJlLTRhNmUtYTJkYi1lOTkzOWYxNWEwMGIv
         dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzhhOWI2YTlhLTIwN2QtNDI5Yi04MTJhLWQ4MGQw
-        ZDY5YjBjZi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtLzhmYjc4NzRmLTRiMmUtNGE2ZS1hMmRiLWU5OTM5
+        ZjE1YTAwYi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:37 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:50 GMT
 - request:
     method: patch
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/c8472e35-8acf-4146-b37b-879159699e0b/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/b5c8fe30-d236-4da7-8fc1-6d133d4952b4/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
-        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYTAx
-        ZWM4MjktMmQyMy00OTViLWIzOTEtZGRjMDc2ZGQ1MzBlLyJ9
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOTU0
+        ODk4MzUtYmE3Zi00NzA2LTlhMzItM2FhZjNjZjEzMzNmLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1329,7 +1329,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:37 GMT
+      - Mon, 22 Aug 2022 21:48:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1347,21 +1347,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3cf9803999c64252b82640567e9ca37d
+      - 97f694693ca04961ae7ca9a90c6aa5e8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM1MjQ3YzAyLWU5YzItNDE3
-        Zi1hZTg1LWNjMzY2YWRlZjlmOC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I0NzdkYWZiLWRlODMtNGI4
+        Yi1iM2U3LThhYjkwMzY2ODYxOC8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:37 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:50 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/35247c02-e9c2-417f-ae85-cc366adef9f8/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/b477dafb-de83-4b8b-b3e7-8ab903668618/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1369,7 +1369,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1382,50 +1382,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:37 GMT
+      - Mon, 22 Aug 2022 21:48:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '558'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f9ff355ae0614f78b5622199ac771230
+      - 2641332b7bf54c778cb2bf05e99a2930
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '346'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzUyNDdjMDItZTlj
-        Mi00MTdmLWFlODUtY2MzNjZhZGVmOWY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6MzcuNTIzMDM1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYjQ3N2RhZmItZGU4
+        My00YjhiLWIzZTctOGFiOTAzNjY4NjE4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NTAuNDQ3MjIxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIzY2Y5ODAzOTk5YzY0MjUyYjgyNjQwNTY3
-        ZTljYTM3ZCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM3LjU1
-        OTU3OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6MzcuNjc2
-        MTA0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy81MWI3NmQzNS1hYTBhLTQ0OTMtYmVlNS0xZTdlZTJmZmVjMTQvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI5N2Y2OTQ2OTNjYTA0OTYxYWU3Y2E5YTkw
+        YzZhYTVlOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ4OjUwLjQ5
+        MDA3NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6NTAuNjIx
+        NTA2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9iMGNhMTE4YS05NDk3LTRjYjktOTdjYi1kMjMzZTIyOWU5ZjYvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
         L2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:37 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:50 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/a01ec829-2d23-495b-b391-ddc076dd530e/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/95489835-ba7f-4706-9a32-3aaf3cf1333f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1433,7 +1433,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1446,59 +1446,59 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:37 GMT
+      - Mon, 22 Aug 2022 21:48:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c03b889da9474bf896f8636269016be5
+      - b3ed8f4f617240abb250629f16b9a108
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '249'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vYTAxZWM4MjktMmQyMy00OTViLWIzOTEtZGRjMDc2ZGQ1MzBlLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6MzcuMTA1MzczWiIsInJl
+        cG0vOTU0ODk4MzUtYmE3Zi00NzA2LTlhMzItM2FhZjNjZjEzMzNmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDgtMjJUMjE6NDg6NTAuMDA1MTk5WiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS84YTliNmE5YS0yMDdkLTQyOWItODEyYS1kODBkMGQ2OWIwY2Yv
+        cnBtL3JwbS84ZmI3ODc0Zi00YjJlLTRhNmUtYTJkYi1lOTkzOWYxNWEwMGIv
         dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtLzhhOWI2YTlhLTIwN2QtNDI5Yi04MTJhLWQ4MGQw
-        ZDY5YjBjZi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtLzhmYjc4NzRmLTRiMmUtNGE2ZS1hMmRiLWU5OTM5
+        ZjE1YTAwYi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:37 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:50 GMT
 - request:
     method: patch
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/c8472e35-8acf-4146-b37b-879159699e0b/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/b5c8fe30-d236-4da7-8fc1-6d133d4952b4/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
-        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYTAx
-        ZWM4MjktMmQyMy00OTViLWIzOTEtZGRjMDc2ZGQ1MzBlLyJ9
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOTU0
+        ODk4MzUtYmE3Zi00NzA2LTlhMzItM2FhZjNjZjEzMzNmLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1511,7 +1511,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:37 GMT
+      - Mon, 22 Aug 2022 21:48:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1529,35 +1529,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2c24633c5252466fb4b9ce7a097b498e
+      - 28b95dec09ca4241a1de1ae3ca5dda86
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MwZmFlYTY5LWJlODMtNGJm
-        MS04OWE5LTRkMThjN2I2ZDY5ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg4NDhjYWFmLTBkOGYtNGNl
+        NC1iYjFlLWNmZDcxYzBlYmRhYy8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:37 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:50 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/exporters/core/pulp/
     body:
       encoding: UTF-8
       base64_string: |
         eyJuYW1lIjoiRW1wdHlfT3JnYW5pemF0aW9uX0FDTUVfRGVmYXVsdF9Db250
         ZW50Vmlld18xLjAiLCJwYXRoIjoiL3Zhci9saWIvcHVscC9leHBvcnRzL0Vt
-        cHR5X09yZ2FuaXphdGlvbi9BQ01FIERlZmF1bHQgQ29udGVudFZpZXcvMS4w
-        L2RyZWFtLWRlc3RpbmF0aW9uL2RhdGVfZGlyIiwicmVwb3NpdG9yaWVzIjpb
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84YTliNmE5YS0y
-        MDdkLTQyOWItODEyYS1kODBkMGQ2OWIwY2YvIl19
+        cHR5X09yZ2FuaXphdGlvbi9vcmdfZGVmYXVsdF9sYWJlbC8xLjAvZHJlYW0t
+        ZGVzdGluYXRpb24vZGF0ZV9kaXIiLCJyZXBvc2l0b3JpZXMiOlsiL3B1bHAv
+        YXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzhmYjc4NzRmLTRiMmUtNGE2
+        ZS1hMmRiLWU5OTM5ZjE1YTAwYi8iXX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1570,13 +1570,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:38 GMT
+      - Mon, 22 Aug 2022 21:48:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/exporters/core/pulp/f7e17d0b-69eb-4fcc-841c-c73644f9052a/"
+      - "/pulp/api/v3/exporters/core/pulp/e9b1db6b-3b39-448a-bf24-8a1a01be8a0c/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1584,34 +1584,34 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '404'
+      - '397'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 4561345e503c49cdac687cebff3f090f
+      - c75077ee6f2a4bdbbe65a182fbca61e6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
-        cC9mN2UxN2QwYi02OWViLTRmY2MtODQxYy1jNzM2NDRmOTA1MmEvIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyMi0wNy0xOVQxODo0NjozOC4wMDAzODFaIiwibmFt
+        cC9lOWIxZGI2Yi0zYjM5LTQ0OGEtYmYyNC04YTFhMDFiZThhMGMvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMi0wOC0yMlQyMTo0ODo1MS4wMTEzNzVaIiwibmFt
         ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
         ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
-        cmdhbml6YXRpb24vQUNNRSBEZWZhdWx0IENvbnRlbnRWaWV3LzEuMC9kcmVh
-        bS1kZXN0aW5hdGlvbi9kYXRlX2RpciIsInJlcG9zaXRvcmllcyI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOGE5YjZhOWEtMjA3ZC00
-        MjliLTgxMmEtZDgwZDBkNjliMGNmLyJdLCJsYXN0X2V4cG9ydCI6bnVsbH0=
+        cmdhbml6YXRpb24vb3JnX2RlZmF1bHRfbGFiZWwvMS4wL2RyZWFtLWRlc3Rp
+        bmF0aW9uL2RhdGVfZGlyIiwicmVwb3NpdG9yaWVzIjpbIi9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS84ZmI3ODc0Zi00YjJlLTRhNmUtYTJk
+        Yi1lOTkzOWYxNWEwMGIvIl0sImxhc3RfZXhwb3J0IjpudWxsfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:51 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/f7e17d0b-69eb-4fcc-841c-c73644f9052a/exports/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/exporters/core/pulp/e9b1db6b-3b39-448a-bf24-8a1a01be8a0c/exports/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1619,7 +1619,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1632,7 +1632,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:38 GMT
+      - Mon, 22 Aug 2022 21:48:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1650,21 +1650,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8baf9ccd05d54747b10ea321ee5461cd
+      - bba0ff9bfdd44473aceffe5e30f9c5e9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:51 GMT
 - request:
     method: patch
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/f7e17d0b-69eb-4fcc-841c-c73644f9052a/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/exporters/core/pulp/e9b1db6b-3b39-448a-bf24-8a1a01be8a0c/
     body:
       encoding: UTF-8
       base64_string: 'eyJsYXN0X2V4cG9ydCI6bnVsbH0=
@@ -1674,7 +1674,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1687,7 +1687,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:38 GMT
+      - Mon, 22 Aug 2022 21:48:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1705,21 +1705,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 25b2c2da63c049cab49b7c6b3f7e1006
+      - 59641b9ec1ed42869776cb46f37f5457
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmMDc1ZGM5LTYyNDMtNGJh
-        ZS1hYzk0LTk4OTE1ZTc4MTAxYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzllZDM5N2Y2LTcyMjItNDRk
+        Zi1hZTcxLTM0MmZhNjMyMzgyNy8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:51 GMT
 - request:
     method: delete
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/f7e17d0b-69eb-4fcc-841c-c73644f9052a/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/exporters/core/pulp/e9b1db6b-3b39-448a-bf24-8a1a01be8a0c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1727,7 +1727,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1740,7 +1740,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:38 GMT
+      - Mon, 22 Aug 2022 21:48:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1758,21 +1758,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 71e0d82dfcd14fc9bac4e80800cee143
+      - a9dc63cbc85b49998e922c849c15a8de
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E2NWYwOWNiLTk1ZWQtNDNh
-        OC1hMzRlLWY5MzY5MTJjYmZkZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RiMzM4NjYwLWViOTItNGFm
+        Mi05MDNlLWNhZWMzOTBmNmEyMS8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:51 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/a65f09cb-95ed-43a8-a34e-f936912cbfdf/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/db338660-eb92-4af2-903e-caec390f6a21/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1780,7 +1780,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1793,51 +1793,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:38 GMT
+      - Mon, 22 Aug 2022 21:48:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '606'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ab239fc66dfe4d4bb2bf224f13a0d067
+      - 040223d8f8504d239f6efcd83c3ec4c7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '370'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTY1ZjA5Y2ItOTVl
-        ZC00M2E4LWEzNGUtZjkzNjkxMmNiZmRmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6MzguMjcxNDU2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGIzMzg2NjAtZWI5
+        Mi00YWYyLTkwM2UtY2FlYzM5MGY2YTIxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NTEuMzI1ODE0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI3MWUwZDgyZGZjZDE0ZmM5YmFjNGU4MDgw
-        MGNlZTE0MyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM4LjMy
-        Mjg0N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6MzguMzUw
-        NjEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy83NGM0MDcyYS0zNjIzLTQ4NDItOGZhZS1lNGM0MjAwODk5YjAvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJhOWRjNjNjYmM4NWI0OTk5OGU5MjJjODQ5
+        YzE1YThkZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ4OjUxLjM3
+        MTg2OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6NTEuNDAw
+        MTE3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9kODc1ODBiOC0wNTg2LTRjYmMtYmFjZS0zMTc1Y2YwZmQ3MjcvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVscC9mN2UxN2QwYi02OWViLTRmY2Mt
-        ODQxYy1jNzM2NDRmOTA1MmEvIl19
+        cGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVscC9lOWIxZGI2Yi0zYjM5LTQ0OGEt
+        YmYyNC04YTFhMDFiZThhMGMvIl19
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:51 GMT
 - request:
     method: delete
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/d9c75e34-c60b-4096-b7f8-57a9f22f3baf/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/a9d6f1f3-df5d-4daa-9ad5-ff300a433392/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1845,7 +1845,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1858,7 +1858,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:38 GMT
+      - Mon, 22 Aug 2022 21:48:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1876,21 +1876,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5dda6d3013f44dbeb38dcc45d6082c7e
+      - 2bfcfb80e2324fd1b90ae38569324c4e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwZTM2MzllLWQ1NzEtNDBk
-        OS1iYzlhLWM4M2QzOWQ3YzM0Yi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkzN2U4MjNmLTg3NzctNDRl
+        Mi04YTI2LTQ2MTVkZTRlYjIyMC8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:51 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/90e3639e-d571-40d9-bc9a-c83d39d7c34b/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/937e823f-8777-44e2-8a26-4615de4eb220/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1898,7 +1898,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1911,51 +1911,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:38 GMT
+      - Mon, 22 Aug 2022 21:48:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 918cc0f839564890b3d416d4efe4b20d
+      - 2a3f5f1b967a474ba6effe7a8672d1bf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTBlMzYzOWUtZDU3
-        MS00MGQ5LWJjOWEtYzgzZDM5ZDdjMzRiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6MzguNjM1MzE4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTM3ZTgyM2YtODc3
+        Ny00NGUyLThhMjYtNDYxNWRlNGViMjIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NTEuNzU4MTA0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI1ZGRhNmQzMDEzZjQ0ZGJlYjM4ZGNjNDVk
-        NjA4MmM3ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM4LjY3
-        Njc1M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6MzguNzE2
-        MzU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy81MWI3NmQzNS1hYTBhLTQ0OTMtYmVlNS0xZTdlZTJmZmVjMTQvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyYmZjZmI4MGUyMzI0ZmQxYjkwYWUzODU2
+        OTMyNGM0ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ4OjUxLjc5
+        MjE3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6NTEuODM2
+        MDEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9iMGNhMTE4YS05NDk3LTRjYjktOTdjYi1kMjMzZTIyOWU5ZjYvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q5Yzc1ZTM0LWM2MGItNDA5Ni1iN2Y4
-        LTU3YTlmMjJmM2JhZi8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E5ZDZmMWYzLWRmNWQtNGRhYS05YWQ1
+        LWZmMzAwYTQzMzM5Mi8iXX0=
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:51 GMT
 - request:
     method: delete
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/c8472e35-8acf-4146-b37b-879159699e0b/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/b5c8fe30-d236-4da7-8fc1-6d133d4952b4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1963,7 +1963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1976,7 +1976,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:38 GMT
+      - Mon, 22 Aug 2022 21:48:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1994,21 +1994,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8008c477d64148658e03f5b1b636a4e3
+      - a3df563a5e6446c0b2df4d3df51f2165
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk3OWU4MTc4LTMyYTMtNDkz
-        YS1hOGQzLTdmNWUwODY0ZDkyZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZkMDllNjE1LTQ4YmUtNDZk
+        ZC1iNWJmLWVlYmYxMDEyNDFlNi8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:51 GMT
 - request:
     method: delete
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/8a9b6a9a-207d-429b-812a-d80d0d69b0cf/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/8fb7874f-4b2e-4a6e-a2db-e9939f15a00b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2016,7 +2016,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -2029,7 +2029,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:38 GMT
+      - Mon, 22 Aug 2022 21:48:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2047,21 +2047,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6825933e0b794973af954428e3fd3679
+      - f157e0d6c8884131bacf91f15e3baa21
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFiMzAwOWFkLTBlYmUtNGZl
-        Zi1hYTQxLWE0ZWIwMTc2ZTlhMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MxMTcyMjdkLWM0OTMtNDQz
+        NS05YjZiLWIxYmU3ZTFkODIxMC8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:38 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:52 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/1b3009ad-0ebe-4fef-aa41-a4eb0176e9a2/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/c117227d-c493-4435-9b6b-b1be7e1d8210/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2069,7 +2069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2082,46 +2082,46 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:39 GMT
+      - Mon, 22 Aug 2022 21:48:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 3d441dd88ff2488db2ff2922397da5dd
+      - c5c5bf408be74dbebeb2ef9202ab9b2a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMWIzMDA5YWQtMGVi
-        ZS00ZmVmLWFhNDEtYTRlYjAxNzZlOWEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6MzguODg0Nzk3WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzExNzIyN2QtYzQ5
+        My00NDM1LTliNmItYjFiZTdlMWQ4MjEwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NTIuMDA5MzY5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiI2ODI1OTMzZTBiNzk0OTczYWY5NTQ0Mjhl
-        M2ZkMzY3OSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM4Ljky
-        NTQyNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6MzkuMDU1
-        NjcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy81MWI3NmQzNS1hYTBhLTQ0OTMtYmVlNS0xZTdlZTJmZmVjMTQvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJmMTU3ZTBkNmM4ODg0MTMxYmFjZjkxZjE1
+        ZTNiYWEyMSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ4OjUyLjAz
+        ODgyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6NTIuMTgw
+        MTM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9iMGNhMTE4YS05NDk3LTRjYjktOTdjYi1kMjMzZTIyOWU5ZjYvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOGE5YjZhOWEtMjA3ZC00Mjli
-        LTgxMmEtZDgwZDBkNjliMGNmLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vOGZiNzg3NGYtNGIyZS00YTZl
+        LWEyZGItZTk5MzlmMTVhMDBiLyJdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:39 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:52 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/katello/content_view_version/export/destroy_exporter.yml
+++ b/test/fixtures/vcr_cassettes/actions/katello/content_view_version/export/destroy_exporter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:39 GMT
+      - Mon, 22 Aug 2022 21:48:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -41,21 +41,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a375aee550524352a5678c22fc4ff7fd
+      - e737796337fe41b2916900ea678553d2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:39 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:52 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -76,7 +76,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:39 GMT
+      - Mon, 22 Aug 2022 21:48:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -94,21 +94,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a45839203efb45e8a06a37eb5c5ade1a
+      - ee87c8c4e9b94d56aaa6c81d160190de
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:39 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:52 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -116,7 +116,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -129,7 +129,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:39 GMT
+      - Mon, 22 Aug 2022 21:48:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -147,21 +147,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9903e684b6a449b890e539520cdce3c8
+      - 7ebafbeaa62645789f1b72cd27f3620c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:39 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:52 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -169,7 +169,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -182,7 +182,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:39 GMT
+      - Mon, 22 Aug 2022 21:48:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -200,21 +200,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6412d1dc305341e0a8021fa8fbef9f77
+      - b4310b6d87de4a47af660a999a9a8e03
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:39 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:52 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -231,7 +231,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -244,13 +244,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:39 GMT
+      - Mon, 22 Aug 2022 21:48:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/4db5798c-e6fb-446b-8f76-bb4d4a008b0c/"
+      - "/pulp/api/v3/remotes/rpm/rpm/a52a1877-12af-49cd-9e58-21a600072244/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -264,32 +264,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - feb95e18a4fd45d8b42649311e653b54
+      - 3c296e48661f43e183af6955d85eda4c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRk
-        YjU3OThjLWU2ZmItNDQ2Yi04Zjc2LWJiNGQ0YTAwOGIwYy8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM5LjczOTU0N1oiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E1
+        MmExODc3LTEyYWYtNDljZC05ZTU4LTIxYTYwMDA3MjI0NC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA4LTIyVDIxOjQ4OjUzLjAwNTI5OVoiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjM5LjczOTU2MloiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA4LTIyVDIxOjQ4OjUzLjAwNTMxNloiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:39 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:53 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -299,7 +299,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -312,13 +312,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:39 GMT
+      - Mon, 22 Aug 2022 21:48:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/de0f7ea0-c0ff-4ce7-8556-79a297392853/"
+      - "/pulp/api/v3/repositories/rpm/rpm/d5a6fbc2-f684-43c5-a60e-aaab240f3f89/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -332,22 +332,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5010307d8aac406c9ec4ea28159c3b86
+      - 8ee73ccf283b475cbb60095e16cddc79
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZGUwZjdlYTAtYzBmZi00Y2U3LTg1NTYtNzlhMjk3MzkyODUzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6MzkuODkxNDk2WiIsInZl
+        cG0vZDVhNmZiYzItZjY4NC00M2M1LWE2MGUtYWFhYjI0MGYzZjg5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDgtMjJUMjE6NDg6NTMuMjM4ODI4WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vZGUwZjdlYTAtYzBmZi00Y2U3LTg1NTYtNzlhMjk3MzkyODUzL3ZlcnNp
+        cG0vZDVhNmZiYzItZjY4NC00M2M1LWE2MGUtYWFhYjI0MGYzZjg5L3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kZTBmN2VhMC1j
-        MGZmLTRjZTctODU1Ni03OWEyOTczOTI4NTMvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kNWE2ZmJjMi1m
+        Njg0LTQzYzUtYTYwZS1hYWFiMjQwZjNmODkvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -356,21 +356,21 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:39 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:53 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vZGUwZjdlYTAtYzBmZi00Y2U3LTg1NTYtNzlhMjk3Mzky
-        ODUzL3ZlcnNpb25zLzAvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vZDVhNmZiYzItZjY4NC00M2M1LWE2MGUtYWFhYjI0MGYz
+        Zjg5L3ZlcnNpb25zLzAvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -383,7 +383,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:40 GMT
+      - Mon, 22 Aug 2022 21:48:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -401,21 +401,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5ed5aace6adb4f48aa94b67c2508bead
+      - 0441da12fbe247b2b10a83c6a2359653
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMzODU3NGE1LWRkNDUtNDEx
-        OS1hNTYzLTQ4M2U3OWZiYWU1Zi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhkYjVmMWY3LTkzNGEtNDc3
+        NS1iN2VlLWJiOTVmZTBjOGM3NC8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:40 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:53 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/338574a5-dd45-4119-a563-483e79fbae5f/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/8db5f1f7-934a-4775-b7ee-bb95fe0c8c74/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -423,7 +423,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -436,56 +436,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:40 GMT
+      - Mon, 22 Aug 2022 21:48:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 54349dd0896b458d838f646e5b480377
+      - a515add2124a4b6bae2ceee274cfde9f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '477'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzM4NTc0YTUtZGQ0
-        NS00MTE5LWE1NjMtNDgzZTc5ZmJhZTVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NDAuMjc1NTM1WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGRiNWYxZjctOTM0
+        YS00Nzc1LWI3ZWUtYmI5NWZlMGM4Yzc0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NTMuNzcyMDk4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjVlZDVhYWNlNmFkYjRmNDhhYTk0YjY3YzI1
-        MDhiZWFkIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDAuMzIw
-        NDIxWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0xOVQxODo0Njo0MC40Njk3
-        OTlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBmMjMwNTg2LWIwNzUtNGE5NC1hY2QyLWFmNWE2NzMyOTQ1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjA0NDFkYTEyZmJlMjQ3YjJiMTBhODNjNmEy
+        MzU5NjUzIiwic3RhcnRlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6NTMuODA3
+        NjQ2WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wOC0yMlQyMTo0ODo1My45NTI4
+        OTNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzL2Q4NzU4MGI4LTA1ODYtNGNiYy1iYWNlLTMxNzVjZjBmZDcyNy8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNDUxNWFh
-        MTYtMjYwMS00YWM4LWIxNWYtYjIzZjc5MWI5ZGZlLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZTllM2Mw
+        NTYtOGIxYS00YzExLWIzZDEtYTdlN2YyZThlZDQyLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vZGUwZjdlYTAtYzBmZi00Y2U3LTg1NTYtNzlhMjk3
-        MzkyODUzLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vZDVhNmZiYzItZjY4NC00M2M1LWE2MGUtYWFhYjI0
+        MGYzZjg5LyJdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:40 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:54 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -493,7 +493,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -506,7 +506,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:40 GMT
+      - Mon, 22 Aug 2022 21:48:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -524,21 +524,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f9c235a7352c4afbaf96ec8e0ef361b3
+      - f6f55a37e1f1406fa1906642cdd22db7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:40 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:54 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/4515aa16-2601-4ac8-b15f-b23f791b9dfe/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/e9e3c056-8b1a-4c11-b3d1-a7e7f2e8ed42/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -546,7 +546,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -559,60 +559,60 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:40 GMT
+      - Mon, 22 Aug 2022 21:48:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bfc8f34c980943bbbbfe505651c1621e
+      - fb21ac9f912a469b9bbaef076a666f6c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '250'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vNDUxNWFhMTYtMjYwMS00YWM4LWIxNWYtYjIzZjc5MWI5ZGZlLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDAuMzQzNTU0WiIsInJl
+        cG0vZTllM2MwNTYtOGIxYS00YzExLWIzZDEtYTdlN2YyZThlZDQyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDgtMjJUMjE6NDg6NTMuODI0MjQ0WiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9kZTBmN2VhMC1jMGZmLTRjZTctODU1Ni03OWEyOTczOTI4NTMv
+        cnBtL3JwbS9kNWE2ZmJjMi1mNjg0LTQzYzUtYTYwZS1hYWFiMjQwZjNmODkv
         dmVyc2lvbnMvMC8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2RlMGY3ZWEwLWMwZmYtNGNlNy04NTU2LTc5YTI5
-        NzM5Mjg1My8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtL2Q1YTZmYmMyLWY2ODQtNDNjNS1hNjBlLWFhYWIy
+        NDBmM2Y4OS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:40 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:54 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vNDUxNWFhMTYtMjYwMS00YWM4LWIxNWYtYjIz
-        Zjc5MWI5ZGZlLyJ9
+        bGljYXRpb25zL3JwbS9ycG0vZTllM2MwNTYtOGIxYS00YzExLWIzZDEtYTdl
+        N2YyZThlZDQyLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -625,7 +625,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:40 GMT
+      - Mon, 22 Aug 2022 21:48:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -643,21 +643,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - fa3693b073334d9eb566199147d7ae4e
+      - d55720e92dd3476c88ad9c28654acbea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkZjQwNjA0LWQ2MGYtNGQy
-        Mi1hOTVjLWY0ZTdhODNkYmUwNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M4ODIzYWI0LWRmZWYtNDU1
+        My1hNmFhLWVmZmQwMzljNzk0Ny8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:40 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:54 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/2df40604-d60f-4d22-a95c-f4e7a83dbe05/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/c8823ab4-dfef-4553-a6aa-effd039c7947/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -665,7 +665,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -678,52 +678,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:40 GMT
+      - Mon, 22 Aug 2022 21:48:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '632'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ec55dc713b254e4eaf6973d615506907
+      - 3c3a999de27b4b2a800d63a24d7a41d7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '378'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmRmNDA2MDQtZDYw
-        Zi00ZDIyLWE5NWMtZjRlN2E4M2RiZTA1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NDAuNjkxMDM2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzg4MjNhYjQtZGZl
+        Zi00NTUzLWE2YWEtZWZmZDAzOWM3OTQ3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NTQuMTY3MTIzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwibG9nZ2luZ19jaWQiOiJmYTM2OTNiMDczMzM0ZDllYjU2NjE5OTE0
-        N2Q3YWU0ZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQwLjcz
-        MjM4MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDAuODU5
-        NjE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy83NGM0MDcyYS0zNjIzLTQ4NDItOGZhZS1lNGM0MjAwODk5YjAvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJkNTU3MjBlOTJkZDM0NzZjODhhZDljMjg2
+        NTRhY2JlYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ4OjU0LjIy
+        Mzc1MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6NTQuMzU5
+        ODg4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9kODc1ODBiOC0wNTg2LTRjYmMtYmFjZS0zMTc1Y2YwZmQ3MjcvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMzdl
-        YjAxZDItZDMyNi00NjE5LTg2NzQtZDZhMjZmOWNlNGM2LyJdLCJyZXNlcnZl
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vNDBm
+        M2E4ZmEtZDQxMy00MzY1LTkyYzMtZTEzZDM1MGM2Mzg0LyJdLCJyZXNlcnZl
         ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
         XX0=
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:40 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:54 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/37eb01d2-d326-4619-8674-d6a26f9ce4c6/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/40f3a8fa-d413-4365-92c3-e13d350c6384/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -731,7 +731,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -744,48 +744,48 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:40 GMT
+      - Mon, 22 Aug 2022 21:48:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '482'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2f8b4aa2c38f44429e37f98a4a7e3f49
+      - 9af68ed2c9f64b3d9b13acf2fb5f0315
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '301'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzM3ZWIwMWQyLWQzMjYtNDYxOS04Njc0LWQ2YTI2ZjljZTRjNi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQwLjg0NTczM1oiLCJi
+        cnBtLzQwZjNhOGZhLWQ0MTMtNDM2NS05MmMzLWUxM2QzNTBjNjM4NC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA4LTIyVDIxOjQ4OjU0LjM0MzUxN1oiLCJi
         YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
-        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL3phbnppYmFyLmxh
-        Z3JhbmdlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01FX0NvcnBvcmF0
-        aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIsImNvbnRlbnRf
-        Z3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGlj
-        YXRlIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9h
-        cGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNDUxNWFhMTYtMjYwMS00YWM4
-        LWIxNWYtYjIzZjc5MWI5ZGZlLyJ9
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczcta2F0
+        ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0FD
+        TUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwv
+        IiwiY29udGVudF9ndWFyZCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJuYW1l
+        IjoiMl9kdXBsaWNhdGUiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlv
+        biI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS9lOWUzYzA1
+        Ni04YjFhLTRjMTEtYjNkMS1hN2U3ZjJlOGVkNDIvIn0=
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:40 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:54 GMT
 - request:
     method: patch
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/4db5798c-e6fb-446b-8f76-bb4d4a008b0c/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/a52a1877-12af-49cd-9e58-21a600072244/
     body:
       encoding: UTF-8
       base64_string: |
@@ -802,7 +802,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -815,7 +815,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:41 GMT
+      - Mon, 22 Aug 2022 21:48:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -833,21 +833,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 00eee17411114703b33e16c8d8150e97
+      - bbfee55d7dc04f8cad2e0b8079807905
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc0YmRiMGYxLWU5MDEtNDQ5
-        OC1hMGZlLWRkYzBlZDhmMzJhOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhiM2FlYzY2LWE0M2QtNDMy
+        OS1hMTU2LTk5ODZhODFiYzkwNS8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:41 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:55 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/74bdb0f1-e901-4498-a0fe-ddc0ed8f32a9/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/8b3aec66-a43d-4329-a156-9986a81bc905/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -855,7 +855,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -868,63 +868,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:41 GMT
+      - Mon, 22 Aug 2022 21:48:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8b0ac0cd138540af91880f14b4967021
+      - 8df245499d4f455c9c6beb0db17cbf61
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNzRiZGIwZjEtZTkw
-        MS00NDk4LWEwZmUtZGRjMGVkOGYzMmE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NDEuNDM0NzE2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGIzYWVjNjYtYTQz
+        ZC00MzI5LWExNTYtOTk4NmE4MWJjOTA1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NTUuMTA2NzM2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIwMGVlZTE3NDExMTE0NzAzYjMzZTE2Yzhk
-        ODE1MGU5NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQxLjQ3
-        Nzk5NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDEuNTA3
-        NTY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy83NGM0MDcyYS0zNjIzLTQ4NDItOGZhZS1lNGM0MjAwODk5YjAvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJiYmZlZTU1ZDdkYzA0ZjhjYWQyZTBiODA3
+        OTgwNzkwNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ4OjU1LjEz
+        NTQzN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6NTUuMTU2
+        OTc1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9kODc1ODBiOC0wNTg2LTRjYmMtYmFjZS0zMTc1Y2YwZmQ3MjcvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRkYjU3OThjLWU2ZmItNDQ2Yi04Zjc2
-        LWJiNGQ0YTAwOGIwYy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E1MmExODc3LTEyYWYtNDljZC05ZTU4
+        LTIxYTYwMDA3MjI0NC8iXX0=
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:41 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:55 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/de0f7ea0-c0ff-4ce7-8556-79a297392853/sync/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/d5a6fbc2-f684-43c5-a60e-aaab240f3f89/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRkYjU3
-        OThjLWU2ZmItNDQ2Yi04Zjc2LWJiNGQ0YTAwOGIwYy8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E1MmEx
+        ODc3LTEyYWYtNDljZC05ZTU4LTIxYTYwMDA3MjI0NC8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -937,7 +937,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:41 GMT
+      - Mon, 22 Aug 2022 21:48:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -955,21 +955,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 145dea17e3fd4b64b9a49369fcf62e06
+      - 2b33140df56949bfad5754eb157f3cc8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JlZDE2NTI5LTA3MDEtNGM4
-        Yi04OThhLWYzZjEyZDhkZWU3ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M2ZTc0YTI4LWRmZjktNDAz
+        My1iNjUyLTIxNjFlZjM3NjVlMC8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:41 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:55 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/bed16529-0701-4c8b-898a-f3f12d8dee7e/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/c6e74a28-dff9-4033-b652-2161ef3765e0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -977,7 +977,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -990,42 +990,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:42 GMT
+      - Mon, 22 Aug 2022 21:48:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 71e9f57e47024a66a3a2ceffdbb566dd
+      - e1030913e9ed4d3bb30f1906d75d4073
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '607'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmVkMTY1MjktMDcw
-        MS00YzhiLTg5OGEtZjNmMTJkOGRlZTdlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NDEuNjI1MDk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYzZlNzRhMjgtZGZm
+        OS00MDMzLWI2NTItMjE2MWVmMzc2NWUwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NTUuMjk1MTgxWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIxNDVkZWExN2UzZmQ0YjY0Yjlh
-        NDkzNjlmY2Y2MmUwNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2
-        OjQxLjY3Mjc1OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6
-        NDIuODI2MjEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8zNjAxYmE4OC1hYzM2LTQwNzctYjhhNC04YTA3ODlmYzJk
-        OGMvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIyYjMzMTQwZGY1Njk0OWJmYWQ1
+        NzU0ZWIxNTdmM2NjOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ4
+        OjU1LjMyNTYyNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6
+        NTYuNDA3Mjg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy80N2Y4OGFkYy1mYWM1LTRlYjYtYTFjNi02NTlkM2Y4Mzk3
+        N2QvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1038,34 +1038,34 @@ http_interactions:
         c2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRv
         d25sb2FkaW5nLmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
         YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
-        QXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250
-        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
-        MzYsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
-        Q29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0
-        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgi
+        VW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5n
+        LmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJk
+        b25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5n
+        IENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRl
+        IjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjM2LCJzdWZmaXgi
         Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtL2RlMGY3ZWEwLWMwZmYtNGNlNy04NTU2LTc5
-        YTI5NzM5Mjg1My92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cG9zaXRvcmllcy9ycG0vcnBtL2Q1YTZmYmMyLWY2ODQtNDNjNS1hNjBlLWFh
+        YWIyNDBmM2Y4OS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
         cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9k
-        ZTBmN2VhMC1jMGZmLTRjZTctODU1Ni03OWEyOTczOTI4NTMvIiwic2hhcmVk
-        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vNGRiNTc5OGMtZTZmYi00
-        NDZiLThmNzYtYmI0ZDRhMDA4YjBjLyJdfQ==
+        NWE2ZmJjMi1mNjg0LTQzYzUtYTYwZS1hYWFiMjQwZjNmODkvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vYTUyYTE4NzctMTJhZi00
+        OWNkLTllNTgtMjFhNjAwMDcyMjQ0LyJdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:42 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:56 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vZGUwZjdlYTAtYzBmZi00Y2U3LTg1NTYtNzlhMjk3Mzky
-        ODUzL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vZDVhNmZiYzItZjY4NC00M2M1LWE2MGUtYWFhYjI0MGYz
+        Zjg5L3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1078,7 +1078,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:43 GMT
+      - Mon, 22 Aug 2022 21:48:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1096,21 +1096,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 72b3cf8d68f74432beef70615b8e194d
+      - 66edccd38ea04172abe00b41392d50a3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EwYmNhZTFmLThiZDctNDhm
-        OC04ZDRkLTE3NzI4ODJhOGE2NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA2ZjUwNDM5LTI3MjYtNDZj
+        Yy04NTQ5LWU4YmMzYzFmNWYzYy8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:56 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/a0bcae1f-8bd7-48f8-8d4d-1772882a8a65/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/06f50439-2726-46cc-8549-e8bc3c1f5f3c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1118,7 +1118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1131,56 +1131,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:43 GMT
+      - Mon, 22 Aug 2022 21:48:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f6039bd98a5c4f52bc4da4396e32a632
+      - 8b2bf3b7f7f14e4ab09e0e4f79c7715e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '478'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTBiY2FlMWYtOGJk
-        Ny00OGY4LThkNGQtMTc3Mjg4MmE4YTY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NDIuOTkxNDMxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDZmNTA0MzktMjcy
+        Ni00NmNjLTg1NDktZThiYzNjMWY1ZjNjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NTYuNTcyMjAyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjcyYjNjZjhkNjhmNzQ0MzJiZWVmNzA2MTVi
-        OGUxOTRkIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDMuMDMw
-        NTAxWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0xOVQxODo0Njo0My4yMzI2
-        OTdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBmMjMwNTg2LWIwNzUtNGE5NC1hY2QyLWFmNWE2NzMyOTQ1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjY2ZWRjY2QzOGVhMDQxNzJhYmUwMGI0MTM5
+        MmQ1MGEzIiwic3RhcnRlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6NTYuNjIy
+        OTAwWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wOC0yMlQyMTo0ODo1Ni44MjM2
+        NDhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzL2IwY2ExMThhLTk0OTctNGNiOS05N2NiLWQyMzNlMjI5ZTlmNi8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMTExMzA3
-        ZTMtNDQ2MS00MjllLTg5OGQtYjZmZDBiOTVjNjE2LyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZTFkMDZj
+        OTMtMjJiNS00NTE4LWJkZWItNWFjY2M3MWQ5ZDMzLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vZGUwZjdlYTAtYzBmZi00Y2U3LTg1NTYtNzlhMjk3
-        MzkyODUzLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vZDVhNmZiYzItZjY4NC00M2M1LWE2MGUtYWFhYjI0
+        MGYzZjg5LyJdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:56 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1188,7 +1188,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1201,49 +1201,49 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:43 GMT
+      - Mon, 22 Aug 2022 21:48:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '534'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b74690db0e514aeba3eb2b19d2e0d285
+      - 8ccb197234274d04b4c72109d09775ed
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '330'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMzdlYjAxZDItZDMyNi00NjE5LTg2NzQtZDZhMjZmOWNlNGM2
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDAuODQ1NzMz
+        L3JwbS9ycG0vNDBmM2E4ZmEtZDQxMy00MzY1LTkyYzMtZTEzZDM1MGM2Mzg0
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDgtMjJUMjE6NDg6NTQuMzQzNTE3
         WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
-        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vemFuemli
-        YXIubGFncmFuZ2UuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0FDTUVfQ29y
-        cG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwvIiwiY29u
-        dGVudF9ndWFyZCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJuYW1lIjoiMl9k
-        dXBsaWNhdGUiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6Ii9w
-        dWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS80NTE1YWExNi0yNjAx
-        LTRhYzgtYjE1Zi1iMjNmNzkxYjlkZmUvIn1dfQ==
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        Ny1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbS9wdWxwL2NvbnRl
+        bnQvQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9s
+        YWJlbC8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30s
+        Im5hbWUiOiIyX2R1cGxpY2F0ZSIsInJlcG9zaXRvcnkiOm51bGwsInB1Ymxp
+        Y2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBtL2U5
+        ZTNjMDU2LThiMWEtNGMxMS1iM2QxLWE3ZTdmMmU4ZWQ0Mi8ifV19
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:57 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/111307e3-4461-429e-898d-b6fd0b95c616/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/e1d06c93-22b5-4518-bdeb-5accc71d9d33/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1251,7 +1251,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1264,59 +1264,59 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:43 GMT
+      - Mon, 22 Aug 2022 21:48:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2ef3ed454b344ecba01706132c5bdc7f
+      - ffb5acb07e554be09ea6aa86de51f0de
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '249'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMTExMzA3ZTMtNDQ2MS00MjllLTg5OGQtYjZmZDBiOTVjNjE2LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDMuMDUwODU1WiIsInJl
+        cG0vZTFkMDZjOTMtMjJiNS00NTE4LWJkZWItNWFjY2M3MWQ5ZDMzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDgtMjJUMjE6NDg6NTYuNjQwMzUyWiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9kZTBmN2VhMC1jMGZmLTRjZTctODU1Ni03OWEyOTczOTI4NTMv
+        cnBtL3JwbS9kNWE2ZmJjMi1mNjg0LTQzYzUtYTYwZS1hYWFiMjQwZjNmODkv
         dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2RlMGY3ZWEwLWMwZmYtNGNlNy04NTU2LTc5YTI5
-        NzM5Mjg1My8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtL2Q1YTZmYmMyLWY2ODQtNDNjNS1hNjBlLWFhYWIy
+        NDBmM2Y4OS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:57 GMT
 - request:
     method: patch
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/37eb01d2-d326-4619-8674-d6a26f9ce4c6/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/40f3a8fa-d413-4365-92c3-e13d350c6384/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
-        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMTEx
-        MzA3ZTMtNDQ2MS00MjllLTg5OGQtYjZmZDBiOTVjNjE2LyJ9
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZTFk
+        MDZjOTMtMjJiNS00NTE4LWJkZWItNWFjY2M3MWQ5ZDMzLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1329,7 +1329,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:43 GMT
+      - Mon, 22 Aug 2022 21:48:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1347,21 +1347,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 057446ad0ac4429fa0246322e13f541f
+      - 682292d33349443c93feb2aa34d05b07
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzViMTk5YzcwLTA5ZmEtNDcx
-        MS1hNzg5LTcwMDI0NDg2NzhmNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY3NzA4NzExLTIwMTgtNGJk
+        Yy1iZTBlLTEwY2QyODM5ZWZmZi8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:57 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/5b199c70-09fa-4711-a789-7002448678f6/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/67708711-2018-4bdc-be0e-10cd2839efff/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1369,7 +1369,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1382,50 +1382,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:43 GMT
+      - Mon, 22 Aug 2022 21:48:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '558'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d8b9ae5b80f64881a7fd00b69dba7768
+      - 456954cf3f564a06954eb86eb9fb2724
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '345'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWIxOTljNzAtMDlm
-        YS00NzExLWE3ODktNzAwMjQ0ODY3OGY2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NDMuNDA1MTgwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjc3MDg3MTEtMjAx
+        OC00YmRjLWJlMGUtMTBjZDI4MzllZmZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NTcuMTI5NzM4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIwNTc0NDZhZDBhYzQ0MjlmYTAyNDYzMjJl
-        MTNmNTQxZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQzLjQ0
-        NTAwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDMuNTYz
-        MDEyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy81MWI3NmQzNS1hYTBhLTQ0OTMtYmVlNS0xZTdlZTJmZmVjMTQvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI2ODIyOTJkMzMzNDk0NDNjOTNmZWIyYWEz
+        NGQwNWIwNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ4OjU3LjE2
+        ODA5NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6NTcuMzAz
+        MTE5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jM2VhNmFmNS01Y2NkLTRhYzctODVmNi1lNDVhMzY5MzEyMGQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
         L2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:57 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/111307e3-4461-429e-898d-b6fd0b95c616/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/e1d06c93-22b5-4518-bdeb-5accc71d9d33/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1433,7 +1433,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1446,59 +1446,59 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:43 GMT
+      - Mon, 22 Aug 2022 21:48:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 226afad64c834e4c950f3ce3591ee3f4
+      - 6b4744fdfb2e4ab0962574fe8ab144ea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '249'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMTExMzA3ZTMtNDQ2MS00MjllLTg5OGQtYjZmZDBiOTVjNjE2LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDMuMDUwODU1WiIsInJl
+        cG0vZTFkMDZjOTMtMjJiNS00NTE4LWJkZWItNWFjY2M3MWQ5ZDMzLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDgtMjJUMjE6NDg6NTYuNjQwMzUyWiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9kZTBmN2VhMC1jMGZmLTRjZTctODU1Ni03OWEyOTczOTI4NTMv
+        cnBtL3JwbS9kNWE2ZmJjMi1mNjg0LTQzYzUtYTYwZS1hYWFiMjQwZjNmODkv
         dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2RlMGY3ZWEwLWMwZmYtNGNlNy04NTU2LTc5YTI5
-        NzM5Mjg1My8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtL2Q1YTZmYmMyLWY2ODQtNDNjNS1hNjBlLWFhYWIy
+        NDBmM2Y4OS8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:57 GMT
 - request:
     method: patch
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/37eb01d2-d326-4619-8674-d6a26f9ce4c6/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/40f3a8fa-d413-4365-92c3-e13d350c6384/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
-        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMTEx
-        MzA3ZTMtNDQ2MS00MjllLTg5OGQtYjZmZDBiOTVjNjE2LyJ9
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vZTFk
+        MDZjOTMtMjJiNS00NTE4LWJkZWItNWFjY2M3MWQ5ZDMzLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1511,7 +1511,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:43 GMT
+      - Mon, 22 Aug 2022 21:48:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1529,35 +1529,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 38ebc076f6ab49ee8db834f9b6139ea8
+      - 73d1a8ea5e9f44c38dc02775e68f820b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VlMjgxNjBhLTczMjQtNGU5
-        YS1iMmQ1LTY0MjNiMmM0MDg5YS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhmMzk2NDdiLWRjYjMtNDlm
+        Yy1hMTlkLTVmZDJkM2UzYmJkZC8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:57 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/exporters/core/pulp/
     body:
       encoding: UTF-8
       base64_string: |
         eyJuYW1lIjoiRW1wdHlfT3JnYW5pemF0aW9uX0FDTUVfRGVmYXVsdF9Db250
         ZW50Vmlld18xLjAiLCJwYXRoIjoiL3Zhci9saWIvcHVscC9leHBvcnRzL0Vt
-        cHR5X09yZ2FuaXphdGlvbi9BQ01FIERlZmF1bHQgQ29udGVudFZpZXcvMS4w
-        L2RyZWFtLWRlc3RpbmF0aW9uL2RhdGVfZGlyIiwicmVwb3NpdG9yaWVzIjpb
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kZTBmN2VhMC1j
-        MGZmLTRjZTctODU1Ni03OWEyOTczOTI4NTMvIl19
+        cHR5X09yZ2FuaXphdGlvbi9vcmdfZGVmYXVsdF9sYWJlbC8xLjAvZHJlYW0t
+        ZGVzdGluYXRpb24vZGF0ZV9kaXIiLCJyZXBvc2l0b3JpZXMiOlsiL3B1bHAv
+        YXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Q1YTZmYmMyLWY2ODQtNDNj
+        NS1hNjBlLWFhYWIyNDBmM2Y4OS8iXX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1570,13 +1570,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:43 GMT
+      - Mon, 22 Aug 2022 21:48:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/exporters/core/pulp/7168f696-e39e-487a-9833-6c3beca73e15/"
+      - "/pulp/api/v3/exporters/core/pulp/75488e8a-d489-4747-9f87-d95fb6af16f6/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1584,34 +1584,34 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '404'
+      - '397'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 76e683c5c4634e048cca2058763e5380
+      - 3c4420a53194483ba358c72dd5a753ac
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
-        cC83MTY4ZjY5Ni1lMzllLTQ4N2EtOTgzMy02YzNiZWNhNzNlMTUvIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyMi0wNy0xOVQxODo0Njo0My45MTAxMjNaIiwibmFt
+        cC83NTQ4OGU4YS1kNDg5LTQ3NDctOWY4Ny1kOTVmYjZhZjE2ZjYvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMi0wOC0yMlQyMTo0ODo1Ny43Mzc2NzVaIiwibmFt
         ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
         ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
-        cmdhbml6YXRpb24vQUNNRSBEZWZhdWx0IENvbnRlbnRWaWV3LzEuMC9kcmVh
-        bS1kZXN0aW5hdGlvbi9kYXRlX2RpciIsInJlcG9zaXRvcmllcyI6WyIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGUwZjdlYTAtYzBmZi00
-        Y2U3LTg1NTYtNzlhMjk3MzkyODUzLyJdLCJsYXN0X2V4cG9ydCI6bnVsbH0=
+        cmdhbml6YXRpb24vb3JnX2RlZmF1bHRfbGFiZWwvMS4wL2RyZWFtLWRlc3Rp
+        bmF0aW9uL2RhdGVfZGlyIiwicmVwb3NpdG9yaWVzIjpbIi9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9kNWE2ZmJjMi1mNjg0LTQzYzUtYTYw
+        ZS1hYWFiMjQwZjNmODkvIl0sImxhc3RfZXhwb3J0IjpudWxsfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:43 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:57 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/7168f696-e39e-487a-9833-6c3beca73e15/exports/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/exporters/core/pulp/75488e8a-d489-4747-9f87-d95fb6af16f6/exports/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1619,7 +1619,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1632,7 +1632,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:44 GMT
+      - Mon, 22 Aug 2022 21:48:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1650,21 +1650,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5e582416b09e4b5894eda1507c91c551
+      - fdefc1e4669a485db3e1268c5c7a0c2c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:57 GMT
 - request:
     method: patch
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/7168f696-e39e-487a-9833-6c3beca73e15/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/exporters/core/pulp/75488e8a-d489-4747-9f87-d95fb6af16f6/
     body:
       encoding: UTF-8
       base64_string: 'eyJsYXN0X2V4cG9ydCI6bnVsbH0=
@@ -1674,7 +1674,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1687,7 +1687,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:44 GMT
+      - Mon, 22 Aug 2022 21:48:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1705,21 +1705,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d38dbb6f5a044004b1ee77aea9af6f46
+      - 3c513f8788c74342a1aa4ea146eb78be
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmYTUxN2MyLTc5YzAtNDIz
-        Yi1iMDcxLTBiNDBkZTc2MzI2NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I5OWVmMjI5LTkwOGYtNGEw
+        NS1hZWZhLTQ3YWYwNWY1NGYzMS8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:57 GMT
 - request:
     method: delete
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/7168f696-e39e-487a-9833-6c3beca73e15/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/exporters/core/pulp/75488e8a-d489-4747-9f87-d95fb6af16f6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1727,7 +1727,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1740,7 +1740,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:44 GMT
+      - Mon, 22 Aug 2022 21:48:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1758,21 +1758,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 221149f5db2d48c0822a85ea0d2e43c8
+      - 07a8e0a0e2f844e7942abc65fbd9ad57
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM4NTRkMjIwLTlmMGUtNGE3
-        ZC1iYmFlLTc3ZjljM2E3NTViZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM3Nzk4ZTMxLWQ2YzQtNDhl
+        MS1hY2FmLTUxZjJhZmVhNWUyZi8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:58 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/3854d220-9f0e-4a7d-bbae-77f9c3a755be/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/37798e31-d6c4-48e1-acaf-51f2afea5e2f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1780,7 +1780,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1793,51 +1793,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:44 GMT
+      - Mon, 22 Aug 2022 21:48:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '606'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 873125a59e2b4679a0eb31d422585430
+      - 8a36f8f540ad4bd59e519b50ef1fc1e9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzg1NGQyMjAtOWYw
-        ZS00YTdkLWJiYWUtNzdmOWMzYTc1NWJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NDQuMjEzNDg4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzc3OThlMzEtZDZj
+        NC00OGUxLWFjYWYtNTFmMmFmZWE1ZTJmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NTguMDIwODI5WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIyMjExNDlmNWRiMmQ0OGMwODIyYTg1ZWEw
-        ZDJlNDNjOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ0LjI1
-        NTMwNloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDQuMjg1
-        NTc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zNjAxYmE4OC1hYzM2LTQwNzctYjhhNC04YTA3ODlmYzJkOGMvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIwN2E4ZTBhMGUyZjg0NGU3OTQyYWJjNjVm
+        YmQ5YWQ1NyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ4OjU4LjA1
+        NzIyM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6NTguMDg1
+        OTQ0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9kODc1ODBiOC0wNTg2LTRjYmMtYmFjZS0zMTc1Y2YwZmQ3MjcvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVscC83MTY4ZjY5Ni1lMzllLTQ4N2Et
-        OTgzMy02YzNiZWNhNzNlMTUvIl19
+        cGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVscC83NTQ4OGU4YS1kNDg5LTQ3NDct
+        OWY4Ny1kOTVmYjZhZjE2ZjYvIl19
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:58 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/7168f696-e39e-487a-9833-6c3beca73e15/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/exporters/core/pulp/75488e8a-d489-4747-9f87-d95fb6af16f6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1845,7 +1845,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1858,7 +1858,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:44 GMT
+      - Mon, 22 Aug 2022 21:48:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1876,21 +1876,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 6039063992a64cb58770838d8adc1f4c
+      - b07903c524734397adc1d6a9b1e550d7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
 
 '
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:58 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/7168f696-e39e-487a-9833-6c3beca73e15/exports/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/exporters/core/pulp/75488e8a-d489-4747-9f87-d95fb6af16f6/exports/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1898,7 +1898,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1911,7 +1911,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:44 GMT
+      - Mon, 22 Aug 2022 21:48:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1929,21 +1929,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b99c720f8a0e4b48b65246e3876226bd
+      - 217e18ea2ee84e1fbf1b9aaff9773c85
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
 
 '
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:58 GMT
 - request:
     method: delete
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/4db5798c-e6fb-446b-8f76-bb4d4a008b0c/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/a52a1877-12af-49cd-9e58-21a600072244/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1951,7 +1951,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1964,7 +1964,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:44 GMT
+      - Mon, 22 Aug 2022 21:48:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1982,21 +1982,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e75a2498f4d748acaea7fabd7318476f
+      - 4efe85bfa0ba4436850dd70077592228
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY5ODVjZGNiLTdjZGUtNGYy
-        Ny1iNDdmLWQzNThmMDNkMGU1NC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk5NWNlMGQ1LWYwZjgtNGYz
+        Zi1iMzVmLTU1YzIzMmJmMGUzZi8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:58 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/6985cdcb-7cde-4f27-b47f-d358f03d0e54/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/995ce0d5-f0f8-4f3f-b35f-55c232bf0e3f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2004,7 +2004,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2017,51 +2017,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:44 GMT
+      - Mon, 22 Aug 2022 21:48:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2bc04ccb0b6e4d358cefb3668c8f0c9c
+      - b8badc44dcc2408b935a843217f9cb95
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '371'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjk4NWNkY2ItN2Nk
-        ZS00ZjI3LWI0N2YtZDM1OGYwM2QwZTU0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NDQuNzgwODAzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTk1Y2UwZDUtZjBm
+        OC00ZjNmLWIzNWYtNTVjMjMyYmYwZTNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NTguNDUwNzkzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJlNzVhMjQ5OGY0ZDc0OGFjYWVhN2ZhYmQ3
-        MzE4NDc2ZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ0Ljgy
-        OTgyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDQuODY5
-        OTM0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy83NGM0MDcyYS0zNjIzLTQ4NDItOGZhZS1lNGM0MjAwODk5YjAvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0ZWZlODViZmEwYmE0NDM2ODUwZGQ3MDA3
+        NzU5MjIyOCIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ4OjU4LjQ4
+        MTk3NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6NTguNTIy
+        MDIxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9kODc1ODBiOC0wNTg2LTRjYmMtYmFjZS0zMTc1Y2YwZmQ3MjcvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzRkYjU3OThjLWU2ZmItNDQ2Yi04Zjc2
-        LWJiNGQ0YTAwOGIwYy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2E1MmExODc3LTEyYWYtNDljZC05ZTU4
+        LTIxYTYwMDA3MjI0NC8iXX0=
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:58 GMT
 - request:
     method: delete
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/37eb01d2-d326-4619-8674-d6a26f9ce4c6/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/40f3a8fa-d413-4365-92c3-e13d350c6384/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2069,7 +2069,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -2082,7 +2082,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:44 GMT
+      - Mon, 22 Aug 2022 21:48:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2100,21 +2100,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 56a765c3b7b04a1ca335eeb0d40b5077
+      - 1c7f258b1dd8415388389534d6f2db1a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNmYjI0YjhlLTA0ODEtNDdm
-        My04ZDAyLTU0ODljMzYyN2IyZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYxMzE4ZTA2LTAwNmUtNGRi
+        MC05ODA5LWYzMjRjZTkwYzdmMy8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:44 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:58 GMT
 - request:
     method: delete
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/de0f7ea0-c0ff-4ce7-8556-79a297392853/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/d5a6fbc2-f684-43c5-a60e-aaab240f3f89/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2122,7 +2122,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -2135,7 +2135,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:45 GMT
+      - Mon, 22 Aug 2022 21:48:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2153,21 +2153,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - c1d395932ed941c6a3eae4316582ab45
+      - 422864430c8345eb9a52064cf40b7075
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EyMzg3NjcwLWM1OWMtNGNl
-        ZC04NzY2LTk1YmQyMzFhZTM5ZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNkMDQ4NDEyLWZkMTAtNDIw
+        My05ZTVkLWQxOGM2ZDI5ZmUwMy8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:45 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:58 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/a2387670-c59c-4ced-8766-95bd231ae39e/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/3d048412-fd10-4203-9e5d-d18c6d29fe03/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2175,7 +2175,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2188,46 +2188,46 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:45 GMT
+      - Mon, 22 Aug 2022 21:48:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 7d2cdc020cb94dde873468ebdd714fa8
+      - eea8be9521ae4535b83abbabf7a2db93
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '375'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTIzODc2NzAtYzU5
-        Yy00Y2VkLTg3NjYtOTViZDIzMWFlMzllLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NDUuMDYxNzAyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2QwNDg0MTItZmQx
+        MC00MjAzLTllNWQtZDE4YzZkMjlmZTAzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDg6NTguNjg5ODMzWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJjMWQzOTU5MzJlZDk0MWM2YTNlYWU0MzE2
-        NTgyYWI0NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ1LjEw
-        NzgyMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDUuMjIw
-        ODA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zNjAxYmE4OC1hYzM2LTQwNzctYjhhNC04YTA3ODlmYzJkOGMvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI0MjI4NjQ0MzBjODM0NWViOWE1MjA2NGNm
+        NDBiNzA3NSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ4OjU4Ljcx
+        OTc4MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDg6NTguODQ1
+        NDY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9iMGNhMTE4YS05NDk3LTRjYjktOTdjYi1kMjMzZTIyOWU5ZjYvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZGUwZjdlYTAtYzBmZi00Y2U3
-        LTg1NTYtNzlhMjk3MzkyODUzLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDVhNmZiYzItZjY4NC00M2M1
+        LWE2MGUtYWFhYjI0MGYzZjg5LyJdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:45 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:58 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/katello/content_view_version/export/export.yml
+++ b/test/fixtures/vcr_cassettes/actions/katello/content_view_version/export/export.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:45 GMT
+      - Mon, 22 Aug 2022 21:48:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -41,21 +41,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 61c62976839640eebb9e13a263292a92
+      - 610c156475224ffe865e335243798fad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:45 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:59 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -76,7 +76,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:45 GMT
+      - Mon, 22 Aug 2022 21:48:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -94,21 +94,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e751be181b62424ba6caaa31be4031eb
+      - db45dcb80d9d4e48933169d6bff92cf0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:45 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:59 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -116,7 +116,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -129,7 +129,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:45 GMT
+      - Mon, 22 Aug 2022 21:48:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -147,21 +147,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5481e93fe03c425f83f54a07b6965207
+      - 01f636483def426eb69f59e49d0f0dc0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:45 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:59 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -169,7 +169,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -182,7 +182,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:45 GMT
+      - Mon, 22 Aug 2022 21:48:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -200,21 +200,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 8dcb95eb0b0a47afadf87a868921b682
+      - 37409da899ca463da5fd51cdef050878
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:45 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:59 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -231,7 +231,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -244,13 +244,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:45 GMT
+      - Mon, 22 Aug 2022 21:48:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/d63541bf-e3d9-47a1-98aa-a4ee71ab120c/"
+      - "/pulp/api/v3/remotes/rpm/rpm/02abc97c-3209-4418-bc0f-c34c339ec1af/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -264,32 +264,32 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 5d88727bf00044238a6afcdda59fe456
+      - fd44b33efcf54b13a9f8935b9c45b65e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q2
-        MzU0MWJmLWUzZDktNDdhMS05OGFhLWE0ZWU3MWFiMTIwYy8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ1Ljg2NTIwM1oiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAy
+        YWJjOTdjLTMyMDktNDQxOC1iYzBmLWMzNGMzMzllYzFhZi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIyLTA4LTIyVDIxOjQ4OjU5LjU4NTkwMloiLCJuYW1lIjoi
         Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
         cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwiY2FfY2Vy
         dCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
         cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ1Ljg2NTIxOFoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDIyLTA4LTIyVDIxOjQ4OjU5LjU4NTkzMFoiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
         NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwiaGVhZGVycyI6bnVs
         bCwicmF0ZV9saW1pdCI6MCwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:45 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:59 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
@@ -299,7 +299,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -312,13 +312,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:46 GMT
+      - Mon, 22 Aug 2022 21:48:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/c3d0fe0e-9f92-479d-b3c5-fa1105d2f43b/"
+      - "/pulp/api/v3/repositories/rpm/rpm/a112e767-f15c-45ba-8b70-6df3122be4cf/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -332,22 +332,22 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b4586556c6fb4e1988351f64d6a03d3d
+      - b5682acedffd4962aa52a23486e275cb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1ZDJmNDNiLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDYuMDAwMjk1WiIsInZl
+        cG0vYTExMmU3NjctZjE1Yy00NWJhLThiNzAtNmRmMzEyMmJlNGNmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDgtMjJUMjE6NDg6NTkuNzIzMzc2WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1ZDJmNDNiL3ZlcnNp
+        cG0vYTExMmU3NjctZjE1Yy00NWJhLThiNzAtNmRmMzEyMmJlNGNmL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jM2QwZmUwZS05
-        ZjkyLTQ3OWQtYjNjNS1mYTExMDVkMmY0M2IvdmVyc2lvbnMvMC8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hMTEyZTc2Ny1m
+        MTVjLTQ1YmEtOGI3MC02ZGYzMTIyYmU0Y2YvdmVyc2lvbnMvMC8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -356,21 +356,21 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:46 GMT
+  recorded_at: Mon, 22 Aug 2022 21:48:59 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1ZDJm
-        NDNiL3ZlcnNpb25zLzAvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vYTExMmU3NjctZjE1Yy00NWJhLThiNzAtNmRmMzEyMmJl
+        NGNmL3ZlcnNpb25zLzAvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -383,7 +383,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:46 GMT
+      - Mon, 22 Aug 2022 21:49:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -401,21 +401,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 90001392f7ad4e87a661d8cd9c14d42c
+      - 29110dd9538441d3b6037051840ea0fa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QxZmM4OWZjLTk2MjMtNDJi
-        MS1hYzY4LWJlNmVkMWRlNDZiMi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk2M2Q5MzgyLWEwNjYtNGJl
+        OC04YWY1LWNjY2I0ODg5MjgxNi8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:46 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:00 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/d1fc89fc-9623-42b1-ac68-be6ed1de46b2/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/963d9382-a066-4be8-8af5-cccb48892816/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -423,7 +423,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -436,56 +436,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:46 GMT
+      - Mon, 22 Aug 2022 21:49:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0fd725902b8048a696a29fd0fa485a15
+      - c45d352957574b2d8baf03ccebb18332
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDFmYzg5ZmMtOTYy
-        My00MmIxLWFjNjgtYmU2ZWQxZGU0NmIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NDYuMzE4ODM2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTYzZDkzODItYTA2
+        Ni00YmU4LThhZjUtY2NjYjQ4ODkyODE2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDk6MDAuMDg2NTQ2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6IjkwMDAxMzkyZjdhZDRlODdhNjYxZDhjZDlj
-        MTRkNDJjIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDYuMzY1
-        ODQzWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0xOVQxODo0Njo0Ni41MTM1
-        MjdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBmMjMwNTg2LWIwNzUtNGE5NC1hY2QyLWFmNWE2NzMyOTQ1MS8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6IjI5MTEwZGQ5NTM4NDQxZDNiNjAzNzA1MTg0
+        MGVhMGZhIiwic3RhcnRlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDk6MDAuMTE5
+        MjQ4WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wOC0yMlQyMTo0OTowMC4zMDEw
+        NjZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzL2MzZWE2YWY1LTVjY2QtNGFjNy04NWY2LWU0NWEzNjkzMTIwZC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOWM4NWE4
-        OTMtYmYyNC00ZDZkLWE2YWEtZDNkN2EyMWEyZDBiLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNmFmNmEx
+        M2ItZmZmNi00YzE5LWIzNmYtYmNkNDk0MTlhN2Q0LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1
-        ZDJmNDNiLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vYTExMmU3NjctZjE1Yy00NWJhLThiNzAtNmRmMzEy
+        MmJlNGNmLyJdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:46 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:00 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -493,7 +493,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -506,7 +506,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:46 GMT
+      - Mon, 22 Aug 2022 21:49:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -524,21 +524,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - daded6bb98fe4efda4cd7e600a6f6834
+      - 1cdd39eaf78d4be6a4c0e508c5e6765a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:46 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:00 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/9c85a893-bf24-4d6d-a6aa-d3d7a21a2d0b/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/6af6a13b-fff6-4c19-b36f-bcd49419a7d4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -546,7 +546,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -559,60 +559,60 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:46 GMT
+      - Mon, 22 Aug 2022 21:49:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 94f4e4eae1e547c782dd3daeb730b7ec
+      - 7b5ee69b47b04fdcb53de9c64a586e21
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '249'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vOWM4NWE4OTMtYmYyNC00ZDZkLWE2YWEtZDNkN2EyMWEyZDBiLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDYuMzg2MzA0WiIsInJl
+        cG0vNmFmNmExM2ItZmZmNi00YzE5LWIzNmYtYmNkNDk0MTlhN2Q0LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDgtMjJUMjE6NDk6MDAuMTQwNzczWiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jM2QwZmUwZS05ZjkyLTQ3OWQtYjNjNS1mYTExMDVkMmY0M2Iv
+        cnBtL3JwbS9hMTEyZTc2Ny1mMTVjLTQ1YmEtOGI3MC02ZGYzMTIyYmU0Y2Yv
         dmVyc2lvbnMvMC8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2MzZDBmZTBlLTlmOTItNDc5ZC1iM2M1LWZhMTEw
-        NWQyZjQzYi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtL2ExMTJlNzY3LWYxNWMtNDViYS04YjcwLTZkZjMx
+        MjJiZTRjZi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:46 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:00 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vOWM4NWE4OTMtYmYyNC00ZDZkLWE2YWEtZDNk
-        N2EyMWEyZDBiLyJ9
+        bGljYXRpb25zL3JwbS9ycG0vNmFmNmExM2ItZmZmNi00YzE5LWIzNmYtYmNk
+        NDk0MTlhN2Q0LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -625,7 +625,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:46 GMT
+      - Mon, 22 Aug 2022 21:49:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -643,21 +643,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bb0c6d1c22ab40a2bf01e321d90c420e
+      - dedbeffd4e68420cbac94f719d07b812
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRhMGU1MjE3LWFjMTMtNDY1
-        My1iZjY0LWE5ZGZkN2ZmYTkyMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhlOTI5YWZhLTg1MjItNGNj
+        OC1hYzYwLWRkOWEzYWMxZjIzZC8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:46 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:00 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/4a0e5217-ac13-4653-bf64-a9dfd7ffa920/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/8e929afa-8522-4cc8-ac60-dd9a3ac1f23d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -665,7 +665,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -678,52 +678,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:47 GMT
+      - Mon, 22 Aug 2022 21:49:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '632'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 72772c8a1b0b435eb95e7ccc4c0ade5e
+      - ca727ac15e274a748dd989176afa2fd0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '376'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGEwZTUyMTctYWMx
-        My00NjUzLWJmNjQtYTlkZmQ3ZmZhOTIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NDYuNzQ5MDczWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOGU5MjlhZmEtODUy
+        Mi00Y2M4LWFjNjAtZGQ5YTNhYzFmMjNkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDk6MDAuNTU0NDg4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
-        YXRlIiwibG9nZ2luZ19jaWQiOiJiYjBjNmQxYzIyYWI0MGEyYmYwMWUzMjFk
-        OTBjNDIwZSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ2Ljc5
-        NTg0N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDYuOTIx
-        NDg4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy83NGM0MDcyYS0zNjIzLTQ4NDItOGZhZS1lNGM0MjAwODk5YjAvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJkZWRiZWZmZDRlNjg0MjBjYmFjOTRmNzE5
+        ZDA3YjgxMiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ5OjAwLjU4
+        OTQwM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDk6MDAuNzMz
+        NzIwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9iMGNhMTE4YS05NDk3LTRjYjktOTdjYi1kMjMzZTIyOWU5ZjYvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vYTZl
-        Y2RhYTAtZmUxZi00MjUwLTgyOWYtNjc5NGM4OTI4MGM2LyJdLCJyZXNlcnZl
+        Y2VzIjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vZDU5
+        MWZjNTUtMzg0My00YmE3LWExNjUtMzRlOTViNWVjM2Q1LyJdLCJyZXNlcnZl
         ZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8i
         XX0=
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:47 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:00 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/a6ecdaa0-fe1f-4250-829f-6794c89280c6/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/d591fc55-3843-4ba7-a165-34e95b5ec3d5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -731,7 +731,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -744,48 +744,48 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:47 GMT
+      - Mon, 22 Aug 2022 21:49:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '482'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e55b109588034eb98693655b926ff5c7
+      - 74fc2cd25ae343e697e55ef6a41163ae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '299'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtL2E2ZWNkYWEwLWZlMWYtNDI1MC04MjlmLTY3OTRjODkyODBjNi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ2LjkwNzMxOVoiLCJi
+        cnBtL2Q1OTFmYzU1LTM4NDMtNGJhNy1hMTY1LTM0ZTk1YjVlYzNkNS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDIyLTA4LTIyVDIxOjQ5OjAwLjcxNjYzN1oiLCJi
         YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
-        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL3phbnppYmFyLmxh
-        Z3JhbmdlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01FX0NvcnBvcmF0
-        aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIsImNvbnRlbnRf
-        Z3VhcmQiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGlj
-        YXRlIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9h
-        cGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOWM4NWE4OTMtYmYyNC00ZDZk
-        LWE2YWEtZDNkN2EyMWEyZDBiLyJ9
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczcta2F0
+        ZWxsby1kZXZlbC1zdGFibGUuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0FD
+        TUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwv
+        IiwiY29udGVudF9ndWFyZCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJuYW1l
+        IjoiMl9kdXBsaWNhdGUiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlv
+        biI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS82YWY2YTEz
+        Yi1mZmY2LTRjMTktYjM2Zi1iY2Q0OTQxOWE3ZDQvIn0=
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:47 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:00 GMT
 - request:
     method: patch
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/d63541bf-e3d9-47a1-98aa-a4ee71ab120c/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/02abc97c-3209-4418-bc0f-c34c339ec1af/
     body:
       encoding: UTF-8
       base64_string: |
@@ -802,7 +802,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -815,7 +815,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:47 GMT
+      - Mon, 22 Aug 2022 21:49:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -833,21 +833,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 0f20356daae64ce4961cee7645acc551
+      - 6e7982b371714bc2b3247f108ebc8b23
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNkYjliMmExLTBkOGItNGZk
-        MC1iNGJiLTVjYTY2M2M5NWQ1Mi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRmMTYzNDI4LTg5MTYtNDFl
+        MC1iYWEwLWM2YzM2Yjg2MDI1My8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:47 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:01 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/3db9b2a1-0d8b-4fd0-b4bb-5ca663c95d52/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/4f163428-8916-41e0-baa0-c6c36b860253/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -855,7 +855,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -868,63 +868,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:47 GMT
+      - Mon, 22 Aug 2022 21:49:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d06c3aa5949c48e7b6e852eafc03afda
+      - aba58fc8d1f84e7598083aafb9789e21
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2RiOWIyYTEtMGQ4
-        Yi00ZmQwLWI0YmItNWNhNjYzYzk1ZDUyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NDcuNDU5NDUzWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGYxNjM0MjgtODkx
+        Ni00MWUwLWJhYTAtYzZjMzZiODYwMjUzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDk6MDEuMjM1ODc1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiIwZjIwMzU2ZGFhZTY0Y2U0OTYxY2VlNzY0
-        NWFjYzU1MSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ3LjUw
-        MzA1NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDcuNTMw
-        NzkzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8wZjIzMDU4Ni1iMDc1LTRhOTQtYWNkMi1hZjVhNjczMjk0NTEvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiI2ZTc5ODJiMzcxNzE0YmMyYjMyNDdmMTA4
+        ZWJjOGIyMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ5OjAxLjI4
+        MDk0NloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDk6MDEuMzA3
+        MDM0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy80N2Y4OGFkYy1mYWM1LTRlYjYtYTFjNi02NTlkM2Y4Mzk3N2QvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q2MzU0MWJmLWUzZDktNDdhMS05OGFh
-        LWE0ZWU3MWFiMTIwYy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAyYWJjOTdjLTMyMDktNDQxOC1iYzBm
+        LWMzNGMzMzllYzFhZi8iXX0=
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:47 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:01 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/c3d0fe0e-9f92-479d-b3c5-fa1105d2f43b/sync/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/a112e767-f15c-45ba-8b70-6df3122be4cf/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q2MzU0
-        MWJmLWUzZDktNDdhMS05OGFhLWE0ZWU3MWFiMTIwYy8iLCJzeW5jX3BvbGlj
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAyYWJj
+        OTdjLTMyMDktNDQxOC1iYzBmLWMzNGMzMzllYzFhZi8iLCJzeW5jX3BvbGlj
         eSI6Im1pcnJvcl9jb250ZW50X29ubHkiLCJza2lwX3R5cGVzIjpbXSwib3B0
         aW1pemUiOnRydWV9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -937,7 +937,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:47 GMT
+      - Mon, 22 Aug 2022 21:49:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -955,21 +955,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 33f504a0e2584e4b92fe02ffb37734aa
+      - '08130be66d6846799c38cebdf8aa26f7'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JkYjU0MzgyLTExNTctNDYw
-        MS1hZWY4LTY5OTA1YjlkMGYyOS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRkZThhZjhmLTVmMjMtNGMz
+        YS1iNWM1LWI3Yjg3OTg1YmUxMS8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:47 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:01 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/bdb54382-1157-4601-aef8-69905b9d0f29/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/4de8af8f-5f23-4c3a-b5c5-b7b87985be11/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -977,7 +977,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -990,42 +990,42 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:49 GMT
+      - Mon, 22 Aug 2022 21:49:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1510'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d7a67081715b469bb1138ee6983d5886
+      - 8d068372ac314c2c834e71d8b2afbe56
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '602'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmRiNTQzODItMTE1
-        Ny00NjAxLWFlZjgtNjk5MDViOWQwZjI5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NDcuNjU2OTkwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGRlOGFmOGYtNWYy
+        My00YzNhLWI1YzUtYjdiODc5ODViZTExLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDk6MDEuNDM1ODE4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
-        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIzM2Y1MDRhMGUyNTg0ZTRiOTJm
-        ZTAyZmZiMzc3MzRhYSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2
-        OjQ3LjcwODIyOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6
-        NDguOTY3OTg4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy83NGM0MDcyYS0zNjIzLTQ4NDItOGZhZS1lNGM0MjAwODk5
-        YjAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIwODEzMGJlNjZkNjg0Njc5OWMz
+        OGNlYmRmOGFhMjZmNyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ5
+        OjAxLjQ2NTI5MloiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDk6
+        MDIuNDgzMjU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy9jM2VhNmFmNS01Y2NkLTRhYzctODVmNi1lNDVhMzY5MzEy
+        MGQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
         IkRvd25sb2FkaW5nIE1ldGFkYXRhIEZpbGVzIiwiY29kZSI6InN5bmMuZG93
         bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
@@ -1044,28 +1044,28 @@ http_interactions:
         IENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRl
         IjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjM2LCJzdWZmaXgi
         Om51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9ycG0vcnBtL2MzZDBmZTBlLTlmOTItNDc5ZC1iM2M1LWZh
-        MTEwNWQyZjQzYi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
-        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9j
-        M2QwZmUwZS05ZjkyLTQ3OWQtYjNjNS1mYTExMDVkMmY0M2IvIiwic2hhcmVk
-        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vZDYzNTQxYmYtZTNkOS00
-        N2ExLTk4YWEtYTRlZTcxYWIxMjBjLyJdfQ==
+        cG9zaXRvcmllcy9ycG0vcnBtL2ExMTJlNzY3LWYxNWMtNDViYS04YjcwLTZk
+        ZjMxMjJiZTRjZi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
+        cmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9h
+        MTEyZTc2Ny1mMTVjLTQ1YmEtOGI3MC02ZGYzMTIyYmU0Y2YvIiwic2hhcmVk
+        Oi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vMDJhYmM5N2MtMzIwOS00
+        NDE4LWJjMGYtYzM0YzMzOWVjMWFmLyJdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:02 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1ZDJm
-        NDNiL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+        aWVzL3JwbS9ycG0vYTExMmU3NjctZjE1Yy00NWJhLThiNzAtNmRmMzEyMmJl
+        NGNmL3ZlcnNpb25zLzEvIiwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1078,7 +1078,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:49 GMT
+      - Mon, 22 Aug 2022 21:49:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1096,21 +1096,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - b1b896fecc8f46b3acc2bc0ae07badbd
+      - 7843ed7acef843e39ffe3cf468d7e8c5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JmMmM0ZTk4LThlOGItNGVh
-        My05OTg5LWI2NGEzMTY1NzgzNi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU0ZGZlNDg3LTBhMzgtNGQ4
+        My04YTNkLTJlYWMxOWIyYzgzOC8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:02 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/bf2c4e98-8e8b-4ea3-9989-b64a31657836/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/54dfe487-0a38-4d83-8a3d-2eac19b2c838/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1118,7 +1118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1131,56 +1131,56 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:49 GMT
+      - Mon, 22 Aug 2022 21:49:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '820'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - bd8e66b57587462d96330dc42d12b5eb
+      - 517e3d1daa044445aa3304423bf84507
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '475'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYmYyYzRlOTgtOGU4
-        Yi00ZWEzLTk5ODktYjY0YTMxNjU3ODM2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NDkuMjE1OTkyWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNTRkZmU0ODctMGEz
+        OC00ZDgzLThhM2QtMmVhYzE5YjJjODM4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDk6MDIuNjUzMDEwWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
-        c2giLCJsb2dnaW5nX2NpZCI6ImIxYjg5NmZlY2M4ZjQ2YjNhY2MyYmMwYWUw
-        N2JhZGJkIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDkuMjY0
-        MzQ0WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0xOVQxODo0Njo0OS40ODY4
-        ODlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzUxYjc2ZDM1LWFhMGEtNDQ5My1iZWU1LTFlN2VlMmZmZWMxNC8iLCJw
+        c2giLCJsb2dnaW5nX2NpZCI6Ijc4NDNlZDdhY2VmODQzZTM5ZmZlM2NmNDY4
+        ZDdlOGM1Iiwic3RhcnRlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDk6MDIuNjgx
+        MzcwWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wOC0yMlQyMTo0OTowMi45MTE0
+        NjRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzQ3Zjg4YWRjLWZhYzUtNGViNi1hMWM2LTY1OWQzZjgzOTc3ZC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJh
         dGluZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2Vu
         ZXJhdGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
         OjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNl
-        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYWI0OWI4
-        YzUtY2FjNy00ZjBkLTliOTgtNGVmNWI3ZDU4MDcwLyJdLCJyZXNlcnZlZF9y
+        cyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMTQyZjAz
+        OWYtZWQ0Yy00NjZjLTk5YjAtOGFjYjdiZTUyNjc5LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL3JwbS9ycG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1
-        ZDJmNDNiLyJdfQ==
+        dG9yaWVzL3JwbS9ycG0vYTExMmU3NjctZjE1Yy00NWJhLThiNzAtNmRmMzEy
+        MmJlNGNmLyJdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:02 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1188,7 +1188,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1201,49 +1201,49 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:49 GMT
+      - Mon, 22 Aug 2022 21:49:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '534'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 297ee6b79e524a8787eb56a96052f51d
+      - b12b848057634f108c313ee9099a5e73
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '330'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vYTZlY2RhYTAtZmUxZi00MjUwLTgyOWYtNjc5NGM4OTI4MGM2
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDYuOTA3MzE5
+        L3JwbS9ycG0vZDU5MWZjNTUtMzg0My00YmE3LWExNjUtMzRlOTViNWVjM2Q1
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjItMDgtMjJUMjE6NDk6MDAuNzE2NjM3
         WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
-        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vemFuemli
-        YXIubGFncmFuZ2UuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0FDTUVfQ29y
-        cG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwvIiwiY29u
-        dGVudF9ndWFyZCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJuYW1lIjoiMl9k
-        dXBsaWNhdGUiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6Ii9w
-        dWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS85Yzg1YTg5My1iZjI0
-        LTRkNmQtYTZhYS1kM2Q3YTIxYTJkMGIvIn1dfQ==
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
+        Ny1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFtcGxlLmNvbS9wdWxwL2NvbnRl
+        bnQvQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9s
+        YWJlbC8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJwdWxwX2xhYmVscyI6e30s
+        Im5hbWUiOiIyX2R1cGxpY2F0ZSIsInJlcG9zaXRvcnkiOm51bGwsInB1Ymxp
+        Y2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBtLzZh
+        ZjZhMTNiLWZmZjYtNGMxOS1iMzZmLWJjZDQ5NDE5YTdkNC8ifV19
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:03 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/ab49b8c5-cac7-4f0d-9b98-4ef5b7d58070/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/142f039f-ed4c-466c-99b0-8acb7be52679/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1251,7 +1251,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1264,59 +1264,59 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:49 GMT
+      - Mon, 22 Aug 2022 21:49:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 94197545d942442ca42a1b54428134c9
+      - 42bde9c7dd6040cab6b871c20c326ce8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '250'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vYWI0OWI4YzUtY2FjNy00ZjBkLTliOTgtNGVmNWI3ZDU4MDcwLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDkuMjg4NzA4WiIsInJl
+        cG0vMTQyZjAzOWYtZWQ0Yy00NjZjLTk5YjAtOGFjYjdiZTUyNjc5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDgtMjJUMjE6NDk6MDIuNzAwMDAyWiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jM2QwZmUwZS05ZjkyLTQ3OWQtYjNjNS1mYTExMDVkMmY0M2Iv
+        cnBtL3JwbS9hMTEyZTc2Ny1mMTVjLTQ1YmEtOGI3MC02ZGYzMTIyYmU0Y2Yv
         dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2MzZDBmZTBlLTlmOTItNDc5ZC1iM2M1LWZhMTEw
-        NWQyZjQzYi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtL2ExMTJlNzY3LWYxNWMtNDViYS04YjcwLTZkZjMx
+        MjJiZTRjZi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:03 GMT
 - request:
     method: patch
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/a6ecdaa0-fe1f-4250-829f-6794c89280c6/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/d591fc55-3843-4ba7-a165-34e95b5ec3d5/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
-        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYWI0
-        OWI4YzUtY2FjNy00ZjBkLTliOTgtNGVmNWI3ZDU4MDcwLyJ9
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMTQy
+        ZjAzOWYtZWQ0Yy00NjZjLTk5YjAtOGFjYjdiZTUyNjc5LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1329,7 +1329,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:49 GMT
+      - Mon, 22 Aug 2022 21:49:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1347,21 +1347,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 587578b1e46f425bb218212a4ce5e719
+      - ee031dc80fe841f2b87fd89accdc5fcf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRhZTIwMDUyLWQ4OGItNDFi
-        Ny1iM2U4LWIzYjMwMDZjMzk5OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ0YzQ5Mjg3LWUzYWYtNGM1
+        MS1hNjUyLTIxYTMyMDA5MzFmZS8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:03 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/4ae20052-d88b-41b7-b3e8-b3b3006c3999/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/44c49287-e3af-4c51-a652-21a3200931fe/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1369,7 +1369,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1382,50 +1382,50 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:49 GMT
+      - Mon, 22 Aug 2022 21:49:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '558'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d999a9fac1f84e21b45a58504dd93e88
+      - 9de9f1305c54492c855192be1e42c6d5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '346'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGFlMjAwNTItZDg4
-        Yi00MWI3LWIzZTgtYjNiMzAwNmMzOTk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NDkuNjg2MzI2WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDRjNDkyODctZTNh
+        Zi00YzUxLWE2NTItMjFhMzIwMDkzMWZlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDk6MDMuMTM2NDg1WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
-        YXRlIiwibG9nZ2luZ19jaWQiOiI1ODc1NzhiMWU0NmY0MjViYjIxODIxMmE0
-        Y2U1ZTcxOSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjQ5Ljcz
-        NjI0M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NDkuODU2
-        MTcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy83NGM0MDcyYS0zNjIzLTQ4NDItOGZhZS1lNGM0MjAwODk5YjAvIiwi
+        YXRlIiwibG9nZ2luZ19jaWQiOiJlZTAzMWRjODBmZTg0MWYyYjg3ZmQ4OWFj
+        Y2RjNWZjZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ5OjAzLjE2
+        NjkwN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDk6MDMuMjk5
+        OTYzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9jM2VhNmFmNS01Y2NkLTRhYzctODVmNi1lNDVhMzY5MzEyMGQvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3Yz
         L2Rpc3RyaWJ1dGlvbnMvIl19
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:03 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/publications/rpm/rpm/ab49b8c5-cac7-4f0d-9b98-4ef5b7d58070/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/142f039f-ed4c-466c-99b0-8acb7be52679/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1433,7 +1433,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1446,59 +1446,59 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:49 GMT
+      - Mon, 22 Aug 2022 21:49:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '447'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e54036e0c3404f80bef4a7dd8bb3f20a
+      - 852186f9651749d3ac8844a45dd0ee51
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '250'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vYWI0OWI4YzUtY2FjNy00ZjBkLTliOTgtNGVmNWI3ZDU4MDcwLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDkuMjg4NzA4WiIsInJl
+        cG0vMTQyZjAzOWYtZWQ0Yy00NjZjLTk5YjAtOGFjYjdiZTUyNjc5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDgtMjJUMjE6NDk6MDIuNzAwMDAyWiIsInJl
         cG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS9jM2QwZmUwZS05ZjkyLTQ3OWQtYjNjNS1mYTExMDVkMmY0M2Iv
+        cnBtL3JwbS9hMTEyZTc2Ny1mMTVjLTQ1YmEtOGI3MC02ZGYzMTIyYmU0Y2Yv
         dmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2MzZDBmZTBlLTlmOTItNDc5ZC1iM2M1LWZhMTEw
-        NWQyZjQzYi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
+        aXRvcmllcy9ycG0vcnBtL2ExMTJlNzY3LWYxNWMtNDViYS04YjcwLTZkZjMx
+        MjJiZTRjZi8iLCJtZXRhZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2Iiwi
         cGFja2FnZV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOjAs
         InJlcG9fZ3BnY2hlY2siOjAsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2V9
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:03 GMT
 - request:
     method: patch
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/a6ecdaa0-fe1f-4250-829f-6794c89280c6/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/d591fc55-3843-4ba7-a165-34e95b5ec3d5/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
-        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vYWI0
-        OWI4YzUtY2FjNy00ZjBkLTliOTgtNGVmNWI3ZDU4MDcwLyJ9
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMTQy
+        ZjAzOWYtZWQ0Yy00NjZjLTk5YjAtOGFjYjdiZTUyNjc5LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1511,7 +1511,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:49 GMT
+      - Mon, 22 Aug 2022 21:49:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1529,35 +1529,35 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9e0644574e2041d7a98269405116e047
+      - e2100292f806419d8c6491eecd9bad09
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc5YTVlYTNkLTVkMzEtNDE1
-        ZC1iNzk0LWVhNDY2MjBjNDVlZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIwYWVkNTFmLTgxOTMtNGI4
+        Ni05YzMzLWVjYmFhMWQ0ZDY2Ni8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:49 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:03 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/exporters/core/pulp/
     body:
       encoding: UTF-8
       base64_string: |
         eyJuYW1lIjoiRW1wdHlfT3JnYW5pemF0aW9uX0FDTUVfRGVmYXVsdF9Db250
         ZW50Vmlld18xLjAiLCJwYXRoIjoiL3Zhci9saWIvcHVscC9leHBvcnRzL0Vt
-        cHR5X09yZ2FuaXphdGlvbi9BQ01FIERlZmF1bHQgQ29udGVudFZpZXcvMS4w
-        L2Zvby9kYXRlX2RpciIsInJlcG9zaXRvcmllcyI6WyIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUt
-        ZmExMTA1ZDJmNDNiLyJdfQ==
+        cHR5X09yZ2FuaXphdGlvbi9vcmdfZGVmYXVsdF9sYWJlbC8xLjAvZm9vL2Rh
+        dGVfZGlyIiwicmVwb3NpdG9yaWVzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcnBtL3JwbS9hMTEyZTc2Ny1mMTVjLTQ1YmEtOGI3MC02ZGYzMTIy
+        YmU0Y2YvIl19
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1570,13 +1570,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:50 GMT
+      - Mon, 22 Aug 2022 21:49:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/exporters/core/pulp/a069771f-3479-4915-a304-f7d94768761f/"
+      - "/pulp/api/v3/exporters/core/pulp/a27c5169-2f15-4491-86a5-8399a0339d31/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1584,45 +1584,45 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '390'
+      - '383'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 392d729d588b48f7b8bdb6a974fde5e7
+      - 93339243034b4b81b259fabecd2b2c01
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVs
-        cC9hMDY5NzcxZi0zNDc5LTQ5MTUtYTMwNC1mN2Q5NDc2ODc2MWYvIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyMi0wNy0xOVQxODo0Njo1MC4zNjIxNDRaIiwibmFt
+        cC9hMjdjNTE2OS0yZjE1LTQ0OTEtODZhNS04Mzk5YTAzMzlkMzEvIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyMi0wOC0yMlQyMTo0OTowMy44MDE1NDlaIiwibmFt
         ZSI6IkVtcHR5X09yZ2FuaXphdGlvbl9BQ01FX0RlZmF1bHRfQ29udGVudFZp
         ZXdfMS4wIiwicGF0aCI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9P
-        cmdhbml6YXRpb24vQUNNRSBEZWZhdWx0IENvbnRlbnRWaWV3LzEuMC9mb28v
-        ZGF0ZV9kaXIiLCJyZXBvc2l0b3JpZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9ycG0vcnBtL2MzZDBmZTBlLTlmOTItNDc5ZC1iM2M1LWZhMTEw
-        NWQyZjQzYi8iXSwibGFzdF9leHBvcnQiOm51bGx9
+        cmdhbml6YXRpb24vb3JnX2RlZmF1bHRfbGFiZWwvMS4wL2Zvby9kYXRlX2Rp
+        ciIsInJlcG9zaXRvcmllcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L3JwbS9ycG0vYTExMmU3NjctZjE1Yy00NWJhLThiNzAtNmRmMzEyMmJlNGNm
+        LyJdLCJsYXN0X2V4cG9ydCI6bnVsbH0=
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:50 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:03 GMT
 - request:
     method: post
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/a069771f-3479-4915-a304-f7d94768761f/exports/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/exporters/core/pulp/a27c5169-2f15-4491-86a5-8399a0339d31/exports/
     body:
       encoding: UTF-8
       base64_string: |
         eyJ2ZXJzaW9ucyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1ZDJmNDNiL3ZlcnNp
+        cG0vYTExMmU3NjctZjE1Yy00NWJhLThiNzAtNmRmMzEyMmJlNGNmL3ZlcnNp
         b25zLzEvIl0sImNodW5rX3NpemUiOiIwLjFHQiJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1635,7 +1635,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:50 GMT
+      - Mon, 22 Aug 2022 21:49:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1653,21 +1653,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f14f8c6f40d14c43aa5fd03eda6bcb91
+      - 9c6b860c52ee455eb4148bb6c689436d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YzYjRjNmE5LTc0YTctNDFj
-        My04NGJhLTVmMDZhOTA1ZTUwYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNlMGIwNGJkLWFjZWMtNDdm
+        Ni04MjMxLTI2OGRjYjZmNDA5Ny8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:50 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:03 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/f3b4c6a9-74a7-41c3-84ba-5f06a905e50c/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/3e0b04bd-acec-47f6-8231-268dcb6f4097/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1675,7 +1675,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1688,41 +1688,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:51 GMT
+      - Mon, 22 Aug 2022 21:49:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1001'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 555a52fbb3e846ce9d98c1949b2653fa
+      - faa688c88de94de5af53fa9a057a1b87
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '509'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZjNiNGM2YTktNzRh
-        Ny00MWMzLTg0YmEtNWYwNmE5MDVlNTBjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NTAuNDQ2NDMxWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvM2UwYjA0YmQtYWNl
+        Yy00N2Y2LTgyMzEtMjY4ZGNiNmY0MDk3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDk6MDMuODczMDM0WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5leHBvcnQucHVscF9leHBv
-        cnQiLCJsb2dnaW5nX2NpZCI6ImYxNGY4YzZmNDBkMTRjNDNhYTVmZDAzZWRh
-        NmJjYjkxIiwic3RhcnRlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NTAuNDk0
-        OTE1WiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wNy0xOVQxODo0Njo1MC45Njky
-        OTdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzBmMjMwNTg2LWIwNzUtNGE5NC1hY2QyLWFmNWE2NzMyOTQ1MS8iLCJw
+        cnQiLCJsb2dnaW5nX2NpZCI6IjljNmI4NjBjNTJlZTQ1NWViNDE0OGJiNmM2
+        ODk0MzZkIiwic3RhcnRlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDk6MDMuOTA5
+        MDQxWiIsImZpbmlzaGVkX2F0IjoiMjAyMi0wOC0yMlQyMTo0OTowNC4zODY5
+        NDBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzL2Q4NzU4MGI4LTA1ODYtNGNiYy1iYWNlLTMxNzVjZjBmZDcyNy8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRXhwb3J0
         aW5nIEFydGlmYWN0cyIsImNvZGUiOiJleHBvcnQuYXJ0aWZhY3RzIiwic3Rh
@@ -1732,16 +1732,16 @@ http_interactions:
         b3J0LnJlcG8udmVyc2lvbi5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQi
         LCJ0b3RhbCI6MzYsImRvbmUiOjM2LCJzdWZmaXgiOm51bGx9XSwiY3JlYXRl
         ZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2V4cG9ydGVycy9jb3JlL3B1
-        bHAvYTA2OTc3MWYtMzQ3OS00OTE1LWEzMDQtZjdkOTQ3Njg3NjFmL2V4cG9y
-        dHMvYzRhYWVkZTItNzQ3YS00ZjA4LWI5YzEtYzI3MWI5ZTk4MWYwLyJdLCJy
+        bHAvYTI3YzUxNjktMmYxNS00NDkxLTg2YTUtODM5OWEwMzM5ZDMxL2V4cG9y
+        dHMvMjQ0YTk5MmUtODI1MC00MzUxLWJmNWUtYzVlZWUxY2ZjNTlkLyJdLCJy
         ZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9leHBv
-        cnRlcnMvY29yZS9wdWxwL2EwNjk3NzFmLTM0NzktNDkxNS1hMzA0LWY3ZDk0
-        NzY4NzYxZi8iXX0=
+        cnRlcnMvY29yZS9wdWxwL2EyN2M1MTY5LTJmMTUtNDQ5MS04NmE1LTgzOTlh
+        MDMzOWQzMS8iXX0=
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:04 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/a069771f-3479-4915-a304-f7d94768761f/exports/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/exporters/core/pulp/a27c5169-2f15-4491-86a5-8399a0339d31/exports/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1749,7 +1749,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1762,65 +1762,65 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:51 GMT
+      - Mon, 22 Aug 2022 21:49:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1221'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - ddb3bcfc994747de8464bbf70cce5b4a
+      - 7410b653c0384e29a8bbb20e5b3254bf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '546'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9leHBvcnRlcnMvY29y
-        ZS9wdWxwL2EwNjk3NzFmLTM0NzktNDkxNS1hMzA0LWY3ZDk0NzY4NzYxZi9l
-        eHBvcnRzL2M0YWFlZGUyLTc0N2EtNGYwOC1iOWMxLWMyNzFiOWU5ODFmMC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjUwLjYyMDE4NFoi
-        LCJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YzYjRjNmE5LTc0YTctNDFj
-        My04NGJhLTVmMDZhOTA1ZTUwYy8iLCJleHBvcnRlZF9yZXNvdXJjZXMiOlsi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2MzZDBmZTBlLTlm
-        OTItNDc5ZC1iM2M1LWZhMTEwNWQyZjQzYi92ZXJzaW9ucy8xLyJdLCJwYXJh
+        ZS9wdWxwL2EyN2M1MTY5LTJmMTUtNDQ5MS04NmE1LTgzOTlhMDMzOWQzMS9l
+        eHBvcnRzLzI0NGE5OTJlLTgyNTAtNDM1MS1iZjVlLWM1ZWVlMWNmYzU5ZC8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA4LTIyVDIxOjQ5OjA0LjA1NjI1N1oi
+        LCJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNlMGIwNGJkLWFjZWMtNDdm
+        Ni04MjMxLTI2OGRjYjZmNDA5Ny8iLCJleHBvcnRlZF9yZXNvdXJjZXMiOlsi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2ExMTJlNzY3LWYx
+        NWMtNDViYS04YjcwLTZkZjMxMjJiZTRjZi92ZXJzaW9ucy8xLyJdLCJwYXJh
         bXMiOnsidmVyc2lvbnMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
-        cG0vcnBtL2MzZDBmZTBlLTlmOTItNDc5ZC1iM2M1LWZhMTEwNWQyZjQzYi92
+        cG0vcnBtL2ExMTJlNzY3LWYxNWMtNDViYS04YjcwLTZkZjMxMjJiZTRjZi92
         ZXJzaW9ucy8xLyJdLCJjaHVua19zaXplIjoiMC4xR0IifSwib3V0cHV0X2Zp
         bGVfaW5mbyI6eyIvdmFyL2xpYi9wdWxwL2V4cG9ydHMvRW1wdHlfT3JnYW5p
-        emF0aW9uL0FDTUUgRGVmYXVsdCBDb250ZW50Vmlldy8xLjAvZm9vL2RhdGVf
-        ZGlyL2V4cG9ydC1jNGFhZWRlMi03NDdhLTRmMDgtYjljMS1jMjcxYjllOTgx
-        ZjAtMjAyMjA3MTlfMTg0Ni10b2MuanNvbiI6IjAzZmY0MzZjN2JkMGZjNDhh
-        ODFmMTYxYmQxZDA1NjZjZjg4MDUxMDY4MzFjZTcyOGJmZjc2ZGIwYjAzZTRl
-        MjIiLCIvdmFyL2xpYi9wdWxwL2V4cG9ydHMvRW1wdHlfT3JnYW5pemF0aW9u
-        L0FDTUUgRGVmYXVsdCBDb250ZW50Vmlldy8xLjAvZm9vL2RhdGVfZGlyL2V4
-        cG9ydC1jNGFhZWRlMi03NDdhLTRmMDgtYjljMS1jMjcxYjllOTgxZjAtMjAy
-        MjA3MTlfMTg0Ni50YXIuZ3ouMDAwMCI6ImEwNmUzNDJjM2RmMGRiMDlhYzE1
-        MTc4MGVmNmM0MzZiMjE1NzViZGVkNGFiMjI5YmM3OTJjNzJhM2VmY2ZiMGQi
-        fSwidG9jX2luZm8iOnsiZmlsZSI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9F
-        bXB0eV9Pcmdhbml6YXRpb24vQUNNRSBEZWZhdWx0IENvbnRlbnRWaWV3LzEu
-        MC9mb28vZGF0ZV9kaXIvZXhwb3J0LWM0YWFlZGUyLTc0N2EtNGYwOC1iOWMx
-        LWMyNzFiOWU5ODFmMC0yMDIyMDcxOV8xODQ2LXRvYy5qc29uIiwic2hhMjU2
-        IjoiMDNmZjQzNmM3YmQwZmM0OGE4MWYxNjFiZDFkMDU2NmNmODgwNTEwNjgz
-        MWNlNzI4YmZmNzZkYjBiMDNlNGUyMiJ9fV19
+        emF0aW9uL29yZ19kZWZhdWx0X2xhYmVsLzEuMC9mb28vZGF0ZV9kaXIvZXhw
+        b3J0LTI0NGE5OTJlLTgyNTAtNDM1MS1iZjVlLWM1ZWVlMWNmYzU5ZC0yMDIy
+        MDgyMl8yMTQ5LXRvYy5qc29uIjoiYmZiZjRhNjVlMmVhZGMzY2YwODg2ZTU1
+        MmM1NmE3ZGE2MmE3NzRhMzE2OWJlZWU2MjQ4OTVjZjlmZjA5ZDg2NiIsIi92
+        YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9Pcmdhbml6YXRpb24vb3JnX2Rl
+        ZmF1bHRfbGFiZWwvMS4wL2Zvby9kYXRlX2Rpci9leHBvcnQtMjQ0YTk5MmUt
+        ODI1MC00MzUxLWJmNWUtYzVlZWUxY2ZjNTlkLTIwMjIwODIyXzIxNDkudGFy
+        Lmd6LjAwMDAiOiI0Y2FiMDUzMjkwZjNlYzRiMDU5OGU2MzBiNjdjZjc4Y2Q4
+        MGRiYjRiOWNmOWM5MTlhMTdjYzFmNmE3NzMyNGE4In0sInRvY19pbmZvIjp7
+        ImZpbGUiOiIvdmFyL2xpYi9wdWxwL2V4cG9ydHMvRW1wdHlfT3JnYW5pemF0
+        aW9uL29yZ19kZWZhdWx0X2xhYmVsLzEuMC9mb28vZGF0ZV9kaXIvZXhwb3J0
+        LTI0NGE5OTJlLTgyNTAtNDM1MS1iZjVlLWM1ZWVlMWNmYzU5ZC0yMDIyMDgy
+        Ml8yMTQ5LXRvYy5qc29uIiwic2hhMjU2IjoiYmZiZjRhNjVlMmVhZGMzY2Yw
+        ODg2ZTU1MmM1NmE3ZGE2MmE3NzRhMzE2OWJlZWU2MjQ4OTVjZjlmZjA5ZDg2
+        NiJ9fV19
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:04 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/c3d0fe0e-9f92-479d-b3c5-fa1105d2f43b/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/a112e767-f15c-45ba-8b70-6df3122be4cf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1828,7 +1828,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -1841,40 +1841,40 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:51 GMT
+      - Mon, 22 Aug 2022 21:49:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '631'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 83f06e481eb048ecb92dbe699b031a39
+      - '0764651681b9405cada94ef1c1f2c22b'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '287'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1ZDJmNDNiLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjItMDctMTlUMTg6NDY6NDYuMDAwMjk1WiIsInZl
+        cG0vYTExMmU3NjctZjE1Yy00NWJhLThiNzAtNmRmMzEyMmJlNGNmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjItMDgtMjJUMjE6NDg6NTkuNzIzMzc2WiIsInZl
         cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vYzNkMGZlMGUtOWY5Mi00NzlkLWIzYzUtZmExMTA1ZDJmNDNiL3ZlcnNp
+        cG0vYTExMmU3NjctZjE1Yy00NWJhLThiNzAtNmRmMzEyMmJlNGNmL3ZlcnNp
         b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9jM2QwZmUwZS05
-        ZjkyLTQ3OWQtYjNjNS1mYTExMDVkMmY0M2IvdmVyc2lvbnMvMS8iLCJuYW1l
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS9hMTEyZTc2Ny1m
+        MTVjLTQ1YmEtOGI3MC02ZGYzMTIyYmU0Y2YvdmVyc2lvbnMvMS8iLCJuYW1l
         IjoiMl9kdXBsaWNhdGUiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3Jl
         cG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2gi
         OmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJldGFp
@@ -1883,10 +1883,10 @@ http_interactions:
         IjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZhbHNl
         fQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:04 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/a069771f-3479-4915-a304-f7d94768761f/exports/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/exporters/core/pulp/a27c5169-2f15-4491-86a5-8399a0339d31/exports/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1894,7 +1894,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1907,65 +1907,65 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:51 GMT
+      - Mon, 22 Aug 2022 21:49:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '1221'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 67dcc91bfb444cd89f0d27a4a95c8902
+      - 560f9829b9184e30a9148ce08a1b313a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '546'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9leHBvcnRlcnMvY29y
-        ZS9wdWxwL2EwNjk3NzFmLTM0NzktNDkxNS1hMzA0LWY3ZDk0NzY4NzYxZi9l
-        eHBvcnRzL2M0YWFlZGUyLTc0N2EtNGYwOC1iOWMxLWMyNzFiOWU5ODFmMC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA3LTE5VDE4OjQ2OjUwLjYyMDE4NFoi
-        LCJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YzYjRjNmE5LTc0YTctNDFj
-        My04NGJhLTVmMDZhOTA1ZTUwYy8iLCJleHBvcnRlZF9yZXNvdXJjZXMiOlsi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2MzZDBmZTBlLTlm
-        OTItNDc5ZC1iM2M1LWZhMTEwNWQyZjQzYi92ZXJzaW9ucy8xLyJdLCJwYXJh
+        ZS9wdWxwL2EyN2M1MTY5LTJmMTUtNDQ5MS04NmE1LTgzOTlhMDMzOWQzMS9l
+        eHBvcnRzLzI0NGE5OTJlLTgyNTAtNDM1MS1iZjVlLWM1ZWVlMWNmYzU5ZC8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDIyLTA4LTIyVDIxOjQ5OjA0LjA1NjI1N1oi
+        LCJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNlMGIwNGJkLWFjZWMtNDdm
+        Ni04MjMxLTI2OGRjYjZmNDA5Ny8iLCJleHBvcnRlZF9yZXNvdXJjZXMiOlsi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2ExMTJlNzY3LWYx
+        NWMtNDViYS04YjcwLTZkZjMxMjJiZTRjZi92ZXJzaW9ucy8xLyJdLCJwYXJh
         bXMiOnsidmVyc2lvbnMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9y
-        cG0vcnBtL2MzZDBmZTBlLTlmOTItNDc5ZC1iM2M1LWZhMTEwNWQyZjQzYi92
+        cG0vcnBtL2ExMTJlNzY3LWYxNWMtNDViYS04YjcwLTZkZjMxMjJiZTRjZi92
         ZXJzaW9ucy8xLyJdLCJjaHVua19zaXplIjoiMC4xR0IifSwib3V0cHV0X2Zp
         bGVfaW5mbyI6eyIvdmFyL2xpYi9wdWxwL2V4cG9ydHMvRW1wdHlfT3JnYW5p
-        emF0aW9uL0FDTUUgRGVmYXVsdCBDb250ZW50Vmlldy8xLjAvZm9vL2RhdGVf
-        ZGlyL2V4cG9ydC1jNGFhZWRlMi03NDdhLTRmMDgtYjljMS1jMjcxYjllOTgx
-        ZjAtMjAyMjA3MTlfMTg0Ni10b2MuanNvbiI6IjAzZmY0MzZjN2JkMGZjNDhh
-        ODFmMTYxYmQxZDA1NjZjZjg4MDUxMDY4MzFjZTcyOGJmZjc2ZGIwYjAzZTRl
-        MjIiLCIvdmFyL2xpYi9wdWxwL2V4cG9ydHMvRW1wdHlfT3JnYW5pemF0aW9u
-        L0FDTUUgRGVmYXVsdCBDb250ZW50Vmlldy8xLjAvZm9vL2RhdGVfZGlyL2V4
-        cG9ydC1jNGFhZWRlMi03NDdhLTRmMDgtYjljMS1jMjcxYjllOTgxZjAtMjAy
-        MjA3MTlfMTg0Ni50YXIuZ3ouMDAwMCI6ImEwNmUzNDJjM2RmMGRiMDlhYzE1
-        MTc4MGVmNmM0MzZiMjE1NzViZGVkNGFiMjI5YmM3OTJjNzJhM2VmY2ZiMGQi
-        fSwidG9jX2luZm8iOnsiZmlsZSI6Ii92YXIvbGliL3B1bHAvZXhwb3J0cy9F
-        bXB0eV9Pcmdhbml6YXRpb24vQUNNRSBEZWZhdWx0IENvbnRlbnRWaWV3LzEu
-        MC9mb28vZGF0ZV9kaXIvZXhwb3J0LWM0YWFlZGUyLTc0N2EtNGYwOC1iOWMx
-        LWMyNzFiOWU5ODFmMC0yMDIyMDcxOV8xODQ2LXRvYy5qc29uIiwic2hhMjU2
-        IjoiMDNmZjQzNmM3YmQwZmM0OGE4MWYxNjFiZDFkMDU2NmNmODgwNTEwNjgz
-        MWNlNzI4YmZmNzZkYjBiMDNlNGUyMiJ9fV19
+        emF0aW9uL29yZ19kZWZhdWx0X2xhYmVsLzEuMC9mb28vZGF0ZV9kaXIvZXhw
+        b3J0LTI0NGE5OTJlLTgyNTAtNDM1MS1iZjVlLWM1ZWVlMWNmYzU5ZC0yMDIy
+        MDgyMl8yMTQ5LXRvYy5qc29uIjoiYmZiZjRhNjVlMmVhZGMzY2YwODg2ZTU1
+        MmM1NmE3ZGE2MmE3NzRhMzE2OWJlZWU2MjQ4OTVjZjlmZjA5ZDg2NiIsIi92
+        YXIvbGliL3B1bHAvZXhwb3J0cy9FbXB0eV9Pcmdhbml6YXRpb24vb3JnX2Rl
+        ZmF1bHRfbGFiZWwvMS4wL2Zvby9kYXRlX2Rpci9leHBvcnQtMjQ0YTk5MmUt
+        ODI1MC00MzUxLWJmNWUtYzVlZWUxY2ZjNTlkLTIwMjIwODIyXzIxNDkudGFy
+        Lmd6LjAwMDAiOiI0Y2FiMDUzMjkwZjNlYzRiMDU5OGU2MzBiNjdjZjc4Y2Q4
+        MGRiYjRiOWNmOWM5MTlhMTdjYzFmNmE3NzMyNGE4In0sInRvY19pbmZvIjp7
+        ImZpbGUiOiIvdmFyL2xpYi9wdWxwL2V4cG9ydHMvRW1wdHlfT3JnYW5pemF0
+        aW9uL29yZ19kZWZhdWx0X2xhYmVsLzEuMC9mb28vZGF0ZV9kaXIvZXhwb3J0
+        LTI0NGE5OTJlLTgyNTAtNDM1MS1iZjVlLWM1ZWVlMWNmYzU5ZC0yMDIyMDgy
+        Ml8yMTQ5LXRvYy5qc29uIiwic2hhMjU2IjoiYmZiZjRhNjVlMmVhZGMzY2Yw
+        ODg2ZTU1MmM1NmE3ZGE2MmE3NzRhMzE2OWJlZWU2MjQ4OTVjZjlmZjA5ZDg2
+        NiJ9fV19
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:04 GMT
 - request:
     method: patch
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/a069771f-3479-4915-a304-f7d94768761f/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/exporters/core/pulp/a27c5169-2f15-4491-86a5-8399a0339d31/
     body:
       encoding: UTF-8
       base64_string: 'eyJsYXN0X2V4cG9ydCI6bnVsbH0=
@@ -1975,7 +1975,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -1988,7 +1988,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:51 GMT
+      - Mon, 22 Aug 2022 21:49:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2006,21 +2006,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - d322adf0125d4fa0aa8ca37577c0008f
+      - 15d503538ed842f4ba5236fcc502cd3a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkMmEwNDRlLWExZDUtNDg5
-        MC04ZTcyLWMxMzg0ODY3ODNiYS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM2YjhmZjg5LWZkMzItNGYy
+        MC05NDUxLWNhZjMzNzI3NzYwNC8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:04 GMT
 - request:
     method: delete
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/a069771f-3479-4915-a304-f7d94768761f/exports/c4aaede2-747a-4f08-b9c1-c271b9e981f0/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/exporters/core/pulp/a27c5169-2f15-4491-86a5-8399a0339d31/exports/244a992e-8250-4351-bf5e-c5eee1cfc59d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2028,7 +2028,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Authorization:
       - Basic Og==
       Accept-Encoding:
@@ -2041,7 +2041,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:51 GMT
+      - Mon, 22 Aug 2022 21:49:04 GMT
       Server:
       - gunicorn
       Vary:
@@ -2055,19 +2055,19 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 31c55e0003f1451293c1c7ca3235d5ec
+      - 9d9502549cdd40f08a3b5bb3f5ce2349
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:04 GMT
 - request:
     method: delete
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/exporters/core/pulp/a069771f-3479-4915-a304-f7d94768761f/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/exporters/core/pulp/a27c5169-2f15-4491-86a5-8399a0339d31/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2075,7 +2075,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2088,7 +2088,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:51 GMT
+      - Mon, 22 Aug 2022 21:49:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2106,21 +2106,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 04a864a8b58842f8ae7e447aeac5d786
+      - 865be0c9c95a43e8bb698825c437ee06
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZlMzhmODgzLWQ1OGQtNGRi
-        Ni1hNTNlLTUwMDc4MDM0ODQ4OC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEzM2M0ZWUwLWY0NDctNDYy
+        YS04MmIzLWE1M2NhOTJjY2IwZS8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:04 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/6e38f883-d58d-4db6-a53e-500780348488/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/133c4ee0-f447-462a-82b3-a53ca92ccb0e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2128,7 +2128,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2141,51 +2141,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:51 GMT
+      - Mon, 22 Aug 2022 21:49:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '606'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 2b2cf937cbd94707b39f40738fe6d66f
+      - bc584e95c8da4a89b432dbb7cb9eb294
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '369'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNmUzOGY4ODMtZDU4
-        ZC00ZGI2LWE1M2UtNTAwNzgwMzQ4NDg4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NTEuNDUwMzcwWiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMTMzYzRlZTAtZjQ0
+        Ny00NjJhLTgyYjMtYTUzY2E5MmNjYjBlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDk6MDQuODU3NTY2WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIwNGE4NjRhOGI1ODg0MmY4YWU3ZTQ0N2Fl
-        YWM1ZDc4NiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjUxLjQ5
-        MzEwOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NTEuNTIy
-        NDM4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy81MWI3NmQzNS1hYTBhLTQ0OTMtYmVlNS0xZTdlZTJmZmVjMTQvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4NjViZTBjOWM5NWE0M2U4YmI2OTg4MjVj
+        NDM3ZWUwNiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ5OjA0Ljg5
+        MTA0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDk6MDQuOTE3
+        Nzg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9iMGNhMTE4YS05NDk3LTRjYjktOTdjYi1kMjMzZTIyOWU5ZjYvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVscC9hMDY5NzcxZi0zNDc5LTQ5MTUt
-        YTMwNC1mN2Q5NDc2ODc2MWYvIl19
+        cGkvdjMvZXhwb3J0ZXJzL2NvcmUvcHVscC9hMjdjNTE2OS0yZjE1LTQ0OTEt
+        ODZhNS04Mzk5YTAzMzlkMzEvIl19
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:04 GMT
 - request:
     method: delete
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/remotes/rpm/rpm/d63541bf-e3d9-47a1-98aa-a4ee71ab120c/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/02abc97c-3209-4418-bc0f-c34c339ec1af/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2193,7 +2193,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -2206,7 +2206,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:51 GMT
+      - Mon, 22 Aug 2022 21:49:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2224,21 +2224,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 362c8d713ff7468aae2edeee3bc29f05
+      - 56cdc34be29a446ca79f681d19eff61f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FmZTk1Yjg3LWYxOTAtNDc2
-        Ny05NzlkLWU3Y2U4ZTE1ZWRiZS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk5YTVmNmQ5LTM2NGEtNDMw
+        Yy04MDhjLWE5YTY2MjFkZDIyZS8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:05 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/afe95b87-f190-4767-979d-e7ce8e15edbe/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/99a5f6d9-364a-430c-808c-a9a6621dd22e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2246,7 +2246,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2259,51 +2259,51 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:51 GMT
+      - Mon, 22 Aug 2022 21:49:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '602'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - 9c1382b0cad34d23ae0b145614e61648
+      - 2d6c6c32fe0944419df319b97fc946ea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '372'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWZlOTViODctZjE5
-        MC00NzY3LTk3OWQtZTdjZThlMTVlZGJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NTEuODU1NjI4WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOTlhNWY2ZDktMzY0
+        YS00MzBjLTgwOGMtYTlhNjYyMWRkMjJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDk6MDUuMjYyNTYyWiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiIzNjJjOGQ3MTNmZjc0NjhhYWUyZWRlZWUz
-        YmMyOWYwNSIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjUxLjkw
-        NDE2OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NTEuOTUy
-        MTQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy8zNjAxYmE4OC1hYzM2LTQwNzctYjhhNC04YTA3ODlmYzJkOGMvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1NmNkYzM0YmUyOWE0NDZjYTc5ZjY4MWQx
+        OWVmZjYxZiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ5OjA1LjI5
+        NTEzMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDk6MDUuMzM1
+        NjY0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9kODc1ODBiOC0wNTg2LTRjYmMtYmFjZS0zMTc1Y2YwZmQ3MjcvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtL2Q2MzU0MWJmLWUzZDktNDdhMS05OGFh
-        LWE0ZWU3MWFiMTIwYy8iXX0=
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAyYWJjOTdjLTMyMDktNDQxOC1iYzBm
+        LWMzNGMzMzllYzFhZi8iXX0=
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:51 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:05 GMT
 - request:
     method: delete
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/distributions/rpm/rpm/a6ecdaa0-fe1f-4250-829f-6794c89280c6/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/d591fc55-3843-4ba7-a165-34e95b5ec3d5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2311,7 +2311,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -2324,7 +2324,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:52 GMT
+      - Mon, 22 Aug 2022 21:49:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2342,21 +2342,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - e1eee041624f43ac86487b5f2ffabf7c
+      - 119e682d0d1b461cb0a0e4c0cf081f0d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UyMzE3NmNmLTY1ODgtNDc0
-        Ni1hMjMyLTlkY2QwMmJkNjM0NC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ5YzZlNDRkLTVkNTgtNGI0
+        OS1hNzZjLWY1YjI2OWQxZjBjYS8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:52 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:05 GMT
 - request:
     method: delete
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/repositories/rpm/rpm/c3d0fe0e-9f92-479d-b3c5-fa1105d2f43b/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/a112e767-f15c-45ba-8b70-6df3122be4cf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2364,7 +2364,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.17.7/ruby
+      - OpenAPI-Generator/3.17.11/ruby
       Accept:
       - application/json
       Authorization:
@@ -2377,7 +2377,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:52 GMT
+      - Mon, 22 Aug 2022 21:49:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2395,21 +2395,21 @@ http_interactions:
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - f09b5ab842c04410a12b2a9bf843e472
+      - d58e22f5353e427abcf8bc27da577fc3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ViOTdmODdkLWU4NmYtNDYy
-        OS1hYjdkLTYxZjI4NzZlNWMxZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FmNGZlN2ZkLWNmNzktNDdk
+        MS04MTNlLWJhZDY2ODg1OWRhZi8ifQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:52 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:05 GMT
 - request:
     method: get
-    uri: https://zanzibar.lagrange.example.com/pulp/api/v3/tasks/eb97f87d-e86f-4629-ab7d-61f2876e5c1d/
+    uri: https://centos7-katello-devel-stable.example.com/pulp/api/v3/tasks/af4fe7fd-cf79-47d1-813e-bad668859daf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2417,7 +2417,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.18.5/ruby
+      - OpenAPI-Generator/3.18.7/ruby
       Accept:
       - application/json
       Authorization:
@@ -2430,46 +2430,46 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jul 2022 18:46:52 GMT
+      - Mon, 22 Aug 2022 21:49:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie,Accept-Encoding
+      - Accept,Cookie
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
+      Content-Length:
+      - '607'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
       - same-origin
       Correlation-Id:
-      - a1244afedacd4dda99dce716398c9a7d
+      - d2fb918bb7684420a0ce09effbce3e93
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 zanzibar.lagrange.example.com
-      Content-Length:
-      - '373'
+      - 1.1 centos7-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZWI5N2Y4N2QtZTg2
-        Zi00NjI5LWFiN2QtNjFmMjg3NmU1YzFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjItMDctMTlUMTg6NDY6NTIuMTQyNDU0WiIsInN0YXRlIjoiY29tcGxldGVk
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYWY0ZmU3ZmQtY2Y3
+        OS00N2QxLTgxM2UtYmFkNjY4ODU5ZGFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjItMDgtMjJUMjE6NDk6MDUuNTA5OTQ4WiIsInN0YXRlIjoiY29tcGxldGVk
         IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
-        ZXRlIiwibG9nZ2luZ19jaWQiOiJmMDliNWFiODQyYzA0NDEwYTEyYjJhOWJm
-        ODQzZTQ3MiIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA3LTE5VDE4OjQ2OjUyLjE5
-        MTcyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDctMTlUMTg6NDY6NTIuMzEy
-        MDIxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
-        a2Vycy81MWI3NmQzNS1hYTBhLTQ0OTMtYmVlNS0xZTdlZTJmZmVjMTQvIiwi
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJkNThlMjJmNTM1M2U0MjdhYmNmOGJjMjdk
+        YTU3N2ZjMyIsInN0YXJ0ZWRfYXQiOiIyMDIyLTA4LTIyVDIxOjQ5OjA1LjU0
+        MDMzNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjItMDgtMjJUMjE6NDk6MDUuNjY2
+        MTUyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy9iMGNhMTE4YS05NDk3LTRjYjktOTdjYi1kMjMzZTIyOWU5ZjYvIiwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYzNkMGZlMGUtOWY5Mi00Nzlk
-        LWIzYzUtZmExMTA1ZDJmNDNiLyJdfQ==
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vYTExMmU3NjctZjE1Yy00NWJh
+        LThiNzAtNmRmMzEyMmJlNGNmLyJdfQ==
     http_version: 
-  recorded_at: Tue, 19 Jul 2022 18:46:52 GMT
+  recorded_at: Mon, 22 Aug 2022 21:49:05 GMT
 recorded_with: VCR 3.0.3

--- a/test/services/katello/pulp3/content_view_version/export_test.rb
+++ b/test/services/katello/pulp3/content_view_version/export_test.rb
@@ -160,10 +160,17 @@ module Katello
             assert_match(/Specify an export chunk size less than 1_000_000 GB/, exception.message)
           end
 
-          def setup_environment
+          it "Generates Exporter path correctly" do
+            cvv = katello_content_view_versions(:library_view_solve_deps_version)
+            export = setup_environment(version: :library_view_solve_deps_version)
+            assert_includes export.generate_exporter_path, cvv.content_view.label
+            refute_includes export.generate_exporter_path, ' '
+          end
+
+          def setup_environment(version: :library_view_version_2)
             proxy = SmartProxy.pulp_primary
             SmartProxy.any_instance.stubs(:pulp_primary).returns(proxy)
-            version = katello_content_view_versions(:library_view_version_2)
+            version = katello_content_view_versions(version)
             fetch_exporter(smart_proxy: proxy, content_view_version: version)
           end
         end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
When exporting a content view version with a space its name we include that space in the generated path. Its not necessarily a bug but ideally we'd like path to be something like -> 
`/var/lib/pulp/exports/Test_Organization/Test_CV/1.0/2022-08-03T00-17-11-00-00/metadata.json`
vs 
`/var/lib/pulp/exports/Test_Organization/Test CV/1.0/2022-08-03T00-17-11-00-00/metadata.json`

The cv name without and with space.

#### Considerations taken when implementing this change?
This issue was introduced when the previous syncable export work got merged and got caught on bats tests. So useful.

#### What are the testing steps for this pull request?
- Create a CV name with a space in it
- Add a simple custom repo or rh repo with `immediate` download policy
- Publish
- Export the content view version via hammer. 
 - `hammer content-export complete version --id=<cvv-id>`
 
Before this PR, you 'd see something like

`/var/lib/pulp/exports/Test_Organization/Test CV/1.0/2022-08-03T00-17-11-00-00/metadata.json` with the space

After this PR

`/var/lib/pulp/exports/Test_Organization/Test_CV/1.0/2022-08-03T00-17-11-00-00/metadata.json` with the space
