### PR TITLE
[CP] 4.6.2.1

### DIFF
--- a/app/services/katello/content_unit_indexer.rb
+++ b/app/services/katello/content_unit_indexer.rb
@@ -22,7 +22,6 @@ module Katello
     end
 
     def import_all(filtered_indexing = false)
-      additive = filtered_indexing || (@repository&.mirroring_policy == 'additive')
       association_tracker = RepoAssociationTracker.new(@content_type, @service_class, @repository)
       units_from_pulp.each do |units|
         units.each do |unit|
@@ -52,7 +51,7 @@ module Katello
       end
 
       if @model_class.many_repository_associations && @repository
-        sync_repository_associations(association_tracker, additive: additive)
+        sync_repository_associations(association_tracker, additive: filtered_indexing)
       end
     end
 

--- a/webpack/components/Table/TableHooks.js
+++ b/webpack/components/Table/TableHooks.js
@@ -145,6 +145,7 @@ export const useBulkSelect = ({
   initialArry = [],
   initialSearchQuery = '',
   idColumn = 'id',
+  filtersQuery = '',
   isSelectable,
 }) => {
   const { selectionSet: inclusionSet, ...selectOptions } =
@@ -208,7 +209,7 @@ export const useBulkSelect = ({
 
   const fetchBulkParams = (idColumnName = idColumn) => {
     const searchQueryWithExclusionSet = () => {
-      const query = [searchQuery,
+      const query = [searchQuery, filtersQuery,
         !isEmpty(exclusionSet) && `${idColumnName} !^ (${[...exclusionSet].join(',')})`];
       return query.filter(item => item).join(' and ');
     };

--- a/webpack/components/Table/__test__/useBulkSelect.test.js
+++ b/webpack/components/Table/__test__/useBulkSelect.test.js
@@ -1,0 +1,99 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useBulkSelect } from '../TableHooks';
+
+const isSelectable = () => true;
+const idColumn = 'errata_id';
+const metadata = {
+  error: null, selectable: 2, subtotal: 2, total: 2,
+};
+const results = [
+  {
+    errata_id: 'RHSA-2022:2031',
+    id: 311,
+    severity: 'Low',
+    type: 'security',
+  },
+  {
+    errata_id: 'RHSA-2022:2110',
+    id: 17,
+    severity: 'Low',
+    type: 'security',
+  },
+];
+
+it('returns a scoped search string based on inclusionSet', () => {
+  const { result } = renderHook(() => useBulkSelect({
+    results,
+    metadata,
+    idColumn,
+    isSelectable,
+  }));
+
+  act(() => {
+    result.current.selectOne(true, 'RHSA-2022:2031');
+  });
+
+  expect(result.current.fetchBulkParams()).toBe('errata_id ^ (RHSA-2022:2031)');
+});
+
+it('returns a scoped search string based on exclusionSet', () => {
+  const { result } = renderHook(() => useBulkSelect({
+    results,
+    metadata,
+    idColumn,
+    isSelectable,
+  }));
+
+  act(() => {
+    result.current.selectAll(true);
+  });
+
+  act(() => {
+    result.current.selectOne(false, 'RHSA-2022:2031');
+  });
+
+  expect(result.current.fetchBulkParams()).toBe('errata_id !^ (RHSA-2022:2031)');
+});
+
+it('adds search query to scoped search string based on exclusionSet', () => {
+  const { result } = renderHook(() => useBulkSelect({
+    results,
+    metadata,
+    idColumn,
+    isSelectable,
+  }));
+
+  act(() => {
+    result.current.updateSearchQuery('type=security');
+  });
+
+  act(() => {
+    result.current.selectAll(true);
+  });
+
+  act(() => {
+    result.current.selectOne(false, 'RHSA-2022:2031');
+  });
+
+  expect(result.current.fetchBulkParams()).toBe('type=security and errata_id !^ (RHSA-2022:2031)');
+});
+
+it('adds filter dropdown query to scoped search string', () => {
+  const { result } = renderHook(() => useBulkSelect({
+    results,
+    metadata,
+    idColumn,
+    isSelectable,
+    filtersQuery: 'severity=Low',
+  }));
+
+  act(() => {
+    result.current.selectAll(true);
+  });
+
+  act(() => {
+    result.current.selectOne(false, 'RHSA-2022:2031');
+  });
+
+  expect(result.current.fetchBulkParams()).toBe('severity=Low and errata_id !^ (RHSA-2022:2031)');
+});

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -120,6 +120,17 @@ export const ErrataTab = () => {
     initialSortColumnName: 'Errata',
   });
 
+  const filtersQuery = () => {
+    const query = [];
+    if (errataTypeSelected !== ERRATA_TYPE) {
+      query.push(`type=${TYPES_TO_PARAM[errataTypeSelected]}`);
+    }
+    if (errataSeveritySelected !== ERRATA_SEVERITY) {
+      query.push(`severity=${SEVERITIES_TO_PARAM[errataSeveritySelected]}`);
+    }
+    return query.join(' and ');
+  };
+
   const fetchItems = useCallback(
     (params) => {
       if (!hostId) return hostIdNotReady;
@@ -155,6 +166,7 @@ export const ErrataTab = () => {
     results,
     metadata,
     idColumn: 'errata_id',
+    filtersQuery: filtersQuery(),
     isSelectable: result => result.installable,
     initialSearchQuery: searchParam || '',
   });


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Cherry-picking 2 skipped cherrypicks from 4.4.2 which was released after 4.6 branching.

Cherry Picks for repository: katello
----------------------------------------------
Pick All: git cherry-pick -x 886539694b79390f890505be7ae0de26f472fabf 9da8f63c47ee3d1935703dbf9f7daaf22b4b06a4


35045 - 2022-08-11 19:01:11 UTC: [886539694b79390f890505be7ae0de26f472fabf] All errata are applied when user only selects certain errata
35120 - 2022-08-16 16:01:13 UTC: [9da8f63c47ee3d1935703dbf9f7daaf22b4b06a4] Retain packages on Repository removes RPMs from Pulp but not from Katello
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
