### PR TITLE
Fixes #35740 - Composite content view versions can be emptied out during same-repo merging

### DIFF
--- a/app/lib/actions/pulp3/orchestration/repository/copy_all_units.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/copy_all_units.rb
@@ -24,6 +24,7 @@ module Actions
                   copy_actions = []
                   #since we're creating a new version from the first repo, start copying at the 2nd
                   source_repositories[1..-1].each do |source_repo|
+                    # TODO: In a future refactor, can :copy_all be utilized?  Filters should not be needed in this code segment.
                     copy_actions << plan_action(Actions::Pulp3::Repository::CopyContent, source_repo, smart_proxy, target_repo,
                                                 filter_ids: filter_ids, solve_dependencies: solve_dependencies,
                                                 rpm_filenames: rpm_filenames, remove_all: false)

--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -210,7 +210,8 @@ module Katello
               tasks << add_content(slice, first_slice)
               first_slice = false
             end
-          else
+          # If we're merging composite cv repositories, don't clear out the Pulp repository.
+          elsif remove_all
             tasks << remove_all_content
           end
           tasks

--- a/test/services/katello/pulp3/repository/yum/yum_test.rb
+++ b/test/services/katello/pulp3/repository/yum/yum_test.rb
@@ -12,6 +12,12 @@ module Katello
             @proxy = SmartProxy.pulp_primary
           end
 
+          def test_copy_units_does_not_clear_repo_during_composite_merger
+            service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
+            service.expects(:remove_all_content).never
+            service.copy_units(@repo, [], false)
+          end
+
           def test_additional_content_hrefs_properly_includes_errata
             service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
             rpm = ::Katello::Rpm.create(name: "foobar", filename: "foobar-1.3.4.rpm", nvra: "foobar-1.2.3", pulp_id: "test")


### PR DESCRIPTION


#### What are the changes introduced in this pull request?
This PR stops repositories from being completely cleared out at composite CV publish time.  The `remove_all` flag comes from a bit of the `CopyAllUnits` action that only runs when the related CV is composite.

#### Considerations taken when implementing this change?
I was considering refactoring the part of `CopyAllUnits` that pertains to composite CVs to use `copy_all`, since filters shouldn't be present.  However, since this piece of code may make it back to older versions of Katello, I wanted to keep it as simple as possible. I left a TODO for getting to this down the road.

#### What are the testing steps for this pull request?
Follow the steps from the issue:
1) Create two component content views with the same repository in it
2) Add a filter to one of the repositories to clear out all content
3) Publish both content views
4) Create a composite content view with both component content views in it
5) Publish that content view
6) If there is any content in the composite content view version, add `source_repositories = source_repositories.reverse` here: https://github.com/Katello/katello/blob/master/app/lib/actions/pulp3/orchestration/repository/copy_all_units.rb#L21
7) The next publish of the composite version should result in no content being available in the component content view version

Also, it would be work running an incremental update on a component CV version that is part of a composite and ensuring that the resulting composite incremental CV version makes sense.  In particular, try running incremental update twice on a version with different RPM packages.  For example, incrementally add foo.rpm to version 1.0, creating 1.1, and then incrementally add bar.rpm to version 1.0, creating version 1.2. I want to ensure that, in the incremental update case, the content is cleared out appropriately. There have been issues in the past with incremental versions affecting each other (e.g. version 1.1 gets foo.rpm, version 1.2 gets bar.rpm and foo.rpm when it was only requested to get bar.rpm).