### PR TITLE
Fixes #36038 - Add validations for ACS creation and update in hammer

### DIFF
--- a/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
+++ b/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
@@ -88,9 +88,6 @@ module Katello
         find_smart_proxies
       end
 
-      # Check for invalid params
-      check_params_for_invalid_updates
-
       if params[:product_ids].nil?
         @products = @alternate_content_source.products
       elsif params[:product_ids] == []
@@ -129,21 +126,6 @@ module Katello
       ]
 
       params.require(:alternate_content_source).permit(*keys).to_h.with_indifferent_access
-    end
-
-    def check_params_for_invalid_updates
-      # Check parameters which cannot be validated at the model level, throwing
-      # errors where neccessary
-
-      # Check that the combination of params[:product_ids] and ACS type is allowed:
-      #            | simplified | custom  | rhui
-      # -----------+------------+---------+---------
-      # nil        | ok         | ok      | ok
-      # []         | ok         | invalid | invalid
-      # [foo, ...] | ok         | invalid | invalid
-      unless @alternate_content_source&.simplified? || params[:product_ids].nil?
-        (fail HttpErrors::UnprocessableEntity, "Products must remain blank for ACS of type #{@alternate_content_source&.alternate_content_source_type}")
-      end
     end
 
     def find_smart_proxies

--- a/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
+++ b/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
@@ -87,7 +87,6 @@ module Katello
       else
         find_smart_proxies
       end
-
       if params[:product_ids].nil?
         @products = @alternate_content_source.products
       elsif params[:product_ids] == []
@@ -95,6 +94,7 @@ module Katello
       else
         find_products
       end
+
       sync_task(::Actions::Katello::AlternateContentSource::Update, @alternate_content_source, @smart_proxies, @products, acs_params.except(:smart_proxy_ids, :smart_proxy_names, :product_ids))
       respond_for_show(:resource => @alternate_content_source)
     end

--- a/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
+++ b/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
@@ -116,9 +116,6 @@ module Katello
     protected
 
     def acs_params
