### PR TITLE
Refs #35236 - ak update requires the existence of organization

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -341,6 +341,7 @@ module Katello
     end
 
     def validate_release_version
+      @organization ||= find_organization
       if params[:release_version].present? && !@organization.library.available_releases.include?(params[:release_version])
         fail HttpErrors::BadRequest, _("Invalid release version: [%s]") % params[:release_version]
       end

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -295,6 +295,11 @@ module Katello
       assert_match 'Validation failed: Max hosts is not a number', @response.body
     end
 
+    def test_should_not_update_with_invalid_release
+      put(:update, params: { :organization_id => @organization.id, :id => @activation_key.id, :release_version => "foo" })
+      assert_response :bad_request
+    end
+
     test_attributes :pid => 'ec225dad-2d27-4b37-989d-1ba2c7f74ac4'
     def test_update_auto_attach
       new_auto_attach = !@activation_key.auto_attach


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Make sure `organization` exists to avoid an error like:
```
Could not update the activation key:
  undefined method `library' for nil:NilClass
```
#### Considerations taken when implementing this change?
Followup of https://github.com/Katello/katello/pull/10200

#### What are the testing steps for this pull request?
hammer activation-key update --name=test5 --organization-id=1 --release-version='willthiswork'
Before
```
Could not update the activation key:
  undefined method `library' for nil:NilClass
```
After
```
Could not update the activation key:
  Invalid release version: [willthiswork]
```

