### PR TITLE
Fixes #35566 - provisioning templates for EL hosts incorrectly require kickstart repo

### DIFF
--- a/app/lib/katello/concerns/renderer_extensions.rb
+++ b/app/lib/katello/concerns/renderer_extensions.rb
@@ -11,7 +11,8 @@ module Katello
           content_view = host.try(:content_facet).try(:content_view) || host.try(:content_view)
 
           if content_view && host.operatingsystem.is_a?(Redhat) &&
-                  host.operatingsystem.kickstart_repos(host).first.present?
+                  host.operatingsystem.kickstart_repos(host).first.present? &&
+                  host&.content_facet&.kickstart_repository.present?
             @mediapath ||= host.operatingsystem.mediumpath(medium_provider)
           end
         end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
When testing this PR (https://github.com/Katello/katello/pull/10271), the new job template would not render because it included a provisioning template snippet that requires a kickstart repo to be assigned to the host's content facet.  This is a bug in Katello's renderer extension code. We shouldn't error out if a host is missing a kickstart repo.

#### Considerations taken when implementing this change?
This should not break any scenario because the edited method would break every time a kickstart repo is missing.

#### What are the testing steps for this pull request?
1) Import the templates from this PR: https://github.com/Katello/katello/pull/10271
2) Create a CentOS 8 host and sync CentOS 8 appstream + baseos
3) Confirm that the host gets the correct operating system assigned
4) Confirm that `host.operatingsystem.kickstart_repos(host)` returns something
5) Try rendering the `change_content_source` job template for the host. This can be done from the job template page.