### PR TITLE
Fixes #35505 - Syncable format Imports

### DIFF
--- a/app/controllers/katello/api/v2/content_imports_controller.rb
+++ b/app/controllers/katello/api/v2/content_imports_controller.rb
@@ -66,6 +66,7 @@ module Katello
         :toc,
         :incremental,
         :destination_server,
+        :format,
         gpg_keys: {},
         content_view: [:name, :label, :description, :generated_for],
         content_view_version: [:major, :minor, :description],

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -9,10 +9,10 @@ module Actions
         execution_plan_hooks.use :trigger_capsule_sync, :on => :success
 
         # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity
-        def plan(content_view, description = "", options = {importing: false}) # rubocop:disable Metrics/PerceivedComplexity
+        def plan(content_view, description = "", options = {importing: false, syncable: false}) # rubocop:disable Metrics/PerceivedComplexity
           action_subject(content_view)
 
-          content_view.check_ready_to_publish!(importing: options[:importing])
+          content_view.check_ready_to_publish!(options.slice(:importing, :syncable))
 
           if options[:repos_units].present?
             valid_labels_from_cv = content_view.repositories.map(&:label)

--- a/app/lib/actions/katello/content_view_version/auto_create_redhat_repositories.rb
+++ b/app/lib/actions/katello/content_view_version/auto_create_redhat_repositories.rb
@@ -2,16 +2,20 @@ module Actions
   module Katello
     module ContentViewVersion
       class AutoCreateRedhatRepositories < Actions::Base
-        def plan(import:)
+        def plan(import:, path:)
           helper = ::Katello::Pulp3::ContentViewVersion::ImportableRepositories.new(
             organization: import.organization,
-            metadata_repositories: import.metadata_map.repositories.select { |r| r.redhat }
+            metadata_repositories: import.metadata_map.repositories.select { |r| r.redhat },
+            syncable_format: import.metadata_map.syncable_format?,
+            path: path
           )
           helper.generate!
 
           sequence do
             helper.creatable.each do |root|
-              plan_action(::Actions::Katello::RepositorySet::EnableRepository, root[:product], root[:content], root[:substitutions])
+              plan_action(::Actions::Katello::RepositorySet::EnableRepository,
+                            root[:product], root[:content], root[:substitutions],
+                            override_url: root[:override_url])
             end
             helper.updatable.each do |root|
               plan_action(::Actions::Katello::Repository::Update, root[:repository], root[:options])

--- a/app/lib/actions/katello/content_view_version/auto_create_repositories.rb
+++ b/app/lib/actions/katello/content_view_version/auto_create_repositories.rb
@@ -2,10 +2,12 @@ module Actions
   module Katello
     module ContentViewVersion
       class AutoCreateRepositories < Actions::Base
-        def plan(import:)
+        def plan(import:, path:)
           helper = ::Katello::Pulp3::ContentViewVersion::ImportableRepositories.new(
             organization: import.organization,
-            metadata_repositories: import.metadata_map.repositories.select { |r| !r.redhat }
+            metadata_repositories: import.metadata_map.repositories.select { |r| !r.redhat },
+            syncable_format: import.metadata_map.syncable_format?,
+            path: path
           )
           helper.generate!
 

--- a/app/lib/katello/resources/cdn/katello_cdn.rb
+++ b/app/lib/katello/resources/cdn/katello_cdn.rb
@@ -33,19 +33,9 @@ module Katello
           results = json_body['results']
 
           results.map do |repo|
-            arch = repo['arch']
-            arch = nil if arch == "noarch"
-            substitutions = {
-              :releasever => repo['minor'],
-              :basearch => arch
-            }.compact
-            path = substitutions.inject(content_path) do |path_url, (key, value)|
-              path_url.gsub("$#{key}", value)
-            end
-            {
-              path: path,
-              substitutions: substitutions
-            }
+            Katello::Content.substitute_content_path(arch: repo[:arch],
+                                                     releasever: repo[:minor],
+                                                     content_path: content_path)
           end
         end
 

--- a/app/models/katello/content.rb
+++ b/app/models/katello/content.rb
@@ -63,5 +63,20 @@ module Katello
       new_url_subs = new_url&.scan(/\$\w+/)&.sort
       current_subs == new_url_subs
     end
+
+    def self.substitute_content_path(arch: nil, releasever: nil, content_path:)
+      arch = nil if arch == "noarch"
+      substitutions = {
+        :releasever => releasever,
+        :basearch => arch
+      }.compact
+      path = substitutions.inject(content_path) do |path_url, (key, value)|
+        path_url.gsub("$#{key}", value)
+      end
+      {
+        path: path,
+        substitutions: substitutions
+      }
+    end
   end
 end

