### PR TITLE
Fixes #35559 - Change Content Source LCE dropdown should not show multiple Library entries

### DIFF
--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -1,11 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
-import { Modal, Button, SelectOption, Alert, Flex } from '@patternfly/react-core';
-import {
-  global_palette_black_600 as pfDescriptionColor,
-} from '@patternfly/react-tokens';
+import { Modal, Button, Alert } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
@@ -15,41 +11,14 @@ import { ENVIRONMENT_PATHS_KEY } from '../../../../../scenes/ContentViews/compon
 import api from '../../../../../services/api';
 import getContentViews from '../../../../../scenes/ContentViews/ContentViewsActions';
 import { selectContentViews, selectContentViewStatus } from '../../../../../scenes/ContentViews/ContentViewSelectors';
-import { uniq } from '../../../../../utils/helpers';
-import ContentViewIcon from '../../../../../scenes/ContentViews/components/ContentViewIcon';
 import updateHostContentViewAndEnvironment from './HostContentViewActions';
 import HOST_CV_AND_ENV_KEY from './HostContentViewConstants';
 import { getHostDetails } from '../../HostDetailsActions';
 import ContentViewSelect from '../../../../../scenes/ContentViews/components/ContentViewSelect/ContentViewSelect';
+import ContentViewSelectOption
+  from '../../../../../scenes/ContentViews/components/ContentViewSelect/ContentViewSelectOption';
 
 const ENV_PATH_OPTIONS = { key: ENVIRONMENT_PATHS_KEY };
