### PR TITLE
Fixes #35730 - Show include artifact checkboxes for rpm and module stream

### DIFF
--- a/webpack/components/Table/EmptyStateMessage.js
+++ b/webpack/components/Table/EmptyStateMessage.js
@@ -11,7 +11,7 @@ import {
 } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { CubeIcon, ExclamationCircleIcon, SearchIcon, CheckCircleIcon } from '@patternfly/react-icons';
+import { CubeIcon, ExclamationCircleIcon, SearchIcon, CheckCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { global_danger_color_200 as dangerColor, global_success_color_100 as successColor } from '@patternfly/react-tokens';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectHostDetailsClearSearch } from '../extensions/HostDetails/HostDetailsSelectors';
@@ -76,8 +76,8 @@ const EmptyStateMessage = ({
       >
         <KatelloEmptyStateIcon
           error={!!error}
-          search={search}
-          customIcon={customIcon}
+          search={search && !showPrimaryAction}
+          customIcon={PlusCircleIcon}
           happyIcon={happy}
         />
         <Title headingLevel="h2" size="lg" ouiaId="empty-state-title">

--- a/webpack/scenes/ContentViews/Details/Filters/ArtifactsWithNoErrata.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ArtifactsWithNoErrata.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Checkbox } from '@patternfly/react-core';
+import { Switch } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { editCVFilter } from '../ContentViewDetailActions';
 
@@ -23,24 +23,24 @@ export const ArtifactsWithNoErrataRenderer = ({ filterDetails }) => {
   const getLabel = () => {
     switch (true) {
     case type === 'modulemd' && inclusion:
-      return __('Include all Module Streams with no errata.');
+      return __('Include all module streams not associated to any errata');
     case type === 'modulemd' && !inclusion:
-      return __('Exclude all Module Streams with no errata.');
+      return __('Exclude all module streams not associated to any errata');
     case !inclusion:
-      return __('Exclude all RPMs with no errata.');
+      return __('Exclude all RPMs not associated to any errata');
     default:
-      return __('Include all RPMs with no errata.');
+      return __('Include all RPMs not associated to any errata');
     }
   };
 
-  return (<Checkbox
+  return (<Switch
     ouiaId="artifactsNoErrata"
     id="artifactsNoErrata"
     name="artifactsNoErrata"
-    label=<p style={{ marginTop: '4px' }}>{getLabel()}</p>
+    label={getLabel()}
     isChecked={artifactsNoErrata}
     isDisabled={isLoading}
-    onChange={setArtifactsNoErrata}
+    onChange={checked => setArtifactsNoErrata(checked)}
   />);
 };
 

--- a/webpack/scenes/ContentViews/Details/Filters/CVModuleStreamFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVModuleStreamFilterContent.js
@@ -25,7 +25,6 @@ import getContentViewDetails, {
 } from '../ContentViewDetailActions';
 import AddedStatusLabel from '../../../../components/AddedStatusLabel';
 import AffectedRepositoryTable from './AffectedRepositories/AffectedRepositoryTable';
-import { ArtifactsWithNoErrataRenderer } from './ArtifactsWithNoErrata';
 import { ADDED, ALL_STATUSES, NOT_ADDED } from '../../ContentViewsConstants';
 import { hasPermission } from '../../helpers';
 
@@ -275,11 +274,6 @@ const CVModuleStreamFilterContent = ({
                         {__('Remove')}
                       </DropdownItem>]
                     }
-                  />
-                </SplitItem>
-                <SplitItem>
-                  <ArtifactsWithNoErrataRenderer
-                    filterDetails={filterDetails}
                   />
                 </SplitItem>
               </Split>

--- a/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
@@ -6,7 +6,6 @@ import { TableVariant } from '@patternfly/react-table';
 import { Tabs, Tab, TabTitleText, Split, SplitItem, Dropdown, DropdownItem, KebabToggle, Button } from '@patternfly/react-core';
 import { STATUS } from 'foremanReact/constants';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { ArtifactsWithNoErrataRenderer } from './ArtifactsWithNoErrata';
 import onSelect from '../../../../components/Table/helpers';
 import TableWrapper from '../../../../components/Table/TableWrapper';
 import {
@@ -219,11 +218,6 @@ const CVRpmFilterContent = ({
                             {__('Remove')}
                           </DropdownItem>]
                         }
-                      />
-                    </SplitItem>
-                    <SplitItem>
-                      <ArtifactsWithNoErrataRenderer
-                        filterDetails={filterDetails}
                       />
                     </SplitItem>
                   </Split>}

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/CVRpmFilterContent.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/CVRpmFilterContent.test.js
@@ -249,10 +249,10 @@ test('Remove rpm filter rule in a self-closing modal', async (done) => {
   expect(queryByText(cvFilterName)).toBeNull();
   await patientlyWaitFor(() => {
     expect(getByText(cvFilterName)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[0]).toBeInTheDocument();
+    expect(getAllByLabelText('Actions')[1]).toBeInTheDocument();
   });
 
-  getAllByLabelText('Actions')[0].click();
+  getAllByLabelText('Actions')[1].click();
 
   await patientlyWaitFor(() => {
     expect(getByText('Remove')).toBeInTheDocument();
@@ -311,10 +311,10 @@ test('Edit rpm filter rule in a self-closing modal', async (done) => {
   expect(queryByText(cvFilterName)).toBeNull();
   await patientlyWaitFor(() => {
     expect(getByText(cvFilterName)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[0]).toBeInTheDocument();
+    expect(getAllByLabelText('Actions')[1]).toBeInTheDocument();
   });
 
-  getAllByLabelText('Actions')[0].click();
+  getAllByLabelText('Actions')[1].click();
 
   await patientlyWaitFor(() => {
     expect(getByText('Edit')).toBeInTheDocument();

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/ContentViewPackageGroupFilter.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/ContentViewPackageGroupFilter.test.js
@@ -118,10 +118,10 @@ test('Can remove a filter rule', async (done) => {
 
   await patientlyWaitFor(() => {
     expect(getByText(name)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[1]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'false');
   });
-  fireEvent.click(getAllByLabelText('Actions')[1]);
-  expect(getAllByLabelText('Actions')[1]).toHaveAttribute('aria-expanded', 'true');
+  fireEvent.click(getAllByLabelText('Actions')[2]);
+  expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'true');
   await patientlyWaitFor(() => expect(getByText('Remove')).toBeInTheDocument());
   fireEvent.click(getByText('Remove'));
 
@@ -175,10 +175,10 @@ test('Can add a filter rule', async (done) => {
 
   await patientlyWaitFor(() => {
     expect(getByText(name)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Actions')[3]).toHaveAttribute('aria-expanded', 'false');
   });
-  fireEvent.click(getAllByLabelText('Actions')[2]);
-  expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'true');
+  fireEvent.click(getAllByLabelText('Actions')[3]);
+  expect(getAllByLabelText('Actions')[3]).toHaveAttribute('aria-expanded', 'true');
   await patientlyWaitFor(() => expect(getByText('Add')).toBeInTheDocument());
   fireEvent.click(getByText('Add'));
 

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataIDFilter.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataIDFilter.test.js
@@ -132,10 +132,10 @@ test('Can add a filter rule', async (done) => {
 
   await patientlyWaitFor(() => {
     expect(getByText(errataId)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Actions')[3]).toHaveAttribute('aria-expanded', 'false');
   });
-  fireEvent.click(getAllByLabelText('Actions')[2]);
-  expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'true');
+  fireEvent.click(getAllByLabelText('Actions')[3]);
+  expect(getAllByLabelText('Actions')[3]).toHaveAttribute('aria-expanded', 'true');
   await patientlyWaitFor(() => expect(getByText('Add')).toBeInTheDocument());
   fireEvent.click(getByText('Add'));
 
@@ -190,10 +190,10 @@ test('Can remove a filter rule', async (done) => {
 
   await patientlyWaitFor(() => {
     expect(getByText(errataId)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[1]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'false');
   });
-  fireEvent.click(getAllByLabelText('Actions')[1]);
-  expect(getAllByLabelText('Actions')[1]).toHaveAttribute('aria-expanded', 'true');
+  fireEvent.click(getAllByLabelText('Actions')[2]);
+  expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'true');
   await patientlyWaitFor(() => expect(getByText('Remove')).toBeInTheDocument());
   fireEvent.click(getByText('Remove'));
 

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/cvModuleStreamFilter.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/cvModuleStreamFilter.test.js
@@ -132,20 +132,18 @@ test('Can add a filter rule', async (done) => {
 
   await patientlyWaitFor(() => {
     expect(getByText(name)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Actions')[3]).toHaveAttribute('aria-expanded', 'false');
   });
-  fireEvent.click(getAllByLabelText('Actions')[2]);
-  expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'true');
+  fireEvent.click(getAllByLabelText('Actions')[3]);
+  expect(getAllByLabelText('Actions')[3]).toHaveAttribute('aria-expanded', 'true');
   await patientlyWaitFor(() => expect(getByText('Add')).toBeInTheDocument());
   fireEvent.click(getByText('Add'));
-
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(cvFilterScope);
   assertNockRequest(cvFiltersScope);
   assertNockRequest(cvFiltersRuleScope);
   assertNockRequest(cvRequestCallbackScope);
-
   assertNockRequest(moduleStreamsScope, done);
 });
 
@@ -190,10 +188,10 @@ test('Can remove a filter rule', async (done) => {
 
   await patientlyWaitFor(() => {
     expect(getByText(name)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[1]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'false');
   });
-  fireEvent.click(getAllByLabelText('Actions')[1]);
-  expect(getAllByLabelText('Actions')[1]).toHaveAttribute('aria-expanded', 'true');
+  fireEvent.click(getAllByLabelText('Actions')[2]);
+  expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'true');
   await patientlyWaitFor(() => expect(getByText('Remove')).toBeInTheDocument());
   fireEvent.click(getByText('Remove'));
 


### PR DESCRIPTION
Move Include/Exclude all RPMs with no errata and Include/Exclude all module streams with no errata checkboxes on RPM and Module stream filter details view

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a RPM filter and a module stream filter.
2. The Include/Exclude all RPMs with no errata and Include/Exclude all module streams with no errata should be visible and editable even without any filter rules added.