### PR TITLE
Fixes #35886 - Allow installed_debs method

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -479,7 +479,7 @@ end
 
 class ::Host::Managed::Jail < Safemode::Jail
   allow :content_source, :subscription_manager_configuration_url, :rhsm_organization_label,
-        :host_collections, :pools, :hypervisor_host,
+        :host_collections, :pools, :hypervisor_host, :installed_debs,
         :installed_packages, :traces_helpers, :advisory_ids, :package_names_for_job_template,
         :filtered_entitlement_quantity_consumed, :bound_repositories,
         :single_content_view, :single_lifecycle_environment


### PR DESCRIPTION
I need to use `installed_debs` method in my Job template to search a installed packages in Debian/Ubuntu hosts. Like [this](https://github.com/maccelf/foreman_kernel_care/blob/552a493012762938db3c29f1cbfd5643900e8a0c/app/views/foreman_kernel_care/job_templates/kernel_version.erb#L11) 

So to do it i need to allow `installed_debs` method in class `::Host::Managed::Jail`
```ruby
class ::Host::Managed::Jail < Safemode::Jail
  allow :installed_debs