### PR TITLE
Fixes #35153 - Incorrect permission referenced in repo task page

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repositories.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repositories.routes.js
@@ -169,7 +169,7 @@
         })
         .state('product.repository.tasks.index', {
             url: '/tasks',
-            permission: 'view_repositories',
+            permission: 'view_products',
             templateUrl: 'products/details/repositories/details/views/repository-tasks.html',
             ncyBreadcrumb: {
                 label: "{{'Tasks' | translate }}",
@@ -178,7 +178,7 @@
         })
         .state('product.repository.tasks.details', {
             url: '/tasks/:taskId',
-            permission: 'view_repositories',
+            permission: 'view_products',
             controller: 'TaskDetailsController',
             templateUrl: 'tasks/views/task-details.html',
             ncyBreadcrumb: {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Use 'view_products' permission instead of 'view_repositories'.
PS: I am fairly certain no permission called 'view_repositories' exists. The repository permissions are driven by product level permissions.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Create a role with all permissions from 'Product and Repositories' header and Foreman Task permissions.
Sync a repository and ensure you don't see a 403 page redirect.