### PR TITLE
Fixes #35643 - Edit ansible_collections menu link to /content/ansible_collections

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -164,7 +164,7 @@ Foreman::Plugin.register :katello do
     menu :top_menu,
          :ansible_collections,
          :caption => N_('Ansible Collections'),
-         :url => '/ansible_collections',
+         :url => '/content/ansible_collections',
          :url_hash => {:controller => 'katello/api/v2/ansible_collections',
                        :action => 'index'},
          :engine => Katello::Engine,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Changes the menu link for ansible_collections to avoid a redirect.


#### Considerations taken when implementing this change?
...

#### What are the testing steps for this pull request?
Click on the "Ansible Collections" button in the side menu. It should lead to content/ansible_collections