### PR TITLE
Fixes #35368 - Prevent multiple envs in host registration

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -313,6 +313,9 @@ module Katello
 
       if params.key?(:environment_id)
         environment = get_content_view_environment("cp_id", params[:environment_id])
+      elsif params.key?(:environments)
+        fail HttpErrors::BadRequest, _('Multiple environments are not supported.') if params['environments'].length > 1
+        environment = get_content_view_environment("cp_id", params['environments'].first['id'])
       elsif params.key?(:organization_id) && !params.key?(:environment_id)
         organization = Organization.current
         environment = organization.library.content_view_environment


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* New subscription manager version starting with EL8 now support being registered to multiple envs. We have a new version of Candlepin that allows this, until we add in support for multiple envs, we want to throw an error if multiples are being passed in.

#### Considerations taken when implementing this change?

* For hosts with EL8+ subscription-manager has changed the `environment_id` param to `environments` so added that in the controller if/else logic and added a line to throw an error if multiple envs are being passed in.
* I tried registering with multiple envs with EL7 which uses `environment_id` and it does not support passing in multiples so did not touch that legacy area.

#### What are the testing steps for this pull request?

* Check out PR
* Create a content view so you have a 2nd environment
* Spin up an EL8 client and try to register with 1 environment and make sure that works
* Unregister and try to register again passing in multiple envs IE `Library, Library/view`
* Verify you get a failure on your client and see the error in the rails logs