### PR TITLE
Fixes #36042 - RHUI ACS content type validation

### DIFF
--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -44,7 +44,13 @@ module Katello
     validates :content_type, inclusion: {
       in: ->(_) { RepositoryTypeManager.defined_repository_types.keys & CONTENT_TYPES },
       allow_blank: false,
-      message: ->(_, _) { _("is not allowed for ACS. Must be one of the following: %s") % (RepositoryTypeManager.defined_repository_types.keys & CONTENT_TYPES).join(',') }
+      message: ->(_, _) { _("is not allowed for ACS. Must be one of the following: %s") % (RepositoryTypeManager.defined_repository_types.keys & CONTENT_TYPES).join(',') }    
+    }
+    # validates :content_type, if: -> { rhui? }, inclusion: [::Katello::Repository::YUM_TYPE], message: "RHUI ACS only allows for 'yum' content-type"
+
+    validates :content_type, if: -> { rhui? }, inclusion: {
+      in: [::Katello::Repository::YUM_TYPE],
+      message: "%'{value}' is not valid for RHUI ACS"
     }
     validates_with Validators::AlternateContentSourcePathValidator, :attributes => [:base_url, :subpaths], :if => :custom?
 

--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -44,13 +44,11 @@ module Katello
     validates :content_type, inclusion: {
       in: ->(_) { RepositoryTypeManager.defined_repository_types.keys & CONTENT_TYPES },
       allow_blank: false,
-      message: ->(_, _) { _("is not allowed for ACS. Must be one of the following: %s") % (RepositoryTypeManager.defined_repository_types.keys & CONTENT_TYPES).join(',') }    
+      message: ->(_, _) { _("is not allowed for ACS. Must be one of the following: %s") % (RepositoryTypeManager.defined_repository_types.keys & CONTENT_TYPES).join(',') }
     }
-    # validates :content_type, if: -> { rhui? }, inclusion: [::Katello::Repository::YUM_TYPE], message: "RHUI ACS only allows for 'yum' content-type"
-
     validates :content_type, if: -> { rhui? }, inclusion: {
       in: [::Katello::Repository::YUM_TYPE],
-      message: "%'{value}' is not valid for RHUI ACS"
+      message: "'%{value}' is not valid for RHUI ACS"
     }
     validates_with Validators::AlternateContentSourcePathValidator, :attributes => [:base_url, :subpaths], :if => :custom?
 

--- a/test/fixtures/models/katello_alternate_content_sources.yml
+++ b/test/fixtures/models/katello_alternate_content_sources.yml
@@ -11,6 +11,19 @@ yum_alternate_content_source:
   upstream_username:              admin
   upstream_password:              changeme
 
+yum_alternate_content_source_rhui:
+  name:                           Yum ACS RHUI
+  label:                          yum_acs_fixture_rhui
+  ssl_ca_cert_id:                 <%= ActiveRecord::FixtureSet.identify(:fedora_ca) %>
+  ssl_client_cert_id:             <%= ActiveRecord::FixtureSet.identify(:fedora_cert) %>
+  ssl_client_key_id:              <%= ActiveRecord::FixtureSet.identify(:fedora_key) %>
+  content_type:                   yum
+  base_url:                       "https://fixtures.pulpproject.org/"
+  alternate_content_source_type:  rhui
+  verify_ssl:                     true
+  upstream_username:              admin
+  upstream_password:              changeme
+
 file_alternate_content_source:
   name:                           File ACS
   label:                          file_acs_fixture

--- a/test/models/katello/alternate_content_source_test.rb
+++ b/test/models/katello/alternate_content_source_test.rb
@@ -7,6 +7,7 @@ module Katello
       @yum_acs = katello_alternate_content_sources(:yum_alternate_content_source)
       @file_acs = katello_alternate_content_sources(:file_alternate_content_source)
       @simplified_acs = katello_alternate_content_sources(:yum_simplified_alternate_content_source)
+      @rhui_acs = katello_alternate_content_sources(:yum_alternate_content_source_rhui)
       @simplified_acs.verify_ssl = nil
       Setting['content_default_http_proxy'] = proxy.name
     end
@@ -110,8 +111,9 @@ module Katello
 
     def test_with_type
       @yum_acs.save!
+      @rhui_acs.save!
       @simplified_acs.save!
-      assert_equal [@yum_acs, @simplified_acs].sort, AlternateContentSource.with_type('yum').sort
+      assert_equal [@yum_acs, @rhui_acs, @simplified_acs].sort, AlternateContentSource.with_type('yum').sort
     end
   end
 
@@ -137,6 +139,8 @@ module Katello
       SmartProxyAlternateContentSource.create(alternate_content_source_id: @simplified_acs.id, smart_proxy_id: ::SmartProxy.pulp_primary.id, remote_href: 'remote_href2', alternate_content_source_href: 'acs_href2', repository_id: @repo2.id)
       @simplified_acs.save
       @simplified_acs.reload
+
+      @rhui_acs = katello_alternate_content_sources(:yum_alternate_content_source_rhui)
     end
 
     def test_search_name
@@ -151,7 +155,7 @@ module Katello
 
     def test_search_base_url
       acss = AlternateContentSource.search_for("base_url = \"#{@yum_acs.base_url}\"")
-      assert_equal acss.sort, [@file_acs, @yum_acs].sort
+      assert_equal acss.sort, [@file_acs, @yum_acs, @rhui_acs].sort
     end
 
     def test_search_subpath
@@ -163,7 +167,7 @@ module Katello
 
     def test_search_content_type
       acss = AlternateContentSource.search_for("content_type = \"#{@yum_acs.content_type}\"")
-      assert_equal acss.sort, [@yum_acs, @simplified_acs].sort
+      assert_equal acss.sort, [@yum_acs, @simplified_acs, @rhui_acs].sort
     end
 
     def test_search_acs_type
@@ -173,7 +177,7 @@ module Katello
 
     def test_search_upstream_username
       acss = AlternateContentSource.search_for("upstream_username = \"#{@yum_acs.upstream_username}\"")
-      assert_equal acss.sort, [@file_acs, @yum_acs].sort
+      assert_equal acss.sort, [@file_acs, @yum_acs, @rhui_acs].sort
     end
 
     def test_search_smart_proxy_id


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
RHUI-type ACS will now reject creation and update attempts where the content-type is set to 'file', as they only support 'yum'-type content. Added testing to ensure this functionality survives updates.

#### Considerations taken when implementing this change?
N/A

#### What are the testing steps for this pull request?
1. Attempt to create a RHUI ACS via hammer or API with --content-type "file":

```
hammer alternate-content-source create --alternate-content-source-type "rhui" --content-type "file" --name "Test RHUI hammer" --base-url "https://rhui.example.com/pulp/content" --subpaths "test/repo1/,test/repo2/" --smart-proxy-ids 1
```

The creation should fail:

```
 Could not create the Alternate Content Source.:
   Validation failed: Content type 'file' is not valid for RHUI ACS
```

2. Attempt to update an existing 'yum' RHUI ACS to type 'file':

```
curl -sku admin:password -H "Content-type: application/json" -X PUT -d '{"content_type": "file"}' https://$(hostname)/katello/api/alternate_content_sources/191
```

The update should fail:

```
{"displayMessage":"Validation failed: Content type 'file' is not valid for RHUI ACS","errors":{"content_type":["'file' is not valid for RHUI ACS"]}}
```