### PR TITLE
Fixes #35484 - Unable to apply all Errata via Remote Execution on Web UI with "Select All"

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -406,7 +406,7 @@ module Katello
       fail Katello::Errors::InvalidRepositoryContent, _("Cannot upload Ansible collections.") if @repository.ansible_collection?
       unless params[:content_type].empty? || RepositoryTypeManager.uploadable_content_types.map(&:label).include?(params[:content_type])
         msg = _("Invalid params provided - content_type must be one of %s") %
-          RepositoryTypeManager.uploadable_content_types.map(&:label).join(",")
+          RepositoryTypeManager.uploadable_content_types.map(&:label).sort.join(",")
         fail HttpErrors::UnprocessableEntity, msg
       end
 

--- a/app/services/katello/bulk_items_helper.rb
+++ b/app/services/katello/bulk_items_helper.rb
@@ -20,12 +20,12 @@ module Katello
       params[:excluded] ||= {}
 
       items = model_scope
-      if params[:included][:ids]
+      if params[:included][:ids].present?
         items = model_scope.where(key => params[:included][:ids])
-      elsif params[:included][:search]
+      elsif params[:included][:search].present?
         items = model_scope.search_for(params[:included][:search])
       end
-      if params[:excluded][:ids]
+      if params[:excluded][:ids].present?
         items = items.where.not(key => params[:excluded][:ids])
       end
 

--- a/test/services/katello/bulk_items_helper_test.rb
+++ b/test/services/katello/bulk_items_helper_test.rb
@@ -1,0 +1,14 @@
+require 'katello_test_helper'
+
+module Katello
+  class BulkItemsHelperTest < ActiveSupport::TestCase
+    def test_select_all_errata
+      bulk_params = { included: { ids: [], search: '' }, excluded: { ids: [] } }
+      bulk_items = ::Katello::BulkItemsHelper.new(bulk_params: bulk_params,
+        model_scope: ::Katello::Erratum.all,
+        key: :errata_id).fetch
+
+      assert_equal_arrays ::Katello::Erratum.all.to_a, bulk_items
+    end
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fixes `BulkItemsHelper.fetch()` so that empty includes/excludes correctly return all items unfiltered.  The code accepted `[]` as true, which caused the wrong `if` statements to execute.

#### Considerations taken when implementing this change?
The new test should help ensure this doesn't break again.

#### What are the testing steps for this pull request?
1) Register a content host that has some errata.
2) Apply errata with REX by using the "Select all #" option in both the old content host details page AND the "Manage Errata" modal from the content host index page.
3) Try applying all errata again, this time ensuring that un-checked errata are not included in the REX job.
4) Try applying single errata without using "Select all #".
5) Ensure that applying all errata from the new host details page works as well.