### PR TITLE
Fixes #35232 - Fix repo sets empty state when Limit to Environment selected

### DIFF
--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -43,6 +43,7 @@ const TableWrapper = ({
   clearSelectedResults,
   emptySearchBody,
   hideSearch,
+  alwaysHideToolbar,
   nodesBelowSearch,
   bookmarkController,
   readOnlyBookmarks,
@@ -60,8 +61,8 @@ const TableWrapper = ({
   const showPagination = !unresolvedStatusOrNoRows;
   const filtersAreActive = activeFilters?.length &&
     !isEqual(new Set(activeFilters), new Set(allTableProps.defaultFilters));
-  const hideToolbar = !searchQuery && !filtersAreActive &&
-    allTableProps.status === STATUS.RESOLVED && total === 0;
+  const hideToolbar = alwaysHideToolbar || (!searchQuery && !filtersAreActive &&
+    allTableProps.status === STATUS.RESOLVED && total === 0);
   const showActionButtons = actionButtons && (alwaysShowActionButtons || !hideToolbar);
   const showToggleGroup = toggleGroup && (alwaysShowToggleGroup || !hideToolbar);
   const paginationParams = useCallback(() =>
@@ -305,6 +306,7 @@ TableWrapper.propTypes = {
   areAllRowsSelected: PropTypes.func,
   emptySearchBody: PropTypes.string,
   hideSearch: PropTypes.bool,
+  alwaysHideToolbar: PropTypes.bool,
   nodesBelowSearch: PropTypes.node,
   bookmarkController: PropTypes.string,
   readOnlyBookmarks: PropTypes.bool,
@@ -335,6 +337,7 @@ TableWrapper.defaultProps = {
   areAllRowsSelected: noop,
   emptySearchBody: __('Try changing your search settings.'),
   hideSearch: false,
+  alwaysHideToolbar: false,
   nodesBelowSearch: null,
   bookmarkController: undefined,
   readOnlyBookmarks: false,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add a call-to-action for the "Limit to Environment" repo sets empty state.
![image](https://user-images.githubusercontent.com/22042343/212360083-18fde73b-9599-4d71-95d5-04b03f38aa2f.png)


#### Considerations taken when implementing this change?

I first tried just adding the toggle group states to `activeFilters` and `defaultFilters`, but it didn't work well. It feels better to track them separately.

#### What are the testing steps for this pull request?

1. Assign your host to an empty content view
2. New host details page > Content > Repository sets -- see the new empty state and verify that the link works
