### PR TITLE
Fixes #35567 - For non docker uploads require name/checksum

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -441,7 +441,7 @@ module Katello
       param 'content_unit_id', String
       param 'size', String
       param 'checksum', String
-      param 'name', String, :desc => N_("Needs to only be set for file repositories or docker tags")
+      param 'name', String, :desc => N_("Needs to only be set for file repositories or docker tags"), :required => true
       param 'digest', String, :desc => N_("Needs to only be set for docker tags")
     end
     Katello::RepositoryTypeManager.generic_repository_types.each_pair do |_, repo_type|
@@ -460,6 +460,14 @@ module Katello
 
       uploads = (params[:uploads] || []).map do |upload|
         upload.permit(:id, :content_unit_id, :size, :checksum, :name, :digest).to_h
+      end
+
+      if @repository.content_type != 'docker' && uploads.first['checksum'].nil?
+        fail HttpErrors::BadRequest, _('Checksum is a required parameter.')
+      end
+
+      if uploads.first['name'].nil?
+        fail HttpErrors::BadRequest, _('Name is a required parameter.')
       end
 
       begin

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -983,26 +983,26 @@ module Katello
 
     def test_import_uploads_without_checksum
       uploads = [{'id' => '1', 'size' => '12333', 'name' => 'test'}]
-      @controller.expects(:sync_task)
-        .with(::Actions::Katello::Repository::ImportUpload, @repository, uploads,
-              generate_metadata: true, content_type: nil, sync_capsule: true)
-        .returns(build_task_stub)
 
       put :import_uploads, params: { id: @repository.id, uploads: uploads }
 
-      assert_response :success
+      response = JSON.parse(@response.body)
+      assert response.key?('displayMessage')
+      assert_equal 'Checksum is a required parameter.', response['displayMessage']
+
+      assert_response :bad_request
     end
 
     def test_import_uploads_without_name
       uploads = [{'id' => '1', 'size' => '12333', 'checksum' => 'asf23421324'}]
-      @controller.expects(:sync_task)
-        .with(::Actions::Katello::Repository::ImportUpload, @repository, uploads,
-              generate_metadata: true, content_type: nil, sync_capsule: true)
-        .returns(build_task_stub)
 
       put :import_uploads, params: { id: @repository.id, uploads: uploads }
 
-      assert_response :success
+      response = JSON.parse(@response.body)
+      assert response.key?('displayMessage')
+      assert_equal 'Name is a required parameter.', response['displayMessage']
+
+      assert_response :bad_request
     end
 
     def test_import_uploads_file


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* We require checksum and name to be uploaded on all repos in pulp except for docker. 
* This improves on the PR made by lfu to only fail if name/checksum are not present for non docker content types

#### Considerations taken when implementing this change?

* Made sure docker repo commands still work fine with hammer

#### What are the testing steps for this pull request?

* Check out PR
* Create a custom product and repo
* Download 3 RPMs from https://mirror.steadfast.net/epel/7Server/x86_64/Packages/
* Use the script here like so `./upload_package_to_repo.sh REPOID /path/to/package.rpm`
* Verify it works fine normally
* From the latest curl method, remove either
```bash
\"checksum\": \"${checksum}\"
or
\"name\": \"${pkgname}\"
```

** Script: **
```bash
if [ $# -lt 2 ]; then
echo "too few arguments"
exit
fi

repoid=${1}
package=${2}
pkgname=${package##*/}
creds=admin:redhat
saturl=$(hostname -f)
size=$(wc -c $package | awk '{ print $1}')
checksum=$(sha256sum $package | awk '{ print $1}')

upload_url=$(curl --header "Accept:application/json" \
--header "Content-Type:application/json" \
--request POST --insecure --user $creds \
--data "{\"size\": ${size}}" \
[https://${saturl}/katello/api/repositories/${repoid}/content_uploads](https://%24%7Bsaturl%7D/katello/api/repositories/$%7Brepoid%7D/content_uploads) | cut -d\" -f4 )

curl --header "Accept:application/json" \
--header "Content-Type:multipart/form-data" \
--request PUT --insecure --user $creds \
--data-urlencode "content@${package}" \
--data-urlencode offset=0 \
--data-urlencode size=${size} \
[https://${saturl}/katello/api/repositories/${repoid}/content_uploads/${upload_url](https://%24%7Bsaturl%7D/katello/api/repositories/$%7Brepoid%7D/content_uploads/$%7Bupload_url)}

curl --header "Accept:application/json" \
--header "Content-Type:application/json" \
--request PUT --insecure \
--user $creds \
--data "{\"uploads\":[{\"id\": \"${upload_url}\", \"checksum\": \"${checksum}\", \"name\": \"${pkgname}\"}]}" \
[https://${saturl}/katello/api/repositories/${repoid}/import_uploads](https://%24%7Bsaturl%7D/katello/api/repositories/$%7Brepoid%7D/import_uploads)
```