### PR TITLE
Fixes #35774 - don't fail if #{Rails.root}/tmp is not available

### DIFF
--- a/app/lib/katello/event_daemon/runner.rb
+++ b/app/lib/katello/event_daemon/runner.rb
@@ -7,6 +7,7 @@ module Katello
 
       class << self
         def initialize
+          FileUtils.mkdir_p(tmp_dir)
           FileUtils.touch(lock_file)
         end
 
@@ -24,12 +25,16 @@ module Katello
           pid_dir.join('katello_event_daemon.pid')
         end
 
+        def tmp_dir
+          Rails.root.join('tmp')
+        end
+
         def pid_dir
-          Rails.root.join('tmp', 'pids')
+          tmp_dir.join('pids')
         end
 
         def lock_file
-          Rails.root.join('tmp', 'katello_event_daemon.lock')
+          tmp_dir.join('katello_event_daemon.lock')
         end
 
         def write_pid_file

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -146,7 +146,7 @@ module Katello
         )
       end
 
-      Katello::EventDaemon::Runner.initialize
+      Katello::EventDaemon::Runner.initialize unless Foreman.in_rake?
       Katello::EventDaemon::Runner.register_service(:candlepin_events, Katello::CandlepinEventListener)
       Katello::EventDaemon::Runner.register_service(:katello_events, Katello::EventMonitor::PollerThread)
       Katello::EventDaemon::Runner.register_service(:katello_agent_events, Katello::EventDaemon::Services::AgentEventReceiver) if ::Katello.with_katello_agent?


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This can happen in rake tasks, so let's:
1. not initialize EventDaemon in rake at all -- it won't run anyway
2. ensure the `tmp` directory is properly created before use

#### Considerations taken when implementing this change?

To solving the issue @quba42 has been seeing, *one* of the changes is sufficient, but I thought both make the code overall more robust.

#### What are the testing steps for this pull request?

As @quba42 to run a patched build, I was not able to reproduce this myself as it is a race condition somewhere