### PR TITLE
Fixes #35864 - Remove all non-srpm content types from ignorable content

### DIFF
--- a/db/migrate/20220228173251_remove_drpm_from_ignorable_content.rb
+++ b/db/migrate/20220228173251_remove_drpm_from_ignorable_content.rb
@@ -1,12 +1,16 @@
 class RemoveDrpmFromIgnorableContent < ActiveRecord::Migration[6.0]
   def up
-    Katello::RootRepository.select { |r| r&.ignorable_content&.include? "drpm" }.each do |root|
-      root.ignorable_content = root.ignorable_content - ["drpm"]
+    Katello::RootRepository.select { |r| !r&.ignorable_content&.blank? }.each do |root|
+      if root&.ignorable_content&.include?("srpm")
+        root.ignorable_content = ["srpm"]
+      else
+        root.ignorable_content = []
+      end
       root.save!
     end
   end
 
   def down
-    fail ActiveRecord::IrreversibleMigration
+    #noop
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Update migration to allow clearning out **_all_** content types from ignorable_content.
#### Considerations taken when implementing this change?
For some reason, some users seem to have content types like errata in ignorable content. Even though that is wrong, we want to handle that case to not fail the migration and correct the data during the migration.
#### What are the testing steps for this pull request?
1. Testing this involves upgrading from 4.4 -> 4.5 but the alternative steps are below.
2. Update https://github.com/Katello/katello/blob/master/app/models/katello/root_repository.rb#L20 locally to add:
`IGNORABLE_CONTENT_UNIT_TYPES = %w(srpm erratum drpm rpm).freeze`
3. Create few yum repos 
4. bundle exec rails c
5. 
`
root1 = Katello::RootRepository.find(1)
root1.ignorable_content = ["erratum"]
root1.save!
`
6. Repeat the above with couple of dirrent root records with different ignorable_content like ["srpm", "drpm"], ["drpm"] etc.
7. Copy the file db/migrate/20220228173251_remove_drpm_from_ignorable_content.rb on this branch into a **new** file. example: db/migrate/20221213173255_remove_drpm_from_ignorable_content.rb
8. Run bundle exec rails db:migrate
9. Go back to console and check all the root.ignorable_content fields. The repos that contained srpm in the ignorable_content array would be left with only "srpm" in the ignorable_content.
10. The repos that did not contain srpm in the ignorable_content array would be left with empty ignorable_content.