### PR TITLE
Fixes #35580 - Allow host to register with multiple content view environments

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -40,7 +40,7 @@ module Katello
       respond_for_index :collection => @collection
     end
 
-    def index_response(reload_host = false)
+    def index_response(reload_host: false)
       # Host needs to be reloaded because of lazy accessor
       @host.reload if reload_host
       presenter = ::Katello::HostSubscriptionsPresenter.new(@host)
@@ -55,7 +55,7 @@ module Katello
       end
 
       sync_task(::Actions::Katello::Host::AutoAttachSubscriptions, @host)
-      respond_for_index(:collection => index_response(true), :template => "index")
+      respond_for_index(:collection => index_response(reload_host: true), :template => "index")
     end
 
     api :DELETE, "/hosts/:host_id/subscriptions/", N_("Unregister the host as a subscription consumer")
@@ -126,7 +126,7 @@ module Katello
       end
 
       sync_task(::Actions::Katello::Host::RemoveSubscriptions, @host, pool_id_quantities.values)
-      respond_for_index(:collection => index_response(true), :template => "index")
+      respond_for_index(:collection => index_response(reload_host: true), :template => "index")
     end
 
     api :PUT, "/hosts/:host_id/subscriptions/add_subscriptions", N_("Add a subscription to a host")
@@ -145,7 +145,7 @@ module Katello
       end
 
       sync_task(::Actions::Katello::Host::AttachSubscriptions, @host, pools_with_quantities)
-      respond_for_index(:collection => index_response(true), :template => "index")
+      respond_for_index(:collection => index_response(reload_host: true), :template => "index")
     end
 
     api :GET, "/hosts/:host_id/subscriptions/product_content", N_("Get content and overrides for the host")
@@ -154,7 +154,7 @@ module Katello
     param :content_access_mode_env, :bool, :desc => N_("Limit content to just that available in the host's content view version")
     param_group :search, Api::V2::ApiController
     def product_content
-      # note this is just there as a place holder for apipie.
+      # NOTE: this is just there as a placeholder for apipie.
       # The routing would automatically redirect it to repository_sets#index
     end
 
@@ -206,7 +206,7 @@ module Katello
     def find_content_view_environment
       @content_view_environment = Katello::ContentViewEnvironment.where(:content_view_id => params[:content_view_id],
                                                                         :environment_id => params[:lifecycle_environment_id]).first
-      fail HttpErrors::NotFound, _("Couldn't find specified Content View and Lifecycle Environment.") if @content_view_environment.nil?
+      fail HttpErrors::NotFound, _("Couldn't find specified content view and lifecycle environment.") if @content_view_environment.nil?
     end
 
     def check_subscriptions

--- a/app/controllers/katello/concerns/authorization/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/concerns/authorization/api/v2/content_views_controller.rb
@@ -118,7 +118,10 @@ module Katello
       # and also ensure that the environments have the remove permission
       return deny_access unless KTEnvironment.promotable.where(:id => env_ids).count == env_ids.size && view.promotable_or_removable?
 
-      total_count = Katello::Host::ContentFacet.where(:content_view_id => view, :lifecycle_environment_id => env_ids).count
+      total_count = Katello::Host::ContentFacet.in_content_views_and_environments(
+        :content_views => [view],
+        :lifecycle_environments => ::Katello::KTEnvironment.where(id: env_ids)
+      ).count
       if total_count > 0
         unless options[:system_content_view_id] && options[:system_environment_id]
           fail _("Unable to reassign content hosts. Please provide system_content_view_id and system_environment_id.")

--- a/app/controllers/katello/concerns/content_facet_hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/content_facet_hosts_controller_extensions.rb
@@ -1,0 +1,26 @@
+module Katello
+  module Concerns
+    module ContentFacetHostsControllerExtensions
+      extend ActiveSupport::Concern
+      # include ForemanTasks::Triggers # do I need this?
+
+      included do
+        before_action :set_up_content_view_environment, only: [:update]
+
+        def set_up_content_view_environment
+          return unless params[:host] && params[:host][:content_facet_attributes]
+          cv_id = params[:host][:content_facet_attributes].delete(:content_view_id)
+          env_id = params[:host][:content_facet_attributes].delete(:lifecycle_environment_id)
+          Rails.logger.info "set_up_content_view_environment: cv_id=#{cv_id}, env_id=#{env_id}"
+          if (cv_id.present? && env_id.present?)
+            @host.content_facet.assign_single_environment(
+              lifecycle_environment_id: env_id,
+              content_view_id: cv_id
+            )
+            Rails.logger.info "set_up_content_view_environment: done"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/katello/concerns/content_facet_hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/content_facet_hosts_controller_extensions.rb
@@ -2,8 +2,6 @@ module Katello
   module Concerns
     module ContentFacetHostsControllerExtensions
       extend ActiveSupport::Concern
-      # include ForemanTasks::Triggers # do I need this?
-
       included do
         before_action :set_up_content_view_environment, only: [:update]
 

--- a/app/controllers/katello/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/hosts_controller_extensions.rb
@@ -57,15 +57,15 @@ module Katello
             format.csv do
               @hosts = resource_base_with_search.where(organization_id: params[:organization_id])
                          .preload(:subscription_facet, :host_statuses, :operatingsystem,
-                                  :applicable_rpms, :lifecycle_environment, :content_view)
+                                  :applicable_rpms, :content_view_environments)
               csv_response(@hosts,
                 [:name, :subscription_status_label, 'content_facet.installable_security_errata_count',
                  'content_facet.installable_bugfix_errata_count', 'content_facet.installable_enhancement_errata_count',
-                 'content_facet.upgradable_rpm_count', :operatingsystem, :lifecycle_environment, :content_view,
+                 'content_facet.upgradable_rpm_count', :operatingsystem, :content_view_environment_names,
                  'subscription_facet.registered_at', 'subscription_facet.last_checkin'],
                 ['Name', 'Subscription Status', 'Installable Updates - Security',
                  'Installable Updates - Bug Fixes', 'Installable Updates - Enhancements',
-                 'Installable Updates - Package Count', 'OS', 'Environment', 'Content View',
+                 'Installable Updates - Package Count', 'OS', 'Content View Environments',
                  'Registered', 'Last Checkin'])
             end
           end

--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -310,7 +310,7 @@ module Katello
 
     private
 
-    def decide_content_source_id(host_or_hostgroup, hostgroup)
+    def inherited_or_own_content_source_id(host_or_hostgroup, hostgroup)
       content_source_id = hostgroup.inherited_content_source_id
       if host_or_hostgroup.content_source_id && (hostgroup.inherited_content_source_id != host_or_hostgroup.content_source_id)
         content_source_id = host_or_hostgroup.content_source_id
@@ -318,7 +318,7 @@ module Katello
       content_source_id
     end
 
-    def decide_facet_attributes(host_or_hostgroup, hostgroup)
+    def inherited_or_own_facet_attributes(host_or_hostgroup, hostgroup)
       lifecycle_environment_id = hostgroup.inherited_lifecycle_environment_id
       content_view_id = hostgroup.inherited_content_view_id
       case host_or_hostgroup
@@ -341,8 +341,8 @@ module Katello
     end
 
     def hostgroup_content_facet(hostgroup, param_host)
