### PR TITLE
Fixes #35752 - Make errata search filtered with ID work in Web UI

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -24,7 +24,8 @@ module Katello
     has_many :cves, :class_name => "Katello::ErratumCve", :dependent => :destroy, :inverse_of => :erratum
     has_many :packages, :class_name => "Katello::ErratumPackage", :dependent => :destroy, :inverse_of => :erratum
 
-    scoped_search :on => :errata_id, :only_explicit => true
+    scoped_search :on => :id, :rename => :db_id, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
+    scoped_search :on => :errata_id, :complete_value => true, :only_explicit => true
     scoped_search :on => :errata_id, :rename => :id, :complete_value => true, :only_explicit => true
     scoped_search :on => :title
     scoped_search :on => :title, :rename => :synopsis, :complete_value => true, :only_explicit => true


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add `db_id` to allow errata search on errata's DB `id`.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Before
Try to search the Errata from GUI with Errata ID : " errata_id = RHSA-2020:2031"
Try to search the Errata from GUI with ID: "id  =  RHSA-2020:2031"

After
Try to search the Errata from GUI with: " errata_id = RHSA-2020:2031"
Try to search the Errata from GUI with: " id = RHSA-2020:2031"
Try to search the Errata from GUI with: "db_id  =  6597"