### PR TITLE
Fixes #35989 - Audit CV UI ouiaids

### DIFF
--- a/webpack/scenes/ContentViews/Details/ContentViewDetails.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetails.js
@@ -82,6 +82,7 @@ export default () => {
   const dropDownItems = [
     <DropdownItem
       key="copy"
+      ouiaId="cv-copy"
       onClick={() => {
         setCopying(true);
       }}
@@ -90,6 +91,7 @@ export default () => {
     </DropdownItem>,
     <DropdownItem
       key="delete"
+      ouiaId="cv-delete"
       onClick={() => {
         setDeleting(true);
       }}

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetailsHeader.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetailsHeader.js
@@ -67,6 +67,7 @@ const ContentViewFilterDetailsHeader = ({
   const dropDownItems = [
     <DropdownItem
       key="delete"
+      ouiaId="cv-filter-delete"
       onClick={() => {
         dispatch(deleteContentViewFilter(filterId, () => {
           push(`/content_views/${cvId}#/filters/`);

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/CVRpmFilterContent.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/CVRpmFilterContent.test.js
@@ -136,9 +136,15 @@ test('Can search for package rules in package filter details', async (done) => {
 
 test('Can add package rules to filter in a self-closing modal', async (done) => {
   const { name: cvFilterName } = cvFilterDetails;
-  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
-  const autocompleteNameScope = mockAutocomplete(nockInstance, autocompleteNameUrl);
-  const autocompleteArchScope = mockAutocomplete(nockInstance, autocompleteArchUrl);
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl, true, undefined, 2);
+  const autocompleteNameScope = mockAutocomplete(
+    nockInstance, autocompleteNameUrl, true,
+    undefined, 2,
+  );
+  const autocompleteArchScope = mockAutocomplete(
+    nockInstance, autocompleteArchUrl, true,
+    undefined, 2,
+  );
   const searchDelayScope = mockSetting(nockInstance, 'autosearch_delay', 0, 3);
   const autoSearchScope = mockSetting(nockInstance, 'autosearch_while_typing', undefined, 3);
 
@@ -259,6 +265,10 @@ test('Remove rpm filter rule in a self-closing modal', async (done) => {
   });
 
   getByText('Remove').click();
+  await patientlyWaitFor(() => {
+    expect(getByText(cvFilterName)).toBeInTheDocument();
+    expect(getAllByLabelText('Actions')[1]).toBeInTheDocument();
+  });
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(searchDelayScope);
@@ -274,8 +284,14 @@ test('Remove rpm filter rule in a self-closing modal', async (done) => {
 test('Edit rpm filter rule in a self-closing modal', async (done) => {
   const { name: cvFilterName } = cvFilterDetails;
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl, true, undefined, 2);
-  const autocompleteNameScope = mockAutocomplete(nockInstance, autocompleteNameUrl);
-  const autocompleteArchScope = mockAutocomplete(nockInstance, autocompleteArchUrl);
+  const autocompleteNameScope = mockAutocomplete(
+    nockInstance, autocompleteNameUrl, true,
+    undefined, 2,
+  );
+  const autocompleteArchScope = mockAutocomplete(
+    nockInstance, autocompleteArchUrl, true,
+    undefined, 2,
+  );
   const searchDelayScope = mockSetting(nockInstance, 'autosearch_delay', 0, 3);
   const autoSearchScope = mockSetting(nockInstance, 'autosearch_while_typing', undefined, 3);
   const cvFiltersScope = nockInstance


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Also (hopefully) fixes webpack/scenes/ContentViews/Details/Filters/__tests__/CVRpmFilterContent.test.js by adding extra autocomplete nocks as happens in UI and waits for page to refresh after remove in the test.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Uncomment `webpack/global_test_setup.js` as described in comments in the file.
Run `npx jest webpack/scenes/ContentViews/`
See if any components complain about ouia-ids.