### PR TITLE
Fixes #35120 - Indexing with additive content

### DIFF
--- a/app/services/katello/content_unit_indexer.rb
+++ b/app/services/katello/content_unit_indexer.rb
@@ -22,7 +22,6 @@ module Katello
     end
 
     def import_all(filtered_indexing = false)
-      additive = filtered_indexing || (@repository&.mirroring_policy == 'additive')
       association_tracker = RepoAssociationTracker.new(@content_type, @service_class, @repository)
       units_from_pulp.each do |units|
         units.each do |unit|
@@ -52,7 +51,7 @@ module Katello
       end
 
       if @model_class.many_repository_associations && @repository
-        sync_repository_associations(association_tracker, additive: additive)
+        sync_repository_associations(association_tracker, additive: filtered_indexing)
       end
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
We should not enforce "additive" indexing. Sync_policy (mirroring_policy on the UI) should be enforced at the time of sync and passed to pulp.(Happens currently). Once pulp syncs according to the provided policy, katello should trust pulp as source of truth and not force additive content beyond what pulp does. 
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a yum repo with URL : https://fixtures.pulpproject.org/rpm-unsigned/
2. Set Mirroring Policy to "Additive" and Retain package versions to 5
3. Sync repo.
4. You should have 35 rpms.
5. Edit repo and set Retain package versions to 1.
6. Complete sync the repo

Without change: Pulp will have a new version of repo with 31 rpms. Katello still shows 35 rpms.
With change: Pulp and katello rpms count will match.