### PR TITLE
Fixes #35608 - Remove ACS from labs and place it in the Content section

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,9 @@ Katello::Engine.routes.draw do
 
   match '/content' => 'react#index', :via => [:get]
 
+  match '/alternate_content_sources' => 'react#index', :via => [:get]
+  match '/alternate_content_sources/*page' => 'react#index', :via => [:get]
+
   Katello::RepositoryTypeManager.generic_ui_content_types(false).each do |type|
     get "/#{type.pluralize}", to: redirect("/content/#{type.pluralize}")
     get "/#{type.pluralize}/:page", to: redirect("/content/#{type.pluralize}/%{page}")

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -45,6 +45,15 @@ Foreman::Plugin.register :katello do
          :turbolinks => false
 
     menu :top_menu,
+         :alternate_content_sources,
+         :url => '/alternate_content_sources',
+         :url_hash => {:controller => 'katello/api/v2/alternate_content_sources_controller',
+                       :action => 'index'},
+         :caption => N_('Alternate Content Sources'),
+         :engine => Katello::Engine,
+         :turbolinks => false
+
+    menu :top_menu,
          :sync_plans,
          :caption => N_('Sync Plans'),
          :url => '/sync_plans',
@@ -193,15 +202,6 @@ Foreman::Plugin.register :katello do
        :engine => Katello::Engine,
        :parent => :hosts_menu,
        :after => :content_hosts,
-       :turbolinks => false
-
-  menu :labs_menu,
-       :alternate_content_sources,
-       :url => '/labs/alternate_content_sources',
-       :url_hash => {:controller => 'katello/api/v2/alternate_content_sources_controller',
-                     :action => 'index'},
-       :caption => N_('Alternate Content Sources'),
-       :parent => :lab_features_menu,
        :turbolinks => false
 
   extend_template_helpers Katello::KatelloUrlsHelper

--- a/webpack/containers/Application/config.js
+++ b/webpack/containers/Application/config.js
@@ -72,11 +72,11 @@ export const links = [
     component: WithOrganization(withHeader(ChangeContentSource, { title: __('Change host content source') })),
   },
   {
-    path: 'labs/alternate_content_sources',
+    path: 'alternate_content_sources',
     component: WithOrganization(withHeader(AlternateContentSource, { title: __('Alternate Content Sources') })),
   },
   {
-    path: 'labs/alternate_content_sources/:id([0-9]+)',
+    path: 'alternate_content_sources/:id([0-9]+)',
     component: WithOrganization(withHeader(AlternateContentSource, { title: __('Alternate Content Sources') })),
     exact: false,
   },

