### PR TITLE
Fixes #35926 - Include SmartProxyAuth into RegistrationController

### DIFF
--- a/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
@@ -2,7 +2,6 @@ module Katello
   module Concerns
     module Api::V2::RegistrationControllerExtensions
       extend ActiveSupport::Concern
-      include ::Foreman::Controller::SmartProxyAuth
 
       def prepare_host
         if params['uuid']

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -215,6 +215,7 @@ module Katello
       ::Api::V2::HostsController.include Katello::Concerns::ContentFacetHostsControllerExtensions
       ::Api::V2::HostgroupsController.include Katello::Concerns::Api::V2::HostgroupsControllerExtensions
       ::Api::V2::SmartProxiesController.include Katello::Concerns::Api::V2::SmartProxiesControllerExtensions
+      ::Api::V2::RegistrationController.include ::Foreman::Controller::SmartProxyAuth
       ::Api::V2::RegistrationController.prepend Katello::Concerns::Api::V2::RegistrationControllerExtensions
       ::Api::V2::RegistrationCommandsController.include Katello::Concerns::Api::V2::RegistrationCommandsControllerExtensions
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
When https://github.com/Katello/katello/pull/10315 patch is applied on production environment with older
Katello versions (like katello-4.5.0), registration will start failing on following error:

undefined local variable or method `auth_smart_proxy' for #<Api::V2::RegistrationController:0x00007f84842a5728>

Fix is to include SmartProxyAuth into the RegistrationController
instead of RegistrationControllerExtensions module.

#### Considerations taken when implementing this change?
See https://bugzilla.redhat.com/show_bug.cgi?id=2158959

#### What are the testing steps for this pull request?
* Register & subscribe host through the proxy
* Verify that it has been registered and it's subscribed to the Forman