### PR TITLE
Fixes #35834 - select content source before LCE and CV 

### DIFF
--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -57,14 +57,16 @@ module Katello
       end
     end
 
-    def fetch_lifecycle_environment(host, options = {})
-      return host.lifecycle_environment if host.try(:lifecycle_environment_id)
+    def fetch_lifecycle_environment(host_or_hostgroup, options = {})
+      return host_or_hostgroup.single_lifecycle_environment if host_or_hostgroup.try(:single_lifecycle_environment)
+      return host_or_hostgroup.lifecycle_environment if host_or_hostgroup.try(:lifecycle_environment)
       selected_host_group = options.fetch(:selected_host_group, nil)
       return selected_host_group.lifecycle_environment if selected_host_group.present?
     end
 
-    def fetch_content_view(host, options = {})
-      return host.single_content_view if host.try(:single_content_view)
+    def fetch_content_view(host_or_hostgroup, options = {})
+      return host_or_hostgroup.single_content_view if host_or_hostgroup.try(:single_content_view)
+      return host_or_hostgroup.content_view if host_or_hostgroup.try(:content_view)
       selected_host_group = options.fetch(:selected_host_group, nil)
       return selected_host_group.content_view if selected_host_group.present?
     end

--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -5,6 +5,26 @@
     option.kt-cv  { margin-left: 1em; }
 </style>
 <% spinner_path = asset_path('spinner.gif') %>
+<% edit_action = params[:action] == 'edit' %>
+
+<% if edit_action && !using_hostgroups_page? %>
+  <div style="margin-left: 270px">
+    <%= link_to _("Change content source"), "/change_host_content_source?host_id=#{@host.id}" %>
+  </div>
+<% end %>
+
+<% cs_select_id =  using_hostgroups_page? ? :content_source_id : :content_source_id %>
+<% cs_select_name =  using_hostgroups_page? ? 'hostgroup[content_source_id]' : 'host[content_facet_attributes][content_source_id]' %>
+<% cs_select_attr = using_hostgroups_page? ? 'content_source' : 'content_facet.content_source' %>
+
+<%= field(f, cs_select_attr, {:label => _("Content Source")}) do
+  if using_hostgroups_page?
+    select_tag cs_select_id, content_source_options(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path},
+               :class => 'form-control',  :name => cs_select_name
+  else
+    select_tag cs_select_id, content_source_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cs_select_name, :disabled => edit_action
+  end
+end %>
 
 <% env_select_id = using_hostgroups_page? ? :hostgroup_lifecycle_environment_id : :host_lifecycle_environment_id %>
 <% env_select_name =  using_hostgroups_page? ? 'hostgroup[lifecycle_environment_id]' : 'host[content_facet_attributes][lifecycle_environment_id]' %>
@@ -15,7 +35,7 @@
     select_tag env_select_id, lifecycle_environment_options(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)),
                :class => 'form-control',  :name => env_select_name
   else
-    select_tag env_select_id, lifecycle_environment_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name
+    select_tag env_select_id, lifecycle_environment_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name, :disabled => edit_action
   end
 end %>
 
@@ -27,19 +47,6 @@ end %>
     select_tag cv_select_id,  content_views_for_host(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :data => {"spinner_path" => spinner_path},
                :class => 'form-control',  :name => cv_select_name
   else
-    select_tag cv_select_id,  content_views_for_host(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cv_select_name
-  end
-end %>
-
-<% cs_select_id =  using_hostgroups_page? ? :content_source_id : :content_source_id %>
-<% cs_select_name =  using_hostgroups_page? ? 'hostgroup[content_source_id]' : 'host[content_facet_attributes][content_source_id]' %>
-<% cs_select_attr = using_hostgroups_page? ? 'content_source' : 'content_facet.content_source' %>
-
-<%= field(f, cs_select_attr, {:label => _("Content Source")}) do
-  if using_hostgroups_page?
-    select_tag cs_select_id, content_source_options(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path},
-               :class => 'form-control',  :name => cs_select_name
-  else
-    select_tag cs_select_id, content_source_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cs_select_name
+    select_tag cv_select_id,  content_views_for_host(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cv_select_name, :disabled => edit_action
   end
 end %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
In Create Host, show Content source field before both Lifecycle environment and Content view fields.

When `Edit Host`, all Content source, Lifecycle environment and Content view fields should be disabled to honor `Change content source` task which is available in the kebab dropdown list.

#### Considerations taken when implementing this change?
Lifecycle environment, Content view and Content source are all saved into a host's content facet.
Content facet would not be created if either Lifecycle environment or Content view is blank due to [this checking](https://github.com/Katello/katello/blob/4950081967a99de4b68825cbe86ea8845334b155/app/models/katello/concerns/content_facet_host_extensions.rb#L62).

[Decision](https://docs.google.com/document/d/18lB3EPatXtCi-GZRNUxT7ujr_LniiInp0Tk7G30RR7U/edit) made during a meeting.

#### What are the testing steps for this pull request?
All Hosts - Create Host
Select Content source and all other required fields in all tabs

Before
With either Lifecycle environment or Content view blank, selected content source is not persistent.

After
Selected Content source field is preserved.