### PR TITLE
Fixes #35588 - Prevent the deletion of content credentials when they are in use

### DIFF
--- a/app/models/katello/content_credential.rb
+++ b/app/models/katello/content_credential.rb
@@ -9,26 +9,25 @@ module Katello
     GPG_KEY_TYPE = 'gpg_key'.freeze
     CERT_TYPE = 'cert'.freeze
 
-    has_many :root_repositories, :class_name => "Katello::RootRepository", :inverse_of => :gpg_key, :dependent => :nullify, :foreign_key => 'gpg_key_id'
+    has_many :root_repositories, :class_name => "Katello::RootRepository", :inverse_of => :gpg_key, :dependent => :restrict_with_exception, :foreign_key => 'gpg_key_id'
     has_many :repositories, :through => :root_repositories
 
-    has_many :products, :class_name => "Katello::Product", :inverse_of => :gpg_key, :dependent => :nullify, :foreign_key => 'gpg_key_id'
-
+    has_many :products, :class_name => "Katello::Product", :inverse_of => :gpg_key, :dependent => :restrict_with_exception, :foreign_key => 'gpg_key_id'
     has_many :ssl_ca_cdn_configurations, :class_name => "Katello::CdnConfiguration", :foreign_key => 'ssl_ca_credential_id',
       :inverse_of => :ssl_ca_credential, :dependent => :nullify
 
     has_many :ssl_ca_products, :class_name => "Katello::Product", :foreign_key => "ssl_ca_cert_id",
-                               :inverse_of => :ssl_ca_cert, :dependent => :nullify
+                               :inverse_of => :ssl_ca_cert, :dependent => :restrict_with_exception
     has_many :ssl_client_products, :class_name => "Katello::Product", :foreign_key => "ssl_client_cert_id",
-                                   :inverse_of => :ssl_client_cert, :dependent => :nullify
+                                   :inverse_of => :ssl_client_cert, :dependent => :restrict_with_exception
     has_many :ssl_key_products, :class_name => "Katello::Product", :foreign_key => "ssl_client_key_id",
-                                :inverse_of => :ssl_client_key, :dependent => :nullify
+                                :inverse_of => :ssl_client_key, :dependent => :restrict_with_exception
     has_many :ssl_ca_root_repos, :class_name => "Katello::RootRepository", :foreign_key => "ssl_ca_cert_id",
-                            :inverse_of => :ssl_ca_cert, :dependent => :nullify
+                            :inverse_of => :ssl_ca_cert, :dependent => :restrict_with_exception
     has_many :ssl_client_root_repos, :class_name => "Katello::RootRepository", :foreign_key => "ssl_client_cert_id",
-                                :inverse_of => :ssl_client_cert, :dependent => :nullify
+                                :inverse_of => :ssl_client_cert, :dependent => :restrict_with_exception
     has_many :ssl_key_root_repos, :class_name => "Katello::RootRepository", :foreign_key => "ssl_client_key_id",
-                             :inverse_of => :ssl_client_key, :dependent => :nullify
+                             :inverse_of => :ssl_client_key, :dependent => :restrict_with_exception
     has_many :ssl_ca_alternate_content_sources, :class_name => "Katello::AlternateContentSource", :foreign_key => "ssl_ca_cert_id",
                                 :inverse_of => :ssl_ca_cert, :dependent => :nullify
     has_many :ssl_client_alternate_content_sources, :class_name => "Katello::AlternateContentSource", :foreign_key => "ssl_client_cert_id",

--- a/engines/bastion/app/assets/javascripts/bastion/components/notification.service.js
+++ b/engines/bastion/app/assets/javascripts/bastion/components/notification.service.js
@@ -32,6 +32,6 @@ angular.module('Bastion.components').service("Notification", ['$interpolate', 'f
     };
 
     this.setErrorMessage = function (message, context) {
-        foreman.toastNotifications.notify({message: interpolateIfNeeded(message, context), type: 'error'});
+        foreman.toastNotifications.notify({message: interpolateIfNeeded(message, context), type: 'danger'});
     };
 }]);

