### PR TITLE
Fixes #35425 - Can import prod/repo with diff label but same name

### DIFF
--- a/app/lib/actions/katello/product/destroy.rb
+++ b/app/lib/actions/katello/product/destroy.rb
@@ -11,7 +11,7 @@ module Actions
           unless organization_destroy || product.user_deletable?
             if product.redhat?
               fail _("Cannot delete Red Hat product: %{product}") % { :product => product.name }
-            elsif !product.published_content_view_versions.empty?
+            elsif !product.published_content_view_versions.not_ignorable.empty?
               fail _("Cannot delete product with repositories published in a content view.  Product: %{product}, %{view_versions}") %
                        { :product => product.name, :view_versions => view_versions(product) }
             end

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -56,7 +56,7 @@ module Katello
     scope :with_organization_id, ->(organization_id) do
       joins(:content_view).where("#{Katello::ContentView.table_name}.organization_id" => organization_id)
     end
-
+    scope :not_ignorable, -> { where(content_view_id: Katello::ContentView.ignore_generated) }
     scope :triggered_by, ->(content_view_version_id) do
       sql = Katello::ContentViewHistory.where(:triggered_by_id => content_view_version_id).select(:katello_content_view_version_id).to_sql
       where("#{Katello::ContentViewVersion.table_name}.id in (#{sql})")

--- a/app/services/katello/pulp3/content_view_version/importable_products.rb
+++ b/app/services/katello/pulp3/content_view_version/importable_products.rb
@@ -37,10 +37,20 @@ module Katello
         def create_params(metadata_product)
           {
             gpg_key_id: gpg_key_id(metadata_product),
-            name: metadata_product.name,
+            name: find_unique_name(metadata_product),
             label: metadata_product.label,
             description: metadata_product.description
           }
+        end
+
+        def find_unique_name(metadata_product)
+          name = metadata_product.name
+          i = 1
+          while @products_in_library.where(name: name).exists?
+            name = "#{metadata_product.name} #{i}"
+            i += 1
+          end
+          name
         end
 
         def update_params(metadata_product)

--- a/test/actions/katello/product_test.rb
+++ b/test/actions/katello/product_test.rb
@@ -193,7 +193,7 @@ module ::Actions::Katello::Product
       action.stubs(:action_subject).with do |subject, _params|
         assert_equal subject, product
       end
-      product.expects(:published_content_view_versions).returns([])
+      product.expects(:published_content_view_versions).returns(::Katello::ContentViewVersion.none)
       product.expects(:product_contents).returns([])
       default_view_repos = product.repositories.in_default_view.map(&:id)
 

--- a/test/services/katello/pulp3/content_view_version/importable_products_test.rb
+++ b/test/services/katello/pulp3/content_view_version/importable_products_test.rb
@@ -35,6 +35,27 @@ module Katello
             assert_nil helper.creatable.second[:product].gpg_key_id
             assert_equal gpg_key.id, helper.updatable.first[:options][:gpg_key_id]
           end
+
+          it "Fetches the right product name to auto create" do
+            repo = katello_repositories(:fedora_17_x86_64)
+            gpg_key = katello_gpg_keys(:fedora_gpg_key)
+
+            metadata_gpg_key = stub('metadata gpg key', name: gpg_key.name)
+            label = "#{repo.product.label}-f000"
+
+            metadata_products = [
+              stub(label: label, name: repo.product.name, description: repo.product.description, redhat: false, gpg_key: metadata_gpg_key)
+            ]
+
+            helper = Katello::Pulp3::ContentViewVersion::ImportableProducts.new(
+              organization: repo.organization,
+              metadata_products: metadata_products
+            )
+            helper.generate!
+
+            assert_includes helper.creatable.map { |prod| prod[:product].label }, label
+            assert_includes helper.creatable.map { |prod| prod[:product].name }, "#{repo.product.name} 1"
+          end
         end
       end
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Here is the situation you are importing a repository via content-import. The label of the product in the import metadata is not present in the system. However a product with the same name already exists.

Before this commit you would see an error along "Name already taken" if you tried to import in the above scenario

This commit facilitates importing a custom product/repo with a new name if product/repo with same name but different label already exists. It creates a new product/repo with a number appended next to the product/repo name to make it unique.

- Also added ability to delete products which have repos belonging to generated content views.

#### Considerations taken when implementing this change?

- Debate on whether it should be `"#{product.name}-#{SecureRandom.hex}"` or `"#{product.name} 1"` or `"#{product.name} <number>"` 

Finally settled on numbering.

#### What are the testing steps for this pull request?
In Upstream Satellite/Org
1. `hammer organization create --name=upstream` (any org name will do)
2. `hammer product create --name=custom --organization=upstream`
3. `hammer repository create --name=repo --content-type=yum --url=https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/ --product=custom --organization=upstream`
4. `hammer repository synchronize --name=repo --product=custom --organization=upstream`
5. Export via `hammer content-export complete repository --name=repo --product=custom --organization=upstream`

Make a note of the path

In the Downstream Satellite/org
1. `hammer organization create --name=downstream` (any org name will do)
2. Create a product with same name but different label -> `hammer product create --name=custom --organization=downstream --label=custom_product`
3. `hammer content-import repository --path=<import path> --organization=downstream`

Before PR
Could not import the archive.:
  Validation failed: Name has already been taken for a product in this organization.

After PR
Successful import with a new custom product `<product name> <number>` and repo added to it
