### PR TITLE
Fixes #36124 - fix wording of errata_status_installable setting

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -475,8 +475,8 @@ Foreman::Plugin.register :katello do
       setting 'errata_status_installable',
         type: :boolean,
         default: false,
-        full_name: N_('Installable errata from content view'),
-        description: N_("Calculate errata host status based only on errata in a host's content view and lifecycle environment")
+        full_name: N_('Generate errata status from directly-installable content'),
+        description: N_("If true, only errata that can be installed without an incremental update will affect the host's errata status.")
 
       setting 'restrict_composite_view',
         type: :boolean,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The setting `errata_status_installable` had a bad description. I had to look at the code to figure out what the setting does. Turns out, it's about whether to base your host's errata status on installable or applicable errata. I'm updating the setting's full name and description so that others don't have to wonder.

#### Considerations taken when implementing this change?

The short name `errata_status_installable` isn't changing, so we don't have to worry about a migration or anything.

#### What are the testing steps for this pull request?

view Administer > Settings > Content > you should now see the new name "Generate errata status from directly-installable content" and the new description.
