### PR TITLE
Fixes #35606 - Can syncably import from webserver

### DIFF
--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -13,7 +13,7 @@ module Actions
           action_subject(content_view)
 
           content_view.check_ready_to_publish!(options.slice(:importing, :syncable))
-          unless options[:importing]
+          unless options[:importing] || options[:syncable]
             ::Katello::Util::CandlepinRepositoryChecker.check_repositories_for_publish!(content_view)
           end
 

--- a/app/services/katello/pulp3/content_view_version/import_validator.rb
+++ b/app/services/katello/pulp3/content_view_version/import_validator.rb
@@ -17,6 +17,7 @@ module Katello
             fail _("Content view not provided in the metadata")
           end
 
+          ensure_non_syncable_path_valid! unless @metadata_map.syncable_format?
           ensure_pulp_importable!
           if @content_view && !@content_view.default?
             ensure_non_composite!
@@ -26,6 +27,13 @@ module Katello
           ensure_manifest_imported!
           ensure_metadata_matches_repos_in_library!
           ensure_redhat_products_metadata_are_in_the_library!
+        end
+
+        def ensure_non_syncable_path_valid!
+          uri = URI(@path)
+          unless uri.scheme.blank? || uri.scheme == "file"
+            fail _("Invalid path provided. Content can be only imported from file system. ")
+          end
         end
 
         def ensure_non_composite!

--- a/app/services/katello/pulp3/content_view_version/importable_repositories.rb
+++ b/app/services/katello/pulp3/content_view_version/importable_repositories.rb
@@ -120,7 +120,12 @@ module Katello
 
         def fetch_feed_url(metadata_repo)
           return unless @syncable_format
-          "file://#{@path.chomp('/')}#{metadata_repo.content.url}"
+          uri = URI(@path)
+          if uri.scheme.blank? || uri.scheme == "file"
+            "file://#{uri.path.chomp('/')}#{metadata_repo.content.url}"
+          else
+            "#{@path.chomp('/')}#{metadata_repo.content.url}"
+          end
         end
 
         def update_repo_params(metadata_repo)

--- a/test/services/katello/pulp3/content_view_version/import_validator_test.rb
+++ b/test/services/katello/pulp3/content_view_version/import_validator_test.rb
@@ -26,7 +26,7 @@ module Katello
             stub('import',
               organization: @content_view.organization,
               content_view: @content_view,
-              path: @path,
+              path: '/var/lib/pulp/exports',
               metadata_map: metadata_map,
               intersecting_repos_library_and_metadata: @intersecting_repos,
               smart_proxy: @smart_proxy || smart_proxies(:one)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This commit adds some code changes to facilitate syncably importing from a webserver.
The idea here is that users instead of copying bits across multiple disconnected importing satellites, copy it to a webserver instead that is accessible to all the satellites. They then run the content-import providing the url for the `--path` attribute.

 `hammer content-import version --organization=import-org --path=https://<fqdn>/<syncable_dump>`

The main difference between existing syncable import and this is that, this PR facilitates pulling from a webserver instead of disk.
 
#### Considerations taken when implementing this change?
The code does the following:

1. Pulls the metadata json from the webserver
2. Auto creates products
3. Auto creates repositories with the feed url pointing to the http webserver
4. Syncs the repositories
5. Creates a CV if needed and adds the repos to this
6. Publishes the CV if one was created. 

This is all code that is already in main branch except for step 3
This only works for syncable exported content not regular

#### What are the testing steps for this pull request?

1. Check out this branch and https://github.com/Katello/hammer-cli-katello/pull/867
2. Create a few custom repos + redhat repos with download policy set to immediate
3. Sync those repos
4. Add them to a content view and then publish
5. Now export that version syncably ->
```
$ hammer content-export complete version --id=100 --format=syncable

[....................................................................................................................................................................] [100%]
Generated /var/lib/pulp/exports/<....>/metadata.json
$ cd  /var/lib/pulp/exports/<....>/
$ python3 -m http.server 5050
Serving HTTP on 0.0.0.0 port 5050 (http://0.0.0.0:5050/) ...
```
6. Go to `http://<dev box>:5050` on the browser. Make sure you see the `manifest.json`
7. Now create a new org 
8.  import a manifest in the new org
9. Set the cdn configuration to `Export Sync`
```
$ hammer content-import version --organization=new-org --path=http://<devel-box>:5050
[....................................................................................................................................................................] [100%]

```


You should see 
1. repos created/enabled with url pointing to your http server,
2. cv and cvv created 
3. Verify the content is the same.