### PR TITLE
Fixes #35336 - System purpose card should not show when host is unregistered

### DIFF
--- a/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeCard.js
@@ -27,7 +27,7 @@ import { propsToCamelCase } from 'foremanReact/common/helpers';
 import './SystemPurposeCard.scss';
 import SystemPurposeEditModal from './SystemPurposeEditModal';
 import { selectHostDetailsStatus } from '../../HostDetailsSelectors';
-import { hasRequiredPermissions } from '../../hostDetailsHelpers';
+import { hasRequiredPermissions, hostIsNotRegistered } from '../../hostDetailsHelpers';
 
 const SystemPurposeCard = ({ hostDetails }) => {
   const showEditButton = hasRequiredPermissions(['edit_hosts'], hostDetails?.permissions);
@@ -56,6 +56,8 @@ const SystemPurposeCard = ({ hostDetails }) => {
       </GridItem>
     );
   }
+
+  if (hostIsNotRegistered({ hostDetails })) return null;
 
   return (
     <GridItem rowSpan={1} md={6} lg={4} xl2={3}>

--- a/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/__tests__/SystemPurposeCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/__tests__/SystemPurposeCard.test.js
@@ -20,6 +20,7 @@ const baseHostDetails = {
     purpose_usage: 'Production',
     service_level: 'Premium',
     release_version: '8',
+    uuid: '12345',
   },
 };
 

--- a/webpack/components/extensions/HostDetails/DetailsTabCards/HwPropertiesCard.js
+++ b/webpack/components/extensions/HostDetails/DetailsTabCards/HwPropertiesCard.js
@@ -12,6 +12,7 @@ import {
 } from '@patternfly/react-core';
 import CardTemplate from 'foremanReact/components/HostDetails/Templates/CardItem/CardTemplate';
 import { TranslatedPlural } from '../../../Table/components/TranslatedPlural';
+import { hostIsNotRegistered } from '../hostDetailsHelpers';
 
 const HostDisks = ({ totalDisks }) => {
   if (!totalDisks) return null;
@@ -32,6 +33,7 @@ HostDisks.defaultProps = {
 };
 
 const HwPropertiesCard = ({ isExpandedGlobal, hostDetails }) => {
+  if (hostIsNotRegistered({ hostDetails })) return null;
   const { facts } = hostDetails || {};
   const model = facts?.['virt::host_type'];
   const cpuCount = facts?.['cpu::cpu(s)'];


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The system purpose card was trying to render even for unregistered hosts. This breaks the entire host details page.

This change will check if the host is registered before rendering the system purpose card.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Check that the new host detail page renders properly with both registered and unregistered hosts.