-
-const ContentViewDescription = ({ cv, versionNumber }) => {
-  const descriptionStyle = {
-    fontSize: '12px',
-    fontWeight: 400,
-    color: pfDescriptionColor.value,
-  };
-  if (cv.default) return <span style={descriptionStyle}>{__('Library')}</span>;
-  return (
-    <span style={descriptionStyle}>
-      <FormattedMessage
-        id={`content-view-${cv.id}-version-${cv.latest_version}`}
-        defaultMessage="Version {versionNumber}"
-        values={{ versionNumber }}
-      />
-    </span>
-  );
-};
-
-ContentViewDescription.propTypes = {
-  cv: PropTypes.shape({
-    default: PropTypes.bool.isRequired,
-    id: PropTypes.number.isRequired,
-    latest_version: PropTypes.string.isRequired,
-  }).isRequired,
-  versionNumber: PropTypes.string.isRequired,
-};
 
 const ChangeHostCVModal = ({
   isOpen,
@@ -66,6 +35,7 @@ const ChangeHostCVModal = ({
   const [cvSelectOpen, setCVSelectOpen] = useState(false);
   const dispatch = useDispatch();
   const contentViewsInEnvResponse = useSelector(state => selectContentViews(state, `FOR_ENV_${hostEnvId}`));
+  const { results } = contentViewsInEnvResponse;
   const contentViewsInEnvStatus = useSelector(state => selectContentViewStatus(state, `FOR_ENV_${hostEnvId}`));
   const hostUpdateStatus = useSelector(state => selectAPIStatus(state, HOST_CV_AND_ENV_KEY));
   useAPI( // No TableWrapper here, so we can useAPI from Foreman
@@ -73,6 +43,7 @@ const ChangeHostCVModal = ({
     api.getApiUrl(`/organizations/${orgId}/environments/paths?permission_type=promotable`),
     ENV_PATH_OPTIONS,
   );
+  const selectedCVForHostId = results?.find(cv => cv.name === selectedCVForHost)?.id;
 
   const handleModalClose = () => {
     setCVSelectOpen(false);
@@ -102,13 +73,6 @@ const ChangeHostCVModal = ({
   const { results: contentViewsInEnv = [] } = contentViewsInEnvResponse;
   const canSave = !!(selectedCVForHost && selectedEnvForHost.length);
 
-  const relevantVersionObjFromCv = (cv, env) => { // returns the entire version object
-    const versions = cv.versions.filter(version => new Set(version.environment_ids).has(env.id));
-    return uniq(versions)?.[0];
-  };
-  const relevantVersionFromCv = (cv, env) =>
-    relevantVersionObjFromCv(cv, env)?.version; // returns the version text e.g. "1.0"
-
   const refreshHostDetails = () => {
     handleModalClose();
     return dispatch(getHostDetails({ hostname: hostName }));
@@ -119,7 +83,7 @@ const ChangeHostCVModal = ({
       id: hostId,
       host: {
         content_facet_attributes: {
-          content_view_id: selectedCVForHost,
+          content_view_id: selectedCVForHostId,
           lifecycle_environment_id: selectedEnvId,
         },
       },
@@ -183,7 +147,7 @@ const ChangeHostCVModal = ({
         headerText={__('Select environment')}
         isDisabled={hostUpdateStatus === STATUS.PENDING}
       />
-      {selectedEnvForHost.length > 0 &&
+      {selectedEnvForHost.length > 0 && contentViewsInEnvStatus !== STATUS.PENDING &&
         <ContentViewSelect
           selections={selectedCVForHost}
           onClear={() => setSelectedCVForHost(null)}
@@ -193,35 +157,9 @@ const ChangeHostCVModal = ({
           onToggle={isExpanded => setCVSelectOpen(isExpanded)}
           placeholderText={cvPlaceholderText()}
         >
-          {contentViewsInEnv?.map(cv => (
-            <SelectOption
-              key={cv.id}
-              value={cv.id}
-            >
-              <Flex
-                direction={{ default: 'row', sm: 'row' }}
-                flexWrap={{ default: 'nowrap' }}
-                alignItems={{ default: 'alignItemsCenter', sm: 'alignItemsCenter' }}
-              >
-                <ContentViewIcon
-                  composite={cv.composite}
-                  size="sm"
-                />
-                <Flex
-                  direction={{ default: 'column', sm: 'column' }}
-                  flexWrap={{ default: 'nowrap' }}
-                  alignItems={{ default: 'alignItemsFlexStart', sm: 'alignItemsFlexStart' }}
-                >
-                  {cv.name}
-                  <ContentViewDescription
-                    cv={cv}
-                    versionNumber={relevantVersionFromCv(cv, selectedEnv)}
-                  />
-                </Flex>
-              </Flex>
-            </SelectOption>
-          ))
-          }
+          {(contentViewsInEnv.length !== 0) &&
+              contentViewsInEnv?.map(cv =>
+                <ContentViewSelectOption key={cv.id} cv={cv} env={selectedEnvForHost[0]} />)}
         </ContentViewSelect>
       }
     </Modal>

--- a/webpack/scenes/ContentViews/components/ContentViewSelect/ContentViewSelectOption.js
+++ b/webpack/scenes/ContentViews/components/ContentViewSelect/ContentViewSelectOption.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Flex, SelectOption } from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import {
+  global_palette_black_600 as pfDescriptionColor,
+} from '@patternfly/react-tokens';
+import { uniq } from '../../../../utils/helpers';
+import ContentViewIcon from '../../../../scenes/ContentViews/components/ContentViewIcon';
+
+const relevantVersionObjFromCv = (cv, env) => { // returns the entire version object
+  const versions = cv.versions.filter(version => new Set(version.environment_ids).has(env.id));
+  return uniq(versions)?.[0];
+};
+
+const relevantVersionFromCv = (cv, env) =>
+  relevantVersionObjFromCv(cv, env)?.version; // returns the version text e.g. "1.0"
+
+const ContentViewDescription = ({ cv, versionNumber }) => {
+  const descriptionStyle = {
+    fontSize: '12px',
+    fontWeight: 400,
+    color: pfDescriptionColor.value,
+  };
+  if (cv.default) return <span style={descriptionStyle}>{__('Library')}</span>;
+  return (
+    <span style={descriptionStyle}>
+      <FormattedMessage
+        id={`content-view-${cv.id}-version-${cv.latest_version}`}
+        defaultMessage="Version {versionNumber}"
+        values={{ versionNumber }}
+      />
+    </span>
+  );
+};
+
+ContentViewDescription.propTypes = {
+  cv: PropTypes.shape({
+    default: PropTypes.bool.isRequired,
+    id: PropTypes.number.isRequired,
+    latest_version: PropTypes.string.isRequired,
+  }).isRequired,
+  versionNumber: PropTypes.string.isRequired,
+};
+
+const ContentViewSelectOption = (cv, env) => (
+  <SelectOption
+    key={cv.id}
+    value={`${cv.id}`}
+  >
+    <Flex
+      direction={{ default: 'row', sm: 'row' }}
+      flexWrap={{ default: 'nowrap' }}
+      alignItems={{ default: 'alignItemsCenter', sm: 'alignItemsCenter' }}
+    >
+      <ContentViewIcon
+        composite={cv.composite}
+        size="sm"
+      />
+      <Flex
+        direction={{ default: 'column', sm: 'column' }}
+        flexWrap={{ default: 'nowrap' }}
+        alignItems={{ default: 'alignItemsFlexStart', sm: 'alignItemsFlexStart' }}
+      >
+        {cv.name}
+        <ContentViewDescription
+          cv={cv}
+          versionNumber={relevantVersionFromCv(cv, env)}
+        />
+      </Flex>
+    </Flex>
+  </SelectOption>
+);
+
+export default ContentViewSelectOption;

--- a/webpack/scenes/ContentViews/components/ContentViewSelect/ContentViewSelectOption.js
+++ b/webpack/scenes/ContentViews/components/ContentViewSelect/ContentViewSelectOption.js
@@ -1,23 +1,15 @@
 import React from 'react';
-import { Flex, SelectOption } from '@patternfly/react-core';
-import { translate as __ } from 'foremanReact/common/I18n';
 import PropTypes from 'prop-types';
+import { Flex, SelectOption } from '@patternfly/react-core';
 import { FormattedMessage } from 'react-intl';
+import { translate as __ } from 'foremanReact/common/I18n';
 import {
   global_palette_black_600 as pfDescriptionColor,
 } from '@patternfly/react-tokens';
-import { uniq } from '../../../../utils/helpers';
 import ContentViewIcon from '../../../../scenes/ContentViews/components/ContentViewIcon';
+import { uniq } from '../../../../utils/helpers';
 
-const relevantVersionObjFromCv = (cv, env) => { // returns the entire version object
-  const versions = cv.versions.filter(version => new Set(version.environment_ids).has(env.id));
-  return uniq(versions)?.[0];
-};
-
-const relevantVersionFromCv = (cv, env) =>
-  relevantVersionObjFromCv(cv, env)?.version; // returns the version text e.g. "1.0"
-
-const ContentViewDescription = ({ cv, versionNumber }) => {
+export const ContentViewDescription = ({ cv, versionNumber }) => {
   const descriptionStyle = {
     fontSize: '12px',
     fontWeight: 400,
@@ -44,10 +36,18 @@ ContentViewDescription.propTypes = {
   versionNumber: PropTypes.string.isRequired,
 };
 
-const ContentViewSelectOption = (cv, env) => (
+export const relevantVersionObjFromCv = (cv, env) => { // returns the entire version object
+  const versions = cv.versions.filter(version => new Set(version.environment_ids).has(env.id));
+  return uniq(versions)?.[0];
+};
+
+export const relevantVersionFromCv = (cv, env) =>
+    relevantVersionObjFromCv(cv, env)?.version; // returns the version text e.g. "1.0"
+
+const ContentViewSelectOption = ({ cv, env }) => (
   <SelectOption
     key={cv.id}
-    value={`${cv.id}`}
+    value={`${cv.name}`}
   >
     <Flex
       direction={{ default: 'row', sm: 'row' }}
@@ -72,5 +72,16 @@ const ContentViewSelectOption = (cv, env) => (
     </Flex>
   </SelectOption>
 );
+
+ContentViewSelectOption.propTypes = {
+  cv: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired,
+    composite: PropTypes.bool.isRequired,
+  }).isRequired,
+  env: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+  }).isRequired,
+};
 
 export default ContentViewSelectOption;

--- a/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.js
+++ b/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.js
@@ -47,7 +47,7 @@ const EnvironmentPaths = ({
           return (
             <div className="env-path" key={index}>
               {index === 0 && <hr />}
-              <FormGroup key={`fg-${index}`} isInline fieldId="environment-checkbox-group">
+              <FormGroup key={`fg-${index}`} isInline fieldId="environment-checkbox-group" style={{ display: 'block' }}>
                 {environments.map(env =>
                   (<CheckboxOrRadio
                     isChecked={(publishing && env.library) ||

--- a/webpack/scenes/Hosts/ChangeContentSource/index.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/index.js
@@ -52,8 +52,9 @@ const ChangeContentSourcePage = () => {
 
   const [contentSourceId, setCapsuleId] = useState('');
   const [selectedEnvironment, setSelectedEnvironment] = useState([]);
-  const [contentViewId, setContentViewId] = useState('');
+  const [contentViewName, setContentViewName] = useState('');
 
+  const contentViewId = contentViews?.find(cv => cv.name === contentViewName)?.id;
   const noHostSpecified = getHostIds(urlParams.host_id).length === 0 && urlParams.searchParam === '';
   const environmentId = selectedEnvironment[0]?.id;
 
@@ -72,7 +73,7 @@ const ChangeContentSourcePage = () => {
   const handleContentSource = (id) => {
     setCapsuleId(id);
     setSelectedEnvironment([]);
-    setContentViewId('');
+    setContentViewName('');
 
     if (id) {
       dispatch(getProxy(id));
@@ -94,7 +95,7 @@ const ChangeContentSourcePage = () => {
 
   const handleEnvironment = (selection) => {
     setSelectedEnvironment(selection);
-    setContentViewId('');
+    setContentViewName('');
 
     if (selection[0].id) {
       dispatch(getContentViews(selection[0].id));
@@ -148,8 +149,8 @@ const ChangeContentSourcePage = () => {
               handleEnvironment={handleEnvironment}
               environments={selectedEnvironment}
               contentViews={contentViews}
-              handleContentView={setContentViewId}
-              contentViewId={contentViewId}
+              handleContentView={setContentViewName}
+              contentViewName={contentViewName}
               contentSources={contentSources}
               contentSourceId={contentSourceId}
               handleContentSource={handleContentSource}

--- a/webpack/scenes/Hosts/ChangeContentSource/index.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/index.js
@@ -14,7 +14,6 @@ import { selectApiDataStatus,
   selectApiChangeContentStatus,
   selectContentHosts,
   selectContentHostsWithoutContent,
-  selectEnvironments,
   selectContentSources,
   selectJobInvocationPath,
   selectContentViews,
@@ -45,7 +44,6 @@ const ChangeContentSourcePage = () => {
 
   const contentHosts = useSelector(selectContentHosts);
   const hostsWithoutContent = useSelector(selectContentHostsWithoutContent);
-  const environments = useSelector(selectEnvironments);
   const contentSources = useSelector(selectContentSources);
   const jobInvocationPath = useSelector(selectJobInvocationPath);
 
@@ -53,10 +51,11 @@ const ChangeContentSourcePage = () => {
   const contentViews = useSelector(selectContentViews);
 
   const [contentSourceId, setCapsuleId] = useState('');
-  const [environmentId, setEnvironmentId] = useState('');
+  const [selectedEnvironment, setSelectedEnvironment] = useState([]);
   const [contentViewId, setContentViewId] = useState('');
 
   const noHostSpecified = getHostIds(urlParams.host_id).length === 0 && urlParams.searchParam === '';
+  const environmentId = selectedEnvironment[0]?.id;
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -72,7 +71,7 @@ const ChangeContentSourcePage = () => {
 
   const handleContentSource = (id) => {
     setCapsuleId(id);
-    setEnvironmentId('');
+    setSelectedEnvironment([]);
     setContentViewId('');
 
     if (id) {
@@ -93,12 +92,12 @@ const ChangeContentSourcePage = () => {
     return ([linkHosts, linkContent]);
   };
 
-  const handleEnvironment = (envId) => {
-    setEnvironmentId(envId);
+  const handleEnvironment = (selection) => {
+    setSelectedEnvironment(selection);
     setContentViewId('');
 
-    if (envId) {
-      dispatch(getContentViews(envId));
+    if (selection[0].id) {
+      dispatch(getContentViews(selection[0].id));
     }
   };
   useEffect(() => {
@@ -146,9 +145,8 @@ const ChangeContentSourcePage = () => {
 
             <ContentSourceForm
               handleSubmit={handleSubmit}
-              environments={environments}
               handleEnvironment={handleEnvironment}
-              environmentId={environmentId}
+              environments={selectedEnvironment}
               contentViews={contentViews}
               handleContentView={setContentViewId}
               contentViewId={contentViewId}

--- a/webpack/scenes/Hosts/ChangeContentSource/selectors.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/selectors.js
@@ -3,6 +3,7 @@ import {
   selectAPIResponse,
   selectAPIError,
 } from 'foremanReact/redux/API/APISelectors';
+import { STATUS } from 'foremanReact/constants';
 
 import { CHANGE_CONTENT_SOURCE_DATA, CHANGE_CONTENT_SOURCE_PROXY, CHANGE_CONTENT_SOURCE, CHANGE_CONTENT_SOURCE_VIEWS } from './constants';
 
@@ -36,6 +37,9 @@ export const selectJobInvocationPath = state =>
 
 export const selectContentViews = state =>
   selectAPIResponse(state, CHANGE_CONTENT_SOURCE_VIEWS).results || [];
+
+export const selectContentViewsStatus = state =>
+  selectAPIStatus(state, CHANGE_CONTENT_SOURCE_VIEWS) || STATUS.PENDING;
 
 export const selectTemplate = state =>
   selectAPIResponse(state, CHANGE_CONTENT_SOURCE) || '';

--- a/webpack/scenes/Hosts/ChangeContentSource/styles.scss
+++ b/webpack/scenes/Hosts/ChangeContentSource/styles.scss
@@ -13,3 +13,7 @@
 .margin-top-20 {
   margin-top: 20px;
 }
+
+.set-select-width {
+  width: 60%
+}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
There should be only one 'Library' selection in the dropdown. Which Library it is depends on the organization selector.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create at least one extra org
2. Create at least one content view in Default Organization (this will make the problem easier to see)
3. Register a host to Default Organization
4. Go to change that host's content source (host details > kebab > Change Content Source)
5. Select the Satellite as the content source
6. Observe the selections for Lifecycle Environment