### PR TITLE
Fixes #36074 - Saving RHUI alternate content source with a malformed Base URL is possible

### DIFF
--- a/webpack/scenes/AlternateContentSources/Create/ACSCreateWizard.js
+++ b/webpack/scenes/AlternateContentSources/Create/ACSCreateWizard.js
@@ -51,15 +51,17 @@ const ACSCreateWizard = ({ show, setIsOpen }) => {
     [dispatch],
   );
 
+  const subPathValidated = areSubPathsValid(subpaths) ? 'default' : 'error';
+  const urlValidated = (url === '' || isValidUrl(url, acsType)) ? 'default' : 'error';
+
+  const urlAndPathsValid = () => url !== '' && urlValidated !== 'error' && subPathValidated !== 'error';
+
   const credentialsFilled = () => {
     if (authentication === 'manual') {
       return username !== '';
     }
     return true;
   };
-
-  const subPathValidated = areSubPathsValid(subpaths) ? 'default' : 'error';
-  const urlValidated = (url === '' || isValidUrl(url)) ? 'default' : 'error';
 
   const sourceTypeStep = {
     id: 1,
@@ -88,7 +90,7 @@ const ACSCreateWizard = ({ show, setIsOpen }) => {
     id: 4,
     name: __('Select products'),
     component: <ACSProducts />,
-    canJumpTo: smartProxies.length,
+    canJumpTo: smartProxies.length && name !== '',
     enableNext: productIds.length,
   };
 
@@ -96,16 +98,16 @@ const ACSCreateWizard = ({ show, setIsOpen }) => {
     id: 5,
     name: __('URL and paths'),
     component: <AcsUrlPaths />,
-    canJumpTo: (acsType === 'custom' || acsType === 'rhui') && (smartProxies.length),
-    enableNext: url !== '' && urlValidated !== 'error' && subPathValidated !== 'error',
+    canJumpTo: (acsType === 'custom' || acsType === 'rhui') && (smartProxies.length) && name !== '',
+    enableNext: urlAndPathsValid(),
   };
 
   const credentialsStep = {
     id: 6,
     name: __('Credentials'),
     component: <ACSCredentials />,
-    canJumpTo: url !== '' && urlValidated !== 'error' && subPathValidated !== 'error',
-    enableNext: (url !== '' || productIds.length) && smartProxies.length && name !== '' && acsType && contentType && credentialsFilled(),
+    canJumpTo: urlAndPathsValid() && (smartProxies.length) && name !== '',
+    enableNext: (urlAndPathsValid() || productIds.length) && smartProxies.length && name !== '' && acsType && contentType && credentialsFilled(),
   };
 
   const reviewStep = {
@@ -113,8 +115,8 @@ const ACSCreateWizard = ({ show, setIsOpen }) => {
     name: __('Review details'),
     component: <ACSReview />,
     nextButtonText: __('Add'),
-    canJumpTo: (url !== '' || productIds.length) && smartProxies.length && name !== '' && acsType && contentType && credentialsFilled(),
-    enableNext: (url !== '' || productIds.length) && smartProxies.length && name !== '' && acsType && contentType,
+    canJumpTo: (urlAndPathsValid() || productIds.length) && smartProxies.length && name !== '' && acsType && contentType && credentialsFilled(),
+    enableNext: (urlAndPathsValid() || productIds.length) && smartProxies.length && name !== '' && acsType && contentType,
   };
 
   const finishStep = {

--- a/webpack/scenes/AlternateContentSources/Create/Steps/AcsUrlPaths.js
+++ b/webpack/scenes/AlternateContentSources/Create/Steps/AcsUrlPaths.js
@@ -16,16 +16,8 @@ const AcsUrlPaths = () => {
     acsType, url, setUrl, subpaths, setSubpaths,
   } = useContext(ACSCreateContext);
 
+  const urlValidated = (url === '' || isValidUrl(url, acsType)) ? 'default' : 'error';
   const subPathValidated = areSubPathsValid(subpaths) ? 'default' : 'error';
-  const [urlValidated, setUrlValidated] = React.useState('default');
-  const handleUrlChange = (newUrl, _event) => {
-    setUrl(newUrl);
-    if (isValidUrl(newUrl, acsType)) {
-      setUrlValidated('success');
-    } else {
-      setUrlValidated('error');
-    }
-  };
 
   const baseURLplaceholder = acsType === 'rhui' ?
     'https://rhui-server.example.com/pulp/content' :
@@ -63,7 +55,7 @@ const AcsUrlPaths = () => {
             placeholder={baseURLplaceholder}
             value={url}
             validated={urlValidated}
-            onChange={handleUrlChange}
+            onChange={value => setUrl(value)}
           />
         </FormGroup>
         {acsType === 'rhui' &&

--- a/webpack/scenes/AlternateContentSources/Create/__tests__/acsCreate.test.js
+++ b/webpack/scenes/AlternateContentSources/Create/__tests__/acsCreate.test.js
@@ -45,7 +45,7 @@ const createSimplifiedACSDetails = {
 const createRHUIACSDetails = {
   name: 'acs_rhui_test',
   description: '',
-  base_url: 'https://test_url.com/',
+  base_url: 'https://test_url.com/pulp/content',
   subpaths: ['test/repo1/', 'test/repo2/'],
   smart_proxy_names: ['centos7-katello-devel-stable.example.com'],
   content_type: 'yum',
@@ -297,8 +297,8 @@ test('Can display create wizard and create RHUI ACS', async (done) => {
   // Go to URL and subpath step
   fireEvent.click(getByText('Next'));
 
-  fireEvent.change(getByLabelText('acs_base_url_field'), { target: { value: 'https://test_url.com/' } });
-  expect(getByLabelText('acs_base_url_field')).toHaveAttribute('value', 'https://test_url.com/');
+  fireEvent.change(getByLabelText('acs_base_url_field'), { target: { value: 'https://test_url.com/pulp/content' } });
+  expect(getByLabelText('acs_base_url_field')).toHaveAttribute('value', 'https://test_url.com/pulp/content');
   fireEvent.change(getByLabelText('acs_subpath_field'), { target: { value: 'test/repo1/,test/repo2/' } });
 
   // Mock content credential data

--- a/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditURLPaths.js
+++ b/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditURLPaths.js
@@ -7,13 +7,19 @@ import { editACS, getACSDetails } from '../../ACSActions';
 import { areSubPathsValid, isValidUrl } from '../../helpers';
 
 const ACSEditURLPaths = ({ onClose, acsId, acsDetails }) => {
-  const { subpaths, base_url: url } = acsDetails;
+  const { subpaths, base_url: url, alternate_content_source_type: acsType } = acsDetails;
   const dispatch = useDispatch();
   const [acsUrl, setAcsUrl] = useState(url);
   const [acsSubpath, setAcsSubpath] = useState(subpaths.join() || '');
   const [saving, setSaving] = useState(false);
   const subPathValidated = areSubPathsValid(acsSubpath) ? 'default' : 'error';
-  const urlValidated = (acsUrl === '' || isValidUrl(acsUrl)) ? 'default' : 'error';
+  const urlValidated = (acsUrl === '' || isValidUrl(acsUrl, acsType)) ? 'default' : 'error';
+  const baseURLplaceholder = acsType === 'rhui' ?
+    'https://rhui-server.example.com/pulp/content' :
+    'http:// or https://';
+  const helperTextInvalid = acsType === 'rhui' ?
+    'http://rhui-server.example.com/pulp/content or https://rhui-server.example.com/pulp/content' :
+    'http://, https:// or file://';
 
   const onSubmit = () => {
     setSaving(true);
@@ -56,7 +62,7 @@ const ACSEditURLPaths = ({ onClose, acsId, acsDetails }) => {
           label={__('Base URL')}
           type="string"
           fieldId="acs_base_url"
-          helperTextInvalid="http://, https:// or file://"
+          helperTextInvalid={helperTextInvalid}
           validated={urlValidated}
           isRequired
         >
@@ -66,7 +72,7 @@ const ACSEditURLPaths = ({ onClose, acsId, acsDetails }) => {
             id="acs_base_url_field"
             name="acs_base_url_field"
             aria-label="acs_base_url_field"
-            placeholder="https:// or file://"
+            placeholder={baseURLplaceholder}
             value={acsUrl}
             validated={urlValidated}
             onChange={value => setAcsUrl(value)}
@@ -119,12 +125,14 @@ ACSEditURLPaths.propTypes = {
   acsDetails: PropTypes.shape({
     base_url: PropTypes.string,
     subpaths: PropTypes.arrayOf(PropTypes.string),
+    alternate_content_source_type: PropTypes.string,
     id: PropTypes.number,
   }),
 };
 
 ACSEditURLPaths.defaultProps = {
   acsDetails: {
+    alternate_content_source_type: '',
     base_url: '',
     subpaths: '',
     id: undefined,

--- a/webpack/scenes/AlternateContentSources/helpers.js
+++ b/webpack/scenes/AlternateContentSources/helpers.js
@@ -3,7 +3,7 @@ export const isValidUrl = (urlString, acsType = '') => {
     const urlFromString = new URL(urlString);
     let valid = urlFromString.protocol === 'https:' || urlFromString.protocol === 'http:' || urlFromString.protocol === 'file:';
     if (acsType === 'rhui') {
-      valid = valid && urlFromString.pathname === '/pulp/content';
+      valid = urlFromString.pathname.endsWith('/pulp/content');
     }
     return valid;
   } catch (e) {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Fixes up the ACS create UI for RHUI.  Ensures that a bad RHUI Base URL cannot be passed through. Also corrects the URL validation when editing RHUI ACSs.

#### Considerations taken when implementing this change?

There was a funny bug with Wizard steps being skipped. For some reason, the `startAtStep` value was being edited. When I removed that, it fixed the weird skipping.

#### What are the testing steps for this pull request?
1) Create a RHUI ACS and check that the enabling of the "Next" button makes sense
2) Same a (1) but also check the steps that can be skipped to.
3) Check that editing a RHUI ACS validates the URL correctly (it should check for the `/pulp/content` at the end)
4) Check all of the above for the other ACS types
5) Try editing other ACS types