### PR TITLE
Fixes #35589 - Add repository subtab to CVV compare

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -234,6 +234,51 @@ module Katello
       query
     end
 
+    api :GET, "/repositories/compare/", N_("List :resource")
+    param :content_view_version_ids, Array, :desc => N_("content view versions to compare")
+    param :repository_id, :number, :desc => N_("Library repository id to restrict comparisons to")
+    param :restrict_comparison, String, :desc => N_("Return same, different or all results")
+
+    def compare
+      fail _("No content_view_version_ids provided") if params[:content_view_version_ids].empty?
+      @versions = ContentViewVersion.readable.where(:id => params[:content_view_version_ids])
+      if @versions.count != params[:content_view_version_ids].uniq.length
+        missing = params[:content_view_version_ids] - @versions.pluck(:id)
+        fail HttpErrors::NotFound, _("Couldn't find content view versions '%s'") % missing.join(',')
+      end
+
+      archived_version_repos = Katello::Repository.where(:content_view_version_id => @versions&.pluck(:id))&.archived
+      repos = Katello::Repository.where(id: archived_version_repos&.pluck(:library_instance_id))
+      repos = repos.where(:root_id => @repo.root_id) if @repo
+      collection = restrict_comparison(repos, @versions, params[:restrict_comparison])
+      collection = scoped_search(collection.distinct, :name, :asc)
+      collection[:results] = collection[:results].map { |item| ContentViewVersionComparePresenter.new(item, @versions, @repo) }
+      respond_for_index(:collection => collection)
+    end
+
+    def restrict_comparison(collection, content_view_versions = nil, compare = 'all')
+      case compare
+      when 'same'
+        same_repo_ids = compare_same(collection, content_view_versions)
+        collection.where(id: same_repo_ids)
+      when 'different'
+        same_repo_ids = compare_same(collection, content_view_versions)
+        collection.where.not(id: same_repo_ids)
+      else
+        collection
+      end
+    end
+
+    def compare_same(collection, content_view_versions = nil)
+      same_repo_ids = []
+      collection.each do |repo|
+        if (content_view_versions&.pluck(:id)&.- repo.published_in_versions&.pluck(:id))&.empty?
+          same_repo_ids << repo.id
+        end
+      end
+      same_repo_ids
+    end
+
     api :POST, "/repositories", N_("Create a custom repository")
     param :name, String, :desc => N_("Name of the repository"), :required => true
     param :description, String, :desc => N_("Description of the repository"), :required => false

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -250,8 +250,8 @@ module Katello
       archived_version_repos = Katello::Repository.where(:content_view_version_id => @versions&.pluck(:id))&.archived
       repos = Katello::Repository.where(id: archived_version_repos&.pluck(:library_instance_id))
       repos = repos.where(:root_id => @repo.root_id) if @repo
-      collection = restrict_comparison(repos, @versions, params[:restrict_comparison])
-      collection = scoped_search(collection.distinct, :name, :asc)
+      repositories = restrict_comparison(repos, @versions, params[:restrict_comparison])
+      collection = scoped_search(repositories.distinct, :name, :asc)
       collection[:results] = collection[:results].map { |item| ContentViewVersionComparePresenter.new(item, @versions, @repo) }
       respond_for_index(:collection => collection)
     end

--- a/app/presenters/katello/content_view_version_compare_presenter.rb
+++ b/app/presenters/katello/content_view_version_compare_presenter.rb
@@ -13,6 +13,11 @@ module Katello
       item_repos.map(&:content_view_version_id) & @versions.map(&:id)
     end
 
+    def comparison_repositories
+      repo = @item
+      @versions.map(&:id) & repo&.published_in_versions&.pluck(:id)
+    end
+
     def respond_to?(method)
       return method.to_s == 'comparison' || @item.respond_to?(method)
     end

--- a/app/views/katello/api/v2/repositories/compare.json.rabl
+++ b/app/views/katello/api/v2/repositories/compare.json.rabl
@@ -1,0 +1,10 @@
+object false
+
+extends "katello/api/v2/common/metadata"
+
+child @collection[:results] => :results do
+  extends 'katello/api/v2/repositories/base'
+  node :comparison do |result|
+    result.comparison_repositories
+  end
+end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -322,6 +322,7 @@ Katello::Engine.routes.draw do
             get :auto_complete_search
             get :repository_types
             get :content_types