-      lifecycle_environment_id, content_view_id = decide_facet_attributes(param_host, hostgroup)
-      content_source_id = decide_content_source_id(param_host, hostgroup)
+      lifecycle_environment_id, content_view_id = inherited_or_own_facet_attributes(param_host, hostgroup)
+      content_source_id = inherited_or_own_content_source_id(param_host, hostgroup)
       facet = ::Katello::Host::ContentFacet.new(:content_source_id => content_source_id)
       facet.assign_single_environment(
         :lifecycle_environment_id => lifecycle_environment_id,

--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -64,7 +64,7 @@ module Katello
     end
 
     def fetch_content_view(host, options = {})
-      return host.content_view if host.try(:content_view_id)
+      return host.single_content_view if host.try(:single_content_view)
       selected_host_group = options.fetch(:selected_host_group, nil)
       return selected_host_group.content_view if selected_host_group.present?
     end
@@ -75,8 +75,12 @@ module Katello
       return selected_host_group.content_source if selected_host_group.present?
     end
 
-    def accessible_lifecycle_environments(org, host)
-      selected = host.lifecycle_environment
+    def accessible_lifecycle_environments(org, host_or_hostgroup)
+      selected = if host_or_hostgroup.is_a?(::Host::Managed)
+                   host_or_hostgroup.try(:single_lifecycle_environment)
+                 else
+                   host_or_hostgroup.lifecycle_environment
+                 end
       envs = org.kt_environments.readable.order(:name)
       envs |= [selected] if selected.present? && org == selected.organization
       envs
@@ -207,9 +211,11 @@ module Katello
         if (host.is_a? ::Hostgroup)
           new_host.content_facet = hostgroup_content_facet(host, param_host)
         elsif host.content_facet.present?
-          new_host.content_facet = ::Katello::Host::ContentFacet.new(:lifecycle_environment_id => host.content_facet.lifecycle_environment_id,
-                                                          :content_view_id => host.content_facet.content_view_id,
-                                                          :content_source_id => host.content_source_id)
+          new_host.content_facet = ::Katello::Host::ContentFacet.new(:content_source_id => host.content_source_id)
+          new_host.content_facet.assign_single_environment(
+            :lifecycle_environment => host.content_facet.single_lifecycle_environment,
+            :content_view => host.content_facet.single_content_view
+          )
         end
         new_host.operatingsystem.kickstart_repos(new_host).map { |repo| OpenStruct.new(repo) }
       else
@@ -243,9 +249,11 @@ module Katello
         content_view = fetch_inherited_param(host_params[:content_view_id], ::Katello::ContentView, parent&.content_view)
         content_source = fetch_inherited_param(host_params[:content_source_id], ::SmartProxy, parent&.content_source)
 
-        host.content_facet = Host::ContentFacet.new(:lifecycle_environment_id => lifecycle_env.id,
-                                                    :content_view_id => content_view.id,
-                                                    :content_source => content_source)
+        host.content_facet = Host::ContentFacet.new(:content_source => content_source)
+        host.content_facet.assign_single_environment(
+          :lifecycle_environment_id => lifecycle_env.id,
+          :content_view_id => content_view.id
+        )
         if host.operatingsystem.is_a?(Redhat)
           view_options = host.operatingsystem.kickstart_repos(host).map { |repo| OpenStruct.new(repo) }
         end
@@ -302,22 +310,45 @@ module Katello
 
     private
 
-    def hostgroup_content_facet(hostgroup, param_host)
+    def decide_content_source_id(host_or_hostgroup, hostgroup)
+      content_source_id = hostgroup.inherited_content_source_id
+      if host_or_hostgroup.content_source_id && (hostgroup.inherited_content_source_id != host_or_hostgroup.content_source_id)
+        content_source_id = host_or_hostgroup.content_source_id
+      end
+      content_source_id
+    end
+
+    def decide_facet_attributes(host_or_hostgroup, hostgroup)
       lifecycle_environment_id = hostgroup.inherited_lifecycle_environment_id
       content_view_id = hostgroup.inherited_content_view_id
-      content_source_id = hostgroup.inherited_content_source_id
-      if param_host.lifecycle_environment_id && (hostgroup.inherited_lifecycle_environment_id != param_host.lifecycle_environment_id)
-        lifecycle_environment_id = param_host.lifecycle_environment_id
+      case host_or_hostgroup
+      when ::Hostgroup
+        if host_or_hostgroup.lifecycle_environment_id && (hostgroup.inherited_lifecycle_environment_id != host_or_hostgroup.lifecycle_environment_id)
+          lifecycle_environment_id = host_or_hostgroup.lifecycle_environment_id
+        end
+        if host_or_hostgroup.content_view_id && (hostgroup.inherited_content_view_id != host_or_hostgroup.content_view_id)
+          content_view_id = host_or_hostgroup.content_view_id
+        end
+      when ::Host::Managed
+        if host_or_hostgroup.single_lifecycle_environment && (hostgroup.inherited_lifecycle_environment_id != host_or_hostgroup.single_lifecycle_environment.id)
+          lifecycle_environment_id = host_or_hostgroup.single_lifecycle_environment.id
+        end
+        if host_or_hostgroup.single_content_view && (hostgroup.inherited_content_view_id != host_or_hostgroup.single_content_view.id)
+          content_view_id = host_or_hostgroup.single_content_view.id
+        end
       end
-      if param_host.content_view_id && (hostgroup.inherited_content_view_id != param_host.content_view_id)
-        content_view_id = param_host.content_view_id
-      end
-      if param_host.content_source_id && (hostgroup.inherited_content_source_id != param_host.content_source_id)
-        content_source_id = param_host.content_source_id
-      end
-      ::Katello::Host::ContentFacet.new(:lifecycle_environment_id => lifecycle_environment_id,
-                                        :content_view_id => content_view_id,
-                                        :content_source_id => content_source_id)
+      [lifecycle_environment_id, content_view_id]
+    end
+
+    def hostgroup_content_facet(hostgroup, param_host)
+      lifecycle_environment_id, content_view_id = decide_facet_attributes(param_host, hostgroup)
+      content_source_id = decide_content_source_id(param_host, hostgroup)
+      facet = ::Katello::Host::ContentFacet.new(:content_source_id => content_source_id)
+      facet.assign_single_environment(
+        :lifecycle_environment_id => lifecycle_environment_id,
+        :content_view_id => content_view_id
+      )
+      facet
     end
   end
 end

--- a/app/helpers/katello/katello_urls_helper.rb
+++ b/app/helpers/katello/katello_urls_helper.rb
@@ -43,20 +43,5 @@ module Katello
       optional :content_type, String, desc: 'Content type', default: 'repos'
       returns String, desc: 'Absolute path to a file'
     end
-    def repository_url(content_path, _content_type = nil, schema = 'http')
-      return content_path if content_path =~ %r|^([\w\-\+]+)://|
-      url = if @host.content_source
-              "#{schema}://#{@host.content_source.hostname}"
-            else
-              foreman_settings_url(schema)
-            end
-      content_path = content_path.sub(%r|^/|, '')
-      if @host.content_view && !@host.content_view.default?
-        content_path = [@host.content_view.label, content_path].join('/')
-      end
-      path = ::Katello::Glue::Pulp::Repos.repo_path_from_content_path(
-        @host.lifecycle_environment, content_path)
-      "#{url}/pulp/content/#{path}"
-    end
   end
 end

--- a/app/lib/actions/candlepin/owner/destroy_imports.rb
+++ b/app/lib/actions/candlepin/owner/destroy_imports.rb
@@ -8,7 +8,7 @@ module Actions
 
         def run
           organization = ::Organization.find_by!(label: input[:label])
-          output[:response] = ::Katello::Resources::Candlepin::Owner.destroy_imports(organization.label, true)
+          output[:response] = ::Katello::Resources::Candlepin::Owner.destroy_imports(organization.label, wait_until_complete: true)
           organization.redhat_provider.index_subscriptions
         end
       end

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -112,8 +112,12 @@ module Actions
           version.update_content_counts!
           # update errata applicability counts for all hosts in the CV & Library
           unless input[:skip_promotion]
-            ::Katello::Host::ContentFacet.where(:content_view_id => input[:content_view_id],
-                                                :lifecycle_environment_id => input[:environment_id]).each do |facet|
+            content_view = ::Katello::ContentView.find(input[:content_view_id])
+            lifecycle_environment = ::Katello::KTEnvironment.find(input[:environment_id])
+            ::Katello::Host::ContentFacet.in_content_views_and_environments(
+              content_views: [content_view],
+              lifecycle_environments: [lifecycle_environment]
+            ).each do |facet|
               facet.update_applicability_counts
               facet.update_errata_status
             end

--- a/app/lib/actions/katello/content_view/remove.rb
+++ b/app/lib/actions/katello/content_view/remove.rb
@@ -71,10 +71,17 @@ module Actions
                       content_view_history_ids: cv_histories.map { |history| history.id })
 
             if organization_destroy
-              content_view.hostgroups.destroy_all
-              content_view.hosts.destroy_all
+              destroy_hosts_and_hostgroups(content_view: content_view)
             end
           end
+        end
+
+        def destroy_hosts_and_hostgroups(content_view:)
+          content_view.hostgroups.destroy_all
+          host_ids = content_view.hosts.ids
+          ::Katello::Host::ContentFacet.where(:host_id => host_ids).destroy_all
+          ::Katello::Host::SubscriptionFacet.where(:host_id => host_ids).destroy_all
+          ::Host::Managed.where(:id => host_ids).destroy_all
         end
 
         def check_version_deletion(versions, cv_envs)

--- a/app/lib/actions/katello/content_view_version/destroy.rb
+++ b/app/lib/actions/katello/content_view_version/destroy.rb
@@ -3,7 +3,7 @@ module Actions
     module ContentViewVersion
       class Destroy < Actions::Base
         def plan(version, options = {})
-          version.validate_destroyable!(options[:skip_environment_check])
+          version.validate_destroyable!(skip_environment_check: options[:skip_environment_check])
 
           destroy_env_content = !options.fetch(:skip_destroy_env_content, false)
           repos = destroy_env_content ? version.repositories : version.archived_repos

--- a/app/lib/katello/concerns/renderer_extensions.rb
+++ b/app/lib/katello/concerns/renderer_extensions.rb
@@ -8,7 +8,7 @@ module Katello
           super
 
           medium_provider = Katello::ManagedContentMediumProvider.new(host)
-          content_view = host.try(:content_facet).try(:content_view) || host.try(:content_view)
+          content_view = host.try(:content_facet).try(:single_content_view) || host.try(:single_content_view)
 
           if content_view && host.operatingsystem.is_a?(Redhat) &&
                   host.operatingsystem.kickstart_repos(host).first.present? &&

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -88,7 +88,7 @@ module Katello
         class << self
           delegate :[], to: :json_resource
 
-          def resource(url = self.site + self.path, client_cert = self.client_cert, client_key = self.client_key, ca_file = nil, options = {})
+          def resource(options = {}, url: self.site + self.path, client_cert: self.client_cert, client_key: self.client_key, ca_file: nil)
             cert_store = OpenSSL::X509::Store.new
             cert_store.add_file(ca_file) if ca_file
 
@@ -107,9 +107,9 @@ module Katello
                                     )
           end
 
-          def json_resource(url = self.site + self.path, client_cert = self.client_cert, client_key = self.client_key, ca_file = nil, options = {})
+          def json_resource(options = {}, url: self.site + self.path, client_cert: self.client_cert, client_key: self.client_key, ca_file: nil)
             options.deep_merge!(headers: self.default_headers)
-            resource(url, client_cert, client_key, ca_file, options)
+            resource(options, url: url, client_cert: client_cert, client_key: client_key, ca_file: ca_file)
           end
 
           def rest_client(_http_type = nil, method = :get, path = self.path)
@@ -117,7 +117,7 @@ module Katello
             self.consumer_secret = nil
             self.consumer_key = nil
 
-            resource(self.site + path, client_cert, client_key, nil, http_method: method)
+            resource({ http_method: method }, url: self.site + path, client_cert: client_cert, client_key: client_key, ca_file: nil)
           end
 
           def client_cert

--- a/app/lib/katello/resources/candlepin/owner.rb
+++ b/app/lib/katello/resources/candlepin/owner.rb
@@ -60,7 +60,7 @@ module Katello
             Product.all(organization_name, [:id, :productContent])
           end
 
-          def destroy_imports(organization_name, wait_until_complete = false)
+          def destroy_imports(organization_name, wait_until_complete: false)
             response_json = self.delete(join_path(path(organization_name), 'imports'), self.default_headers)
             response = JSON.parse(response_json).with_indifferent_access
             if wait_until_complete && response['state'] == 'CREATED'

--- a/app/lib/katello/resources/candlepin/upstream_consumer.rb
+++ b/app/lib/katello/resources/candlepin/upstream_consumer.rb
@@ -42,15 +42,14 @@ module Katello
 
           def get_export(url, client_cert, client_key, ca_file)
             logger.debug "Sending GET request to upstream Candlepin: #{url}"
-            return resource(url, client_cert, client_key, ca_file).get
+            return resource(url: url, client_cert: client_cert, client_key: client_key, ca_file: ca_file).get
           rescue RestClient::Exception => e
             raise e
           end
 
           def update(url, client_cert, client_key, ca_file, attributes)
