### PR TITLE
Fixes #35501 - Hides generated component cvvs in composite

### DIFF
--- a/app/controllers/katello/api/v2/content_view_components_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_components_controller.rb
@@ -47,7 +47,7 @@ module Katello
          CAST (#{kcc}.composite_content_view_id as BOOLEAN) ASC, #{kc}.name
       SQL
       query = Katello::ContentView.readable.in_organization(@organization)
-      query = query&.non_composite&.non_default
+      query = query&.non_composite&.non_default&.generated_for_none
       component_cv_ids = Katello::ContentViewComponent.where(composite_content_view_id: @view.id).select(:content_view_id)
       query = case params[:status]
               when "Not added"

--- a/app/models/katello/content_view_component.rb
+++ b/app/models/katello/content_view_component.rb
@@ -56,6 +56,10 @@ module Katello
       if attached_content_view_ids.include?(view.id)
         errors.add(:base, _("Another component already includes content view with ID %s" % view.id))
       end
+
+      unless view.generated_for_none?
+        errors.add(:base, _("Cannot add generated content view versions to composite content view"))
+      end
     end
 
     def ensure_valid_attributes

--- a/test/models/content_view_component_test.rb
+++ b/test/models/content_view_component_test.rb
@@ -117,6 +117,21 @@ module Katello
                              /^Another component already includes content view with ID/)
     end
 
+    def test_create_content_view_with_generate_cv_components
+      view1 = create(:katello_content_view)
+      view1.generated_for_repository_export!
+      create(:katello_content_view_version, :content_view => view1)
+      component = ContentViewComponent.create(:composite_content_view => @composite,
+                                   :content_view => view1, :latest => true)
+      refute_with_error(component, /^Cannot add generated content view versions to composite content view/)
+
+      view1.generated_for_none!
+      @composite = @composite.reload
+      component = ContentViewComponent.create!(:composite_content_view => @composite,
+                                              :content_view => view1, :latest => true)
+      assert_valid component
+    end
+
     def test_latest_versions
       # test that it gets the latest versions correctly
       view1 = create(:katello_content_view)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When we ask for a list of component cvv's available for a composite, the backend api also returns component cvvs that are from export/import generated content views (like export-library/export-repository) etc. These versions are not meant to be included in the composite.

This commit changes this behavior by filtering out generated content views all together.

Also adds validation to not add generated content view versions to a composite

#### What are the testing steps for this pull request?

1. Export a repository or library
2. Create a Composite CV
3. Go to 'Content Views' tab of composite cv details page

Before PR
You'd notice the `Export-*` content views

After PR
No `Export-*` cvs

Additional ideas
0. Checkout PR
1. Export a content view version.
2. Go to 'Content Views' tab of composite cv details page
3. Make sure the exported CVV is still there on that page.