+            get :compare
           end
           member do
             put :republish

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -83,6 +83,7 @@ module Katello
                    'katello/api/v2/errata' => [:index, :show, :auto_complete_search, :compare],
                    'katello/api/v2/module_streams' => [:index, :show, :auto_complete_search, :compare],
                    'katello/api/v2/ansible_collections' => [:index, :show, :auto_complete_search, :compare],
+                   'katello/api/v2/repositories' => [:index, :show, :auto_complete_search, :compare],
                    'katello/content_views' => [:auto_complete, :auto_complete_search],
                    'katello/errata' => [:short_details, :auto_complete],
                    'katello/packages' => [:details, :auto_complete],

--- a/webpack/scenes/ContentViews/ContentViewsConstants.js
+++ b/webpack/scenes/ContentViews/ContentViewsConstants.js
@@ -63,6 +63,7 @@ export const addComponentSuccessMessage = component => (component ? __('Updated 
 export const genericContentCompareKey = (pluralLabel, versionOne, versionTwo, viewBy) => `${toUpper(pluralLabel)}_COMPARE_${versionOne}_${versionTwo}_VIEW_BY_${toUpper(viewBy)}`;
 export const cvPackageGroupsCompareKey = (versionOne, versionTwo, viewBy) => `${PACKAGE_GROUPS_KEY}_COMPARE_${versionOne}_${versionTwo}_VIEW_BY_${toUpper(viewBy)}`;
 export const cvRPMPackagesCompareKey = (versionOne, versionTwo, viewBy) => `${PACKAGES_KEY}_COMPARE_${versionOne}_${versionTwo}_VIEW_BY_${toUpper(viewBy)}`;
+export const cvRepositoriesCompareKey = (versionOne, versionTwo, viewBy) => `REPOSITORIES_COMPARE_${versionOne}_${versionTwo}_VIEW_BY_${toUpper(viewBy)}`;
 export const cvErrataCompareKey = (versionOne, versionTwo, viewBy) => `${ERRATA_KEY}_COMPARE_${versionOne}_${versionTwo}_VIEW_BY_${toUpper(viewBy)}`;
 export const cvModuleStreamsCompareKey = (versionOne, versionTwo, viewBy) => `${MODULE_STREAMS_KEY}_COMPARE_${versionOne}_${versionTwo}_VIEW_BY_${toUpper(viewBy)}`;
 export const cvDebPackagesCompareKey = (versionOne, versionTwo, viewBy) => `${DEB_PACKAGES_KEY}_COMPARE_${versionOne}_${versionTwo}_VIEW_BY_${toUpper(viewBy)}`;

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
@@ -57,6 +57,7 @@ import {
   cvDebPackagesCompareKey,
   filesCompareKey,
   genericContentCompareKey,
+  cvRepositoriesCompareKey,
 } from '../ContentViewsConstants';
 import api, { foremanApi, orgId } from '../../../services/api';
 import { getResponseErrorMsgs } from '../../../utils/helpers';
@@ -95,6 +96,19 @@ export const getRPMPackagesComparison = (versionOne, versionTwo, viewBy, params)
     key: cvRPMPackagesCompareKey(versionOne, versionTwo, viewBy),
     params: apiParams,
     errorToast: error => __(`Something went wrong while retrieving the packages! ${getResponseErrorMsgs(error.response)}`),
+    url: api.getApiUrl(apiUrl),
+  });
+};
+
+export const getRepositoriesComparison = (versionOne, versionTwo, viewBy, params) => {
+  const versions = { content_view_version_ids: [versionOne, versionTwo] };
+  const restrictComparison = { restrict_comparison: viewBy };
+  const apiParams = { ...versions, ...restrictComparison, ...params };
+  const apiUrl = '/repositories/compare';
+  return get({
+    key: cvRepositoriesCompareKey(versionOne, versionTwo, viewBy),
+    params: apiParams,
+    errorToast: error => __(`Something went wrong while retrieving the repositories! ${getResponseErrorMsgs(error.response)}`),
     url: api.getApiUrl(apiUrl),
   });
 };

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
@@ -44,7 +44,7 @@ import {
   cvDockerTagsCompareKey,
   cvDebPackagesCompareKey,
   filesCompareKey,
-  genericContentCompareKey,
+  genericContentCompareKey, cvRepositoriesCompareKey,
 } from '../ContentViewsConstants';
 
 export const selectCVDetails = (state, cvId) =>
