### PR TITLE
Fixes #35818 - Fix repository sets NilClass error when all items selected

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -176,7 +176,6 @@ module Katello
       content_override_values = @content_overrides.map do |override_params|
         validate_content_overrides_enabled(override_params)
       end
-
       sync_task(::Actions::Katello::Host::UpdateContentOverrides, @host, content_override_values, false)
       fetch_product_content
     end
@@ -232,7 +231,7 @@ module Katello
     end
 
     def find_content_overrides
-      if params.dig(:content_overrides_search, :search).present?
+      if !params.dig(:content_overrides_search, :search).nil?
         content_labels = ::Katello::Content.joins(:product_contents)
                             .where("#{Katello::ProductContent.table_name}.product_id": @host.organization.products.subscribable.enabled)
                             .search_for(params[:content_overrides_search][:search])

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -230,6 +230,17 @@ module Katello
       assert_template 'katello/api/v2/repository_sets/index'
     end
 
+    def test_find_content_overrides_with_empty_string_search
+      controller = ::Katello::Api::V2::HostSubscriptionsController.new
+      controller.params = { :host_id => @host.id, :content_overrides => "wrong", :content_overrides_search => { :search => '' } }
+      controller.instance_variable_set(:@host, @host)
+      controller.send(:find_content_overrides)
+
+      # content_overrides should be set from search param, not content_overrides param
+      result = controller.instance_variable_get(:@content_overrides)
+      refute_equal result, "wrong"
+    end
+
     def test_content_override_bulk
       content_overrides = [{:content_label => 'some-content', :value => 1}]
       expected_content_labels = content_overrides.map { |co| co[:content_label] }


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

In `Api::V2::HostSubscriptionsController#find_content_overrides`, the value from `params[:content_overrides_search][:search]` was checked using `.present?`. Since Rails' `#present?` considers an empty string to be not "present," this was breaking the Select All functionality on the new host details page Repository Sets tab. To fix it, we switch to checking explicitly for `nil` instead.

#### Considerations taken when implementing this change?

This shouldn't interfere with the fix in https://github.com/Katello/katello/pull/10363.

#### What are the testing steps for this pull request?

New host details > Repository Sets tab:

1. Select All repository sets with the checkbox -> Override to Disabled / Enabled / Reset to default. Make sure it completes with no errors.
2. Make sure other repo set operations continue to work (non-select-all)
3. Make sure the hammer fix mentioned above is still working.
