### PR TITLE
Fixes #35683 - check for content facet before refreshing content host statuses

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -124,8 +124,10 @@ module Katello
       end
 
       def refresh_content_host_status
-        self.host_statuses.where(type: ::Katello::HostStatusManager::STATUSES.map(&:name)).each do |status|
-          status.refresh!
+        if content_facet&.present?
+          self.host_statuses.where(type: ::Katello::HostStatusManager::STATUSES.map(&:name)).each do |status|
+            status.refresh!
+          end
         end
         refresh_global_status
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When refreshing content host status, our logic didn't first check to see if the host even has a content facet. This caused errors such as that described in https://community.theforeman.org/t/build-status-for-host-without-content-can-not-be-set-to-build-refresh-content-host-statuses-fails/30487 

#### Considerations taken when implementing this change?

I originally just had `return unless content_facet`. But I thought it'd still be prudent to refresh the non-content statuses, so I changed it so that it reaches the `refresh_global_status` call regardless.

#### What are the testing steps for this pull request?

I'm not that good at the provisioning / build stuff, so here's how I faked it in Rails console:

```
host = Host.find 1 # make sure this host doesn't have content, e.g. host.content_facet returns []
host.host_statuses << Katello::ErrataStatus.new(host: host)
host.refresh_content_host_status
```

Before this PR:
```
NoMethodError: undefined method `security' for nil:NilClass
Did you mean?  secure_token
```

After:
```
0
```

