### PR TITLE
Fixes #35344 - Add Alternate Content Sources tab to content credentials

### DIFF
--- a/app/views/katello/api/v2/content_credentials/show.json.rabl
+++ b/app/views/katello/api/v2/content_credentials/show.json.rabl
@@ -31,6 +31,18 @@ child :root_repositories => :gpg_key_repos do
   end
 end
 
+child :ssl_ca_alternate_content_sources => :ssl_ca_alternate_content_sources do
+  attributes :id, :name
+end
+
+child :ssl_client_alternate_content_sources => :ssl_client_alternate_content_sources do
+  attributes :id, :name
+end
+
+child :ssl_client_key_alternate_content_sources => :ssl_client_key_alternate_content_sources do
+  attributes :id, :name
+end
+
 child :ssl_ca_products => :ssl_ca_products do
   attributes :id, :cp_id, :name
   node :repository_count do |product|

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/content-credential.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/content-credential.factory.js
@@ -25,6 +25,12 @@ angular.module("Bastion.content-credentials").factory("ContentCredential", [
             "ssl_key_products": "SSL Client Key"
         };
 
+        var acsTypeMap = {
+            "ssl_ca_alternate_content_sources": "SSL CA Cert",
+            "ssl_client_alternate_content_sources": "SSL Client Cert",
+            "ssl_key_alternate_content_sources": "SSL Client Key"
+        };
+
         function appendData(allData, fullCredential, usedAs) {
             angular.forEach(fullCredential, function(data) {
                 data.usedAs = usedAs;
@@ -53,6 +59,17 @@ angular.module("Bastion.content-credentials").factory("ContentCredential", [
                     params: { id: "auto_complete_search" }
                 },
                 update: { method: "PUT" },
+                acs: {
+                    method: "GET",
+                    transformResponse: function(data) {
+                        var allAcs = parseContentCredentialData(data, acsTypeMap);
+                        return {
+                            total: allAcs.length,
+                            subtotal: allAcs.length,
+                            results: allAcs
+                        };
+                    }
+                },
                 products: {
                     method: "GET",
                     transformResponse: function(data) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/content-credentials.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/content-credentials.routes.js
@@ -52,6 +52,16 @@ angular.module('Bastion.content-credentials').config(['$stateProvider', function
             parent: 'content-credentials'
         }
     })
+    .state('content-credential.acs', {
+        url: '/alternate_content_sources',
+        permission: 'view_content_credentials',
+        controller: 'ContentCredentialACSController',
+        templateUrl: 'content-credentials/details/views/content-credential-acs.html',
+        ncyBreadcrumb: {
+            label: "{{ 'Alternate Content Sources' | translate }}",
+            parent: 'content-credential.info'
+        }
+    })
     .state('content-credential.products', {
         url: '/products',
         permission: 'view_content_credentials',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/details/content-credential-acs.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/details/content-credential-acs.controller.js
@@ -1,0 +1,36 @@
+/**
+ * @ngdoc object
+ * @name  Bastion.content-credentials.controller:ContentCredentialACSController
+ *
+ * @requires $scope
+ * @requires Nutupane
+ * @requires ContentCredential
+ * @requires ApiErrorHandler
+ *
+ * @description
+ *   Page for Content Credential acs
+ */
+(function () {
+    function ContentCredentialACSController($scope, Nutupane, ContentCredential, ApiErrorHandler) {
+      var nutupane = new Nutupane(ContentCredential, {
+          id: $scope.$stateParams.contentCredentialId
+      }, 'acs');
+      $scope.controllerName = 'katello_content_credentials';
+      nutupane.primaryOnly = true;
+
+      $scope.panel = $scope.panel || {error: false, loading: false};
+
+      $scope.contentCredential = ContentCredential.get({id: $scope.$stateParams.contentCredentialId}, function () {
+          $scope.panel.error = false;
+          $scope.panel.loading = false;
+      }, function (response) {
+          $scope.panel.loading = false;
+          ApiErrorHandler.handleGETRequestErrors(response, $scope);
+      });
+
+      $scope.table = nutupane.table;
+  }
+
+    angular.module('Bastion.content-credentials').controller('ContentCredentialACSController', ContentCredentialACSController);
+    ContentCredentialACSController.$inject = ['$scope', 'Nutupane', 'ContentCredential', 'ApiErrorHandler'];
+})();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/details/views/content-credential-acs.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/details/views/content-credential-acs.html
@@ -1,0 +1,38 @@
+<span page-title ng-model="contentCredential">{{ 'Alternate Content Sources for ' | translate }} {{ contentCredential.name }}</span>
+
+<div data-extend-template="layouts/partials/table.html">
+  <span data-block="no-rows-message" translate>
+    You currently don't have any Alternate Content Sources associated with this Content Credential.
+  </span>
+
+  <div data-block="search">
+    <input type="text" class="form-control" stop-event="click"
+            placeholder="{{ 'Filter...' | translate }}"
+            ng-model="contentCredentialACSFilter"/>
+  </div>
+
+
+  <div data-block="table">
+    <table bst-table="table" class="table table-striped table-bordered">
+      <thead>
+        <tr bst-table-head>
+          <th bst-table-column="name" sortable><span translate>Name</span></th>
+          <th bst-table-column="usedAs" sortable><span translate>Used as</span></th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr bst-table-row ng-repeat="alternate_content_source in table.rows | filter:contentCredentialACSFilter">
+          <td bst-table-cell>
+            <a href="/alternate_content_sources/{{ alternate_content_source.id }}/details" target="_self">
+              {{ alternate_content_source.name }}
+            </a>
+          </td>
+          <td bst-table-cell>
+              {{ alternate_content_source.usedAs }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/details/views/content-credential-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/details/views/content-credential-details.html
@@ -27,6 +27,9 @@
       <li ng-class="{active: stateIncludes('content-credential.repositories')}">
         <a ui-sref="content-credential.repositories" translate>Repositories</a>
       </li>
+      <li ng-class="{active: stateIncludes('content-credential.acs')}">
+        <a ui-sref="content-credential.acs" translate>Alternate Content Sources</a>
+      </li>
     </ul>
   </nav>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/views/content-credentials.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/views/content-credentials.html
@@ -26,8 +26,9 @@
         <th bst-table-column="name" sortable><span translate>Name</span></th>
         <th bst-table-column="organization"><span translate>Organization</span></th>
         <th bst-table-column="content_type"><span translate>Type</span></th>
-        <th bst-table-column="products" class="number-cell"><span translate>Product Count</span></th>
-        <th bst-table-column class="number-cell"><span translate>Repository Count</span></th>
+        <th bst-table-column="products" class="number-cell"><span translate>Products</span></th>
+        <th bst-table-column class="number-cell"><span translate>Repositories</span></th>
+        <th bst-table-column class="acs"><span translate>Alternate Content Sources</span></th>
       </tr>
       </thead>
 
@@ -47,6 +48,10 @@
             contentCredential.ssl_client_root_repos.length +
             contentCredential.ssl_key_root_repos.length || 0 }}
         </td>
+        <td bst-table-cell class="number-cell">{{ contentCredential.ssl_ca_alternate_content_sources.length +
+          contentCredential.ssl_client_alternate_content_sources.length +
+          contentCredential.ssl_client_key_alternate_content_sources.length || 0 }}
+      </td>
       </tr>
       </tbody>
     </table>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/katello-features.run.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/katello-features.run.js
@@ -27,6 +27,7 @@
             'content-credentials.new',
             'content-credential.info',
             'content-credential.products',
+            'content-credential.acs',
             'content-credential.repositories'
         ];
 

--- a/engines/bastion_katello/test/content-credentials/content-credentials.factory.test.js
+++ b/engines/bastion_katello/test/content-credentials/content-credentials.factory.test.js
@@ -37,6 +37,9 @@ describe("Factory: ContentCredential", function() {
             product: { id: 1, cp_id: "644602083972", name: "test_product" }
           }
         ],
+        ssl_ca_alternate_content_sources: [{ id: 1, name: "fakeacs" }],
+        ssl_client_alternate_content_sources: [],
+        ssl_key_alternate_content_sources: [],
         ssl_ca_products: [],
         ssl_ca_root_repos: [],
         ssl_client_products: [],
@@ -54,7 +57,7 @@ describe("Factory: ContentCredential", function() {
         records: [
           contentCredential          
         ],
-        total: 2,
+        total: 3,
         subtotal: 1
       };
 
@@ -80,6 +83,19 @@ describe("Factory: ContentCredential", function() {
 
     ContentCredential.queryPaged(function(contentCredentials) {
       expect(contentCredentials.records.length).toBe(1);
+    });
+  });
+
+  it("provides a way to get a list of acs", function() {
+    $httpBackend
+      .expectGET("katello/api/v2/content_credentials?organization_id=ACME")
+      .respond(contentCredentials);
+
+    ContentCredential.queryPaged(function(contentCredentials) {
+      expect(contentCredentials.records[0].ssl_ca_alternate_content_sources).toBeDefined();
+      expect(contentCredentials.records[0].ssl_ca_alternate_content_sources.length).toBe(1);
+      expect(contentCredentials.records[0].ssl_ca_alternate_content_sources[0].id).toBe(1);
+      expect(contentCredentials.records[0].ssl_ca_alternate_content_sources[0].name).toBe("fakeacs");
     });
   });
 

--- a/engines/bastion_katello/test/content-credentials/details/content-credential-acs.controller.test.js
+++ b/engines/bastion_katello/test/content-credentials/details/content-credential-acs.controller.test.js
@@ -1,0 +1,39 @@
+describe('Controller: ContentCredentialACSController', function() {
+  var $scope;
+
+  beforeEach(module(
+      'Bastion.content-credentials',
+      'Bastion.test-mocks'
+  ));
+
+  beforeEach(inject(function($injector) {
+      var $controller = $injector.get('$controller'),
+          $q = $injector.get('$q'),
+          ContentCredential = $injector.get('MockResource').$new(),
+          Nutupane;
+
+      $scope = $injector.get('$rootScope').$new();
+      $scope.$stateParams = {
+          contentCredentialId: 1
+      };
+
+      Nutupane = function() {
+          this.table = {};
+      };
+
+      $controller('ContentCredentialACSController', {
+          $scope: $scope,
+          Nutupane: Nutupane,
+          ContentCredential: ContentCredential
+      });
+
+  }));
+
+  it('retrieves and puts a content credential on the scope', function() {
+      expect($scope.contentCredential).toBeDefined();
+  });
+
+  it("sets up the content credential products nutupane table", function() {
+      expect($scope.table).toBeDefined();
+  });
+});


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Added a new column on the main content credential page for ACS
* Added a new tab on the content credential details page for ACS with a link to the ACS and how it's being used ie `ssl ca/key/cert`
* Added factory and controller tests in AngularJS :heart: 
* Added a `has_many` acs to the content credential model so we can do:
```ruby
foo = ::Katello::ContentCredential.last
foo.alternate_content_credentials
```
* Returned the ACS content credentials type in the content credential rabl
* Added a new route in the content credentials details for the new tab
* Added a new controller/view for the ACS tab in the content credential details
* Changed Product/Repo count to just Products/Repos on the main content credential tab
* Added a call to the content credential factory to grab ACS info for the main page

#### Considerations taken when implementing this change?

* If you check out the PR and the move ACS pr out of labs is not checked out as well/merged then when you click the acs link in the content credentials details tab it will give a route error.

#### What are the testing steps for this pull request?

* Check out PR
* Start up Foreman webserver
* Create a content credential of type `ssl ca`
* Create an ACS and attach `ssl ca` to it
* View the main content credential page and see that it shows an ACS in the column
* View the content credential details and click the new ACS tab, verify it shows the name of the ACS and how it's being used by the ACS
* The link won't work until this pr is merged: https://github.com/Katello/katello/pull/10313 but you can see it will link to the ACS in question
* Verify there are not any console errors on the content credential pages
