### PR TITLE
Fixes #35549 - Delete repo even when included in composite content view

### DIFF
--- a/app/models/katello/authorization/repository.rb
+++ b/app/models/katello/authorization/repository.rb
@@ -6,12 +6,12 @@ module Katello
 
     def deletable?(remove_from_content_view_versions = true)
       return false unless product.editable?
-      remove_from_content_view_versions || !promoted? || (self.content_views.exists? && !self.content_views.generated_for_none.exists?)
+      remove_from_content_view_versions || !promoted? || (self.content_views_all(include_composite: true).exists? && !self.content_views_all(include_composite: true).generated_for_none.exists?)
     end
 
     def redhat_deletable?(remove_from_content_view_versions = false)
       return false unless product.editable?
-      remove_from_content_view_versions || !self.promoted? || (self.content_views.exists? && !self.content_views.generated_for_none.exists?)
+      remove_from_content_view_versions || !self.promoted? || (self.content_views_all(include_composite: true).exists? && !self.content_views_all(include_composite: true).generated_for_none.exists?)
     end
 
     def readable?

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -760,6 +760,15 @@ module Katello
       return true
     end
 
+    def content_views_all(include_composite: false)
+      if include_composite
+        cv_ids = library_instances_inverse&.joins(:content_view_version)&.map { |cvv| cvv&.content_view&.id }
+        return ContentView.where(id: cv_ids.uniq)
+      else
+        return self.content_views
+      end
+    end
+
     def sync_hook
       run_callbacks :sync do
         logger.debug "custom hook after_sync on #{name} will be executed if defined."

--- a/test/models/authorization/repository_authorization_test.rb
+++ b/test/models/authorization/repository_authorization_test.rb
@@ -1,5 +1,4 @@
 require 'models/authorization/authorization_base'
-
 module Katello
   class RepositoryAuthorizationAdminTest < AuthorizationTestBase
     def setup
@@ -46,9 +45,9 @@ module Katello
       repository = Repository.find(katello_repositories(:rhel_7_x86_64).id)
       repository.stubs(:promoted?).returns(true)
       content_views = Katello::ContentView.where(id: katello_content_views(:library_dev_staging_view).id)
-      repository.stubs(:content_views).returns(content_views)
+      repository.stubs(:content_views_all).returns(content_views)
       content_views.first.generated_for_repository_export!
-      assert repository.content_views.exists?
+      assert repository.content_views_all(include_composite: true).exists?
       refute repository.content_views.generated_for_none.exists?
       assert repository.redhat_deletable?
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Allows deleting repos even when included in composite content views.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create and sync a repo
2. Add repo to a component content view and publish
3. Create a composite content view and add the component content view from above with latest version.
4. Publish the composite content view.
5. Verify you see the repository in version details of the newly published version.
6. Go to repository page and delete the repository.
7. You should see the composite view in the confirmation modal.
8. Delete. Task should succeed.
