### PR TITLE
Fixes #35810 - Use 'search' url param instead of 'host_ids' for job wizard

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
@@ -1132,7 +1132,7 @@ test('Can apply errata in bulk via customized remote execution', async (done) =>
   expect(viaRexAction).toBeInTheDocument();
   expect(viaRexAction).toHaveAttribute(
     'href',
-    `/job_invocations/new?feature=${feature}&host_ids=name%20%5E%20(${hostName})&inputs%5BErrata%20search%20query%5D=errata_id%20%5E%20(${errata})`,
+    `/job_invocations/new?feature=${feature}&search=name%20%5E%20(${hostName})&inputs%5BErrata%20search%20query%5D=errata_id%20%5E%20(${errata})`,
   );
 
   viaRexAction.click();
@@ -1248,7 +1248,7 @@ test('Can apply a single erratum to the host via customized remote execution', a
   viaRexAction.click();
   expect(viaRexAction).toHaveAttribute(
     'href',
-    `/job_invocations/new?feature=${feature}&host_ids=name%20%5E%20(${hostName})&inputs%5BErrata%20search%20query%5D=errata_id%20=%20${errataId}`,
+    `/job_invocations/new?feature=${feature}&search=name%20%5E%20(${hostName})&inputs%5BErrata%20search%20query%5D=errata_id%20=%20${errataId}`,
   );
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done);

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/moduleStreamsTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/moduleStreamsTab.test.js
@@ -208,8 +208,8 @@ test('Can provide dropdown actions with redirects on Module Streams with customi
   await patientlyWaitFor(() => expect(getByLabelText('customize-checkbox-3')).toBeInTheDocument());
   fireEvent.click(getByLabelText('customize-checkbox-3'));
   await patientlyWaitFor(() => expect(getByText('Enable')).toBeInTheDocument());
-  expect(getByText('Enable')).toHaveAttribute('href', '/job_invocations/new?feature=katello_module_stream_action&host_ids=name%20%5E%20(test-host)&inputs%5Baction%5D=enable&inputs%5Bmodule_spec%5D=walrus:2.4');
-  expect(getByText('Install')).toHaveAttribute('href', '/job_invocations/new?feature=katello_module_stream_action&host_ids=name%20%5E%20(test-host)&inputs%5Baction%5D=install&inputs%5Bmodule_spec%5D=walrus:2.4');
+  expect(getByText('Enable')).toHaveAttribute('href', '/job_invocations/new?feature=katello_module_stream_action&search=name%20%5E%20(test-host)&inputs%5Baction%5D=enable&inputs%5Bmodule_spec%5D=walrus:2.4');
+  expect(getByText('Install')).toHaveAttribute('href', '/job_invocations/new?feature=katello_module_stream_action&search=name%20%5E%20(test-host)&inputs%5Baction%5D=install&inputs%5Bmodule_spec%5D=walrus:2.4');
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done);
   act(done);

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/packageInstallModal.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/packageInstallModal.test.js
@@ -310,7 +310,7 @@ test('Can install a package via customized remote execution', async (done) => {
   expect(customizedRexOption).toBeInTheDocument();
   expect(customizedRexOption).toHaveAttribute(
     'href',
-    `/job_invocations/new?feature=${REX_FEATURES.KATELLO_PACKAGE_INSTALL}&host_ids=name%20%5E%20(test-host)&inputs%5Bpackage%5D=duck,cheetah`,
+    `/job_invocations/new?feature=${REX_FEATURES.KATELLO_PACKAGE_INSTALL}&search=name%20%5E%20(test-host)&inputs%5Bpackage%5D=duck,cheetah`,
   );
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done);
@@ -348,7 +348,7 @@ test('Uses package_install_by_search_query template when in select all mode', as
   expect(customizedRexOption).toBeInTheDocument();
   expect(customizedRexOption).toHaveAttribute(
     'href',
-    `/job_invocations/new?feature=${REX_FEATURES.KATELLO_PACKAGE_INSTALL_BY_SEARCH}&host_ids=name%20%5E%20(test-host)&inputs%5BPackage%20search%20query%5D=id%20!%5E%20(32376)`,
+    `/job_invocations/new?feature=${REX_FEATURES.KATELLO_PACKAGE_INSTALL_BY_SEARCH}&search=name%20%5E%20(test-host)&inputs%5BPackage%20search%20query%5D=id%20!%5E%20(32376)`,
   );
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done);

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/packagesTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/packagesTab.test.js
@@ -261,7 +261,7 @@ test('Can upgrade a package via customized remote execution', async (done) => {
   expect(rexAction).toBeInTheDocument();
   expect(rexAction).toHaveAttribute(
     'href',
-    `/job_invocations/new?feature=${feature}&host_ids=name%20%5E%20(${hostname})&inputs%5Bpackage%5D=${packageName}`,
+    `/job_invocations/new?feature=${feature}&search=name%20%5E%20(${hostname})&inputs%5Bpackage%5D=${packageName}`,
   );
 
   fireEvent.click(rexAction);
@@ -338,7 +338,7 @@ test('Can bulk upgrade via customized remote execution', async (done) => {
   const feature = REX_FEATURES.KATELLO_PACKAGES_UPDATE_BY_SEARCH;
   const packages = `${firstPackage.id},${secondPackage.id}`;
   const job =
-    `/job_invocations/new?feature=${feature}&host_ids=name%20%5E%20(${hostname})&inputs%5BPackages%20search%20query%5D=id%20%5E%20(${packages})&inputs%5BSelected%20update%20versions%5D=%5B%5D`;
+    `/job_invocations/new?feature=${feature}&search=name%20%5E%20(${hostname})&inputs%5BPackages%20search%20query%5D=id%20%5E%20(${packages})&inputs%5BSelected%20update%20versions%5D=%5B%5D`;
 
   getByRole('checkbox', { name: 'Select row 0' }).click();
   expect(getByLabelText('Select row 0').checked).toEqual(true);

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
@@ -298,7 +298,7 @@ describe('With tracer installed', () => {
     });
     expect(viaCustomizedRexAction).toHaveAttribute(
       'href',
-      `/job_invocations/new?feature=${feature}&host_ids=name%20%5E%20(${hostName})&inputs%5BTraces%20search%20query%5D=id%20=%20${firstTrace.id}`,
+      `/job_invocations/new?feature=${feature}&search=name%20%5E%20(${hostName})&inputs%5BTraces%20search%20query%5D=id%20=%20${firstTrace.id}`,
     );
 
     assertNockRequest(autocompleteScope);
@@ -331,7 +331,7 @@ describe('With tracer installed', () => {
     expect(viaCustomizedRexAction).toBeInTheDocument();
     expect(viaCustomizedRexAction).toHaveAttribute(
       'href',
-      `/job_invocations/new?feature=${feature}&host_ids=name%20%5E%20(${hostName})&inputs%5BTraces%20search%20query%5D=id%20%5E%20(${firstTrace.id})`,
+      `/job_invocations/new?feature=${feature}&search=name%20%5E%20(${hostName})&inputs%5BTraces%20search%20query%5D=id%20%5E%20(${firstTrace.id})`,
     );
 
     assertNockRequest(autocompleteScope);
@@ -430,7 +430,7 @@ describe('Without tracer installed', () => {
     expect(enableTracesModalLink)
       .toHaveAttribute(
         'href',
-        `/job_invocations/new?feature=${feature}&host_ids=name%20%5E%20(${hostName})&inputs%5Bpackage%5D=katello-host-tools-tracer`,
+        `/job_invocations/new?feature=${feature}&search=name%20%5E%20(${hostName})&inputs%5Bpackage%5D=katello-host-tools-tracer`,
       );
     enableTracesModalLink.click();
     expect(enableTracesModalLink).toHaveClass('pf-m-in-progress');

--- a/webpack/components/extensions/HostDetails/Tabs/customizedRexUrlHelpers.js
+++ b/webpack/components/extensions/HostDetails/Tabs/customizedRexUrlHelpers.js
@@ -10,7 +10,7 @@ export const createJob = ({
   const inputParams = Object.keys(inputs).map(key => `inputs[${key}]=${inputs[key]}`);
   const params = [
     `feature=${feature}`,
-    `host_ids=name ^ (${hostname})`,
+    `search=name ^ (${hostname})`,
     ...inputParams,
   ];
   const urlQuery = encodeURI(params.join('&'));


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Change the 'via customized remote execution' options in the new host details page to use the `search` url param instead of `host_ids`. This will make them compatible with the new job wizard.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Perform any customized REX action on the new host details page
ensure that the host search is filled in for you.  (see the BZ https://bugzilla.redhat.com/show_bug.cgi?id=2149990 for more details)