### PR TITLE
Fixes #35627 - Use proxy registration_url from Proxy in registration

### DIFF
--- a/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
@@ -2,6 +2,7 @@ module Katello
   module Concerns
     module Api::V2::RegistrationControllerExtensions
       extend ActiveSupport::Concern
+      include ::Foreman::Controller::SmartProxyAuth
 
       def prepare_host
         if params['uuid']
@@ -35,13 +36,18 @@ module Katello
 
       def smart_proxy
         @smart_proxy ||= begin
-          proxy = params[:url] ? SmartProxy.unscoped.find_by(url: params[:url]) : SmartProxy.pulp_primary
+          proxy = params[:url] ? find_smart_proxy : SmartProxy.pulp_primary
 
           fail Foreman::Exception, _('Smart proxy content source not found!') unless proxy
           fail Foreman::Exception, _('Pulp 3 is not enabled on Smart proxy!') unless proxy.pulp3_enabled?
 
           proxy
         end
+      end
+
+      def find_smart_proxy
+        auth_smart_proxy
+        @detected_proxy
       end
     end
   end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Use registration_url from proxy's `registration` module while registering hosts

#### Considerations taken when implementing this change?
[RFC: Host registration and Load balancers](https://community.theforeman.org/t/rfc-host-registration-and-load-balancers/30462)

#### What are the testing steps for this pull request?
* Configure proxy & haproxy
* Try to register hosts to the Foreman
* Verify that register host is configured to the haproxy & can consume data

#### Related PRs
* https://github.com/theforeman/foreman/pull/9464
* https://github.com/theforeman/smart-proxy/pull/850