### PR TITLE
Re-index module profile RPMs and add description back to module streams

### DIFF
--- a/app/views/katello/api/v2/module_streams/show.json.rabl
+++ b/app/views/katello/api/v2/module_streams/show.json.rabl
@@ -6,6 +6,13 @@ child :artifacts => :artifacts do
   attributes :id, :name
 end
 
+child :profiles => :profiles do
+  attributes :id, :name
+  child :rpms => :rpms do
+    attributes :id, :name
+  end
+end
+
 child :library_repositories => :repositories do
   attributes :id, :name
   glue :product do

--- a/webpack/components/Content/Details/ContentDetails.js
+++ b/webpack/components/Content/Details/ContentDetails.js
@@ -36,7 +36,7 @@ const ContentDetails = (props) => {
         loading={loading}
         loadingText={__('Loading')}
       >
-        <TabContainer id="content-tabs-container" defaultActiveKey={1}>
+        <TabContainer id="content-tabs-container" defaultActiveKey={1} style={{ margin: '0', padding: '0' }}>
           <Grid>
             <Row>
               <Col sm={12}>

--- a/webpack/components/Content/Details/__tests__/__snapshots__/ContentDetails.test.js.snap
+++ b/webpack/components/Content/Details/__tests__/__snapshots__/ContentDetails.test.js.snap
@@ -10,6 +10,12 @@ exports[`Content Details Info should render and contain appropriate components 1
     <ForwardRef
       defaultActiveKey={1}
       id="content-tabs-container"
+      style={
+        Object {
+          "margin": "0",
+          "padding": "0",
+        }
+      }
     >
       <Grid
         bsClass="container"

--- a/webpack/scenes/ModuleStreams/Details/ModuleDetailsSchema.js
+++ b/webpack/scenes/ModuleStreams/Details/ModuleDetailsSchema.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
 import ModuleStreamDetailArtifacts from './ModuleStreamDetailArtifacts';
+import ModuleStreamDetailProfiles from './Profiles/ModuleStreamDetailProfiles';
 import ContentDetailInfo from '../../../components/Content/Details/ContentDetailInfo';
 import ContentDetailRepositories from '../../../components/Content/Details/ContentDetailRepositories';
 
@@ -16,7 +17,7 @@ export const displayMap = new Map([
 ]);
 
 export default (detailInfo) => {
-  const { repositories, artifacts } = detailInfo;
+  const { repositories, profiles, artifacts } = detailInfo;
 
   return [
     {
@@ -36,6 +37,14 @@ export default (detailInfo) => {
     },
     {
       key: 3,
+      tabHeader: __('Profiles'),
+      tabContent: (profiles && profiles.length ?
+        <ModuleStreamDetailProfiles profiles={profiles} /> :
+        __('No profiles to show')
+      ),
+    },
+    {
+      key: 4,
       tabHeader: __('Artifacts'),
       tabContent: (artifacts && artifacts.length ?
         <ModuleStreamDetailArtifacts artifacts={artifacts} /> :

--- a/webpack/scenes/ModuleStreams/Details/ModuleStreamDetails.js
+++ b/webpack/scenes/ModuleStreams/Details/ModuleStreamDetails.js
@@ -42,7 +42,7 @@ class ModuleStreamDetails extends Component {
     };
 
     return (
-      <div>
+      <div style={{ margin: '24px' }}>
         {!loading && <BreadcrumbsBar
           isLoadingResources={loading}
           onSwitcherItemClick={(e, url) => this.handleBreadcrumbSwitcherItem(e, url)}

--- a/webpack/scenes/ModuleStreams/Details/__tests__/__snapshots__/ModuleStreamDetails.test.js.snap
+++ b/webpack/scenes/ModuleStreams/Details/__tests__/__snapshots__/ModuleStreamDetails.test.js.snap
@@ -1,7 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Module stream details page rendering renders with loading state 1`] = `
-<div>
+<div
+  style={
+    Object {
+      "margin": "24px",
+    }
+  }
+>
   <ContentDetails
     contentDetails={
       Object {
@@ -76,6 +82,11 @@ exports[`Module stream details page rendering renders with loading state 1`] = `
         },
         Object {
           "key": 3,
+          "tabContent": "No profiles to show",
+          "tabHeader": "Profiles",
+        },
+        Object {
+          "key": 4,
           "tabContent": "No artifacts to show",
           "tabHeader": "Artifacts",
         },
@@ -86,7 +97,13 @@ exports[`Module stream details page rendering renders with loading state 1`] = `
 `;
 
 exports[`Module stream details page rendering renders with module stream provided 1`] = `
-<div>
+<div
+  style={
+    Object {
+      "margin": "24px",
+    }
+  }
+>
   <BreadcrumbsBar
     breadcrumbItems={
       Array [
@@ -392,6 +409,84 @@ exports[`Module stream details page rendering renders with module stream provide
         },
         Object {
           "key": 3,
+          "tabContent": <ModuleStreamDetailProfiles
+            profiles={
+              Array [
+                Object {
+                  "id": 37,
+                  "name": "default",
+                  "rpms": Array [
+                    Object {
+                      "id": 108,
+                      "name": "perl",
+                    },
+                    Object {
+                      "id": 110,
+                      "name": "foo",
+                    },
+                    Object {
+                      "id": 111,
+                      "name": "rpm_0",
+                    },
+                    Object {
+                      "id": 112,
+                      "name": "rpm_1",
+                    },
+                    Object {
+                      "id": 113,
+                      "name": "rpm_2",
+                    },
+                    Object {
+                      "id": 114,
+                      "name": "rpm_3",
+                    },
+                    Object {
+                      "id": 115,
+                      "name": "rpm_4",
+                    },
+                    Object {
+                      "id": 116,
+                      "name": "rpm_5",
+                    },
+                    Object {
+                      "id": 117,
+                      "name": "rpm_6",
+                    },
+                    Object {
+                      "id": 118,
+                      "name": "rpm_7",
+                    },
+                    Object {
+                      "id": 119,
+                      "name": "rpm_8",
+                    },
+                    Object {
+                      "id": 120,
+                      "name": "rpm_9",
+                    },
+                    Object {
+                      "id": 121,
+                      "name": "rpm_10",
+                    },
+                  ],
+                },
+                Object {
+                  "id": 38,
+                  "name": "minimal",
+                  "rpms": Array [
+                    Object {
+                      "id": 84,
+                      "name": "python2-avocado",
+                    },
+                  ],
+                },
+              ]
+            }
+          />,
+          "tabHeader": "Profiles",
+        },
+        Object {
+          "key": 4,
           "tabContent": <ModuleStreamDetailArtifacts
             artifacts={
               Array [


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Re-index module profile RPMs and adds description back to module streams
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Sync a modular repo with pulpcore 3.18
2. Notice the missing module profiles + description on module stream.
3. On a pulpcore 3.21 box, checkout this PR and reindex module streams. Notice module profiles and description.