### PR TITLE
Fixes #35459 - Non-enabled repository types make it into the apipie help-text

### DIFF
--- a/app/services/katello/repository_type.rb
+++ b/app/services/katello/repository_type.rb
@@ -174,7 +174,9 @@ module Katello
           label: label,
           generic_browser: generic_browser,
           generic: false,
-          removable: removable
+          removable: removable,
+          uploadable: uploadable,
+          indexed: index && index_on_pulp3
         }
       end
 

--- a/app/services/katello/repository_type_manager.rb
+++ b/app/services/katello/repository_type_manager.rb
@@ -139,9 +139,10 @@ module Katello
         enabled_repository_types[katello_label]
       end
 
-      def find_content_type(katello_label)
+      def find_content_type(katello_label, indexable = false)
         enabled_repository_types.values.each do |repo_type|
-          repo_type.content_types.each do |content_type|
+          content_types = indexable ? repo_type.content_types_to_index : repo_type.content_types
+          content_types.each do |content_type|
             return content_type if content_type.label == katello_label.to_s
           end
         end
@@ -167,7 +168,7 @@ module Katello
       def check_content_matches_repo_type!(repository, content_type)
         repo_content_types = repository.repository_type.content_types.collect { |type| type.label }
         unless repo_content_types.include?(content_type)
-          fail _("Content type %{content_type} is incompatible with repositories of type %{repo_type}") %
+          fail HttpErrors::BadRequest, _("Content type %{content_type} is incompatible with repositories of type %{repo_type}") %
                  { content_type: content_type, repo_type: repository.content_type }
         end
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Removes references to defined repository types in the repositories API apipie.  These repository types may not be enabled on the server and thus are misleading. Instead, we point the user to use the repository types API.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1) Look at the apipie help-text for the following, ensuring that repository or content unit types are not there:
```
GET /repositories
POST /repositories
PUT /repositories/:id/remove_content
POST /repositories/:id/upload_content
```
2) Try sending the `content_type` or `with_content` parameters to ensure they still work.  Try sending types that don't exist. I had to move the validations into their own manual checks.

3) Check apipie in general to ensure types like "deb" don't show up if they're not enabled.

TODO:
- [x] Make a hammer PR that either shows the available types or suggests a different command to find them.