### PR TITLE
Fixes #35369 - Moved the syncable repo exports to a different cv

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -66,7 +66,7 @@ module Katello
 
     def index_relation
       content_views = ContentView.readable
-      content_views = content_views.not_generated_for_repository unless Foreman::Cast.to_bool(params[:include_generated])
+      content_views = content_views.ignore_generated unless Foreman::Cast.to_bool(params[:include_generated])
       content_views = content_views.where(:organization_id => @organization.id) if @organization
       content_views = content_views.in_environment(@environment) if @environment
       content_views = ::Foreman::Cast.to_bool(params[:nondefault]) ? content_views.non_default : content_views.default if params[:nondefault]

--- a/app/lib/actions/pulp3/orchestration/content_view_version/export_library.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/export_library.rb
@@ -10,10 +10,10 @@ module Actions
                                  format: ::Katello::Pulp3::ContentViewVersion::Export::IMPORTABLE)
             action_subject(organization)
             validate_repositories_immediate!(organization) if fail_on_missing_content
-
             content_view = ::Katello::Pulp3::ContentViewVersion::Export.find_library_export_view(destination_server: destination_server,
                                                                            organization: organization,
-                                                                           create_by_default: true)
+                                                                           create_by_default: true,
+                                                                           format: format)
             repo_ids_in_library = organization.default_content_view_version.repositories.exportable.immediate_or_none.pluck(:id)
             content_view.update!(repository_ids: repo_ids_in_library)
 

--- a/app/lib/actions/pulp3/orchestration/content_view_version/export_repository.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/export_repository.rb
@@ -12,7 +12,8 @@ module Actions
 
             content_view = ::Katello::Pulp3::ContentViewVersion::Export.find_repository_export_view(
                                                                            repository: repository,
-                                                                           create_by_default: true)
+                                                                           create_by_default: true,
+                                                                           format: format)
             content_view.update!(repository_ids: [repository.library_instance_or_self.id])
 
             sequence do

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -88,8 +88,12 @@ module Katello
     scope :non_composite, -> { where(:composite => [nil, false]) }
     scope :generated, -> { where.not(:generated_for => :none) }
     scope :generated_for_repository, -> { where(:generated_for => [:repository_export, :repository_import]) }
-    scope :not_generated_for_repository, -> { where.not(id: generated_for_repository) }
-
+    scope :ignore_generated, -> {
+      where.not(:generated_for => [:repository_export,
+                                   :repository_import,
+                                   :library_export_syncable,
+                                   :repository_export_syncable])
+    }
     scope :generated_for_library, -> { where(:generated_for => [:library_export, :library_import]) }
 
     scoped_search :on => :name, :complete_value => true
@@ -104,7 +108,9 @@ module Katello
       library_export: 1,
       repository_export: 2,
       library_import: 3,
-      repository_import: 4
+      repository_import: 4,
+      library_export_syncable: 5,
+      repository_export_syncable: 6
     }, _prefix: true
 
     set_crud_hooks :content_view

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -341,7 +341,7 @@ module Katello
 
     def published_in_versions
       Katello::ContentViewVersion.with_repositories(self.library_instances_inverse)
-                                 .where(content_view_id: Katello::ContentView.not_generated_for_repository).distinct
+                                 .where(content_view_id: Katello::ContentView.ignore_generated).distinct
     end
 
     def self.errata_with_package_counts(repo)
@@ -668,7 +668,7 @@ module Katello
 
     def self.smart_proxy_syncable
       joins(:content_view_version => :content_view).
-        merge(ContentView.not_generated_for_repository).
+        merge(ContentView.ignore_generated).
         where.not(environment_id: nil)
     end
 

--- a/app/services/katello/pulp3/content_view_version/export.rb
+++ b/app/services/katello/pulp3/content_view_version/export.rb
@@ -191,21 +191,38 @@ module Katello
 
         def self.find_library_export_view(create_by_default: false,
                                           destination_server:,
-                                          organization:)
+                                          organization:,
+                                          format: IMPORTABLE)
+          if format == IMPORTABLE
+            generated_for = :library_export
+            name = ::Katello::ContentView::EXPORT_LIBRARY
+          else
+            generated_for = :library_export_syncable
+            name = "#{::Katello::ContentView::EXPORT_LIBRARY}-SYNCABLE"
+          end
+
           find_generated_export_view(create_by_default: create_by_default,
                                      destination_server: destination_server,
                                      organization: organization,
-                                     name: ::Katello::ContentView::EXPORT_LIBRARY,
-                                     generated_for: :library_export)
+                                     name: name,
+                                     generated_for: generated_for)
         end
 
         def self.find_repository_export_view(create_by_default: false,
-                                              repository:)
+                                              repository:,
+                                              format: IMPORTABLE)
+          if format == IMPORTABLE
+            generated_for = :repository_export
+            name = "Export-#{repository.label}-#{repository.library_instance_or_self.id}"
+          else
+            generated_for = :repository_export_syncable
+            name = "Export-SYNCABLE-#{repository.label}-#{repository.library_instance_or_self.id}"
+          end
           find_generated_export_view(create_by_default: create_by_default,
                                      destination_server: nil,
                                      organization: repository.organization,
-                                     name: "Export-#{repository.label}-#{repository.library_instance_or_self.id}",
-                                     generated_for: :repository_export)
+                                     name: name,
+                                     generated_for: generated_for)
         end
 
         def self.generate_product_repo_strings(repositories:)

