### PR TITLE
Fixes #35503 - Notify user only when new errata are added to repo

### DIFF
--- a/app/lib/actions/katello/repository/errata_mail.rb
+++ b/app/lib/actions/katello/repository/errata_mail.rb
@@ -2,18 +2,21 @@ module Actions
   module Katello
     module Repository
       class ErrataMail < Actions::EntryAction
-        middleware.use Actions::Middleware::ExecuteIfContentsChanged
-
-        def plan(repo, contents_changed = nil)
-          last_updated = repo.repository_errata.order('updated_at ASC').last.try(:updated_at) || Time.now
-          plan_self(:repo => repo.id, :contents_changed => contents_changed, :last_updated => last_updated.to_s)
+        def plan(repo)
+          plan_self(:repo => repo.id, :associated_errata_before_syncing => repo.repository_errata.pluck(:erratum_id).uniq.sort.reverse, :new_associated_errata => [])
         end
 
         def run
           ::User.current = ::User.anonymous_admin
           repo = ::Katello::Repository.find(input[:repo])
+          input[:new_associated_errata] = repo.repository_errata.pluck(:erratum_id).uniq.sort.reverse - input[:associated_errata_before_syncing]
+
           users = ::User.select { |user| user.receives?(:sync_errata) && user.organization_ids.include?(repo.organization.id) && user.can?(:view_products, repo.product) }.compact
-          errata = ::Katello::Erratum.where(:id => repo.repository_errata.where('katello_repository_errata.updated_at > ?', input['last_updated'].to_datetime).pluck(:erratum_id))
+          errata = ::Katello::Erratum.where(:id => input[:new_associated_errata])
+
+          [:associated_errata_before_syncing, :new_associated_errata].each do |key|
+            input[key] = "Trimmed list... (#{input[key].length} #{key.to_s.gsub('_', ' ')})" if input[key].length > 3
+          end
 
           begin
             MailNotification[:sync_errata].deliver(:users => users, :repo => repo, :errata => errata) unless (users.blank? || errata.blank?)

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -51,7 +51,7 @@ module Actions
               plan_action(Katello::Repository::FetchPxeFiles, :id => repo.id)
               plan_action(Katello::Repository::CorrectChecksum, repo)
               concurrence do
-                plan_action(Katello::Repository::ErrataMail, repo, output[:contents_changed])
+                plan_action(Katello::Repository::ErrataMail, repo)
                 plan_action(Actions::Katello::Applicability::Repository::Regenerate, :repo_ids => [repo.id]) if generate_applicability
               end
               plan_self(:id => repo.id, :sync_result => output, :skip_metadata_check => skip_metadata_check, :validate_contents => validate_contents,

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -793,11 +793,11 @@ module ::Actions::Katello::Repository
 
     it 'plans' do
       action = create_action action_class
-      planned_action = plan_action action, repository, true
-      last_updated = repository.repository_errata.order("updated_at desc").first.updated_at.to_s
+      planned_action = plan_action action, repository
+      old_errata_ids = repository.errata.map(&:id).uniq.sort.reverse
       new_errata = ::Katello::Erratum.where.not(:id => repository.repository_errata.pluck(:erratum_id)).first
       repository.errata << new_errata
-      assert_equal planned_action.execution_plan.planned_run_steps.first.input, "repo" => repository.id, "contents_changed" => true, "last_updated" => last_updated
+      assert_equal planned_action.execution_plan.planned_run_steps.first.input, "repo" => repository.id, "associated_errata_before_syncing" => old_errata_ids, "new_associated_errata" => []
     end
   end
 


### PR DESCRIPTION
Co-authored-by: William Bradford Clark <wclark@redhat.com>
Co-authored-by: Pavel Moravec <pmoravec@redhat.com>

#### What are the changes introduced in this pull request?

Instead of using contents_changed for input (and corresponding middleware) we use new inputs associated_errata_before_syncing and new_associated_errata; in planning, we set the former to the current list of associated errata and initialize the latter as an empty array. Later in the run step (after the repository has synced) we re-calculate the associated errata and set new_associated_errata as the difference -- only sending the notification email when this is non-empty.

#### Considerations taken when implementing this change?

To avoid keeping potentially large arrays in the database (and to create better UX viewing the action in the dynflow console), after we are done _using_ the new inputs to determine what (if any) emails to send, we truncate them and replace with a message displaying the count of errata rather than the complete list of IDs. More than 3 errata was chosen (somewhat arbitrarily) as a cutoff point, because the full information will be available in the email itself. This prevents us from seeing very large inputs for the action when viewing the action in dynflow console _after the action has run_.

#### What are the testing steps for this pull request?

1. Install sendmail/postfix on development environment
2. systemctl enable --now postfix
3. Configure email address and notification subscriptions for user
4. Enable and sync a repository containing errata
5. After sync is complete, observe task in dynflow console and validate that we have `associated_errata_before_syncing: []` and some number of `new_associated_errata`
6. Read mail in `/var/spool/mail/$user`
7. Immediately re-sync the repository
8. This time the inputs are reversed -- we observe some number of existing `associated_errata_before_syncing` but `new_associated_errata` is `[]`
9. There is no additional mail in `/var/spool/mail/$user`