### PR TITLE
Fixes #35704 - Drop the term 'Subscription Watch'

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -115,7 +115,7 @@
       <div class="divider"></div>
 
       <div style="display: inline-block"><h4 translate>System Purpose</h4></div>
-      <div style="display: inline-block"><i class="pficon-info" title="{{ 'System Purpose allows you to set the system\'s intended use on your network and improves the accuracy of auto attaching subscriptions.' | translate }}"></i></div>
+      <div style="display: inline-block"><i class="pficon-info" title="{{ 'System purpose enables you to set the system\'s intended use on your network and improves reporting accuracy in the Subscriptions service of the Red Hat Hybrid Cloud Console.' | translate }}"></i></div>
 
       <dl class="dl-horizontal dl-horizontal-left">
         <dt translate ng-hide="simpleContentAccessEnabled">System Purpose Status</dt>

--- a/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeCard.js
@@ -78,7 +78,7 @@ const SystemPurposeCard = ({ hostDetails }) => {
                 </FlexItem>
                 <FlexItem>
                   <Tooltip
-                    content={__('System purpose allows you to set the system\'s intended use on your network and improves the reporting of usage in Subscription Watch.')}
+                    content={__('System purpose enables you to set the system\'s intended use on your network and improves reporting accuracy in the Subscriptions service of the Red Hat Hybrid Cloud Console.')}
                     position="top"
                     enableFlip
                     isContentLeftAligned

--- a/webpack/scenes/Subscriptions/SubscriptionConstants.js
+++ b/webpack/scenes/Subscriptions/SubscriptionConstants.js
@@ -37,7 +37,8 @@ export const SUBSCRIPTIONS_CLOSE_DELETE_MODAL = 'SUBSCRIPTIONS_CLOSE_DELETE_MODA
 export const SUBSCRIPTIONS_DISABLE_DELETE_BUTTON = 'SUBSCRIPTIONS_DISABLE_DELETE_BUTTON';
 export const SUBSCRIPTIONS_ENABLE_DELETE_BUTTON = 'SUBSCRIPTIONS_ENABLE_DELETE_BUTTON';
 
-export const SUBSCRIPTION_WATCH_URL = 'https://access.redhat.com/articles/subscription-watch';
+export const SUBSCRIPTIONS_SERVICE_DOC_URL = 'https://access.redhat.com/documentation/en-us/subscription_central/2021/html-single/getting_started_with_the_subscriptions_service/index';
+export const SUBSCRIPTIONS_SERVICE_URL = 'https://console.redhat.com/subscriptions';
 export const SCA_URL = 'https://access.redhat.com/articles/simple-content-access';
 
 export const MANIFEST_DELETE_TASK_LABEL = 'Actions::Katello::Organization::ManifestDelete';

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -16,7 +16,7 @@ import { filterRHSubscriptions } from './SubscriptionHelpers';
 import api, { orgId } from '../../services/api';
 
 import { createSubscriptionParams } from './SubscriptionActions.js';
-import { SUBSCRIPTION_TABLE_NAME, SUBSCRIPTION_WATCH_URL, SCA_URL } from './SubscriptionConstants';
+import { SUBSCRIPTION_TABLE_NAME, SUBSCRIPTIONS_SERVICE_DOC_URL, SCA_URL } from './SubscriptionConstants';
 import './SubscriptionsPage.scss';
 
 class SubscriptionsPage extends Component {
@@ -104,7 +104,7 @@ class SubscriptionsPage extends Component {
     if (!hasUpstreamConnection) {
       disabledReason = __('This is disabled because no connection could be made to the upstream Manifest.');
     } else if (task) {
-      disabledReason = __('This is disabled because a manifest related task is in progress.');
+      disabledReason = __('This is disabled because a manifest-related task is in progress.');
     } else if (deleteButton && !disabledReason) {
       disabledReason = __('This is disabled because no subscriptions are selected.');
     } else if (!isManifestImported) {
@@ -223,14 +223,14 @@ class SubscriptionsPage extends Component {
         <FormattedMessage
           id="sca-alert"
           values={{
-            subscriptionWatch: <a href={SUBSCRIPTION_WATCH_URL} target="_blank" rel="noreferrer">{__('Subscription Watch')}</a>,
+            subscriptionsService: <a href={SUBSCRIPTIONS_SERVICE_DOC_URL} target="_blank" rel="noreferrer">{__('Subscriptions service')}</a>,
             br: <br />,
             scaLink: <a href={SCA_URL} target="_blank" rel="noreferrer">{__('Simple Content Access')}</a>,
           }}
           defaultMessage={simpleContentAccess ? __(`This organization has Simple Content Access enabled.
           Hosts are not required to have subscriptions attached to access repositories.
           {br}
-          Learn more about your overall subscription usage at {subscriptionWatch}.`) : __('This organization is not using {scaLink}. Legacy subscription management is deprecated and will be removed in a future version.')}
+          Learn more about your overall subscription usage with the {subscriptionsService}.`) : __('This organization is not using {scaLink}. Legacy subscription management is deprecated and will be removed in a future version.')}
         />
       </Alert>
     );

--- a/webpack/scenes/Subscriptions/components/SubscriptionsToolbar/SubscriptionsToolbar.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsToolbar/SubscriptionsToolbar.js
@@ -4,7 +4,7 @@ import { Row, Col, Form, FormGroup, Button } from 'patternfly-react';
 import { LinkContainer } from 'react-router-bootstrap';
 import { noop } from 'foremanReact/common/helpers';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { SUBSCRIPTION_WATCH_URL } from '../../SubscriptionConstants';
+import { SUBSCRIPTIONS_SERVICE_URL } from '../../SubscriptionConstants';
 
 import Search from '../../../../components/Search/index';
 import TooltipButton from '../../../../components/TooltipButton';
@@ -61,12 +61,12 @@ const SubscriptionsToolbar = ({
 
             {isManifestImported &&
               <a
-                href={SUBSCRIPTION_WATCH_URL}
+                href={SUBSCRIPTIONS_SERVICE_URL}
                 className="btn btn-default"
                 target="_blank"
                 rel="noreferrer"
               >
-                {__('Subscription Watch')}
+                {__('View Subscription Usage')}
               </a>
             }
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The term 'Subscription Watch' is no longer used by Red Hat officially.

In Katello, we have a few places where we need to change this now-outdated term.

Current usage of 'Subscription Watch':
1. New & old host details page - 'System purpose'  - hover over question mark icon and view tooltip.
3. Subscriptions page - Simple Content Access banner
4. Subscriptions page - 'Subscription Watch' button

Existing wording:
1. 'System purpose allows you to set the system's intended use on your network and improves the reporting of usage in Subscription Watch.'
2. 'This organization has Simple Content Access enabled. Hosts are not required to have subscriptions attached to access repositories.
Learn more about your overall subscription usage at [Subscription Watch].' (links to https://access.redhat.com/articles/subscription-watch)
3. Button text is 'Subscription Watch' - links to same article as above

New wording (per Jamie Prevatt):
1. 'System purpose enables you to set the system's intended use on your network and improves reporting accuracy in the Subscriptions service of the Red Hat Hybrid Cloud Console.'
2. 'This organization has Simple Content Access enabled. Hosts are not required to have subscriptions attached to access repositories. Learn more about your overall subscription usage with the [Subscriptions service].' (URL should be changed to the official documentation at https://access.redhat.com/documentation/en-us/subscription_central/2021/html-single/getting_started_with_the_subscriptions_service/index)
3. New button text 'View Subscription Usage' - links to the actual app at https://console.redhat.com/subscriptions

#### What are the testing steps for this pull request?

view changes in the following locations
1. New host details page
2. Old content host details page
3. Subscriptions page - banner
4. Subscriptions page - button 
