### PR TITLE
Fixes #35848 - Handles content move during manifest

### DIFF
--- a/app/lib/katello/util/candlepin_repository_checker.rb
+++ b/app/lib/katello/util/candlepin_repository_checker.rb
@@ -33,6 +33,8 @@ module Katello
       end
 
       def self.repository_exist_in_backend?(repository)
+        return false if repository.root.content_id.blank?
+
         ::Katello::Resources::Candlepin::Content.get(repository.organization.label, repository.root.content_id)
         true
       rescue RestClient::NotFound

--- a/app/models/katello/content.rb
+++ b/app/models/katello/content.rb
@@ -41,7 +41,7 @@ module Katello
         cp_products = ::Katello::Resources::Candlepin::Product.all(org.label, [:id, :productContent])
         product_hash = cp_products.group_by { |prod| prod['id'] }
 
-        prod_content_importer = Katello::ProductContentImporter.new
+        prod_content_importer = Katello::ProductContentImporter.new(product_hash)
         org.products.each do |product|
           product_json = product_hash[product.cp_id]&.first
 

--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -122,7 +122,7 @@ module Katello
         cp_products = ::Katello::Resources::Candlepin::Product.all(organization.label, [:id, :name, :multiplier, :productContent])
         cp_products = cp_products.select { |prod| Glue::Candlepin::Product.engineering_product_id?(prod['id']) }
 
-        prod_content_importer = Katello::ProductContentImporter.new
+        prod_content_importer = Katello::ProductContentImporter.new(cp_products)
 
         Katello::Logging.time("Imported #{cp_products.size} products") do
           cp_products.each do |product_json|

--- a/app/services/katello/product_content_importer.rb
+++ b/app/services/katello/product_content_importer.rb
@@ -95,7 +95,6 @@ module Katello
 
     private def existing_content_map
       if @existing_content_map.nil?
-
         @existing_content_map = {}
         Katello::Content.where(:organization_id => @product_mapping.keys.first.organization.id).to_a.each do |content|
           @existing_content_map[content[:cp_content_id]] = content

--- a/app/services/katello/product_content_importer.rb
+++ b/app/services/katello/product_content_importer.rb
@@ -22,30 +22,66 @@ module Katello
     # }
     attr_reader :content_url_updated
 
-    def initialize
+    def initialize(cp_products = [])
       @contents_to_create = []
       @product_contents_to_create = []
       @product_mapping = {}
       @content_url_updated = []
+      @cp_products = cp_products
     end
 
     def add_product_content(product, product_content_json)
       @product_mapping[product] = product_content_json.map(&:with_indifferent_access)
     end
 
+    def find_product_for_content(content_id)
+      prod = @cp_products.find do |prod_json|
+        prod_json['productContent'].any? do |product_content_json|
+          product_content_json["content"]["id"] == content_id
+        end
+      end
+      ::Katello::Product.find_by(cp_id: prod["id"]) if prod
+    end
+
     def import
       return if @product_mapping.blank?
-
+      product_contents_to_move = []
+      product_contents_to_delete = []
       @product_mapping.each do |product, prod_contents_json|
-        existing_product_contents = product.product_contents.to_a
 
+        content_ids = prod_contents_json.map {|pc|  pc[:content][:id]}
+        # Identify if there are any product_content that should not be
+        # part of this product.
+        product_contents_to_delete_or_move = product.
+                                        product_contents.
+                                        joins(:content).
+                                        where.not(content: {:cp_content_id => content_ids} )
+
+        # Identify if product content actually moved between 2 different products
+        product_contents_to_move = product_contents_to_delete_or_move.select do |pc|
+          content_exists?(product.organization, pc.content)
+        end
+
+        product_contents_to_move.each do |pc|
+          content = pc.content
+          root_repo = product.root_repositories.find_by(content_id: content.cp_content_id)
+          actual_product = find_product_for_content(content.cp_content_id)
+          if actual_product.present? && root_repo.product != actual_product
+            root_repo.update!(product_id: actual_product.id)
+            pc.update!(product_id: actual_product.id)
+          else
+            pc.destroy!
+          end
+        end
+
+        product.reload
+        existing_product_contents = product.product_contents.to_a
         prod_contents_json.each do |prod_content_json|
           content = create_or_update_content(product, prod_content_json)
           existing_content_map[content.cp_content_id] = content if content.new_record?
           create_or_update_product_content(product, existing_product_contents, content, prod_content_json[:enabled])
         end
       end
