### PR TITLE
Fixes #35668 - Show both applicable and installable errata on overview card

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -83,13 +83,23 @@ module Katello
       end
 
       def errata_counts
-        hash = {
+        installable_hash = {
           :security => installable_security_errata_count,
           :bugfix => installable_bugfix_errata_count,
           :enhancement => installable_enhancement_errata_count
         }
-        hash[:total] = hash.values.inject(:+)
-        hash
+        installable_hash[:total] = installable_hash.values.inject(:+)
+        # same for applicable, but we need to get the counts from the db
+        applicable_hash = {
+          :security => applicable_errata.security.count,
+          :bugfix => applicable_errata.bugfix.count,
+          :enhancement => applicable_errata.enhancement.count
+        }
+        applicable_hash[:total] = applicable_hash.values.inject(:+)
+        # keeping installable at the top level for backward compatibility
+        installable_hash.merge({
+          :applicable => applicable_hash
+        })
       end
 
       def self.trigger_applicability_generation(host_ids)

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -98,8 +98,8 @@ module Katello
         applicable_hash[:total] = applicable_hash.values.inject(:+)
         # keeping installable at the top level for backward compatibility
         installable_hash.merge({
-          :applicable => applicable_hash
-        })
+                                 :applicable => applicable_hash
+                               })
       end
 
       def self.trigger_applicability_generation(host_ids)

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -343,7 +343,13 @@ module Katello
         :security => 1,
         :bugfix => 2,
         :enhancement => 3,
-        :total => 6
+        :total => 6,
+        :applicable => { # it's fake data don't worry about it!
+          :security => 0,
+          :bugfix => 0,
+          :enhancement => 0,
+          :total => 0
+        }
       }
 
       assert_equal expected, content_facet.errata_counts

--- a/webpack/components/Errata/errataHelpers.js
+++ b/webpack/components/Errata/errataHelpers.js
@@ -1,0 +1,33 @@
+export const errataStatusContemplation = (errataStatus) => {
+  // from backend errata_status.rb:
+  // NEEDED_SECURITY_ERRATA = 3
+  // NEEDED_ERRATA = 2
+  // UNKNOWN = 1
+  // UP_TO_DATE = 0
+  const neededErrata = ([2, 3].includes(Number(errataStatus)));
+  const allUpToDate = (errataStatus === 0);
+  const otherErrataStatus = (!allUpToDate && !neededErrata);
+
+  return {
+    neededErrata,
+    allUpToDate,
+    otherErrataStatus,
+  };
+};
+
+export const friendlyErrataStatus = (errataStatus) => {
+  switch (errataStatus) {
+  case 0:
+    return 'All up to date';
+  case 1:
+    return 'Unknown';
+  // eslint-disable-next-line no-sequences
+  case 2:
+  case 3:
+    return 'Needed';
+  default:
+    return 'Unknown';
+  }
+};
+
+export default errataStatusContemplation;

