### PR TITLE
Fixes #35364 - Wait for content_action_finish_timeout or the task-result

### DIFF
--- a/app/lib/actions/katello/agent_action.rb
+++ b/app/lib/actions/katello/agent_action.rb
@@ -91,6 +91,7 @@ module Actions
           if finish_limit < DateTime.now
             fail _("Host did not finish content action in %s seconds.  The task has been cancelled.") % finish_timeout
           end
+          suspend
         end
       end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds test fix for PR: https://github.com/Katello/katello/pull/10233
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Refer to https://github.com/Katello/katello/pull/10233