### PR TITLE
Fixes #35874 - Registration fails in method: host_setup_extension

### DIFF
--- a/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
@@ -20,8 +20,7 @@ module Katello
 
       def host_setup_extension
         if params['host']['lifecycle_environment_id']
-          new_lce = KTEnvironment.readable.find(params['host']['lifecycle_environment_id'])
-          @host.content_facet.lifecycle_environment = new_lce
+          @host.content_facet.assign_single_environment(content_view_id: @host&.content_views&.first&.id, lifecycle_environment_id: params['host']['lifecycle_environment_id'])
           @host.update_candlepin_associations
         end
 

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -96,6 +96,11 @@ module Katello
         unless lifecycle_environment_id
           fail _("Lifecycle environment must be specified")
         end
+
+        unless content_view_id
+          fail _("Content view must be specified")
+        end
+
         content_view_environment = ::Katello::ContentViewEnvironment
           .where(:content_view_id => content_view_id, :environment_id => lifecycle_environment_id)
           .first_or_create do |cve|


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Remove host_setup_extension method that uses @host.content_facet.lifecycle_environment
#### Considerations taken when implementing this change?
The method seems to be unnecessary and the registration workflow works correctly without this method. 
#### What are the testing steps for this pull request?
1. Create a CV, activation key and use the global registration flow to get the registration commands.
2. Register a host using the generated registration commands.
3. Notice an error on master.
4. On this PR, you shouldn't see any failures and registration should complete successfully.