--- a/webpack/components/Errata/index.js
+++ b/webpack/components/Errata/index.js
@@ -176,7 +176,7 @@ export const ErrataSeverity = ({ severity }) => {
       {color &&
         <span style={{ marginRight: '4px' }}>
           <Tooltip content={label} >
-            <SecurityIcon color={color} style={{ verticalAlign: '-0.2em' }}/>
+            <SecurityIcon color={color} style={{ verticalAlign: '-0.2em' }} />
           </Tooltip>
         </span>
       }

--- a/webpack/components/Errata/index.js
+++ b/webpack/components/Errata/index.js
@@ -190,7 +190,7 @@ ErrataSeverity.propTypes = {
 };
 
 export const ErrataToggleGroupItem = ({
-  text, tooltipText, isSelected, onChange,
+  text, tooltipText, isSelected, onChange, ...toggleGroupItemProps
 }) => (
   <ToggleGroupItem
     text={
@@ -207,6 +207,7 @@ export const ErrataToggleGroupItem = ({
     }
     isSelected={isSelected}
     onChange={onChange}
+    {...toggleGroupItemProps}
   />
 );
 

--- a/webpack/components/Errata/index.js
+++ b/webpack/components/Errata/index.js
@@ -14,7 +14,6 @@ import {
   SecurityIcon,
   EnhancementIcon,
   SquareIcon,
-  OutlinedQuestionCircleIcon,
 } from '@patternfly/react-icons';
 import { TranslatedAnchor } from '../Table/components/TranslatedPlural';
 
@@ -192,23 +191,18 @@ ErrataSeverity.propTypes = {
 export const ErrataToggleGroupItem = ({
   text, tooltipText, isSelected, onChange, ...toggleGroupItemProps
 }) => (
-  <ToggleGroupItem
-    text={
-      <>
-        {text}
-        <Tooltip
-          content={tooltipText}
-          position="top"
-          enableFlip
-        >
-          <OutlinedQuestionCircleIcon style={{ marginBottom: '-2px', marginLeft: '0.3rem' }} color="gray" />
-        </Tooltip>
-      </>
-    }
-    isSelected={isSelected}
-    onChange={onChange}
-    {...toggleGroupItemProps}
-  />
+  <Tooltip
+    content={tooltipText}
+    position="top"
+    enableFlip
+  >
+    <ToggleGroupItem
+      text={text}
+      isSelected={isSelected}
+      onChange={onChange}
+      {...toggleGroupItemProps}
+    />
+  </Tooltip>
 );
 
 ErrataToggleGroupItem.propTypes = {

--- a/webpack/components/Errata/index.js
+++ b/webpack/components/Errata/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { TableText } from '@patternfly/react-table';
-import { Tooltip } from '@patternfly/react-core';
+import { Tooltip, ToggleGroupItem } from '@patternfly/react-core';
 import {
   chart_color_black_500 as pfBlack,
   chart_color_gold_400 as pfGold,
@@ -14,6 +14,7 @@ import {
   SecurityIcon,
   EnhancementIcon,
   SquareIcon,
+  OutlinedQuestionCircleIcon,
 } from '@patternfly/react-icons';
 import { TranslatedAnchor } from '../Table/components/TranslatedPlural';
 
@@ -22,7 +23,6 @@ export const ErrataMapper = ({ data, id, errataCategory }) =>
     <ErrataSummary count={count} type={type} key={`${count} ${type}`} id={id} errataCategory={errataCategory} />);
 
 export const ErrataSummary = ({ type, count, errataCategory }) => {
-  const show = errataCategory === 'applicable' ? 'all' : 'installable';
   let ErrataIcon;
   let label;
   let url;
@@ -36,7 +36,7 @@ export const ErrataSummary = ({ type, count, errataCategory }) => {
       <TranslatedAnchor
         id="errata-card-security-count"
         style={{ marginLeft: '0.4rem' }}
-        href={`#/Content/errata?type=security&show=${show}`}
+        href={`#/Content/errata?type=security&show=${errataCategory}`}
         count={count}
         plural="security advisories"
         singular="security advisory"
@@ -54,7 +54,7 @@ export const ErrataSummary = ({ type, count, errataCategory }) => {
       <TranslatedAnchor
         id="errata-card-bugfix-count"
         style={{ marginLeft: '0.4rem' }}
-        href={`#/Content/errata?type=bugfix&show=${show}`}
+        href={`#/Content/errata?type=bugfix&show=${errataCategory}`}
         count={count}
         plural="bug fixes"
         singular="bug fix"
@@ -72,7 +72,7 @@ export const ErrataSummary = ({ type, count, errataCategory }) => {
       <TranslatedAnchor
         id="errata-card-enhancement-count"
         style={{ marginLeft: '0.4rem' }}
-        href={`#/Content/errata?type=enhancement&show=${show}`}
+        href={`#/Content/errata?type=enhancement&show=${errataCategory}`}
         count={count}
         plural="enhancements"
         singular="enhancement"
@@ -181,4 +181,32 @@ export const ErrataSeverity = ({ severity }) => {
 
 ErrataSeverity.propTypes = {
   severity: PropTypes.string.isRequired,
+};
+
+export const ErrataToggleGroupItem = ({
+  text, tooltipText, isSelected, onChange,
+}) => (
+  <ToggleGroupItem
+    text={
+      <>
+        {text}
+        <Tooltip
+          content={tooltipText}
+          position="top"
+          enableFlip
+        >
+          <OutlinedQuestionCircleIcon style={{ marginBottom: '-2px', marginLeft: '0.3rem' }} color="gray" />
+        </Tooltip>
+      </>
+    }
+    isSelected={isSelected}
+    onChange={onChange}
+  />
+);
+
+ErrataToggleGroupItem.propTypes = {
+  text: PropTypes.string.isRequired,
+  tooltipText: PropTypes.string.isRequired,
+  isSelected: PropTypes.bool.isRequired,
+  onChange: PropTypes.func.isRequired,
 };

--- a/webpack/components/Errata/index.js
+++ b/webpack/components/Errata/index.js
@@ -109,10 +109,12 @@ ErrataSummary.propTypes = {
 export const ErrataType = ({ type }) => {
   let ErrataIcon;
   let label;
+  let verticalAlign = '-0.125em';
   switch (type) {
   case 'security':
     label = __('Security');
     ErrataIcon = SecurityIcon;
+    verticalAlign = '-0.2em';
     break;
   case 'recommended':
   case 'bugfix':
@@ -131,9 +133,11 @@ export const ErrataType = ({ type }) => {
 
   return (
     <TableText wrapModifier="nowrap">
-      <Tooltip content={label} >
-        <ErrataIcon style={{ marginRight: '4px' }} />
-      </Tooltip>
+      <span style={{ marginRight: '4px' }}>
+        <Tooltip content={label}>
+          <ErrataIcon style={{ verticalAlign }} />
+        </Tooltip>
+      </span>
       {label}
     </TableText>
   );
@@ -170,9 +174,11 @@ export const ErrataSeverity = ({ severity }) => {
   return (
     <TableText wrapModifier="nowrap">
       {color &&
-        <Tooltip content={label} >
-          <SecurityIcon color={color} />
-        </Tooltip>
+        <span style={{ marginRight: '4px' }}>
+          <Tooltip content={label} >
+            <SecurityIcon color={color} style={{ verticalAlign: '-0.2em' }}/>
+          </Tooltip>
+        </span>
       }
       {label}
     </TableText>

--- a/webpack/components/Errata/index.js
+++ b/webpack/components/Errata/index.js
@@ -103,6 +103,7 @@ export const ErrataSummary = ({ type, count, errataCategory }) => {
 ErrataSummary.propTypes = {
   type: PropTypes.string.isRequired,
   count: PropTypes.number.isRequired,
+  errataCategory: PropTypes.string.isRequired,
 };
 
 export const ErrataType = ({ type }) => {

--- a/webpack/components/Errata/index.js
+++ b/webpack/components/Errata/index.js
@@ -17,9 +17,12 @@ import {
 } from '@patternfly/react-icons';
 import { TranslatedAnchor } from '../Table/components/TranslatedPlural';
 
-export const ErrataMapper = ({ data, id }) => data.map(({ x: type, y: count }) => <ErrataSummary count={count} type={type} key={`${count} ${type}`} id={id} />);
+export const ErrataMapper = ({ data, id, errataCategory }) =>
+  data.map(({ x: type, y: count }) =>
+    <ErrataSummary count={count} type={type} key={`${count} ${type}`} id={id} errataCategory={errataCategory} />);
 
-export const ErrataSummary = ({ type, count }) => {
+export const ErrataSummary = ({ type, count, errataCategory }) => {
+  const show = errataCategory === 'applicable' ? 'all' : 'installable';
   let ErrataIcon;
   let label;
   let url;
@@ -33,7 +36,7 @@ export const ErrataSummary = ({ type, count }) => {
       <TranslatedAnchor
         id="errata-card-security-count"
         style={{ marginLeft: '0.4rem' }}
-        href="#/Content/errata?type=security"
+        href={`#/Content/errata?type=security&show=${show}`}
         count={count}
         plural="security advisories"
         singular="security advisory"
@@ -51,7 +54,7 @@ export const ErrataSummary = ({ type, count }) => {
       <TranslatedAnchor
         id="errata-card-bugfix-count"
         style={{ marginLeft: '0.4rem' }}
-        href="#/Content/errata?type=bugfix"
+        href={`#/Content/errata?type=bugfix&show=${show}`}
         count={count}
         plural="bug fixes"
         singular="bug fix"
@@ -69,7 +72,7 @@ export const ErrataSummary = ({ type, count }) => {
       <TranslatedAnchor
         id="errata-card-enhancement-count"
         style={{ marginLeft: '0.4rem' }}
-        href="#/Content/errata?type=enhancement"
+        href={`#/Content/errata?type=enhancement&show=${show}`}
         count={count}
         plural="enhancements"
         singular="enhancement"

--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
@@ -19,23 +19,7 @@ import { hostIsRegistered } from '../hostDetailsHelpers';
 import { TranslatedAnchor } from '../../../Table/components/TranslatedPlural';
 import EmptyStateMessage from '../../../Table/EmptyStateMessage';
 import './ErrataOverviewCard.scss';
-
-const statusContemplation = (errataStatus) => {
-  // from backend errata_status.rb:
-  // NEEDED_SECURITY_ERRATA = 3
-  // NEEDED_ERRATA = 2
-  // UNKNOWN = 1
-  // UP_TO_DATE = 0
-  const neededErrata = ([2, 3].includes(Number(errataStatus)));
-  const allUpToDate = (errataStatus === 0);
-  const otherErrataStatus = (!allUpToDate && !neededErrata);
-
-  return {
-    neededErrata,
-    allUpToDate,
-    otherErrataStatus,
-  };
-};
+import { errataStatusContemplation } from '../../../Errata/errataHelpers';
 
 function HostInstallableErrata({
   id, errataCounts, errataStatus, errataCategory, errataStatusLabel,
@@ -45,7 +29,7 @@ function HostInstallableErrata({
   const errataSecurity = counts.security;
   const errataBug = counts.bugfix;
   const errataEnhance = counts.enhancement;
-  const { neededErrata, allUpToDate, otherErrataStatus } = statusContemplation(errataStatus);
+  const { neededErrata, allUpToDate, otherErrataStatus } = errataStatusContemplation(errataStatus);
   const chartData = [{
     w: 'security advisories', x: 'security', y: errataSecurity, z: errataTotal,
   }, {
@@ -126,7 +110,7 @@ const ErrataOverviewCard = ({ hostDetails }) => {
     errata_status: errataStatus,
     errata_status_label: errataStatusLabel,
   } = hostDetails;
-  const { neededErrata } = statusContemplation(errataStatus);
+  const { neededErrata } = errataStatusContemplation(errataStatus);
   return (
     <GridItem rowSpan={1} md={6} lg={4} xl2={3} >
       <Card ouiaId="errata-card">

--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
@@ -121,12 +121,14 @@ const ErrataOverviewCard = ({ hostDetails }) => {
               <ToggleGroup isCompact>
                 <ErrataToggleGroupItem
                   text={__('Applicable')}
+                  aria-label="Show applicable errata chart"
                   tooltipText={__('Applicable errata apply to at least one package installed on the host.')}
                   isSelected={errataCategory === 'applicable'}
                   onChange={selected => selected && setErrataCategory('applicable')}
                 />
                 <ErrataToggleGroupItem
                   text={__('Installable')}
+                  aria-label="Show installable errata chart"
                   tooltipText={__('Installable errata are applicable errata that are available in the host\'s content view and lifecycle environment.')}
                   isSelected={errataCategory === 'installable'}
                   onChange={selected => selected && setErrataCategory('installable')}

--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Card,
   CardHeader,
@@ -7,6 +7,8 @@ import {
   Flex,
   FlexItem,
   GridItem,
+  ToggleGroup,
+  ToggleGroupItem,
 } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
@@ -19,12 +21,14 @@ import EmptyStateMessage from '../../../Table/EmptyStateMessage';
 import './ErrataOverviewCard.scss';
 
 function HostInstallableErrata({
-  id, errataCounts, errataStatus,
+  id, errataCounts, errataStatus, errataCategory,
 }) {
-  const errataTotal = errataCounts.total;
-  const errataSecurity = errataCounts.security;
-  const errataBug = errataCounts.bugfix;
-  const errataEnhance = errataCounts.enhancement;
+  const counts = errataCategory === 'applicable' ? errataCounts.applicable : errataCounts;
+  const show = errataCategory === 'applicable' ? 'all' : 'installable';
+  const errataTotal = counts.total;
+  const errataSecurity = counts.security;
+  const errataBug = counts.bugfix;
+  const errataEnhance = counts.enhancement;
   const chartData = [{
     w: 'security advisories', x: 'security', y: errataSecurity, z: errataTotal,
   }, {
@@ -33,74 +37,95 @@ function HostInstallableErrata({
     w: 'enhancements', x: 'enhancement', y: errataEnhance, z: errataTotal,
   }];
   return (
-    <GridItem rowSpan={1} md={6} lg={4} xl2={3} >
-      <Card ouiaId="errata-card">
-        <CardHeader>
-          <CardTitle>{__('Installable errata')}</CardTitle>
-        </CardHeader>
-        <CardBody>
-          {errataStatus === 0 &&
-            <EmptyStateMessage
-              title={__('All errata up-to-date')}
-              body={__('No action required')}
-              happy
+    <CardBody>
+      {errataStatus === 0 &&
+        <EmptyStateMessage
+          title={__('All errata up-to-date')}
+          body={__('No action required')}
+          happy
+        />
+      }
+      {errataStatus !== 0 &&
+        <Flex direction="column">
+          <FlexItem>
+            <TranslatedAnchor
+              id="errata-card-total-count"
+              href={`#/Content/errata?show=${show}`}
+              count={errataTotal}
+              plural="errata"
+              singular="erratum"
+              ariaLabel={`${errataTotal} total errata`}
             />
-          }
-          {errataStatus !== 0 &&
-            <Flex direction="column">
-              <FlexItem>
-                <TranslatedAnchor
-                  id="errata-card-total-count"
-                  href="#/Content/errata"
-                  count={errataTotal}
-                  plural="errata"
-                  singular="erratum"
-                  ariaLabel={`${errataTotal} total errata`}
+          </FlexItem>
+          <Flex flexWrap={{ xl: 'nowrap' }} direction="row" alignItems={{ default: 'alignItemsCenter' }}>
+            <div className="piechart-overflow" style={{ overflow: 'visible', minWidth: '140px', maxHeight: '155px' }}>
+              <div className="erratachart" style={{ minWidth: '300px', minHeight: '300px' }}>
+                <ChartPie
+                  ariaDesc="errataChart"
+                  data={chartData}
+                  constrainToVisibleArea
+                  labels={({ datum }) => `${datum.y} ${datum.w}`}
+                  padding={{
+                    bottom: 20,
+                    left: 20,
+                    right: 140,
+                    top: 20,
+                  }}
+                  width={250}
+                  height={130}
                 />
+              </div>
+            </div>
+            <div className="erratalegend" style={{ minWidth: '140px' }}>
+              <FlexItem>
+                <ErrataMapper data={chartData} id={id} errataCategory={errataCategory} />
               </FlexItem>
-              <Flex flexWrap={{ xl: 'nowrap' }} direction="row" alignItems={{ default: 'alignItemsCenter' }}>
-                <div className="piechart-overflow" style={{ overflow: 'visible', minWidth: '140px', maxHeight: '155px' }}>
-                  <div className="erratachart" style={{ minWidth: '300px', minHeight: '300px' }}>
-                    <ChartPie
-                      ariaDesc="errataChart"
-                      data={chartData}
-                      constrainToVisibleArea
-                      labels={({ datum }) => `${datum.y} ${datum.w}`}
-                      padding={{
-                        bottom: 20,
-                        left: 20,
-                        right: 140,
-                        top: 20,
-                      }}
-                      width={250}
-                      height={130}
-                    />
-                  </div>
-                </div>
-                <div className="erratalegend" style={{ minWidth: '140px' }}>
-                  <FlexItem>
-                    <ErrataMapper data={chartData} id={id} />
-                  </FlexItem>
-                </div>
-              </Flex>
-            </Flex>
-          }
-        </CardBody>
-      </Card>
-    </GridItem>
+            </div>
+          </Flex>
+        </Flex>
+      }
+    </CardBody>
   );
 }
 
 const ErrataOverviewCard = ({ hostDetails }) => {
-  if (hostIsRegistered({ hostDetails }) && hostDetails.content_facet_attributes) {
-    const { id: hostId, errata_status: errataStatus } = hostDetails;
-    return (<HostInstallableErrata
-      {...propsToCamelCase(hostDetails.content_facet_attributes)}
-      id={hostId}
-      errataStatus={errataStatus}
-    />);
-  }
-  return null;
+  const hostPopulated = (hostIsRegistered({ hostDetails }) &&
+    !!hostDetails.content_facet_attributes);
+
+  const [errataCategory, setErrataCategory] = useState('applicable');
+  if (!hostPopulated) return null;
+  const { id: hostId, errata_status: errataStatus } = hostDetails;
+  return (
+    <GridItem rowSpan={1} md={6} lg={4} xl2={3} >
+      <Card ouiaId="errata-card">
+        <CardHeader>
+          <Flex spaceItems={{ default: 'spaceItemsXl' }}>
+            <CardTitle>{__('Errata')}</CardTitle>
+            {errataStatus !== 0 &&
+              <ToggleGroup>
+                <ToggleGroupItem
+                  text={__('Installable')}
+                  isSelected={errataCategory === 'installable'}
+                  onChange={selected => selected && setErrataCategory('installable')}
+                />
+                <ToggleGroupItem
+                  text={__('Applicable')}
+                  isSelected={errataCategory === 'applicable'}
+                  onChange={selected => selected && setErrataCategory('applicable')}
+                />
+              </ToggleGroup>
+            }
+          </Flex>
+        </CardHeader>
+        <HostInstallableErrata
+          {...propsToCamelCase(hostDetails.content_facet_attributes)}
+          id={hostId}
+          errataCategory={errataCategory}
+          errataStatus={errataStatus}
+        />
+      </Card>
+    </GridItem>
+  );
 };
 
 HostInstallableErrata.propTypes = {
@@ -110,12 +135,19 @@ HostInstallableErrata.propTypes = {
     enhancement: PropTypes.number,
     security: PropTypes.number,
     total: PropTypes.number,
+    applicable: PropTypes.shape({
+      bugfix: PropTypes.number,
+      enhancement: PropTypes.number,
+      security: PropTypes.number,
+    }),
   }).isRequired,
   errataStatus: PropTypes.number,
+  errataCategory: PropTypes.string,
 };
 
 HostInstallableErrata.defaultProps = {
   errataStatus: undefined,
+  errataCategory: 'applicable',
 };
 
 ErrataOverviewCard.propTypes = {

--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
@@ -41,7 +41,6 @@ function HostInstallableErrata({
   id, errataCounts, errataStatus, errataCategory, errataStatusLabel,
 }) {
   const counts = errataCategory === 'applicable' ? errataCounts.applicable : errataCounts;
-  const show = errataCategory === 'applicable' ? 'all' : 'installable';
   const errataTotal = counts.total;
   const errataSecurity = counts.security;
   const errataBug = counts.bugfix;
@@ -78,7 +77,7 @@ function HostInstallableErrata({
           <FlexItem>
             <TranslatedAnchor
               id="errata-card-total-count"
-              href={`#/Content/errata?show=${show}`}
+              href={`#/Content/errata?show=${errataCategory}`}
               count={errataTotal}
               plural="errata"
               singular="erratum"

--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
@@ -8,15 +8,13 @@ import {
   FlexItem,
   GridItem,
   ToggleGroup,
-  ToggleGroupItem,
-  Tooltip,
 } from '@patternfly/react-core';
-import { OutlinedQuestionCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
 import PropTypes from 'prop-types';
 import { ChartPie } from '@patternfly/react-charts';
-import { ErrataMapper } from '../../../../components/Errata';
+import { ErrataMapper, ErrataToggleGroupItem } from '../../../../components/Errata';
 import { hostIsRegistered } from '../hostDetailsHelpers';
 import { TranslatedAnchor } from '../../../Table/components/TranslatedPlural';
 import EmptyStateMessage from '../../../Table/EmptyStateMessage';
@@ -118,34 +116,6 @@ function HostInstallableErrata({
   );
 }
 
-const ErrataToggleGroupItem = ({
-  text, tooltipText, isSelected, onChange,
-}) => (
-  <ToggleGroupItem
-    text={
-      <>
-        {text}
-        <Tooltip
-          content={tooltipText}
-          position="top"
-          enableFlip
-        >
-          <OutlinedQuestionCircleIcon style={{ marginBottom: '-2px', marginLeft: '0.3rem' }} color="gray" />
-        </Tooltip>
-      </>
-    }
-    isSelected={isSelected}
-    onChange={onChange}
-  />
-);
-
-ErrataToggleGroupItem.propTypes = {
-  text: PropTypes.string.isRequired,
-  tooltipText: PropTypes.string.isRequired,
-  isSelected: PropTypes.bool.isRequired,
-  onChange: PropTypes.func.isRequired,
-};
-
 const ErrataOverviewCard = ({ hostDetails }) => {
   const hostPopulated = (hostIsRegistered({ hostDetails }) &&
     !!hostDetails.content_facet_attributes);
@@ -168,7 +138,7 @@ const ErrataOverviewCard = ({ hostDetails }) => {
               <ToggleGroup isCompact>
                 <ErrataToggleGroupItem
                   text={__('Applicable')}
-                  tooltipText={__('Applicable errata are errata that apply to at least one package installed on the host.')}
+                  tooltipText={__('Applicable errata apply to at least one package installed on the host.')}
                   isSelected={errataCategory === 'applicable'}
                   onChange={selected => selected && setErrataCategory('applicable')}
                 />

--- a/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
@@ -144,9 +144,8 @@ describe('With errata', () => {
     const { getByText }
       = renderWithRedux(<ErrataOverviewCard hostDetails={hostDetails} />, renderOptions);
     // find the Applicable toggle button, then find the svg next to it
-    const applicableToggle = getByText('Applicable');
-    const questionMark = applicableToggle.querySelector('svg');
-    fireEvent.mouseEnter(questionMark);
+    const applicableToggle = getByText('Applicable').parentElement.parentElement;
+    fireEvent.mouseEnter(applicableToggle);
     // expect the tooltip to be visible
     await patientlyWaitFor(() => expect(getByText('Applicable errata apply to at least one package installed on the host.')).toBeInTheDocument());
   });

--- a/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { renderWithRedux, fireEvent } from 'react-testing-lib-wrapper';
+import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
+
 import ErrataOverviewCard from '../ErrataOverviewCard';
 
 const baseHostDetails = {
@@ -64,7 +65,6 @@ describe('Without errata', () => {
     expect(getByText('All errata up-to-date')).toBeInTheDocument();
   });
 
-  // test for showing warning empty state when it has unknown errata status
   test('shows warning empty state when it has unknown errata status', () => {
     const hostDetails = {
       ...baseHostDetails,
@@ -122,7 +122,36 @@ describe('With errata', () => {
     expect(getByLabelText('10 bug fixes')).toBeInTheDocument();
   });
 
-  test('Can toggle between applicable and installable with toggle group', () => {
+  test('has cute little tooltips', async () => {
+    const hostDetails = {
+      ...baseHostDetails,
+      errata_status: 2,
+      content_facet_attributes: {
+        errata_counts: {
+          bugfix: 10,
+          enhancement: 20,
+          security: 30,
+          total: 60,
+          applicable: {
+            bugfix: 10,
+            enhancement: 20,
+            security: 30,
+            total: 60,
+          },
+        },
+      },
+    };
+    const { getByText }
+      = renderWithRedux(<ErrataOverviewCard hostDetails={hostDetails} />, renderOptions);
+    // find the Applicable toggle button, then find the svg next to it
+    const applicableToggle = getByText('Applicable');
+    const questionMark = applicableToggle.querySelector('svg');
+    fireEvent.mouseEnter(questionMark);
+    // expect the tooltip to be visible
+    await patientlyWaitFor(() => expect(getByText('Applicable errata apply to at least one package installed on the host.')).toBeInTheDocument());
+  });
+
+  test('can toggle between applicable and installable with toggle group', () => {
     const hostDetails = {
       ...baseHostDetails,
       errata_status: 2,

--- a/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
@@ -189,4 +189,34 @@ describe('With errata', () => {
     expect(getByLabelText('20 enhancements')).toBeInTheDocument();
     expect(getByLabelText('10 bug fixes')).toBeInTheDocument();
   });
+  test('applicable view links to show=applicable; installable view links to show=installable', () => {
+    const hostDetails = {
+      ...baseHostDetails,
+      errata_status: 2,
+      content_facet_attributes: {
+        errata_counts: {
+          bugfix: 10,
+          enhancement: 20,
+          security: 30,
+          total: 60,
+          applicable: {
+            bugfix: 11,
+            enhancement: 21,
+            security: 31,
+            total: 61,
+          },
+        },
+      },
+    };
+    const { getByText, getByLabelText }
+      = renderWithRedux(<ErrataOverviewCard hostDetails={hostDetails} />, renderOptions);
+    expect(getByText('Applicable').parentElement).toHaveAttribute('aria-pressed', 'true');
+    expect(getByText('Installable').parentElement).toHaveAttribute('aria-pressed', 'false');
+
+    expect(getByLabelText('61 total errata').closest('a')).toHaveAttribute('href', '#/Content/errata?show=applicable');
+    fireEvent.click(getByText('Installable'));
+    expect(getByText('Applicable').parentElement).toHaveAttribute('aria-pressed', 'false');
+    expect(getByText('Installable').parentElement).toHaveAttribute('aria-pressed', 'true');
+    expect(getByLabelText('30 security advisories').closest('a')).toHaveAttribute('href', '#/Content/errata?type=security&show=installable');
+  });
 });

--- a/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
@@ -1,11 +1,28 @@
 import React from 'react';
-import { render, renderWithRedux } from 'react-testing-lib-wrapper';
+import { renderWithRedux } from 'react-testing-lib-wrapper';
 import ErrataOverviewCard from '../ErrataOverviewCard';
 
 const baseHostDetails = {
   id: 2,
   subscription_facet_attributes: {
     uuid: '123',
+  },
+};
+const baseFacetAttributes = {
+  errata_status: 0, // all up to date
+  content_facet_attributes: {
+    errata_counts: {
+      bugfix: 0,
+      enhancement: 0,
+      security: 0,
+      total: 0,
+      applicable: {
+        bugfix: 0,
+        enhancement: 0,
+        security: 0,
+        total: 0,
+      },
+    },
   },
 };
 const renderOptions = {
@@ -22,18 +39,11 @@ describe('Without errata', () => {
   test('shows zero counts when there are 0 installable errata', () => {
     const hostDetails = {
       ...baseHostDetails,
-      errata_status: 1,
-      content_facet_attributes: {
-        errata_counts: {
-          bugfix: 0,
-          enhancement: 0,
-          security: 0,
-          total: 0,
-        },
-      },
+      ...baseFacetAttributes,
+      errata_status: 2,
     };
     /* eslint-disable max-len */
-    const { queryByLabelText, getByLabelText } = render(<ErrataOverviewCard hostDetails={hostDetails} />);
+    const { queryByLabelText, getByLabelText } = renderWithRedux(<ErrataOverviewCard hostDetails={hostDetails} />, renderOptions);
     /* eslint-enable max-len */
     expect(queryByLabelText('errataChart')).not.toBeInTheDocument();
     expect(getByLabelText('0 total errata')).toBeInTheDocument();
@@ -45,15 +55,7 @@ describe('Without errata', () => {
   test('shows empty state when there are 0 errata', () => {
     const hostDetails = {
       ...baseHostDetails,
-      errata_status: 0,
-      content_facet_attributes: {
-        errata_counts: {
-          bugfix: 0,
-          enhancement: 0,
-          security: 0,
-          total: 0,
-        },
-      },
+      ...baseFacetAttributes,
     };
     /* eslint-disable max-len */
     const { queryByLabelText, getByText } = renderWithRedux(<ErrataOverviewCard hostDetails={hostDetails} />, renderOptions);
@@ -65,21 +67,14 @@ describe('Without errata', () => {
   test('does not show errata card when host not registered', () => {
     const hostDetails = {
       ...baseHostDetails,
-      content_facet_attributes: {
-        errata_counts: {
-          bugfix: 0,
-          enhancement: 0,
-          security: 0,
-          total: 0,
-        },
-      },
+      ...baseFacetAttributes,
       subscription_facet_attributes: undefined,
     };
     /* eslint-disable max-len */
-    const { queryByLabelText, queryByText } = render(<ErrataOverviewCard hostDetails={hostDetails} />);
+    const { queryByLabelText, queryByText } = renderWithRedux(<ErrataOverviewCard hostDetails={hostDetails} />, renderOptions);
     /* eslint-enable max-len */
     expect(queryByLabelText('errataChart')).not.toBeInTheDocument();
-    expect(queryByText('0 errata')).not.toBeInTheDocument();
+    expect(queryByText('No errata')).not.toBeInTheDocument();
   });
 });
 
@@ -87,16 +82,24 @@ describe('With errata', () => {
   test('shows links when there are errata', () => {
     const hostDetails = {
       ...baseHostDetails,
+      errata_status: 2,
       content_facet_attributes: {
         errata_counts: {
           bugfix: 10,
           enhancement: 20,
           security: 30,
           total: 60,
+          applicable: {
+            bugfix: 10,
+            enhancement: 20,
+            security: 30,
+            total: 60,
+          },
         },
       },
     };
-    const { getByLabelText, container } = render(<ErrataOverviewCard hostDetails={hostDetails} />);
+    const { getByLabelText, container }
+      = renderWithRedux(<ErrataOverviewCard hostDetails={hostDetails} />, renderOptions);
     expect(container.getElementsByClassName('erratachart')).toHaveLength(1);
     expect(container.getElementsByClassName('erratalegend')).toHaveLength(1);
 

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -43,6 +43,7 @@ import { defaultRemoteActionMethod,
   userPermissionsFromHostDetails } from '../../hostDetailsHelpers';
 import SortableColumnHeaders from '../../../../Table/components/SortableColumnHeaders';
 import { useRexJobPolling } from '../RemoteExecutionHooks';
+import { errataStatusContemplation, friendlyErrataStatus } from '../../../../Errata/errataHelpers';
 
 const recalculateApplicability = ['edit_hosts'];
 const invokeRexJobs = ['create_job_invocations'];
@@ -56,6 +57,7 @@ export const ErrataTab = () => {
     name: hostname,
     content_facet_attributes: contentFacetAttributes,
     errata_status: errataStatus,
+    errata_status_label: errataStatusLabel,
   } = hostDetails;
   const userPermissions = userPermissionsFromHostDetails({ hostDetails });
   const showRecalculate =
@@ -94,11 +96,30 @@ export const ErrataTab = () => {
     setIsActionOpen(prev => !prev);
   };
 
-  const allUpToDate = errataStatus === 0;
-  const emptyContentTitle = allUpToDate ? __('All errata up-to-date') : __('This host has errata that are applicable, but not installable.');
-  const emptyContentBody = allUpToDate ? __('No action is needed because there are no applicable errata for this host.') : __("You may want to check the host's content view and lifecycle environment.");
+  const { allUpToDate } = errataStatusContemplation(errataStatus);
   const emptySearchTitle = __('No matching errata found');
   const emptySearchBody = __('Try changing your search settings.');
+
+  let emptyContentTitle;
+  let emptyContentBody;
+  switch (friendlyErrataStatus(errataStatus)) {
+  case 'All up to date':
+    emptyContentTitle = __('All up to date');
+    emptyContentBody = __('No action is needed because there are no applicable errata for this host.');
+    break;
+  case 'Needed':
+    emptyContentTitle = __('This host has errata that are applicable, but not installable.');
+    emptyContentBody = __("You may want to check the host's content view and lifecycle environment.");
+    break;
+  case 'Unknown':
+    emptyContentTitle = __('Unknown errata status');
+    emptyContentBody = errataStatusLabel;
+    break;
+  default:
+    emptyContentTitle = emptySearchTitle;
+    emptyContentBody = emptySearchBody;
+  }
+
   const errorSearchTitle = __('Problem searching errata');
   const columnHeaders = [
     __('Errata'),

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -3,7 +3,7 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 import { useSelector, useDispatch } from 'react-redux';
 import {
   Split, SplitItem, ActionList, ActionListItem, Dropdown,
-  DropdownItem, KebabToggle, Skeleton, Tooltip, ToggleGroup, ToggleGroupItem,
+  DropdownItem, KebabToggle, Skeleton, Tooltip, ToggleGroup,
   DropdownToggle, DropdownToggleAction,
 } from '@patternfly/react-core';
 import { TimesIcon, CheckIcon } from '@patternfly/react-icons';
@@ -26,7 +26,7 @@ import { propsToCamelCase } from 'foremanReact/common/helpers';
 import SelectableDropdown from '../../../../SelectableDropdown';
 import { useSet, useBulkSelect, useUrlParams, useTableSort } from '../../../../../components/Table/TableHooks';
 import TableWrapper from '../../../../../components/Table/TableWrapper';
-import { ErrataType, ErrataSeverity } from '../../../../../components/Errata';
+import { ErrataType, ErrataSeverity, ErrataToggleGroupItem } from '../../../../../components/Errata';
 import { getInstallableErrata, regenerateApplicability, applyViaKatelloAgent } from './HostErrataActions';
 import ErratumExpansionDetail from './ErratumExpansionDetail';
 import ErratumExpansionContents from './ErratumExpansionContents';
@@ -65,8 +65,8 @@ export const ErrataTab = () => {
     );
   const contentFacet = propsToCamelCase(contentFacetAttributes ?? {});
   const dispatch = useDispatch();
-  const toggleGroupStates = ['all', 'installable'];
-  const [ALL, INSTALLABLE] = toggleGroupStates;
+  const toggleGroupStates = ['applicable', 'installable'];
+  const [APPLICABLE, INSTALLABLE] = toggleGroupStates;
   const ERRATA_TYPE = __('Type');
   const ERRATA_SEVERITY = __('Severity');
   const [isBulkActionOpen, setIsBulkActionOpen] = useState(false);
@@ -148,13 +148,13 @@ export const ErrataTab = () => {
       return getInstallableErrata(
         hostId,
         {
-          include_applicable: toggleGroupState === ALL,
+          include_applicable: toggleGroupState === APPLICABLE,
           ...apiSortParams,
           ...modifiedParams,
         },
       );
     },
-    [hostId, toggleGroupState, ALL, ERRATA_SEVERITY, ERRATA_TYPE,
+    [hostId, toggleGroupState, APPLICABLE, ERRATA_SEVERITY, ERRATA_TYPE,
       errataTypeSelected, errataSeveritySelected, apiSortParams],
   );
 
@@ -411,17 +411,19 @@ export const ErrataTab = () => {
       {hostIsNonLibrary &&
         <SplitItem>
           <ToggleGroup aria-label="Installable Errata">
-            <ToggleGroupItem
-              text={__('All')}
-              buttonId="allToggle"
-              aria-label="Show All"
-              isSelected={toggleGroupState === ALL}
-              onChange={() => setToggleGroupState(ALL)}
+            <ErrataToggleGroupItem
+              text={__('Applicable')}
+              tooltipText={__('Applicable errata apply to at least one package installed on the host.')}
+              buttonId="applicableToggle"
+              aria-label="Show applicable errata"
+              isSelected={toggleGroupState === APPLICABLE}
+              onChange={() => setToggleGroupState(APPLICABLE)}
             />
-            <ToggleGroupItem
+            <ErrataToggleGroupItem
               text={__('Installable')}
+              tooltipText={__('Installable errata are applicable errata that are available in the host\'s content view and lifecycle environment.')}
               buttonId="installableToggle"
-              aria-label="Show Installable"
+              aria-label="Show installable errata"
               isSelected={toggleGroupState === INSTALLABLE}
               onChange={() => setToggleGroupState(INSTALLABLE)}
             />

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -96,7 +96,7 @@ export const ErrataTab = () => {
     setIsActionOpen(prev => !prev);
   };
 
-  const { allUpToDate } = errataStatusContemplation(errataStatus);
+  const { allUpToDate, neededErrata } = errataStatusContemplation(errataStatus);
   const emptySearchTitle = __('No matching errata found');
   const emptySearchBody = __('Try changing your search settings.');
 
@@ -495,7 +495,7 @@ export const ErrataTab = () => {
           displaySelectAllCheckbox={showActions}
           requestKey={HOST_ERRATA_KEY}
           alwaysShowActionButtons={false}
-          alwaysShowToggleGroup={hostIsNonLibrary}
+          alwaysShowToggleGroup={hostIsNonLibrary && neededErrata}
         >
           <Thead>
             <Tr ouiaId="row-header">

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
@@ -49,6 +49,8 @@ const renderOptions = (facetAttributes = contentFacetAttributes) => ({
         response: {
           id: 1,
           name: hostName,
+          errata_status_label: 'Security errata applicable',
+          errata_status: 2,
           content_facet_attributes: { ...facetAttributes },
         },
         status: 'RESOLVED',

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
@@ -750,14 +750,16 @@ test('Can toggle with the Toggle Group ', async (done) => {
 
   const {
     queryByLabelText,
+    getByText,
     getAllByText,
   } = renderWithRedux(<ErrataTab />, renderOptions(cfWithErrataTotal(mockErrata.total)));
 
   // Assert that the errata are now showing on the screen, but wait for them to appear.
   await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
   expect(queryByLabelText('Installable Errata')).toBeInTheDocument();
-  expect(queryByLabelText('Show Installable')).toHaveAttribute('aria-pressed', 'true');
-  expect(queryByLabelText('Show All')).toHaveAttribute('aria-pressed', 'false');
+  expect(getByText('Applicable')).toBeInTheDocument();
+  expect(getByText('Applicable').parentElement).toHaveAttribute('aria-pressed', 'false');
+  expect(getAllByText('Installable')[0].parentElement).toHaveAttribute('aria-pressed', 'true');
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done); // Pass jest callback to confirm test is done
 });


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add a toggle group "Applicable / Installable" (with tooltips) to the errata overview card.
Add an empty state for when a host has unknown errata status.
Update the ErrataTab toggle group with the tooltips as well.

![errata-card-new-message](https://user-images.githubusercontent.com/22042343/198050129-7b075d2b-8625-409b-a6e3-12be1bcbda8a.png)
![errata-tab-toggle](https://user-images.githubusercontent.com/22042343/197841699-352736cc-1858-4e82-8c39-b03c2b45c9bd.png)
![unknown-errata-status](https://user-images.githubusercontent.com/22042343/197841702-280015ca-1657-46ee-8070-819680ac6b45.png)



#### Considerations taken when implementing this change?

We don't currently store applicable errata counts in the DB for each host.  I decided to keep it that way; applicable errata are calculated on demand in the rabl instead of adding new columns to the database.

#### What are the testing steps for this pull request?

1. Get a host with differing numbers of applicable and installable errata
2. View the overview card
3. Verify that when you click on a link, the resulting page is filtered to "All" errata when the toggle group is on "Applicable," and "Installable" when on "Installable."
4. Also view the new tooltips on the Errata page