### PR TITLE
Fixes #35517 - Redirect to library repo from CV version and hide actions on non-library repos

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details.controller.js
@@ -84,6 +84,13 @@
             return result;
         };
 
+        $scope.hideActionsButtons = function(repository) {
+            if (repository.library_instance_id) {
+                return true;
+            }
+            return false;
+        };
+
         $scope.disableSyncLink = function (adavancedSync) {
             return $scope.hideSyncButton($scope.repository, adavancedSync);
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-details.html
@@ -6,7 +6,7 @@
   </header>
 
   <div data-block="item-actions" bst-feature-flag="custom_products">
-    <span select-action-dropdown>
+    <span ng-hide="hideActionsButtons(repository)" select-action-dropdown>
       <ul class="dropdown-menu-right" uib-dropdown-menu role="menu">
         <li role="menuitem" ng-hide="hideSyncButton(repository, false)" ng-class="{disabled: disableSyncLink()}">
           <a ng-click="syncRepository(repository)" disable-link="disableSyncLink()" translate>

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
@@ -109,7 +109,7 @@ export default ({ cvId, versionId }) => [
       {
         title: __('Name'),
         getProperty: item => (
-          <a href={urlBuilder(`products/${item?.product?.id}/repositories/${item?.id}`, '')}>
+          <a href={urlBuilder(`products/${item?.product?.id}/repositories/${item?.library_instance_id ?? item?.id}`, '')}>
             {item?.name}
           </a>),
       },


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
1. CV version details repo links should redirect to library repo.
2. We shouldn't be able to perform normal repo actions on non-library repos at least from the UI.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
a) 
1. Create a repo, add it to CV and publish a new version.
2. Go to version > Repositories> repo.
3. Check the IDs on the 2: CV version > Repositories> repo and CV > Repositories. These should be the same with this PR.
b)
1. Right click on UI and check the networks tab when landing on CV > versions> repositories sub-tab.
2. For the API call : https://centos8-katello-devel-stable.example.com/katello/api/v2/repositories?content_view_version_id=.....
From the results, pick id of one of the results and go to /products/1/repositories/:id.
3. Actions should be hidden on the page.
4. For regular library repos, you should still see actions on the page.