### PR TITLE
Fixes #35723 - CV dashboard widget hides generated

### DIFF
--- a/app/views/dashboard/_content_views_widget.html.erb
+++ b/app/views/dashboard/_content_views_widget.html.erb
@@ -3,7 +3,7 @@
 </h4>
 
 <% organizations = Organization.current.present? ? [Organization.current] : User.current.allowed_organizations %>
-<% histories = Katello::ContentViewHistory.includes(:content_view_version => [:content_view]).includes(:task, :environment).in_organizations(organizations) %>
+<% histories = Katello::ContentViewHistory.includes(:content_view_version => [:content_view]).includes(:task, :environment).in_organizations(organizations).where("#{Katello::ContentView.table_name}.generated_for" => :none) %>
 <% histories = histories.readable.limit(6) %>
 
 <% if histories.empty? %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Hide generated content views from the Content View Dashboard widget.

#### What are the testing steps for this pull request?

- Export/Import repositories/content views 
- Go to Main Dashboard

Before PR
You'd see the generated `Export-*` content views
 
After PR
No generated content views