### PR TITLE
Fixes #34973 - New host details: Hide module streams tab for EL7 hosts

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/ContentTab/constants.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ContentTab/constants.js
@@ -1,10 +1,11 @@
 import { translate as __ } from 'foremanReact/common/I18n';
 import { hideRepoSetsTab } from '../RepositorySetsTab/RepositorySetsTab';
+import { hideModuleStreamsTab } from '../ModuleStreamsTab/ModuleStreamsTab';
 
 const SECONDARY_TABS = [
   { key: 'packages', title: __('Packages') },
   { key: 'errata', title: __('Errata') },
-  { key: 'module-streams', title: __('Module streams') },
+  { key: 'module-streams', hideTab: hideModuleStreamsTab, title: __('Module streams') },
   { key: 'Repository sets', hideTab: hideRepoSetsTab, title: __('Repository sets') },
 ];
 

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -46,6 +46,10 @@ import {
   userPermissionsFromHostDetails,
 } from '../../hostDetailsHelpers';
 
+export const hideModuleStreamsTab = ({ hostDetails }) => {
+  const osMatch = hostDetails?.operatingsystem_name?.match(/(\w+) (\d+)/);
+  return !(osMatch && osMatch[1].match(/RedHat|CentOS/i) && Number(osMatch[2]) > 7);
+};
 
 const EnabledIcon = ({ streamText, streamInstallStatus, upgradable }) => {
   switch (true) {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
New host details - Hide module streams tab for EL7 hosts

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
New host details page
Module streams tab should not be displayed under Content for EL7/CentOS 7.