### PR TITLE
Fixes #35657 - Fix orphan delete

### DIFF
--- a/app/services/katello/pulp3/ansible_collection.rb
+++ b/app/services/katello/pulp3/ansible_collection.rb
@@ -30,21 +30,24 @@ module Katello
       end
 
       def self.insert_child_associations(units, pulp_id_to_id)
-        tag_names = units.map { |unit| unit['tags'].map { |tag| tag[:name] } }.flatten
-        tag_rows = tag_names.map { |name| {name: name } }
-        Katello::AnsibleTag.insert_all(tag_rows, unique_by: [:name]) if tag_rows.any?
-
+        insert_tags units
         collection_tag_rows = []
         units.each do |unit|
           katello_id = pulp_id_to_id[unit['pulp_href']]
           #delete old tags
-          unit_tags = unit['tags'].map { |tag| tag[:name] }
+          unit_tags = unit['tags']&.map { |tag| tag[:name] }
           Katello::AnsibleCollectionTag.where(:ansible_collection_id => katello_id).where.not(:ansible_tag_id => Katello::AnsibleTag.where(:name => unit_tags)).delete_all
-          collection_tag_rows += Katello::AnsibleTag.where(:name => unit_tags).pluck(:id).map { |tag_id| {ansible_collection_id: katello_id, ansible_tag_id: tag_id} }
+          collection_tag_rows += Katello::AnsibleTag.where(:name => unit_tags)&.pluck(:id)&.map { |tag_id| {ansible_collection_id: katello_id, ansible_tag_id: tag_id} }
         end
 
         collection_tag_rows.flatten!
         Katello::AnsibleCollectionTag.insert_all(collection_tag_rows, unique_by: [:ansible_collection_id, :ansible_tag_id]) unless collection_tag_rows.empty?
+      end
+
+      def self.insert_tags(units)
+        tag_names = units.map { |unit| unit['tags']&.map { |tag| tag[:name] } }&.flatten
+        tag_rows = tag_names&.compact&.map { |name| {name: name } }
+        Katello::AnsibleTag.insert_all(tag_rows, unique_by: [:name]) if tag_rows.any?
       end
     end
   end

--- a/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
+++ b/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
@@ -26,7 +26,7 @@ module Katello
           api = repo_type.pulp3_api(smart_proxy)
           version_hrefs = api.repository_versions
           orphan_version_hrefs = api.list_all.collect do |pulp_repo|
-            mirror_repo_versions = api.versions_list_for_repository(pulp_repo.pulp_href, ordering: :_created)
+            mirror_repo_versions = api.versions_list_for_repository(pulp_repo.pulp_href, ordering: ['-pulp_created'])
             version_hrefs = mirror_repo_versions.select { |repo_version| repo_version.number != 0 }.collect { |version| version.pulp_href }
 
             version_hrefs - [pulp_repo.latest_version_href]
@@ -83,7 +83,7 @@ module Katello
 
           remotes.each do |remote|
             if !repo_names.include?(remote.name) && !acs_remotes.include?(remote.pulp_href)
-              tasks << api.delete_remote(href: remote.pulp_href)
+              tasks << api.delete_remote(remote.pulp_href)
             end
           end
         end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
1. Allows indexing ansible collections without tags
2. Allow orphan cleanup on proxies
#### Considerations taken when implementing this change?
Pulp deb has an issue with syncing content to proxies I ran into during working on this. I have filed an issue for that.
#### What are the testing steps for this pull request?
Create repos of all types.
Sync a proxy with library environment
Move proxy to a different env and sync again
On console run bundle exec rails katello:delete_orphaned_content.