### PR TITLE
Fixes #35693 - Use optimize and complete sync for APT repos

### DIFF
--- a/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
@@ -34,7 +34,7 @@ module Katello
       syncable_products = @products.syncable
       syncable_roots = RootRepository.where(:product_id => syncable_products).has_url
 
-      syncable_roots = syncable_roots.yum_type if skip_metadata_check || validate_contents
+      syncable_roots = syncable_roots.skipable_metadata_check if skip_metadata_check || validate_contents
       syncable_roots = syncable_roots.where.not(:download_policy => ::Katello::RootRepository::DOWNLOAD_ON_DEMAND) if validate_contents
 
       syncable_repositories = Katello::Repository.where(:root_id => syncable_roots).in_default_view

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -346,7 +346,7 @@ module Katello
     param :id, :number, :required => true, :desc => N_("repository ID")
     param :source_url, String, :desc => N_("temporarily override feed URL for sync"), :required => false
     param :incremental, :bool, :desc => N_("perform an incremental import"), :required => false
-    param :skip_metadata_check, :bool, :desc => N_("Force sync even if no upstream changes are detected. Only used with yum repositories."), :required => false
+    param :skip_metadata_check, :bool, :desc => N_("Force sync even if no upstream changes are detected. Only used with yum or deb repositories."), :required => false
     param :validate_contents, :bool, :desc => N_("Force a sync and validate the checksums of all content. Only used with yum repositories."), :required => false
     def sync
       sync_options = {

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -21,6 +21,7 @@ module Katello
     CHECKSUM_TYPES = %w(sha1 sha256).freeze
 
     SUBSCRIBABLE_TYPES = [Repository::YUM_TYPE, Repository::OSTREE_TYPE, Repository::DEB_TYPE].freeze
+    SKIPABLE_METADATA_TYPES = [Repository::YUM_TYPE, Repository::DEB_TYPE].freeze
 
     CONTENT_ATTRIBUTE_RESTRICTIONS = {
       :download_policy => [Repository::YUM_TYPE, Repository::DEB_TYPE, Repository::DOCKER_TYPE]
@@ -101,6 +102,7 @@ module Katello
       :message => _("must be one of the following: %s") % HTTP_PROXY_POLICIES.join(', ')
     }
     scope :subscribable, -> { where(content_type: RootRepository::SUBSCRIBABLE_TYPES) }
+    scope :skipable_metadata_check, -> { where(content_type: RootRepository::SKIPABLE_METADATA_TYPES) }
     scope :has_url, -> { where.not(:url => nil) }
     scope :with_repository_attribute, ->(attr, value) { joins(:repositories).where("#{Katello::Repository.table_name}.#{attr}" => value) }
     scope :in_content_view_version, ->(version) { with_repository_attribute(:content_view_version_id, version) }

--- a/app/services/katello/pulp3/repository/apt.rb
+++ b/app/services/katello/pulp3/repository/apt.rb
@@ -24,6 +24,12 @@ module Katello
           common_remote_options.merge(deb_remote_options)
         end
 
+        def sync_url_params(sync_options)
+          params = super
+          params[:optimize] = sync_options[:optimize] if sync_options.key?(:optimize)
+          params
+        end
+
         def mirror_remote_options
           super.merge(
             {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/views/products-bulk-advanced-sync-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/views/products-bulk-advanced-sync-modal.html
@@ -12,7 +12,7 @@
 
     <div class="help-block">
       <span translate>
-        Selecting "Complete Sync" will cause only Yum repositories of the selected product to be synced.
+        Selecting "Complete Sync" will cause only yum/deb repositories of the selected product to be synced.
       </span>
     </div>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-advanced-sync-options.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-advanced-sync-options.html
@@ -12,7 +12,7 @@
     </div>
   </div>
 
-  <div class="radio" ng-hide="repository.content_type === 'deb'">
+  <div class="radio">
     <label>
       <input type="radio" ng-model="syncType" value="skipMetadataCheck" />
       <span translate>
@@ -21,10 +21,10 @@
     </label>
     <div class="help-block">
       <span translate>
-        Sync even if the upstream metadata appears to have no change. This option is only relevant for yum repositories and will take longer than an optimized sync. Choose this option if:
+        Sync even if the upstream metadata appears to have no change. This option is only relevant for yum/deb repositories and will take longer than an optimized sync. Choose this option if:
       </span>
       <ul class="list-aligned">
-        <li translate>One or more RPMs are not showing up in the local repository even though they exist in the upstream repository.</li>
+        <li translate>One or more packages are not showing up in the local repository even though they exist in the upstream repository.</li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

They allow for Katello to make use of the pulp_deb optimize sync mode, which uses exactly the same interface as the pulp_rpm optimize sync.

#### Considerations taken when implementing this change?

This requires pulp_deb 2.20.0 and pulpcore 3.21 as well as updated client rubygems. These versions will probably not be available in Katello for some time, so this PR is more for discussion for now.

#### What are the testing steps for this pull request?

There are three places where these changes can be used from:

- smart proxy page > Synchronize (drop down) > Optimize Sync or Complete Sync
- Repository page (of a deb type repo) > Select Action > Advanced Sync > Optimize Sync or Complete Sync > Sync
- Products page > Select products that include deb type repos > Select Action > Advanced Sync > Optimize Sync or Complete Sync

In each case, the corresponding underlying pulp sync task needs to be called with the correctly set `optimize` flag.