### PR TITLE
Fixes #36064 - Don't try to assign empty CV/LCE to a cloned host

### DIFF
--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -212,10 +212,13 @@ module Katello
           new_host.content_facet = hostgroup_content_facet(host, param_host)
         elsif host.content_facet.present?
           new_host.content_facet = ::Katello::Host::ContentFacet.new(:content_source_id => host.content_source_id)
-          new_host.content_facet.assign_single_environment(
-            :lifecycle_environment => host.content_facet.single_lifecycle_environment,
-            :content_view => host.content_facet.single_content_view
-          )
+          if host.single_content_view_environment?
+            # assign new_host the same CVE as host
+            new_host.content_facet.assign_single_environment(
+              :lifecycle_environment => host.content_facet.single_lifecycle_environment,
+              :content_view => host.content_facet.single_content_view
+            )
+          end
         end
         new_host.operatingsystem.kickstart_repos(new_host).map { |repo| OpenStruct.new(repo) }
       else
@@ -344,10 +347,12 @@ module Katello
       lifecycle_environment_id, content_view_id = inherited_or_own_facet_attributes(param_host, hostgroup)
       content_source_id = inherited_or_own_content_source_id(param_host, hostgroup)
       facet = ::Katello::Host::ContentFacet.new(:content_source_id => content_source_id)
-      facet.assign_single_environment(
-        :lifecycle_environment_id => lifecycle_environment_id,
-        :content_view_id => content_view_id
-      )
+      if content_view_id && lifecycle_environment_id
+        facet.assign_single_environment(
+          :lifecycle_environment_id => lifecycle_environment_id,
+          :content_view_id => content_view_id
+        )
+      end
       facet
     end
   end

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -65,10 +65,12 @@ module Katello
       end
 
       def multi_content_view_environment?
+        # returns false if there are no content view environments
         content_view_environments.size > 1
       end
 
       def single_content_view_environment?
+        # also returns false if there are no content view environments
         content_view_environments.size == 1
       end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Host cloning was broken! In `hosts_and_hostgroups_helper`, the `kickstart_repository_options` method was taking the original host's content view and lifecycle environment and assigning it to the cloned host, without first checking to see if the original host even had a CVE assigned. Now, it skips cloning the CVE if the original host doesn't have one.

#### Considerations taken when implementing this change?

Currently only works for single-environment hosts. I didn't cover multi-environment hosts because we haven't yet adapted anything else for multi-environment hosts.  But we'll have to do that eventually.

For now, for a multi-environment host it just wouldn't clone the multiple CVEs and your cloned host would be left with no CVE. But at least you won't get a Rails error.

#### What are the testing steps for this pull request?

Try, from either the old or new host UI, to clone a host that doesn't have a LCE/CV assigned.
