### PR TITLE
Fixes #35624 - Overwrite installation media

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -10,6 +10,12 @@ module Katello
           (content_source_id.blank? || (content_facet && content_facet.kickstart_repository.blank?)) && super
         end
 
+        def inherited_attributes
+          inherited_attrs = super
+          inherited_attrs.delete('medium_id') if content_facet && !content_facet.kickstart_repository.blank?
+          inherited_attrs
+        end
+
         def smart_proxy_ids
           ids = super
           ids << content_source_id

--- a/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
@@ -1,5 +1,6 @@
 <%
 kickstart_repo_id = using_hostgroups_page? ? kickstart_repository_id(@hostgroup) : kickstart_repository_id(@host, :selected_host_group => @hostgroup)
+kickstart_repo_id = 'unset' if kickstart_repo_id.blank?
 host = using_hostgroups_page? ? @hostgroup : @host
 kickstart_options = kickstart_repository_options(host, :selected_host_group => @hostgroup)
 ks_repo_select_id =  using_hostgroups_page? ? :host_group_kickstart_repository_id : :host_kickstart_repository_id

--- a/test/helpers/hosts_and_hostgroups_helper_test.rb
+++ b/test/helpers/hosts_and_hostgroups_helper_test.rb
@@ -293,6 +293,37 @@ class HostsAndHostGroupsHelperKickstartRepositoryIDTest < HostsAndHostGroupsHelp
     @hostgroup.medium_id = id
     assert_nil kickstart_repository_id(::Host.new, :selected_host_group => @hostgroup)
   end
+
+  test "must handle overwrite to use kickstart repository instead of hostgroup's medium" do
+    id = 100
+    @hostgroup.content_facet.kickstart_repository_id = nil
+    @hostgroup.medium_id = 1000
+
+    host = ::Host.new(:architecture => @arch, :operatingsystem => @os, :hostgroup => @hostgroup,
+                      :content_facet_attributes => {:lifecycle_environment_id => @env.id,
+                                                    :content_view_id => @cv.id,
+                                                    :content_source_id => @content_source.id,
+                                                    :kickstart_repository_id => id}
+                     )
+    assert_empty host.medium_id
+    assert_equal id, kickstart_repository_id(host)
+  end
+
+  test "must handle overwrite to use medium instead of hostgroup's kickstart repository" do
+    id = 100
+    @hostgroup.content_facet.kickstart_repository_id = 1000
+    @hostgroup.medium_id = nil
+
+    host = ::Host.new(:architecture => @arch, :operatingsystem => @os, :hostgroup => @hostgroup,
+                      :medium_id => id,
+                      :content_facet_attributes => {:lifecycle_environment_id => @env.id,
+                                                    :content_view_id => @cv.id,
+                                                    :content_source_id => @content_source.id,
+                                                    :kickstart_repository_id => nil}
+                     )
+    assert_equal id, host.medium_id
+    assert_nil kickstart_repository_id(host)
+  end
 end
 
 class HostAndHostGroupsHelperContentSourceTests < HostsAndHostGroupsHelperTestBase


### PR DESCRIPTION
The issue is because of two bugs:
1. The following JS method in app/assets/javascripts/katello//hosts/host_and_hostgroup_edit.js doesn't work as expected and therefore it does not clean Synced Content / All-Media selection if you switch between Media Selection:
```
KT.hosts.get_synced_content_dropdown` = function() {
    return $('select[data-kickstart-repository-id]');
};
```

The code does not work for new hosts, because kickstart_repo_id is empty and therefore, the `data-kickstart-repository-id` is not set => JQuery select can not work

2. Even if medium_id is not given, due to the inherited values from Hostgroup, the medium_id is set from the selected Hostgroup. This needs to be prevented if the kickstart_repository_id is given
