### PR TITLE
Fixes #35614 - extra modular packages and errata copied into CVV

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -152,6 +152,10 @@ module Katello
       end
     end
 
+    def module_stream_specs
+      packages.collect { |package| package.module_streams.map(&:module_spec) }.flatten.uniq
+    end
+
     def module_stream_objects
       streams = packages.map do |pack|
         pack.module_streams

--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -439,7 +439,8 @@ module Katello
 
           errata_to_include = filter_errata_by_pulp_href(source_repository.errata, content_unit_hrefs,
                                                          source_repository.rpms.pluck(:filename) +
-                                                         source_repository.srpms.pluck(:filename)) -
+                                                         source_repository.srpms.pluck(:filename),
+                                                         source_repository.module_streams.map(&:module_spec)) -
                                                          all_excluded_errata
           content_unit_hrefs += errata_to_include.collect do |erratum|
             erratum.repository_errata.where(repository_id: source_repository.id).pluck(:erratum_pulp3_href)

--- a/test/fixtures/models/katello_rpms.yml
+++ b/test/fixtures/models/katello_rpms.yml
@@ -50,6 +50,13 @@ modular:
   nvra:     mod-99-108.x86_64
   modular: true
 
+modular_with_erratum_package:
+  name:     modular_with_erratum_package
+  pulp_id:  foobarmodularrpm
+  filename: foobarmod-1.3.4.rpm
+  modular:  true
+
+
 
 one_two:
   name:     one

--- a/test/lib/util/errata_test.rb
+++ b/test/lib/util/errata_test.rb
@@ -36,29 +36,60 @@ module Katello
       @erratum2.save!
 
       @empty_erratum = Katello::Erratum.create(:errata_id => "empty", :pulp_id => "empty")
+
+      @modular_erratum = katello_errata(:modular)
+      @modular_rpm = katello_rpms(:modular_with_erratum_package)
+      @modular_erratum_package = @modular_erratum.packages.first
+      @module_stream = @modular_erratum_package.module_streams.first
+    end
+
+    # https://projects.theforeman.org/issues/35614
+    def test_filter_by_pulp_href_excludes_errata_with_missing_module_streams
+      # If the erratum's modular RPM count is no longer 1, the test no longer makes sense.
+      # Ensure that all modular packages are accounted for in the final assertion.
+      # The same goes for the number of module streams that the single RPM belongs to.
+      assert_equal 1, @modular_erratum.packages.count
+      assert_equal 1, @modular_erratum_package.module_streams.count
+      assert_equal [@erratum], filter_errata_by_pulp_href([@modular_erratum, @erratum],
+                                                          [@fedora_one.pulp_id, @fedora_two.pulp_id, @modular_rpm.pulp_id],
+                                                          [@fedora_one.filename, @fedora_two.filename, @modular_erratum_package.filename],
+                                                          [@module_stream.module_spec])
+    end
+
+    # https://projects.theforeman.org/issues/35614
+    def test_filter_by_pulp_href_includes_errata_with_proper_module_streams
+      # If the erratum's modular RPM count is no longer 1, the test no longer makes sense.
+      # Ensure that all modular packages are accounted for in the final assertion.
+      # The same goes for the number of module streams that the single RPM belongs to.
+      assert_equal 1, @modular_erratum.packages.count
+      assert_equal 1, @modular_erratum_package.module_streams.count
+      assert_equal [@erratum, @modular_erratum].sort, filter_errata_by_pulp_href([@modular_erratum, @erratum],
+                                                          [@fedora_one.pulp_id, @fedora_two.pulp_id, @modular_rpm.pulp_id, @module_stream.pulp_id],
+                                                          [@fedora_one.filename, @fedora_two.filename, @modular_erratum_package.filename],
+                                                          [@module_stream.module_spec])
     end
 
     def test_filter_by_pulp_id_returns_nothing_with_empty_list_of_pulp_ids
-      assert_empty filter_errata_by_pulp_href([@erratum, @erratum2], [], [@fedora_one.filename, @fedora_two.filename])
+      assert_empty filter_errata_by_pulp_href([@erratum, @erratum2], [], [@fedora_one.filename, @fedora_two.filename], [])
     end
 
     def test_filter_by_pulp_id_returns_nothing_with_empty_list_of_errata
-      assert_empty filter_errata_by_pulp_href([], [@fedora_one.pulp_id], [@fedora_one.filename, @fedora_two.filename])
+      assert_empty filter_errata_by_pulp_href([], [@fedora_one.pulp_id], [@fedora_one.filename, @fedora_two.filename], [])
     end
 
-    # "Proper" errata here means errata with no RPMs that exist in its source repo any empty errata.
+    # "Proper" errata here means errata with no RPMs that exist in its source repo and any empty errata.
     def test_filter_by_pulp_id_returns_proper_errata_if_no_matching_packages
-      assert_equal [@erratum2, @empty_erratum].sort, filter_errata_by_pulp_href([@erratum, @erratum2, @empty_erratum], ["floop"], [@fedora_one.filename, @fedora_two.filename]).sort
+      assert_equal [@erratum2, @empty_erratum].sort, filter_errata_by_pulp_href([@erratum, @erratum2, @empty_erratum], ["floop"], [@fedora_one.filename, @fedora_two.filename], []).sort
     end
 
     def test_filter_by_pulp_id_returns_proper_errata_with_some_matching_packages
-      assert_equal [@erratum2, @empty_erratum].sort, filter_errata_by_pulp_href([@erratum, @erratum2, @empty_erratum], [@fedora_one.pulp_id], [@fedora_one.filename, @fedora_two.filename]).sort
+      assert_equal [@erratum2, @empty_erratum].sort, filter_errata_by_pulp_href([@erratum, @erratum2, @empty_erratum], [@fedora_one.pulp_id], [@fedora_one.filename, @fedora_two.filename], []).sort
     end
 
     def test_filter_by_pulp_id_identifies_errata_with_all_matching_packages
       assert_equal [@erratum, @erratum2, @empty_erratum].sort, filter_errata_by_pulp_href([@erratum, @erratum2, @empty_erratum],
         [@fedora_one.pulp_id, @fedora_two.pulp_id],
-        [@fedora_one.filename, @fedora_two.filename]).sort
+        [@fedora_one.filename, @fedora_two.filename], []).sort
     end
 
     def test_filter_by_pulp_id_includes_errata_with_missing_packages_not_in_source_repo
@@ -68,7 +99,7 @@ module Katello
                                        filename: 'missing-package-1.0.el27.noarch.rpm')
       assert_equal [@erratum, @erratum2, @empty_erratum].sort, filter_errata_by_pulp_href([@erratum, @erratum2, @empty_erratum],
                                                           [@fedora_one.pulp_id, @fedora_two.pulp_id],
-                                                          [@fedora_one.filename, @fedora_two.filename]).sort
+                                                          [@fedora_one.filename, @fedora_two.filename], []).sort
     end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Causes errata to no longer be copied into content view versions unless both its module streams and packages are satisfied.

#### Considerations taken when implementing this change?
This affects both copy_all_units and multi_copy_all_units. They should both work however since the parent method is called the same way.

#### What are the testing steps for this pull request?
Follow the reproducer steps on the issue: https://projects.theforeman.org/issues/35614