### PR TITLE
Fixes #35275 - Task group errors do not drill into child task errors

### DIFF
--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/task_group/error_with_errors.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/task_group/error_with_errors.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos8-katello-devel.sajha.example.com/pulp/api/v3/tasks/?limit=2000&offset=0&state__in=failed&task_group=/pulp/api/v3/task-groups/d9841aaa-8a47-4e31-9018-10e4430766bf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.21.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 26 Oct 2022 01:23:15 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 35fd3f04462c41bab945526ad2b07442
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.sajha.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 26 Oct 2022 01:23:15 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Look into failed tasks of a task group and return the task errors for easier debugging in tasks.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a custom ACS with a fake URL and fake subpaths.
2. Refresh
3. Pulp triggers the refresh as a task group with 1 task for each subpath. Check if the task group error on refresh dynflow task filters up all pulp task errors. 