### PR TITLE
Fixes #35927 - ensure upstream auth is nil if empty string

### DIFF
--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -385,6 +385,8 @@ module Katello
         remote_options[:download_concurrency] = root.download_concurrency unless root.download_concurrency.blank?
         remote_options.merge!(username: root&.upstream_username,
                               password: root&.upstream_password)
+        remote_options[:username] = nil if remote_options[:username] == ''
+        remote_options[:password] = nil if remote_options[:password] == ''
         remote_options.merge!(ssl_remote_options)
       end
 

--- a/db/migrate/20230119003859_ensure_repo_username_password_nil_not_blank.rb
+++ b/db/migrate/20230119003859_ensure_repo_username_password_nil_not_blank.rb
@@ -1,0 +1,9 @@
+class EnsureRepoUsernamePasswordNilNotBlank < ActiveRecord::Migration[6.1]
+  def change
+    ::Katello::Repository.library.each do |repo|
+      if repo.upstream_username == '' && repo.upstream_password == ''
+        repo.update(upstream_username: nil, upstream_password: nil)
+      end
+    end
+  end
+end

--- a/test/services/katello/pulp3/repository/apt/apt_test.rb
+++ b/test/services/katello/pulp3/repository/apt/apt_test.rb
@@ -42,8 +42,8 @@ module Katello
             @repo.root.upstream_username = ''
             @repo.root.upstream_password = ''
 
-            assert_equal '', service.common_remote_options[:username]
-            assert_equal '', service.common_remote_options[:password]
+            assert_nil service.common_remote_options[:username]
+            assert_nil service.common_remote_options[:password]
           end
 
           def test_publication_options_wo_signing_service

--- a/test/services/katello/pulp3/repository/yum/yum_test.rb
+++ b/test/services/katello/pulp3/repository/yum/yum_test.rb
@@ -140,8 +140,8 @@ module Katello
             @repo.root.upstream_username = ''
             @repo.root.upstream_password = ''
 
-            assert_equal '', service.common_remote_options[:username]
-            assert_equal '', service.common_remote_options[:password]
+            assert_nil service.common_remote_options[:username]
+            assert_nil service.common_remote_options[:password]
           end
 
           def test_sles_authentication_token_when_set


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Pulp does not allow empty string username and passwords on remotes. So, if the username or password is blank, change it to nil so that Pulp clears the field out completely.


#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1) Create a repo with a username and password.
2) Check the remote in the pulpcore database to check that username and password exist
3) Clear out the username and password in the UI and check the DB again