### PR TITLE
Fixes #35503 - Calculate errata_mail errata list via updated_at per erratum

### DIFF
--- a/app/lib/actions/katello/repository/errata_mail.rb
+++ b/app/lib/actions/katello/repository/errata_mail.rb
@@ -13,7 +13,7 @@ module Actions
           ::User.current = ::User.anonymous_admin
           repo = ::Katello::Repository.find(input[:repo])
           users = ::User.select { |user| user.receives?(:sync_errata) && user.organization_ids.include?(repo.organization.id) && user.can?(:view_products, repo.product) }.compact
-          errata = ::Katello::Erratum.where(:id => repo.repository_errata.where('katello_repository_errata.updated_at > ?', input['last_updated'].to_datetime).pluck(:erratum_id))
+          errata = ::Katello::Erratum.where(:id => repo.repository_errata.pluck(:erratum_id)).where('updated_at < ?', input['last_updated'].to_datetime)
 
           begin
             MailNotification[:sync_errata].deliver(:users => users, :repo => repo, :errata => errata) unless (users.blank? || errata.blank?)


### PR DESCRIPTION
Previously this was done per the updated_at attribute on katello_repository_errata

CC: @pmoravec @hao-yu @sjha4 
