### PR TITLE
Fixes #35512 - Don't trigger autosearch until you've typed an operator

### DIFF
--- a/webpack/components/Search/Search.js
+++ b/webpack/components/Search/Search.js
@@ -12,6 +12,25 @@ import {
   AUTOSEARCH_WHILE_TYPING,
 } from '../../scenes/Settings/SettingsConstants';
 
+// Don't trigger auto-search until you've typed an operator and begun to type a value
+const searchContainsOperator = (search = '') => {
+  const operators = ['>=', '<=', '>', '<', '~', '^', '!^', '=', '!=', '~', '!~'];
+  return operators.some(operator => search.includes(operator) && !search.trim().endsWith(operator));
+};
+// Apply the above function only to the last 'key = value' pair, if there are multiple
+const allowSearch = (originalSearch = '') => {
+  const search = originalSearch.toLowerCase().trim();
+  // find the last occurrence of 'or' or 'and'
+  const lastOr = originalSearch.lastIndexOf('or');
+  const lastAnd = originalSearch.lastIndexOf('and');
+  if (lastOr === -1 && lastAnd === -1) {
+    return searchContainsOperator(search);
+  }
+  const winningOperator = lastOr > lastAnd ? 'or' : 'and';
+  const lastSearch = search.split(winningOperator);
+  return searchContainsOperator(lastSearch.at(-1));
+};
+
 const Search = ({
   onSearch,
   updateSearchQuery,
@@ -62,7 +81,7 @@ const Search = ({
       }
     }
 
-    if (autoSearchEnabled && patternfly4) {
+    if (autoSearchEnabled && patternfly4 && allowSearch(searchTerm)) {
       onSearch(searchTerm || '');
     }
   };

--- a/webpack/components/Search/Search.js
+++ b/webpack/components/Search/Search.js
@@ -21,14 +21,14 @@ const searchContainsOperator = (search = '') => {
 const allowSearch = (originalSearch = '') => {
   const search = originalSearch.toLowerCase().trim();
   // find the last occurrence of 'or' or 'and'
-  const lastOr = originalSearch.lastIndexOf('or');
-  const lastAnd = originalSearch.lastIndexOf('and');
+  const lastOr = originalSearch.lastIndexOf(' or ');
+  const lastAnd = originalSearch.lastIndexOf(' and ');
   if (lastOr === -1 && lastAnd === -1) {
     return searchContainsOperator(search);
   }
-  const winningOperator = lastOr > lastAnd ? 'or' : 'and';
+  const winningOperator = lastOr > lastAnd ? ' or ' : ' and ';
   const lastSearch = search.split(winningOperator);
-  return searchContainsOperator(lastSearch.at(-1));
+  return searchContainsOperator(lastSearch[lastSearch.length - 1]);
 };
 
 const Search = ({
@@ -80,7 +80,6 @@ const Search = ({
         })));
       }
     }
-
     if (autoSearchEnabled && patternfly4 && allowSearch(searchTerm)) {
       onSearch(searchTerm || '');
     }

--- a/webpack/components/Search/__tests__/search.test.js
+++ b/webpack/components/Search/__tests__/search.test.js
@@ -77,8 +77,8 @@ test('search function is called when search is typed into with autosearch', asyn
   const mockSearch = jest.fn();
 
   const { getByLabelText } = renderWithRedux(<Search {...{ ...props, onSearch: mockSearch }} />);
-  fireEvent.change(getByLabelText(/text input for search/i), { target: { value: 'foo' } });
-  await patientlyWaitFor(() => expect(mockSearch.mock.calls).toHaveLength(2));
+  fireEvent.change(getByLabelText(/text input for search/i), { target: { value: 'name = foo' } });
+  await patientlyWaitFor(() => expect(mockSearch.mock.calls).toHaveLength(1));
 
   assertNockRequest(autoSearchScope);
   assertNockRequest(autocompleteScope, done);
@@ -98,7 +98,7 @@ test('search function is called by clicking search button without autosearch', a
     expect(searchButton).toBeInTheDocument();
   });
   searchButton.click();
-  expect(mockSearch.mock.calls).toHaveLength(3);
+  expect(mockSearch.mock.calls).toHaveLength(1);
   assertNockRequest(autoSearchScope);
   assertNockRequest(autocompleteScope, done);
 });

--- a/webpack/scenes/ContentViews/Details/Filters/MatchContentModal/__tests__/CVRpmMatchContentModal.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/MatchContentModal/__tests__/CVRpmMatchContentModal.test.js
@@ -73,7 +73,7 @@ test('Can search with filter', async (done) => {
     expect(queryByText(secondMatchContentName)).toBeInTheDocument();
   });
 
