### PR TITLE
Fixes #36122 - Hide unsyncable content type warning

### DIFF
--- a/app/views/foreman/smart_proxies/_content_sync.html.erb
+++ b/app/views/foreman/smart_proxies/_content_sync.html.erb
@@ -19,7 +19,7 @@
   </div>
 
   <br>
-  <div ng-hide="syncStatus.unsyncable_content_types.length == 0">
+  <div ng-hide="syncStatus === undefined || syncStatus.unsyncable_content_types.length == 0">
     <span translate>
       Pulp plugin missing for synchronizable content types: <b>{{ syncStatus.unsyncable_content_types.join(", ") }}.</b><br />
       Repositories containing these content types will not be synced.


### PR DESCRIPTION
until the information is actually loaded

#### What are the changes introduced in this pull request?
The warning is supposed to be based on some data, but the condition was failing if the data was not loaded yet. These changes take that option into consideration.

#### Considerations taken when implementing this change?

Carrying some default state in the angular controller would probably be cleaner, but this seems to work

#### What are the testing steps for this pull request?

1) Have an external content proxy
2) Visit its detail page
