### PR TITLE
Fixes #35861 - CV publish error when host tied to content facet is not found

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -38,7 +38,7 @@ module Katello
 
       validates_with ::AssociationExistsValidator, attributes: [:content_source]
       validates_with Katello::Validators::GeneratedContentViewValidator
-      validates :host, :presence => true, :allow_blank => false
+      validates :host, :presence => true, :allow_blank => true
 
       attr_accessor :cves_changed
 

--- a/lib/katello/tasks/clean_orphaned_facets.rb
+++ b/lib/katello/tasks/clean_orphaned_facets.rb
@@ -1,0 +1,20 @@
+namespace :katello do
+  desc "Remove orphaned and unneeded content/subscription facets."
+  task :clean_orphaned_facets => ["environment"] do
+    User.current = User.anonymous_admin
+    remove_orphan_facets
+  end
+
+  def remove_orphan_facets
+    ::Katello::Host::ContentFacet.select { |c| c.host.nil? }&.each do |content_facet|
+      Rails.logger.info "Deleting content facet with id: #{content_facet.id}\n"
+      content_facet.destroy
+    end
+    Katello::Host::SubscriptionFacet.select { |s| s.host.nil? }&.each do |subscription_facet|
+      Rails.logger.info "Deleting subscription facet with id: #{subscription_facet.id}\n"
+      subscription_facet.destroy
+    end
+  rescue RuntimeError => e
+    Rails.logger.error "Task failed: #{e}"
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
1. Throw an error if the content host tied to a CV has had it's host deleted for some reason.
2. Add a task to clean orphaned content and subscription facets.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Working on it to avoid adding steps that involve delete FK constraints in the DB. 🐱 
Adding steps to reproduce on dev.
1. Create a CV and add an activation key for the CV.
2. Register a host with the activation key.
3. Go to `psql -d katello -U katello`
4. DELETE from host where id='id'
5. ALTER table to remove the FK constraints that fail.
 Follow steps here for the queries to run:  https://github.com/Katello/katello/pull/10391#issuecomment-1371230005
7. Once the host has been deleted, try publishing the CV again. You should see the error.
![Screenshot from 2023-01-04 12-42-48](https://user-images.githubusercontent.com/21146741/210616900-a655a353-9d95-4aab-a4f6-1585acb76e83.png)

8. Checkout this branch and publish again.
9. Run the rails task as the error message states.
10. The orphaned content facet and subscription facet will be deleted.
11. Publish again. It should succeed.