-  fireEvent.change(getByLabelText(/text input for search/i), { target: { value: firstMatchContent.nvra } });
+  fireEvent.change(getByLabelText(/text input for search/i), { target: { value: `nvra = ${firstMatchContent.nvra}` } });
 
   await patientlyWaitFor(() => {
     expect(queryByText('Matching content')).toBeInTheDocument();

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/CVContainerImageFilterContent.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/CVContainerImageFilterContent.test.js
@@ -179,7 +179,7 @@ test('Can add filter rules', async (done) => {
     expect(getAllByLabelText('text input for search')[0]).toBeInTheDocument();
   });
 
-  fireEvent.change(getAllByLabelText('text input for search')[0], { target: { value: addedRule.name } });
+  fireEvent.change(getAllByLabelText('text input for search')[0], { target: { value: `name = ${addedRule.name}` } });
 
   await patientlyWaitFor(() => {
     expect(getByLabelText('add_edit_filter_rule')).toBeInTheDocument();
@@ -255,7 +255,7 @@ test('Can edit filter rules', async (done) => {
     fireEvent.click(queryByText('Edit'));
   });
 
-  fireEvent.change(getAllByLabelText('text input for search')[0], { target: { value: addedRule.name } });
+  fireEvent.change(getAllByLabelText('text input for search')[0], { target: { value: `name = ${addedRule.name}` } });
 
   await patientlyWaitFor(() => {
     expect(getByLabelText('add_edit_filter_rule')).toBeInTheDocument();

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/CVRpmFilterContent.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/CVRpmFilterContent.test.js
@@ -117,7 +117,7 @@ test('Can search for package rules in package filter details', async (done) => {
   });
 
   // Search and only searched result shows
-  fireEvent.change(getByLabelText(/text input for search/i), { target: { value: lastPackageRuleName } });
+  fireEvent.change(getByLabelText(/text input for search/i), { target: { value: `name = ${lastPackageRuleName}` } });
   await patientlyWaitFor(() => {
     expect(getByText(lastPackageRuleName)).toBeInTheDocument();
     expect(queryByText(firstPackageRuleName)).not.toBeInTheDocument();

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilterDetails.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilterDetails.test.js
@@ -118,7 +118,7 @@ test('Can search for package groups in package group filter', async (done) => {
   });
 
   // Search and only searched result shows
-  fireEvent.change(getByLabelText(/text input for search/i), { target: { value: lastPackageGroupName } });
+  fireEvent.change(getByLabelText(/text input for search/i), { target: { value: `name = ${lastPackageGroupName}` } });
   await patientlyWaitFor(() => {
     expect(getByText(lastPackageGroupName)).toBeInTheDocument();
     expect(queryByText(firstPackageGroupName)).not.toBeInTheDocument();

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilters.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilters.test.js
@@ -88,7 +88,7 @@ test('Can search for filter', async (done) => {
   // Looking for description because the name is in the search bar and could match
   await patientlyWaitFor(() => expect(getByText(description)).toBeInTheDocument());
   // Search for a filter by name
-  fireEvent.change(getByLabelText(/text input for search/i), { target: { value: name } });
+  fireEvent.change(getByLabelText(/text input for search/i), { target: { value: `name = ${name}` } });
   // Only the first filter should be showing, not the last one
   await patientlyWaitFor(() => {
     expect(getByText(description)).toBeInTheDocument();


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Description of problem:
In any content search bar, the initial click shows a dropdown of filter keys. These are literal search terms and not key designators.

How reproducible:
100%

Steps to Reproduce:
1. Register host. 
2. Click on host > Content > Packages. 
3. Click on search bar. 

Actual results:
Search is launched for the Key and not the Value of the filter.

Expected results:
Search is launched for the Value of the filter.

#### Solution

This change prevents the autosearch from triggering until the user has typed
1. an operator - `['>=', '<=', '>', '<', '~', '^', '!^', '=', '!=', '~', '!~']`
2. at least part of a value.

This will eliminate most of the premature searches.

#### Considerations taken when implementing this change?

The only downside is that if you're searching _not_ using scoped_search syntax (which by the way you can do and scoped_search supports!), you'll now have to press the Enter key to complete the search.

#### What are the testing steps for this pull request?

Go to any content search (new host details or CV UI)
Click in the search bar and select a field, then select the operator (for example `errata_id = `)
After applying this change, notice that searches are not executed immediately
Type a value, and notice that the autosearch is now triggered