### PR TITLE
Fixes #35537 - ACS create wizard: review details step displays password in plaintext when manual auth is selected

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -116,12 +116,12 @@ module Katello
     def index
       unless params[:content_type].empty? || RepositoryTypeManager.find(params[:content_type])
         msg = _("Invalid params provided - content_type must be one of %s") %
-          RepositoryTypeManager.enabled_repository_types.keys.join(",")
+          RepositoryTypeManager.enabled_repository_types.keys.sort.join(",")
         fail HttpErrors::UnprocessableEntity, msg
       end
       unless params[:with_content].empty? || RepositoryTypeManager.find_content_type(params[:with_content], true)
         msg = _("Invalid params provided - with_content must be one of %s") %
-          RepositoryTypeManager.indexable_content_types.map(&:label).join(",")
+          RepositoryTypeManager.indexable_content_types.map(&:label).sort.join(",")
         fail HttpErrors::UnprocessableEntity, msg
       end
       base_args = [index_relation.distinct, :name, :asc]
@@ -243,7 +243,7 @@ module Katello
       repo_params = repository_params
       unless RepositoryTypeManager.creatable_by_user?(repo_params[:content_type], false)
         msg = _("Invalid params provided - content_type must be one of %s") %
-          RepositoryTypeManager.creatable_repository_types.keys.join(",")
+          RepositoryTypeManager.creatable_repository_types.keys.sort.join(",")
         fail HttpErrors::UnprocessableEntity, msg
       end
 
@@ -389,7 +389,7 @@ module Katello
     def remove_content
       unless params[:content_type].empty? || RepositoryTypeManager.removable_content_types.map(&:label).include?(params[:content_type])
         msg = _("Invalid params provided - content_type must be one of %s") %
-          RepositoryTypeManager.removable_content_types.map(&:label).join(",")
+          RepositoryTypeManager.removable_content_types.map(&:label).sort.join(",")
         fail HttpErrors::UnprocessableEntity, msg
       end
       sync_capsule = ::Foreman::Cast.to_bool(params.fetch(:sync_capsule, true))

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -68,9 +68,9 @@ module Katello
       get :index, params: { :organization_id => @organization.id, :with_content => 'cheese' }
 
       assert_response 422
-      response = "{\"displayMessage\":\"Invalid params provided - with_content must be one of ansible_collection,deb,docker_manifest,docker_manifest_list,docker_tag,file" \
-        ",ostree_ref,python_package,rpm,modulemd,erratum,package_group,srpm\",\"errors\":"\
-        "[\"Invalid params provided - with_content must be one of ansible_collection,deb,docker_manifest,docker_manifest_list,docker_tag,file,ostree_ref,python_package,rpm,modulemd,erratum,package_group,srpm\"]}"
+      response = "{\"displayMessage\":\"Invalid params provided - with_content must be one of ansible_collection,deb,docker_manifest,docker_manifest_list,docker_tag,erratum,file,modulemd,"\
+          "ostree_ref,package_group,python_package,rpm,srpm\",\"errors\":"\
+        "[\"Invalid params provided - with_content must be one of ansible_collection,deb,docker_manifest,docker_manifest_list,docker_tag,erratum,file,modulemd,ostree_ref,package_group,python_package,rpm,srpm\"]}"
       assert_match response, @response.body
     end
 

--- a/webpack/scenes/AlternateContentSources/Create/Steps/ACSReview.js
+++ b/webpack/scenes/AlternateContentSources/Create/Steps/ACSReview.js
@@ -3,6 +3,7 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import { TextContent, TextList, TextListItem, TextListItemVariants, TextListVariants } from '@patternfly/react-core';
 import ACSCreateContext from '../ACSCreateContext';
 import WizardHeader from '../../../ContentViews/components/WizardHeader';
+import InactiveText from '../../../ContentViews/components/InactiveText';
 
 const ACSReview = () => {
   const {
@@ -76,7 +77,7 @@ const ACSReview = () => {
                   </TextListItem>
                   <TextListItem component={TextListItemVariants.dt}>{__('Password')}</TextListItem>
                   <TextListItem component={TextListItemVariants.dd}>
-                    {password}
+                    {password.length > 0 ? '••••••••' : <InactiveText text={__('N/A')} />}
                   </TextListItem>
                 </>
               )}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Masks the password in the final review if there is one.

#### Considerations taken when implementing this change?
I'm not bothering to display the length of the password correctly for more security.

#### What are the testing steps for this pull request?
Create an ACS with a "manual" auth password and see that the password is masked on the final page. Also ensure that the password displayed makes sense when one isn't set.