### PR TITLE
Fixes #35640 - fix broken hammer host subscription content-override

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -232,7 +232,7 @@ module Katello
     end
 
     def find_content_overrides
-      if params[:content_overrides_search]
+      if params.dig(:content_overrides_search, :search).present?
         content_labels = ::Katello::Content.joins(:product_contents)
                             .where("#{Katello::ProductContent.table_name}.product_id": @host.organization.products.subscribable.enabled)
                             .search_for(params[:content_overrides_search][:search])


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fix hammer to override repository sets correctly.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
```
hammer host subscription content-override --host-id 2 --content-label Default_Organization_fake-product_fake-repo --override-name 'enabled' --value=1
hammer host subscription content-override --host-id 2 --content-label Default_Organization_fake-product_fake-repo --override-name 'enabled' --value=0
hammer host subscription content-override --host-id 2 --content-label Default_Organization_fake-product_fake-repo --remove
```
Check Host - Content - Repository sets from UI.

Before
All repos were overridden to disabled when trying to disable/enable one repo.
All repos were reset too default when trying to reset one repo.

After 
Specified repo will be enabled/disabled/reset.