### PR TITLE
Demo - Recurring Content view publishing

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -50,6 +50,7 @@ module Katello
 
     has_many :repository_references, :class_name => 'Katello::Pulp3::RepositoryReference',
              :dependent => :destroy, :inverse_of => :content_view
+    belongs_to :task_group, :class_name => 'Katello::ContentViewTaskGroup', :inverse_of => :content_view
 
     validates_lengths_from_database :except => [:label]
     validates :label, :uniqueness => { :scope => :organization_id },

--- a/app/models/katello/content_view_task_group.rb
+++ b/app/models/katello/content_view_task_group.rb
@@ -1,0 +1,9 @@
+module Katello
+  class ContentViewTaskGroup < ::ForemanTasks::TaskGroup
+    has_one :content_view, :foreign_key => :task_group_id, :dependent => :nullify, :inverse_of => :task_group, :class_name => "Katello::ContentView"
+
+    def resource_name
+      N_('Content View')
+    end
+  end
+end

--- a/app/views/katello/content_view_task_groups/_content_view_task_groups.html.erb
+++ b/app/views/katello/content_view_task_groups/_content_view_task_groups.html.erb
@@ -1,0 +1,2 @@
+<%= _("Content View: ") %>
+<%= link_to(task_groups.first.content_view.name, "/content_views/#{task_groups.first.content_view.id}") %>

--- a/db/migrate/20220908200746_add_content_view_task_group.rb
+++ b/db/migrate/20220908200746_add_content_view_task_group.rb
@@ -1,0 +1,6 @@
+class AddContentViewTaskGroup < ActiveRecord::Migration[6.1]
+  def change
+    add_column :katello_content_views, :task_group_id, :integer, :index => true
+    add_foreign_key :katello_content_views, :foreman_tasks_task_groups, :column => :task_group_id
+  end
+end


### PR DESCRIPTION
Demo recurring publishing of CVs.

To play:
Checkout this PR and run db:migrate

In foreman console: 

cron = "* * * * *"
recurring_logic = ForemanTasks::RecurringLogic.new_from_cronline(cron)
recurring_logic.save!
cv = Katello::ContentView.find(:id)
recurring_logic.start(::Actions::Katello::ContentView::Publish, cv)