### PR TITLE
Fixes #36051 - ForeignKeyViolation on ACS create when invalid --ssl-* argument is provided 

### DIFF
--- a/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
+++ b/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
@@ -71,14 +71,7 @@ module Katello
     def create
       @alternate_content_source = ::Katello::AlternateContentSource.new(acs_params.except(:smart_proxy_ids, :smart_proxy_names, :product_ids))
 
-      # Check that ssl-* params are not included if the ACS is of type 'simplified'
-      # This is handled in the controller to allow us to validate key absence before key value being valid.
-      # See https://bugzilla.redhat.com/show_bug.cgi?id=2159963 for more info
-      if @alternate_content_source.simplified?
-        (fail HttpErrors::UnprocessableEntity, "SSL ca cert must remain blank for ACS of type #{@alternate_content_source&.alternate_content_source_type}") unless @alternate_content_source.ssl_ca_cert_id.nil?
-        (fail HttpErrors::UnprocessableEntity, "SSL client cert must remain blank for ACS of type #{@alternate_content_source&.alternate_content_source_type}") unless @alternate_content_source.ssl_client_cert_id.nil?
-        (fail HttpErrors::UnprocessableEntity, "SSL ca cert must remain blank for ACS of type #{@alternate_content_source&.alternate_content_source_type}") unless @alternate_content_source.ssl_ca_cert_id.nil?
-      end
+      check_params_for_invalid_create
 
       sync_task(::Actions::Katello::AlternateContentSource::Create, @alternate_content_source, @smart_proxies, @products)
       @alternate_content_source.reload

--- a/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
+++ b/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
@@ -125,21 +125,6 @@ module Katello
       params.require(:alternate_content_source).permit(*keys).to_h.with_indifferent_access
     end
 
-    def check_params_for_invalid_updates
-      # Check parameters which cannot be validated at the model level, throwing
-      # errors where neccessary
-
-      # Check that the combination of params[:product_ids] and ACS type is allowed:
-      #            | simplified | custom  | rhui
-      # -----------+------------+---------+---------
-      # nil        | ok         | ok      | ok
-      # []         | ok         | invalid | invalid
-      # [foo, ...] | ok         | invalid | invalid
-      unless @alternate_content_source&.simplified? || params[:product_ids].nil?
-        (fail HttpErrors::UnprocessableEntity, "Products must remain blank for ACS of type #{@alternate_content_source&.alternate_content_source_type}")
-      end
-    end
-
     def find_smart_proxies
       if params[:smart_proxy_ids]
         @smart_proxies = ::SmartProxy.where(id: params[:smart_proxy_ids])

--- a/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
+++ b/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
@@ -70,9 +70,6 @@ module Katello
     param_group :acs
     def create
       @alternate_content_source = ::Katello::AlternateContentSource.new(acs_params.except(:smart_proxy_ids, :smart_proxy_names, :product_ids))
-
-      check_params_for_invalid_create
-
       sync_task(::Actions::Katello::AlternateContentSource::Create, @alternate_content_source, @smart_proxies, @products)
       @alternate_content_source.reload
       respond_for_create(resource: @alternate_content_source)

--- a/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
+++ b/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
@@ -70,6 +70,16 @@ module Katello
     param_group :acs
     def create
       @alternate_content_source = ::Katello::AlternateContentSource.new(acs_params.except(:smart_proxy_ids, :smart_proxy_names, :product_ids))
+
+      # Check that ssl-* params are not included if the ACS is of type 'simplified'
+      # This is handled in the controller to allow us to validate key absence before key value being valid.
+      # See https://bugzilla.redhat.com/show_bug.cgi?id=2159963 for more info
+      if @alternate_content_source.simplified?
+        (fail HttpErrors::UnprocessableEntity, "SSL ca cert must remain blank for ACS of type #{@alternate_content_source&.alternate_content_source_type}") unless @alternate_content_source.ssl_ca_cert_id.nil?
+        (fail HttpErrors::UnprocessableEntity, "SSL client cert must remain blank for ACS of type #{@alternate_content_source&.alternate_content_source_type}") unless @alternate_content_source.ssl_client_cert_id.nil?
+        (fail HttpErrors::UnprocessableEntity, "SSL ca cert must remain blank for ACS of type #{@alternate_content_source&.alternate_content_source_type}") unless @alternate_content_source.ssl_ca_cert_id.nil?
+      end
+
       sync_task(::Actions::Katello::AlternateContentSource::Create, @alternate_content_source, @smart_proxies, @products)
       @alternate_content_source.reload
       respond_for_create(resource: @alternate_content_source)

