### PR TITLE
Fixes #35458 - Add environments param to candlepin update call

### DIFF
--- a/app/lib/katello/resources/candlepin/consumer.rb
+++ b/app/lib/katello/resources/candlepin/consumer.rb
@@ -69,6 +69,9 @@ module Katello
             if params.empty?
               true
             else
+              if params.key?(:environment) && params[:environment].key?(:id)
+                params[:environments] = [{"id": params[:environment][:id]}]
+              end
               self.put(path(uuid), params.to_json, self.default_headers).body
             end
             # consumer update doesn't return any data atm


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
The 
#### Considerations taken when implementing this change?
so it used to be that if you wanted to update the consumer's enviornment you would send

{ "environment": "newEnv" }

but now because you can specify multiple environments
you have to send

{ "environments" : ["name" : "newEnv" ] }
or

{ "environments" : ["id" : "newEnvId" ] }

#### What are the testing steps for this pull request?

1. Create and assign a host to a CV/Env.
2. On the hosts UI update the CV/ENV on the host.
3. On the host run sub-man refresh
4. Make sure the enabled repos  are updated in /etc/yum.repos.d/redhat.repo