### PR TITLE
Fixes #35935 - add info about reclaiming space from orphans

### DIFF
--- a/app/views/foreman/smart_proxies/_content_sync.html.erb
+++ b/app/views/foreman/smart_proxies/_content_sync.html.erb
@@ -56,6 +56,7 @@
         <a ng-click="reclaimSpace()" ng-hide="syncStatus.download_policy != 'on_demand'">
           <span translate><strong>Reclaim Space</strong></span>
           <p translate> Delete cached content units from an "On Demand" Smart Proxy.</p>
+          <p translate> Storage used by deleted repositories will be reclaimed during the next orphan cleanup run.</p>
         </a>
       </li>
     </ul>

--- a/app/views/foreman/smart_proxies/_reclaim_space.html.erb
+++ b/app/views/foreman/smart_proxies/_reclaim_space.html.erb
@@ -3,6 +3,7 @@
   <p translate>
     <strong>Warning</strong>: reclaiming space will delete all cached content units in "On Demand" repositories on this Smart Proxy.<br>
     Take precaution when cleaning custom repositories whose upstream parents don't keep old package versions.
+    Storage used by deleted repositories will be reclaimed during the next orphan cleanup run.
   </p>
   <div class="button">
     <button class="btn btn-default" type="button" id="reclaimSpaceButton" ng-click="reclaimSpace()" translate>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds a clarification to ensure users that disk space used by deleted repositories will be cleaned automatically.

This is in regards to confusion caused by trying to run space reclamation on smart proxies that have no repositories on them.

#### Considerations taken when implementing this change?
I don't think the added text makes the UI look bulky, but it's a consideration.

#### What are the testing steps for this pull request?
Find my new warnings in the UI for both Pulp Primary smart proxies and Smart Proxy Mirrors / Capsules / whatever you want to call every other smart proxy