### PR TITLE
Update version to 4.6.2.1

### DIFF
--- a/lib/katello/version.rb
+++ b/lib/katello/version.rb
@@ -1,3 +1,3 @@
 module Katello
-  VERSION = "4.6.2".freeze
+  VERSION = "4.6.2.1".freeze
 end


### PR DESCRIPTION
Planning to cut a 4.6.2.1 release since 4.6.2 isn't out for release yet and we have made .z releases for previous releases.