### PR TITLE
Refs #35861 - Do not allow blank for content facet host

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -38,7 +38,7 @@ module Katello
 
       validates_with ::AssociationExistsValidator, attributes: [:content_source]
       validates_with Katello::Validators::GeneratedContentViewValidator
-      validates :host, :presence => true, :allow_blank => true
+      validates :host, :presence => true, :allow_blank => false
 
       attr_accessor :cves_changed
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Should not allow nil as host for content facet host.
#### Considerations taken when implementing this change?
This is basically reverting a change from the parent PR for [35861](https://github.com/Katello/katello/pull/10391)
#### What are the testing steps for this pull request?
No real testing required because the db validations exist to not allow this. However, make sure you can't delete a host tied to a content facet from foreman console.