### PR TITLE
CVV Compare - Sorting compare tables

### DIFF
--- a/webpack/components/Table/TableHooks.js
+++ b/webpack/components/Table/TableHooks.js
@@ -281,6 +281,10 @@ export const useTableSort = ({
   const [activeSortColumn, setActiveSortColumn] = useState(translatedInitialSortColumnName);
   const [activeSortDirection, setActiveSortDirection] = useState('asc');
 
+  if (!allColumns.includes(activeSortColumn)) {
+    setActiveSortColumn(translatedInitialSortColumnName);
+  }
+
   // Patternfly sort function
   const onSort = (_event, index, direction) => {
     setActiveSortColumn(allColumns?.[index]);

--- a/webpack/scenes/AlternateContentSources/Details/ACSExpandableDetails.js
+++ b/webpack/scenes/AlternateContentSources/Details/ACSExpandableDetails.js
@@ -207,7 +207,7 @@ const ACSExpandableDetails = () => {
               <InactiveText text="N/A" />
                             }
             </List>
-            <TextContent className="margin-0-24">
+            <TextContent className="margin-0-24 expandable-section-text" style={{ marginTop: '24px' }}>
               <TextList component={TextListVariants.dl}>
                 <TextListItem component={TextListItemVariants.dt}>
                   {__('Use HTTP Proxies')}
@@ -329,15 +329,6 @@ const ACSExpandableDetails = () => {
                   >
                     {subpaths.join()}
                   </TextListItem>
-                  <TextListItem component={TextListItemVariants.dt}>
-                    {__('Verify SSL')}
-                  </TextListItem>
-                  <TextListItem
-                    aria-label="verifySSL_value"
-                    component={TextListItemVariants.dd}
-                  >
-                    {verifySsl ? 'true' : 'false'}
-                  </TextListItem>
                 </TextList>
               </TextContent>
             </ExpandableSection>
@@ -379,6 +370,15 @@ const ACSExpandableDetails = () => {
             >
               <TextContent className="margin-0-24 expandable-section-text">
                 <TextList component={TextListVariants.dl}>
+                  <TextListItem component={TextListItemVariants.dt}>
+                    {__('Verify SSL')}
+                  </TextListItem>
+                  <TextListItem
+                    aria-label="verifySSL_value"
+                    component={TextListItemVariants.dd}
+                  >
+                    {verifySsl ? 'true' : 'false'}
+                  </TextListItem>
                   <TextListItem component={TextListItemVariants.dt}>
                     {__('SSL CA certificate')}
                   </TextListItem>

--- a/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditCredentials.js
+++ b/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditCredentials.js
@@ -14,6 +14,7 @@ import {
   ModalVariant,
   Radio,
   TextInput,
+  Switch,
 } from '@patternfly/react-core';
 import { editACS, getACSDetails } from '../../ACSActions';
 import {
@@ -31,6 +32,7 @@ const ACSEditCredentials = ({ onClose, acsId, acsDetails }) => {
     ssl_client_key: sslClientKey,
     upstream_username: username,
     upstream_password_exists: passwordExists,
+    verify_ssl: verifySsl,
   } = acsDetails;
   const dispatch = useDispatch();
   const contentCredentials = useSelector(selectContentCredentials);
@@ -40,6 +42,7 @@ const ACSEditCredentials = ({ onClose, acsId, acsDetails }) => {
   const [acsCAcert, setAcsCAcert] = useState(sslCACert?.id);
   const [acsSslClientCert, setAcsSslClientCert] = useState(sslClientCert?.id);
   const [acsSslClientKey, setAcsSslClientKey] = useState(sslClientKey?.id);
+  const [acsVerifySSL, setAcsVerifySSL] = useState(verifySsl);
   const getAuthenticationState = () => {
     if (username) {
       return 'manual';
@@ -62,6 +65,7 @@ const ACSEditCredentials = ({ onClose, acsId, acsDetails }) => {
     setSaving(true);
     let params = {
       ssl_ca_cert_id: acsCAcert,
+      verify_ssl: acsVerifySSL,
     };
 
     if (authentication === 'credentials') {
@@ -124,6 +128,14 @@ const ACSEditCredentials = ({ onClose, acsId, acsDetails }) => {
         onSubmit();
       }}
       >
+        <FormGroup label={__('Verify SSL')} fieldId="verify_ssl">
+          <Switch
+            id="verify-ssl-switch"
+            aria-label="verify-ssl-switch"
+            isChecked={acsVerifySSL}
+            onChange={checked => setAcsVerifySSL(checked)}
+          />
+        </FormGroup>
         <FormGroup
           label={__('SSL CA certificate')}
           type="string"
@@ -322,6 +334,7 @@ ACSEditCredentials.propTypes = {
     ssl_client_key: PropTypes.shape({ id: PropTypes.number }),
     upstream_username: PropTypes.string,
     upstream_password_exists: PropTypes.bool,
+    verify_ssl: PropTypes.bool,
   }),
 };
 
@@ -335,6 +348,7 @@ ACSEditCredentials.defaultProps = {
     ssl_client_key: { id: undefined },
     upstream_username: undefined,
     upstream_password_exists: false,
+    verify_ssl: false,
   },
 };
 

--- a/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditURLPaths.js
+++ b/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditURLPaths.js
@@ -2,15 +2,14 @@ import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { ActionGroup, Button, Form, FormGroup, Modal, ModalVariant, Switch, TextArea, TextInput } from '@patternfly/react-core';
+import { ActionGroup, Button, Form, FormGroup, Modal, ModalVariant, TextArea, TextInput } from '@patternfly/react-core';
 import { editACS, getACSDetails } from '../../ACSActions';
 import { areSubPathsValid, isValidUrl } from '../../helpers';
 
 const ACSEditURLPaths = ({ onClose, acsId, acsDetails }) => {
-  const { subpaths, base_url: url, verify_ssl: verifySsl } = acsDetails;
+  const { subpaths, base_url: url } = acsDetails;
   const dispatch = useDispatch();
   const [acsUrl, setAcsUrl] = useState(url);
-  const [acsVerifySSL, setAcsVerifySSL] = useState(verifySsl);
   const [acsSubpath, setAcsSubpath] = useState(subpaths.join() || '');
   const [saving, setSaving] = useState(false);
   const subPathValidated = areSubPathsValid(acsSubpath) ? 'default' : 'error';
@@ -21,7 +20,6 @@ const ACSEditURLPaths = ({ onClose, acsId, acsDetails }) => {
     let params = {
       id: acsId,
       base_url: acsUrl,
-      verify_ssl: acsVerifySSL,
     };
     if (acsSubpath !== '') {
       params = { subpaths: acsSubpath.split(','), ...params };
@@ -91,14 +89,6 @@ const ACSEditURLPaths = ({ onClose, acsId, acsDetails }) => {
             aria-label="acs_subpath_field"
           />
         </FormGroup>
-        <FormGroup label={__('Verify SSL')} fieldId="verify_ssl">
-          <Switch
-            id="verify-ssl-switch"
-            aria-label="verify-ssl-switch"
-            isChecked={acsVerifySSL}
-            onChange={checked => setAcsVerifySSL(checked)}
-          />
-        </FormGroup>
         <ActionGroup>
           <Button
             ouiaId="edit-acs-url-submit"
@@ -129,7 +119,6 @@ ACSEditURLPaths.propTypes = {
   acsDetails: PropTypes.shape({
     base_url: PropTypes.string,
     subpaths: PropTypes.arrayOf(PropTypes.string),
-    verify_ssl: PropTypes.bool,
     id: PropTypes.number,
   }),
 };
@@ -139,7 +128,6 @@ ACSEditURLPaths.defaultProps = {
     base_url: '',
     subpaths: '',
     id: undefined,
-    verify_ssl: false,
   },
 };
 

--- a/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareConfig.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareConfig.js
@@ -120,6 +120,10 @@ export default ({
         { title: __(`Version ${versionOne}`), getProperty: item => compareContent(item, versionOneId) },
         { title: __(`Version ${versionTwo}`), getProperty: item => compareContent(item, versionTwoId) },
       ],
+      sortConfig: {
+        [__('Name')]: 'name',
+        [__('Type')]: 'content_type',
+      },
     },
     {
       name: __('RPM packages'),
@@ -151,6 +155,12 @@ export default ({
         { title: __(`Version ${versionOne}`), getProperty: item => compareContent(item, versionOneId) },
         { title: __(`Version ${versionTwo}`), getProperty: item => compareContent(item, versionTwoId) },
       ],
+      sortConfig: {
+        [__('Name')]: 'nvra',
+        [__('Version')]: 'version',
+        [__('Release')]: 'release',
+        [__('Arch')]: 'arch',
+      },
     },
     {
       name: __('RPM package groups'),
@@ -168,6 +178,9 @@ export default ({
         { title: __(`Version ${versionOne}`), getProperty: item => compareContent(item, versionOneId) },
         { title: __(`Version ${versionTwo}`), getProperty: item => compareContent(item, versionTwoId) },
       ],
+      sortConfig: {
+        [__('Name')]: 'name',
+      },
     },
     {
       name: __('Files'),
@@ -190,6 +203,9 @@ export default ({
         { title: __(`Version ${versionOne}`), getProperty: item => compareContent(item, versionOneId) },
         { title: __(`Version ${versionTwo}`), getProperty: item => compareContent(item, versionTwoId) },
       ],
+      sortConfig: {
+        [__('Name')]: 'name',
+      },
     },
     {
       name: __('Errata'),
@@ -247,6 +263,11 @@ export default ({
         { title: __(`Version ${versionOne}`), getProperty: item => compareContent(item, versionOneId) },
         { title: __(`Version ${versionTwo}`), getProperty: item => compareContent(item, versionTwoId) },
       ],
+      sortConfig: {
+        [__('Errata ID')]: 'errata_id',
+        [__('Title')]: 'title',
+        [__('Type')]: 'type',
+      },
     },
     {
       name: __('Module streams'),
@@ -273,6 +294,13 @@ export default ({
         { title: __(`Version ${versionOne}`), getProperty: item => compareContent(item, versionOneId) },
         { title: __(`Version ${versionTwo}`), getProperty: item => compareContent(item, versionTwoId) },
       ],
+      sortConfig: {
+        [__('Name')]: 'name',
+        [__('Stream')]: 'stream',
+        [__('Version')]: 'version',
+        [__('Context')]: 'context',
+        [__('Arch')]: 'arch',
+      },
     },
     {
       name: __('Deb packages'),
@@ -297,6 +325,11 @@ export default ({
         { title: __(`Version ${versionOne}`), getProperty: item => compareContent(item, versionOneId) },
         { title: __(`Version ${versionTwo}`), getProperty: item => compareContent(item, versionTwoId) },
       ],
+      sortConfig: {
+        [__('Name')]: 'name',
+        [__('Version')]: 'version',
+        [__('Architecture')]: 'architecture',
+      },
     },
     {
       name: __('Container tags'),
@@ -327,6 +360,9 @@ export default ({
         { title: __(`Version ${versionOne}`), getProperty: item => compareContent(item, versionOneId) },
         { title: __(`Version ${versionTwo}`), getProperty: item => compareContent(item, versionTwoId) },
       ],
+      sortConfig: {
+        [__('Name')]: 'name',
+      },
     },
     ...ContentConfig.filter(config => !(config.names.pluralLabel === 'ostree_refs')).map(({
       names: { pluralLowercase, pluralLabel, singularLabel },
@@ -353,6 +389,9 @@ export default ({
         { title: __(`Version ${versionOne}`), getProperty: item => compareContent(item, versionOneId) },
         { title: __(`Version ${versionTwo}`), getProperty: item => compareContent(item, versionTwoId) },
       ],
+      sortConfig: {
+        [__('Name')]: 'name',
+      },
     })),
   ]);
 };


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds sorting to CVV compare subtabs table
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Select 2 CV versions and click compare.
2. On the compare screen > check the tabs and notice the sorting on pre-defined columns.
3. Click on the sorting enabled column and watch table refresh to sort data on that field.