### PR TITLE
Fixes #35337 - Index ModuleStreamErratumPackages correctly in first run

### DIFF
--- a/app/services/katello/pulp3/erratum.rb
+++ b/app/services/katello/pulp3/erratum.rb
@@ -55,12 +55,15 @@ module Katello
           bugzillas += build_bugzillas(katello_id, unit['references'])
           cves += build_cves(katello_id, unit['references'])
           packages += build_packages(katello_id, unit['pkglist'])
-          modules += build_modules(katello_id, unit['pkglist'])
         end
 
         Katello::ErratumBugzilla.insert_all(bugzillas, unique_by: [:erratum_id, :bug_id, :href]) if bugzillas.any?
         Katello::ErratumCve.insert_all(cves, unique_by: [:erratum_id, :cve_id, :href]) if cves.any?
         Katello::ErratumPackage.insert_all(packages, unique_by: [:erratum_id, :nvrea, :name, :filename]) if packages.any?
+        units.each do |unit|
+          katello_id = pulp_id_to_id[unit['id']]
+          modules += build_modules(katello_id, unit['pkglist'])
+        end
         ModuleStreamErratumPackage.insert_all(modules, unique_by: [:module_stream_id, :erratum_package_id]) if modules.any?
         nil
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Allow ErratumPackages to be saved before building and saving ModuleStreamErratumPackages
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1. Sync Appstream repo for example.
2. In console: `Katello::ModuleStreamErratumPackage.count` 
3. This will return 0 after first sync on master.
4. On this branch, it should correctly index and Katello::ModuleStreamErratumPackage.count should be > 0