### PR TITLE
Fixes #35878 - CV and LCE name show empty strings in RepoSets banner

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -185,9 +185,11 @@ const RepositorySetsTab = () => {
   const {
     contentViewDefault,
     lifecycleEnvironmentLibrary,
-    contentViewName,
-    lifecycleEnvironmentName,
+    contentView,
+    lifecycleEnvironment,
   } = contentFacet;
+  const { name: contentViewName } = contentView ?? {};
+  const { name: lifecycleEnvironmentName } = lifecycleEnvironment ?? {};
   const nonLibraryHost = contentViewDefault === false ||
     lifecycleEnvironmentLibrary === false;
   const [isBulkActionOpen, setIsBulkActionOpen] = useState(false);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When you set the toggle to 'Limit to environment', the Repository Sets tab has a banner

```
Showing only repositories in the "My CV" content view and "dev" environment.
```

However, since the multi-CV work it has said

```
Showing only repositories in the "" content view and "" environment.
```

This is because Rails no longer provides the methods `content_view_name` and `lifecycle_environment_name` on content facets.

This fixes that.

#### Considerations taken when implementing this change?

When we start updating the UI for multi-CV, we'll have to change this text again. But I didn't want to do that prematurely.

#### What are the testing steps for this pull request?

put a host in a non-library CV/LCE
view the Repo Sets tab
