### PR TITLE
Fixes #35191 - Strip errata trailing whitespace before saving

### DIFF
--- a/app/services/katello/pulp3/erratum.rb
+++ b/app/services/katello/pulp3/erratum.rb
@@ -28,6 +28,7 @@ module Katello
       def self.generate_model_row(unit)
         keys = %w(title id severity issued_date type description reboot_suggested solution updated_date summary)
         custom_json = unit.slice(*keys)
+        custom_json.inject(HashWithIndifferentAccess.new({})) { |h, (k, v)| h.merge({ k => v.respond_to?(:strip) ? v.strip : v }) }
         custom_json['pulp_id'] = custom_json['id']
         custom_json["issued"] = custom_json.delete("issued_date")
         custom_json["updated"] = custom_json.delete("updated_date")

--- a/test/controllers/api/v2/api_controller_test.rb
+++ b/test/controllers/api/v2/api_controller_test.rb
@@ -41,9 +41,9 @@ module Katello
 
       response = @controller.scoped_search(@query, @default_sort[0], @default_sort[1], @options)
       refute_empty response[:results], "results"
-      assert_equal 5, response[:subtotal], "subtotal"
-      assert_equal 5, response[:total], "total"
-      assert_equal 5, response[:selectable], "selectable"
+      assert_equal 6, response[:subtotal], "subtotal"
+      assert_equal 6, response[:total], "total"
+      assert_equal 6, response[:selectable], "selectable"
       assert_equal 1, response[:page], "page"
       assert_equal Setting[:entries_per_page], response[:per_page], "per page"
       assert_nil response[:error], "error"
@@ -115,7 +115,7 @@ module Katello
       options = {resource_class: Katello::Erratum}
 
       results = @controller.scoped_search(query, "errata_id", "asc", options)[:results]
-      assert_equal ["RHBA-2014-013", "RHEA-2014-111", "RHEA-2017-007", "RHEA-2019-002", "RHSA-1999-1231"], results.map(&:errata_id)
+      assert_equal ["RHBA-2014-013", "RHEA-2014-111", "RHEA-2017-007", "RHEA-2019-002", "RHEA-2022-007", "RHSA-1999-1231"], results.map(&:errata_id)
     end
 
     def test_scoped_search_order_via_hammer_order
@@ -126,7 +126,7 @@ module Katello
       options = {resource_class: Katello::Erratum}
 
       results = @controller.scoped_search(query, "errata_id", "desc", options)[:results]
-      assert_equal ["RHBA-2014-013", "RHEA-2014-111", "RHEA-2017-007", "RHEA-2019-002", "RHSA-1999-1231"].sort.reverse, results.map(&:errata_id)
+      assert_equal ["RHBA-2014-013", "RHEA-2014-111", "RHEA-2017-007", "RHEA-2019-002", "RHEA-2022-007", "RHSA-1999-1231"].sort.reverse, results.map(&:errata_id)
     end
 
     def test_scoped_search_invalid_column

--- a/test/controllers/api/v2/errata_controller_test.rb
+++ b/test/controllers/api/v2/errata_controller_test.rb
@@ -146,7 +146,7 @@ module Katello
       get :index, params: { :organization_id => @test_repo.organization.id }
 
       assert_response :success
-      assert_equal JSON.parse(response.body)['results'].map { |item| item['errata_id'] }, ["RHSA-1999-1231", "RHBA-2014-013"]
+      assert_equal JSON.parse(response.body)['results'].map { |item| item['errata_id'] }, ["RHSA-1999-1231", "RHBA-2014-013", "RHEA-2022-007"]
     end
 
     def test_show

--- a/test/fixtures/models/katello_errata.yml
+++ b/test/fixtures/models/katello_errata.yml
@@ -47,3 +47,13 @@ modular:
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
   issued: <%= 3.days.ago %>
+
+trailing_whitespace:
+  errata_id: "RHEA-2022-007"
+  errata_type: "bugfix"
+  title: "trailing_whitespace"
+  pulp_id: "trailing_whitespace"
+  description: "You know I had to do it to em\n"
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+  issued: <%= 3.days.ago %>

--- a/test/fixtures/models/katello_repository_errata.yml
+++ b/test/fixtures/models/katello_repository_errata.yml
@@ -22,3 +22,8 @@ fedora_17_x86_64_dev_bugfix:
     erratum_id: <%= ActiveRecord::FixtureSet.identify(:bugfix) %>
     repository_id: <%= ActiveRecord::FixtureSet.identify(:fedora_17_x86_64_dev) %>
     erratum_pulp3_href: "fedora_17_x86_64_dev_bugfix_href"
+
+fedora_17_x86_64_trailing_whitespace:
+    erratum_id: <%= ActiveRecord::FixtureSet.identify(:trailing_whitespace) %>
+    repository_id: <%= ActiveRecord::FixtureSet.identify(:fedora_17_x86_64) %>
+    erratum_pulp3_href: "fedora_17_x86_64_trailing_whitespace_href"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Strip trailing whitespace from errata description, title, etc before saving, to avoid discrepancy between pulp record vs. katello record

#### What are the testing steps for this pull request?

See https://projects.theforeman.org/issues/35191 but note that the _symptom_ described there should already be resolved by https://github.com/Katello/katello/commit/e626c4ce9078ddfd36bfe3216a85bacc96427212