### PR TITLE
Fixes #35954 - Properly propagate org create errors

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -82,6 +82,9 @@ module Katello
       respond_for_create :resource => @organization
     rescue => e
       ::Foreman::Logging.exception('Could not create organization', e)
+      # Force @organization.errors to be populated
+      # Organization.new may raise so @organization may not be set
+      @organization&.valid?
       process_resource_error(message: e.message, resource: @organization)
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

We are now forcing validations to run on a model before trying to display any errors it may have.

#### What are the testing steps for this pull request?

Try creating an organization with invalid label through api or hammer. Before this fix it fails without any indication what went wrong, the request ends up with an ISE. After the fix, the validation errors should be returned, request should fail with 422.
