### PR TITLE
Fixes #35773 - Checks for empty cacert on connecting via Http Proxy

### DIFF
--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -92,7 +92,7 @@ module Katello
             cert_store = OpenSSL::X509::Store.new
             cert_store.add_file(ca_file) if ca_file
 
-            if proxy&.cacert
+            if proxy&.cacert&.present?
               Foreman::Util.add_ca_bundle_to_store(proxy.cacert, cert_store)
             end
             RestClient::Resource.new(url,

--- a/app/lib/katello/resources/cdn.rb
+++ b/app/lib/katello/resources/cdn.rb
@@ -49,7 +49,7 @@ module Katello
             @cert_store.add_file(options[:ssl_ca_file])
           end
 
-          if @cert_store && proxy&.cacert
+          if @cert_store && proxy&.cacert&.present?
             Foreman::Util.add_ca_bundle_to_store(proxy.cacert, @cert_store)
           end
 

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -447,7 +447,7 @@ module Katello
       end
 
       def append_proxy_cacert(options)
-        if root.http_proxy&.cacert && options.key?(:cacert)
+        if root.http_proxy&.cacert&.present? && options.key?(:cacert)
           options[:cacert] += "\n#{root.http_proxy&.cacert}"
         end
         options

--- a/test/lib/resources/candlepin_test.rb
+++ b/test/lib/resources/candlepin_test.rb
@@ -33,6 +33,18 @@ module Katello
 
           assert_equal 'proxy://admin:password@foo.com:1000', UpstreamCandlepinResource.proxy_uri
         end
+
+        def test_global_proxy_no_cacert
+          proxy = FactoryBot.create(:http_proxy, :url => 'http://foo.com:1000',
+                                    :username => 'admin',
+                                    :password => 'password',
+                                    :cacert => "")
+          UpstreamCandlepinResource.stubs(:proxy).returns(proxy)
+          Foreman::Util.expects(:add_ca_bundle_to_store).never
+          OpenSSL::X509::Certificate.expects(:new)
+          OpenSSL::PKey::RSA.expects(:new)
+          UpstreamCandlepinResource.resource("http://www.foo.com", "", "")
+        end
       end
 
       class ProductTest < ActiveSupport::TestCase

--- a/test/lib/resources/cdn_test.rb
+++ b/test/lib/resources/cdn_test.rb
@@ -17,6 +17,17 @@ class CdnResourceTest < ActiveSupport::TestCase
     assert_nil cdn_resource.http_downloader.ssl_version
   end
 
+  def test_http_proxy_no_cacert
+    proxy = FactoryBot.create(:http_proxy, :url => 'http://foo.com:1000',
+                              :username => 'admin',
+                              :password => 'password',
+                              :cacert => "")
+    Katello::Resources::CDN::CdnResource.any_instance.stubs(:proxy).returns(proxy)
+    OpenSSL::X509::Store.any_instance.stubs(:add_file)
+    Foreman::Util.expects(:add_ca_bundle_to_store).never
+    Katello::Resources::CDN::CdnResource.new('http://foo.com', ssl_ca_file: "lol")
+  end
+
   def test_http_downloader_bad_param
     Setting[:cdn_ssl_version] = 'Foo'
     assert_raise RuntimeError do

--- a/test/lib/resources/cdn_test.rb
+++ b/test/lib/resources/cdn_test.rb
@@ -23,7 +23,7 @@ class CdnResourceTest < ActiveSupport::TestCase
                               :password => 'password',
                               :cacert => "")
     Katello::Resources::CDN::CdnResource.any_instance.stubs(:proxy).returns(proxy)
-    OpenSSL::X509::Store.any_instance.stubs(:add_file)
+    OpenSSL::X509::Store.any_instance.expects(:add_file)
     Foreman::Util.expects(:add_ca_bundle_to_store).never
     Katello::Resources::CDN::CdnResource.new('http://foo.com', ssl_ca_file: "lol")
   end

--- a/test/services/katello/pulp3/repository/yum/yum_test.rb
+++ b/test/services/katello/pulp3/repository/yum/yum_test.rb
@@ -18,6 +18,18 @@ module Katello
             service.copy_units(@repo, [], false)
           end
 
+          def test_append_proxy_cacert
+            service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
+            http_proxy = FactoryBot.create(:http_proxy, :url => 'http://foo.com:1000',
+                              :username => 'admin',
+                              :password => 'password',
+                              :cacert => "")
+            ::Katello::RootRepository.any_instance.expects(:http_proxy).returns(http_proxy)
+            cert = "MY cert"
+            options = service.append_proxy_cacert(cacert: cert)
+            assert_equal(options[:cacert], cert)
+          end
+
           def test_additional_content_hrefs_properly_includes_errata
             service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
             rpm = ::Katello::Rpm.create(name: "foobar", filename: "foobar-1.3.4.rpm", nvra: "foobar-1.2.3", pulp_id: "test")


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Given an http proxy, katello tries to add proxy's cacert while connecting to cdn/upstream. Unfortunately it checked for blank cacert incorrectly.
This PR adds a `.present?` to check for blank certs  (`""` is considered true while `"".present?` is false in ruby.) 

#### What are the testing steps for this pull request?
Check out the steps listed in the redmine
- Setup a proxy. My ruby one which runs proxy on port 8777
```ruby
#!/usr/bin/ruby
require 'webrick'
require 'webrick/httpproxy'

proxy = WEBrick::HTTPProxyServer.new Port: 8777

trap 'INT'  do proxy.shutdown end
trap 'TERM' do proxy.shutdown end

proxy.start
```

- Setup an http proxy in ui with url set to `http://localhost:8777` and make sure you can connect via test connection
- Mark this http proxy as the default http proxy in settings
- Try any of the following operations

1. Enable repositories
2. Check out Subscriptions
3. Sync stuff

Before PR:
```Katello::HttpErrors::BadRequest: no certificate or crl found```

After PR:
No such errors.
