### PR TITLE
Fixes #35575 - Always show toggle group when host is non-library

### DIFF
--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -19,6 +19,7 @@ import { orgId } from '../../services/api';
 const TableWrapper = ({
   actionButtons,
   alwaysShowActionButtons,
+  alwaysShowToggleGroup,
   toggleGroup,
   children,
   metadata,
@@ -62,7 +63,7 @@ const TableWrapper = ({
   const hideToolbar = !searchQuery && !filtersAreActive &&
     allTableProps.status === STATUS.RESOLVED && total === 0;
   const showActionButtons = actionButtons && (alwaysShowActionButtons || !hideToolbar);
-  const showToggleGroup = toggleGroup && !hideToolbar;
+  const showToggleGroup = toggleGroup && (alwaysShowToggleGroup || !hideToolbar);
   const paginationParams = useCallback(() =>
     ({ per_page: perPage, page }), [perPage, page]);
   const prevRequest = useRef({});
@@ -275,6 +276,7 @@ TableWrapper.propTypes = {
   searchPlaceholderText: PropTypes.string,
   actionButtons: PropTypes.node,
   alwaysShowActionButtons: PropTypes.bool,
+  alwaysShowToggleGroup: PropTypes.bool,
   toggleGroup: PropTypes.node,
   children: PropTypes.node,
   // additionalListeners are anything that should trigger another API call, e.g. a filter
@@ -319,6 +321,7 @@ TableWrapper.defaultProps = {
   searchPlaceholderText: undefined,
   actionButtons: null,
   alwaysShowActionButtons: true,
+  alwaysShowToggleGroup: false,
   toggleGroup: null,
   displaySelectAllCheckbox: false,
   selectedCount: 0,

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -472,6 +472,7 @@ export const ErrataTab = () => {
           displaySelectAllCheckbox={showActions}
           requestKey={HOST_ERRATA_KEY}
           alwaysShowActionButtons={false}
+          alwaysShowToggleGroup={hostIsNonLibrary}
         >
           <Thead>
             <Tr ouiaId="row-header">


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

new host details UI - When a host has applicable errata but none of them are installable, the 'All / Installable' toggle group is incorrectly hidden. As a result, you are unable to navigate to 'All' to show the applicable errata.

This fixes that by always showing the toggle group unless the host is in the default CV and environment.

#### Considerations taken when implementing this change?

Used the pattern already existing for `alwaysShowActionButtons` and added a new prop `alwaysShowToggleGroup`. The default is false so this shouldn't affect anything besides ErrataTab.

#### What are the testing steps for this pull request?

Get a host with applicable & installable errata, then change that host to a CV/E that doesn't have those errata.
Navigate to Content > Errata.

_Before:_ You'll see an error that the host has errata that are applicable, but not installable. (which is true) But you can't do anything about it.
_After:_ You'll see the same error, but the toggle group will show and you can click 'All'.