--- a/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
+++ b/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
@@ -125,6 +125,20 @@ module Katello
       params.require(:alternate_content_source).permit(*keys).to_h.with_indifferent_access
     end
 
+    def check_params_for_invalid_updates
+      # Check parameters which cannot be validated at the model level, throwing
+      # errors where neccessary
+
+      # Disallow users from updating ACS type or content type: these should be static
+      (fail HttpErrors::UnprocessableEntity, "Content type cannot be modified once ACS is created") if params[:content_type].nil?
+      (fail HttpErrors::UnprocessableEntity, "ACS type cannot be modified once ACS is created") if params[:alternate_content_source_type].nil?
+
+      # Check that this acs is simplified before allowing products to be cleared / updated
+      unless @alternate_content_source&.simplified? || params[:product_ids].nil?
+        (fail HttpErrors::UnprocessableEntity, "Products must remain blank for ACS of type #{@alternate_content_source&.alternate_content_source_type}")
+      end
+    end
+
     def find_smart_proxies
       if params[:smart_proxy_ids]
         @smart_proxies = ::SmartProxy.where(id: params[:smart_proxy_ids])

--- a/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
+++ b/app/controllers/katello/api/v2/alternate_content_sources_controller.rb
@@ -129,11 +129,12 @@ module Katello
       # Check parameters which cannot be validated at the model level, throwing
       # errors where neccessary
 
-      # Disallow users from updating ACS type or content type: these should be static
-      (fail HttpErrors::UnprocessableEntity, "Content type cannot be modified once ACS is created") if params[:content_type].nil?
-      (fail HttpErrors::UnprocessableEntity, "ACS type cannot be modified once ACS is created") if params[:alternate_content_source_type].nil?
-
-      # Check that this acs is simplified before allowing products to be cleared / updated
+      # Check that the combination of params[:product_ids] and ACS type is allowed:
+      #            | simplified | custom  | rhui
+      # -----------+------------+---------+---------
+      # nil        | ok         | ok      | ok
+      # []         | ok         | invalid | invalid
+      # [foo, ...] | ok         | invalid | invalid
       unless @alternate_content_source&.simplified? || params[:product_ids].nil?
         (fail HttpErrors::UnprocessableEntity, "Products must remain blank for ACS of type #{@alternate_content_source&.alternate_content_source_type}")
       end

--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -61,7 +61,7 @@ module Katello
 
     validate :constraint_acs_update, on: :update
 
-    # Validate the ssl_id params. 
+    # Validate the ssl_id params.
     # We breakout some validation into a function to allow for us to set
     # the object name correctly in error messages
     validate :validate_ssl_ids
@@ -150,7 +150,7 @@ module Katello
     # custom     | must be blank | keys required
     # rhui       | must be blank | keys required
     # simplified | must be blank | must be blank
-    # 
+    #
     def validate_ssl_ids
       if simplified? || !verify_ssl
         if changes.keys.include? "ssl_ca_cert_id"

--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -16,22 +16,12 @@ module Katello
 
     encrypts :upstream_password
 
-    # Validate the ssl_id params.
     belongs_to :ssl_ca_cert, inverse_of: :ssl_ca_alternate_content_sources, class_name: "Katello::ContentCredential"
     belongs_to :ssl_client_cert, inverse_of: :ssl_client_alternate_content_sources, class_name: "Katello::ContentCredential"
     belongs_to :ssl_client_key, inverse_of: :ssl_key_alternate_content_sources, class_name: "Katello::ContentCredential"
-    # We breakout some validation into a function to allow for us to set
-    # the object name correctly in error messages
+    # We breakout ssl-* validation into a function to allow for us to set
+    # the object name correctly in complex error messages
     validate :validate_ssl_ids
-    validates :ssl_ca_cert, if: -> { ssl_ca_cert_id.present? }, presence: {
-      message: "id is invalid"
-    }
-    validates :ssl_client_cert, if: -> { ssl_client_cert_id.present? }, presence: {
-      message: "id is invalid"
-    }
-    validates :ssl_client_key, if: -> { ssl_client_key_id.present? }, presence: {
-      message: "id is invalid"
-    }
 
     has_many :alternate_content_source_products, dependent: :delete_all, inverse_of: :alternate_content_source,
              class_name: "Katello::AlternateContentSourceProduct"
@@ -146,8 +136,9 @@ module Katello
       end
     end
 
-    # Throw errors for non-blank ssl keys if the ACS is simplified
+    # Validate ssl-* ids which require complex/custom error messages
     def validate_ssl_ids
+      # Simplified ACS's should never have ssl-* params populated
       if simplified?
         if changes.keys.include? "ssl_ca_cert_id"
           errors.add(:ssl_ca_cert, "must be blank")
