### PR TITLE
Fixes #35937 - it is a Host Collection, not Group

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-hosts-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-hosts-list.html
@@ -14,7 +14,7 @@
   </div>
 
   <span data-block="no-rows-message" translate>
-    You currently don't have any Hosts in this Host Group, you can add Content Hosts after selecting the 'Add' tab.
+    You currently don't have any Hosts in this Host Collection, you can add Content Hosts after selecting the 'Add' tab.
   </span>
 
   <span data-block="no-search-results-message" translate>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

minor fixup.

The text when viewing a Host *Collection* containing 0 hosts speaks of Host Groups, not Collections.

This trivial PR fixes that.

#### Considerations taken when implementing this change?

TBH, not really any, it is a one word change. 

#### What are the testing steps for this pull request?

Verify that there is no typo introduced by the word change