### PR TITLE
Fixes #35398 - Re-fetch host details when errata counts are out of date

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useMemo } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { useSelector, useDispatch } from 'react-redux';
 import {
@@ -84,8 +84,10 @@ export const ErrataTab = () => {
     = useState(PARAM_TO_FRIENDLY_NAME[initialType] ?? ERRATA_TYPE);
   const [errataSeveritySelected, setErrataSeveritySelected]
     = useState(PARAM_TO_FRIENDLY_NAME[initialSeverity] ?? ERRATA_SEVERITY);
-  const activeFilters = [errataTypeSelected, errataSeveritySelected];
-  const defaultFilters = [ERRATA_TYPE, ERRATA_SEVERITY];
+  const activeFilters = useMemo(() =>
+    [errataTypeSelected, errataSeveritySelected], [errataTypeSelected, errataSeveritySelected]);
+  const defaultFilters = useMemo(() =>
+    [ERRATA_TYPE, ERRATA_SEVERITY], [ERRATA_SEVERITY, ERRATA_TYPE]);
 
   const [isActionOpen, setIsActionOpen] = useState(false);
   const onActionToggle = () => {
@@ -218,7 +220,7 @@ export const ErrataTab = () => {
       dispatch(getHostDetails({ hostname })); // this will update the errata overview chart
     }
   }, [activeFilters, defaultFilters, metadata,
-    contentFacet.errataCounts.total, contentFacet, dispatch, hostname]);
+    contentFacet.errataCounts?.total, contentFacet, dispatch, hostname]);
 
   if (!hostId) return <Skeleton />;
 

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -35,7 +35,7 @@ import {
 import { removePackage, updatePackage, removePackages, updatePackages, installPackageBySearch } from '../RemoteExecutionActions';
 import { katelloPackageUpdateUrl, packagesUpdateUrl } from '../customizedRexUrlHelpers';
 import './PackagesTab.scss';
-import hostIdNotReady from '../../HostDetailsActions';
+import hostIdNotReady, { getHostDetails } from '../../HostDetailsActions';
 import PackageInstallModal from './PackageInstallModal';
 import { defaultRemoteActionMethod,
   hasRequiredPermissions as can,
@@ -170,7 +170,7 @@ export const PackagesTab = () => {
     triggerJobStart: triggerPackageUpgrade,
     lastCompletedJob: lastCompletedPackageUpgrade,
     isPolling: isUpgradeInProgress,
-  } = useRexJobPolling(packageUpgradeAction);
+  } = useRexJobPolling(packageUpgradeAction, getHostDetails({ hostname }));
 
   const packageBulkUpgradeAction = bulkParams => updatePackages({
     hostname,
@@ -181,7 +181,7 @@ export const PackagesTab = () => {
     triggerJobStart: triggerBulkPackageUpgrade,
     lastCompletedJob: lastCompletedBulkPackageUpgrade,
     isPolling: isBulkUpgradeInProgress,
-  } = useRexJobPolling(packageBulkUpgradeAction);
+  } = useRexJobPolling(packageBulkUpgradeAction, getHostDetails({ hostname }));
 
   const packageInstallAction
     = bulkParams => installPackageBySearch({ hostname, search: bulkParams });
@@ -190,7 +190,7 @@ export const PackagesTab = () => {
     triggerJobStart: triggerPackageInstall,
     lastCompletedJob: lastCompletedPackageInstall,
     isPolling: isInstallInProgress,
-  } = useRexJobPolling(packageInstallAction);
+  } = useRexJobPolling(packageInstallAction, getHostDetails({ hostname }));
 
   const actionInProgress = (isRemoveInProgress || isUpgradeInProgress
     || isBulkRemoveInProgress || isBulkUpgradeInProgress || isInstallInProgress);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When you apply errata to a host, the host does a package profile upload and the host's stored errata counts are updated. However, this change was not being reflected soon enough in the UI.  This would result in symptoms like

* when you apply all errata from the Errata tab, you would see a message 'This host has errata that are applicable, but not installable'
* when you've recently upgraded or downgraded a package on the host, the errata counts in the errata overview card won't match those in the Errata tab

The change in this PR is to re-fetch the host details, including content facet and errata counts, under the following conditions:

1. When you apply one or more errata on the Errata tab and the REX job completes
2. When you upgrade or install a package on the Packages tab
3. When you load the Errata tab (and you aren't searching or filtering results) and the total number of results don't match the stored errata count

This ensures that the Errata overview card totals are always up to date.

#### Considerations taken when implementing this change?
I have a bit of logic for #3 so that it doesn't fetch too many times.

#### What are the testing steps for this pull request?

### Setup
1. Create a custom repository with the url `https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/`
2. Sync the repo
3. On your host, install the `walrus` package
4. `yum -y downgrade walrus`

You will now have one installable erratum.

After applying the erratum, you can run `yum -y downgrade walrus` again to reset to this state.

I recommend going thru Scenarios 1-3 first without this PR applied, then with the PR applied.

### Scenario 1
Recreate the issue: Apply the errata from the Errata tab and stay on the page. 

You'll see the 'This host has errata that are applicable, but not installable' message. If you click the Overview tab, you'll see the pie chart with 1 erratum.  Refreshing the page in the browser, you'll see 'All errata are up-to-date' in both places.

After applying this PR: Apply the errata from the Errata tab and stay on the page.  You'll immediately see 'All errata are up-to-date' on both the Errata tab and overview card.

### Scenario 2
`yum -y downgrade walrus` and refresh the browser to get the installable errata again.
On the Packages tab, search for 'walrus' and upgrade it. (Do not leave the host details page while the job is running.)
When the toast notification appears that the job is complete, go to the Overview tab: You'll see the pie chart with 1 erratum.  But go to the Errata tab: You'll see the Sea Erratum is not in the list.

After applying this PR: After upgrading the package, you'll immediately see 'All errata are up-to-date' on both the Errata tab and overview card.

### Scenario 3
`yum -y downgrade walrus` and refresh the browser to get the installable errata again.
`yum -y upgrade walrus` on the host: This will upgrade without the host details page knowing about it.

On the Overview tab, you'll still see the pie chart with 1 erratum.
Go to the Errata tab, though, and you'll see 'This host has errata that are applicable, but not installable'. Refreshing the browser will get you a correct message both on the Overview card and Errata tab.

After applying this PR: After upgrading the package, go to the Errata tab. It will realize that the host errata count doesn't match the results it's just retrieved from the API, and re-fetch the host details with the upgraded errata counts. You should now see 'All errata are up-to-date' both on the Errata tab and overview card.

