### PR TITLE
Fixes #35511 - Navigating to content view page from the left panel after creating a cv does not work

### DIFF
--- a/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
+++ b/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
@@ -4,7 +4,6 @@ import { STATUS } from 'foremanReact/constants';
 import { translate as __ } from 'foremanReact/common/I18n';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
-import { Redirect } from 'react-router-dom';
 import { Form, FormGroup, TextInput, TextArea, Checkbox, ActionGroup, Button, Tile, Grid, GridItem } from '@patternfly/react-core';
 import { createContentView } from '../ContentViewsActions';
 import { selectCreateContentViews, selectCreateContentViewStatus, selectCreateContentViewError } from './ContentViewCreateSelectors';
@@ -73,11 +72,10 @@ const CreateContentViewForm = ({ setModalOpen }) => {
 
   if (redirect) {
     const { id } = response;
-    if (composite) { return (<Redirect to={`/content_views/${id}#/contentviews`} />); }
-    return (<Redirect to={`/content_views/${id}#/repositories`} />);
+    if (composite) { window.location.assign(`/content_views/${id}#/contentviews`); } else { window.location.assign(`/content_views/${id}#/repositories`); }
   }
 
-  const submitDisabled = !name?.length || !label?.length || saving || labelValidated === 'error';
+  const submitDisabled = !name?.length || !label?.length || saving || redirect || labelValidated === 'error';
 
   return (
     <Form onSubmit={(e) => {
@@ -198,6 +196,7 @@ const CreateContentViewForm = ({ setModalOpen }) => {
           aria-label="create_content_view"
           variant="primary"
           isDisabled={submitDisabled}
+          isLoading={saving || redirect}
           type="submit"
         >
           {__('Create content view')}

--- a/webpack/scenes/ContentViews/Create/__tests__/createContentView.test.js
+++ b/webpack/scenes/ContentViews/Create/__tests__/createContentView.test.js
@@ -8,7 +8,14 @@ import cvCreateData from './contentViewCreateResult.fixtures.json';
 
 const cvCreatePath = api.getApiUrl('/content_views');
 
-const setModalOpen = jest.fn();
+const mockFn = jest.fn();
+
+delete window.location;
+window.location = { assign: mockFn };
+
+afterEach(() => {
+  mockFn.mockClear();
+});
 
 const createDetails = {
   name: '1232123',
@@ -22,7 +29,7 @@ const createDetails = {
 
 const createdCVDetails = { ...cvCreateData };
 
-const form = <CreateContentViewForm setModalOpen={setModalOpen} />;
+const form = <CreateContentViewForm setModalOpen={mockFn} />;
 
 test('Can save content view from form', async (done) => {
   const createscope = nockInstance
@@ -44,7 +51,7 @@ test('Form closes itself upon save', async (done) => {
   const createscope = nockInstance
     .post(cvCreatePath, createDetails)
     .reply(201, createdCVDetails);
-  const { getByText, queryByText, getByLabelText } = renderWithRedux(form);
+  const { getByText, getByLabelText } = renderWithRedux(form);
   expect(getByText('Description')).toBeInTheDocument();
   expect(getByText('Name')).toBeInTheDocument();
   expect(getByText('Label')).toBeInTheDocument();
@@ -52,11 +59,11 @@ test('Form closes itself upon save', async (done) => {
   fireEvent.change(getByLabelText('input_name'), { target: { value: '1232123' } });
 
   await patientlyWaitFor(() => { expect(getByLabelText('input_label')).toHaveAttribute('value', '1232123'); });
-
+  jest.spyOn(window.location, 'assign');
   getByLabelText('create_content_view').click();
-  // Form closes it self on success
+  // Form closes it self on success by calling location.assign()
   await patientlyWaitFor(() => {
-    expect(queryByText('Description')).not.toBeInTheDocument();
+    expect(window.location.assign).toHaveBeenCalled();
   });
 
   assertNockRequest(createscope, done);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Go to Content > Content Views
Create a new CV.
You should land on repositories tab of new CV. ( or content view tab of new Composite Content View.)
Try going to Content > Content Views from navigation.
