### PR TITLE
Fixes #35382 - Add rake task to refresh repos on all pulp proxies

### DIFF
--- a/lib/katello/tasks/refresh_repos.rake
+++ b/lib/katello/tasks/refresh_repos.rake
@@ -1,0 +1,8 @@
+namespace :katello do
+  desc 'Refresh all repositories in all smart proxies and main server'
+  task :refresh_repos => ["environment", "dynflow:client"] do
+    User.current = User.anonymous_api_admin
+    ::ForemanTasks.async_task(::Actions::BulkAction, ::Actions::Pulp3::Orchestration::Repository::RefreshRepos, SmartProxy.all)
+    puts _("Repos are being refreshed in the background.")
+  end
+end

--- a/test/lib/tasks/refresh_repos_test.rb
+++ b/test/lib/tasks/refresh_repos_test.rb
@@ -1,0 +1,18 @@
+require 'katello_test_helper'
+require 'rake'
+
+module Katello
+  class RefreshReposTest < ActiveSupport::TestCase
+    def setup
+      Rake.application.rake_require 'katello/tasks/refresh_repos'
+      Rake::Task['katello:refresh_repos'].reenable
+      Rake::Task.define_task(:environment)
+      Rake::Task.define_task('dynflow:client')
+    end
+
+    def test_refresh_repos_on_smart_proxies
+      ::ForemanTasks.expects(:async_task).with(::Actions::BulkAction, ::Actions::Pulp3::Orchestration::Repository::RefreshRepos, SmartProxy.all)
+      Rake.application.invoke_task('katello:refresh_repos')
+    end
+  end
+end


### PR DESCRIPTION
Co-authored-by: Joniel Pasqualetto jpasqual@redhat.com

#### What are the changes introduced in this pull request?

* When changing the certs from self installed certs to ones signed by a custom CA, the problem is that the `ca_cert` on the remote (inside pulp3) does not get updated after changing the certificate.
* Added a rake task to loop through the proxies and katello to refresh the repos

#### Considerations taken when implementing this change?

* N/A

#### What are the testing steps for this pull request?

* Check out PR
* Try running the rake task and see if you see the task get generated in the UI/logs
* Bonus if you have a smart proxy attached to your devel box to make sure it hits that.
