### PR TITLE
Fixes #36044 - Update pf4 to 2022.16+ release

### DIFF
--- a/webpack/components/RoutedTabs/index.js
+++ b/webpack/components/RoutedTabs/index.js
@@ -22,17 +22,13 @@ const RoutedTabs = ({
         className="margin-0-24"
       >
         {tabs.map(({ key, title }) => (
-          <a
-            key={key}
+          <Tab
             href={`#/${key}`}
-            style={{ textDecoration: 'none' }}
-          >
-            <Tab
-              eventKey={key}
-              aria-label={title}
-              title={<TabTitleText>{title}</TabTitleText>}
-            />
-          </a>
+            key={key}
+            eventKey={key}
+            aria-label={title}
+            title={<TabTitleText>{title}</TabTitleText>}
+          />
         ))}
       </Tabs>
       <div className="margin-16-0">
@@ -64,4 +60,3 @@ RoutedTabs.defaultProps = {
 };
 
 export default withRouter(RoutedTabs);
-

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/packagesTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/packagesTab.test.js
@@ -405,7 +405,7 @@ test('Remove is disabled when in select all mode', async (done) => {
   fireEvent.click(selectAllCheckbox);
   getByRole('button', { name: 'bulk_actions' }).click();
 
-  const removeButton = getByRole('button', { name: 'bulk_remove' });
+  const removeButton = getByRole('menuitem', { name: 'bulk_remove' });
   await patientlyWaitFor(() => expect(removeButton).toBeInTheDocument());
   expect(removeButton).toHaveAttribute('aria-disabled', 'true');
 

--- a/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/ActivationKeys.test.js.snap
+++ b/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/ActivationKeys.test.js.snap
@@ -35,8 +35,10 @@ exports[`ActivationKeys renders 1`] = `
     inputAutoComplete="off"
     inputIdPrefix=""
     isCreatable={false}
+    isCreateOptionOnTop={false}
     isCreateSelectOptionObject={false}
     isDisabled={true}
+    isFlipEnabled={true}
     isGrouped={false}
     isInputFilterPersisted={false}
     isInputValuePersisted={false}
@@ -53,15 +55,20 @@ exports[`ActivationKeys renders 1`] = `
     ouiaSafe={true}
     placeholderText="No Activation keys to select"
     position="left"
+    removeFindDomNode={false}
     removeSelectionAriaLabel="Remove"
     selections={Array []}
+    shouldResetOnSelect={true}
     toggleAriaLabel="Options menu"
     toggleIcon={null}
     toggleId={null}
+    toggleIndicator={null}
+    typeAheadAriaDescribedby=""
     typeAheadAriaLabel=""
     validated="default"
     variant="typeaheadmulti"
     width=""
+    zIndex={9999}
   />
 </FormGroup>
 `;

--- a/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/Force.test.js.snap
+++ b/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/Force.test.js.snap
@@ -6,9 +6,11 @@ exports[`Force renders 1`] = `
 >
   <Checkbox
     className=""
+    component="div"
     id="reg_katello_force"
     isChecked={false}
     isDisabled={false}
+    isRequired={false}
     isValid={true}
     label={
       <span>

--- a/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/IgnoreSubmanErrors.test.js.snap
+++ b/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/IgnoreSubmanErrors.test.js.snap
@@ -6,9 +6,11 @@ exports[`IgnoreSubmanErrors renders 1`] = `
 >
   <Checkbox
     className=""
+    component="div"
     id="reg_katello_ignore"
     isChecked={false}
     isDisabled={false}
+    isRequired={false}
     isValid={true}
     label={
       <span>

--- a/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/LifeCycleEnvironment.test.js.snap
+++ b/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/LifeCycleEnvironment.test.js.snap
@@ -10,6 +10,7 @@ exports[`LifecycleEnvironment renders 1`] = `
     className="without_select2"
     id="reg_katello_lce"
     isDisabled={true}
+    isIconSprite={false}
     isRequired={false}
     onBlur={[Function]}
     onChange={[Function]}

--- a/webpack/scenes/AlternateContentSources/Create/ACSCreateWizard.js
+++ b/webpack/scenes/AlternateContentSources/Create/ACSCreateWizard.js
@@ -40,7 +40,6 @@ const ACSCreateWizard = ({ show, setIsOpen }) => {
   const [caCertName, setCACertName] = useState('');
   const [productIds, setProductIds] = useState([]);
   const [productNames, setProductNames] = useState([]);
-  const [currentStep, setCurrentStep] = useState(1);
   const dispatch = useDispatch();
 
   useEffect(
@@ -139,8 +138,6 @@ const ACSCreateWizard = ({ show, setIsOpen }) => {
     <ACSCreateContext.Provider value={{
       show,
       setIsOpen,
-      currentStep,
-      setCurrentStep,
       acsType,
       setAcsType,
       contentType,
@@ -186,10 +183,6 @@ const ACSCreateWizard = ({ show, setIsOpen }) => {
       <Wizard
         title={__('Add an alternate content source')}
         steps={steps}
-        startAtStep={currentStep}
-        onGoToStep={({ id }) => setCurrentStep(id)}
-        onNext={({ id }) => setCurrentStep(id)}
-        onBack={({ id }) => setCurrentStep(id)}
         onClose={() => {
           setIsOpen(false);
         }}

--- a/webpack/scenes/AlternateContentSources/Create/Steps/ACSCreateFinish.js
+++ b/webpack/scenes/AlternateContentSources/Create/Steps/ACSCreateFinish.js
@@ -1,7 +1,9 @@
 import React, { useCallback, useContext, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import useDeepCompareEffect from 'use-deep-compare-effect';
+import { WizardContextConsumer } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
 import ACSCreateContext from '../ACSCreateContext';
@@ -9,10 +11,16 @@ import { selectCreateACS, selectCreateACSError, selectCreateACSStatus } from '..
 import getAlternateContentSources, { createACS } from '../../ACSActions';
 import Loading from '../../../../components/Loading';
 
-const ACSCreateFinish = () => {
+const ACSCreateFinishWrapper = () => (
+  <WizardContextConsumer>
+    {({ activeStep }) => <ACSCreateFinish activeStep={activeStep} />}
+  </WizardContextConsumer>
+);
+
+const ACSCreateFinish = ({ activeStep }) => {
   const { push } = useHistory();
+  const currentStep = activeStep.id;
   const {
-    currentStep,
     setIsOpen,
     acsType,
     contentType,
@@ -94,4 +102,10 @@ const ACSCreateFinish = () => {
   return <Loading loadingText={__('Saving alternate content source...')} />;
 };
 
-export default ACSCreateFinish;
+ACSCreateFinish.propTypes = {
+  activeStep: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+  }).isRequired,
+};
+
+export default ACSCreateFinishWrapper;

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
@@ -205,7 +205,7 @@ const CVErrataDateFilterContent = ({
                     value={startDate}
                     invalidFormatText={invalidDateFormat}
                     dateFormat={dateFormat}
-                    onChange={setStartDate}
+                    onChange={(e, val) => setStartDate(val)}
                     dateParse={dateParse}
                     placeholder={startEntry ? 'MM/DD/YYYY' : __('Start date')}
                     isDisabled={!hasPermission(permissions, 'edit_content_views')}
@@ -227,7 +227,7 @@ const CVErrataDateFilterContent = ({
                     value={endDate}
                     invalidFormatText={invalidDateFormat}
                     dateFormat={dateFormat}
-                    onChange={setEndDate}
+                    onChange={(e, val) => setEndDate(val)}
                     dateParse={dateParse}
                     placeholder={endEntry ? 'MM/DD/YYYY' : __('End date')}
                     isDisabled={!hasPermission(permissions, 'edit_content_views')}

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
@@ -206,12 +206,12 @@ const CVErrataIDFilterContent = ({
     } else setSelectedTypes([...selectedTypes, selection]);
   };
 
-  const setValidStartDate = (value) => {
+  const setValidStartDate = (e, value) => {
     setStartDate(value);
     if (validAPIDate(value)) setApiStartDate(value);
   };
 
-  const setValidEndDate = (value) => {
+  const setValidEndDate = (e, value) => {
     setEndDate(value);
     if (validAPIDate(value)) setApiEndDate(value);
   };


### PR DESCRIPTION
Thank you Katello team for the great tests, was able to find which things broke during the update and fix them.
* Changes to Wizard step functions break the ASC step navigation.
* DatePicker onChange function changed arguments
* Tab has an href prop, and Tabs break when Tab is wrapped so removed the `a` tag wrap
Blocked by https://github.com/theforeman/foreman/pull/9593