### PR TITLE
Fixes #36025 - Ensure custom products don't use Red Hat provider

### DIFF
--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -56,6 +56,12 @@ module Katello
         end
       end
 
+      def import_candlepin_records(pools, org)
+        # Skip import of pools that were associated with an orphaned custom product
+        pools = pools.reject { |cp_pool| ::Katello::Glue::Provider.orphaned_custom_product?(cp_pool['productId'], org) }
+        super(pools, org)
+      end
+
       def import_candlepin_record(record:, organization:)
         subscription = determine_subscription(
           product_id: record['productId'],

--- a/app/models/katello/glue/candlepin/product.rb
+++ b/app/models/katello/glue/candlepin/product.rb
@@ -32,7 +32,7 @@ module Katello
       id.match(/^\d+$/) #engineering products are numeric
     end
 
-    def self.import_from_cp(attrs, organization)
+    def self.import_redhat_product_from_cp(attrs, organization)
       import_logger = attrs[:import_logger]
 
       product_attrs = {'name' => attrs['name'],
@@ -48,6 +48,12 @@ module Katello
         logger&.error "Failed to create product #{attrs['name']}: #{e}"
       end
       raise e
+    end
+
+    def self.custom_product_id?(id)
+      # Engineering products with 12 digits are custom products (see Katello::Product#unused_product_id)
+      # however, previously generated ids are random and can be shorter than 12 digits
+      id =~ /^\d{8,12}$/
     end
 
     module InstanceMethods

--- a/app/models/katello/glue/candlepin/subscription.rb
+++ b/app/models/katello/glue/candlepin/subscription.rb
@@ -21,6 +21,11 @@ module Katello
           !Glue::Candlepin::Product.engineering_product_id?(product['id']) || Katello::Product.find_by(:cp_id => product['id']).try(:custom?)
         end
       end
+
+      def import_candlepin_records(cp_subs, org)
+        cp_subs = cp_subs.reject { |cp_subscription| ::Katello::Glue::Provider.orphaned_custom_product?(cp_subscription['productId'], org) }
+        super(cp_subs, org)
+      end
     end
 
     module InstanceMethods

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -56,7 +56,10 @@ module Katello
     validate :subscription_matches_organization
 
     def subscription_matches_organization
-      errors.add(:base, _("A Pool and its Subscription cannot belong to different organizations")) unless subscription&.organization_id == self.organization_id
+      return if errors[:subscription].any? || errors[:organization].any? # let other validations catch this
+      unless subscription&.organization_id == self.organization_id
+        errors.add(:base, _("A Pool and its Subscription cannot belong to different organizations."))
+      end
     end
 
     DAYS_RECENTLY_EXPIRED = 30

--- a/app/services/katello/pulp3/content_view_version/export_validation_error.rb
+++ b/app/services/katello/pulp3/content_view_version/export_validation_error.rb
@@ -1,0 +1,7 @@
+module Katello
+  module Pulp3
+    module ContentViewVersion
+      class ExportValidationError < HttpErrors::BadRequest; end
+    end
+  end
+end

--- a/app/services/katello/pulp3/content_view_version/export_validator.rb
+++ b/app/services/katello/pulp3/content_view_version/export_validator.rb
@@ -1,7 +1,6 @@
 module Katello
   module Pulp3
     module ContentViewVersion
-      class ExportValidationError < HttpErrors::BadRequest; end
       class ExportValidator
         delegate :content_view_version, :from_content_view_version, :format, :repositories,
                  :smart_proxy, :version_href_to_repository_href, to: :@export_service

--- a/db/seeds.d/111-upgrade_tasks.rb
+++ b/db/seeds.d/111-upgrade_tasks.rb
@@ -7,6 +7,7 @@ UpgradeTask.define_tasks(:katello) do
     {:name => 'katello:upgrades:4.1:fix_invalid_pools'},
     {:name => 'katello:upgrades:4.1:reupdate_content_import_export_perms'},
     {:name => 'katello:upgrades:4.2:remove_checksum_values'},
-    {:name => 'katello:upgrades:4.4:publish_import_cvvs'}
+    {:name => 'katello:upgrades:4.4:publish_import_cvvs'},
+    {:name => 'katello:upgrades:4.8:fix_incorrect_providers'}
   ]
 end

--- a/lib/katello/tasks/clean_candlepin_orphaned_products.rake
+++ b/lib/katello/tasks/clean_candlepin_orphaned_products.rake
@@ -1,0 +1,38 @@
+namespace :katello do
+  desc "Removes custom products (and their associated pools and subscriptions) from Candlepin that are not in Katello"
+  task :clean_candlepin_orphaned_products => ["dynflow:client", "environment"] do
+    User.current = User.anonymous_admin #set a user for orchestration
+
+    deleted_products_counts = {}
+    Organization.all.each do |org|
+      print "Cleaning Candlepin orphaned custom products for organization #{org.name}\n"
+
+      cp_products = Katello::Resources::Candlepin::Product.all(org.label)
+      cp_products = cp_products.select { |prod| Katello::Glue::Candlepin::Product.engineering_product_id?(prod['id']) }
+      cp_product_ids = cp_products.map { |cp_product| cp_product['id'] }
+
+      katello_product_ids = Katello::Product.where(:organization_id => org.id).pluck(:cp_id)
+      orphaned_cp_product_ids = cp_product_ids - katello_product_ids
+      orphaned_cp_product_ids.each do |cp_product_id|
+        print "Deleting Candlepin orphaned custom product #{cp_product_id} (and its associated pools and subscriptions)\n"
+        ForemanTasks.sync_task(
+          ::Actions::Candlepin::Product::DeletePools,
+          cp_id: cp_product_id, organization_label: org.label)
+
+        ForemanTasks.sync_task(
+          ::Actions::Candlepin::Product::DeleteSubscriptions,
+          cp_id: cp_product_id, organization_label: org.label)
+
+        ForemanTasks.sync_task(
+          ::Actions::Candlepin::Product::Destroy,
+          owner: org.label, cp_id: cp_product_id)
+      end
+
+      deleted_products_counts[org.name] = orphaned_cp_product_ids.length
+    end
+
+    deleted_products_counts.each do |org_name, deleted_products_count|
+      print "Deleted #{deleted_products_count} Candlepin orphaned custom products for organization #{org_name}\n"
+    end
+  end
+end

--- a/lib/katello/tasks/reimport.rake
+++ b/lib/katello/tasks/reimport.rake
@@ -14,7 +14,6 @@ namespace :katello do
   desc "Reimports information from backend systems"
   task :reimport => ["dynflow:client", "katello:check_ping"] do
     User.current = User.anonymous_admin #set a user for orchestration
-    Dir.glob(Katello::Engine.root.to_s + '/app/models/katello/*.rb').each { |file| require file }
 
     models = [
       Katello::Subscription,
@@ -32,7 +31,7 @@ namespace :katello do
       ack_key.import_pools
     end
 
-    print "Importing Linked Repositories"
+    print "Importing Linked Repositories\n"
     Katello::Repository.linked_repositories.each(&:index_content)
   end
 end

--- a/lib/katello/tasks/upgrades/4.8/fix_incorrect_providers.rake
+++ b/lib/katello/tasks/upgrades/4.8/fix_incorrect_providers.rake
@@ -1,0 +1,29 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '4.8' do
+      desc "Fix custom products incorrectly assigned a Red Hat provider"
+      task :fix_incorrect_providers => ["dynflow:client", "environment"] do
+        User.current = User.anonymous_admin #set a user for orchestration
+
+        print "Fixing incorrect providers\n"
+        incorrect_provider_count = 0
+        error_msgs = []
+        Katello::Product.redhat.includes(:organization).each do |product|
+          if ::Katello::Glue::Candlepin::Product.custom_product_id?(product.cp_id)
+            print "Fixing provider for #{product.name}\n"
+            incorrect_provider_count += 1
+            product.provider = product.organization.anonymous_provider
+            product.save!
+          end
+        end
+
+        print "Fixed #{incorrect_provider_count} incorrect providers\n"
+        if error_msgs.any?
+          print "Errors while fixing providers: #{error_msgs.join("\n")}\n"
+        end
+
+        Rake::Task['katello:clean_candlepin_orphaned_products'].invoke
+      end
+    end
+  end
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -89,12 +89,13 @@ module Katello
       specify { Product.new(:label => "shoo", :name => 'contains space', :provider => @provider).must_be :valid? }
       specify { Product.new(:label => "bar foo", :name => "foo", :provider => @provider).wont_be :valid? }
       it "should not be successful when creating a product with a duplicate name in one organization" do
-        @p = Product.create!(ProductTestData::SIMPLE_PRODUCT.merge(:organization_id => @organization.id))
-
-        Product.new(:name => @p.name, :label => @p.name,
-                    :id => @p.cp_id,
-                    :provider => @p.provider
-                   ).wont_be :valid?
+        @p = Product.create!(ProductTestData::SIMPLE_PRODUCT.merge(:organization_id => @organization.id, :provider_id => @provider.id))
+        np = Product.new(:name => @p.name, :label => @p.name,
+                    :cp_id => "42424242424",
+                    :provider => @p.provider,
+                    :organization => @organization
+                   )
+        np.wont_be :valid?
       end
     end
 
@@ -114,7 +115,13 @@ module Katello
     end
 
     it 'should be destroyable' do
-      product = create(:katello_product, :fedora, provider: create(:katello_provider), organization: @organization)
+      product = create(
+                       :katello_product,
+                       :fedora,
+                       name: 'to be destroyed',
+                       label: 'to_be_destroyed',
+                       provider: create(:katello_provider),
+                       organization: @organization)
       assert product.destroy
     end
   end

--- a/test/actions/katello/alternate_content_source_test.rb
+++ b/test/actions/katello/alternate_content_source_test.rb
@@ -111,7 +111,10 @@ module ::Actions::Katello::AlternateContentSource
 
     it 'fails to create simplified during update with empty product' do
       action.expects(:action_subject).with(simplified_acs)
-      empty_product = ::Katello::Product.create(name: 'empty', organization_id: ::Organization.first)
+      empty_product = ::Katello::Product.create(
+        name: 'empty',
+        organization_id: ::Organization.first.id,
+        provider: ::Organization.first.anonymous_provider)
       assert_raises ActiveRecord::RecordInvalid do
         plan_action action, simplified_acs, [proxy, mirror], [empty_product], {}
       end

--- a/test/factories/product_factory.rb
+++ b/test/factories/product_factory.rb
@@ -2,12 +2,17 @@ FactoryBot.define do
   factory :katello_product, :class => Katello::Product do
     sequence(:name) { |n| "Product #{n}" }
     sequence(:label) { |n| "product_#{n}" }
+    sequence(:cp_id) { |n| (100_000_000_000 + n).to_s }
     association :provider, :factory => :katello_provider, :strategy => :build
 
     trait :fedora do
       name { "Fedora" }
       description { "The open source Linux distribution." }
       label { "fedora_label" }
+    end
+
+    trait :redhat do
+      sequence(:cp_id) { |n| "RH00000#{n}" }
     end
 
     trait :with_provider do

--- a/test/fixtures/models/katello_products.yml
+++ b/test/fixtures/models/katello_products.yml
@@ -2,7 +2,7 @@ debian:
   name:            Debian
   description:     The universal operating system
   label:           debian_label
-  cp_id:           debian
+  cp_id:           123123123000
   provider_id:     <%= ActiveRecord::FixtureSet.identify(:anonymous) %>
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
 
@@ -10,7 +10,7 @@ fedora:
   name:         Fedora
   description:  An open source Linux distribution.
   label:        fedora_label
-  cp_id:        fedora
+  cp_id:        123123123001
   provider_id:  <%= ActiveRecord::FixtureSet.identify(:anonymous) %>
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
 
@@ -25,7 +25,7 @@ redhat:
 puppet_product:
   name:         Puppet Product
   description:  A product for puppet content
-  cp_id:        puppet
+  cp_id:        123123123002
   label:        puppet_product
   provider_id:  <%= ActiveRecord::FixtureSet.identify(:anonymous) %>
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
@@ -33,14 +33,14 @@ puppet_product:
 ostree_product:
   name:         OSTree Product
   description:  A product for ostree content
-  cp_id:        ostree
+  cp_id:        123123123003
   label:        ostree_product
   provider_id:  <%= ActiveRecord::FixtureSet.identify(:anonymous) %>
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
 
 empty_product:
   name:         Empty Product
-  cp_id:        empty_product
+  cp_id:        123123123004
   label:        empty_product
   provider_id:  <%= ActiveRecord::FixtureSet.identify(:anonymous) %>
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
@@ -55,7 +55,7 @@ empty_redhat:
 
 empty_product_2:
   name:         Empty Product_2
-  cp_id:        empty_product_2
+  cp_id:        123123123005
   label:        empty_product_2
   provider_id:  <%= ActiveRecord::FixtureSet.identify(:anonymous) %>
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
@@ -64,6 +64,6 @@ oracle:
   name:         Oracle
   description:  An open source Linux distribution.
   label:        oracle_label
-  cp_id:        oracle
+  cp_id:        123123123006
   provider_id:  <%= ActiveRecord::FixtureSet.identify(:anonymous) %>
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>

--- a/test/models/pool_test.rb
+++ b/test/models/pool_test.rb
@@ -139,6 +139,7 @@ module Katello
       Katello::Resources::Candlepin::Pool.expects(:get_for_owner).returns([pool_data])
       Katello::Resources::Candlepin::Pool.expects(:find).returns(pool_data)
       Katello::Pool.any_instance.expects(:import_managed_associations).returns
+      Organization.any_instance.expects(:redhat_provider).returns(katello_providers(:redhat))
       Pool.import_all(org)
 
       refute_empty Katello::Pool.where(organization: org)

--- a/test/services/katello/pulp3/content_view_version/export_test.rb
+++ b/test/services/katello/pulp3/content_view_version/export_test.rb
@@ -96,7 +96,7 @@ module Katello
             ::Katello::Pulp3::ContentViewVersion::ExportValidator.any_instance.expects(:version_href_to_repository_href).with("1").returns("1")
             ::Katello::Pulp3::ContentViewVersion::ExportValidator.any_instance.expects(:version_href_to_repository_href).with(nil).returns(nil).at_least_once
 
-            exception = assert_raises(Katello::Pulp3::ContentViewVersion::ExportValidationError) do
+            exception = assert_raises(::Katello::Pulp3::ContentViewVersion::ExportValidationError) do
               export.validate!(fail_on_missing_content: true, validate_incremental: true)
             end
             assert_match(/cannot be incrementally updated/, exception.message)
@@ -169,7 +169,7 @@ module Katello
           it "fails on validate! if chunk_size is >= 1_000_000GB" do
             export = setup_environment
 
-            exception = assert_raises(Katello::Pulp3::ContentViewVersion::ExportValidationError) do
+            exception = assert_raises(::Katello::Pulp3::ContentViewVersion::ExportValidationError) do
               export.validate!(fail_on_missing_content: false, validate_incremental: false, chunk_size: 1e6)
             end
             assert_match(/Specify an export chunk size less than 1_000_000 GB/, exception.message)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Thanks to @hao-yu for doing most of the heavy lifting here :)

There are two situations where Katello needs to import product data from Candlepin and create new `::Katello::Product`s:

1. during manifest refresh
2. during `rake katello:reimport`

When doing this import, Katello was assuming that any product in Candlepin is automatically a Red Hat product. This is an incorrect assumption. If a _custom_ product has been deleted from Katello but remains in Candlepin, it was getting incorrectly reimported as a Red Hat product. This results in a few problems:

1. a seemingly unrelated error message about a Subscription being blank;
2. a second error that a Pool and a Subscription must belong to the same organization; and
3. most importantly, the inability to complete a successful manifest import or refresh.

This PR tackles this problem in a few ways:

1. As it turns out, the Candlepin ID of custom products is actually set in Katello, and is (usually) a 12-digit numeric string. When reimporting, we can use this to recognize custom products and ~~avoid assigning them to a Red Hat provider~~ avoid reimporting them. 
2. If your custom products have already been assigned an incorrect provider, you need a way to clean them up. I added this capability in a new upgrade rake task.
3. The error "A Pool and its Subscription cannot belong to different organizations" is actually irrelevant here. It was being triggered because Subscription was `nil` and `nil` is not equal to whatever the Pool was. I improved the validation by suppressing this message unless both Pool and Subscription are present.

#### Considerations taken when implementing this change?

The mechanism through which Katello assigns IDs to custom products was previously

```rb
SecureRandom.random_number(999_999_999_999)
```

At first glance you may think this will give you a 12-digit random number. But it actually gives you an integer _between_ 0 and 999,999,999,999. As a consequence, most custom products will have assigned `cp_id`s that are 12 digits. But occasionally one will be 11 digits. And less occasionally, it'll be 10. And even less than that, 9 digits. And so on.

So I altered Katello's definition of a custom product ID to allow between 8 and 12 digits. Based on probability, this seems reasonable, as less than 1 in 10,000 custom products will have an ID less than 8 digits:
```
[18] pry(main)> result = []
=> []
[19] pry(main)> 10000.times { result << SecureRandom.random_number(999_999_999_999).to_s.length }
=> 10000
[20] pry(main)> result.count(12)
=> 9019
[21] pry(main)> result.count(11)
=> 885
[22] pry(main)> result.count(10)
=> 85
[23] pry(main)> result.count(9)
=> 10
[24] pry(main)> result.count(8)
=> 1
[25] pry(main)> result.count(7)
=> 0
[26] pry(main)> result.count(6)
=> 0
[27] pry(main)> result.count(5)
=> 0
[28] pry(main)> result.count(4)
=> 0
[29] pry(main)> result.count(3)
=> 0
[30] pry(main)> result.count(2)
=> 0
[31] pry(main)> result.count(1)
=> 0
```

I also altered the way Katello generates IDs so that they will always be 12 digits going forward. But that won't help us with already-existing custom products.

#### What are the testing steps for this pull request?

Steps to reproduce:
1. Create a custom product.

2. Run the following command to delete the custom product from Katello database only
```rb
bundle exec rails console
product = Katello::Product.find_by_name("<PRODUCT NAME>")
product.provider    <====================== This should be an "Anonymous" provider
product.destroy
exit
```

3. Before checking out this patch, attempt a manifest refresh. It should fail with warning.
4. You can also try `rake katello:reimport` which will also fail.
5. Check out the product in Rails console again:
```rb
product = Katello::Product.find_by_name("test_custom_product")
```

See that it now has a 'Red Hat' provider.

6. Check out the patch and run a manifest refresh. It may fail with "Subscription can't be blank", but you shouldn't see "A Pool and its Subscription cannot belong to different organizations."
7. Run `bundle exec rake katello:upgrades:4.8:fix_incorrect_products`. It should note that it fixed 1 incorrect product.
8. Manifest refresh should now complete successfully.
9. Create another custom product, then delete it in Rails console.
10. Do the manifest refresh again. It should succeed. The log will have a warning "Found orphaned custom product".
11. Run `rake katello:delete_orphaned_custom_products`. It will tell you that it deleted 1 orphaned custom product for your organization.
12. Manifest refresh should now succeed always, whether or not you have orphaned products in Candlepin.