-            logger.debug "Sending POST request to upstream Candlepin: #{url} #{attributes.to_json}"
-
-            return resource(url, client_cert, client_key, ca_file).put(attributes.to_json,
+            logger.debug "Sending PUT request to upstream Candlepin: #{url} #{attributes.to_json}"
+            return resource(url: url, client_cert: client_cert, client_key: client_key, ca_file: ca_file).put(attributes.to_json,
                                                                        'accept' => 'application/json',
                                                                        'accept-language' => I18n.locale,
                                                                        'content-type' => 'application/json')

--- a/app/lib/katello/validators/content_view_environment_org_validator.rb
+++ b/app/lib/katello/validators/content_view_environment_org_validator.rb
@@ -5,8 +5,11 @@ module Katello
         environment_id = record.respond_to?(:lifecycle_environment_id) ? record.lifecycle_environment_id : record.environment_id
         view = ContentView.where(:id => record.content_view_id).first
         environment = KTEnvironment.where(:id => environment_id).first
-        unless view.organization == environment.organization
-          record.errors[:base] << _("%{view_label} could not be promoted to %{environment_label} because the content view and the environment are not in the same organization!") % {:view_label => view.label, :environment_label => environment.label}
+        unless view && environment
+          record.errors[:base] << _("Content view environments must have both a content view and an environment")
+        end
+        unless view&.organization == environment&.organization
+          record.errors[:base] << _("%{view_label} could not be promoted to %{environment_label} because the content view and the environment are not in the same organization!") % {:view_label => view&.label, :environment_label => environment&.label}
         end
       end
     end

--- a/app/lib/katello/validators/content_view_environment_validator.rb
+++ b/app/lib/katello/validators/content_view_environment_validator.rb
@@ -4,7 +4,6 @@ module Katello
       def validate(record)
         #support lifecycle_environment_id for foreman models
         environment_id = record.respond_to?(:lifecycle_environment_id) ? record.lifecycle_environment_id : record.environment_id
-
         if record.content_view_id
           view = ContentView.where(:id => record.content_view_id).first
           if environment_id
@@ -15,7 +14,7 @@ module Katello
             end
           end
           if view&.generated_for_repository?
-            record.errors[:base] << _("Generated Content views cannot be assigned to Host/Activation Keys")
+            record.errors[:base] << _("Generated content views cannot be assigned to hosts or activation keys")
           end
         end
       end

--- a/app/lib/katello/validators/generated_content_view_validator.rb
+++ b/app/lib/katello/validators/generated_content_view_validator.rb
@@ -1,0 +1,16 @@
+module Katello
+  module Validators
+    class GeneratedContentViewValidator < ActiveModel::Validator
+      def validate(record)
+        record.content_view_environments.each do |cve|
+          if cve.content_view_id
+            view = ContentView.where(:id => cve.content_view_id).first
+            if view&.generated_for_repository?
+              record.errors[:base] << _("Content view '%{cv_name}' is a generated content view, which cannot be assigned to hosts or activation keys.") % { :cv_name => view.name }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/mailers/katello/errata_mailer.rb
+++ b/app/mailers/katello/errata_mailer.rb
@@ -33,8 +33,10 @@ module Katello
       ::User.as(user.login) do
         @content_view = options[:content_view]
         @environment = options[:environment]
-        @content_facets = Katello::Host::ContentFacet.where(:lifecycle_environment_id => @environment.id,
-                                                            :content_view_id => @content_view.id)
+        @content_facets = Katello::Host::ContentFacet.in_content_views_and_environments(
+          :lifecycle_environments => [@environment],
+          :content_views => [@content_view]
+        )
         @hosts = ::Host::Managed.authorized("view_hosts").where(:id => @content_facets.pluck(:host_id))
         @errata = @content_facets.map(&:installable_errata).flatten.uniq
 

--- a/app/models/katello/concerns/subscription_facet_host_extensions.rb
+++ b/app/models/katello/concerns/subscription_facet_host_extensions.rb
@@ -63,6 +63,7 @@ module Katello
       end
 
       def update_candlepin_associations(consumer_params = nil)
+        content_facet.cves_changed = false if content_facet
         content_facet&.save!
 
         auto_attach_enabled_via_checkin = consumer_params.try(:[], 'autoheal')

--- a/app/models/katello/content_view_environment_content_facet.rb
+++ b/app/models/katello/content_view_environment_content_facet.rb
@@ -1,0 +1,9 @@
+module Katello
+  class ContentViewEnvironmentContentFacet < Katello::Model
+    belongs_to :content_view_environment, :class_name => "::Katello::ContentViewEnvironment", :inverse_of => :content_view_environment_content_facets
+    belongs_to :content_facet, :class_name => "::Katello::Host::ContentFacet", :inverse_of => :content_view_environment_content_facets
+
+    validates :content_view_environment_id, presence: true
+    validates :content_facet_id, presence: true, unless: :new_record?
+  end
+end

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -99,8 +99,7 @@ module Katello
     def self.for_version(version)
       major, minor = version.to_s.split('.')
       minor ||= 0
-      query = where(:major => major, :minor => minor)
-      query
+      where(:major => major, :minor => minor)
     end
 
     def to_s
@@ -333,9 +332,10 @@ module Katello
     def update_content_counts!
       self.content_counts = {}
       RepositoryTypeManager.indexable_content_types.each do |content_type|
-        if content_type&.model_class::CONTENT_TYPE == DockerTag::CONTENT_TYPE
+        case content_type&.model_class::CONTENT_TYPE
+        when DockerTag::CONTENT_TYPE
           content_counts[DockerTag::CONTENT_TYPE] = docker_tags.count
-        elsif content_type&.model_class::CONTENT_TYPE == GenericContentUnit::CONTENT_TYPE
+        when GenericContentUnit::CONTENT_TYPE
           content_counts[content_type.content_type] = content_type&.model_class&.in_repositories(self.repositories.archived)&.where(:content_type => content_type.content_type)&.count
         else
           content_counts[content_type&.model_class::CONTENT_TYPE] = content_type&.model_class&.in_repositories(self.repositories.archived)&.count
@@ -378,7 +378,7 @@ module Katello
       content_view.check_docker_repository_names!(to_env)
     end
 
-    def validate_destroyable!(skip_environment_check = false)
+    def validate_destroyable!(skip_environment_check: false)
       unless organization.being_deleted?
         if !skip_environment_check && in_environment?
           fail _("Cannot delete version while it is in environments: %s") %

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -10,9 +10,14 @@ module Katello
       SUBSCRIPTION_MANAGER_PACKAGE_NAME = 'subscription-manager'.freeze
 
       belongs_to :kickstart_repository, :class_name => "::Katello::Repository", :inverse_of => :kickstart_content_facets
-      belongs_to :content_view, :inverse_of => :content_facets, :class_name => "Katello::ContentView"
-      belongs_to :lifecycle_environment, :inverse_of => :content_facets, :class_name => "Katello::KTEnvironment"
       belongs_to :content_source, :class_name => "::SmartProxy", :inverse_of => :content_facets
+
+      has_many :content_view_environment_content_facets, :class_name => "Katello::ContentViewEnvironmentContentFacet", :dependent => :destroy, :inverse_of => :content_facet
+      has_many :content_view_environments, :through => :content_view_environment_content_facets,
+               :class_name => "Katello::ContentViewEnvironment", :source => :content_view_environment,
+               :after_add => :mark_cves_changed, :after_remove => :mark_cves_changed
+      has_many :content_views, :through => :content_view_environments, :class_name => "Katello::ContentView"
+      has_many :lifecycle_environments, :through => :content_view_environments, :class_name => "Katello::KTEnvironment"
 
       has_many :content_facet_errata, :class_name => "Katello::ContentFacetErratum", :dependent => :delete_all, :inverse_of => :content_facet
       has_many :applicable_errata, :through => :content_facet_errata, :class_name => "Katello::Erratum", :source => :erratum
@@ -31,11 +36,80 @@ module Katello
       has_many :content_facet_applicable_module_streams, :class_name => "Katello::ContentFacetApplicableModuleStream", :dependent => :delete_all, :inverse_of => :content_facet
       has_many :applicable_module_streams, :through => :content_facet_applicable_module_streams, :class_name => "Katello::ModuleStream", :source => :module_stream
 
-      validates :content_view, :presence => true, :allow_blank => false
-      validates :lifecycle_environment, :presence => true, :allow_blank => false
       validates_with ::AssociationExistsValidator, attributes: [:content_source]
+      validates_with Katello::Validators::GeneratedContentViewValidator
       validates :host, :presence => true, :allow_blank => false
-      validates_with Validators::ContentViewEnvironmentValidator
+
+      attr_accessor :cves_changed
+
+      def initialize(*args)
+        init_args = args.first || {}
+        env_id = init_args.delete(:lifecycle_environment_id)
+        cv_id = init_args.delete(:content_view_id)
+        super(*args)
+        if env_id && cv_id
+          assign_single_environment(
+            lifecycle_environment_id: env_id,
+            content_view_id: cv_id
+          )
+        end
+        self.cves_changed = false
+      end
+
+      def mark_cves_changed(_cve)
+        self.cves_changed = true
+      end
+
+      def cves_changed?
+        cves_changed
+      end
+
+      def multi_content_view_environment?
+        content_view_environments.size > 1
+      end
+
+      def single_content_view_environment?
+        content_view_environments.size == 1
+      end
+
+      def single_content_view
+        if multi_content_view_environment?
+          Rails.logger.warn _("Content facet for host %s has more than one content view. Use #content_views instead.") % host.name
+        end
+        content_view_environments&.first&.content_view
+      end
+
+      def single_lifecycle_environment
+        if multi_content_view_environment?
+          Rails.logger.warn _("Content facet for host %s has more than one lifecycle environment. Use #lifecycle_environments instead.") % host.name
+        end
+        content_view_environments&.first&.lifecycle_environment
+      end
+
+      def assign_single_environment(
+        content_view_id: nil, lifecycle_environment_id: nil, environment_id: nil,
+        content_view: nil, lifecycle_environment: nil, environment: nil
+      )
+        lifecycle_environment_id ||= environment_id || lifecycle_environment&.id || environment&.id
+        content_view_id ||= content_view&.id
+
+        unless lifecycle_environment_id
+          fail _("Lifecycle environment must be specified")
+        end
+        content_view_environment = ::Katello::ContentViewEnvironment
+          .where(:content_view_id => content_view_id, :environment_id => lifecycle_environment_id)
+          .first_or_create do |cve|
+          Rails.logger.info("ContentViewEnvironment not found for content view '#{cve.content_view_name}' and environment '#{cve.environment&.name}'; creating a new one.")
+        end
+        fail _("Unable to create ContentViewEnvironment. Check the logs for more information.") if content_view_environment.nil?
+        self.content_view_environments = [content_view_environment]
+      end
+
+      def default_environment?
+        content_view_environments.any? do |cve|
+          cve.content_view.default? && cve.lifecycle_environment.library?
+        end
+      end
 
       def update_repositories_by_paths(paths)
         prefixes = %w(/pulp/deb/ /pulp/repos/ /pulp/content/)
@@ -138,13 +212,21 @@ module Katello
       end
 
       def self.in_content_view_version_environments(version_environments)
-        #takes a structure of [{:content_view_version => ContentViewVersion, :environments => [KTEnvironment]}]
+        # takes a structure of [{:content_view_version => ContentViewVersion, :environments => [KTEnvironment]}]
+        relation = self.joins(:content_view_environment_content_facets => :content_view_environment)
         queries = version_environments.map do |version_environment|
           version = version_environment[:content_view_version]
           env_ids = version_environment[:environments].map(&:id)
-          "(#{table_name}.content_view_id = #{version.content_view_id} AND #{table_name}.lifecycle_environment_id IN (#{env_ids.join(',')}))"
+          "(#{::Katello::ContentViewEnvironment.table_name}.content_view_version_id = #{version.id} AND #{::Katello::ContentViewEnvironment.table_name}.environment_id IN (#{env_ids.join(',')}))"
         end
-        where(queries.join(" OR "))
+        relation.where(queries.join(" OR "))
+      end
+
+      def self.in_content_views_and_environments(content_views: nil, lifecycle_environments: nil)
+        relation = self.joins(:content_view_environment_content_facets => :content_view_environment)
+        relation = relation.where("#{::Katello::ContentViewEnvironment.table_name}.content_view_id" => content_views) if content_views
+        relation = relation.where("#{::Katello::ContentViewEnvironment.table_name}.environment_id" => lifecycle_environments) if lifecycle_environments
+        relation
       end
 
       def self.with_non_installable_errata(errata, hosts = nil)
@@ -202,12 +284,10 @@ module Katello
              where("#{facet_repository}.content_facet_id = #{self.table_name}.id")
       end
 
-      def content_view_version
-        content_view.version(lifecycle_environment)
-      end
-
       def available_releases
-        self.content_view.version(self.lifecycle_environment).available_releases
+        self.content_view_environments.flat_map do |cve|
+          cve.content_view.version(cve.lifecycle_environment).available_releases
+        end
       end
 
       def katello_agent_installed?
@@ -230,6 +310,11 @@ module Katello
         host.get_status(::Katello::ErrataStatus).refresh!
         host.refresh_global_status!
       end
+
+      # TODO: uncomment when we need to display multiple CVE names in the UI
+      # def content_view_environment_names
+      #   content_view_environments.map(&:candlepin_name).join(', ')
+      # end
 
       def self.joins_installable_relation(content_model, facet_join_model)
         facet_repository = Katello::ContentFacetRepository.table_name
@@ -267,16 +352,16 @@ module Katello
         property :upgradable_rpm_count, Integer, desc: 'Returns upgradable RPM count'
         property :content_source, 'SmartProxy', desc: 'Returns Smart Proxy object as the content source'
         prop_group :katello_idname_props, Katello::Model, meta: { resource: 'content_source' }
-        prop_group :katello_idname_props, Katello::Model, meta: { resource: 'content_view' }
+        # prop_group :katello_idname_props, Katello::Model, meta: { resource: 'content_view' }
         property :errata_counts, Hash, desc: 'Returns key=value object with errata counts, e.g. {security: 0, bugfix: 0, enhancement: 0, total: 0}'
         property :kickstart_repository, 'Repository', desc: 'Returns Kickstart repository object'
         prop_group :katello_idname_props, Katello::Model, meta: { resource: 'kickstart_repository' }
-        prop_group :katello_idname_props, Katello::Model, meta: { resource: 'lifecycle_environment' }
+        # prop_group :katello_idname_props, Katello::Model, meta: { resource: 'lifecycle_environment' }
       end
       class Jail < ::Safemode::Jail
-        allow :applicable_deb_count, :applicable_module_stream_count, :applicable_rpm_count, :content_source, :content_source_id, :content_source_name, :content_view_id,
-              :content_view_name, :errata_counts, :id, :kickstart_repository, :kickstart_repository_id, :kickstart_repository_name,
-              :lifecycle_environment_id, :lifecycle_environment_name, :upgradable_deb_count, :upgradable_module_stream_count, :upgradable_rpm_count, :uuid
+        allow :applicable_deb_count, :applicable_module_stream_count, :applicable_rpm_count, :content_source, :content_source_id, :content_source_name,
+              :errata_counts, :id, :kickstart_repository, :kickstart_repository_id, :kickstart_repository_name,
+              :upgradable_deb_count, :upgradable_module_stream_count, :upgradable_rpm_count, :uuid
       end
     end
   end

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -352,11 +352,9 @@ module Katello
         property :upgradable_rpm_count, Integer, desc: 'Returns upgradable RPM count'
         property :content_source, 'SmartProxy', desc: 'Returns Smart Proxy object as the content source'
         prop_group :katello_idname_props, Katello::Model, meta: { resource: 'content_source' }
-        # prop_group :katello_idname_props, Katello::Model, meta: { resource: 'content_view' }
         property :errata_counts, Hash, desc: 'Returns key=value object with errata counts, e.g. {security: 0, bugfix: 0, enhancement: 0, total: 0}'
         property :kickstart_repository, 'Repository', desc: 'Returns Kickstart repository object'
         prop_group :katello_idname_props, Katello::Model, meta: { resource: 'kickstart_repository' }
-        # prop_group :katello_idname_props, Katello::Model, meta: { resource: 'lifecycle_environment' }
       end
       class Jail < ::Safemode::Jail
         allow :applicable_deb_count, :applicable_module_stream_count, :applicable_rpm_count, :content_source, :content_source_id, :content_source_name,

--- a/app/models/katello/host/info_provider.rb
+++ b/app/models/katello/host/info_provider.rb
@@ -6,15 +6,21 @@ module Katello
       def host_info
         info = {}
         info['parameters'] = {
-          'foreman_host_collections' => host.host_collections.map(&:name),
-          'lifecycle_environment' => host.lifecycle_environment.try(:label),
-
-          'content_view' => host.content_view.try(:label),
-          'content_view_info' => content_view_info
+          'foreman_host_collections' => host.host_collections.map(&:name)
         }
 
         if host.content_facet.present?
           info['parameters']['kickstart_repository'] = host.content_facet.kickstart_repository.try(:label)
+          if host.single_content_view_environment?
+            info['parameters']['lifecycle_environment'] = host.single_lifecycle_environment.try(:label)
+            info['parameters']['content_view'] = host.single_content_view.try(:label)
+            info['parameters']['content_view_info'] = content_view_info(host.content_view_environments.first)
+          end
+          info['parameters']['content_views'] = host.content_view_environments.map do |cve|
+            content_view_info(cve).merge(
+              'lifecycle_environment' => cve.lifecycle_environment.try(:label)
+            )
+          end
         end
 
         if (rhsm_url = host.content_source&.rhsm_url)
@@ -28,25 +34,23 @@ module Katello
         info
       end
 
-      def content_view_info
-        return {} if host.content_view.blank?
-
-        content_view_info = {
-          'label' => host.content_view.try(:label),
-          'latest-version' => host.content_view.try(:latest_version),
-          'version' => content_version.try(:version),
-          'published' => content_version.try(:created_at).try(:time).to_s,
-          'components' => content_view_components
+      def content_view_info(content_view_environment)
+        content_view = content_view_environment.content_view
+        return {} if content_view.blank?
+        {
+          'label' => content_view.try(:label),
+          'latest-version' => content_view.try(:latest_version),
+          'version' => content_version(content_view_environment).try(:version),
+          'published' => content_version(content_view_environment).try(:created_at).try(:time).to_s,
+          'components' => content_view_components(content_view_environment)
         }
-
-        content_view_info
       end
 
-      def content_view_components
-        return {} unless host.content_view.try(:composite)
+      def content_view_components(content_view_environment)
+        return {} unless content_view_environment.content_view.try(:composite)
 
         components = {}
-        content_version.try(:content_view_version_components).map do |cv|
+        content_version(content_view_environment).try(:content_view_version_components).map do |cv|
           cv_label = cv.component_version.content_view.label
           components[cv_label] = {}
           components[cv_label]['version'] = cv.component_version.try(:version)
@@ -55,8 +59,8 @@ module Katello
         components
       end
 
-      def content_version
-        host.content_view.try(:version, host.lifecycle_environment)
+      def content_version(content_view_environment)
+        content_view_environment.content_view.try(:version, content_view_environment.lifecycle_environment)
       end
     end
   end

--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -18,17 +18,22 @@ module Katello
     has_many :successors, :class_name => "Katello::KTEnvironment", :through => :env_successors, :source => :env
 
     has_many :repositories, :class_name => "Katello::Repository", dependent: :destroy, foreign_key: :environment_id
-    has_many :content_view_environments, :class_name => "Katello::ContentViewEnvironment",
-                                         :foreign_key => :environment_id, :inverse_of => :environment, :dependent => :restrict_with_exception
-    has_many :content_view_versions, :through => :content_view_environments, :inverse_of => :environments
-    has_many :content_views, :through => :content_view_environments, :inverse_of => :environments
     has_many :content_view_histories, :class_name => "Katello::ContentViewHistory", :dependent => :destroy,
-                                      :inverse_of => :environment, :foreign_key => :katello_environment_id
+    :inverse_of => :environment, :foreign_key => :katello_environment_id
 
-    has_many :content_facets, :class_name => "Katello::Host::ContentFacet", :foreign_key => :lifecycle_environment_id,
-                          :inverse_of => :lifecycle_environment, :dependent => :restrict_with_exception
-    has_many :hosts,      :class_name => "::Host::Managed", :through => :content_facets,
+    has_many :content_view_environments, :class_name => "Katello::ContentViewEnvironment",
+             :foreign_key => :environment_id, :inverse_of => :environment, :dependent => :destroy
+    has_many :content_view_environment_content_facets, :through => :content_view_environments,
+                          :class_name => "Katello::ContentViewEnvironmentContentFacet",
                           :inverse_of => :lifecycle_environment
+    has_many :content_facets, :through => :content_view_environment_content_facets,
+                          :class_name => "Katello::Host::ContentFacet",
+                          :inverse_of => :lifecycle_environments
+    has_many :content_views, :through => :content_view_environments
+    has_many :content_view_versions, :through => :content_view_environments, :inverse_of => :environments
+
+    has_many :hosts,      :class_name => "::Host::Managed", :through => :content_facets,
+                          :inverse_of => :lifecycle_environments
     has_many :hostgroup_content_facets, :class_name => "Katello::Hostgroup::ContentFacet", :foreign_key => :lifecycle_environment_id,
                           :inverse_of => :lifecycle_environment, :dependent => :restrict_with_exception
     has_many :hostgroups, :class_name => "::Hostgroup", :through => :hostgroup_content_facets,

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -413,9 +413,10 @@ module Katello
     end
 
     def http_proxy
-      if http_proxy_policy == NO_DEFAULT_HTTP_PROXY
+      case http_proxy_policy
+      when NO_DEFAULT_HTTP_PROXY
         return nil
-      elsif http_proxy_policy == GLOBAL_DEFAULT_HTTP_PROXY
+      when GLOBAL_DEFAULT_HTTP_PROXY
         return HttpProxy.default_global_content_proxy
       end
       super

--- a/app/services/katello/candlepin/consumer.rb
+++ b/app/services/katello/candlepin/consumer.rb
@@ -16,8 +16,8 @@ module Katello
       lazy_accessor :entitlements, :initializer => lambda { |_s| Resources::Candlepin::Consumer.entitlements(uuid) }
       lazy_accessor :consumer_attributes, :initializer => lambda { |_s| Resources::Candlepin::Consumer.get(uuid) }
       lazy_accessor :installed_products, :initializer => lambda { |_s| consumer_attributes['installedProducts'] }
-      lazy_accessor :available_pools, :initializer => lambda { |_s| Resources::Candlepin::Consumer.available_pools(owner_label, uuid, false) }
-      lazy_accessor :all_available_pools, :initializer => lambda { |_s| Resources::Candlepin::Consumer.available_pools(owner_label, uuid, true) }
+      lazy_accessor :available_pools, :initializer => lambda { |_s| Resources::Candlepin::Consumer.available_pools(owner_label, uuid, listall: false) }
+      lazy_accessor :all_available_pools, :initializer => lambda { |_s| Resources::Candlepin::Consumer.available_pools(owner_label, uuid, listall: true) }
       lazy_accessor :content_overrides, :initializer => (lambda do |_s|
                                                            Resources::Candlepin::Consumer.content_overrides(uuid).map do |override|
                                                              ::Katello::ContentOverride.from_entitlement_hash(override)

--- a/app/services/katello/product_content_finder.rb
+++ b/app/services/katello/product_content_finder.rb
@@ -2,9 +2,8 @@ module Katello
   class ProductContentFinder
     attr_accessor :match_environment, :match_subscription, :consumable
 
-    #consumable must implement:
-    #  content_view
-    #  lifecycle_environment
+    # consumable must implement:
+    #  content_view_environments
     #  organization
     #  products
     def initialize(params = {})
@@ -16,16 +15,20 @@ module Katello
 
     def product_content
       if match_environment
-        environment = consumable.lifecycle_environment
-        view = consumable.content_view
-        return ProductContent.none unless environment && view
-        version = ContentViewVersion.in_environment(environment).where(:content_view_id => view).first
+        if consumable.is_a?(::Katello::ActivationKey) # TODO: remove this when AKs are refactored for multi CV
+          environment = consumable.lifecycle_environment
+          view = consumable.content_view
+          return ProductContent.none unless environment && view
+          versions = ContentViewVersion.in_environment(environment).where(:content_view_id => view).first
+        else # consumable is a SubscriptionFacet
+          versions = consumable.content_view_environments.select(:content_view_version_id).map(&:content_view_version_id)
+        end
       end
 
       considered_products = match_subscription ? consumable.products : consumable.organization.products.enabled.uniq
 
       roots = Katello::RootRepository.where(:product_id => considered_products).subscribable
-      roots = roots.in_content_view_version(version) if version
+      roots = roots.in_content_view_version(versions) if versions.present?
 
       consumable.organization.enabled_product_content_for(roots)
     end

--- a/app/views/katello/api/v2/content_facet/base.json.rabl
+++ b/app/views/katello/api/v2/content_facet/base.json.rabl
@@ -10,11 +10,28 @@ attributes :applicable_rpm_count => :applicable_package_count
 attributes :upgradable_rpm_count => :upgradable_package_count
 attributes :applicable_module_stream_count, :upgradable_module_stream_count
 
-child :content_view => :content_view do
+node :content_view do |content_facet|
+  content_view = content_facet.single_content_view
+  {
+    :id => content_view.id,
+    :name => content_view.name,
+    :composite => content_view.composite?
+  }
+end
+
+node :lifecycle_environment do |content_facet|
+  lifecycle_environment = content_facet.single_lifecycle_environment
+  {
+    :id => lifecycle_environment.id,
+    :name => lifecycle_environment.name
+  }
+end
+
+child :content_views => :content_views do
   attributes :id, :name, :composite
 end
 
-child :lifecycle_environment => :lifecycle_environment do
+child :lifecycle_environments => :lifecycle_environments do
   attributes :id, :name
 end
 

--- a/app/views/katello/api/v2/content_facet/show.json.rabl
+++ b/app/views/katello/api/v2/content_facet/show.json.rabl
@@ -2,7 +2,8 @@ child :content_facet => :content_facet_attributes do
   extends 'katello/api/v2/content_facet/base'
 
   node do |content_facet|
-    version = content_facet.content_view_version
+    content_facet.single_content_view # just so Rails gives a warning and we remember to fix this
+    version = content_facet.content_view_environments.first.content_view_version
     {
       :content_view_version => version.version,
       :content_view_version_id => version.id,
@@ -11,11 +12,11 @@ child :content_facet => :content_facet_attributes do
   end
 
   node :content_view_default? do |content_facet|
-    content_facet.content_view.default?
+    content_facet.single_content_view.default?
   end
 
   node :lifecycle_environment_library? do |content_facet|
-    content_facet.lifecycle_environment.library?
+    content_facet.single_lifecycle_environment.library?
   end
 
   node :katello_agent_installed do |content_facet|

--- a/app/views/katello/api/v2/content_views/base.json.rabl
+++ b/app/views/katello/api/v2/content_views/base.json.rabl
@@ -44,7 +44,7 @@ node :environments do |cv|
       label: env.label,
       name: env.label,
       activation_keys: cv&.activation_keys&.in_environment(env)&.ids,
-      hosts: cv&.hosts&.in_environment(env)&.ids,
+      hosts: cv&.hosts&.in_environments([env])&.ids,
       permissions: {readable: env.readable?}
     }
   end

--- a/app/views/katello/api/v2/hosts/base.json.rabl
+++ b/app/views/katello/api/v2/hosts/base.json.rabl
@@ -1,7 +1,31 @@
 object @resource
 
 @resource ||= @object
+@facet = @resource.content_facet
 
 attributes :id, :name, :description
-attributes :content_view, :content_view_id
-attributes :lifecycle_environment => :environment
+if @facet
+  node :content_view do
+    if @facet.single_content_view_environment?
+      content_view = @facet.single_content_view
+      {
+        :id => content_view.id,
+        :name => content_view.name,
+        :composite => content_view.composite?
+      }
+    else
+      "multiple"
+    end
+  end
+  node :lifecycle_environment do
+    if @facet.single_content_view_environment?
+      lifecycle_environment = @facet.single_lifecycle_environment
+      {
+        :id => lifecycle_environment.id,
+        :name => lifecycle_environment.name
+      }
+    else
+      "multiple"
+    end
+  end
+end

--- a/app/views/katello/api/v2/hosts/base.json.rabl
+++ b/app/views/katello/api/v2/hosts/base.json.rabl
@@ -6,26 +6,18 @@ object @resource
 attributes :id, :name, :description
 if @facet
   node :content_view do
-    if @facet.single_content_view_environment?
-      content_view = @facet.single_content_view
-      {
-        :id => content_view.id,
-        :name => content_view.name,
-        :composite => content_view.composite?
-      }
-    else
-      "multiple"
-    end
+    content_view = @facet&.single_content_view || {}
+    {
+      :id => content_view.id,
+      :name => content_view.name,
+      :composite => content_view.composite?
+    }
   end
   node :lifecycle_environment do
-    if @facet.single_content_view_environment?
-      lifecycle_environment = @facet.single_lifecycle_environment
-      {
-        :id => lifecycle_environment.id,
-        :name => lifecycle_environment.name
-      }
-    else
-      "multiple"
-    end
+    lifecycle_environment = @facet&.single_lifecycle_environment || {}
+    {
+      :id => lifecycle_environment.id,
+      :name => lifecycle_environment.name
+    }
   end
 end

--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -8,7 +8,7 @@
 
 <% env_select_id = using_hostgroups_page? ? :hostgroup_lifecycle_environment_id : :host_lifecycle_environment_id %>
 <% env_select_name =  using_hostgroups_page? ? 'hostgroup[lifecycle_environment_id]' : 'host[content_facet_attributes][lifecycle_environment_id]' %>
-<% env_select_attr = using_hostgroups_page? ? 'lifecycle_environment' : 'content_facet.lifecycle_environment' %>
+<% env_select_attr = using_hostgroups_page? ? 'lifecycle_environment' : 'content_facet.single_lifecycle_environment' %>
 
 <%= field(f, env_select_attr, {:label => _("Lifecycle Environment")}) do
   if using_hostgroups_page?
@@ -21,7 +21,7 @@ end %>
 
 <% cv_select_id =  using_hostgroups_page? ? :hostgroup_content_view_id : :host_content_view_id %>
 <% cv_select_name =  using_hostgroups_page? ? 'hostgroup[content_view_id]' : 'host[content_facet_attributes][content_view_id]' %>
-<% cv_select_attr = using_hostgroups_page? ? 'content_view' : 'content_facet.content_view' %>
+<% cv_select_attr = using_hostgroups_page? ? 'content_view' : 'content_facet.single_content_view' %>
 <%= field(f, cv_select_attr, {:label => _("Content View")}) do
   if using_hostgroups_page?
     select_tag cv_select_id,  content_views_for_host(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :data => {"spinner_path" => spinner_path},

--- a/db/migrate/20220929204746_add_content_view_environment_content_facet.rb
+++ b/db/migrate/20220929204746_add_content_view_environment_content_facet.rb
@@ -1,0 +1,50 @@
+class AddContentViewEnvironmentContentFacet < ActiveRecord::Migration[6.1]
+  class FakeContentFacet < ApplicationRecord
+    self.table_name = 'katello_content_facets'
+  end
+
+  def up
+    create_table :katello_content_view_environment_content_facets do |t|
+      t.references :content_view_environment, :null => false, :index => false, :foreign_key => { :to_table => 'katello_content_view_environments' }
+      t.references :content_facet, :null => false, :index => false, :foreign_key => { :to_table => 'katello_content_facets' }
+    end
+    FakeContentFacet.all.each do |content_facet|
+      cve_id = ::Katello::KTEnvironment.find(content_facet.lifecycle_environment_id)
+          .content_view_environments
+          .find_by(content_view_id: content_facet.content_view_id)
+          .id
+      ::Katello::ContentViewEnvironmentContentFacet.create(
+        content_facet_id: content_facet.id,
+        content_view_environment_id: cve_id
+      )
+    end
+
+    remove_column :katello_content_facets, :content_view_id
+    remove_column :katello_content_facets, :lifecycle_environment_id
+  end
+
+  def down
+    add_column :katello_content_facets, :content_view_id, :integer, :index => true
+    add_column :katello_content_facets, :lifecycle_environment_id, :integer, :index => true
+
+    add_foreign_key "katello_content_facets", "katello_content_views",
+                    :name => "katello_content_facets_content_view_id", :column => "content_view_id"
+
+    add_foreign_key "katello_content_facets", "katello_environments",
+                    :name => "katello_content_facets_life_environment_id", :column => "lifecycle_environment_id"
+
+    ::Katello::Host::ContentFacet.reset_column_information
+
+    ::Katello::ContentViewEnvironmentContentFacet.all.each do |cvecf|
+      content_facet = cvecf.content_facet
+      content_facet.content_view_id = cvecf.content_view_environment.content_view_id
+      content_facet.lifecycle_environment_id = cvecf.content_view_environment.environment_id
+      content_facet.save(validate: false)
+    end
+
+    change_column :katello_content_facets, :content_view_id, :integer, :null => false
+    change_column :katello_content_facets, :lifecycle_environment_id, :integer, :null => false
+
+    drop_table :katello_content_view_environment_content_facets
+  end
+end

--- a/db/migrate/20220929204746_add_content_view_environment_content_facet.rb
+++ b/db/migrate/20220929204746_add_content_view_environment_content_facet.rb
@@ -13,10 +13,12 @@ class AddContentViewEnvironmentContentFacet < ActiveRecord::Migration[6.1]
           .content_view_environments
           .find_by(content_view_id: content_facet.content_view_id)
           .id
-      ::Katello::ContentViewEnvironmentContentFacet.create(
+      unless ::Katello::ContentViewEnvironmentContentFacet.create(
         content_facet_id: content_facet.id,
         content_view_environment_id: cve_id
       )
+        Rails.logger.warn "Failed to create ContentViewEnvironmentContentFacet for content_facet #{content_facet.id}"
+      end
     end
 
     remove_column :katello_content_facets, :content_view_id

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -175,6 +175,7 @@ module Katello
 
       #Controller extensions
       ::HostsController.include Katello::Concerns::HostsControllerExtensions
+      ::HostsController.include Katello::Concerns::ContentFacetHostsControllerExtensions
       ::SmartProxiesController.include Katello::Concerns::SmartProxiesControllerExtensions
       ::RegistrationCommandsController.prepend Katello::Concerns::RegistrationCommandsControllerExtensions
 
@@ -212,6 +213,7 @@ module Katello
 
       #Api controller extensions
       ::Api::V2::HostsController.include Katello::Concerns::Api::V2::HostsControllerExtensions
+      ::Api::V2::HostsController.include Katello::Concerns::ContentFacetHostsControllerExtensions
       ::Api::V2::HostgroupsController.include Katello::Concerns::Api::V2::HostgroupsControllerExtensions
       ::Api::V2::SmartProxiesController.include Katello::Concerns::Api::V2::SmartProxiesControllerExtensions
       ::Api::V2::RegistrationController.prepend Katello::Concerns::Api::V2::RegistrationControllerExtensions

--- a/spec/helpers/katello_url_helper_spec.rb
+++ b/spec/helpers/katello_url_helper_spec.rb
@@ -4,75 +4,75 @@ module Katello
   describe KatelloUrlHelper do
     describe "Valid https? Urls" do
       it "should validate clean http urls" do
-        kurl_valid?('http://www.hugheshoney.com').must_equal(true)
-        kurl_valid?('HTtp://www.hugheshoney.com').must_equal(true)
-        kurl_valid?('http://www.hugheshoney.com:8888').must_equal(true)
-        kurl_valid?('http://www.hugheshoney.com:8888/homepage/index.html').must_equal(true)
-        kurl_valid?('http://9seng.cz/katello').must_equal(true)
+        assert kurl_valid?('http://www.hugheshoney.com')
+        assert kurl_valid?('HTtp://www.hugheshoney.com')
+        assert kurl_valid?('http://www.hugheshoney.com:8888')
+        assert kurl_valid?('http://www.hugheshoney.com:8888/homepage/index.html')
+        assert kurl_valid?('http://9seng.cz/katello')
       end
       it "should validate clean https urls" do
-        kurl_valid?('https://www.hugheshoney.com').must_equal(true)
-        kurl_valid?('https://www.hugheshoney.com:8888').must_equal(true)
-        kurl_valid?('https://www.hugheshoney.com:8888/homepage/index.html').must_equal(true)
+        assert kurl_valid?('https://www.hugheshoney.com')
+        assert kurl_valid?('https://www.hugheshoney.com:8888')
+        assert kurl_valid?('https://www.hugheshoney.com:8888/homepage/index.html')
       end
       it "should validate clean ipv4 urls" do
-        kurl_valid?('https://65.190.152.28').must_equal(true)
-        kurl_valid?('http://65.190.152.28:88').must_equal(true)
-        kurl_valid?('http://65.190.152.28:88/homepage/index.html').must_equal(true)
+        assert kurl_valid?('https://65.190.152.28')
+        assert kurl_valid?('http://65.190.152.28:88')
+        assert kurl_valid?('http://65.190.152.28:88/homepage/index.html')
       end
       it "should validate clean localhost urls" do
-        kurl_valid?('http://localhost').must_equal(true)
-        kurl_valid?('https://localhost').must_equal(true)
-        kurl_valid?('https://127.0.0.1/').must_equal(true)
-        kurl_valid?('https://127.0.0.1/index.php').must_equal(true)
-        kurl_valid?('https://127.0.0.1:80/index.php').must_equal(true)
+        assert kurl_valid?('http://localhost')
+        assert kurl_valid?('https://localhost')
+        assert kurl_valid?('https://127.0.0.1/')
+        assert kurl_valid?('https://127.0.0.1/index.php')
+        assert kurl_valid?('https://127.0.0.1:80/index.php')
       end
       it "should validate clean ftp urls" do
-        kurl_valid?('ftp://65.190.152.28').must_equal(true)
-        kurl_valid?('Ftp://65.190.152.28').must_equal(true)
-        kurl_valid?('ftp://65.190.152.28/fedora/x86_64').must_equal(true)
-        kurl_valid?('ftp://ftp.fedorahosted.org/rpms/index.html').must_equal(true)
+        assert kurl_valid?('ftp://65.190.152.28')
+        assert kurl_valid?('Ftp://65.190.152.28')
+        assert kurl_valid?('ftp://65.190.152.28/fedora/x86_64')
+        assert kurl_valid?('ftp://ftp.fedorahosted.org/rpms/index.html')
       end
 
       it "should validate file urls" do
-        kurl_valid?('file://opt/repo').must_equal(true)
-        kurl_valid?('/opt/repo').must_equal(false)
-        kurl_valid?('file://opt/repo-is-long/').must_equal(true)
-        kurl_valid?('/opt/repo-for-me').must_equal(false)
+        assert kurl_valid?('file://opt/repo')
+        refute kurl_valid?('/opt/repo')
+        assert kurl_valid?('file://opt/repo-is-long/')
+        refute kurl_valid?('/opt/repo-for-me')
       end
 
       it "should validate file urls with multiple slashes" do
-        kurl_valid?('file://///opt/repo').must_equal(true)
-        kurl_valid?('file://///opt/').must_equal(true)
-        kurl_valid?('File://///opt/').must_equal(true)
-        kurl_valid?('/////opt/repo').must_equal(false)
-        kurl_valid?('/////opt/repo').must_equal(false)
+        assert kurl_valid?('file://///opt/repo')
+        assert kurl_valid?('file://///opt/')
+        assert kurl_valid?('File://///opt/')
+        refute kurl_valid?('/////opt/repo')
+        refute kurl_valid?('/////opt/repo')
       end
 
       it "should validate not fully qualified domain names" do
-        kurl_valid?('http://seng9/katello').must_equal(true)
-        kurl_valid?('http://s-eng').must_equal(true)
-        kurl_valid?('http://seng').must_equal(true)
+        assert kurl_valid?('http://seng9/katello')
+        assert kurl_valid?('http://s-eng')
+        assert kurl_valid?('http://seng')
       end
 
       it "should validate urls with usernames and passwords" do
-        kurl_valid?('http://admin:admin@foo.com/').must_equal(true)
+        assert kurl_valid?('http://admin:admin@foo.com/')
       end
     end
 
     describe "Invalid Urls" do
       it "should catch invalid missing protocols" do
-        kurl_valid?('123.190.152.28').must_equal(false)
-        kurl_valid?('www.hugheshoney.com').must_equal(false)
+        refute kurl_valid?('123.190.152.28')
+        refute kurl_valid?('www.hugheshoney.com')
       end
       it "should catch invalid generic urls" do
-        kurl_valid?('www..foo.com').must_equal(false)
-        kurl_valid?('www..foo.com').must_equal(false)
-        kurl_valid?('htttp://foo.bar.edu').must_equal(false)
+        refute kurl_valid?('www..foo.com')
+        refute kurl_valid?('www..foo.com')
+        refute kurl_valid?('htttp://foo.bar.edu')
       end
       it "should catch domains with invalid dashes" do
-        kurl_valid?('-seng9').must_equal(false)
-        kurl_valid?('seng9-.com').must_equal(false)
+        refute kurl_valid?('-seng9')
+        refute kurl_valid?('seng9-.com')
       end
     end
   end

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -78,9 +78,9 @@ module ::Actions::Katello::ContentView
       it 'updates errata counts and status' do
         content_facet = katello_content_facets(:content_facet_two)
         action.stubs(:input).returns(
-          content_view_version_id: content_facet.content_view_version.id,
-          content_view_id: content_facet.content_view_id,
-          environment_id: content_facet.lifecycle_environment_id,
+          content_view_version_id: content_facet.content_view_environments.first.content_view_version.id,
+          content_view_id: content_facet.content_view_environments.first.content_view_id,
+          environment_id: content_facet.content_view_environments.first.environment_id,
           history_id: Katello::ContentViewHistory.first.id
         )
         Katello::Host::ContentFacet.any_instance.expects(:update_applicability_counts)
@@ -125,8 +125,8 @@ module ::Actions::Katello::ContentView
       it 'updates errata counts and status' do
         content_facet = katello_content_facets(:content_facet_two)
         action.stubs(:input).returns(
-          content_view_id: content_facet.content_view_id,
-          environment_id: content_facet.lifecycle_environment_id,
+          content_view_id: content_facet.content_view_environments.first.content_view_id,
+          environment_id: content_facet.content_view_environments.first.environment_id,
           history_id: Katello::ContentViewHistory.first.id
         )
         Katello::Host::ContentFacet.any_instance.expects(:update_applicability_counts)
@@ -269,8 +269,6 @@ module ::Actions::Katello::ContentView
     end
 
     it 'plans for removing environments' do
-      Katello::Host::ContentFacet.update_all(content_view_id: content_view.id)
-
       assert_raises(RuntimeError) do
         action.validate_options(content_view, [cv_env], [], {})
       end

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -481,10 +481,6 @@ module Katello
                      ]
 
       env_ids = [@dev.id.to_s, @staging.id.to_s]
-      ::Katello::Host::ContentFacet.expects(:where).at_least_once.returns([]).with do |args|
-        args[:content_view_id].id == @library_dev_staging_view.id && args[:lifecycle_environment_id] == env_ids
-      end
-
       Katello::ActivationKey.expects(:where).at_least_once.returns([]).with do |args|
         args[:content_view_id].id == @library_dev_staging_view.id && args[:environment_id] == env_ids
       end
@@ -612,12 +608,6 @@ module Katello
                       [ak_edit_permission, ak_cv_remove_permission, ak_env_remove_permission,
                        alternate_env_read_permission, bad_cv_read_permission]
                      ]
-
-      env_ids = [ak.environment.id.to_i]
-
-      ::Katello::Host::ContentFacet.expects(:where).at_least_once.returns([]).with do |args|
-        args[:content_view_id].id == ak.content_view.id && args[:lifecycle_environment_id].map(&:to_i) == env_ids
-      end
 
       assert_protected_action(:remove, allowed_perms, denied_perms) do
         put :remove, params: { :id => ak.content_view.id, :environment_ids => [ak.environment.id], :key_content_view_id => alternate_cv.id, :key_environment_id => alternate_env.id }

--- a/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
@@ -517,8 +517,8 @@ module Katello
                                             host_ids: [host.id] }
       assert_response :success
 
-      assert_equal host.reload.lifecycle_environment, lifecycle_environment
-      assert_equal host.reload.content_view, content_view
+      assert_equal host.reload.single_lifecycle_environment, lifecycle_environment
+      assert_equal host.reload.single_content_view, content_view
       assert_equal host.reload.content_source_id, content_source.id
 
       assert_includes @response.body, "Configure subscription-manager"

--- a/test/controllers/foreman/hosts_controller_test.rb
+++ b/test/controllers/foreman/hosts_controller_test.rb
@@ -26,13 +26,12 @@ class HostsControllerTest < ActionController::TestCase
     post :update_multiple_organization, params: { host_ids: [@host.id],
                                                   organization: { id: destination_org.id, optimistic_import: "yes" } }
 
-    assert_not_equal destination_org.id, @host.reload.organization_id
+    refute_equal destination_org.id, @host.reload.organization_id
     assert_equal "Unregister host host1.example.com before assigning an organization", flash[:error]
   end
 
   test 'can update host same organization' do
     destination_org = @host.organization
-
     post :update_multiple_organization, params: { host_ids: [@host.id],
                                                   organization: { id: destination_org.id, optimistic_import: "yes" } }
 
@@ -52,6 +51,7 @@ class HostsControllerTest < ActionController::TestCase
   end
 
   test 'empty content facet parameters are removed' do
+    orig_cves = @host.content_facet.content_view_environment_ids.to_a
     post :create, params: { :host => {
       :name => 'test_content',
       :content_facet_attributes => {
@@ -59,7 +59,7 @@ class HostsControllerTest < ActionController::TestCase
         :content_source_id => ""
       }
     } }, session: set_session_user
-    assert_empty assigns('host').content_facet
+    assert_equal orig_cves, @host.content_facet.content_view_environment_ids
   end
 
   context 'csv' do
@@ -89,8 +89,7 @@ class HostsControllerTest < ActionController::TestCase
         'Installable Updates - Enhancements',
         'Installable Updates - Package Count',
         'OS',
-        'Environment',
-        'Content View',
+        'Content View Environments',
         'Registered',
         'Last Checkin'
       ]

--- a/test/factories/host_factory.rb
+++ b/test/factories/host_factory.rb
@@ -11,8 +11,12 @@ FactoryBot.modify do
 
       after(:build) do |host, evaluator|
         if host.content_facet
-          host.content_facet.content_view = evaluator.content_view if evaluator.content_view
-          host.content_facet.lifecycle_environment = evaluator.lifecycle_environment if evaluator.lifecycle_environment
+          if evaluator.content_view && evaluator.lifecycle_environment
+            host.content_facet.assign_single_environment(
+              content_view_id: evaluator.content_view.id,
+              lifecycle_environment_id: evaluator.lifecycle_environment.id
+            )
+          end
           host.content_facet.content_source = evaluator.content_source if evaluator.content_source
         end
       end

--- a/test/fixtures/models/katello_content_facets.yml
+++ b/test/fixtures/models/katello_content_facets.yml
@@ -1,17 +1,11 @@
 content_facet_one:
   host_id:  <%= ActiveRecord::FixtureSet.identify(:one) %>
-  content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_view) %>
-  lifecycle_environment_id: <%= ActiveRecord::FixtureSet.identify(:library) %>
   uuid: "content_facet_one"
 
 content_facet_two:
   host_id:  <%= ActiveRecord::FixtureSet.identify(:two) %>
