### PR TITLE
Fixes #35915 - Add RHEL to the OS filter list for Module Stream Tab

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -47,7 +47,7 @@ import {
 } from '../../hostDetailsHelpers';
 
 const moduleStreamSupported = ({ os, version }) =>
-  os.match(/RedHat|CentOS|Rocky|AlmaLinux|OracleLinux/i) && Number(version) > 7;
+  os.match(/RedHat|RHEL|CentOS|Rocky|AlmaLinux|OracleLinux/i) && Number(version) > 7;
 export const hideModuleStreamsTab = ({ hostDetails }) => {
   const osMatch = hostDetails?.operatingsystem_name?.match(/(\w+) (\d+)/);
   if (!osMatch) return true;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* On a production install of Katello(on RHEL)/Satellite the host itself is generated with Puppet and creates an OS name called RHEL, Katello creates the name normally.
* Adding RHEL to the filter list

#### Considerations taken when implementing this change?

* N/A

#### What are the testing steps for this pull request?

* Register a RHEL 8.7 host and verify you can see the module streams tab still
* Bonus points for changing the redux state to operatingsystem_name(pin):"RHEL 8.7"