### PR TITLE
Fixes #36043 - Assign content view correctly when reassigning hosts

### DIFF
--- a/app/lib/actions/katello/host/reassign.rb
+++ b/app/lib/actions/katello/host/reassign.rb
@@ -3,8 +3,10 @@ module Actions
     module Host
       class Reassign < Actions::Base
         def plan(host, content_view_id, environment_id)
-          host.content_facet.content_view = ::Katello::ContentView.find(content_view_id)
-          host.content_facet.lifecycle_environment = ::Katello::KTEnvironment.find(environment_id)
+          host.content_facet.assign_single_environment(
+            content_view: ::Katello::ContentView.find(content_view_id),
+            lifecycle_environment: ::Katello::KTEnvironment.find(environment_id)
+          )
           host.update_candlepin_associations
         end
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When deleting a content view version that requires reassigning hosts, you get
```
NoMethodError: undefined method `content_view=' for #<Katello::Host::ContentFacet:0x00005614daf63278>
```
This is because it's still trying to set the content view the old way. Instead, `assign_single_environment` should be called.


#### Considerations taken when implementing this change?

not sure how we missed this one :man_shrugging: 

#### What are the testing steps for this pull request?

1. Make a content view and publish it
2. Assign host(s) to the CV
3. Delete the latest version, and select to reassign the hosts to a different CV
4. observe error or lack thereof
