### PR TITLE
Fixes #35168 - stop using single quotes that were breaking translations

### DIFF
--- a/engines/bastion/app/views/bastion/layouts/assets.html.erb
+++ b/engines/bastion/app/views/bastion/layouts/assets.html.erb
@@ -21,17 +21,17 @@
     angular.module('Bastion').value('simpleContentAccessEnabled', <%= Organization.current.simple_content_access? if Organization.current %>);
     angular.module('Bastion').value('isManifestImported', <%= !!Organization.current&.manifest_imported?(cached: true) %>)
     angular.module('Bastion').value('foreman', tfm);
-    angular.module('Bastion').value('repositoryTypes', angular.fromJson('<%= Katello::RepositoryTypeManager.enabled_repository_types.values.to_json.html_safe %>'));
-    angular.module('Bastion').value('deleteHostOnUnregister', angular.fromJson('<%= Setting[:unregister_delete_host] %>'));
-    angular.module('Bastion').value('globalContentProxy', angular.fromJson('<%= Setting[:content_default_http_proxy].empty? ? nil.to_json : Setting[:content_default_http_proxy].to_json.html_safe %>'));
+    angular.module('Bastion').value('repositoryTypes', angular.fromJson(`<%= Katello::RepositoryTypeManager.enabled_repository_types.values.to_json.html_safe %>`));
+    angular.module('Bastion').value('deleteHostOnUnregister', angular.fromJson(`<%= Setting[:unregister_delete_host] %>`));
+    angular.module('Bastion').value('globalContentProxy', angular.fromJson(`<%= Setting[:content_default_http_proxy].empty? ? nil.to_json : Setting[:content_default_http_proxy].to_json.html_safe %>`));
     angular.module('Bastion').value('entriesPerPage', "<%= Setting[:entries_per_page] %>");
     angular.module('Bastion').value('contentViewSolveDependencies', "<%= Setting[:content_view_solve_dependencies] %>");
-    angular.module('Bastion').constant('BastionConfig', angular.fromJson('<%= Bastion.config.to_json.html_safe %>'));
+    angular.module('Bastion').constant('BastionConfig', angular.fromJson(`<%= Bastion.config.to_json.html_safe %>`));
     angular.module('Bastion.auth').value('CurrentUser', {
         id: <%= User.current.id %>,
         admin: <%= User.current.admin || User.current.usergroups.any? { |group| group.admin } %>
     });
-    angular.module('Bastion.auth').value('Permissions', angular.fromJson('<%= User.current.cached_roles.collect { |role| role.permissions }.flatten.to_json.html_safe %>'));
+    angular.module('Bastion.auth').value('Permissions', angular.fromJson(`<%= User.current.cached_roles.collect { |role| role.permissions }.flatten.to_json.html_safe %>`));
     angular.module('Bastion').value('newHostDetailsUI', "<%= Setting[:host_details_ui] %>");
   </script>
   <% Bastion.plugins.each do |name, plugin| %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

In `engines/bastion/app/views/bastion/layouts/assets.html.erb`, we were calling

```js
angular.fromJson('<%= Katello::RepositoryTypeManager.enabled_repository_types.values.to_json.html_safe %>')
```

and other similar ERB expressions, enclosing them in single quotes. But if one of the translation values contained a single quote or apostrophe character, JavaScript would interpret this as ending the string, causing lots of problems.

I realized that the single quotes aren't even required. So I removed them.

```js
angular.fromJson(<%= Katello::RepositoryTypeManager.enabled_repository_types.values.to_json.html_safe %>)
```

#### Considerations taken when implementing this change?

I also considered using template strings - the (`) character. Both approaches seem to work fine; I'm still somewhat on the fence which is best.



#### What are the testing steps for this pull request?

1. Create a user whose language is 'fr'  - Administer > Users > create new > "Language"
2. Impersonate this user
3. Visit Angular Katello pages: Activation Keys, Lifecycle Environments, Products, Content Credentials, Sync Plans
4. Verify that the pages load