### PR TITLE
Fixes #35046 - pluralize and translate errata tooltip

### DIFF
--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
@@ -20,6 +20,7 @@ import { TranslatedAnchor } from '../../../Table/components/TranslatedPlural';
 import EmptyStateMessage from '../../../Table/EmptyStateMessage';
 import './ErrataOverviewCard.scss';
 import { errataStatusContemplation } from '../../../Errata/errataHelpers';
+import { pluralize } from '../../../../utils/helpers';
 
 function HostInstallableErrata({
   id, errataCounts, errataStatus, errataCategory, errataStatusLabel,
@@ -31,11 +32,11 @@ function HostInstallableErrata({
   const errataEnhance = counts.enhancement;
   const { neededErrata, allUpToDate, otherErrataStatus } = errataStatusContemplation(errataStatus);
   const chartData = [{
-    w: 'security advisories', x: 'security', y: errataSecurity, z: errataTotal,
+    w: __('security advisories'), singular: __('security advisory'), x: 'security', y: errataSecurity, z: errataTotal,
   }, {
-    w: 'bug fixes', x: 'bugfix', y: errataBug, z: errataTotal,
+    w: __('bug fixes'), singular: __('bug fix'), x: 'bugfix', y: errataBug, z: errataTotal,
   }, {
-    w: 'enhancements', x: 'enhancement', y: errataEnhance, z: errataTotal,
+    w: __('enhancements'), singular: __('enhancement'), x: 'enhancement', y: errataEnhance, z: errataTotal,
   }];
   return (
     <CardBody>
@@ -75,7 +76,7 @@ function HostInstallableErrata({
                   ariaDesc="errataChart"
                   data={chartData}
                   constrainToVisibleArea
-                  labels={({ datum }) => `${datum.y} ${datum.w}`}
+                  labels={({ datum }) => pluralize(datum.y, datum.singular, datum.w)}
                   padding={{
                     bottom: 20,
                     left: 20,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

1. Translate the pie chart tooltips from the errata overview card
2. Run the counts through our simple pluralizer function to prevent incorrect pluralization such as "1 bug fixes"

#### Considerations taken when implementing this change?

I tried to use `react-intl` but we apparently don't have access to the imperative API documented [here](https://formatjs.io/docs/react-intl/api). So I used the simpler `pluralize` helper function instead.

Also I realized we should probably be translating these tooltips as well.

#### What are the testing steps for this pull request?

Change https://github.com/Katello/katello/blob/4950081967a99de4b68825cbe86ea8845334b155/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js#L30 to

```js
const errataBug = 1;
```

and view the tooltip displayed on mouse hover.