### PR TITLE
Fixes #35687 - add `ignore_types` to the Organizations controller

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -29,6 +29,7 @@ module Katello
         param :hostgroup_ids, Array, N_("Host group IDs"), :required => false
         param :environment_ids, Array, N_("Environment IDs"), :required => false
         param :subnet_ids, Array, N_("Subnet IDs"), :required => false
+        param :ignore_types, Array, N_("List of resources types that will be automatically associated"), :required => false
         param :location_ids, Array, N_("Associated location IDs"), :required => false
       end
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This PR adds `ignore_types` to allowed (documented) parameters of the Organizations Controller

#### Considerations taken when implementing this change?

I wish we could just stop overriding the *whole* Org Controller from Foreman

#### What are the testing steps for this pull request?

Check that `ignore_types` shows up for create and update actions of an Organization in the API documentation.