### PR TITLE
Fixes #35854 - Columns should be empty if there's no data

### DIFF
--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -297,13 +297,13 @@ module Katello
     end
 
     def host_registered_time(host)
-      return _('Never registered') unless host.subscription_facet_attributes&.registered_at
+      return ''.html_safe unless host.subscription_facet_attributes&.registered_at
 
       date_time_relative_value(host.subscription_facet_attributes.registered_at)
     end
 
     def host_checkin_time(host)
-      return _('Never checked in') unless host.subscription_facet_attributes&.last_checkin
+      return ''.html_safe unless host.subscription_facet_attributes&.last_checkin
 
       date_time_relative_value(host.subscription_facet_attributes.last_checkin)
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
On host index page `Registered` and `Last checkin` columns should show up as empty if there's no data.

before:
![registered-last-checkin-before](https://user-images.githubusercontent.com/47797196/207061720-913eb492-406c-42a3-b6b9-e78fda145f6a.png)

after:
![registered-last-checkin-after](https://user-images.githubusercontent.com/47797196/207061763-65830112-2030-4afd-90cb-2ab587be7a67.png)


#### What are the testing steps for this pull request?
In Column selector check  `Registered` and `Last checkin` column.