### PR TITLE
Fixes #35741 - Add Virtual guests to System properties card

### DIFF
--- a/webpack/components/extensions/HostDetails/DetailsTabCards/RegistrationCard.js
+++ b/webpack/components/extensions/HostDetails/DetailsTabCards/RegistrationCard.js
@@ -77,7 +77,7 @@ const RegistrationCard = ({ isExpandedGlobal, hostDetails }) => {
           <RegisteredBy user={login} activationKeys={activationKeys} />
         </DescriptionListGroup>
         <DescriptionListGroup>
-          <DescriptionListTerm>{__('Registered through')}</DescriptionListTerm>
+          <DescriptionListTerm>{__('Content source')}</DescriptionListTerm>
           <DescriptionListDescription>{registeredThrough}</DescriptionListDescription>
         </DescriptionListGroup>
       </DescriptionList>

--- a/webpack/components/extensions/HostDetails/DetailsTabCards/SystemPropertiesCardExtensions.js
+++ b/webpack/components/extensions/HostDetails/DetailsTabCards/SystemPropertiesCardExtensions.js
@@ -5,8 +5,10 @@ import {
   DescriptionListTerm,
   DescriptionListDescription,
   ClipboardCopy,
+  Label,
 } from '@patternfly/react-core';
-import { translate as __ } from 'foremanReact/common/I18n';
+import { sprintf, translate as __ } from 'foremanReact/common/I18n';
+import { propsToCamelCase } from 'foremanReact/common/helpers';
 
 export const SystemPropertiesCardSubscription = ({ hostDetails }) => {
   const subscriptionUuid = hostDetails?.subscription_facet_attributes?.uuid;
@@ -32,6 +34,61 @@ SystemPropertiesCardSubscription.propTypes = {
 };
 
 SystemPropertiesCardSubscription.defaultProps = {
+  hostDetails: {},
+};
+
+export const SystemPropertiesCardVirtualization = ({ hostDetails }) => {
+  if (!hostDetails?.subscription_facet_attributes) return null;
+
+  const {
+    virtualGuests,
+    hypervisor,
+    virtualHost,
+  } = propsToCamelCase(hostDetails.subscription_facet_attributes);
+  const virtualGuestIds = `name ^ (${virtualGuests.map(guest => guest.name).join(', ')})`;
+
+  return (
+    <>
+      {hypervisor &&
+        <DescriptionListGroup>
+          <DescriptionListTerm>{__('Virtual guests')}</DescriptionListTerm>
+          <DescriptionListDescription>
+            <a href={`/hosts?search=${encodeURI(virtualGuestIds)}`}>
+              <Label color="blue" className="virtual-guests-label">
+                {sprintf(__('%s guests'), virtualGuests.length)}
+              </Label>
+            </a>
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      }
+      {virtualHost &&
+        <DescriptionListGroup>
+          <DescriptionListTerm>{__('Virtual host')}</DescriptionListTerm>
+          <DescriptionListDescription>
+            <a href={`/new/hosts/${virtualHost.name}`}>
+              {virtualHost.name}
+            </a>
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      }
+    </>
+  );
+};
+
+SystemPropertiesCardVirtualization.propTypes = {
+  hostDetails: PropTypes.shape({
+    subscription_facet_attributes: PropTypes.shape({
+      virtual_guests: PropTypes.arrayOf(PropTypes.shape({})),
+      hypervisor: PropTypes.bool,
+      virtual_host: PropTypes.shape({
+        id: PropTypes.number,
+        name: PropTypes.string,
+      }),
+    }),
+  }),
+};
+
+SystemPropertiesCardVirtualization.defaultProps = {
   hostDetails: {},
 };
 

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -22,6 +22,7 @@ import HostCollectionsCard from './components/extensions/HostDetails/Cards/HostC
 import { hostIsNotRegistered } from './components/extensions/HostDetails/hostDetailsHelpers';
 import {
   SystemPropertiesCardSubscription,
+  SystemPropertiesCardVirtualization,
   SystemPropertiesCardTracer,
 } from './components/extensions/HostDetails/DetailsTabCards/SystemPropertiesCardExtensions';
 import HostActionsBar from './components/extensions/HostDetails/ActionsBar';
@@ -61,6 +62,7 @@ addGlobalFill('host-tab-details-cards', 'Installed products', <InstalledProducts
 addGlobalFill('host-tab-details-cards', 'Registration details', <RegistrationCard key="registration-details" />, 200);
 addGlobalFill('host-details-tab-properties-1', 'Subscription UUID', <SystemPropertiesCardSubscription key="subscription-uuid" />);
 addGlobalFill('host-details-tab-properties-2', 'Tracer', <SystemPropertiesCardTracer key="tracer-status" />);
+addGlobalFill('host-details-tab-properties-3', 'Virtualization', <SystemPropertiesCardVirtualization key="virtualization" />);
 
 addGlobalFill(
   'host-details-kebab',


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
System properties card updates in Details tab.
- Virtual guests  (for a provider host)
- Registered through  (if registered)
- Virtual host  (for a VM host)

#### Considerations taken when implementing this change?
Depends on https://github.com/theforeman/foreman/pull/9509

mockup: https://jamboard.google.com/d/1GSnT2xhhNfek2DMr2wInAxABEZWeZ4X9OnFCB56Z4Yw/viewer?pli=1

#### What are the testing steps for this pull request?
- Check out the Foreman PR
- Check out the Katello PR
- Ensure new attributes show up at the bottom of the System Properties card in Details tab