### PR TITLE
Fixes #35947  - Consume install_all param when finding hosts

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
@@ -119,7 +119,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkErrataModalC
 
         $scope.installErrataViaRemoteExecution = function(customize) {
             var errataIds = $scope.selectedErrataIds();
-
             $scope.errataActionFormValues.bulkErrataIds = angular.toJson(errataIds);
 
             $scope.errataActionFormValues.remoteAction = 'errata_install';

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
@@ -30,6 +30,16 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
                 $scope.applyingErrata = false;
             }
 
+            function formatBulkHostIds() {
+                var result = IncrementalUpdate.getBulkContentHosts();
+                return angular.toJson({
+                    included: {
+                        ids: result.included.ids,
+                        search: result.included.search
+                    }
+                });
+            }
+
             $scope.applyingErrata = false;
 
             $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
@@ -37,7 +47,7 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
             $scope.errataActionFormValues = {
                 authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, ''),
                 errata: IncrementalUpdate.getErrataIds().join(','),
-                bulkHostIds: angular.toJson({ included: { ids: IncrementalUpdate.getBulkContentHosts().included.ids }}),
+                bulkHostIds: formatBulkHostIds(),
                 customize: false
             };
 
@@ -109,7 +119,6 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
 
             applyErrata = function () {
                 var params = IncrementalUpdate.getBulkContentHosts(), error;
-
                 $scope.applyingErrata = true;
 
                 params['content_type'] = 'errata';
@@ -122,7 +131,6 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
                     });
                     $scope.applyingErrata = false;
                 };
-
                 HostBulkAction.installContent(params, transitionToTask, error);
             };
 

--- a/test/controllers/api/v2/concerns/bulk_hosts_extensions_test.rb
+++ b/test/controllers/api/v2/concerns/bulk_hosts_extensions_test.rb
@@ -19,6 +19,9 @@ module Katello
       @host1 = hosts(:one)
       @host2 = hosts(:two)
       @host3 = hosts(:without_content_facet)
+      @host4 = hosts(:without_subscription_facet)
+      @host5 = hosts(:without_errata)
+      @host6 = hosts(:without_organization)
     end
 
     def permissions
@@ -71,6 +74,27 @@ module Katello
       refute_includes result, @host1
       assert_includes result, @host2
       assert_includes result, @host3
+    end
+
+    def test_select_all_hosts_for_errata_apply
+      @controller.instance_variable_set(
+        :@params,
+        {
+          :install_all => true
+        })
+      result = @controller.find_bulk_hosts(@edit, {})
+
+      assert_equal_arrays [@host1, @host2, @host3, @host4, @host5, @host6], result
+    end
+
+    def test_no_hosts_specified
+      bulk_params = {
+        :included => {}
+      }
+
+      assert_raises(HttpErrors::BadRequest) do
+        @controller.find_bulk_hosts(@edit, bulk_params)
+      end
     end
 
     def test_ids


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When selecting all hosts on the Errata page, Bastion was sending an `install_all` param but the backend was ignoring it. This resulted in an error "No hosts have been specified."

In addition, after fixing that I discovered that Bastion was only sending the `ids` param and not the `search` param, resulting in the "all hosts" selection meaning "ALL hosts, not just those with this errata applicable." That should be fixed now too.

#### Considerations taken when implementing this change?

The bulk errata controller seems to be the only Angular page that sends the `install_all` param.  The name is a bit misleading because it's sent when selecting hosts, not errata.

#### What are the testing steps for this pull request?

1. Content > Errata
2. Select any errata with 1 or more installable hosts, and click Apply Errata
3. On the host list page, Click the checkbox above "Name" to select the page of results
4. (Important) A banner appears with a link to "Select all xxx" - Click this to activate select all. The banner will turn green and say "X results are selected."
5. Click Next and then Confirm

Before this patch: You'd get an error that no hosts have been specified.
After this patch: You'll be taken to the remote execution job.
