### PR TITLE
Fixes #35504 - Simplified ACSs are being created during content view publishing

### DIFF
--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -34,7 +34,7 @@ module Actions
 
             concurrence do
               plan_self(:repository_id => repository.id, :clone => clone)
-              if repository.url.present?
+              if !clone && repository.url.present?
                 repository.product.alternate_content_sources.with_type(repository.content_type).each do |acs|
                   acs.smart_proxies.each do |smart_proxy|
                     smart_proxy_acs = ::Katello::SmartProxyAlternateContentSource.create(alternate_content_source_id: acs.id, smart_proxy_id: smart_proxy.id, repository_id: repository.id)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Stops content view publishes from creating more alternate content sources in Pulp.

A simplified ACS should have Pulp ACSs created when its products receive new repositories. However, new ACSs shouldn't be created at CV publish time. ACSs have essentially nothing to do with CVs.

#### Considerations taken when implementing this change?
CV situations should always use `clone`, which I believe is a safe assumption.

#### What are the testing steps for this pull request?
1) Create a product
2) Add a repo to that product
3) Create a simplified ACS with that product
4) Add another repo and ensure that more ACSs are created (check the repo create Dynflow)
5) Publish a CV with any of the product's repositories and see that more ACSs are NOT create (check the publish task Dynflow)
 