### PR TITLE
Fixes #35857 - don't assume single_content_view etc. is present in RABL templates

### DIFF
--- a/app/views/katello/api/v2/content_facet/base.json.rabl
+++ b/app/views/katello/api/v2/content_facet/base.json.rabl
@@ -12,19 +12,23 @@ attributes :applicable_module_stream_count, :upgradable_module_stream_count
 
 node :content_view do |content_facet|
   content_view = content_facet.single_content_view
-  {
-    :id => content_view.id,
-    :name => content_view.name,
-    :composite => content_view.composite?
-  }
+  if content_view.present?
+    {
+      :id => content_view.id,
+      :name => content_view.name,
+      :composite => content_view.composite?
+    }
+  end
 end
 
 node :lifecycle_environment do |content_facet|
   lifecycle_environment = content_facet.single_lifecycle_environment
-  {
-    :id => lifecycle_environment.id,
-    :name => lifecycle_environment.name
-  }
+  if lifecycle_environment.present?
+    {
+      :id => lifecycle_environment.id,
+      :name => lifecycle_environment.name
+    }
+  end
 end
 
 child :content_views => :content_views do

--- a/app/views/katello/api/v2/content_facet/show.json.rabl
+++ b/app/views/katello/api/v2/content_facet/show.json.rabl
@@ -3,20 +3,22 @@ child :content_facet => :content_facet_attributes do
 
   node do |content_facet|
     content_facet.single_content_view # just so Rails gives a warning and we remember to fix this
-    version = content_facet.content_view_environments.first.content_view_version
-    {
-      :content_view_version => version.version,
-      :content_view_version_id => version.id,
-      :content_view_version_latest => version.latest?
-    }
+    version = content_facet.content_view_environments.first&.content_view_version
+    if version.present?
+      {
+        :content_view_version => version.version,
+        :content_view_version_id => version.id,
+        :content_view_version_latest => version.latest?
+      }
+    end
   end
 
   node :content_view_default? do |content_facet|
-    content_facet.single_content_view.default?
+    content_facet.single_content_view&.default? || false
   end
 
   node :lifecycle_environment_library? do |content_facet|
-    content_facet.single_lifecycle_environment.library?
+    content_facet.single_lifecycle_environment&.library? || false
   end
 
   node :katello_agent_installed do |content_facet|

--- a/app/views/katello/api/v2/hosts/base.json.rabl
+++ b/app/views/katello/api/v2/hosts/base.json.rabl
@@ -6,18 +6,22 @@ object @resource
 attributes :id, :name, :description
 if @facet
   node :content_view do
-    content_view = @facet&.single_content_view || {}
-    {
-      :id => content_view.id,
-      :name => content_view.name,
-      :composite => content_view.composite?
-    }
+    content_view = @facet&.single_content_view
+    if content_view.present?
+      {
+        :id => content_view.id,
+        :name => content_view.name,
+        :composite => content_view.composite?
+      }
+    end
   end
   node :lifecycle_environment do
-    lifecycle_environment = @facet&.single_lifecycle_environment || {}
-    {
-      :id => lifecycle_environment.id,
-      :name => lifecycle_environment.name
-    }
+    lifecycle_environment = @facet&.single_lifecycle_environment
+    if lifecycle_environment.present?
+      {
+        :id => lifecycle_environment.id,
+        :name => lifecycle_environment.name
+      }
+    end
   end
 end

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -41,6 +41,13 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     host_index_and_show(host)
   end
 
+  def test_no_content_view_environments
+    host = FactoryBot.create(:host, :with_content, :with_subscription)
+    assert_empty host.content_facet.content_view_environments
+
+    host_index_and_show(host)
+  end
+
   def test_with_subscriptions
     host = FactoryBot.create(:host, :with_subscription)
     host_index_and_show(host)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

In our RABL templates, `single_content_view` and `single_lifecycle_environment` were being relied on to be non-nil. This caused some NilClass errors when a host had a cleared-out content facet.

#### Considerations taken when implementing this change?

hopefully this will fix nightly

#### What are the testing steps for this pull request?

ermm.. run the pipeline I guess?
