### PR TITLE
Fixes #35386 - Prevents AK destroy if associated to HG

### DIFF
--- a/app/lib/actions/katello/activation_key/destroy.rb
+++ b/app/lib/actions/katello/activation_key/destroy.rb
@@ -3,6 +3,7 @@ module Actions
     module ActivationKey
       class Destroy < Actions::EntryAction
         def plan(activation_key, options = {})
+          activation_key.validate_destroyable!
           skip_candlepin = options.fetch(:skip_candlepin, false)
           action_subject(activation_key)
 

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -211,6 +211,17 @@ module Katello
       assert_includes activation_keys, @purpose_key
     end
 
+    def test_destroy
+      hg = hostgroups(:common)
+      hg.group_parameters.create!(name: "kt_activation_keys", value: @dev_key.name)
+      exception = assert_raises(RuntimeError) do
+        @dev_key.validate_destroyable!
+      end
+      assert_match(/Search and unassociate Hosts\/Hostgroups using params.kt_activation_keys/, exception.message)
+      hg.group_parameters.destroy_all
+      assert @dev_key.validate_destroyable!
+    end
+
     context 'host_collection' do
       setup do
         @host_collection = katello_host_collections(:simple_host_collection)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds validation to AK destroy to ensure it won't get deleted if any hostgroup is using it
Also prints a helpful message giving the user the parameter to  search for.

#### What are the testing steps for this pull request?
1) Create an AK
2) Create a hostgroup and associate the AK to it
3) Delete AK

Before PR:
This delete would be successful but the hostgroup would have a dangling reference to the deleted activation key.

After PR:
You should see a message along 
```
This activation key is associated to one or more Hosts/Hostgroups. Search and unassociate Hosts/Hostgroups using params.kt_activation_keys ~ "<ak name>" before deleting.
````