### PR TITLE
Fixes #35963 - Change empty state on blank manifest

### DIFF
--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -201,14 +201,23 @@ class SubscriptionsPage extends Component {
       loadTableColumns({ columns: getEnabledColumns(columns) });
     };
     const columns = subscriptions.selectedTableColumns;
-    const emptyStateData = {
-      header: __('There are no Subscriptions to display'),
-      description: __('Import a Manifest to manage your Entitlements.'),
-      action: {
-        onClick: () => openManageManifestModal(),
-        title: __('Import a Manifest'),
-      },
-    };
+    const emptyStateData = isManifestImported
+      ? {
+        header: __('There are no Subscriptions to display'),
+        description: __('Add Subscriptions using the Add Subscriptions button.'),
+        action: {
+          title: __('Add subscriptions'),
+          url: 'subscriptions/add',
+        },
+      }
+      : {
+        header: __('There are no Subscriptions to display'),
+        description: __('Import a Manifest to manage your Entitlements.'),
+        action: {
+          onClick: () => openManageManifestModal(),
+          title: __('Import a Manifest'),
+        },
+      };
 
     const SCAAlert = (
       <Alert type={simpleContentAccess ? 'info' : 'warning'}>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* The new workflow is to create a manifest on console.redhat.com
* Import that then add subscriptions
* Before you would get a message saying the manifest has not been imported even though it was
* This changes the empty state by looking at `isManifestImported` and changing the message based on that and removing the import button if an empty manifest is imported.

#### Considerations taken when implementing this change?

* Making sure the manifest page didn't break

#### What are the testing steps for this pull request?

* Create an empty manifest on console.redhat.com or use mine(pm me for it)
* Import that and verify the message changes and the import button does not show up anymore.
* Delete the manifest to make sure the old message comes up

Pics of standard message:
![nomanifest](https://user-images.githubusercontent.com/1518655/217074127-7d8b8c2b-f6c9-4903-bd85-8254b5b0870c.png)

Pic with PR and empty manifest:
![emptymanifest](https://user-images.githubusercontent.com/1518655/217074159-cd7f6cf9-7bec-4c43-98ea-55efc9bd3aed.png)
