### PR TITLE
Fixes #35863 - Stop using #hosts with KTEnvironments

### DIFF
--- a/app/lib/actions/katello/content_view/remove.rb
+++ b/app/lib/actions/katello/content_view/remove.rb
@@ -71,17 +71,16 @@ module Actions
                       content_view_history_ids: cv_histories.map { |history| history.id })
 
             if organization_destroy
-              destroy_hosts_and_hostgroups(content_view: content_view)
+              destroy_host_and_hostgroup_associations(content_view: content_view)
             end
           end
         end
 
-        def destroy_hosts_and_hostgroups(content_view:)
+        def destroy_host_and_hostgroup_associations(content_view:)
           content_view.hostgroups.destroy_all
           host_ids = content_view.hosts.ids
           ::Katello::Host::ContentFacet.where(:host_id => host_ids).destroy_all
           ::Katello::Host::SubscriptionFacet.where(:host_id => host_ids).destroy_all
-          ::Host::Managed.where(:id => host_ids).destroy_all
         end
 
         def check_version_deletion(versions, cv_envs)

--- a/app/lib/actions/katello/environment/destroy.rb
+++ b/app/lib/actions/katello/environment/destroy.rb
@@ -24,12 +24,18 @@ module Actions
             end
 
             if organization_destroy
-              env.hostgroups.clear
-              env.hosts.clear
+              delete_host_and_hostgroup_associations(environment: env)
             end
 
             plan_self
           end
+        end
+
+        def delete_host_and_hostgroup_associations(environment:)
+          environment.hostgroups.delete_all
+          host_ids = environment.hosts.ids
+          ::Katello::Host::ContentFacet.where(:host_id => host_ids).delete_all
+          ::Katello::Host::SubscriptionFacet.where(:host_id => host_ids).delete_all
         end
 
         def humanized_name

--- a/test/actions/katello/environment_test.rb
+++ b/test/actions/katello/environment_test.rb
@@ -31,4 +31,25 @@ module ::Actions::Katello::Environment
       assert_action_planned_with(action, ::Actions::Katello::ContentView::Remove, content_view, :content_view_environments => [cve], :skip_repo_destroy => false, :organization_destroy => false)
     end
   end
+
+  class DestroyWithOrganizationDestroyTest < TestBase
+    let(:action_class) { ::Actions::Katello::Environment::Destroy }
+    let(:action) { create_action action_class }
+
+    let(:environment) { stub }
+
+    it 'plans' do
+      stub_remote_user
+      content_view = stub
+      cve = mock(:content_view => content_view)
+      action.stubs(:action_subject).with(environment)
+      environment.expects(:content_view_environments).returns([cve])
+      environment.expects(:deletable?).returns(true)
+      environment.expects(:hostgroups).returns(::Hostgroup.none)
+      environment.expects(:hosts).returns(::Host.none)
+      environment.expects(:hosts=).never
+      plan_action(action, environment, :organization_destroy => true)
+      assert_action_planned_with(action, ::Actions::Katello::ContentView::Remove, content_view, :content_view_environments => [cve], :skip_repo_destroy => false, :organization_destroy => true)
+    end
+  end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Previously, the path from KTEnvironment to Host was

```
KTEnvironment > ContentFacet > Host
```

This is only 2 hops (e.g. there is only one model between KTEnvironment and Host.)

Now, in our new multiple environment world, it's

```
KTEnvironment > ContentViewEnvironment > ContentViewEnvironmentContentFacet > ::Host::ContentFacet > Host
```

Because there are now 4 hops, modifying the association directly will no longer work:

```rb
environment.hosts.clear # this won't work anymore
```

Instead, we must work around it by finding the host IDs similar to what we already do [here](https://github.com/jeremylenz/katello/blob/899516c90490f86df39c38fbe6052d8d82b2d66f/app/lib/actions/katello/content_view/remove.rb#L79).

#### Considerations taken when implementing this change?

I used `delete_all` rather than `destroy_all` because that's equivalent to `clear` and won't run callbacks.

#### What are the testing steps for this pull request?

Create an organization
Register a host to it
Delete the organization

Before this change:
```
Cannot modify association 'Katello::KTEnvironment#hosts' because it goes through more than one other association.
```

After this change: org should be deleted with no error.