@@ -133,6 +133,16 @@ export const selectCVHistoriesStatus = (state, cvId) =>
 
 export const selectCVHistoriesError = (state, cvId) =>
   selectAPIError(state, cvDetailsHistoryKey(cvId));
+
+export const selectRepositoriesComparison = (state, versionOne, versionTwo, viewBy) =>
+  selectAPIResponse(state, cvRepositoriesCompareKey(versionOne, versionTwo, viewBy)) || {};
+
+export const selectRepositoriesComparisonStatus = (state, versionOne, versionTwo, viewBy) =>
+  selectAPIStatus(state, cvRepositoriesCompareKey(versionOne, versionTwo, viewBy)) ||
+  STATUS.PENDING;
+
+export const selectRepositoriesComparisonError = (state, versionOne, versionTwo, viewBy) =>
+  selectAPIError(state, cvRepositoriesCompareKey(versionOne, versionTwo, viewBy));
 
 export const selectRPMPackagesComparison = (state, versionOne, versionTwo, viewBy) =>
   selectAPIResponse(state, cvRPMPackagesCompareKey(versionOne, versionTwo, viewBy)) || {};

--- a/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompare.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompare.js
@@ -11,6 +11,7 @@ import CVVersionCompareTable from './CVVersionCompareTable';
 import getContentViewDetails, { getContentViewVersionDetails } from '../../ContentViewDetailActions';
 import Loading from '../../../../../components/Loading';
 import './CVVersionCompare.scss';
+import EmptyStateMessage from '../../../../../components/Table/EmptyStateMessage';
 
 const CVVersionCompare = ({
   cvId,
@@ -125,6 +126,13 @@ const CVVersionCompare = ({
               />
             </div>
           </div >) || <Loading />)
+      }
+      {!showTabs &&
+      <EmptyStateMessage
+        title={__('Empty content view versions')}
+        body={__('No content in selected versions.')}
+        search
+      />
       }
     </>
   );