--- a/engines/bastion/test/components/notification.service.test.js
+++ b/engines/bastion/test/components/notification.service.test.js
@@ -21,7 +21,7 @@ describe('Factory: Nofification', function() {
     it("provides a way to set error messages", function () {
         var message = "Everything is broken!";
         Notification.setErrorMessage(message);
-        expect(foreman.toastNotifications.notify).toHaveBeenCalledWith({message: message, type: 'error'});
+        expect(foreman.toastNotifications.notify).toHaveBeenCalledWith({message: message, type: 'danger'});
     });
 
     it("provides a way to set warning messages", function () {

--- a/engines/bastion/vendor/assets/javascripts/bastion/angular/angular.js
+++ b/engines/bastion/vendor/assets/javascripts/bastion/angular/angular.js
@@ -17941,7 +17941,7 @@ function $ParseProvider() {
  * @description
  */
 function $QProvider() {
-  var errorOnUnhandledRejections = true;
+  var errorOnUnhandledRejections = false;
   this.$get = ['$rootScope', '$exceptionHandler', function($rootScope, $exceptionHandler) {
     return qFactory(function(callback) {
       $rootScope.$evalAsync(callback);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/details/content-credential-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/details/content-credential-details.controller.js
@@ -40,9 +40,15 @@ angular.module('Bastion.content-credentials').controller('ContentCredentialDetai
         };
 
         $scope.removeContentCredential = function (contentCredential) {
-            contentCredential.$delete(function () {
+            var deferred = $q.defer();
+            contentCredential.$delete(function (response) {
+                deferred.resolve(response);
                 $scope.transitionTo('content-credentials');
+            }, function (response) {
+                deferred.reject(response);
+                Notification.setErrorMessage(response.data.displayMessage);
             });
+            return deferred.promise;
         };
     }]
 );


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Changed the model to prevent deletion of a content credential if it's associated with a product or repo
* Created unit tests for the model changes
* Came across this https://projects.theforeman.org/issues/33514 when making the UI show the error toast notification, so made a change in AngularJS
* Saw `an with uncaught exceptions` issue on multiple pages in Angular when we have an error toast besides the error that we show, turned off `errorOnUnhandledRejections` We are getting the correct responses back and since we are really not doing much with AngularJS anymore, I feel like it's fine to turn it off, since it just causes uneeded errors in the console.
* Added a toast notification on the content credentials page when we have an error on delete.

#### Considerations taken when implementing this change?

* Made sure content credentials delete still works if not attached to a product/repo

#### What are the testing steps for this pull request?

* Check out PR
* Create a GPG key from here: https://mirror.steadfast.net/centos/RPM-GPG-KEY-CentOS-7
* Create 3 content credentials of ssl type ca/key/cert using the cert below:
```
-----BEGIN CERTIFICATE-----
MIIFITCCBAmgAwIBAgIED/4IDzANBgkqhkiG9w0BAQsFADBBMRAwDgYDVQQKDAdS
ZWQgSGF0MQ0wCwYDVQQLDARwcm9kMR4wHAYDVQQDDBVDZXJ0aWZpY2F0ZSBBdXRo
b3JpdHkwHhcNMjExMTE2MTkwMjI0WhcNMjIxMTExMTkwMjI0WjCBjDELMAkGA1UE
BhMCVVMxFzAVBgNVBAgMDk5vcnRoIENhcm9saW5hMRAwDgYDVQQHDAdSYWxlaWdo
MRAwDgYDVQQKDAdSZWQgSGF0MUAwPgYDVQQDDDdzYXRlbGxpdGUxLmxhdGVzdC1l
bDcuc2F0ZWxsaXRlLmxhYi5lbmcucmR1Mi5yZWRoYXQuY29tMIICIjANBgkqhkiG
9w0BAQEFAAOCAg8AMIICCgKCAgEA7SIppnwh5pnYnreIsmB9YSBd98hJ/AM+kRmQ
rl2JLrQcjq98lS3WQORnVY+At3PcRChvl390B2ZzeZ2/0mZMppjLKJ+9W+MwL42c
iJTgZIr9L5yQLGlD3x356FHoKxhixNp6VJGaco81V6TViB5uHqoeS/cKI5YWyYx4
VgSxUZyQyyiOZLRCRzTSKlzLt7VeDX5REB3xySMN5/i12pwQO+qgIyns7FtiFSAK
ZtoFqwkQ/XOWW3hkaSVXEmUpBXI73IlkZiGfPwnt+u8KY/srMAAx9HABZQ6GP8lz
1tr3VFmsmAZZ8q/uHqKEKzLXW/t3DeFMuOVU0ZyHUjXSZBmE7r3VZd+tnUrAGoJW
W2z4G2Iv8JXxtsnz9TvXHeyRMko27w4wMm0CLN8ZxP9Js25GwY5Jh4KF7i9vWEcq
fWrUPy+/kKzjNF1bEqGHx7CV+7ZEijn1izp1Cw1lIRiTFJ5XdhTxd16UXqO+CtEI
HM9ksxWpic1lUoPpR3+33GXj6TfVaIugQur1LPA9sEp87s09YhmOgg5aFGAv88PE
izhbhMACtwqL4+raYQ/t7VmAr4A4hdsC3PpLw+E1T/ruVijSFJeyU/Fon8rj6oHf
cqRo6BQIy9YEByXVtL50Dqe85nxQMFugpIDM1ZOuBOfxIGpA3kGV+KvnCwogtIJS
EpkzJgMCAwEAAaOB1DCB0TAfBgNVHSMEGDAWgBR72gn1SV3Z11zJNvhV0huXnhEv
fjBCBgNVHREEOzA5gjdzYXRlbGxpdGUxLmxhdGVzdC1lbDcuc2F0ZWxsaXRlLmxh
Yi5lbmcucmR1Mi5yZWRoYXQuY29tMDsGCCsGAQUFBwEBBC8wLTArBggrBgEFBQcw
AYYfaHR0cDovL29jc3AucmVkaGF0LmNvbS9jYS9vY3NwLzAOBgNVHQ8BAf8EBAMC
BPAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA0GCSqGSIb3DQEBCwUA
A4IBAQCUvrIFqoZ9d4YRPnrChb7ORVSsgPQ+W+o5gXwuPWz6vbgCTvK8Dri+YMNB
w5DpDo5IcxniJM1qqBPQb7PLY5HIjBC6sdMdS/0LqGzd7SovVDT246upbC2B8IDT
PB/MGmMGYVUTHbeuMC3qhPHvHe+x57pLNmkkeWQTLQXPJmXh4pOghRFzPSIQMGx8
CbIYS7mAVJ/GSLfif/GyVw1J3XYrMVuu3gMsrLKJ1Px39kEB4SmFCcB/AlWL1xlY
t+i9SDBDhAyNYKoT9g85dVzTpDovzc5Tt/eesw8F2f5IDZJxb1He4Vij+jXKpECW
LGmGrAonnciNuS1laxi8BTVr4bQt
-----END CERTIFICATE-----
```
* Attach a GPG key to a product
* Attach the ssl cert/key/ca to a repo
* Create a content credential of either gpg key or ssl but don't attach to product
* Try to delete the first gpgkey and make sure we get an error and it does not delete
* Try to delete the SSL content credentials and make sure they error and don't delete
* Try to delete the content credential you made that is not attached to a product/repo and make sure it still deletes ok.