### PR TITLE
Fixes #35360 - Add all certificates from provided bundle to cert_store

### DIFF
--- a/app/lib/katello/resources/cdn.rb
+++ b/app/lib/katello/resources/cdn.rb
@@ -42,13 +42,18 @@ module Katello
 
           if options[:ssl_ca_cert].present?
             begin
-              ca_cert = OpenSSL::X509::Certificate.new(options[:ssl_ca_cert])
+              @cert_store = OpenSSL::X509::Store.new
+              delimiter = "-----END CERTIFICATE-----"
+              ca_bundle = options[:ssl_ca_cert].split(delimiter)
+              ca_bundle.each do |ca_bundle_split|
+                ca_bundle_split += delimiter
+                ca_cert = OpenSSL::X509::Certificate.new(ca_bundle_split)
+                @cert_store.add_cert(ca_cert)
+              end
             rescue
               raise _("Invalid SSL CA certificate given for CDN")
             end
 
-            @cert_store = OpenSSL::X509::Store.new
-            @cert_store.add_cert(ca_cert)
           end
 
           @url = url


### PR DESCRIPTION
Current code only adds the first certificate from a bundle to the
cert_store. With this change, it will iterate over all certificates
from a provided CA bundle and add each one of them o the cert_store
used by katello to communicate with an upstream server.

