### PR TITLE
Fixes #35399 - Fix occasional text overflow in errata overview card

### DIFF
--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.scss
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.scss
@@ -1,3 +1,8 @@
 .pf-c-empty-state {
   margin-top: 0;
 }
+.piechart-overflow {
+  margin-right: -20px;
+  position: relative;
+  left: -30px;
+}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

sometimes the phrase '0 enhancements' was overflowing the Errata overview card. This change makes it not do that.

#### Considerations taken when implementing this change?

I considered several screen sizes

#### What are the testing steps for this pull request?

Test the new host detail page at several screen widths and make sure no text overflows the card
