### PR TITLE
Fixes #36041 - Added name validation to ACS creation to improve error message for omitted name

### DIFF
--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -34,7 +34,7 @@ module Katello
     validates :base_url, if: -> { custom? || rhui? }, presence: true
     validates :products, if: -> { custom? || rhui? }, absence: true
     validates :label, :uniqueness => true
-    validates :name, :uniqueness => true
+    validates :name, :uniqueness => true, presence: true
     validates :verify_ssl, if: :custom?, exclusion: [nil]
     validates :alternate_content_source_type, inclusion: {
       in: ->(_) { ACS_TYPES },


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Added name validation to ACS creation to improve error message for omitted name.

#### Considerations taken when implementing this change?
N/A

#### What are the testing steps for this pull request?
Try to create a simplified ACS without providing a name:
> hammer alternate-content-source create --alternate-content-source-type simplified

Validation should fail with an improved error message:

> Validation failed: Name can't be blank