### PR TITLE
Fixes #35596 - Repository sets shows reposets for sca

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -55,7 +55,9 @@ import {
   setContentOverrides,
 } from './RepositorySetsActions';
 
-import { selectOrganization } from '../../Cards/SystemPurposeCard/SystemPurposeSelectors';
+import { selectOrganization, selectOrganizationStatus } from '../../Cards/SystemPurposeCard/SystemPurposeSelectors';
+import { getOrganization } from '../../Cards/SystemPurposeCard/SystemPurposeActions';
+
 import { REPOSITORY_SETS_KEY, STATUSES, STATUS_TO_PARAM, PARAM_TO_FRIENDLY_NAME } from './RepositorySetsConstants.js';
 import { selectRepositorySetsStatus } from './RepositorySetsSelectors';
 import './RepositorySetsTab.scss';
@@ -166,7 +168,10 @@ const RepositorySetsTab = () => {
     content_facet_attributes: contentFacetAttributes,
     organization_id: orgId,
   } = hostDetails;
+
   const organizationDetails = useSelector(state => selectOrganization(state, orgId));
+  const orgStatus = useSelector(state => selectOrganizationStatus(state, orgId));
+
   const {
     simple_content_access: simpleContentAccess,
   } = organizationDetails;
@@ -251,6 +256,12 @@ const RepositorySetsTab = () => {
     [hostId, toggleGroupState, limitToEnvironment,
       simpleContentAccess, apiSortParams, statusSelected, STATUS_LABEL],
   );
+
+  useEffect(() => {
+    if (orgId && orgStatus !== STATUS.RESOLVED) {
+      dispatch(getOrganization({ orgId }));
+    }
+  }, [orgId, orgStatus, dispatch]);
 
   const response = useSelector(state => selectAPIResponse(state, REPOSITORY_SETS_KEY));
   const { results, error: errorSearchBody, ...metadata } = response;
@@ -446,6 +457,7 @@ const RepositorySetsTab = () => {
   } else {
     alertText = nonScaAlert;
   }
+
   return (
     <div>
       <div id="repo-sets-tab">

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -54,6 +54,8 @@ import {
   getHostRepositorySets,
   setContentOverrides,
 } from './RepositorySetsActions';
+
+import { selectOrganization } from '../../Cards/SystemPurposeCard/SystemPurposeSelectors';
 import { REPOSITORY_SETS_KEY, STATUSES, STATUS_TO_PARAM, PARAM_TO_FRIENDLY_NAME } from './RepositorySetsConstants.js';
 import { selectRepositorySetsStatus } from './RepositorySetsSelectors';
 import './RepositorySetsTab.scss';
@@ -161,9 +163,13 @@ const RepositorySetsTab = () => {
   const hostDetails = useSelector(state => selectAPIResponse(state, 'HOST_DETAILS'));
   const {
     id: hostId,
-    subscription_status: subscriptionStatus,
     content_facet_attributes: contentFacetAttributes,
+    organization_id: orgId,
   } = hostDetails;
+  const organizationDetails = useSelector(state => selectOrganization(state, orgId));
+  const {
+    simple_content_access: simpleContentAccess,
+  } = organizationDetails;
   const canDoContentOverrides = can(
     editHosts,
     userPermissionsFromHostDetails({ hostDetails }),
@@ -179,7 +185,6 @@ const RepositorySetsTab = () => {
   } = contentFacet;
   const nonLibraryHost = contentViewDefault === false ||
     lifecycleEnvironmentLibrary === false;
-  const simpleContentAccess = (Number(subscriptionStatus) === 5);
   const [isBulkActionOpen, setIsBulkActionOpen] = useState(false);
   const toggleBulkAction = () => setIsBulkActionOpen(prev => !prev);
   const dispatch = useDispatch();

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySetsTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySetsTab.test.js
@@ -8,7 +8,6 @@ import mockRepoSetData from './repositorySets.fixtures.json';
 import mockBookmarkData from './bookmarks.fixtures.json';
 import mockContentOverride from './contentOverrides.fixtures.json';
 
-
 jest.mock('../../hostDetailsHelpers', () => ({
   ...jest.requireActual('../../hostDetailsHelpers'),
   userPermissionsFromHostDetails: () => ({
@@ -33,8 +32,15 @@ const renderOptions = (facetAttributes = contentFacetAttributes) => ({
       HOST_DETAILS: {
         response: {
           id: 1,
+          organization_id: 1,
           content_facet_attributes: { ...facetAttributes },
-          subscription_status: 5, // Simple Content Access
+        },
+        status: 'RESOLVED',
+      },
+      ORGANIZATION_1: {
+        response: {
+          id: 1,
+          simple_content_access: true,
         },
         status: 'RESOLVED',
       },
@@ -182,7 +188,6 @@ test('Toggle Group shows if it\'s the library environment but a non-default cont
     queryByLabelText,
     getByText,
   } = renderWithRedux(<RepositorySetsTab />, options);
-
   // Assert that the errata are now showing on the screen, but wait for them to appear.
   await patientlyWaitFor(() => expect(getByText(firstRepoSet.contentUrl)).toBeInTheDocument());
   expect(queryByLabelText('Limit to environment')).toBeInTheDocument();


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Prior to this PR if the subscription status of a host is cleared the repository sets page for the host does not show repository sets even if sca is set to true
This PR addresses that by tracking the sca status from the org instead of subscription status of the host.

#### Considerations taken when implementing this change?
Reused the org selector used by system purpose to track sca

#### What are the testing steps for this pull request?

1. Ensure Org has simple content access
1. Create a Custom repository
1. Register a host
1. Go to host => manage statuses
1. Remove the subscription status
1. Now go to the repository sets page

Before PR:
No repo sets shown

After PR:
All repo sets visible