### PR TITLE
Fixes #35341 - Unpin faraday

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -53,7 +53,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "anemone"
 
   #pulp3
-  gem.add_dependency "faraday", "< 1.9"
   gem.add_dependency "pulpcore_client", ">= 3.18.0", "< 3.19.0"
   gem.add_dependency "pulp_file_client", ">= 1.10.0", "< 1.11.0"
   gem.add_dependency "pulp_ansible_client", ">= 0.13.1", "< 0.14"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This reverts commit 64b10e968117c79a441e3f9f1f253605722b2557. The individual pulp gems have Faraday pins and makes this redundant. It only hinders updating to Faraday.

#### Considerations taken when implementing this change?

While the Pulp gems don't allow Faraday 1.x, I manually applied https://github.com/pulp/pulp-openapi-generator/pull/77 and made sure `bundle show faraday` was new enough (1.10.1).

To really update Faraday, we'll need all new gem releases.

#### What are the testing steps for this pull request?

Previously it was mentioned that `test/services/katello/pulp3/content_test.rb` failed, so I manually ran that and it passed.