### PR TITLE
Fixes #35411 - Add ouiaId prop to all supported components in host details

### DIFF
--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -138,6 +138,7 @@ const ChangeHostCVModal = ({
   const modalActions = ([
     <Button
       key="add"
+      ouiaId="change-host-cv-modal-add-button"
       variant="primary"
       onClick={handleSave}
       isDisabled={!canSave}
@@ -145,7 +146,7 @@ const ChangeHostCVModal = ({
     >
       {__('Save')}
     </Button>,
-    <Button key="cancel" variant="link" onClick={handleModalClose}>
+    <Button key="cancel" ouiaId="change-host-cv-modal-cancel-button" variant="link" onClick={handleModalClose}>
       Cancel
     </Button>,
   ]);
@@ -159,6 +160,7 @@ const ChangeHostCVModal = ({
       position="top"
       actions={modalActions}
       id="change-host-cv-modal"
+      ouiaId="change-host-cv-modal"
     >
       {contentViewsInEnvStatus === STATUS.RESOLVED &&
         !!selectedEnvForHost.length && contentViewsInEnv.length === 0 &&

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -53,6 +53,7 @@ const HostContentViewDetails = ({
   const dropdownItems = [
     <DropdownItem
       aria-label="change-host-content-view"
+      ouiaId="change-host-content-view"
       key="change-host-content-view"
       component="button"
       onClick={openModal}
@@ -63,7 +64,7 @@ const HostContentViewDetails = ({
 
   return (
     <GridItem rowSpan={1} md={6} lg={4} xl2={3} >
-      <Card>
+      <Card ouiaId="content-view-details-card">
         <CardHeader>
           <Flex
             alignItems={{ default: 'alignItemsCenter' }}

--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
@@ -34,7 +34,7 @@ function HostInstallableErrata({
   }];
   return (
     <GridItem rowSpan={1} md={6} lg={4} xl2={3} >
-      <Card>
+      <Card ouiaId="errata-card">
         <CardHeader>
           <CardTitle>{__('Installable errata')}</CardTitle>
         </CardHeader>

--- a/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsCard.js
@@ -53,6 +53,7 @@ const HostCollectionsDetails = ({
   const dropdownItems = [
     <DropdownItem
       aria-label="add_host_to_collections"
+      ouiaId="add_host_to_collections"
       key="add_host_to_collections"
       component="button"
       onClick={openAddHostCollectionsModal}
@@ -61,6 +62,7 @@ const HostCollectionsDetails = ({
     </DropdownItem>,
     <DropdownItem
       aria-label="remove_host_from_collections"
+      ouiaId="remove_host_from_collections"
       key="remove_host_from_collections"
       component="button"
       isDisabled={!hostCollections.length}
@@ -82,7 +84,7 @@ const HostCollectionsDetails = ({
 
   return (
     <GridItem rowSpan={1} md={6} lg={4} xl2={3}>
-      <Card>
+      <Card ouiaId="host-collections-card">
         <CardHeader>
           <Flex
             alignItems={{ default: 'alignItemsCenter' }}
@@ -106,6 +108,7 @@ const HostCollectionsDetails = ({
               <FlexItem>
                 <Dropdown
                   toggle={<KebabToggle aria-label="host_collections_bulk_actions" onToggle={toggleBulkAction} />}
+                  ouiaId="host-collections-bulk-actions-dropdown"
                   isOpen={isDropdownOpen}
                   isPlain
                   position="right"

--- a/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsModal.js
@@ -120,10 +120,10 @@ export const HostCollectionsModal = ({
   };
 
   const modalActions = ([
-    <Button key="add" variant="primary" onClick={handleModalAction} isDisabled={!selectedCount}>
+    <Button key="add" ouiaId="add-button" variant="primary" onClick={handleModalAction} isDisabled={!selectedCount}>
       {adding ? __('Add') : __('Remove')}
     </Button>,
-    <Button key="cancel" variant="link" onClick={handleModalCancel}>
+    <Button key="cancel" ouiaId="cancel-button" variant="link" onClick={handleModalCancel}>
       {__('Cancel')}
     </Button>,
   ]);
@@ -136,6 +136,7 @@ export const HostCollectionsModal = ({
       position="top"
       actions={modalActions}
       id={adding ? 'add-host-to-host-collections-modal' : 'remove-host-from-host-collections-modal'}
+      ouiaId="host-collections-modal"
     >
       <FormattedMessage
         className="host-collections-modal-blurb"
@@ -175,7 +176,7 @@ export const HostCollectionsModal = ({
         requestKey={adding ? AVAILABLE_HOST_COLLECTIONS_KEY : REMOVABLE_HOST_COLLECTIONS_KEY}
       >
         <Thead>
-          <Tr>
+          <Tr ouiaId="row-header">
             {columnHeaders.map(col =>
               <Th key={col}>{col}</Th>)}
             <Th />
@@ -188,7 +189,7 @@ export const HostCollectionsModal = ({
             } = propsToCamelCase(hostCollection);
             const isDisabled = (adding && hostLimitExceeded(hostCollection));
             return (
-              <Tr key={id}>
+              <Tr key={id} ouiaId={`row-${id}`}>
                 <Td
                   select={{
                     disable: isDisabled,

--- a/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeEditModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeEditModal.js
@@ -175,6 +175,7 @@ const SystemPurposeEditModal = ({
       position="top"
       actions={modalActions}
       id="syspurpose-edit-modal"
+      ouiaId="syspurpose-edit-modal"
     >
       <FormattedMessage
         className="syspurpose-edit-modal-blurb"
@@ -189,6 +190,7 @@ const SystemPurposeEditModal = ({
           <FormSelect
             id="role"
             name="role"
+            ouiaId="role-select"
             value={selectedRole}
             onChange={setSelectedRole}
           >
@@ -205,6 +207,7 @@ const SystemPurposeEditModal = ({
           <FormSelect
             id="serviceLevel"
             name="serviceLevel"
+            ouiaId="service-level-select"
             value={selectedServiceLevel}
             onChange={setSelectedServiceLevel}
           >
@@ -221,6 +224,7 @@ const SystemPurposeEditModal = ({
           <FormSelect
             id="usage"
             name="usage"
+            ouiaId="usage-select"
             value={selectedUsage}
             onChange={setSelectedUsage}
           >
@@ -237,6 +241,7 @@ const SystemPurposeEditModal = ({
           <FormSelect
             id="release_version"
             name="release_version"
+            ouiaId="release-version-select"
             value={selectedReleaseVersion}
             onChange={setSelectedReleaseVersion}
           >
@@ -256,6 +261,7 @@ const SystemPurposeEditModal = ({
           <Select
             variant={SelectVariant.typeaheadMulti}
             aria-label="syspurpose-addons"
+            ouiaId="syspurpose-addons-select"
             onToggle={toggleAddonSelect}
             onSelect={onAddonSelect}
             selections={selectedAddons}

--- a/webpack/components/extensions/HostDetails/DetailsTabCards/RegistrationCard.js
+++ b/webpack/components/extensions/HostDetails/DetailsTabCards/RegistrationCard.js
@@ -25,7 +25,9 @@ export const RegisteredBy = ({ user, activationKeys }) => {
   return (
     <>
       <List isPlain>
-        <Text component={TextVariants.h4}>{activationKeys.length > 1 ? __('Activation keys') : __('Activation key')}</Text>
+        <Text component={TextVariants.h4} ouiaId="activation-key-text">
+          {activationKeys.length > 1 ? __('Activation keys') : __('Activation key')}
+        </Text>
         {activationKeys.map(key => (
           <ListItem key={key.id}>
             <a href={urlBuilder(`activation_keys/${key.id}`, '')}>{key.name}</a>

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -276,6 +276,7 @@ export const ErrataTab = () => {
   const dropdownKebabItems = [
     <DropdownItem
       aria-label="bulk_add"
+      ouiaId="bulk_add"
       key="bulk_add"
       component="button"
       onClick={recalculateErrata}
@@ -287,6 +288,7 @@ export const ErrataTab = () => {
   const dropdownItems = [
     <DropdownItem
       aria-label="apply_via_remote_execution"
+      ouiaId="apply_via_remote_execution"
       key="apply_via_remote_execution"
       component="button"
       onClick={applyViaRemoteExecution}
@@ -296,6 +298,7 @@ export const ErrataTab = () => {
     </DropdownItem>,
     <DropdownItem
       aria-label="apply_via_customized_remote_execution"
+      ouiaId="apply_via_customized_remote_execution"
       key="apply_via_customized_remote_execution"
       component="a"
       href={bulkCustomizedRexUrl()}
@@ -309,6 +312,7 @@ export const ErrataTab = () => {
     dropdownItems.unshift((
       <DropdownItem
         aria-label="apply_via_katello_agent"
+        ouiaId="apply_via_katello_agent"
         key="apply_via_katello_agent"
         component="button"
         onClick={applyByKatelloAgent}
@@ -340,9 +344,11 @@ export const ErrataTab = () => {
             <ActionListItem>
               <Dropdown
                 aria-label="errata_dropdown"
+                ouiaId="errata_dropdown"
                 toggle={
                   <DropdownToggle
                     aria-label="expand_errata_toggle"
+                    ouiaId="expand_errata_toggle"
                     splitButtonItems={[
                       <DropdownToggleAction key="action" aria-label="bulk_actions" onClick={apply}>
                         {__('Apply')}
@@ -361,6 +367,7 @@ export const ErrataTab = () => {
             {showRecalculate &&
             <ActionListItem>
               <Dropdown
+                ouiaId="bulk-actions-dropdown"
                 toggle={<KebabToggle aria-label="bulk_actions_kebab" onToggle={toggleBulkAction} />}
                 isOpen={isBulkActionOpen}
                 isPlain
@@ -467,7 +474,7 @@ export const ErrataTab = () => {
           alwaysShowActionButtons={false}
         >
           <Thead>
-            <Tr>
+            <Tr ouiaId="row-header">
               <Th key="expand-carat" />
               <Th key="select-all" />
               <SortableColumnHeaders
@@ -522,7 +529,7 @@ export const ErrataTab = () => {
 
               return (
                 <Tbody isExpanded={isExpanded} key={`${id}_${createdAt}`}>
-                  <Tr>
+                  <Tr ouiaId={`row-${rowIndex}`}>
                     <Td
                       expand={{
                         rowIndex,
@@ -568,7 +575,7 @@ export const ErrataTab = () => {
                       />
                     ) : null}
                   </Tr>
-                  <Tr key="child_row" isExpanded={isExpanded}>
+                  <Tr key="child_row" ouiaId="row-child" isExpanded={isExpanded}>
                     {isExpanded && (
                       <>
                         <Td colSpan={3}>

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -160,6 +160,7 @@ const ModuleActionConfirmationModal = ({
       variant={ModalVariant.small}
       isOpen={actionModalOpen}
       aria-label="Module action confirmation modal"
+      ouiaId="Module-action-confirmation-modal"
       title={title}
       titleIconVariant="warning"
       showClose
@@ -167,6 +168,7 @@ const ModuleActionConfirmationModal = ({
       actions={[
         <Button
           aria-label="confirm-module-action"
+          ouiaId="confirm-module-action"
           key="confirm-module-action"
           onClick={() => {
             triggerModuleStreamAction({ hostname, action, moduleSpec });
@@ -177,6 +179,7 @@ const ModuleActionConfirmationModal = ({
         </Button>,
         <Button
           aria-label="cancel-module-action"
+          ouiaId="cancel-module-action"
           key="cancel-module-action"
           variant="link"
           onClick={() => setActionModalOpen(false)}
@@ -185,7 +188,7 @@ const ModuleActionConfirmationModal = ({
         </Button>,
       ]}
     >
-      <Text component={TextVariants.p}>
+      <Text component={TextVariants.p} ouiaId="text">
         {body}
       </Text>
 
@@ -404,7 +407,7 @@ export const ModuleStreamsTab = () => {
           }
         >
           <Thead>
-            <Tr>
+            <Tr ouiaId="header-tr">
               <SortableColumnHeaders
                 columnHeaders={columnHeaders}
                 pfSortParams={pfSortParams}
@@ -425,22 +428,24 @@ export const ModuleStreamsTab = () => {
             }, index) => {
               /* eslint-disable react/no-array-index-key */
               const dropdownItems = [
-                <DropdownItem key={`dropdownItem-checkbox-${id}`}>
+                <DropdownItem key={`dropdownItem-checkbox-${id}`} ouiaId={`dropdownItem-checkbox-${id}`}>
                   <Checkbox
                     aria-label={`customize-checkbox-${id}`}
+                    ouiaId={`customize-checkbox-${id}`}
                     id={`Checkbox${id}`}
                     label={__('Customize with Rex')}
                     isChecked={id === useCustomizedRex}
                     onChange={checked => (checked ? setUseCustomizedRex(id) : setUseCustomizedRex(''))}
                   />
                 </DropdownItem>,
-                <DropdownSeparator key={`separator-${id}`} />,
+                <DropdownSeparator key={`separator-${id}`} ouiaId={`separator-${id}`} />,
 
               ];
               if (id === useCustomizedRex) {
                 dropdownItems.push(
                   <DropdownItem
                     aria-label={`enable-${id}-href`}
+                    ouiaId={`enable-${id}-href`}
                     key={`dropdownItem-enable-url-${id}`}
                     component="a"
                     href={customizedActionURL('enable', moduleSpec)}
@@ -451,6 +456,7 @@ export const ModuleStreamsTab = () => {
                   </DropdownItem>,
                   <DropdownItem
                     aria-label={`disable-${id}-href`}
+                    ouiaId={`disable-${id}-href`}
                     key={`dropdownItem-disable-url-${id}`}
                     component="a"
                     href={customizedActionURL('disable', moduleSpec)}
@@ -462,6 +468,7 @@ export const ModuleStreamsTab = () => {
                   </DropdownItem>,
                   <DropdownItem
                     aria-label={`install-${id}-href`}
+                    ouiaId={`install-${id}-href`}
                     key={`dropdownItem-install-url-${id}`}
                     component="a"
                     href={customizedActionURL('install', moduleSpec)}
@@ -475,6 +482,7 @@ export const ModuleStreamsTab = () => {
                   </DropdownItem>,
                   <DropdownItem
                     aria-label={`update-${id}-href`}
+                    ouiaId={`update-${id}-href`}
                     key={`dropdownItem-update-${id}`}
                     component="a"
                     href={customizedActionURL('update', moduleSpec)}
@@ -484,6 +492,7 @@ export const ModuleStreamsTab = () => {
                   </DropdownItem>,
                   <DropdownItem
                     aria-label={`reset-${id}-href`}
+                    ouiaId={`reset-${id}-href`}
                     key={`dropdownItem-reset-${id}`}
                     component="a"
                     href={customizedActionURL('reset', moduleSpec)}
@@ -493,6 +502,7 @@ export const ModuleStreamsTab = () => {
                   </DropdownItem>,
                   <DropdownItem
                     aria-label={`remove-${id}-href`}
+                    ouiaId={`remove-${id}-href`}
                     key={`dropdownItem-remove-${id}`}
                     component="a"
                     href={customizedActionURL('remove', moduleSpec)}
@@ -505,6 +515,7 @@ export const ModuleStreamsTab = () => {
                 dropdownItems.push(
                   <DropdownItem
                     aria-label={`enable-${id}-button`}
+                    ouiaId={`enable-${id}-button`}
                     key={`dropdownItem-enable-${id}`}
                     component="button"
                     onClick={() => {
@@ -519,6 +530,7 @@ export const ModuleStreamsTab = () => {
                   </DropdownItem>,
                   <DropdownItem
                     aria-label={`disable-${id}-button`}
+                    ouiaId={`disable-${id}-button`}
                     key={`dropdownItem-disable-${id}`}
                     component="button"
                     onClick={() => {
@@ -536,6 +548,7 @@ export const ModuleStreamsTab = () => {
                   </DropdownItem>,
                   <DropdownItem
                     aria-label={`install-${id}-button`}
+                    ouiaId={`install-${id}-button`}
                     key={`dropdownItem-install-${id}`}
                     component="button"
                     onClick={() => {
@@ -553,6 +566,7 @@ export const ModuleStreamsTab = () => {
                   </DropdownItem>,
                   <DropdownItem
                     aria-label={`update-${id}-button`}
+                    ouiaId={`update-${id}-button`}
                     key={`dropdownItem-update-${id}`}
                     component="button"
                     onClick={() => {
@@ -566,6 +580,7 @@ export const ModuleStreamsTab = () => {
                   </DropdownItem>,
                   <DropdownItem
                     aria-label={`reset-${id}-button`}
+                    ouiaId={`reset-${id}-button`}
                     key={`dropdownItem-reset-${id}`}
                     component="button"
                     onClick={() => {
@@ -582,6 +597,7 @@ export const ModuleStreamsTab = () => {
                   </DropdownItem>,
                   <DropdownItem
                     aria-label={`remove-${id}-button`}
+                    ouiaId={`remove-${id}-button`}
                     key={`dropdownItem-remove-${id}`}
                     component="button"
                     onClick={() => {
@@ -599,7 +615,7 @@ export const ModuleStreamsTab = () => {
                 );
               }
               return (
-                <Tr key={`${id} ${index}`}>
+                <Tr key={`${id} ${index}`} ouiaId={`tr-${id}-${index}`}>
                   <Td>
                     <a
                       href={`/module_streams?search=module_spec%3D${moduleSpec}+and+host%3D${hostname}`}
@@ -628,6 +644,7 @@ export const ModuleStreamsTab = () => {
                     <Td key={`actions-td-${id}-${dropdownOpen}`}>
                       <Dropdown
                         aria-label={`actions-dropdown-${id}`}
+                        ouiaId={`actions-dropdown-${id}`}
                         key={`actions-dropdown-${id}-${dropdownOpen}`}
                         isPlain
                         style={{ width: 'inherit' }}

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.js
@@ -35,17 +35,19 @@ const InstallDropdown = ({
   const dropdownItems = [
     <DropdownItem
       key="install-k-agent"
+      ouiaId="install-k-agent"
       component="button"
       onClick={installViaKatelloAgent}
       isDisabled={disableInstallViaKatelloAgent}
     >
       {__('Install via katello-agent')}
     </DropdownItem>,
-    <DropdownItem key="install-rex" component="button" onClick={installViaRex}>
+    <DropdownItem key="install-rex" ouiaId="install-rex" component="button" onClick={installViaRex}>
       {__('Install via remote execution')}
     </DropdownItem>,
     <DropdownItem
       key="install-customized-rex"
+      ouiaId="install-customized-rex"
       component="a"
       href={bulkCustomizedRexUrl}
       onClick={onActionSelect}
@@ -59,10 +61,12 @@ const InstallDropdown = ({
 
   return (
     <Dropdown
+      ouiaId="action-dropdown"
       direction={DropdownDirection.up}
       onSelect={onActionSelect}
       toggle={
         <DropdownToggle
+          ouiaId="install-action-toggle"
           isDisabled={isDisabled}
           splitButtonItems={[
             <DropdownToggleAction key="install" onClick={defaultRemoteAction}>
@@ -174,7 +178,7 @@ const PackageInstallModal = ({
       showKatelloAgent={showKatelloAgent}
       disableInstallViaKatelloAgent={selectedResults.length === 0}
     />,
-    <Button key="cancel" variant="link" onClick={handleModalClose}>
+    <Button key="cancel" ouiaId="cancel-button" variant="link" onClick={handleModalClose}>
       Cancel
     </Button>,
   ]);
@@ -187,6 +191,7 @@ const PackageInstallModal = ({
       width="50%"
       actions={modalActions}
       id="package-install-modal"
+      ouiaId="package-install-modal"
     >
       <FormattedMessage
         className="pkg-install-modal-blurb"
@@ -221,7 +226,7 @@ const PackageInstallModal = ({
         displaySelectAllCheckbox
       >
         <Thead>
-          <Tr>
+          <Tr ouiaId="row-header">
             {columnHeaders.map(col =>
               <Th key={col}>{col}</Th>)}
             <Th />
@@ -236,7 +241,7 @@ const PackageInstallModal = ({
               version,
             } = pkg;
             return (
-              <Tr key={id}>
+              <Tr key={id} ouiaId={`row-${id}`}>
                 <Td
                   select={{
                     disable: false,

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -288,6 +288,7 @@ export const PackagesTab = () => {
   const dropdownUpgradeItems = [
     <DropdownItem
       aria-label="bulk_upgrade_rex"
+      ouiaId="bulk_upgrade_rex"
       key="bulk_upgrade_rex"
       component="button"
       onClick={upgradeBulkViaRemoteExecution}
@@ -296,6 +297,7 @@ export const PackagesTab = () => {
     </DropdownItem>,
     <DropdownItem
       aria-label="bulk_upgrade_customized_rex"
+      ouiaId="bulk_upgrade_customized_rex"
       key="bulk_upgrade_customized_rex"
       component="a"
       href={upgradeViaCustomizedRemoteExecution}
@@ -307,6 +309,7 @@ export const PackagesTab = () => {
   const dropdownRemoveItems = [
     <DropdownItem
       aria-label="bulk_remove"
+      ouiaId="bulk_remove"
       key="bulk_remove"
       component="button"
       onClick={removeBulk}
@@ -314,9 +317,10 @@ export const PackagesTab = () => {
     >
       {__('Remove')}
     </DropdownItem>,
-    <DropdownSeparator key="separator" />,
+    <DropdownSeparator key="separator" ouiaId="separator" />,
     <DropdownItem
       aria-label="install_pkg_on_host"
+      ouiaId="install_pkg_on_host"
       key="install_pkg_on_host"
       component="button"
       onClick={handleInstallPackagesClick}
@@ -338,9 +342,11 @@ export const PackagesTab = () => {
         <ActionList isIconList>
           <ActionListItem>
             <Dropdown
+              ouiaId="upgrade_actions_dropdown"
               onSelect={onActionSelect}
               toggle={
                 <DropdownToggle
+                  ouiaId="upgrade_actions_dropdown_toggle"
                   splitButtonItems={[
                     <DropdownToggleAction key="action" aria-label="upgrade_actions" onClick={upgradeBulk}>
                       {__('Upgrade')}
@@ -362,6 +368,7 @@ export const PackagesTab = () => {
               isOpen={isBulkActionOpen}
               isPlain
               dropdownItems={dropdownRemoveItems}
+              ouiaId="bulk_actions_dropdown"
             />
           </ActionListItem>
         </ActionList>
@@ -429,7 +436,7 @@ export const PackagesTab = () => {
           alwaysShowActionButtons={false}
         >
           <Thead>
-            <Tr>
+            <Tr ouiaId="row-header">
               <Th key="select-all" />
               <SortableColumnHeaders
                 columnHeaders={columnHeaders}
@@ -473,7 +480,7 @@ export const PackagesTab = () => {
               }
 
               return (
-                <Tr key={`${id}`}>
+                <Tr key={`${id}`} ouiaId={`action-row-${id}`}>
                   {showActions ? (
                     <Td
                       select={{

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -339,13 +339,34 @@ const RepositorySetsTab = () => {
   cannot(createBookmarks, userPermissionsFromHostDetails({ hostDetails }));
 
   const dropdownItems = [
-    <DropdownItem aria-label="bulk_enable" key="bulk_enable" ouiaId="bulk_enable" component="button" onClick={enableRepoSets} isDisabled={selectedCount === 0}>
+    <DropdownItem
+      aria-label="bulk_enable"
+      key="bulk_enable"
+      ouiaId="bulk_enable"
+      component="button"
+      onClick={enableRepoSets}
+      isDisabled={selectedCount === 0}
+    >
       {__('Override to enabled')}
     </DropdownItem>,
-    <DropdownItem aria-label="bulk_disable" key="bulk_disable" ouiaId="bulk_disable" component="button" onClick={disableRepoSets} isDisabled={selectedCount === 0}>
+    <DropdownItem
+      aria-label="bulk_disable"
+      key="bulk_disable"
+      ouiaId="bulk_disable"
+      component="button"
+      onClick={disableRepoSets}
+      isDisabled={selectedCount === 0}
+    >
       {__('Override to disabled')}
     </DropdownItem>,
-    <DropdownItem aria-label="bulk_reset_default" key="bulk_reset_default" ouiaId="bulk_reset_default" component="button" onClick={resetToDefaultRepoSets} isDisabled={selectedCount === 0}>
+    <DropdownItem
+      aria-label="bulk_reset_default"
+      key="bulk_reset_default"
+      ouiaId="bulk_reset_default"
+      component="button"
+      onClick={resetToDefaultRepoSets}
+      isDisabled={selectedCount === 0}
+    >
       {__('Reset to default')}
     </DropdownItem>,
   ];

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.js
@@ -43,7 +43,7 @@ const EnableTracerModal = ({ isOpen, setIsOpen, triggerJobStart }) => {
   };
 
   const dropdownItems = dropdownOptions.map(text => (
-    <DropdownItem key={`option_${text}`} onClick={() => setSelectedOption(text)}>{text}</DropdownItem>
+    <DropdownItem key={`option_${text}`} ouiaId={`option_${text}`} onClick={() => setSelectedOption(text)}>{text}</DropdownItem>
   ));
 
   const customizedRexUrl = katelloPackageInstallUrl({ hostname, packages: KATELLO_TRACER_PACKAGE });
@@ -54,6 +54,7 @@ const EnableTracerModal = ({ isOpen, setIsOpen, triggerJobStart }) => {
       return (
         <Button
           key="enable_button"
+          ouiaId="enable-button-via-rex"
           type="submit"
           variant="primary"
           isLoading={buttonLoading}
@@ -67,6 +68,7 @@ const EnableTracerModal = ({ isOpen, setIsOpen, triggerJobStart }) => {
     return (
       <Button
         key="enable_button"
+        ouiaId="enable-button-via-customized-rex"
         component="a"
         isLoading={buttonLoading}
         isDisabled={buttonLoading}
@@ -83,12 +85,13 @@ const EnableTracerModal = ({ isOpen, setIsOpen, triggerJobStart }) => {
     <Modal
       variant={ModalVariant.small}
       title={title}
+      ouiaId="enable-tracer-modal"
       width="28em"
       isOpen={isOpen}
       onClose={handleClose}
       actions={[
         getEnableTracerButton(),
-        <Button key="cancel_button" variant="link" onClick={() => setIsOpen(false)}>{__('Cancel')}</Button>,
+        <Button key="cancel_button" ouiaId="cancel-button" variant="link" onClick={() => setIsOpen(false)}>{__('Cancel')}</Button>,
       ]}
     >
       <Flex direction={{ default: 'column' }}>
@@ -96,9 +99,11 @@ const EnableTracerModal = ({ isOpen, setIsOpen, triggerJobStart }) => {
         <FlexItem><div>{__('Select a provider to install katello-host-tools-tracer')}</div></FlexItem>
         <FlexItem>
           <Dropdown
+            ouiaId="enable-tracer-modal-dropdown"
             toggle={
               <DropdownToggle
                 id="toggle-enable-tracer-modal-dropdown"
+                ouiaId="enable-tracer-modal-dropdown-toggle"
                 onToggle={toggleDropdownOpen}
                 toggleIndicator={CaretDownIcon}
                 isDisabled={buttonLoading}

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesEnabler.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesEnabler.js
@@ -23,6 +23,7 @@ const EnableTracerButton = ({ setEnableTracerModalOpen, pollingStarted }) => (
   <Button
     onClick={() => setEnableTracerModalOpen(true)}
     isDisabled={pollingStarted}
+    ouiaId="enable-traces-button"
   >
     {__('Enable Traces')}
   </Button>
@@ -70,7 +71,7 @@ const TracesEnabler = ({ hostname }) => {
         <Spinner /> :
         <EmptyStateIcon icon={WrenchIcon} />
       }
-      <Title headingLevel="h2" size="lg">
+      <Title ouiaId="enable-tracer-title" headingLevel="h2" size="lg">
         {pollingStarted ? enablingTitle : title}
       </Title>
       <EmptyStateBody>

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
@@ -125,10 +125,24 @@ const TracesTab = () => {
   cannot(createBookmarks, userPermissionsFromHostDetails({ hostDetails }));
 
   const dropdownItems = [
-    <DropdownItem isDisabled={selectedCount === 0} aria-label="bulk_rex" key="bulk_rex" component="button" onClick={onBulkRestartApp}>
+    <DropdownItem
+      isDisabled={selectedCount === 0}
+      aria-label="bulk_rex"
+      ouiaId="bulk_rex"
+      key="bulk_rex"
+      component="button"
+      onClick={onBulkRestartApp}
+    >
       {__('Restart via remote execution')}
     </DropdownItem>,
-    <DropdownItem isDisabled={selectedCount === 0} aria-label="bulk_rex_customized" key="bulk_rex_customized" component="a" href={bulkCustomizedRexUrl()}>
+    <DropdownItem
+      isDisabled={selectedCount === 0}
+      aria-label="bulk_rex_customized"
+      ouiaId="bulk_rex_customized"
+      key="bulk_rex_customized"
+      component="a"
+      href={bulkCustomizedRexUrl()}
+    >
       {__('Restart via customized remote execution')}
     </DropdownItem>,
   ];
@@ -140,9 +154,11 @@ const TracesTab = () => {
           <ActionListItem>
             <Dropdown
               aria-label="bulk_actions_dropdown"
+              ouiaId="bulk_actions_dropdown"
               toggle={
                 <DropdownToggle
                   aria-label="bulk_actions"
+                  ouiaId="bulk_actions"
                   splitButtonItems={[
                     <DropdownToggleAction key="action" onClick={onBulkRestartApp}>
                       {__('Restart app')}
@@ -205,7 +221,7 @@ const TracesTab = () => {
         requestKey={HOST_TRACES_KEY}
       >
         <Thead>
-          <Tr>
+          <Tr ouiaId="row-header">
             <Th key="select_checkbox" />
             <SortableColumnHeaders
               columnHeaders={columnHeaders}
@@ -239,7 +255,7 @@ const TracesTab = () => {
               ];
             }
             return (
-              <Tr key={id} >
+              <Tr key={id} ouiaId={`row-${id}`} >
                 {showActions ? (
                   <Td
                     select={{

--- a/webpack/global_test_setup.js
+++ b/webpack/global_test_setup.js
@@ -6,7 +6,7 @@ import nock from 'nock';
 // output and traceback for actual error.
 const originalConsoleError = global.console.error;
 global.console.error = (error, stack) => {
-  originalConsoleError(error); // ensure error is printed to console , comment
+  originalConsoleError(error); // ensure error is printed to console, comment
   // in case of ouia-id check
 
   /* Uncomment block below to filter out PF4 ouiaId errors */
@@ -15,6 +15,7 @@ global.console.error = (error, stack) => {
   //    'created by PaginationOptionsMenu', 'created by TypeAheadItems',
   //    'The prop `ouiaId` is marked as required in `Modal`, but its value is `undefined`',
   //    'created by WizardHeader', 'created by Navigation',
+  //    'created by ActionsColumn', 'created by InactiveText', 'created by Select',
   //    'created by Context.Consumer'];
 
   /* eslint-disable-next-line no-console */
@@ -25,6 +26,7 @@ global.console.error = (error, stack) => {
   //   originalConsoleError(error); // ensure error is printed to console
   //   console.log(stack); // Prints out original stack trace
   // }
+
   throw new Error(error); // comment this and uncomment the next line when checking for ouia ids
   // if (!error.includes('Failed prop type')) throw new Error(error);
 };


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add ouiaId prop to all supported components in host details

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Follow instructions in comments in katello/webpack/global_test_setup.js
In katello dir, Run `npx jest webpack/components/extensions/HostDetails`