### PR TITLE
Fixes #35590 - RPM uploads fail on Pulpcore 3.21

### DIFF
--- a/app/services/katello/pulp3/pulp_content_unit.rb
+++ b/app/services/katello/pulp3/pulp_content_unit.rb
@@ -17,6 +17,9 @@ module Katello
           repository_type = Katello::Repository.find(opts[:repository_id]).repository_type
           content_type = opts[:content_type]
           self.content_api(repository_type, content_type).create(relative_path, opts)
+        elsif self.content_type == 'rpm' || self.content_type == 'srpm'
+          # The pulp_rpm API bindings expect relative_path to be within the options hash.
+          self.content_api.create(opts)
         else
           self.content_api.create(relative_path, opts)
         end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fixes the arguments sent to the Pulpcore content API bindings to conform to recent changes. `relative_path` now belongs in the options hash.

#### Considerations taken when implementing this change?
None really.

#### What are the testing steps for this pull request?
Try uploading an RPM. Ensure it is a new one that you've never uploaded to Pulp before. Also try uploading files to a file repo.