-
       ::Katello::Content.import(@contents_to_create, recursive: true)
       ::Katello::ProductContent.import(@product_contents_to_create)
     end
@@ -58,6 +94,13 @@ module Katello
         end
       end
       @existing_content_map
+    end
+
+    def content_exists?(org, content)
+        Resources::Candlepin::Content.get(org.label, content.cp_content_id)
+        true
+      rescue RestClient::NotFound
+        false
     end
 
     private def create_or_update_content(product, prod_content_json)

--- a/app/services/katello/product_content_importer.rb
+++ b/app/services/katello/product_content_importer.rb
@@ -66,7 +66,7 @@ module Katello
           content = pc.content
           root_repo = product.root_repositories.find_by(content_id: content.cp_content_id)
           actual_product = find_product_for_content(content.cp_content_id)
-          if actual_product.present? && root_repo.product != actual_product
+          if actual_product.present? && root_repo.present? && root_repo.product != actual_product
             root_repo.update!(product_id: actual_product.id)
             pc.update!(product_id: actual_product.id)
           else

--- a/test/models/content_test.rb
+++ b/test/models/content_test.rb
@@ -40,7 +40,7 @@ module Katello
           }
         end
       end
-
+      Katello::ProductContentImporter.any_instance.stubs(:content_exists?).returns(false)
       Katello::Resources::Candlepin::Product.stubs(:all).returns(*org_products)
 
       Katello::Content.import_all


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Whenever a manifest is uploaded the candlepin instance refreshes its products and contents accordingly.
Katello then refreshes its tables based on candlepin data.

This works well if new content is added. But in some instances the provided manifest content may have moved from one product to another. The sat indexing logic was not  handling this scenario causing duplicate repository sets.

This commit addresses the move aspect. It tries to find the actual product that the content belonged to and moves over the product connected to the root repository.

#### Considerations taken when implementing this change?

Initially I was debating if I should consider the case where content is deleted, but have not seen any instances of CDN doing that. Move is the only case I have seen. 

#### What are the testing steps for this pull request?
To simulate this requires 2 manifests where content has been switched from one product to another. (ping me if you need them. Also attached to the bz)

manifest-1.zip - rhceph-4-tools-for-rhel-8-x86_64-rpms content is in "Red Hat Enterprise Linux for x86_64"

manifest-2.zip - rhceph-4-tools-for-rhel-8-x86_64-rpms content is in "Red Hat Ceph Storage"

1. Add the following section to your /etc/foreman/plugins/katello.yaml (under section katello)
:katello:
:force_manifest_import: SIGNATURE_CONFLICT&force=MANIFEST_SAME
..other entries..

Since manifest-2 is a fake manifest we need this entry to disable import checks by candlepin.

2. "foreman-maintain service restart" for the new config to take affect
3. Import manifest-1.zip
4. Import manifest-2.zip
5. Go to Red Hat repositories page
6. search for "content_label=rhceph-4-tools-for-rhel-8-x86_64-rpms"

Actual results:
You see 2 repository sets with that label.

Enabling repo("rhceph-4-tools-for-rhel-8-x86_64-rpms") via ansible-playbook/hammer label name fails with the below error:-

Exception
~~~~~~~~~~~~
failed: [satellite.example.com -> localhost] (item={'label': 'rhceph-4-tools-for-rhel-8-x86_64-rpms'}) => {"ansible_loop_var": "item", "changed": false, "item": {"label": "rhceph-4-tools-for-rhel-8-x86_64-rpms"}, "msg": "Found too many (2) results while searching for repository_sets with label=\"rhceph-4-tools-for-rhel-8-x86_64-rpms\""}
~~~~~~~~~~~~

With this PR:
Only one entry for repository set with the given label. The manifest indexing process should clear out the product content (ideally.)


