### PR TITLE
Fixes #35633 - expose search params for product_content endpoints

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -230,6 +230,7 @@ module Katello
     param :id, String, :desc => N_("ID of the activation key"), :required => true
     param :content_access_mode_all, :bool, :desc => N_("Get all content available, not just that provided by subscriptions")
     param :content_access_mode_env, :bool, :desc => N_("Limit content to just that available in the activation key's content view version")
+    param_group :search, Api::V2::ApiController
     def product_content
       # note this is just there as a place holder for apipie.
       # The routing would automatically redirect it to repository_sets#index

--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -152,6 +152,7 @@ module Katello
     param :host_id, String, :desc => N_("Id of the host"), :required => true
     param :content_access_mode_all, :bool, :desc => N_("Get all content available, not just that provided by subscriptions")
     param :content_access_mode_env, :bool, :desc => N_("Limit content to just that available in the host's content view version")
+    param_group :search, Api::V2::ApiController
     def product_content
       # note this is just there as a place holder for apipie.
       # The routing would automatically redirect it to repository_sets#index


### PR DESCRIPTION
Fixes: 49799266289075aa71bb5832c841373fd7d04f7b

#### What are the changes introduced in this pull request?

This adds the `search` param group (so `per_page`, `search`, etc parameters) to the `activation_keys/:id/product_content` and `host_subscriptions/:id/product_content` endpoints. Without these params api clients won't send them to the server, thus only getting the default number of results instead of the requested one.

#### Considerations taken when implementing this change?

"make it work" ;-)

#### What are the testing steps for this pull request?

The generated apidoc should contain search related (especially `per_page`) params for the two endpoints