-  content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_dev_view) %>
-  lifecycle_environment_id: <%= ActiveRecord::FixtureSet.identify(:dev) %>
   uuid: "content_facet_two"
 
 without_errata:
   host_id:  <%= ActiveRecord::FixtureSet.identify(:without_errata) %>
-  content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_view) %>
-  lifecycle_environment_id: <%= ActiveRecord::FixtureSet.identify(:library) %>
   uuid: "without_errata"

--- a/test/fixtures/models/katello_content_view_environment_content_facets.yml
+++ b/test/fixtures/models/katello_content_view_environment_content_facets.yml
@@ -1,0 +1,11 @@
+library_cvecf:
+  content_view_environment_id: <%= ActiveRecord::FixtureSet.identify(:library_default_view_environment) %>
+  content_facet_id: <%= ActiveRecord::FixtureSet.identify(:content_facet_one) %>
+
+dev_library_cvecf:
+  content_view_environment_id: <%= ActiveRecord::FixtureSet.identify(:library_dev_view_dev) %>
+  content_facet_id: <%= ActiveRecord::FixtureSet.identify(:content_facet_two) %>
+
+without_errata_cvecf:
+  content_view_environment_id: <%= ActiveRecord::FixtureSet.identify(:library_default_view_environment) %>
+  content_facet_id: <%= ActiveRecord::FixtureSet.identify(:without_errata) %>

