### PR TITLE
Fixes #35539 - update recommended repos

### DIFF
--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -33,15 +33,10 @@ const recommendedRepositoriesSatTools = [
 ];
 
 const recommendedRepositoriesMisc = [
-  'rhel-server-rhscl-7-rpms',
-  'rhel-7-server-satellite-capsule-6.11-rpms',
-  'satellite-capsule-6.11-for-rhel-8-x86_64-rpms',
-  'rhel-7-server-ansible-2.9-rpms',
+  'satellite-capsule-6.12-for-rhel-8-x86_64-rpms',
   'ansible-2-for-rhel-8-x86_64-rpms',
-  'rhel-7-server-satellite-maintenance-6.11-rpms',
-  'rhel-7-server-satellite-utils-6.11-rpms',
-  'satellite-maintenance-6.11-for-rhel-8-x86_64-rpms',
-  'satellite-utils-6.11-for-rhel-8-x86_64-rpms',
+  'satellite-maintenance-6.12-for-rhel-8-x86_64-rpms',
+  'satellite-utils-6.12-for-rhel-8-x86_64-rpms',
 ];
 
 const recommendedRepositorySetLables = recommendedRepositoriesRHEL

--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -22,6 +22,7 @@ const recommendedRepositoriesRHEL = [
   'rhel-7-server-optional-rpms',
   'rhel-7-server-extras-rpms',
   'rhel-7-server-kickstart',
+  'rhel-6-server-els-rpms',
 ];
 
 const recommendedRepositoriesSatTools = [


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

1. Recommended repositories are updated to include rhel 6 els repository
2. Recommended repositories are updated for the Satellite 6.12 release

#### Considerations taken when implementing this change?

1. Satellite 6.12 is el8 only
2. Some Capsule 6.11 (including el7) repositories are preserved under recommended repositories, due to Capsule N-1 support
3. Satellite 6.11 repository is removed from recommended repositories

#### What are the testing steps for this pull request?

1. Upload a subscription manifest containing Satellite Infrastructure and RHEL6 Extended Lifecycle Support SKUs
2. Go to Red Hat Repositories page and check that the repositories are visible under recommended repositories