### PR TITLE
Fixes #36078 - Let link from Content Hosts navigate to Host's Content tab

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,4 +47,7 @@ Katello::Engine.routes.draw do
   match '/organization_select' => 'react#index', :via => [:get]
 
   get '/change_host_content_source', to: 'react#index'
+  constraints(id: /[^\/]+/) do
+    get 'new/hosts/:id/content', to: redirect('new/hosts/%{id}#/Content')
+  end
 end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -100,7 +100,8 @@
             ng-controller="ContentHostStatusController">
           <td bst-table-cell>
             <span ng-switch="newHostDetailsUI">
-              <a ng-switch-when="true" ng-href="/new/hosts/{{host.name}}">{{ host.name }}</a>
+              <a ng-switch-when="true" ng-if="host.subscription_facet_attributes.uuid" ng-href="/new/hosts/{{host.name}}/content">{{ host.name }}</a>
+              <a ng-switch-when="true" ng-if="!host.subscription_facet_attributes.uuid" ng-href="/new/hosts/{{host.name}}">{{ host.name}}</a>
               <a ng-switch-when="false" ui-sref="content-host.info({hostId: host.id})">{{ host.name }}</a>
             </span>
           </td>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Links from Content Hosts should navigate to Host's Content tab.
Depends on https://github.com/theforeman/foreman/pull/9619

#### Considerations taken when implementing this change?
Angular could not handle a link like: `/new/hosts/:id#/Content`

#### What are the testing steps for this pull request?
Hosts - Content Hosts.
Click on the host links.
If `New host details UI` is yes, new host details UI Content tab is displayed for a managed host and Overview tab for non-managed host. 
Otherwise, content host UI is displayed.