--- a/test/helpers/dashboard_helper_test.rb
+++ b/test/helpers/dashboard_helper_test.rb
@@ -8,7 +8,8 @@ class DashboardHelperTest < ActiveSupport::TestCase
   def setup
     User.current = User.anonymous_api_admin
     @library = katello_environments(:library)
-    @host =  FactoryBot.build(:host, :with_content, :with_subscription,
+    ::Host::Managed.any_instance.stubs(:update_candlepin_associations)
+    @host = FactoryBot.build(:host, :with_content, :with_subscription,
                                :content_view => katello_content_views(:library_dev_view),
                                :lifecycle_environment => katello_environments(:library), :id => 101)
     @host.organization = taxonomies(:organization1)

--- a/test/helpers/url_helpers_test.rb
+++ b/test/helpers/url_helpers_test.rb
@@ -21,29 +21,21 @@ class HostUrlHelpers < UrlHelperBase
       label: 'Default_Location',
       title: 'Default Location'
     )
-    @organisation = Organization.new(
+    @organization = Organization.new(
       name: 'Default Organization',
       type: 'Organization',
       label: 'Default_Organization',
       title: 'Default Organization'
     )
 
-    @host = ::Host.new(:architecture => @arch, :operatingsystem => @os,
-                       :content_facet_attributes => {:lifecycle_environment_id => @env.id,
-                                                     :content_view_id => @cv.id,
-                                                     :content_source_id => @content_source.id},
+    @host = FactoryBot.create(:host, :with_content, :architecture => @arch, :operatingsystem => @os,
+                       :content_facet_attributes => { :content_source_id => @content_source.id },
                        :location => @location,
-                       :organization => @organisation,
-                       :lifecycle_environment => @env
+                       :organization => @organization
                       )
-  end
-
-  test 'repository_url must render the right path based on host configuration' do
-    path = "http://#{@host.content_source.hostname}/pulp/content/#{@host.lifecycle_environment.organization.label}/#{@host.lifecycle_environment.label}/custom/zoo/zoo/".freeze
-    assert_equal path, repository_url('/custom/zoo/zoo/')
-
-    @host.content_view = katello_content_views(:library_dev_view)
-    path = "http://#{@host.content_source.hostname}/pulp/content/#{@host.lifecycle_environment.organization.label}/#{@host.lifecycle_environment.label}/#{@host.content_view.label}/custom/zoo/zoo/".freeze
-    assert_equal path, repository_url('/custom/zoo/zoo/')
+    @host.content_facet.assign_single_environment(
+      :lifecycle_environment_id => @env.id,
+      :content_view_id => @cv.id
+    )
   end
 end

--- a/test/lib/concerns/renderer_extensions_test.rb
+++ b/test/lib/concerns/renderer_extensions_test.rb
@@ -9,8 +9,10 @@ module Katello
       @host.content_facet.content_source = smart_proxies(:one)
       @host.operatingsystem = operatingsystems(:redhat)
       @host.content_facet.kickstart_repository = @repo
-      @host.content_facet.content_view = @repo.content_view
-
+      @host.content_facet.assign_single_environment(
+        content_view: @repo.content_view,
+        lifecycle_environment: katello_environments(:library)
+      )
       @hostgroup = ::Hostgroup.new
       @hostgroup.content_source = smart_proxies(:one)
       @hostgroup.operatingsystem = operatingsystems(:redhat)

--- a/test/lib/resources/candlepin_test.rb
+++ b/test/lib/resources/candlepin_test.rb
@@ -43,7 +43,7 @@ module Katello
           Foreman::Util.expects(:add_ca_bundle_to_store).never
           OpenSSL::X509::Certificate.expects(:new)
           OpenSSL::PKey::RSA.expects(:new)
-          UpstreamCandlepinResource.resource("http://www.foo.com", "", "")
+          UpstreamCandlepinResource.resource(url: "http://www.foo.com", client_cert: "", client_key: "")
         end
       end
 

--- a/test/lib/tasks/unify_hosts_test.rb
+++ b/test/lib/tasks/unify_hosts_test.rb
@@ -12,6 +12,7 @@ module Katello
       @environment = katello_environments(:library)
 
       Katello::Candlepin::Consumer.any_instance.stubs(:entitlement_status).returns(Katello::Candlepin::Consumer::ENTITLEMENTS_VALID)
+      ::Host::Managed.any_instance.stubs(:update_candlepin_associations)
 
       ENV['HOSTS'] = nil
       ENV['DRYRUN'] = nil

--- a/test/mailers/errata_mailer_test.rb
+++ b/test/mailers/errata_mailer_test.rb
@@ -54,12 +54,15 @@ module Katello
     def test_promote_errata
       view_repo = Katello::Repository.find(katello_repositories(:rhel_6_x86_64_library_view_1).id)
       @errata_host.content_facet.bound_repositories = [view_repo]
-      @errata_host.content_facet.content_view = katello_content_views(:acme_default)
+      @errata_host.content_facet.assign_single_environment(
+        content_view: katello_content_views(:acme_default),
+        lifecycle_environment: katello_environments(:library)
+      )
       @errata_host.content_facet.save!
 
       ActionMailer::Base.deliveries = []
-      MailNotification[:promote_errata].deliver(:users => [@user], :content_view => @errata_host.content_facet.content_view,
-                                                        :environment => @errata_host.content_facet.lifecycle_environment)
+      MailNotification[:promote_errata].deliver(:users => [@user], :content_view => @errata_host.single_content_view,
+                                                        :environment => @errata_host.single_lifecycle_environment)
       email = ActionMailer::Base.deliveries.first
       assert_includes email.body.encoded, 'RHSA-1999-1231'
     end

--- a/test/models/association_test.rb
+++ b/test/models/association_test.rb
@@ -62,7 +62,7 @@ module Katello
                   end
                   fk_columns.flatten!
                   fk_columns.uniq!
-                  msg = "Foreign Key not defined for  #{model.table_name}.#{association.foreign_key}"
+                  msg = "Foreign key constraint not defined for #{model.table_name}.#{association.foreign_key}"
                   assert_includes fk_columns, association.foreign_key.to_s, msg
                 end
               end

--- a/test/models/concerns/hostgroup_extensions_test.rb
+++ b/test/models/concerns/hostgroup_extensions_test.rb
@@ -190,7 +190,6 @@ module Katello
       # changing the lifecycle environment will trigger
       # code which attempts to reassign the kickstart repo by its label
       hg.lifecycle_environment = @dev_distro.environment
-
       assert hg.save
       assert_equal hg.kickstart_repository_id, @dev_distro.id
     end

--- a/test/models/content_view_environment_test.rb
+++ b/test/models/content_view_environment_test.rb
@@ -8,7 +8,7 @@ module Katello
     end
 
     def test_for_content_facets
-      cve = @content_facet.content_view.content_view_environment(@content_facet.lifecycle_environment)
+      cve = @content_facet.content_view_environments.first
       assert_includes ContentViewEnvironment.for_content_facets(@content_facet), cve
     end
 

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -76,6 +76,7 @@ module Katello
                                       :content_view => katello_content_views(:library_dev_view),
                                       :lifecycle_environment => katello_environments(:library),
                                       :compute_resource_id => compute_resources(:one).id)
+      host.stubs(:update_candlepin_associations)
       host.save
       host.content_facet.applicable_errata << @security
       host.save
@@ -115,7 +116,10 @@ module Katello
     def setup
       super
       @host = hosts(:one)
-      @host.content_facet.content_view = katello_content_views(:library_dev_view)
+      @host.content_facet.assign_single_environment(
+        content_view: katello_content_views(:library_dev_view),
+        lifecycle_environment: katello_environments(:library)
+      )
       @view_repo = katello_repositories(:rhel_6_x86_64_library_view_1)
       @host.content_facet.bound_repositories = [@repo, @view_repo]
       @host.content_facet.save!
@@ -169,7 +173,10 @@ module Katello
       @repo = katello_repositories(:rhel_6_x86_64)
       @security = katello_errata(:security)
       @host = hosts(:one)
-      @host.content_facet.content_view = katello_content_views(:library_dev_view)
+      @host.content_facet.assign_single_environment(
+        content_view: katello_content_views(:library_dev_view),
+        lifecycle_environment: katello_environments(:library)
+      )
       @view_repo = katello_repositories(:rhel_6_x86_64_library_view_1)
       @host.content_facet.bound_repositories = [@repo, @view_repo]
       @host.content_facet.save!
@@ -180,6 +187,7 @@ module Katello
                                       organizations: [@host.organization],
                                       locations: [@host.location])
       @host.hostgroup = hostgroup
