### PR TITLE
Fixes #35735 - Stub pulp3support? for test smart proxy

### DIFF
--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -502,7 +502,11 @@ module ::Actions::Katello::Repository
 
   class UploadDockerTest < TestBase
     let(:action_class) { ::Actions::Katello::Repository::ImportUpload }
-    setup { SmartProxy.stubs(:pulp_primary).returns(SmartProxy.new) }
+    setup do
+      pulp3_proxy = FactoryBot.create(:smart_proxy, :with_pulp3)
+      SmartProxy.stubs(:pulp_primary).returns(pulp3_proxy)
+      SmartProxy.any_instance.stubs(:pulp3_support?).returns true
+    end
     it 'plans' do
       action.expects(:action_subject).with(docker_repository)
 

--- a/test/actions/pulp3/orchestration/multi_copy_all_units_test.rb
+++ b/test/actions/pulp3/orchestration/multi_copy_all_units_test.rb
@@ -40,7 +40,7 @@ module ::Actions::Pulp3
       @repo_clone.reload
 
       refute_empty @repo.rpms
-      assert_equal @repo.rpms.sort, @repo_clone.rpms.sort
+      assert_equal @repo.rpms.order(:id), @repo_clone.rpms.order(:id)
       refute_nil(@repo.version_href)
       refute_nil(@repo_clone.version_href)
       assert_not_equal @repo.version_href, @repo_clone.version_href

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -286,7 +286,7 @@ module Katello
     end
 
     def test_enabled_repositories
-      @host.content_facet = ::Katello::Host::ContentFacet.find_by(uuid: 'abcdefghi')
+      @host.content_facet = ::Katello::Host::ContentFacet.find_by(uuid: 'content_facet_one')
 
       get :enabled_repositories, params: { :host_id => @host.id }
       response_body_hash = JSON.parse(response.body)

--- a/test/fixtures/models/katello_content_facets.yml
+++ b/test/fixtures/models/katello_content_facets.yml
@@ -2,16 +2,16 @@ content_facet_one:
   host_id:  <%= ActiveRecord::FixtureSet.identify(:one) %>
   content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_view) %>
   lifecycle_environment_id: <%= ActiveRecord::FixtureSet.identify(:library) %>
-  uuid: "abcdefghi"
+  uuid: "content_facet_one"
 
 content_facet_two:
   host_id:  <%= ActiveRecord::FixtureSet.identify(:two) %>
   content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_dev_view) %>
   lifecycle_environment_id: <%= ActiveRecord::FixtureSet.identify(:dev) %>
-  uuid: "abcdefghi"
+  uuid: "content_facet_two"
 
 without_errata:
   host_id:  <%= ActiveRecord::FixtureSet.identify(:without_errata) %>
   content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_view) %>
   lifecycle_environment_id: <%= ActiveRecord::FixtureSet.identify(:library) %>
-  uuid: "abcdefghi"
+  uuid: "without_errata"

--- a/test/models/content_view_version_test.rb
+++ b/test/models/content_view_version_test.rb
@@ -129,7 +129,13 @@ module Katello
       cv = katello_content_views(:acme_default)
       cvv = cv.versions.first
 
-      assert cvv.repositories.generic_type.count > 0
+      assert_includes Katello::RootRepository.where(id: cvv.repositories.pluck(:root_id)).pluck(:content_type).uniq, "python"
+
+      #stub RepositoryTypeManager to return python
+      Katello::RepositoryTypeManager.stubs(:indexable_content_types).returns(
+        [Katello::RepositoryType::ContentType.new({model_class: Katello::GenericContentUnit, content_type: 'python_package'})]
+      )
+
       cvv.update_content_counts!
       counts = cvv.content_counts_map
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
stub :pulp3_support? to return true for intermittently failing test.
#### Considerations taken when implementing this change?
This is safe to do as the mock proxy should return true for docker support anyway. It sometimes randomly returns false due to race conditions or whatever reason on CI. Safest option is to stub to return true.
#### What are the testing steps for this pull request?
Run the CI tests a few (hundred?) times. 😝 