### PR TITLE
Fixes #36087 - Add --nobest to all update-minimal job templates

### DIFF
--- a/app/views/foreman/job_templates/install_errata.erb
+++ b/app/views/foreman/job_templates/install_errata.erb
@@ -19,5 +19,5 @@ foreign_input_sets:
     <%= render_template('Package Action - Script Default', :action => 'install -n -t patch', :package => advisories) %>
 <% else %>
     <% advisories = input(:errata).split(',').map { |e| "--advisory=#{e}" }.join(' ') %>
-    <%= render_template('Package Action - Script Default', :action => 'update-minimal', :package => advisories) %>
+    <%= render_template('Package Action - Script Default', :action => 'update-minimal --nobest', :package => advisories) %>
 <% end %>

--- a/app/views/foreman/job_templates/install_errata_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_errata_-_katello_ansible_default.erb
@@ -22,5 +22,5 @@ kind: job_template
 <%= render_template('Run Command - Ansible Default', :command => "apt-get -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" -y --only-upgrade install -y #{advisories}") %>
 <% else -%>
 <% advisories = input(:errata).split(',').map { |e| "--advisory=#{e}" }.join(' ') -%>
-<%= render_template('Run Command - Ansible Default', :command => "yum -y update-minimal #{advisories}") -%>
+<%= render_template('Run Command - Ansible Default', :command => "yum -y update-minimal --nobest #{advisories}") -%>
 <% end -%>

--- a/app/views/foreman/job_templates/install_errata_by_search_query.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query.erb
@@ -24,5 +24,5 @@ foreign_input_sets:
     <% raise "No errata matching given search query" if !input("Errata search query").blank? && advisory_ids.empty? %>
 
     <% advisories = advisory_ids.map { |e| "--advisory=#{e}" }.join(' ') %>
-    <%= render_template('Package Action - Script Default', :action => 'update-minimal', :package => advisories) %>
+    <%= render_template('Package Action - Script Default', :action => 'update-minimal --nobest', :package => advisories) %>
 <% end %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
In order to mitigate eventual issues with security errata installation due to libdnf bugs or other events, applying them with "dnf --nobest" option allows a better end user experience.

All templates involving erratas installation has been updated to benefit from it

#### Considerations taken when implementing this change?
N/A

#### What are the testing steps for this pull request?
Apply errata via job and ensure that the --nobest param is passed to the target host