--- a/webpack/scenes/AlternateContentSources/Create/Steps/ACSCreateFinish.js
+++ b/webpack/scenes/AlternateContentSources/Create/Steps/ACSCreateFinish.js
@@ -81,7 +81,7 @@ const ACSCreateFinish = () => {
     const { id } = response;
     if (id && status === STATUS.RESOLVED && saving) {
       setSaving(false);
-      push(`/labs/alternate_content_sources/${id}/details`);
+      push(`/alternate_content_sources/${id}/details`);
       setIsOpen(false);
     } else if (status === STATUS.ERROR) {
       setSaving(false);

--- a/webpack/scenes/AlternateContentSources/Create/__tests__/acsCreate.test.js
+++ b/webpack/scenes/AlternateContentSources/Create/__tests__/acsCreate.test.js
@@ -9,7 +9,7 @@ import contentCredentialResult from './contentCredentials.fixtures';
 import smartProxyResult from './smartProxy.fixtures';
 import productsResult from './products.fixtures.json';
 
-const withACSRoute = component => <Route path="/labs/alternate_content_sources/">{component}</Route>;
+const withACSRoute = component => <Route path="/alternate_content_sources/">{component}</Route>;
 const ACSIndexPath = api.getApiUrl('/alternate_content_sources');
 const ACSCreatePath = api.getApiUrl('/alternate_content_sources');
 const contentCredentialPath = api.getApiUrl('/content_credentials');
@@ -50,7 +50,7 @@ const noResults = {
 
 const renderOptions = {
   routerParams: {
-    initialEntries: [{ pathname: '/labs/alternate_content_sources/' }],
+    initialEntries: [{ pathname: '/alternate_content_sources/' }],
   },
 };
 

--- a/webpack/scenes/AlternateContentSources/Details/__tests__/ACSEdits.test.js
+++ b/webpack/scenes/AlternateContentSources/Details/__tests__/ACSEdits.test.js
@@ -9,13 +9,13 @@ import simplifiedAcsDetails from './simplifiedAcsDetails.fixtures.json';
 import productsList from './acsProducts.fixtures.json';
 
 const acsDetailsURL = api.getApiUrl('/alternate_content_sources/1');
-const withACSRoute = component => <Route path="/labs/alternate_content_sources/:id([0-9]+)">{component}</Route>;
+const withACSRoute = component => <Route path="/alternate_content_sources/:id([0-9]+)">{component}</Route>;
 const productsURL = api.getApiUrl('/products');
 
 test('Can show custom ACS details expandable sections with edit buttons', async (done) => {
   const renderOptions = {
     routerParams: {
-      initialEntries: [{ pathname: '/labs/alternate_content_sources/1/details' }],
+      initialEntries: [{ pathname: '/alternate_content_sources/1/details' }],
     },
   };
   const acsDetailsScope = nockInstance
@@ -51,7 +51,7 @@ test('Can show custom ACS details expandable sections with edit buttons', async 
 test('Can open and close edit ACS details modal', async (done) => {
   const renderOptions = {
     routerParams: {
-      initialEntries: [{ pathname: '/labs/alternate_content_sources/1/details' }],
+      initialEntries: [{ pathname: '/alternate_content_sources/1/details' }],
     },
   };
   const acsDetailsScope = nockInstance
@@ -94,7 +94,7 @@ test('Can open and close edit ACS details modal', async (done) => {
 test('Can edit ACS details in the edit modal', async (done) => {
   const renderOptions = {
     routerParams: {
-      initialEntries: [{ pathname: '/labs/alternate_content_sources/1/details' }],
+      initialEntries: [{ pathname: '/alternate_content_sources/1/details' }],
     },
   };
   const acsDetailsScope = nockInstance
@@ -144,7 +144,7 @@ test('Can edit ACS details in the edit modal', async (done) => {
 test('Can show simplified ACS details expandable sections with edit buttons', async (done) => {
   const renderOptions = {
     routerParams: {
-      initialEntries: [{ pathname: '/labs/alternate_content_sources/1/details' }],
+      initialEntries: [{ pathname: '/alternate_content_sources/1/details' }],
     },
   };
   const acsDetailsScope = nockInstance
@@ -181,7 +181,7 @@ test('Can show simplified ACS details expandable sections with edit buttons', as
 test('Can edit products in a simplified ACS details edit modal', async (done) => {
   const renderOptions = {
     routerParams: {
-      initialEntries: [{ pathname: '/labs/alternate_content_sources/1/details' }],
+      initialEntries: [{ pathname: '/alternate_content_sources/1/details' }],
     },
   };
   const acsDetailsScope = nockInstance

--- a/webpack/scenes/AlternateContentSources/Details/__tests__/ACSExpandableDetails.test.js
+++ b/webpack/scenes/AlternateContentSources/Details/__tests__/ACSExpandableDetails.test.js
@@ -7,12 +7,12 @@ import ACSExpandableDetails from '../ACSExpandableDetails';
 import acsDetails from './acsDetails.fixtures';
 
 const acsDetailsURL = api.getApiUrl('/alternate_content_sources/1');
-const withACSRoute = component => <Route path="/labs/alternate_content_sources/:id([0-9]+)">{component}</Route>;
+const withACSRoute = component => <Route path="/alternate_content_sources/:id([0-9]+)">{component}</Route>;
 
 test('Can call API and show ACS details expandable sections on page load', async (done) => {
   const renderOptions = {
     routerParams: {
-      initialEntries: [{ pathname: '/labs/alternate_content_sources/1/details' }],
+      initialEntries: [{ pathname: '/alternate_content_sources/1/details' }],
     },
   };
   const acsDetailsScope = nockInstance
@@ -43,7 +43,7 @@ test('Can call API and show ACS details expandable sections on page load', async
 test('Can expand expandable sections on details page', async (done) => {
   const renderOptions = {
     routerParams: {
-      initialEntries: [{ pathname: '/labs/alternate_content_sources/1/details' }],
+      initialEntries: [{ pathname: '/alternate_content_sources/1/details' }],
     },
   };
   const acsDetailsScope = nockInstance

--- a/webpack/scenes/AlternateContentSources/MainTable/ACSTable.js
+++ b/webpack/scenes/AlternateContentSources/MainTable/ACSTable.js
@@ -68,7 +68,7 @@ const ACSTable = () => {
     dispatch(deleteACS(id, () => {
       setDeleting(false);
       if (id.toString() === acsId.toString()) {
-        push('/labs/alternate_content_sources');
+        push('/alternate_content_sources');
       } else {
         dispatch(getAlternateContentSources());
       }
@@ -90,7 +90,7 @@ const ACSTable = () => {
 
   const onCloseClick = () => {
     setExpandedId(null);
-    push('/labs/alternate_content_sources');
+    push('/alternate_content_sources');
     setIsExpanded(false);
   };
 
@@ -266,7 +266,7 @@ const ACSTable = () => {
                   <Tr key={index}>
                     <Td onClick={() => {
                       onClick(id);
-                      push(`/labs/alternate_content_sources/${id}/details`);
+                      push(`/alternate_content_sources/${id}/details`);
                     }}
                     >
                       <Text component="a">{name}</Text>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Updated all of the URLS that used labs to `/alternate_content_sources`
* Updated the engine.rb to move the menu item out of labs under Content

This needs to be merged before https://github.com/Katello/katello/pull/10316

#### What are the testing steps for this pull request?

* Check out PR
* Verify you can see new ACS under Content
* Try to CRUD ACS and make sure it still works