### PR TITLE
Fixes #35595 - Add content profile to selectable columns

### DIFF
--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -269,6 +269,37 @@ module Katello
       [{ action: [_('Change Content Source'), '/change_host_content_source', false], priority: 100 }]
     end
 
+    def host_status_icon(status)
+      colours = [:green, :yellow, :red]
+
+      colour = colours[status] || :red
+
+      icons = {
+        green: "#{colour} host-status pficon pficon-ok status-ok",
+        yellow: "#{colour} host-status pficon pficon-info status-warn",
+        red: "#{colour} host-status pficon pficon-error-circle-o status-error"
+      }
+
+      "<span class=\"#{icons[colour]}\"></span>".html_safe
+    end
+
+    def errata_counts(host)
+      counts = host.content_facet_attributes&.errata_counts || {}
+      render partial: 'katello/hosts/errata_counts', locals: { counts: counts, host: host }
+    end
+
+    def host_registered_time(host)
+      return _('Never registered') unless host.subscription_facet_attributes&.registered_at
+
+      date_time_relative_value(host.subscription_facet_attributes.registered_at)
+    end
+
+    def host_checkin_time(host)
+      return _('Never checked in') unless host.subscription_facet_attributes&.last_checkin
+
+      date_time_relative_value(host.subscription_facet_attributes.last_checkin)
+    end
+
     private
 
     def hostgroup_content_facet(hostgroup, param_host)

--- a/app/views/katello/hosts/_errata_counts.html.erb
+++ b/app/views/katello/hosts/_errata_counts.html.erb
@@ -1,0 +1,46 @@
+<a href="/content_hosts/<%= host.id %>/errata">
+  <span class="aligned-errata-count">
+    <span class="errata-count <%= counts[:security].to_i.positive? ? 'red' : 'black' %>">
+      <span>
+        <%= counts[:security] || 0 %>
+      </span>
+      <i class="fa fa-warning inline-icon" title="<%= _('Security') %>"></i>
+    </span>
+    <span class="errata-count <%= counts[:bugfix].to_i.positive? ? 'yellow' : 'black' %>">
+      <span>
+        <%= counts[:bugfix] || 0 %>
+      </span>
+      <i class="fa fa-bug inline-icon" title="<%= _('Bug Fix') %>"></i>
+    </span>
+    <span class="errata-count <%= counts[:enhancement].to_i.positive? ? 'yellow' : 'black' %>">
+      <span>
+        <%= counts[:enhancement] || 0 %>
+      </span>
+      <i class="fa fa-plus-square inline-icon" title="<%= _('Enhancement') %>"></i>
+    </span>
+  </span>
+</a>
+<% if !host.operatingsystem_name&.match(/Debian|Ubuntu/) %>
+<a href="/content_hosts/<%= host.id %>/packages/applicable">
+  <span class="aligned-errata-count">
+    <span class="errata-count <%= host.content_facet_attributes&.upgradable_rpm_count&.positive? ? 'green' : 'black' %>"
+      <span>
+        <%= host.content_facet_attributes&.upgradable_rpm_count || 0 %>
+      </span>
+      <i class="fa fa-cube inline-icon" title="<%= _('RPM package updates') %>"></i>
+    </span>
+  </span>
+</a>
+<% end %>
+<% if host.operatingsystem_name&.match(/Debian|Ubuntu/) %>
+<a href="/content_hosts/<%= host.id %>/debs/applicable">
+  <span class="aligned-errata-count">
+    <span class="errata-count <%= host.content_facet_attributes&.upgradable_deb_count&.positive? ? 'green' : 'black' %>"
+      <span>
+        <%= host.content_facet_attributes&.upgradable_deb_count || 0 %>
+      </span>
+      <i class="fa fa-cube inline-icon" title="<%= _('DEB package updates') %>"></i>
+    </span>
+  </span>
+</a>
+<% end %>

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -265,6 +265,29 @@ Foreman::Plugin.register :katello do
       :onlyif => proc { |proxy| proxy.pulp_primary? }
   end
 
+  extend_page 'hosts/_list' do |context|
+    context.with_profile :content, _('Content'), default: false do
+      common_th_class = 'hidden-tablet hidden-xs'
+      common_td_class = "#{common_th_class} ellipsis"
+      use_pagelet :hosts_table_column_header, :name
+      use_pagelet :hosts_table_column_content, :name
+      add_pagelet :hosts_table_column_header, key: :subscription_status, label: _('Subscription status'), sortable: true, class: common_th_class, width: '10%'
+      add_pagelet :hosts_table_column_content, key: :subscription_status, class: common_td_class, callback: ->(host) { host_status_icon(host.subscription_global_status) }
+      add_pagelet :hosts_table_column_header, key: :installable_updates, label: _('Installable updates'), class: common_th_class, width: '15%'
+      add_pagelet :hosts_table_column_content, key: :installable_updates, class: common_td_class, callback: ->(host) { errata_counts(host) }
+      use_pagelet :hosts_table_column_header, :os_title
+      use_pagelet :hosts_table_column_content, :os_title
+      add_pagelet :hosts_table_column_header, key: :lifecycle_environment, label: _('Lifecycle environment'), sortable: true, class: common_th_class, width: '10%'
+      add_pagelet :hosts_table_column_content, key: :lifecycle_environment, class: common_td_class, callback: ->(host) { host.content_facet_attributes&.lifecycle_environment&.name }
+      add_pagelet :hosts_table_column_header, key: :content_view, label: _('Content view'), sortable: true, class: common_th_class, width: '10%'
+      add_pagelet :hosts_table_column_content, key: :content_view, class: common_td_class, callback: ->(host) { host.content_facet_attributes&.content_view&.name }
+      add_pagelet :hosts_table_column_header, key: :registered_at, label: _('Registered'), sortable: true, class: common_th_class, width: '10%'
+      add_pagelet :hosts_table_column_content, key: :registered_at, class: common_td_class, callback: ->(host) { host_registered_time(host) }
+      add_pagelet :hosts_table_column_header, key: :last_checkin, label: _('Last checkin'), sortable: true, class: common_th_class, width: '10%'
+      add_pagelet :hosts_table_column_content, key: :last_checkin, class: common_td_class, callback: ->(host) { host_checkin_time(host) }
+    end
+  end
+
   ::Katello::HostStatusManager::STATUSES.each do |status_class|
     register_custom_status(status_class)
   end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Coulmns from `Content Hosts` page are added as selectable columns to `Hosts` page.

#### Considerations taken when implementing this change?

Basically it allows to proceed with merging `Content Hosts` page into `Hosts` page.

#### What are the testing steps for this pull request?

Currently, the only way to see the columns is to use `hammer user table-preference` command to create a preference for `hosts` table with certain columns. Core's and new `Content` profiles can be used. Until https://github.com/theforeman/foreman/pull/9323 is done, there is no other way to select the whole profile.

You can also use https://github.com/theforeman/foreman/pull/9323 to test the feature out as well as provide some feedback while it's still in early stage.