### PR TITLE
Fixes #35632 - As a user, when I click a link to a content host it should take me to the new host details page

### DIFF
--- a/engines/bastion/app/views/bastion/layouts/assets.html.erb
+++ b/engines/bastion/app/views/bastion/layouts/assets.html.erb
@@ -32,6 +32,7 @@
         admin: <%= User.current.admin || User.current.usergroups.any? { |group| group.admin } %>
     });
     angular.module('Bastion.auth').value('Permissions', angular.fromJson('<%= User.current.cached_roles.collect { |role| role.permissions }.flatten.to_json.html_safe %>'));
+    angular.module('Bastion').value('newHostDetailsUI', "<%= Setting[:host_details_ui] %>");
   </script>
   <% Bastion.plugins.each do |name, plugin| %>
     <%= include_plugin_js(plugin) %>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
@@ -14,6 +14,7 @@
  * @requires CurrentOrganization
  * @requires ContentHostsHelper
  * @requires simpleContentAccessEnabled
+ * @requires newHostDetailsUI
  *
  * @description
  *   Provides the functionality specific to Content Hosts for use with the Nutupane UI pattern.
@@ -21,8 +22,8 @@
  *   within the table.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostsController',
-    ['$scope', '$q', '$state', '$location', '$uibModal', 'translate', 'Nutupane', 'Host', 'HostBulkAction', 'Notification', 'CurrentOrganization', 'ContentHostsHelper', 'ContentHostsModalHelper', '$httpParamSerializer', 'simpleContentAccessEnabled',
-    function ($scope, $q, $state, $location, $uibModal, translate, Nutupane, Host, HostBulkAction, Notification, CurrentOrganization, ContentHostsHelper, ContentHostsModalHelper, $httpParamSerializer, simpleContentAccessEnabled) {
+    ['$scope', '$q', '$state', '$location', '$uibModal', 'translate', 'Nutupane', 'Host', 'HostBulkAction', 'Notification', 'CurrentOrganization', 'ContentHostsHelper', 'ContentHostsModalHelper', '$httpParamSerializer', 'simpleContentAccessEnabled', 'newHostDetailsUI',
+    function ($scope, $q, $state, $location, $uibModal, translate, Nutupane, Host, HostBulkAction, Notification, CurrentOrganization, ContentHostsHelper, ContentHostsModalHelper, $httpParamSerializer, simpleContentAccessEnabled, newHostDetailsUI) {
         var nutupane, params, query;
 
         if ($location.search().search) {
@@ -49,6 +50,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsController',
         $scope.table = nutupane.table;
         $scope.nutupane = nutupane;
         $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
+        $scope.newHostDetailsUI = newHostDetailsUI;
 
         // @TODO begin hack necessary because of foreman API bug http://projects.theforeman.org/issues/13877
         $scope.table.sortBy = function (column) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -99,9 +99,10 @@
         <tr bst-table-row ng-repeat="host in table.rows" row-select="host"
             ng-controller="ContentHostStatusController">
           <td bst-table-cell>
-            <a ui-sref="content-host.info({hostId: host.id})">
-              {{ host.name }}
-            </a>
+            <span ng-switch="newHostDetailsUI">
+              <a ng-switch-when="true" ng-href="/new/hosts/{{host.name}}">{{ host.name }}</a>
+              <a ng-switch-when="false" ui-sref="content-host.info({hostId: host.id})">{{ host.name }}</a>
+            </span>
           </td>
           <td bst-table-cell ng-hide="simpleContentAccessEnabled">
             <span ng-class="table.getHostStatusIcon(host.subscription_global_status)">

--- a/engines/bastion_katello/test/content-hosts/content-hosts.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content-hosts.controller.test.js
@@ -53,7 +53,8 @@ describe('Controller: ContentHostsController', function() {
             $uibModal: $uibModal,
             ContentHostsModalHelper:ContentHostsModalHelper,
             CurrentOrganization: 'CurrentOrganization',
-            simpleContentAccessEnabled: 'simpleContentAccessEnabled'
+            simpleContentAccessEnabled: 'simpleContentAccessEnabled',
+            newHostDetailsUI: 'newHostDetailsUI'
         });
     }));
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Based on setting `New host details UI`, the host links on `Hosts` - `Content Hosts` would redirect to either new host details UI or existing content host UI. 

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
`Hosts` - `Content Hosts`.
Click on the host links.
If `New host details UI` is yes, new host details UI is displayed. Otherwise, content host UI is displayed.