+      @host.stubs(:update_candlepin_associations)
       @host.save(validate: false)
       User.current = User.find(users('restricted').id)
       setup_current_user_with_permissions([{ name: "view_hosts",

--- a/test/support/fixtures_support.rb
+++ b/test/support/fixtures_support.rb
@@ -8,6 +8,7 @@ module Katello
       :katello_contents => Katello::Content,
       :katello_content_views => Katello::ContentView,
       :katello_content_view_environments => Katello::ContentViewEnvironment,
+      :katello_content_view_environment_content_facets => Katello::ContentViewEnvironmentContentFacet,
       :katello_content_view_filters => Katello::ContentViewFilter,
       :katello_content_view_erratum_filter_rules => Katello::ContentViewErratumFilterRule,
       :katello_content_view_package_filter_rules => Katello::ContentViewPackageFilterRule,

--- a/test/support/host_support.rb
+++ b/test/support/host_support.rb
@@ -4,8 +4,7 @@ module Support
   class HostSupport
     def self.attach_content_facet(host, view, environment)
       content_facet = Katello::Host::ContentFacet.new
-      content_facet.content_view = view
-      content_facet.lifecycle_environment = environment
+      content_facet.assign_single_environment(content_view: view, lifecycle_environment: environment)
       host.content_facet = content_facet
       host.reload
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Hoo boy. Here we go..

* Remove the content facet `belongs_to` associations for `content_view` and `lifecycle_environment`
* Introduce a new Rails model, `ContentViewEnvironmentContentFacet`, allowing a content facet to be associated with multiple ContentViewEnvironments.
* Add a second purpose to `ContentViewEnvironment` - in addition to keeping track of which CV versions are promoted to a given environment, `ContentViewEnvironment`s now also keep track of what content views are associated with a host's content facet (and as a consequence, which lifecycle environments.)
* Update all relevant Rails associations (`has_many`, `belongs_to`, etc.)
* find every place where we did `content_view = ` or `lifecycle_environment = ` and change those to ~~`content_view_environments = `~~ `assign_single_environment`. This includes
  * hosts_bulk_actions_controller (Change Content Source)
  * hosts_controller_extensions
* Replace the ContentFacet `content_view` and `lifecycle_environment` methods with `single_content_view` and `single_lifecycle_environment`. (this is a stopgap until we actually have full support for multi CV everywhere, and will make it easier to convert all our code)
* `content_facet_host_extensions`: `in_content_view_environment` and `in_environment` are now plural; add singular shim methods with deprecation warnings as a stopgap
* `SubscriptionFacet#backend_update_needed` previously used `content_facet.content_view_id_changed?` et al. to decide if an update is needed. Now that `content_view_id` is no longer an attribute, I had to come up with an alternate method of tracking changes. (thanks Stack Overflow..) We now use an attr_accessor in combination with `has_many`'s `after_add` and `after_remove` callbacks.
* Don't preload nonexistent relations in `plugin.rb`
* Allow you to initiate a ContentFacet with `content_view_id` and `lifecycle_environment_id` attributes as before. This makes it possible for the frontend to send the same params as always, and not break. It's accomplished by hijacking these two params in
  * a new `around_action` added to the hosts_controller_extensions
  * a new `initialize` method on ContentFacet
* Add a setting (defaults to false) to allow registration with multiple environments
![setting-multi-cv](https://user-images.githubusercontent.com/22042343/196213783-c98e0c5d-1367-4ca3-a1a4-b26b1aad7fda.png)
 
#### Note about the UI
My goal for the UI was "don't break anything." So, 

* You can _register_ a host with multiple environments using `subscription-manager`, but you won't see it reflected in the UI.
* You cannot assign a host to multiple environments using the UI. If you change a multi-environment host's CV/LCE via the UI, it will go back to being a single-environment host.
* A host registered to multiple environments won't show any changes in the UI, except Repository Sets (with 'Limit to environment') should show the correct repos.

#### What didn't change yet (for now)

* `::Katello::Host::ContentFacet` has support for multiple CVs and environments, but `::Katello::Hostgroup::ContentFacet` remains single-environment.
* Activation keys remain single-environment.
* Content views don't yet have a priority

#### Still to do:
- [x] fix tests
- [x] fix report templates (in Foreman)
- [x] add setting

#### Considerations taken when implementing this change?

The `single_content_view` and `single_lifecycle_environment` methods are stopgaps that work the same as the previous `content_view` and `lifecycle_environment` methods. This is so the web UI code can remain unchanged for now. Why not just use the old names? I feel like being explicit about this will make it easier to update our code later, and allow more flexibility about when we remove the deprecated methods.

#### What are the testing steps for this pull request?

Make sure to run the migration! And when you switch away from the branch, run

```
bundle exec rails db:migrate:down VERSION=20220929204746
```

To see what environments a host thinks it belongs to:
```
subscription-manager environments --list-enabled
```

To see what environments are available to register to:
```
subscription-manager environments --list
```

To register a host to multiple environments:
```
# delete the host from All hosts in web UI
subscription-manager clean
subscription-manager register --username admin --password changeme --environments Library/env1,cvName/env2
```

To see enabled repos (`enabled: 1`):
```
subscription-manager repos
```

Areas to test:
- [x] Host details page (new UI)
- [x] Content Hosts (old UI)
- [x] Hammer
- [x] CV UI actions
- [x] CV publish
- [x] CV promote
- [x] Host content view change (old and new UI)
- [x] Change Content Source
- [x] Hostgroup host create
- [x] Host create
- [x] Host registration - global registration
- [x] Registration with Activation Keys
- [x] Registration with sub-man register (username & password)
- [x] Report templates (https://github.com/theforeman/foreman/pull/9478)
- [x] Foreman Ansible modules
- [x] and as @ianballou always says.. do the bound repositories make sense?? :smile: 

