### PR TITLE
Refs #35861 - Add empty content facet check to CV promote

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -604,7 +604,7 @@ module Katello
         fail _("Import-only content views can not be published directly") if import_only? && !syncable
         check_composite_action_allowed!(organization.library)
         check_docker_repository_names!([organization.library])
-        check_orphaned_content_facets(environments: self.environments)
+        check_orphaned_content_facets!(environments: self.environments)
       end
 
       true
@@ -651,7 +651,7 @@ module Katello
       true
     end
 
-    def check_orphaned_content_facets(environments: [])
+    def check_orphaned_content_facets!(environments: [])
       ::Katello::Host::ContentFacet.in_content_views_and_environments(
         content_views: [self],
         lifecycle_environments: environments

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -376,6 +376,7 @@ module Katello
       fail _("Default content view versions cannot be promoted") if default?
       content_view.check_composite_action_allowed!(to_env)
       content_view.check_docker_repository_names!(to_env)
+      content_view.check_orphaned_content_facets!(environments: [to_env])
     end
 
     def validate_destroyable!(skip_environment_check: false)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds empty content facet check to promote.
#### Considerations taken when implementing this change?
Noticed an error when promoting a cv to an env with content facet where the host has been deleted.
#### What are the testing steps for this pull request?
1. Create and publish a CV twice and promote one version to environemnt env1 and add an activation key for the CV tied to env1.
2. Register a host with the activation key.
3. Go to `psql -d katello -U katello`
4. DELETE from hosts where id='id'
5. ALTER table to remove the FK constraints that fail.
 Follow steps here for the queries to run:  https://github.com/Katello/katello/pull/10391#issuecomment-1371230005
7. Once the host has been deleted, try promoting one version to env1 . You should see the error.
![Screenshot from 2023-01-04 12-42-48](https://user-images.githubusercontent.com/21146741/210616900-a655a353-9d95-4aab-a4f6-1585acb76e83.png)

8. Checkout this branch and try promoting the other version to env1.
9. Run the rails task as the error message states.
10. The orphaned content facet and subscription facet will be deleted.
11. Promote a version to env1 again. It should succeed.
