### PR TITLE
Fixes #36007 - Migration error 'column settings.category does not exist'

### DIFF
--- a/db/migrate/20220419193414_content_settings_to_dsl_category.rb
+++ b/db/migrate/20220419193414_content_settings_to_dsl_category.rb
@@ -1,5 +1,5 @@
 class ContentSettingsToDslCategory < ActiveRecord::Migration[6.0]
   def up
-    Setting.where(category: 'Setting::Content').update_all(category: 'Setting')
+    Setting.where(category: 'Setting::Content').update_all(category: 'Setting') if column_exists?(:settings, :category)
   end
 end


### PR DESCRIPTION
#### Considerations taken when implementing this change?
See:

https://github.com/theforeman/foreman/pull/9524
https://github.com/theforeman/foreman/pull/9524#issuecomment-1404661119

#### What are the testing steps for this pull request?
* Create fresh DB
* Run migrations
* Check that migration didn't fail with:
```
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

PG::UndefinedColumn: ERROR:  column settings.category does not exist
LINE 1: ... IN (SELECT "settings"."id" FROM "settings" WHERE "settings"...
```