### PR TITLE
Fixes #36033 - prep for Candlepin 4.2.13 contentId

### DIFF
--- a/app/lib/actions/candlepin/environment/set_content.rb
+++ b/app/lib/actions/candlepin/environment/set_content.rb
@@ -52,7 +52,13 @@ module Actions
         def existing_ids
           ::Katello::Resources::Candlepin::Environment.
               find(input[:cp_environment_id])[:environmentContent].map do |content|
-            content[:content][:id]
+            if content.key?('contentId')
+              # Supports Candlepin 4.2.11 and up
+              content['contentId']
+            else
+              # Supports Candlepin versions below 4.2.11
+              content[:content][:id]
+            end
           end
         end
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Changes content and ID to contentId to support the new Candlepin


#### Considerations taken when implementing this change?
We should be upgraded to the new Candlepin first.

#### What are the testing steps for this pull request?
1) Upgrade candlepin http://koji.katello.org/koji/buildinfo?buildID=73990
 -> Don't forget to run database migrations with `cpdb` and restart tomcat
2) Create a lifecycle environment
3) Publish a content view with that lifecycle environment

Without my PR, you should see the error:

```
2023-02-01T15:52:26 [E|bac|ccf1f9da] undefined method `[]' for nil:NilClass (NoMethodError)
 ccf1f9da | /usr/share/gems/gems/katello-4.7.0.7/app/lib/actions/candlepin/environment/set_content.rb:55:in `block in existing_ids'
 ccf1f9da | /usr/share/gems/gems/katello-4.7.0.7/app/lib/actions/candlepin/environment/set_content.rb:54:in `map'
 ccf1f9da | /usr/share/gems/gems/katello-4.7.0.7/app/lib/actions/candlepin/environment/set_content.rb:54:in `existing_ids'
 ccf1f9da | /usr/share/gems/gems/katello-4.7.0.7/app/lib/actions/candlepin/environment/set_content.rb:20:in `finalize'
 ccf1f9da | /usr/share/gems/gems/dynflow-1.6.8/lib/dynflow/action.rb:604:in `block (2 levels) in execute_finalize'
```

The apply the PR, resume the task, and it should complete.