### PR TITLE
Refs #35546 - don't translate archRestricted

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -121,7 +121,7 @@ const ArchRestrictedIcon = ({ archRestricted }) => (
     />}
   >
     <Label color="orange" className="arch-restricted-label" style={{ marginLeft: '8px' }}>
-      {__(archRestricted)}
+      {archRestricted}
     </Label>
   </Tooltip>
 );
@@ -144,7 +144,7 @@ const OsRestrictedIcon = ({ osRestricted }) => (
     />}
   >
     <Label color="blue" className="os-restricted-label" style={{ marginLeft: '8px' }}>
-      {__(osRestricted)}
+      {osRestricted}
     </Label>
   </Tooltip>
 );
@@ -543,7 +543,7 @@ const RepositorySetsTab = () => {
               } = repoSet;
               const { isEnabled, isOverridden } =
                 getEnabledValue({ enabled, enabledContentOverride });
-              const showArchRestricted = archRestricted !== 'noarch';
+              const showArchRestricted = archRestricted && archRestricted !== 'noarch';
               return (
                 <Tr key={id} ouiaId={`tr-${rowIndex}`}>
                   {canDoContentOverrides ? (


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

archRestricted and osRestricted values were being translated when they shouldn't be. This was causing the Repository Sets page to error when a repo has an undefined value for arch restriction.

#### Considerations taken when implementing this change?

No bugs were filed about OS restriction, but I removed that incorrect translation as well.

#### What are the testing steps for this pull request?

To simulate the issue, make this change:
```diff
diff --git a/app/views/katello/api/v2/repository_sets/show.json.rabl b/app/views/katello/api/v2/repository_sets/show.json.rabl
index 396702c898..8a333a53b5 100644
--- a/app/views/katello/api/v2/repository_sets/show.json.rabl
+++ b/app/views/katello/api/v2/repository_sets/show.json.rabl
@@ -38,7 +38,7 @@ child @resource.repositories => :repositories do
 end
 
 node :archRestricted do |pc|
-  pc.repositories&.first&.arch
+  nil
 end
```

On master, you'll get a "No translation key found" error. With this PR, the error should be eliminated.

