### PR TITLE
Fixes #35953 - Clear checksum type when download policy is set to on demand

### DIFF
--- a/app/lib/actions/katello/repository/update.rb
+++ b/app/lib/actions/katello/repository/update.rb
@@ -9,6 +9,7 @@ module Actions
           action_subject root.library_instance
 
           repo_params[:url] = nil if repo_params[:url] == ''
+          repo_params[:checksum_type] = nil if repo_params[:download_policy] == ::Katello::RootRepository::DOWNLOAD_ON_DEMAND
           update_cv_cert_protected = repo_params.key?(:unprotected) && (repo_params[:unprotected] != repository.unprotected)
           create_acs = create_acs?(repository.url, repo_params[:url])
           delete_acs = delete_acs?(repository.url, repo_params[:url])

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
@@ -30,6 +30,7 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                 $scope.repository['ignore_srpms'] = $scope.repository['ignorable_content'] && $scope.repository['ignorable_content'].includes("srpm");
                 $scope.repository['ansible_collection_auth_exists'] = $scope.repository['ansible_collection_auth_url'] && $scope.repository['ansible_collection_auth_token'];
                 $scope.genericContentTypes = RepositoryTypesService.genericContentTypes($scope.repository['content_type']);
+                $scope.immediateDownloadPolicy = $scope.repository['download_policy'] === 'immediate';
             });
 
             $scope.gpgKeys = function () {
@@ -140,6 +141,7 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                 repository.os_versions = $scope.osVersionsParam();
                 repository.$update(function (response) {
                     deferred.resolve(response);
+                    $scope.immediateDownloadPolicy = repository['download_policy'] === 'immediate';
                     $scope.repository.ignore_srpms = $scope.repository.ignorable_content && $scope.repository.ignorable_content.includes("srpm");
                     if (!_.isEmpty(response["include_tags"])) {
                         repository.commaIncludeTags = repository["include_tags"].join(", ");

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -315,6 +315,13 @@
             options-format="id as name for (id, name) in options"
             on-save="save(repository)">
         </dd>
+        <dd>
+          <p bst-alert='info' ng-show="immediateDownloadPolicy && repository.download_policy == 'on_demand'">
+            <span translate>
+              Changing download policy to "On Demand" will also clear the checksum type if set. The repository will use the upstream checksum type to verify downloads.
+            </span>
+          </p>
+        </dd>
       </span>
       <span>
         <dt translate>Mirroring Policy</dt>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Clear checksum type when download policy is updated to on demand.

#### Considerations taken when implementing this change?

When a user has a redhat repo with checksum type and immediate download policy, we block the user from switching to on demand download policy cause we make the checksum type non-editable on the UI for redhat repos.
We should clear out the checksum type when download policy is set to on-demand to allow the update instead of a validation error and no way to work around it.

#### What are the testing steps for this pull request?

1. Enable a redhat repo and confirm download policy is set to immediate.
2. In the console, update checksum_type for the repo to 'sha1'. 
`repo.root.update_attribute(:checksum_type, 'sha1')`
3. Try updating download policy to On Demand.
4. The checksum type will get cleared and download policy will be updated to on-demand. Also, you should see a notice like below:

![Screenshot from 2023-01-16 15-18-16](https://user-images.githubusercontent.com/21146741/212759558-9903336a-b527-4010-947f-e51cae4b7359.png)
