### PR TITLE
Fixes #35742: Make content view dropdown scrollable and searchable

### DIFF
--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
-import { Modal, Button, Select, SelectOption, Alert, Flex } from '@patternfly/react-core';
+import { Modal, Button, SelectOption, Alert, Flex } from '@patternfly/react-core';
 import {
   global_palette_black_600 as pfDescriptionColor,
 } from '@patternfly/react-tokens';
@@ -20,6 +20,7 @@ import ContentViewIcon from '../../../../../scenes/ContentViews/components/Conte
 import updateHostContentViewAndEnvironment from './HostContentViewActions';
 import HOST_CV_AND_ENV_KEY from './HostContentViewConstants';
 import { getHostDetails } from '../../HostDetailsActions';
+import ContentViewSelect from '../../../../../scenes/ContentViews/components/ContentViewSelect/ContentViewSelect';
 
 const ENV_PATH_OPTIONS = { key: ENVIRONMENT_PATHS_KEY };
 
@@ -183,19 +184,13 @@ const ChangeHostCVModal = ({
         isDisabled={hostUpdateStatus === STATUS.PENDING}
       />
       {selectedEnvForHost.length > 0 &&
-      <div style={{ marginTop: '1em' }}>
-        <h3>{__('Select content view')}</h3>
-        <Select
+        <ContentViewSelect
           selections={selectedCVForHost}
+          onClear={() => setSelectedCVForHost(null)}
           onSelect={handleCVSelect}
           isOpen={cvSelectOpen}
-          menuAppendTo="parent"
           isDisabled={contentViewsInEnv.length === 0 || hostUpdateStatus === STATUS.PENDING}
           onToggle={isExpanded => setCVSelectOpen(isExpanded)}
-          ouiaId="select-content-view"
-          id="selectCV"
-          name="selectCV"
-          aria-label="selectCV"
           placeholderText={cvPlaceholderText()}
         >
           {contentViewsInEnv?.map(cv => (
@@ -227,8 +222,7 @@ const ChangeHostCVModal = ({
             </SelectOption>
           ))
           }
-        </Select>
-      </div>
+        </ContentViewSelect>
       }
     </Modal>
   );

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/__tests__/changeHostCVModal.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/__tests__/changeHostCVModal.test.js
@@ -86,7 +86,7 @@ test('Select an env > call CV API > select a CV > Save button is enabled', async
 
   const {
     getAllByText, getByText,
-    findByText, getAllByRole,
+    findByPlaceholderText, getAllByRole,
   } = renderWithRedux(<ChangeHostCVModal
     isOpen
     closeModal={jest.fn()}
@@ -107,7 +107,7 @@ test('Select an env > call CV API > select a CV > Save button is enabled', async
   await act(async () => {
     userEvent.click(envRadio); // Select the Library environment
 
-    const cvDropdown = await findByText('Select a content view');
+    const cvDropdown = await findByPlaceholderText('Select a content view');
     expect(cvDropdown).toBeInTheDocument();
 
     userEvent.click(cvDropdown); // Open the CV dropdown

--- a/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignActivationKeysForm.js
+++ b/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignActivationKeysForm.js
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { ExpandableSection, Select, SelectOption } from '@patternfly/react-core';
+import { ExpandableSection, SelectOption } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
 import getContentViews from '../../ContentViewsActions';
@@ -9,6 +9,7 @@ import { selectContentViewError, selectContentViews, selectContentViewStatus } f
 import CVDeleteContext from '../CVDeleteContext';
 import EnvironmentPaths from '../../components/EnvironmentPaths/EnvironmentPaths';
 import AffectedActivationKeys from '../../Details/Versions/Delete/affectedActivationKeys';
+import ContentViewSelect from '../../components/ContentViewSelect/ContentViewSelect';
 
 const CVDeletionReassignActivationKeysForm = () => {
   const dispatch = useDispatch();
@@ -66,6 +67,11 @@ const CVDeletionReassignActivationKeysForm = () => {
     return results?.filter(cv => cv.id === id)[0]?.name;
   };
 
+  const onClear = () => {
+    setSelectedCVForAK(null);
+    setSelectedCVNameForAK(null);
+  };
+
   const onSelect = (_event, selection) => {
     setSelectedCVForAK(selection);
     setSelectedCVNameForAK(fetchSelectedCVName(selection));
@@ -82,23 +88,17 @@ const CVDeletionReassignActivationKeysForm = () => {
         multiSelect={false}
       />
       {!cvInEnvLoading && selectedEnvForAK.length > 0 &&
-      <div style={{ marginTop: '1em' }}>
-        <h3>{__('Select content view')}</h3>
-        <Select
+        <ContentViewSelect
           selections={selectedCVForAK}
           onSelect={onSelect}
+          onClear={onClear}
           isOpen={cvSelectOpen}
           isDisabled={cvSelectOptions.length === 0}
           onToggle={isExpanded => setCVSelectOpen(isExpanded)}
-          id="selectCV"
-          name="selectCV"
-          aria-label="selectCV"
-          ouiaId="selectCV"
           placeholderText={(cvSelectOptions.length === 0) ? __('No content views available') : __('Select a content view')}
         >
           {cvSelectOptions}
-        </Select>
-      </div>
+        </ContentViewSelect>
       }
       <ExpandableSection
         toggleText={showActivationKeys ?

--- a/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignHostsForm.js
+++ b/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignHostsForm.js
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { ExpandableSection, Select, SelectOption } from '@patternfly/react-core';
+import { ExpandableSection, SelectOption } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
 import getContentViews from '../../ContentViewsActions';
@@ -9,6 +9,7 @@ import { selectContentViewError, selectContentViews, selectContentViewStatus } f
 import CVDeleteContext from '../CVDeleteContext';
 import EnvironmentPaths from '../../components/EnvironmentPaths/EnvironmentPaths';
 import AffectedHosts from '../../Details/Versions/Delete/affectedHosts';
+import ContentViewSelect from '../../components/ContentViewSelect/ContentViewSelect';
 
 
 const CVDeletionReassignHostsForm = () => {
@@ -67,6 +68,11 @@ const CVDeletionReassignHostsForm = () => {
     return results?.filter(cv => cv.id === id)[0]?.name;
   };
 
+  const onClear = () => {
+    setSelectedCVForHosts(null);
+    setSelectedCVNameForHosts(null);
+  };
+
   const onSelect = (_event, selection) => {
     setSelectedCVForHosts(selection);
     setSelectedCVNameForHosts(fetchSelectedCVName(selection));
@@ -83,23 +89,17 @@ const CVDeletionReassignHostsForm = () => {
         multiSelect={false}
       />
       {selectedEnvForHost.length > 0 &&
-      <div style={{ marginTop: '1em' }}>
-        <h3>{__('Select content view')}</h3>
-        <Select
+        <ContentViewSelect
           selections={selectedCVForHosts}
           onSelect={onSelect}
+          onClear={onClear}
           isOpen={cvSelectOpen}
           isDisabled={cvSelectOptions.length === 0}
           onToggle={isExpanded => setCVSelectOpen(isExpanded)}
-          id="selectCV"
-          name="selectCV"
-          aria-label="selectCV"
-          ouiaId="selectCV"
           placeholderText={(cvSelectOptions.length === 0) ? __('No content views available') : __('Select a content view')}
         >
           {cvSelectOptions}
-        </Select>
-      </div>
+        </ContentViewSelect>
       }
       <ExpandableSection
         toggleText={showHosts ? 'Hide hosts' : 'Show hosts'}

--- a/webpack/scenes/ContentViews/Delete/__tests__/contentViewDelete.test.js
+++ b/webpack/scenes/ContentViews/Delete/__tests__/contentViewDelete.test.js
@@ -165,7 +165,7 @@ test('Can open Delete wizard and delete CV with all steps', async (done) => {
     .reply(200, cVDropDownOptionsData);
 
   const {
-    getByText, getByLabelText, getAllByLabelText, getAllByText, queryByText,
+    getByText, getByLabelText, getAllByLabelText, getAllByText, queryByText, getByPlaceholderText,
   } =
     renderWithRedux(<ContentViewsPage />, renderOptions);
   expect(queryByText(firstCV.name)).toBeNull();
@@ -191,9 +191,9 @@ test('Can open Delete wizard and delete CV with all steps', async (done) => {
   fireEvent.click(getByLabelText('test1'));
   await patientlyWaitFor(() => {
     expect(getByText('Select content view')).toBeInTheDocument();
-    expect(getByText('Select a content view')).toBeInTheDocument();
+    expect(getByPlaceholderText('Select a content view')).toBeInTheDocument();
   });
-  fireEvent.click(getByText('Select a content view'));
+  fireEvent.click(getByPlaceholderText('Select a content view'));
   await patientlyWaitFor(() => {
     expect(getByText('cv2')).toBeInTheDocument();
   });
@@ -210,9 +210,9 @@ test('Can open Delete wizard and delete CV with all steps', async (done) => {
   fireEvent.click(getByLabelText('test1'));
   await patientlyWaitFor(() => {
     expect(getByText('Select content view')).toBeInTheDocument();
-    expect(getByText('Select a content view')).toBeInTheDocument();
+    expect(getByPlaceholderText('Select a content view')).toBeInTheDocument();
   });
-  fireEvent.click(getByText('Select a content view'));
+  fireEvent.click(getByPlaceholderText('Select a content view'));
   await patientlyWaitFor(() => {
     expect(getByText('cv2')).toBeInTheDocument();
   });

--- a/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignActivationKeys.js
+++ b/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignActivationKeys.js
@@ -18,10 +18,8 @@ import {
   ExpandableSection,
   Popover,
   PopoverPosition,
-  Select,
   SelectDirection,
   SelectOption,
-  TextContent,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
@@ -39,6 +37,7 @@ import {
   getEnvironmentList,
   getNumberOfActivationKeys,
 } from '../BulkDeleteHelpers';
+import ContentViewSelect from '../../../../components/ContentViewSelect/ContentViewSelect';
 
 export default () => {
   const dispatch = useDispatch();
@@ -107,6 +106,11 @@ export default () => {
     setSelectedEnvForAK(value);
   };
 
+  const onClear = () => {
+    setSelectedCVForAK(null);
+    setSelectedEnvForAK([]);
+  };
+
   const onSelect = (_event, selection) => {
     setSelectedCVForAK(selection);
     setToggleCVSelect(false);
@@ -170,16 +174,11 @@ export default () => {
         headerText={__('Select an environment')}
         multiSelect={false}
       />
-      <TextContent>
-        {__('Select a content view')}
-      </TextContent>
-      <Select
+      <ContentViewSelect
         selections={selectedCVForAK}
         onSelect={onSelect}
+        onClear={onClear}
         isDisabled={cvInEnvLoading || !selectOptions?.length || !selectedEnvForAK?.length}
-        id="selectCV"
-        name="selectCV"
-        aria-label="selectCV"
         placeholderText={placeHolder}
         isOpen={toggleCVSelect}
         onToggle={setToggleCVSelect}
@@ -189,7 +188,7 @@ export default () => {
         width={350}
       >
         {selectOptions}
-      </Select>
+      </ContentViewSelect>
     </>
   );
 };

--- a/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignHosts.js
+++ b/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignHosts.js
@@ -18,10 +18,8 @@ import {
   ExpandableSection,
   Popover,
   PopoverPosition,
-  Select,
   SelectDirection,
   SelectOption,
-  TextContent,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
@@ -40,6 +38,7 @@ import {
   getNumberOfActivationKeys,
   getNumberOfHosts,
 } from '../BulkDeleteHelpers';
+import ContentViewSelect from '../../../../components/ContentViewSelect/ContentViewSelect';
 
 export default () => {
   const dispatch = useDispatch();
@@ -112,6 +111,15 @@ export default () => {
     if (numberOfAKs) {
       setSelectedCVForAK(null);
       setSelectedEnvForAK(value);
+    }
+  };
+
+  const onClear = () => {
+    setSelectedCVForHosts(null);
+    setSelectedEnvForHosts([]);
+    if (numberOfAKs) {
+      setSelectedCVForAK(null);
+      setSelectedEnvForAK([]);
     }
   };
 
@@ -194,16 +202,11 @@ export default () => {
         headerText={__('Select an environment')}
         multiSelect={false}
       />
-      <TextContent>
-        {__('Select a content view')}
-      </TextContent>
-      <Select
+      <ContentViewSelect
         selections={selectedCVForHosts}
         onSelect={onSelect}
+        onClear={onClear}
         isDisabled={cvInEnvLoading || !selectOptions?.length || !selectedEnvForHosts?.length}
-        id="selectCV"
-        name="selectCV"
-        aria-label="selectCV"
         placeholderText={placeHolder}
         isOpen={toggleCVSelect}
         onToggle={setToggleCVSelect}
@@ -213,7 +216,7 @@ export default () => {
         width={350}
       >
         {selectOptions}
-      </Select>
+      </ContentViewSelect>
     </>
   );
 };

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignActivationKeysForm.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignActivationKeysForm.js
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { ExpandableSection, Select, SelectOption } from '@patternfly/react-core';
+import { ExpandableSection, SelectOption } from '@patternfly/react-core';
 import { STATUS } from 'foremanReact/constants';
 import { translate as __ } from 'foremanReact/common/I18n';
 import EnvironmentPaths from '../../../../components/EnvironmentPaths/EnvironmentPaths';
@@ -9,6 +9,7 @@ import getContentViews from '../../../../ContentViewsActions';
 import { selectContentViewError, selectContentViews, selectContentViewStatus } from '../../../../ContentViewSelectors';
 import AffectedActivationKeys from '../affectedActivationKeys';
 import DeleteContext from '../DeleteContext';
+import ContentViewSelect from '../../../../components/ContentViewSelect/ContentViewSelect';
 
 const CVReassignActivationKeysForm = () => {
   const dispatch = useDispatch();
@@ -75,6 +76,11 @@ const CVReassignActivationKeysForm = () => {
     return results.filter(cv => cv.id === id)[0]?.name;
   };
 
+  const onClear = () => {
+    setSelectedCVForAK(null);
+    setSelectedCVNameForAK(null);
+  };
+
   const onSelect = (event, selection) => {
     setSelectedCVForAK(selection);
     setSelectedCVNameForAK(fetchSelectedCVName(selection));
@@ -91,23 +97,17 @@ const CVReassignActivationKeysForm = () => {
         multiSelect={false}
       />
       {!cvInEnvLoading && selectedEnvForAK.length > 0 &&
-        <div style={{ marginTop: '1em' }}>
-          <h3>{__('Select content view')}</h3>
-          <Select
-            selections={selectedCVForAK}
-            onSelect={onSelect}
-            isOpen={cvSelectOpen}
-            isDisabled={cvSelectOptions.length === 0}
-            onToggle={isExpanded => setCVSelectOpen(isExpanded)}
-            id="selectCV"
-            name="selectCV"
-            aria-label="selectCV"
-            ouiaId="selectCV"
-            placeholderText={(cvSelectOptions.length === 0) ? __('No content views available') : __('Select a content view')}
-          >
-            {cvSelectOptions}
-          </Select>
-        </div>
+        <ContentViewSelect
+          selections={selectedCVForAK}
+          onSelect={onSelect}
+          onClear={onClear}
+          isOpen={cvSelectOpen}
+          isDisabled={cvSelectOptions.length === 0}
+          onToggle={isExpanded => setCVSelectOpen(isExpanded)}
+          placeholderText={(cvSelectOptions.length === 0) ? __('No content views available') : __('Select a content view')}
+        >
+          {cvSelectOptions}
+        </ContentViewSelect>
       }
       <ExpandableSection
         toggleText={showActivationKeys ?

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignHostsForm.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignHostsForm.js
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { ExpandableSection, Select, SelectOption } from '@patternfly/react-core';
+import { ExpandableSection, SelectOption } from '@patternfly/react-core';
 import { STATUS } from 'foremanReact/constants';
 import { translate as __ } from 'foremanReact/common/I18n';
 import EnvironmentPaths from '../../../../components/EnvironmentPaths/EnvironmentPaths';
@@ -9,6 +9,7 @@ import getContentViews from '../../../../ContentViewsActions';
 import { selectContentViewError, selectContentViews, selectContentViewStatus } from '../../../../ContentViewSelectors';
 import AffectedHosts from '../affectedHosts';
 import DeleteContext from '../DeleteContext';
+import ContentViewSelect from '../../../../components/ContentViewSelect/ContentViewSelect';
 
 const CVReassignHostsForm = () => {
   const dispatch = useDispatch();
@@ -74,6 +75,11 @@ const CVReassignHostsForm = () => {
     return results.filter(cv => cv.id === id)[0]?.name;
   };
 
+  const onClear = () => {
+    setSelectedCVForHosts(null);
+    setSelectedCVNameForHosts(null);
+  };
+
   const onSelect = (event, selection) => {
     setSelectedCVForHosts(selection);
     setSelectedCVNameForHosts(fetchSelectedCVName(selection));
@@ -90,9 +96,8 @@ const CVReassignHostsForm = () => {
         multiSelect={false}
       />
       {selectedEnvForHost.length > 0 &&
-      <div style={{ marginTop: '1em' }}>
-        <h3>{__('Select content view')}</h3>
-        <Select
+        <ContentViewSelect
+          onClear={onClear}
           selections={selectedCVForHosts}
           onSelect={onSelect}
           isOpen={cvSelectOpen}
@@ -105,8 +110,7 @@ const CVReassignHostsForm = () => {
           placeholderText={(cvSelectOptions.length === 0) ? __('No content views available') : __('Select a content view')}
         >
           {cvSelectOptions}
-        </Select>
-      </div>
+        </ContentViewSelect>
       }
       <ExpandableSection
         toggleText={showHosts ? 'Hide hosts' : 'Show hosts'}

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/__tests__/cvVersionRemove.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/__tests__/cvVersionRemove.test.js
@@ -160,7 +160,7 @@ test('Can open Remove wizard and remove version from environment with hosts', as
 
 
   const {
-    getByText, getAllByText, getByLabelText, getAllByLabelText, queryByText,
+    getByText, getAllByText, getByLabelText, getAllByLabelText, queryByText, getByPlaceholderText,
   } = renderWithRedux(
     <ContentViewVersions cvId={2} details={cvDetailData} />,
     renderOptions,
@@ -190,9 +190,9 @@ test('Can open Remove wizard and remove version from environment with hosts', as
   fireEvent.click(getByLabelText('test1'));
   await patientlyWaitFor(() => {
     expect(getByText('Select content view')).toBeInTheDocument();
-    expect(getByText('Select a content view')).toBeInTheDocument();
+    expect(getByPlaceholderText('Select a content view')).toBeInTheDocument();
   });
-  fireEvent.click(getByText('Select a content view'));
+  fireEvent.click(getByPlaceholderText('Select a content view'));
   await patientlyWaitFor(() => {
     expect(getByText('cv2')).toBeInTheDocument();
   });
@@ -250,7 +250,7 @@ test('Can open Remove wizard and remove version from environment with activation
 
 
   const {
-    getByText, getAllByText, getByLabelText, getAllByLabelText, queryByText,
+    getByText, getAllByText, getByLabelText, getAllByLabelText, queryByText, getByPlaceholderText,
   } = renderWithRedux(
     <ContentViewVersions cvId={2} details={cvDetailData} />,
     renderOptions,
@@ -280,9 +280,9 @@ test('Can open Remove wizard and remove version from environment with activation
   fireEvent.click(getByLabelText('test1'));
   await patientlyWaitFor(() => {
     expect(getByText('Select content view')).toBeInTheDocument();
-    expect(getByText('Select a content view')).toBeInTheDocument();
+    expect(getByPlaceholderText('Select a content view')).toBeInTheDocument();
   });
-  fireEvent.click(getByText('Select a content view'));
+  fireEvent.click(getByPlaceholderText('Select a content view'));
   await patientlyWaitFor(() => {
     expect(getByText('cv2')).toBeInTheDocument();
   });

--- a/webpack/scenes/ContentViews/components/ContentViewSelect/ContentViewSelect.js
+++ b/webpack/scenes/ContentViews/components/ContentViewSelect/ContentViewSelect.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { Select, SelectVariant } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+
+const ContentViewSelect = ({
+  headerText,
+  children,
+  onClear,
+  ...pfSelectProps
+}) => (
+  <div style={{ marginTop: '1em' }}>
+    <h3>{headerText}</h3>
+    <Select
+      variant={SelectVariant.typeahead}
+      onClear={onClear}
+      maxHeight="20rem"
+      menuAppendTo="parent"
+      ouiaId="select-content-view"
+      id="selectCV"
+      name="selectCV"
+      aria-label="selectCV"
+      {...pfSelectProps}
+    >
+      {children}
+    </Select>
+  </div>
+);
+
+ContentViewSelect.propTypes = {
+  headerText: PropTypes.string,
+  onClear: PropTypes.func.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+ContentViewSelect.defaultProps = {
+  headerText: __('Select content view'),
+};
+
+export default ContentViewSelect;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

1. Make the 'Select content view' dropdown scrollable, so its content will no longer spill off the bottom of the screen when there are too many content views to choose from. This is done by adding a `maxHeight` property.
2. Change to the `typeahead` variant so that you can search available content views in the list.
3. Add an `onClear` property and make it required. This adds the 'X' button so you can clear your search.

#### Considerations taken when implementing this change?

This will also make it a bit easier when we change the UI for multi-CV.

I considered abstracting one more level, and making a `ContentViewEnvironmentSelect` component. But I think I'll leave that for later..

#### What are the testing steps for this pull request?

Look at the following CV selector screens:

1. New host details > Content View Details card > kebab > Edit content view assignment
2. Delete content view > reassign affected activation keys
3. Delete content view > reassign affected hosts
4. Content view version promote
5. CV version delete > reassign affected activation keys
6. CV version delete > reassign affected hosts
7. Bulk CV version delete > reassign affected activation keys
8. Bulk CV version delete > reassign affected hosts

