### PR TITLE
Fixes #35367 - Add legacy ch host ui button to new host page

### DIFF
--- a/webpack/components/extensions/HostDetails/ActionsBar/index.js
+++ b/webpack/components/extensions/HostDetails/ActionsBar/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { DropdownItem } from '@patternfly/react-core';
-import { CubeIcon } from '@patternfly/react-icons';
+import { CubeIcon, UndoIcon } from '@patternfly/react-icons';
 
 import { translate as __ } from 'foremanReact/common/I18n';
 import { foremanUrl } from 'foremanReact/common/helpers';
@@ -13,6 +13,13 @@ const HostActionsBar = () => {
 
   return (
     <>
+      <DropdownItem
+        key="katello-legacy-contenthost-ui"
+        href={foremanUrl(`/content_hosts/${hostDetails?.id}`)}
+        icon={<UndoIcon />}
+      >
+        {__('Legacy content host UI')}
+      </DropdownItem>
       <DropdownItem
         key="katello-change-host-content-source"
         href={foremanUrl(`/change_host_content_source?host_id=${hostDetails?.id}`)}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

QE raised a user experience bug around being able to go back to the legacy host UI until it is removed. I added a link in the new host detail kebab with the same icon as the legacy foreman host ui.

#### Considerations taken when implementing this change?

N/A

#### What are the testing steps for this pull request?

* Check out PR
* Navigate to a host in the new host UI page
* Click on the kebab and click Legacy Content Host UI
* Verify that it takes you to the old page for that content host