### PR TITLE
Fixes #35736 - clean orphaned alternate content sources from smart proxies

### DIFF
--- a/app/lib/actions/pulp3/orchestration/orphan_cleanup/remove_orphans.rb
+++ b/app/lib/actions/pulp3/orchestration/orphan_cleanup/remove_orphans.rb
@@ -11,6 +11,7 @@ module Actions
                 if proxy.pulp_mirror?
                   plan_action(Actions::Pulp3::OrphanCleanup::RemoveUnneededRepos, proxy)
                   plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanDistributions, proxy)
+                  plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanAlternateContentSources, proxy)
                   plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanRemotes, proxy)
                 end
               end

--- a/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_alternate_content_sources.rb
+++ b/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_alternate_content_sources.rb
@@ -1,0 +1,16 @@
+module Actions
+  module Pulp3
+    module OrphanCleanup
+      class DeleteOrphanAlternateContentSources < Pulp3::AbstractAsyncTask
+        def plan(smart_proxy)
+          plan_self(:smart_proxy_id => smart_proxy.id)
+        end
+
+        def invoke_external_task
+          smart_proxy_service = ::Katello::Pulp3::SmartProxyRepository.instance_for_type(smart_proxy)
+          smart_proxy_service.delete_orphan_alternate_content_sources
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds alternate content source orphan cleanup.

#### Considerations taken when implementing this change?
ACSs shouldn't need to be cleaned from the main Katello server since a reset will clear out the Pulpcore database.

#### What are the testing steps for this pull request?
1) Create some ACSs on a smart proxy
2) Run orphan cleanup
3) See that it succeeds
4) Destroy the ACSs in Katello via the database (ensure the `SmartProxyAlternateContentSources` are destroyed too)
5) Run orphan cleanup
6) See that the ACSs on the smart proxy get deleted in Pulp
  - You can check this via Dynflow