### PR TITLE
Fixes #35906 - allow pulp_rest debugs for pulp3

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -187,7 +187,7 @@ module Katello
           config.host = uri.host
           config.scheme = uri.scheme
           pulp3_ssl_configuration(config)
-          config.debugging = false
+          config.debugging = ::Foreman::Logging.logger('katello/pulp_rest').debug?
           config.timeout = SETTINGS[:katello][:rest_client_timeout]
           config.logger = ::Foreman::Logging.logger('katello/pulp_rest')
           config.username = self.setting(PULP3_FEATURE, 'username')


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Allow `pulp_rest` debugs to log API requests/response debugs of communication with `pulp3`. That is in line how `pulp_rest` worked with `pulp2`.

#### Considerations taken when implementing this change?

Whenever `foreman`/`katello` logging debug is enabled, the API debugs would be automatically enabled. This might be too coarse setting. Compare with e.g. `sql` debug logs which are disabled even for default debug level enabled (https://github.com/theforeman/foreman/blob/develop/config/application.rb#L262).

Anyway, I dont see an easy way to achieve similar granularity of defaults for verbose logging.

#### What are the testing steps for this pull request?

- enable debug logging of `foreman`/`katello`
- do an action that triggers a request to `pulp` (e.g. create a custom repo, update it, sync it, promote a Content View etc.)
- check if debugs like in https://projects.theforeman.org/issues/35906 are present