### PR TITLE
Fixes #35936 - change to create_or_find_by!

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -271,9 +271,9 @@ module Katello
       def import_module_streams(module_streams)
         streams = {}
         module_streams.each do |module_stream|
-          stream = AvailableModuleStream.where(name: module_stream["name"],
+          stream = AvailableModuleStream.create_or_find_by!(name: module_stream["name"],
                                                context: module_stream["context"],
-                                               stream: module_stream["stream"]).first_or_create!
+                                               stream: module_stream["stream"])
           streams[stream.id] = module_stream
         end
         sync_available_module_stream_associations(streams)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When importing module streams, `first_or_create!` was creating a race condition that could occur during concurrent registrations. This would cause a key constraint error. 

Using `create_or_find_by!` seems to prevent this race condition.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Pablo has tested this and confirmed it works on two downstream builds.
