### PR TITLE
Registration - use registration_url for RHSM configuration

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -456,14 +456,16 @@ module Katello
       end
 
       def rhsm_url
+        proxy_url = setting('Registration', 'registration_url') || url
+
         # Since Foreman 3.1 this setting is set
         if (rhsm_url = setting(SmartProxy::PULP3_FEATURE, 'rhsm_url'))
           URI(rhsm_url)
           # Compatibility fall back
         elsif pulp_primary?
-          URI("https://#{URI.parse(url).host}/rhsm")
+          URI("https://#{URI.parse(proxy_url).host}/rhsm")
         elsif pulp_mirror?
-          URI("https://#{URI.parse(url).host}:8443/rhsm")
+          URI("https://#{URI.parse(proxy_url).host}:8443/rhsm")
         end
       end
 

--- a/test/factories/smart_proxy_factory.rb
+++ b/test/factories/smart_proxy_factory.rb
@@ -40,5 +40,15 @@ FactoryBot.modify do
         smart_proxy_feature.settings[:mirror] = true
       end
     end
+
+    trait :with_load_balancer do
+      after(:build) do |proxy, _evaluator|
+        feature = Feature.find_or_create_by(:name => 'Registration')
+        proxy.features << feature unless proxy.features.include?(feature)
+        smart_proxy_feature = proxy.smart_proxy_features.find { |spf| spf.feature_id == feature.id }
+        smart_proxy_feature.settings ||= {}
+        smart_proxy_feature.settings[:registration_url] = "https://load-balancer.example.com/register"
+      end
+    end
   end
 end

--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -81,6 +81,13 @@ module Katello
       assert_includes @proxy_mirror.rhsm_url.to_s, ":8443/rhsm"
     end
 
+    def test_rhsm_url_with_load_balancer
+      proxy = FactoryBot.build(:smart_proxy, :default_smart_proxy, :with_load_balancer)
+      registration_url = proxy.setting("Registration", 'registration_url')
+
+      assert_includes proxy.rhsm_url.to_s, URI(registration_url).hostname
+    end
+
     def test_sync_container_gateway
       environment = katello_environments(:library)
       with_pulp3_features(capsule_content.smart_proxy)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Follow up to https://github.com/Katello/katello/pull/10315, if Smart Proxy Registration module 
is configured to load balancing (`registration_url` is set),
use this value for RHSM configuration when registering host, see [global registration](https://github.com/theforeman/foreman/blob/develop/app/views/unattended/provisioning_templates/registration/global_registration.erb#L186-L189)

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
* Configure smart proxy to load balancing
* Register host
* Check that correct RHSM URLs are set and it works