### PR TITLE
Fixes #35929 - destroy the product after *all* content is gone

### DIFF
--- a/app/lib/actions/katello/product/destroy.rb
+++ b/app/lib/actions/katello/product/destroy.rb
@@ -46,8 +46,9 @@ module Actions
                               product_id: product.cp_id,
                               content_id: pc.content.cp_content_id)
                 end
-                plan_action(Candlepin::Product::Destroy, cp_id: product.cp_id, :owner => product.organization.label)
               end
+
+              plan_action(Candlepin::Product::Destroy, cp_id: product.cp_id, :owner => product.organization.label)
             end
 
             clear_pool_associations(product)


### PR DESCRIPTION
Otherwise a content delete step can happen *after* the product is already deleted, resulting in `Product with ID "X" could not be found` errors raised from Candlepin.

#### What are the changes introduced in this pull request?

Product deletion happens not in parallel with Content deletion anymore.

#### Considerations taken when implementing this change?

None

#### What are the testing steps for this pull request?

The following script was rather successful (80-90%) in reproducing the issue on Katello 4.5 with Candlepin 4.1.19 (the check is not present in earlier versions of Candlepin 4.1 branch):

```
hammer organization create --name lol
hammer product create --name lol --organization lol
hammer repository create --name lol --content-type yum --product lol --organization lol
hammer content-export complete library --organization lol
hammer content-export incremental library --organization lol
hammer repository delete --name lol --product lol --organization lol
hammer product delete --name lol --organization lol
hammer organization delete --name lol
```