-      # In the past, this method flitered acs keys depending on what type the
-      # acs repo was. This caused silent failures. We're now passing everything
-      # to the model layer to mitigate.
       keys = [
         :name, :label, :description, {smart_proxy_ids: []}, {smart_proxy_names: []}, :content_type,
         :alternate_content_source_type, :use_http_proxies, :base_url, {subpaths: []}, :upstream_username,

--- a/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
+++ b/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
@@ -135,11 +135,12 @@ module Katello
       # Check parameters which cannot be validated at the model level, throwing
       # errors where neccessary
 
-      # Disallow users from updating ACS type or content type: these should be static
-      (fail HttpErrors::UnprocessableEntity, "Content type cannot be modified once ACS is created") if params[:content_type].nil?
-      (fail HttpErrors::UnprocessableEntity, "ACS type cannot be modified once ACS is created") if params[:alternate_content_source_type].nil?
-
-      # Check that this acs is simplified before allowing products to be cleared / updated
+      # Check that the combination of params[:product_ids] and ACS type is allowed:
+      #            | simplified | custom  | rhui
+      # -----------+------------+---------+---------
+      # nil        | ok         | ok      | ok
+      # []         | ok         | invalid | invalid
+      # [foo, ...] | ok         | invalid | invalid
       unless @alternate_content_source&.simplified? || params[:product_ids].nil?
         (fail HttpErrors::UnprocessableEntity, "Products must remain blank for ACS of type #{@alternate_content_source&.alternate_content_source_type}")
       end

--- a/app/lib/actions/katello/alternate_content_source/create.rb
+++ b/app/lib/actions/katello/alternate_content_source/create.rb
@@ -7,7 +7,9 @@ module Actions
         def plan(acs, smart_proxies, products = nil)
           acs.save!
           action_subject(acs)
-          acs.products << products if products.present?
+          if products.present?
+            acs.update!(products: products)
+          end
           smart_proxies = smart_proxies.present? ? smart_proxies.uniq : []
           concurrence do
             smart_proxies.each do |smart_proxy|

--- a/app/lib/actions/katello/alternate_content_source/update.rb
+++ b/app/lib/actions/katello/alternate_content_source/update.rb
@@ -19,12 +19,14 @@ module Actions
           products_to_associate = []
           products_to_disassociate = []
 
-          products = products.uniq
-          products_to_associate = products - acs.products
-          products_to_disassociate = acs.products - products
-          old_product_ids = acs.products.pluck(:id)
-          acs.products = products
-          acs.audit_updated_products(old_product_ids) unless products_to_associate.empty? && products_to_disassociate.empty?
+          if products.present?
+            products = products.uniq
+            products_to_associate = products - acs.products
+            products_to_disassociate = acs.products - products
+            old_product_ids = acs.products.pluck(:id)
+            acs.products = products
+            acs.audit_updated_products(old_product_ids) unless products_to_associate.empty? && products_to_disassociate.empty?
+          end
 
           acs.save!
 

--- a/app/lib/actions/katello/alternate_content_source/update.rb
+++ b/app/lib/actions/katello/alternate_content_source/update.rb
@@ -19,7 +19,7 @@ module Actions
           products_to_associate = []
           products_to_disassociate = []
 
-          if products.present?
+          if products.present? || acs.products.present?
             products = products.uniq
             products_to_associate = products - acs.products
             products_to_disassociate = acs.products - products

--- a/app/lib/actions/katello/alternate_content_source/update.rb
+++ b/app/lib/actions/katello/alternate_content_source/update.rb
@@ -19,14 +19,14 @@ module Actions
           products_to_associate = []
           products_to_disassociate = []
 
-          if acs.simplified?
-            products = products.uniq
-            products_to_associate = products - acs.products
-            products_to_disassociate = acs.products - products
-            old_product_ids = acs.products.pluck(:id)
-            acs.products = products
-            acs.audit_updated_products(old_product_ids) unless products_to_associate.empty? && products_to_disassociate.empty?
-          end
+          products = products.uniq
+          products_to_associate = products - acs.products
+          products_to_disassociate = acs.products - products
+          old_product_ids = acs.products.pluck(:id)
+          acs.products = products
+          acs.audit_updated_products(old_product_ids) unless products_to_associate.empty? && products_to_disassociate.empty?
+
+          acs.save!
 
           concurrence do
             create_acss(acs, smart_proxies_to_associate)

--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -35,6 +35,8 @@ module Katello
     validates :products, if: -> { custom? || rhui? }, absence: true
     validates :label, :uniqueness => true
     validates :name, :uniqueness => true, presence: true
+    # verify ssl must be validated this way due to presence: <bool> failing on a value of false
+    validates :verify_ssl, if: -> { custom? || rhui? }, inclusion: [true, false]
     validates :verify_ssl, if: :custom?, exclusion: [nil]
     validates :alternate_content_source_type, inclusion: {
       in: ->(_) { ACS_TYPES },

--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -117,7 +117,7 @@ module Katello
       write_audit(action: 'update', comment: _('Products updated.'), audited_changes: { 'product_ids' => [old_product_ids, product_ids] })
     end
 
-    def self.humanize_class_name
+    def self.humanize_class_name(_name = nil)
       "Alternate Content Sources"
     end
 

--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -29,7 +29,7 @@ module Katello
              inverse_of: :alternate_content_source
     has_many :smart_proxies, -> { distinct }, through: :smart_proxy_alternate_content_sources
 
-    validates :base_url, :subpaths, :verify_ssl, :upstream_username,
+    validates :base_url, :subpaths, :upstream_username,
               :upstream_password, :ssl_ca_cert, :ssl_client_cert, :ssl_client_key, if: :simplified?, absence: true
     validates :base_url, if: -> { custom? || rhui? }, presence: true
     validates :products, if: -> { custom? || rhui? }, absence: true
@@ -40,7 +40,7 @@ module Katello
       in: [true, false],
       message: "can't be blank"
     }
-    validates :verify_ssl, if: :custom?, exclusion: [nil]
+    validates :verify_ssl, if: :simplified?, inclusion: { in: [nil] }
     validates :alternate_content_source_type, inclusion: {
       in: ->(_) { ACS_TYPES },
       allow_blank: false,

--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -40,7 +40,10 @@ module Katello
       in: [true, false],
       message: "can't be blank"
     }
-    validates :verify_ssl, if: :simplified?, inclusion: { in: [nil] }
+    validates :verify_ssl, if: :simplified?, inclusion: {
+      in: [nil],
+      message: "must be blank"
+    }
     validates :alternate_content_source_type, inclusion: {
       in: ->(_) { ACS_TYPES },
       allow_blank: false,

--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -52,6 +52,8 @@ module Katello
       in: [::Katello::Repository::YUM_TYPE],
       message: "'%{value}' is not valid for RHUI ACS"
     }
+
+    validate :constraint_acs_update, on: :update
     validates_with Validators::AlternateContentSourcePathValidator, :attributes => [:base_url, :subpaths], :if => :custom?
 
     scope :uses_http_proxies, -> { where(use_http_proxies: true) }
@@ -114,6 +116,16 @@ module Katello
 
     def self.humanize_class_name
       "Alternate Content Sources"
+    end
+
+    # Disallow static properties from being modified on update
+    def constraint_acs_update
+      if changes.keys.include? "content_type"
+        errors.add(:content_type, "cannot be modified once an ACS is created")
+      end
+      if changes.keys.include? "alternate_content_source_type"
+        errors.add(:alternate_content_source_type, "cannot be modified once an ACS is created")
+      end
     end
   end
 end

--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -36,7 +36,10 @@ module Katello
     validates :label, :uniqueness => true
     validates :name, :uniqueness => true, presence: true
     # verify ssl must be validated this way due to presence: <bool> failing on a value of false
-    validates :verify_ssl, if: -> { custom? || rhui? }, inclusion: [true, false]
+    validates :verify_ssl, if: -> { custom? || rhui? }, inclusion: {
+      in: [true, false],
+      message: "can't be blank"
+    }
     validates :verify_ssl, if: :custom?, exclusion: [nil]
     validates :alternate_content_source_type, inclusion: {
       in: ->(_) { ACS_TYPES },

--- a/db/migrate/20230203141353_set_new_acs_verify_ssl_default.rb
+++ b/db/migrate/20230203141353_set_new_acs_verify_ssl_default.rb
@@ -1,0 +1,5 @@
+class SetNewAcsVerifySslDefault < ActiveRecord::Migration[6.1]
+    def change
+      change_column_default(:katello_alternate_content_sources, :verify_ssl, nil)
+    end
+  end

--- a/db/migrate/20230203141353_set_new_acs_verify_ssl_default.rb
+++ b/db/migrate/20230203141353_set_new_acs_verify_ssl_default.rb
@@ -1,5 +1,5 @@
 class SetNewAcsVerifySslDefault < ActiveRecord::Migration[6.1]
-    def change
-      change_column_default(:katello_alternate_content_sources, :verify_ssl, nil)
-    end
+  def change
+    change_column_default(:katello_alternate_content_sources, :verify_ssl, nil)
   end
+end

--- a/test/models/katello/alternate_content_source_test.rb
+++ b/test/models/katello/alternate_content_source_test.rb
@@ -117,21 +117,26 @@ module Katello
     end
 
     def test_update_acs_type
-      assert_raises(ActiveRecord::RecordInvalid) do
+      excpetion = assert_raise(ActiveRecord::RecordInvalid) do
         @simplified_acs.update!(alternate_content_source_type: "custom")
       end
-      assert_raises(ActiveRecord::RecordInvalid) do
+      assert_match(/Alternate content source type cannot be modified once an ACS is created/, excpetion.message)
+
+      exception = assert_raises(ActiveRecord::RecordInvalid) do
         @rhui_acs.update!(alternate_content_source_type: "simplified")
       end
+      assert_match(/Alternate content source type cannot be modified once an ACS is created/, excpetion.message)
     end
 
     def test_update_content_type
-      assert_raises(ActiveRecord::RecordInvalid) do
+      exception = assert_raise(ActiveRecord::RecordInvalid) do
         @yum_acs.update!(content_type: "file")
       end
-      assert_raises(ActiveRecord::RecordInvalid) do
+      assert_match(/Content type cannot be modified once an ACS is created/, exception.message)
+      exception = assert_raises(ActiveRecord::RecordInvalid) do
         @file_acs.update!(content_type: "yum")
       end
+      assert_match(/Content type cannot be modified once an ACS is created/, exception.message)
     end
   end
 

--- a/test/models/katello/alternate_content_source_test.rb
+++ b/test/models/katello/alternate_content_source_test.rb
@@ -115,6 +115,24 @@ module Katello
       @simplified_acs.save!
       assert_equal [@yum_acs, @rhui_acs, @simplified_acs].sort, AlternateContentSource.with_type('yum').sort
     end
+
+    def test_update_acs_type
+      assert_raises(ActiveRecord::RecordInvalid) do
+        @simplified_acs.update!(alternate_content_source_type: "custom")
+      end
+      assert_raises(ActiveRecord::RecordInvalid) do
+        @rhui_acs.update!(alternate_content_source_type: "simplified")
+      end
+    end
+
+    def test_update_content_type
+      assert_raises(ActiveRecord::RecordInvalid) do
+        @yum_acs.update!(content_type: "file")
+      end
+      assert_raises(ActiveRecord::RecordInvalid) do
+        @file_acs.update!(content_type: "yum")
+      end
+    end
   end
 
   class AlternateContentSourceSearchTest < ActiveSupport::TestCase

--- a/test/models/katello/alternate_content_source_test.rb
+++ b/test/models/katello/alternate_content_source_test.rb
@@ -117,15 +117,15 @@ module Katello
     end
 
     def test_update_acs_type
-      excpetion = assert_raise(ActiveRecord::RecordInvalid) do
+      exception = assert_raise(ActiveRecord::RecordInvalid) do
         @simplified_acs.update!(alternate_content_source_type: "custom")
       end
-      assert_match(/Alternate content source type cannot be modified once an ACS is created/, excpetion.message)
+      assert_match(/Alternate content source type cannot be modified once an ACS is created/, exception.message)
 
       exception = assert_raises(ActiveRecord::RecordInvalid) do
         @rhui_acs.update!(alternate_content_source_type: "simplified")
       end
-      assert_match(/Alternate content source type cannot be modified once an ACS is created/, excpetion.message)
+      assert_match(/Alternate content source type cannot be modified once an ACS is created/, exception.message)
     end
 
     def test_update_content_type


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Previously, alternate content sources would silently sanitize certain fields in create and update requests through hammer, depending on the ACS type (custom vs simplified vs rhui). The request would go through, using only the applicable fields for the ACS type. These changes now cause these requests to fail and return appropriate error messages. Alternate Content Sources now will also disallow modifying the content-type or alternate-content-source-type fields once created.

Additionally, tests have been added to check this functionality is handled appropriately in the future.

#### Considerations taken when implementing this change?
The controller now passes all inputs to the model layer for validation during creation and for most params during updates. However, due to how --product-ids is handled, logic for rejecting these during update needed to be handled at the controller level. If supplied on an invalid type of ACS, this logic manually throws UnprocessableEntity.

#### What are the testing steps for this pull request?
Testing creation: Using hammer, attempt to create a simplified ACS or custom ACS using restricted arguments. Creation should fail.
Testing update: Create an ACS. Using hammer, attempt to update the ACS using restricted args. The update should fail.

Restricted arguments for custom/rhui ACS: 

- --product-ids

Restricted arguments for simplified ACS: 

- --base-url
- --ssl-ca-cert-id
- --ssl-client-cert-id
- --subpaths
- --upstream-password
- --upstream username
- --verify-ssl

Additionally please attempt to update the alternate-content-source-type and the content-type using curl. Steps below:
```
curl -sku admin:password -H "Content-type: application/json" -X PUT -d '{"content_type": "file"}' https://$(hostname)/katello/api/alternate_content_sources/191
```

The update should fail:
