### PR TITLE
Fixes #35698 - Show SCA deprecation banner regardless of manifest

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
@@ -12,20 +12,18 @@
  * @requires Notification
  * @requires ApiErrorHandler
  * @requires simpleContentAccessEnabled
- * @requires isManifestImported
  *
  * @description
  *   Provides the functionality for the activation key details action pane.
  */
 angular.module('Bastion.activation-keys').controller('ActivationKeyDetailsController',
-    ['$scope', '$state', '$q', 'translate', 'ActivationKey', 'Organization', 'CurrentOrganization', 'Notification', 'ApiErrorHandler', 'simpleContentAccessEnabled', 'isManifestImported',
-    function ($scope, $state, $q, translate, ActivationKey, Organization, CurrentOrganization, Notification, ApiErrorHandler, simpleContentAccessEnabled, isManifestImported) {
+    ['$scope', '$state', '$q', 'translate', 'ActivationKey', 'Organization', 'CurrentOrganization', 'Notification', 'ApiErrorHandler', 'simpleContentAccessEnabled',
+    function ($scope, $state, $q, translate, ActivationKey, Organization, CurrentOrganization, Notification, ApiErrorHandler, simpleContentAccessEnabled) {
         $scope.defaultRoles = ['Red Hat Enterprise Linux Server', 'Red Hat Enterprise Linux Workstation', 'Red Hat Enterprise Linux Compute Node'];
         $scope.defaultUsages = ['Production', 'Development/Test', 'Disaster Recovery'];
 
         $scope.purposeAddonsCount = 0;
         $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
-        $scope.isManifestImported = isManifestImported;
 
         $scope.organization = Organization.get({id: CurrentOrganization}, function(org) {
             $scope.purposeAddonsCount += org.system_purposes.addons.length;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
@@ -14,14 +14,13 @@
  * @requires deleteHostOnUnregister
  * @requires ContentHostsHelper
  * @requires simpleContentAccessEnabled
- * @requires isManifestImported
  *
  * @description
  *   Provides the functionality for the content host details action pane.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostDetailsController',
-    ['$scope', '$state', '$q', '$location', 'translate', 'Host', 'HostSubscription', 'Organization', 'CurrentOrganization', 'Notification', 'MenuExpander', 'ApiErrorHandler', 'deleteHostOnUnregister', 'ContentHostsHelper', 'simpleContentAccessEnabled', 'isManifestImported',
-    function ($scope, $state, $q, $location, translate, Host, HostSubscription, Organization, CurrentOrganization, Notification, MenuExpander, ApiErrorHandler, deleteHostOnUnregister, ContentHostsHelper, simpleContentAccessEnabled, isManifestImported) {
+    ['$scope', '$state', '$q', '$location', 'translate', 'Host', 'HostSubscription', 'Organization', 'CurrentOrganization', 'Notification', 'MenuExpander', 'ApiErrorHandler', 'deleteHostOnUnregister', 'ContentHostsHelper', 'simpleContentAccessEnabled',
+    function ($scope, $state, $q, $location, translate, Host, HostSubscription, Organization, CurrentOrganization, Notification, MenuExpander, ApiErrorHandler, deleteHostOnUnregister, ContentHostsHelper, simpleContentAccessEnabled) {
         $scope.menuExpander = MenuExpander;
 
         $scope.getHostStatusIcon = ContentHostsHelper.getHostStatusIcon;
@@ -37,7 +36,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
 
         $scope.purposeAddonsCount = 0;
         $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
-        $scope.isManifestImported = isManifestImported;
 
         $scope.panel = {
             error: false,

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/content-access-mode-banner.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/content-access-mode-banner.html
@@ -3,8 +3,8 @@
 This organization has Simple Content Access enabled.  Hosts are not required to have subscriptions attached to access repositories.
   </span>
 </div>
-<div id="non-sca-banner" bst-alert="warning" ng-if="isManifestImported && !simpleContentAccessEnabled">
+<div id="non-sca-banner" bst-alert="warning" ng-if="!simpleContentAccessEnabled">
   <span translate>
-This organization is not using <a target="_blank" href="https://access.redhat.com/articles/simple-content-access">Simple Content Access.</a> Legacy subscription management is deprecated and will be removed in a future version.
+This organization is not using <a target="_blank" href="https://access.redhat.com/articles/simple-content-access">Simple Content Access.</a> Entitlement-based subscription management is deprecated and will be removed in a future version.
   </span>
 </div>

--- a/engines/bastion_katello/test/activation-keys/details/activation-key-details.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/details/activation-key-details.controller.test.js
@@ -80,7 +80,6 @@ describe('Controller: ActivationKeyDetailsController', function() {
             Notification: Notification,
             Organization: Organization,
             simpleContentAccessEnabled: 'simpleContentAccessEnabled',
-            isManifestImported: 'isManifestImported'
         });
     }));
 

--- a/engines/bastion_katello/test/content-hosts/details/content-host-details.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-details.controller.test.js
@@ -116,7 +116,6 @@ describe('Controller: ContentHostDetailsController', function() {
             HostSubscription: HostSubscription,
             MenuExpander: MenuExpander,
             simpleContentAccessEnabled: false,
-            isManifestImported: true,
         });
     }));
 

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -230,7 +230,7 @@ class SubscriptionsPage extends Component {
           defaultMessage={simpleContentAccess ? __(`This organization has Simple Content Access enabled.
           Hosts are not required to have subscriptions attached to access repositories.
           {br}
-          Learn more about your overall subscription usage with the {subscriptionsService}.`) : __('This organization is not using {scaLink}. Legacy subscription management is deprecated and will be removed in a future version.')}
+          Learn more about your overall subscription usage with the {subscriptionsService}.`) : __('This organization is not using {scaLink}. Entitlement-based subscription management is deprecated and will be removed in a future version.')}
         />
       </Alert>
     );
@@ -272,7 +272,7 @@ class SubscriptionsPage extends Component {
             />
 
             <div id="subscriptions-table" className="modal-container">
-              {isManifestImported && SCAAlert}
+              {!this.props.organization?.loading && SCAAlert}
               <SubscriptionsTable
                 canManageSubscriptionAllocations={canManageSubscriptionAllocations}
                 loadSubscriptions={this.props.loadSubscriptions}
@@ -330,6 +330,7 @@ SubscriptionsPage.propTypes = {
   }),
   organization: PropTypes.shape({
     id: PropTypes.number,
+    loading: PropTypes.bool,
     owner_details: PropTypes.shape({
       upstreamConsumer: PropTypes.shape({
         name: PropTypes.string,

--- a/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsPage.test.js.snap
+++ b/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsPage.test.js.snap
@@ -67,6 +67,35 @@ exports[`subscriptions page should render 1`] = `
         className="modal-container"
         id="subscriptions-table"
       >
+        <Alert
+          className=""
+          onDismiss={null}
+          type="warning"
+        >
+          <FormattedMessage
+            defaultMessage="This organization is not using {scaLink}. Entitlement-based subscription management is deprecated and will be removed in a future version."
+            id="sca-alert"
+            values={
+              Object {
+                "br": <br />,
+                "scaLink": <a
+                  href="https://access.redhat.com/articles/simple-content-access"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  Simple Content Access
+                </a>,
+                "subscriptionsService": <a
+                  href="https://access.redhat.com/documentation/en-us/subscription_central/2021/html-single/getting_started_with_the_subscriptions_service/index"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  Subscriptions service
+                </a>,
+              }
+            }
+          />
+        </Alert>
         <SubscriptionsTable
           canManageSubscriptionAllocations={false}
           emptyState={


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

1. Show the non-SCA deprecation banner from https://github.com/Katello/katello/pull/9981 even when there is no manifest imported.
2. Slight change to the wording to match https://access.redhat.com/documentation/en-us/red_hat_satellite/6.12/html-single/release_notes/index#ref_deprecated-functionality_assembly_introducing-red-hat-satellite

#### Considerations taken when implementing this change?

changed the logic on the React page to prevent a momentary flash of the wrong banner for SCA-enabled orgs

#### What are the testing steps for this pull request?

Get an org with and without SCA
View the Subscriptions, Activation Key details, and Content host details pages.