--- a/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompare.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompare.js
@@ -51,7 +51,7 @@ const CVVersionCompare = ({
     selectCVVersionDetailsStatus(state, String(getIdFromVersion(versionTwo)
       ?? initialVersionTwoId), cvId));
 
-  const [currentActiveTab, setCurrentActiveTab] = useState(__('RPM packages'));
+  const [currentActiveTab, setCurrentActiveTab] = useState(__('Repositories'));
   const onSelect = (_e, eventKey) => {
     // This prevents needless pushing on repeated clicks of a tab
     if (currentActiveTab !== eventKey) {

--- a/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareConfig.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareConfig.js
@@ -84,7 +84,8 @@ export default ({
     {
       name: __('Repositories'),
       route: 'repositories',
-      getCountKey: item => item?.repositories?.length,
+      getCountKey: (itemVersionOne, itemVersionTwo) =>
+          itemVersionOne?.repositories?.length || itemVersionTwo?.repositories?.length,
       responseSelector: state =>
         selectRepositoriesComparison(state, versionOneId, versionTwoId, viewBy),
       statusSelector: state =>

--- a/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareConfig.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareConfig.js
@@ -23,6 +23,8 @@ import {
   selectDockerTagsComparisonStatus,
   selectGenericContentComparison,
   selectGenericContentComparisonStatus,
+  selectRepositoriesComparison,
+  selectRepositoriesComparisonStatus,
 } from '../../ContentViewDetailSelectors';
 import {
   getPackageGroupsComparison,
@@ -33,9 +35,11 @@ import {
   getDebPackagesComparison,
   getDockerTagsComparison,
   getGenericContentComparison,
+  getRepositoriesComparison,
 } from '../../ContentViewDetailActions';
 
 import ContentConfig from '../../../../Content/ContentConfig';
+import RepoIcon from '../../Repositories/RepoIcon';
 
 export const TableType = PropTypes.shape({
   name: PropTypes.string,
@@ -77,6 +81,45 @@ export default ({
   };
 
   return ([
+    {
+      name: __('Repositories'),
+      route: 'repositories',
+      getCountKey: item => item?.repositories?.length,
+      responseSelector: state =>
+        selectRepositoriesComparison(state, versionOneId, versionTwoId, viewBy),
+      statusSelector: state =>
+        selectRepositoriesComparisonStatus(state, versionOneId, versionTwoId, viewBy),
+      autocompleteEndpoint: '/repositories/auto_complete_search?archived=true',
+      fetchItems: params => getRepositoriesComparison(
+        versionOneId,
+        versionTwoId,
+        viewBy,
+        params,
+      ),
+      columnHeaders: [
+        {
+          title: __('Name'),
+          getProperty: item => (
+            <a href={urlBuilder(`products/${item?.product?.id}/repositories/${item?.id}`, '')}>
+              {item?.name}
+            </a>),
+        },
+        {
+          title: __('Type'),
+          modifier: 'fitContent',
+          getProperty: item => (<RepoIcon type={item?.content_type} />),
+        },
+        {
+          title: __('Product'),
+          getProperty: item => (
+            <a href={urlBuilder(`products/${item?.product?.id}`, '')}>
+              {item?.product?.name}
+            </a>),
+        },
+        { title: __(`Version ${versionOne}`), getProperty: item => compareContent(item, versionOneId) },
+        { title: __(`Version ${versionTwo}`), getProperty: item => compareContent(item, versionTwoId) },
+      ],
+    },
     {
       name: __('RPM packages'),
       getCountKey: (itemVersionOne, itemVersionTwo) =>

--- a/webpack/scenes/ContentViews/Details/Versions/Compare/__tests__/CVVersionCompare.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/__tests__/CVVersionCompare.test.js
@@ -10,6 +10,7 @@ import cvVersionsData from './contentViewVersions.fixtures.json';
 import cvDetailsData from './contentViewDetails.fixtures.json';
 import environmentPathsData from '../../../../Publish/__tests__/environmentPaths.fixtures.json';
 import CVVersionCompare from '../CVVersionCompare';
+import cvCompareRepositoriesData from './cvCompareRepositories.fixtures.json';
 import cvVersionRPMPackagesCompareAllContentData from './RPMPackagesCompareAllContentData.fixtures.json';
 import cvVersionErrataCompareAllContentData from './ErrataCompareAllContentData.fixtures.json';
 import cvVersionPackageGroupsCompareAllContentData from './PackageGroupsCompareAllContentData.fixtures.json';
@@ -88,6 +89,15 @@ afterEach(() => {
 });
 
 const testConfigAllContentTypes = [
+  {
+    name: 'Repositories',
+    autoCompleteUrl: '/repositories/auto_complete_search',
+    dataUrl: api.getApiUrl('/repositories/compare'),
+    data: cvCompareRepositoriesData,
+    textQuery: [
+      head(cvCompareRepositoriesData.results).name,
+      last(cvCompareRepositoriesData.results).name],
+  },
   {
     name: 'RPM packages',
     countKey: 'rpm_count',
@@ -182,6 +192,15 @@ const testConfigAllContentTypes = [
 
 const testConfigThreeContentTypes = [
   {
+    name: 'Repositories',
+    autoCompleteUrl: '/repositories/auto_complete_search',
+    dataUrl: api.getApiUrl('/repositories/compare'),
+    data: cvCompareRepositoriesData,
+    textQuery: [
+      head(cvCompareRepositoriesData.results).name,
+      last(cvCompareRepositoriesData.results).name],
+  },
+  {
     name: 'RPM packages',
     countKey: 'rpm_count',
     autoCompleteUrl: '/packages/auto_complete_search',
@@ -216,6 +235,13 @@ const emptyContentViewByText = contentType => `No matching ${contentType} found.
 
 const testConfigViewByDifferent = [
   {
+    name: 'Repositories',
+    autoCompleteUrl: '/repositories/auto_complete_search',
+    dataUrl: api.getApiUrl('/repositories/compare'),
+    data: cvVersionEmptyContent,
+    textQuery: emptyContentViewByText('Repositories'),
+  },
+  {
     name: 'RPM packages',
     countKey: 'rpm_count',
     autoCompleteUrl: '/packages/auto_complete_search',
@@ -244,6 +270,15 @@ const testConfigViewByDifferent = [
 ];
 
 const testConfigViewBySame = [
+  {
+    name: 'Repositories',
+    autoCompleteUrl: '/repositories/auto_complete_search',
+    dataUrl: api.getApiUrl('/repositories/compare'),
+    data: cvCompareRepositoriesData,
+    textQuery: [
+      head(cvCompareRepositoriesData.results).name,
+      last(cvCompareRepositoriesData.results).name],
+  },
   {
     name: 'RPM packages',
     countKey: 'rpm_count',
@@ -564,10 +599,15 @@ test('Can select viewing by "Different" in the dropdown and see the content in e
     testConfigViewByDifferent.forEach(({ name }) => {
       expect(queryByText(name)).toBeTruthy();
     });
-    expect(getByText('No matching RPM packages found.')).toBeTruthy();
-    (testConfigViewByDifferent.find(({ name }) => name === 'Files')).textQuery.forEach(query => expect(queryAllByText(query)).toBeTruthy());
+    expect(getByText('No matching Repositories found.')).toBeTruthy();
   });
 
+  (testConfigViewByDifferent.find(({ name }) => name === 'Files')).textQuery.forEach(query => expect(queryAllByText(query)).toBeTruthy());
+
+  fireEvent.click(getByText('RPM packages'));
+  await patientlyWaitFor(() => {
+    expect(getByText('No matching RPM packages found.')).toBeTruthy();
+  });
   fireEvent.click(getByText('Errata'));
   await patientlyWaitFor(() => {
     expect(getByText('No matching Errata found.')).toBeTruthy();

--- a/webpack/scenes/ContentViews/Details/Versions/Compare/__tests__/cvCompareRepositories.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/__tests__/cvCompareRepositories.fixtures.json
@@ -1,0 +1,175 @@
+{
+  "total": 2,
+  "subtotal": 2,
+  "selectable": 2,
+  "page": "1",
+  "per_page": "20",
+  "error": null,
+  "search": null,
+  "sort": {
+    "by": "name",
+    "order": "asc"
+  },
+  "results": [
+    {
+      "backend_identifier": "51816595-8c1e-4726-b4d1-0bccc1cd377b",
+      "relative_path": "Default_Organization/Library/custom/prod/modular",
+      "container_repository_name": null,
+      "full_path": "https://centos8-katello-devel.sajha.example.com/pulp/content/Default_Organization/Library/custom/prod/modular/",
+      "library_instance_id": null,
+      "version_href": "/pulp/api/v3/repositories/rpm/rpm/1bb2b611-bf6e-442f-9b2b-2b2cd6f13e33/versions/1/",
+      "remote_href": "/pulp/api/v3/remotes/rpm/rpm/82bdbc37-bd6f-4a2d-9c28-3f15b52328de/",
+      "publication_href": "/pulp/api/v3/publications/rpm/rpm/4ea0da80-829b-4d49-9f92-a479e9e3682b/",
+      "content_counts": {
+        "rpm": 22,
+        "erratum": 7,
+        "package_group": 2,
+        "srpm": 0,
+        "module_stream": 14
+      },
+      "mirroring_policy": "mirror_content_only",
+      "id": 2,
+      "name": "modular",
+      "label": "modular",
+      "description": null,
+      "content_view_versions": [
+        {
+          "id": 2,
+          "version": "1.0",
+          "content_view_id": 2,
+          "content_view_name": "cv1"
+        },
+        {
+          "id": 3,
+          "version": "2.0",
+          "content_view_id": 2,
+          "content_view_name": "cv1"
+        }
+      ],
+      "last_sync": {
+        "id": "0ef7ac00-fc64-4661-afe2-1c5d31ef518a",
+        "username": "admin",
+        "started_at": "2022-10-05 14:41:35 -0400",
+        "ended_at": "2022-10-05 14:41:41 -0400",
+        "state": "stopped",
+        "result": "success",
+        "progress": 1
+      },
+      "content_view": {
+        "id": 1,
+        "name": "Default Organization View"
+      },
+      "content_view_version": {
+        "id": 1,
+        "name": "Default Organization View 1.0",
+        "content_view_id": 1
+      },
+      "kt_environment": {
+        "id": 1,
+        "name": "Library"
+      },
+      "content_type": "yum",
+      "url": "https://partha.fedorapeople.org/test-repos/pteradactyl/",
+      "arch": "noarch",
+      "os_versions": [],
+      "content_id": "1664981685026",
+      "generic_remote_options": null,
+      "major": null,
+      "minor": null,
+      "product": {
+        "id": 1,
+        "cp_id": "275319913074",
+        "name": "prod",
+        "orphaned": false,
+        "redhat": false,
+        "sync_plan": null
+      },
+      "content_label": "Default_Organization_prod_modular",
+      "last_sync_words": "2 days",
+      "comparison": [
+        3,
+        2
+      ]
+    },
+    {
+      "backend_identifier": "bbdf8206-e62d-4faa-a36f-0a060d059a64",
+      "relative_path": "Default_Organization/Library/custom/prod/needed_errata",
+      "container_repository_name": null,
+      "full_path": "https://centos8-katello-devel.sajha.example.com/pulp/content/Default_Organization/Library/custom/prod/needed_errata/",
+      "library_instance_id": null,
+      "version_href": "/pulp/api/v3/repositories/rpm/rpm/6159f08c-5c82-4e69-a31d-3215ccc56c2f/versions/2/",
+      "remote_href": "/pulp/api/v3/remotes/rpm/rpm/0f906008-ab61-4b05-a192-a42787d4b0a6/",
+      "publication_href": "/pulp/api/v3/publications/rpm/rpm/af8612cc-746b-49eb-bfd2-fcbecc79f3fa/",
+      "content_counts": {
+        "rpm": 33,
+        "erratum": 4,
+        "package_group": 0,
+        "srpm": 0,
+        "module_stream": 0
+      },
+      "mirroring_policy": "mirror_content_only",
+      "id": 1,
+      "name": "needed_errata",
+      "label": "needed_errata",
+      "description": null,
+      "content_view_versions": [
+        {
+          "id": 2,
+          "version": "1.0",
+          "content_view_id": 2,
+          "content_view_name": "cv1"
+        },
+        {
+          "id": 3,
+          "version": "2.0",
+          "content_view_id": 2,
+          "content_view_name": "cv1"
+        }
+      ],
+      "last_sync": {
+        "id": "14deabd5-a5a0-49dd-8091-fac74749ef66",
+        "username": "admin",
+        "started_at": "2022-10-05 10:54:15 -0400",
+        "ended_at": "2022-10-05 10:54:22 -0400",
+        "state": "stopped",
+        "result": "success",
+        "progress": 1
+      },
+      "content_view": {
+        "id": 1,
+        "name": "Default Organization View"
+      },
+      "content_view_version": {
+        "id": 1,
+        "name": "Default Organization View 1.0",
+        "content_view_id": 1
+      },
+      "kt_environment": {
+        "id": 1,
+        "name": "Library"
+      },
+      "content_type": "yum",
+      "url": "https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/",
+      "arch": "noarch",
+      "os_versions": [],
+      "content_id": "1664981648561",
+      "generic_remote_options": null,
+      "major": null,
+      "minor": null,
+      "product": {
+        "id": 1,
+        "cp_id": "275319913074",
+        "name": "prod",
+        "orphaned": false,
+        "redhat": false,
+        "sync_plan": null
+      },
+      "content_label": "Default_Organization_prod_needed_errata",
+      "last_sync_words": "2 days",
+      "comparison": [
+        3,
+        2
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
#### To do

- [x] Tests

#### What are the changes introduced in this pull request?
Adds **Repository** comparison to CVV compare.
![Screenshot from 2022-10-03 13-12-22](https://user-images.githubusercontent.com/21146741/193637977-cb1cf665-a183-4148-be9f-5de4e308a689.png)

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Add repos to CV and publish different versions.
2. Select 2 versions and click compare on versions tab
3. You should land on Repositories subtab of the compare screen.
4. Verify that comparison of repositories between versions works correctly along with Same/Different filters.