### PR TITLE
Fixes #35235 - add name/label field validation to CreateContentViewForm

### DIFF
--- a/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
+++ b/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
@@ -25,6 +25,18 @@ const CreateContentViewForm = ({ setModalOpen }) => {
   const [redirect, setRedirect] = useState(false);
   const [saving, setSaving] = useState(false);
 
+  const [labelValidated, setLabelValidated] = useState('default');
+  const handleLabelChange = (newLabel, _event) => {
+    setLabel(newLabel);
+    if (newLabel === '') {
+      setLabelValidated('default');
+    } else if (/^[\w-]+$/.test(newLabel)) {
+      setLabelValidated('success');
+    } else {
+      setLabelValidated('error');
+    }
+  };
+
   const response = useSelector(selectCreateContentViews);
   const status = useSelector(selectCreateContentViewStatus);
   const error = useSelector(selectCreateContentViewError);
@@ -54,7 +66,7 @@ const CreateContentViewForm = ({ setModalOpen }) => {
 
   useEffect(
     () => {
-      setLabel(name.replace(/ /g, '_'));
+      setLabel(name.replace(/[^A-Za-z0-9_-]/g, '_'));
     },
     [name],
   );
@@ -65,7 +77,7 @@ const CreateContentViewForm = ({ setModalOpen }) => {
     return (<Redirect to={`/content_views/${id}#/repositories`} />);
   }
 
-  const submitDisabled = !name?.length || !label?.length || saving;
+  const submitDisabled = !name?.length || !label?.length || saving || labelValidated === 'error';
 
   return (
     <Form onSubmit={(e) => {
@@ -84,7 +96,13 @@ const CreateContentViewForm = ({ setModalOpen }) => {
           onChange={value => setName(value)}
         />
       </FormGroup>
-      <FormGroup label={__('Label')} isRequired fieldId="label">
+      <FormGroup
+        label={__('Label')}
+        isRequired
+        fieldId="label"
+        helperTextInvalid="Must be Ascii alphanumeric, '_' or '-'"
+        validated={labelValidated}
+      >
         <TextInput
           isRequired
           type="text"
@@ -92,7 +110,8 @@ const CreateContentViewForm = ({ setModalOpen }) => {
           aria-label="input_label"
           name="label"
           value={label}
-          onChange={value => setLabel(value)}
+          validated={labelValidated}
+          onChange={handleLabelChange}
         />
       </FormGroup>
       <FormGroup label={__('Description')} fieldId="description">

--- a/webpack/scenes/ContentViews/Create/__tests__/createContentView.test.js
+++ b/webpack/scenes/ContentViews/Create/__tests__/createContentView.test.js
@@ -89,3 +89,11 @@ test('Displays dependent fields correctly', () => {
   expect(queryByText('Auto publish')).not.toBeInTheDocument();
   expect(getByText('Import only')).toBeInTheDocument();
 });
+
+test('Validates label field', () => {
+  const { getByText, getByLabelText } = renderWithRedux(form);
+  expect(getByText('Label')).toBeInTheDocument();
+
+  fireEvent.change(getByLabelText('input_label'), { target: { value: '123 2123' } });
+  expect(getByText('Must be Ascii alphanumeric, \'_\' or \'-\'')).toBeInTheDocument();
+});


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add name/label field validation to CreateContentViewForm

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
- Create Content View
- Name could have any characters. There is no validation from UI side at all. But the special characters in name would be replaced with `_` in label.
- Input `Label` with special characters other than `-` and `_` which should make an error message under the Label field and the `Create Content View` button should be disabled.