### PR TITLE
Fixes #35442 - Correctly validates non yum repo export

### DIFF
--- a/app/lib/actions/pulp3/orchestration/content_view_version/export_library.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/export_library.rb
@@ -14,7 +14,7 @@ module Actions
                                                                            organization: organization,
                                                                            create_by_default: true,
                                                                            format: format)
-            repo_ids_in_library = organization.default_content_view_version.repositories.exportable.immediate_or_none.pluck(:id)
+            repo_ids_in_library = organization.default_content_view_version.repositories.exportable(format: format).immediate_or_none.pluck(:id)
             content_view.update!(repository_ids: repo_ids_in_library)
 
             sequence do

--- a/app/services/katello/pulp3/content_view_version/syncable_format_export.rb
+++ b/app/services/katello/pulp3/content_view_version/syncable_format_export.rb
@@ -24,7 +24,11 @@ module Katello
         end
 
         def generate_repository_exporter_path
-          _org, _content, content_path = repository.library_instance_or_self.relative_path.split("/", 3)
+          if repository.docker?
+            content_path = repository.library_instance_or_self.relative_path
+          else
+            _org, _content, content_path = repository.library_instance_or_self.relative_path.split("/", 3)
+          end
           content_path = content_path.sub(%r|^/|, '')
           "#{generate_exporter_path}/#{content_path}".gsub(/\s/, '_')
         end

--- a/test/support/export_support.rb
+++ b/test/support/export_support.rb
@@ -1,10 +1,13 @@
 module Support
   module ExportSupport
-    def fetch_exporter(smart_proxy:, content_view_version:, destination_server: nil, from_content_view_version: nil)
-      export = ::Katello::Pulp3::ContentViewVersion::Export.new(smart_proxy: smart_proxy,
+    def fetch_exporter(smart_proxy:, content_view_version:,
+                       destination_server: nil, from_content_view_version: nil,
+                       format: ::Katello::Pulp3::ContentViewVersion::Export::IMPORTABLE)
+      export = ::Katello::Pulp3::ContentViewVersion::Export.create(smart_proxy: smart_proxy,
                                                                  content_view_version: content_view_version,
                                                                  destination_server: destination_server,
-                                                                 from_content_view_version: from_content_view_version
+                                                                 from_content_view_version: from_content_view_version,
+                                                                 format: format
                                                                  )
       version_repositories = content_view_version.archived_repos.yum_type
       version_repositories.each_with_index do |repo, index|


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This PR correctly checks for valid export syncable formats which is  file + yum.
This means when you export library/content view version with yum + file + ansible + docker repos in a syncable format it will correctly export only the yum + file subset ignoring docker and ansible.
OTOH if its not a syncable format but importable all 4 formats are valid. So the export will have all 4 types in it.

Additionally this PR raises an error if you are trying to do a repo export in a syncable format for a non supported repository type like ansible/docker.  

#### Considerations taken when implementing this change?
Added some validation to ensure only yum and file are included. 
Made `Repository.exportable` pick up  format parameter so as to ensure the correct types are selected.

#### What are the testing steps for this pull request?
- Checkout -> https://github.com/Katello/hammer-cli-katello/pull/863
-  Create new org 
-  Create + Sync  4 repositories of type yum, file, docker and ansible. 
-  `hammer content-export complete repository --id=<ansible repo id> --format=syncable`

Before PR:
`Unable to export because its download policy is not set to immediate `

After PR:
`Unable to export <ansible repo ..> because it is not an exportable type`

Next try the library one 
- `hammer content-export complete library --organization-id=<org id> --format=syncable`

Before PR:
- ISE on a publication

After PR:
- Clean export of file and yum repos in the directory


