### PR TITLE
Fixes #35965 - properly clean orphaned smart proxy remotes

### DIFF
--- a/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
+++ b/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
@@ -96,7 +96,8 @@ module Katello
 
       def delete_orphan_remotes
         tasks = []
-        repo_names = Katello::Repository.pluck(:pulp_id)
+        smart_proxy_helper = ::Katello::SmartProxyHelper.new(smart_proxy)
+        repo_names = smart_proxy_helper.combined_repos_available_to_capsule.map(&:pulp_id)
         acs_remotes = Katello::SmartProxyAlternateContentSource.pluck(:remote_href)
         pulp3_enabled_repo_types.each do |repo_type|
           api = repo_type.pulp3_api(smart_proxy)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Properly causes orphaned remotes to be deleted from smart proxies during orphan cleanup.  Before, the filtering included all repositories that are in the database. Now, it only considers repositories that are available to the smart proxy.

#### Considerations taken when implementing this change?
None worth mentioning.

#### What are the testing steps for this pull request?
1) Register a smart proxy and create a new pulp-cli profile.
2) Look at the remotes on the smart proxy.
```
pulp --profile proxy rpm remote list
```
3) Sync a smart proxy to some environment.
4) Look at the created remotes.
5) Remove all (or some) environments from the smart proxy
6) Run orphan cleanup: `katello:delete_orphaned_content`
7) Check the remotes again. The remotes associated to the now-removed environments should be gone.
8) Try the process again after re-adding the environments.