### PR TITLE
Fixes #33464 - Bulk ACS delete and refresh

### DIFF
--- a/webpack/scenes/AlternateContentSources/ACSActions.js
+++ b/webpack/scenes/AlternateContentSources/ACSActions.js
@@ -8,6 +8,8 @@ import ACS_KEY, {
   DELETE_ACS_KEY,
   EDIT_ACS_KEY,
   PRODUCTS_KEY,
+  BULK_ACS_REFRESH_KEY,
+  BULK_ACS_DELETE_KEY,
 } from './ACSConstants';
 import { getResponseErrorMsgs } from '../../utils/helpers';
 import { renderTaskStartedToast } from '../Tasks/helpers';
@@ -76,6 +78,30 @@ export const refreshACS = (acsId, handleSuccess) => post({
     return renderTaskStartedToast(response.data);
   },
   errorToast: error => acsErrorToast(error),
+});
+
+export const bulkRefreshACS = (params, handleSuccess) => post({
+  type: API_OPERATIONS.POST,
+  key: BULK_ACS_REFRESH_KEY,
+  url: api.getApiUrl('/alternate_content_sources/bulk/refresh'),
+  params,
+  handleSuccess: (response) => {
+    renderTaskStartedToast(response?.data, __('Bulk alternate content source refresh has started.'));
+    return handleSuccess();
+  },
+  errorToast: error => __('Something went wrong while refreshing alternate content sources: ') + getResponseErrorMsgs(error.response),
+});
+
+export const bulkDeleteACS = (params, handleSuccess) => APIActions.put({
+  type: API_OPERATIONS.PUT,
+  key: BULK_ACS_DELETE_KEY,
+  url: api.getApiUrl('/alternate_content_sources/bulk/destroy'),
+  params,
+  handleSuccess: (response) => {
+    renderTaskStartedToast(response?.data, __('Bulk alternate content source delete has started.'));
+    return handleSuccess();
+  },
+  errorToast: error => __(`Something went wrong while deleting alternate content sources: ${getResponseErrorMsgs(error.response)}`),
 });
 
 export const getProducts = () => get({

--- a/webpack/scenes/AlternateContentSources/ACSConstants.js
+++ b/webpack/scenes/AlternateContentSources/ACSConstants.js
@@ -7,6 +7,8 @@ export const DELETE_ACS_KEY = 'ACS_DELETE';
 export const SMART_PROXY_KEY = 'SMART_PROXY';
 export const PRODUCTS_KEY = 'PRODUCTS';
 export const SSL_CERTS = 'SSL_CERTS';
+export const BULK_ACS_REFRESH_KEY = 'BULK_ACS_REFRESH';
+export const BULK_ACS_DELETE_KEY = 'BULK_ACS_DELETE';
 export const acsRefreshKey = acsId => `${ACS_KEY}_REFRESH_${acsId}`;
 export const acsDetailsKey = acsId => `${ACS_KEY}_DETAILS_${acsId}`;
 

--- a/webpack/scenes/AlternateContentSources/MainTable/__tests__/acsTable.test.js
+++ b/webpack/scenes/AlternateContentSources/MainTable/__tests__/acsTable.test.js
@@ -57,9 +57,10 @@ test('Can handle no ACS being present', async (done) => {
     .query(true)
     .reply(200, noResults);
 
-  const { queryByText } = renderWithRedux(<ACSTable />);
+  const { queryByLabelText, queryByText } = renderWithRedux(<ACSTable />);
 
   expect(queryByText(firstAcs.name)).toBeNull();
+  expect(queryByLabelText('Select all')).not.toBeInTheDocument();
   await patientlyWaitFor(() => expect(queryByText("You currently don't have any alternate content sources.")).toBeInTheDocument());
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done);

--- a/webpack/scenes/Tasks/helpers.js
+++ b/webpack/scenes/Tasks/helpers.js
@@ -33,17 +33,24 @@ const rexJobLink = id => link({
   baseUrl: 'job_invocations',
 });
 
-export const renderTaskStartedToast = (task) => {
+export const renderTaskStartedToast = (task, override = '') => {
   if (!task) return;
 
   const message = (__(`Task ${task.humanized.action} has started.`));
 
-  window.tfm.toastNotifications.notify({
-    message,
-    type: 'info',
-    link: foremanTasksLink(task.id),
-
-  });
+  if (override) {
+    window.tfm.toastNotifications.notify({
+      message: override,
+      type: 'info',
+      link: foremanTasksLink(task.id),
+    });
+  } else {
+    window.tfm.toastNotifications.notify({
+      message,
+      type: 'info',
+      link: foremanTasksLink(task.id),
+    });
+  }
 };
 
 export const renderRexJobStartedToast = ({ id, description, key }) => {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Allows bulk refreshing and deleting ACSs

#### Considerations taken when implementing this change?
No permissions yet, but it sounds like we need to do an entire ACS permission audit anyway.
For the checkbox `<Th>` tag, I set the width to 0 to match the look of other pages. Is that fine?

#### What are the testing steps for this pull request?
1) Create some ACSs
2) Try refreshing them all via a bulk action
3) Try deleting them all via a bulk action
4) Ensure viewing ACS details still works
5) Ensure single ACS refreshing, editing, and deleting still works

TODO:
- [x] Tests
