### PR TITLE
Fixes #35552 - Filter failed capsule tasks by only sync

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -377,7 +377,7 @@ module Katello
       end
 
       def sync_tasks
-        ForemanTasks::Task.for_resource(self)
+        ForemanTasks::Task.for_resource(self).where(:label => 'Actions::Katello::CapsuleContent::Sync')
       end
 
       def active_sync_tasks


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Currently we pull all failed tasks for failed sync tasks which can lead to a faulty response(see bz screenshot) the capsule could be synced but if an Ansible job failed we error out showing the progress bar at 75%
* This PR adds a `.where` to filter by the capsule sync task label

#### Considerations taken when implementing this change?

* Making sure the page still works correctly

#### What are the testing steps for this pull request?

Or I can give you a box to test against if these are too much.

1. Install A Satellite and External Capsule 6.12 (use sat-deploy)

2. Sync some content in satellite as well as capsule

3. Ensure that Ansible feature is not enabled in capsule ( which should be happening by default ).

4. Register a system with capsule via global registration method

5. Turn on the "Prefer registered through Capsule for remote execution" setting in Administer --> Settings --> Content tab of Satellite/

6. Run an Ansible-based job on the target server (ensuring that REX smart-proxy is selected as capsule) and let the job fail.

7. Come back to the Infrastructure --> Capsules page and click open the capsule.

Actual results:

In Step 7,

Top right corner of the UI will immediately show "Last sync failed: 404 Not Found"
Under the Content Sync section, the progress bar will be red and halfway filled, giving the notion that Capsule may not have been properly synced.
Expected results:

The "Content Sync" segment or the Capsule sync status in Satellite UI , should only rely on the last successful\failed capsule sync task and It should not show the status based on the status of the last REX job executed on a target host via the capsule.