### PR TITLE
Fixes #35499 - apipie param_group error host subs controller

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -24,7 +24,7 @@ module Katello
       param :service_level, String, :desc => N_("Service level to be used for autoheal")
       param :hypervisor_guest_uuids, Array, :desc => N_("List of hypervisor guest uuids")
       param :installed_products_attributes, Array, :desc => N_("List of products installed on the host") do
-        param_group :installed_products
+        param_group :installed_products, Api::V2::HostSubscriptionsController
       end
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This PR (https://github.com/Apipie/apipie-rails/pull/774) seems to have caused apipie-rails to be picky about param_groups within param definitions.  To workaround it, I'm just specifying the controller.  Issue to track: https://github.com/Apipie/apipie-rails/issues/779

#### Considerations taken when implementing this change?
None

#### What are the testing steps for this pull request?
Apply the PR and try running some things like the foreman console or the rails server.