@@ -157,6 +148,18 @@ module Katello
         end
         if changes.keys.include? "ssl_client_key_id"
           errors.add(:ssl_client_key, "must be blank")
+        end
+
+      # Custom and RHUI ACS's should have valid keys where populated
+      else
+        if ssl_ca_cert_id.present? && ssl_ca_cert.nil?
+          errors.add(:ssl_ca_cert, "with ID '#{ssl_ca_cert_id}' couldn't be found")
+        end
+        if ssl_client_cert_id.present? && ssl_client_cert.nil?
+          errors.add(:ssl_client_cert, "with ID '#{ssl_client_cert_id}' couldn't be found")
+        end
+        if ssl_client_key_id.present? && ssl_client_key.nil?
+          errors.add(:ssl_client_key, "with ID '#{ssl_client_key_id}' couldn't be found")
         end
       end
     end

--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -30,6 +30,7 @@ module Katello
     has_many :smart_proxies, -> { distinct }, through: :smart_proxy_alternate_content_sources
 
     validates :base_url, :subpaths, :upstream_username,
+    validates :base_url, :subpaths, :upstream_username,
               :upstream_password, :ssl_ca_cert, :ssl_client_cert, :ssl_client_key, if: :simplified?, absence: true
     validates :base_url, if: -> { custom? || rhui? }, presence: true
     validates :products, if: -> { custom? || rhui? }, absence: true

--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -30,7 +30,6 @@ module Katello
     has_many :smart_proxies, -> { distinct }, through: :smart_proxy_alternate_content_sources
 
     validates :base_url, :subpaths, :upstream_username,
-    validates :base_url, :subpaths, :upstream_username,
               :upstream_password, if: :simplified?, absence: true
     validates :base_url, if: -> { custom? || rhui? }, presence: true
     validates :products, if: -> { custom? || rhui? }, absence: true

--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -138,8 +138,6 @@ module Katello
     end
 
     # Disallow --ssl-* properties from being set for simplified ACS
-    # Must be done in method as workaround for validation printing the incorrect
-    # field string.
     def validate_ssl_ids
       if simplified?
         if changes.keys.include? "ssl_ca_cert_id"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Added logic to the ACS controller to improve the verbosity of errors returned when a user tries to create or update any ssl-* parameters on a simplified ACS.

#### Considerations taken when implementing this change?
This PR contains validation logic at the controller level (sort of). Reasons below.
##### Why I think this is ok:
- Active Record Validations will always evaluate a `belongs_to` relation before a `validates` condition. When supplying an invalid --ssl-* param, ARV would first check if the param matched an existing --ssl-* record and would return an error about the mismatched id before returning an error about how the id must be blank with simplified ACS. This essentially meant the Bugzilla ticket was asking for a custom error message to be displayed before the standard mismatched id message. The controller is the place to do something like that.
- There doesn't seem to be a good way to implement changing the order of ARV checks.
- Disabling the `belongs_to` check for simplified ACS's, while probably possible, doesn't seem like the best idea for a relation that needs to always hold.
- Even if the user bypasses the controller, the validation for --ssl-* params still exists for simplified ACS's. While they would  miss the custom error message, they still wouldn't be able to set invalid states. (This was fixed in validation in PR #10435)

##### Reasons this might be an issue:
- If the user bypasses the controller somehow, the custom error message will be missed and the mismatched ssl id message would be displayed instead.
- The logic between simplified and rhui/custom ACS's is diverging quite a bit. Should we consider splitting them into separate classes?

##### Other potentially messy bits:
- I based these changes on #10435 to avoid duplicating work with the --ssl-* param rejection and error handling in the create/update stages. --ssl-* was previously allowed to be passed as an update param with no ill effects. This may cause merge issues.
- `app/controllers/katello/api/v2/alternate_content_sources_controller.rb` contains two nearly duplicate functions: `check_params_for_invalid_create` and `check_params_for_invalid_update`. Due to the slight difference in how params are passed in for the two functions, I needed to separate the logic. If we decide to take a non-controller approach, this can all be deleted.

#### What are the testing steps for this pull request?
1. Have a Satellite with some Prods and Capsules you could refer to in 2.
2. Try to create or update an ACS:
- `hammer alternate-content-source create --alternate-content-source-type simplified --name "Test SACS" --ssl-ca-cert-id 2`
- `hammer alternate-content-source update --id 2 --ssl-ca-cert-id 2`
3. Replace [--ssl-ca-cert-id] with [--ssl-client-cert-id] and [--ssl-client-key-id], repeat above testing.