--- a/app/views/katello/api/v2/capsule_content/sync_status.json.rabl
+++ b/app/views/katello/api/v2/capsule_content/sync_status.json.rabl
@@ -32,7 +32,7 @@ child @lifecycle_environments => :lifecycle_environments do
     end
 
     node :content_views do |env|
-      env.content_views.not_generated_for_repository.map do |content_view|
+      env.content_views.ignore_generated.map do |content_view|
         attributes = {
           :id => content_view.id,
           :label => content_view.label,

--- a/app/views/katello/api/v2/organizations/show.json.rabl
+++ b/app/views/katello/api/v2/organizations/show.json.rabl
@@ -29,7 +29,7 @@ node(:content_view_components_count) do
     in_organization(Organization.current)&.
     non_composite&.
     non_default&.
-    not_generated_for_repository&.count
+    ignore_generated&.count
 end
 
 node :library_id do |org|

--- a/test/services/katello/pulp3/content_view_version/export_test.rb
+++ b/test/services/katello/pulp3/content_view_version/export_test.rb
@@ -88,16 +88,51 @@ module Katello
           end
 
           it 'finds the library export view correctly' do
+            format = ::Katello::Pulp3::ContentViewVersion::Export::IMPORTABLE
             org = get_organization
             assert_nil ::Katello::Pulp3::ContentViewVersion::Export.find_library_export_view(organization: org,
                                                             create_by_default: false,
-                                                            destination_server: nil)
+                                                            destination_server: nil,
+                                                            format: format)
             # now create it
             destination_server = "example.com"
             cv = ::Katello::Pulp3::ContentViewVersion::Export.find_library_export_view(organization: org,
                                                         create_by_default: true,
-                                                        destination_server: destination_server)
+                                                        destination_server: destination_server,
+                                                        format: format)
+            assert cv.generated_for_library_export?
             assert_equal cv.name, "Export-Library-#{destination_server}"
+          end
+
+          it 'finds the library export view correctly for syncable' do
+            format = ::Katello::Pulp3::ContentViewVersion::Export::SYNCABLE
+            org = get_organization
+            assert_nil ::Katello::Pulp3::ContentViewVersion::Export.find_library_export_view(organization: org,
+                                                            create_by_default: false,
+                                                            destination_server: nil,
+                                                            format: format)
+            # now create it
+            destination_server = "example.com"
+            cv = ::Katello::Pulp3::ContentViewVersion::Export.find_library_export_view(organization: org,
+                                                        create_by_default: true,
+                                                        destination_server: destination_server,
+                                                        format: format)
+            assert cv.generated_for_library_export_syncable?
+            assert_equal cv.name, "Export-Library-SYNCABLE-#{destination_server}"
+          end
+
+          it 'finds the repository export view correctly for syncable' do
+            repo = katello_repositories(:rhel_6_x86_64)
+            format = ::Katello::Pulp3::ContentViewVersion::Export::SYNCABLE
+            assert_nil ::Katello::Pulp3::ContentViewVersion::Export.find_repository_export_view(repository: repo,
+                                                            create_by_default: false,
+                                                            format: format)
+            # now create it
+            cv = ::Katello::Pulp3::ContentViewVersion::Export.find_repository_export_view(repository: repo,
+                                                        create_by_default: true,
+                                                        format: format)
+            assert cv.generated_for_repository_export_syncable?
+            assert_match(/^Export-SYNCABLE-#{repo.label}/, cv.name)
           end
 
           it "does not fail on validate! if chunk_size is not specified" do


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Whenever we do an export repository or library we would
1) Find or Create the associated repo/library cv
2) Publish the version
3) Export the published version in a syncable format

With the addition of syncable format we do the same.
This has some unintended consequences
For example
1) Export the repository in an importable format
2) Update the repository contents
3) Now export the same repo in syncable format
4) Finally do an incremental export of the same repo
Notice that it has 0 content to export. That is because it is
incrementally exporting between the repo state in 3 and 4 instead of 1
and 4

This commit fixes this by making the syncable exports happen in an
entirely different content view, so that syncable and non syncable
exports are not mixed.

#### What are the testing steps for this pull request?
1) Export the repository in an importable format => `hammer content-export complete repository --id=<repo-id>`
2) Update the repository contents 
3) Now export the same repo in syncable format =>  `hammer content-export complete repository --id=<repo-id> --format=syncable`
4) Finally do an incremental export of the same repo  => `hammer content-export incremental repository --id=<repo-id>`
Notice that it has 0 content to export. That is because it is
incrementally exporting between the repo state in 3 and 4 instead of 1
and 4

Follow the same steps with this PR checked out on a New Repository. 
It should correctly incrementally export between the repo in 1 and 4

