### PR TITLE
Fixes #35714 - Host details -- enable module stream tab for EL variants

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -46,9 +46,13 @@ import {
   userPermissionsFromHostDetails,
 } from '../../hostDetailsHelpers';
 
+const moduleStreamSupported = ({ os, version }) =>
+  os.match(/RedHat|CentOS|Rocky|AlmaLinux|OracleLinux/i) && Number(version) > 7;
 export const hideModuleStreamsTab = ({ hostDetails }) => {
   const osMatch = hostDetails?.operatingsystem_name?.match(/(\w+) (\d+)/);
-  return !(osMatch && osMatch[1].match(/RedHat|CentOS/i) && Number(osMatch[2]) > 7);
+  if (!osMatch) return true;
+  const [, os, version] = osMatch;
+  return !(osMatch && moduleStreamSupported({ os, version }));
 };
 
 const EnabledIcon = ({ streamText, streamInstallStatus, upgradable }) => {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add module stream tab for `Rocky`, `AlmaLinux` and `OracleLinux`.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Verify module stream tab is displayed for `Rocky`, `AlmaLinux` and `OracleLinux`.