--- a/app/services/katello/pulp3/content_view_version/import.rb
+++ b/app/services/katello/pulp3/content_view_version/import.rb
@@ -156,6 +156,8 @@ module Katello
           fail _("Content View label not provided.") if metadata_map.content_view.label.blank?
 
           params = import_content_view_params
+          return if @metadata_map.syncable_format? && params[:generated_for] != :none
+
           cv = ::Katello::ContentView.find_by(label: params[:label],
                                               organization: organization)
           if cv.blank?

--- a/test/actions/katello/content_view_version/import_test.rb
+++ b/test/actions/katello/content_view_version/import_test.rb
@@ -104,6 +104,7 @@ module ::Actions::Katello::ContentViewVersion
                                     path: path,
                                     metadata: metadata,
                                     importing: true,
+                                    syncable: false,
                                     major: metadata[:content_view_version][:major],
                                     minor: metadata[:content_view_version][:minor])
       end
@@ -123,6 +124,7 @@ module ::Actions::Katello::ContentViewVersion
                                     path: path,
                                     metadata: metadata,
                                     importing: true,
+                                    syncable: false,
                                     major: metadata[:content_view_version][:major],
                                     minor: metadata[:content_view_version][:minor])
       end
@@ -145,6 +147,7 @@ module ::Actions::Katello::ContentViewVersion
                                     path: path,
                                     metadata: metadata,
                                     importing: true,
+                                    syncable: false,
                                     major: metadata[:content_view_version][:major],
                                     minor: metadata[:content_view_version][:minor])
       end

--- a/test/services/katello/pulp3/content_view_version/import_test.rb
+++ b/test/services/katello/pulp3/content_view_version/import_test.rb
@@ -13,7 +13,8 @@ module Katello
             stub('metadata_map',
                  repositories: @metadata_repos,
                  products: @metadata_products,
-                 content_view: @metadata_cv
+                 content_view: @metadata_cv,
+                 syncable_format?: false
                 )
           end
 

--- a/test/services/katello/pulp3/content_view_version/import_validator_test.rb
+++ b/test/services/katello/pulp3/content_view_version/import_validator_test.rb
@@ -19,7 +19,8 @@ module Katello
                  content_view_version: @metadata_cvv,
                  from_content_view_version: @metadata_from_cvv,
                  products: @metadata_products,
-                 repositories: @metadata_repos
+                 repositories: @metadata_repos,
+                 syncable_format?: false
            )
 
             stub('import',


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This PR implements api and hammer bindings for content-import repositories in syncable format
Syncable import should
- Auto Create the appropriate content view (unless it is library or repository)
- Create any custom products and repositories
- Enable any rh repositories
- Update the sync urls of the repositories to point 'file://<dump location>/<repository path>'
- Sync the repositories
- Publish the content view (if one is present)

#### What are the testing steps for this pull request?

-  Check out this PR and https://github.com/Katello/hammer-cli-katello/pull/865
-  Create and sync a custom repo
-  In addition enable an rh repo with download policy set to immediate (In my case I enabled ansible 2.9)
-  Sync the rh repo
-  Add the 2 repos to a content view and publish
-  Export the content view version syncably
```
$ hammer content-export complete version --id=34 --format=syncable
[....................................................................................................................................................................] [100%]
Generated /var/lib/pulp/exports/Default_Organization/cv/1.0/2022-09-08T02-34-44-00-00/metadata.json
```
- Create a new org  
- Subscriptions -> Manage Manifest - Upload Mainfest
- Subscriptions -> Manage Manifest -> CDN Configuration -> Export Sync (not necessary step but might be the real world use case)
- Assuming `/var/lib/pulp/exports/` is in your `ALLOWED_IMPORT_PATHS` in `/etc/pulp/setting.py` 
- Run the following import operation
```
$ hammer content-import  version --organization=<org> --path=/var/lib/pulp/exports/Default_Organization/cv/1.0/2022-09-08T02-34-44-00-00/
[....................................................................................................................................................................] [100%]
```
- In the new org go to  `Content -> Content Views`
- Make sure same CV is created  
- Ensure Versions and counts are accurate 
- Go to `Content -> Products`
-  Verify that the correct repositories are enabled or synced.
- Click on Product and Repository details
- Verify that the download policy is set to immediate
-  Verify that the `Upstream URL` looks like `file:///var/lib/pulp/exports/Default_Organization/cv/1.0/2022-09-08T02-34-44-00-00/content/dist/rhel/server/7/7Server/x86_64/ansible/2.9/os`