### PR TITLE
Fixes #35754 - ACS refresh by name via hammer does not work

### DIFF
--- a/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
+++ b/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
@@ -27,6 +27,7 @@ module Katello
     end
 
     api :GET, "/alternate_content_sources", N_("List alternate content sources.")
+    param :name, String, :desc => N_("Name of the alternate content source"), :required => false
     param_group :search, Api::V2::ApiController
     add_scoped_search_description_for(AlternateContentSource)
     def index
@@ -52,7 +53,9 @@ module Katello
     end
 
     def index_relation
-      AlternateContentSource.readable.distinct
+      query = AlternateContentSource.readable.distinct
+      query = query.where(name: params[:name]) if params[:name]
+      query
     end
 
     api :GET, '/alternate_content_sources/:id', N_('Show an alternate content source.')

--- a/test/controllers/api/v2/alternate_content_sources_controller_test.rb
+++ b/test/controllers/api/v2/alternate_content_sources_controller_test.rb
@@ -35,6 +35,14 @@ module Katello
       assert_template 'api/v2/alternate_content_sources/index'
     end
 
+    def test_index_with_name
+      response = get :index, params: { name: @acs.name }
+
+      assert_response :success
+      assert_template 'api/v2/alternate_content_sources/index'
+      assert_response_ids response, [@acs.id]
+    end
+
     def test_show
       get :show, params: { :id => @acs.id }
 

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -114,13 +114,6 @@ module Katello
       end
     end
 
-    def assert_response_ids(response, expected)
-      body = JSON.parse(response.body)
-      found_ids = body['results'].map { |item| item['id'] }
-      refute_empty expected
-      assert_equal expected.sort, found_ids.sort
-    end
-
     def test_index_with_product_id
       ids = Repository.in_product(@product).where(:library_instance_id => nil).pluck(:id)
 

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -165,6 +165,13 @@ class ActionController::TestCase
     @unauth_permissions = [@create_permission, @update_permission, @destroy_permission, @sync_permission]
   end
 
+  def assert_response_ids(response, expected)
+    body = JSON.parse(response.body)
+    found_ids = body['results'].map { |item| item['id'] }
+    refute_empty expected
+    assert_equal expected.sort, found_ids.sort
+  end
+
   def assert_response(type, message = nil)
     if type == :success
       if response.body.present? && /json/.match(response.headers['Content-Type'])


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds the ability to list ACSs by name. ACS refresh via hammer failed previously because hammer first calls the index API endpoint to find the ACS with the name in question. Then it calls the refresh API using the ID of the returned ACS.  The ACS index endpoint didn't support a name argument other than in the scoped search, so all ACSs were returned, causing the error.

#### Considerations taken when implementing this change?
I moved the `assert_response_ids` method out of the repositories controller test so it could be utilized by all tests.

#### What are the testing steps for this pull request?
1) Make an ACS
2) Try refreshing it via hammer
3) Try listing ACSs with their name via the API and hammer.