### PR TITLE
Fixes #35604 - fix repository sets to reflect SCA status on direct load

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -169,12 +169,12 @@ const RepositorySetsTab = () => {
     organization_id: orgId,
   } = hostDetails;
 
-  const organizationDetails = useSelector(state => selectOrganization(state, orgId));
-  const orgStatus = useSelector(state => selectOrganizationStatus(state, orgId));
-
   const {
     simple_content_access: simpleContentAccess,
-  } = organizationDetails;
+  } = useSelector(state => selectOrganization(state, orgId));
+  const orgStatus = useSelector(state => selectOrganizationStatus(state, orgId));
+  const orgNotLoaded = orgStatus !== STATUS.RESOLVED;
+
   const canDoContentOverrides = can(
     editHosts,
     userPermissionsFromHostDetails({ hostDetails }),
@@ -258,10 +258,10 @@ const RepositorySetsTab = () => {
   );
 
   useEffect(() => {
-    if (orgId && orgStatus !== STATUS.RESOLVED) {
+    if (orgId && orgNotLoaded) {
       dispatch(getOrganization({ orgId }));
     }
-  }, [orgId, orgStatus, dispatch]);
+  }, [orgId, orgNotLoaded, dispatch]);
 
   const response = useSelector(state => selectAPIResponse(state, REPOSITORY_SETS_KEY));
   const { results, error: errorSearchBody, ...metadata } = response;
@@ -289,7 +289,7 @@ const RepositorySetsTab = () => {
     }
   }, [hostDetailsStatus, nonLibraryHost]);
 
-  if (!hostId) return <Skeleton />;
+  if (!hostId || orgNotLoaded) return <Skeleton />;
   const updateResults = newResponse => dispatch({
     type: `${REPOSITORY_SETS_KEY}_SUCCESS`,
     key: REPOSITORY_SETS_KEY,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fix a bug in repository sets to reflect SCA status on direct load.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Ensure Org has simple content access
2. Create a Custom repository
3. Register a host
4. Go to host => manage statuses
5. Remove the subscription status
6. Now go to the repository sets page and copy the url
7. Make sure you are able to see repo sets
8. log off
9. log back in
10. directly go to the reposets url

Before
No Repo sets displayed.

After
Repo sets displayed.