### PR TITLE
Fixes #36083 - Set remote_execution_by_default to true

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -566,7 +566,7 @@ Foreman::Plugin.register :katello do
 
       setting 'remote_execution_by_default',
         type: :boolean,
-        default: false,
+        default: true,
         full_name: N_('Use remote execution by default'),
         description: N_("If this is enabled, remote execution is used instead of katello-agent for remote actions")
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Changed the `remote_execution_by_default` default value to `true`

#### Considerations taken when implementing this change?
The Katello Agent/Goferd has been deprecated and has been replaced by remote execution. The "Satellite WebUI -> Administer -> Settings -> Content -> Use remote execution by default" is by default set to "No". Since Katello Agent/Goferd has been deprecated, this setting should either be set to 'Yes' by default or should be removed.

#### What are the testing steps for this pull request?
Verify that the default setting value is true.

#### Additional thoughts
- is the `katello-agent` deprecated-deprecated?
I wonder if we should really remove all `remote_execution_by_default` related code.

- in case we are keeping the related code,
should we create a migration to set this setting value to `true` in case it was explicitly set to `false`?
