### PR TITLE
Fixes #36095 - Update Angularjs UI links to new host UI

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-associations.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-associations.controller.js
@@ -9,13 +9,14 @@
  * @requires ActivationKey
  * @requires ContentHostsHelper
  * @requires CurrentOrganization
+ * @requires newHostDetailsUI
  *
  * @description
  *   Provides the functionality for activation key associations.
  */
 angular.module('Bastion.activation-keys').controller('ActivationKeyAssociationsController',
-    ['$scope', '$location', 'translate', 'Nutupane', 'ActivationKey', 'ContentHostsHelper', 'CurrentOrganization', 'Host',
-    function ($scope, $location, translate, Nutupane, ActivationKey, ContentHostsHelper, CurrentOrganization, Host) {
+    ['$scope', '$location', 'translate', 'Nutupane', 'ActivationKey', 'ContentHostsHelper', 'CurrentOrganization', 'Host', 'newHostDetailsUI',
+    function ($scope, $location, translate, Nutupane, ActivationKey, ContentHostsHelper, CurrentOrganization, Host, newHostDetailsUI) {
         var contentHostsNutupane, nutupaneParams, params = {
             'organization_id': CurrentOrganization,
             'search': $location.search().search || "",
@@ -46,6 +47,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyAssociationsC
 
         $scope.table = contentHostsNutupane.table;
         $scope.table.working = true;
+        $scope.newHostDetailsUI = newHostDetailsUI;
 
         if ($scope.contentHosts) {
             $scope.table.working = false;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
@@ -28,9 +28,10 @@
         <tr bst-table-row ng-repeat="host in table.rows"
             ng-controller="ContentHostStatusController">
           <td bst-table-cell>
-            <a ui-sref="content-host.info({hostId: host.id})">
-              {{ host.name }}
-            </a>
+            <span ng-switch="newHostDetailsUI">
+              <a ng-switch-when="true" ng-href="/new/hosts/{{host.name}}">{{ host.name }}</a>
+              <a ng-switch-when="false" ui-sref="content-host.info({hostId: host.id})">{{ host.name }}</a>
+            </span>
           </td>
           <td bst-table-cell ng-if="!simpleContentAccessEnabled">
             <span ng-class="getHostStatusIcon(host.subscription_global_status)">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
@@ -16,13 +16,14 @@
  * @requires Notification
  * @requires BastionConfig
  * @requires hostIds
+ * @requires newHostDetailsUI
  *
  * @description
  *   A controller for providing bulk action functionality to the content hosts page.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostsBulkErrataModalController',
-    ['$scope', '$http', '$location', '$window', '$timeout', '$uibModalInstance', 'HostBulkAction', 'HostCollection', 'Nutupane', 'CurrentOrganization', 'Erratum', 'Notification', 'BastionConfig', 'hostIds',
-    function ($scope, $http, $location, $window, $timeout, $uibModalInstance, HostBulkAction, HostCollection, Nutupane, CurrentOrganization, Erratum, Notification, BastionConfig, hostIds) {
+    ['$scope', '$http', '$location', '$window', '$timeout', '$uibModalInstance', 'HostBulkAction', 'HostCollection', 'Nutupane', 'CurrentOrganization', 'Erratum', 'Notification', 'BastionConfig', 'hostIds', 'newHostDetailsUI',
+    function ($scope, $http, $location, $window, $timeout, $uibModalInstance, HostBulkAction, HostCollection, Nutupane, CurrentOrganization, Erratum, Notification, BastionConfig, hostIds, newHostDetailsUI) {
         function installParams() {
             var params = hostIds;
             params['content_type'] = 'errata';
@@ -58,6 +59,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkErrataModalC
         $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
         $scope.allHostsSelected = hostIds.allResultsSelected;
         $scope.hostToolingEnabled = BastionConfig.hostToolingEnabled;
+        $scope.newHostDetailsUI = newHostDetailsUI;
 
         $scope.errataActionFormValues = {
             authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, '')

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
@@ -101,10 +101,16 @@
              <td bst-table-cell>{{ erratum.title }}</td>
              <td class="small" bst-table-cell>{{ erratum.issued }}</td>
              <td class="small" bst-table-cell class="number-cell">
-               <a target="_blank" href="{{ '/content_hosts?search=installable_errata%3D' + erratum.errata_id }}">
-                <span> {{ erratum.affected_hosts_count }} </span>
-                 <span class="fa fa-external-link"/>
-               </a>
+              <span ng-switch="newHostDetailsUI">
+                <a ng-switch-when="true" target="_blank" href="{{ '/hosts?search=installable_errata%3D' + erratum.errata_id }}">
+                  {{ erratum.affected_hosts_count }}
+                <span class="fa fa-external-link"/>
+                </a>
+                <a ng-switch-when="false" target="_blank" href="{{ '/content_hosts?search=installable_errata%3D' + erratum.errata_id }}">
+                {{ erratum.affected_hosts_count }}
+                <span class="fa fa-external-link"/>
+              </a>
+              </span>
              </td>
            </tr>
          </tbody>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/details/deb.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/details/deb.controller.js
@@ -6,11 +6,12 @@
      *
      * @requires Host
      * @requires CurrentOrganization
+     * @requires newHostDetailsUI
      *
      * @description
      *   Provides the functionality for the debs details action pane.
      */
-    function DebController($scope, Deb, Host, CurrentOrganization, ApiErrorHandler) {
+    function DebController($scope, Deb, Host, CurrentOrganization, ApiErrorHandler, newHostDetailsUI) {
         $scope.panel = {
             error: false,
             loading: true
@@ -21,6 +22,7 @@
         }
 
         $scope.installedPackageCount = undefined;
+        $scope.newHostDetailsUI = (newHostDetailsUI === 'true');
 
         $scope.fetchHostCount = function() {
             Host.get({'per_page': 0, 'search': $scope.createRawSearchString('installed_deb'), 'organization_id': CurrentOrganization}, function (data) {
@@ -49,6 +51,6 @@
         .module('Bastion.debs')
         .controller('DebController', DebController);
 
-    DebController.$inject = ['$scope', 'Deb', 'Host', 'CurrentOrganization', 'ApiErrorHandler'];
+    DebController.$inject = ['$scope', 'Deb', 'Host', 'CurrentOrganization', 'ApiErrorHandler', 'newHostDetailsUI'];
 
 })();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/details/views/deb-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/details/views/deb-info.html
@@ -9,7 +9,10 @@
       <dd>
         <i class="fa fa-spinner fa-spin" ng-show="installedDebCount === undefined"></i>
         <span ng-show="installedDebCount !== undefined">
-          <a href="{{ '/content_hosts?search=' + createSearchString('installed_deb') }}" translate>
+          <a ng-if="newHostDetailsUI" href="{{ '/hosts?search=' + createSearchString('installed_deb') }}" translate>
+            {{ installedDebCount }} Host(s)
+          </a>
+          <a ng-if="!newHostDetailsUI" href="{{ '/content_hosts?search=' + createSearchString('installed_deb') }}" translate>
             {{ installedDebCount }} Host(s)
           </a>
         </span>
@@ -17,14 +20,20 @@
 
       <dt translate>Applicable To</dt>
       <dd>
-        <a href="{{ '/content_hosts?search=' + createSearchString('applicable_debs') }}" translate>
+        <a ng-if="newHostDetailsUI" href="{{ '/hosts?search=' + createSearchString('applicable_debs') }}" translate>
+          {{ deb.hosts_applicable_count }} Host(s)
+        </a>
+        <a ng-if="!newHostDetailsUI" href="{{ '/content_hosts?search=' + createSearchString('applicable_debs') }}" translate>
           {{ deb.hosts_applicable_count }} Host(s)
         </a>
       </dd>
 
       <dt translate>Upgradable For</dt>
       <dd>
-        <a href="{{ '/content_hosts?search=' + createSearchString('upgradable_debs') }}" translate>
+        <a ng-if="newHostDetailsUI" href="{{ '/hosts?search=' + createSearchString('upgradable_debs') }}" translate>
+          {{ deb.hosts_available_count }} Host(s)
+        </a>
+        <a ng-if="!newHostDetailsUI" href="{{ '/content_hosts?search=' + createSearchString('upgradable_debs') }}" translate>
           {{ deb.hosts_available_count }} Host(s)
         </a>
       </dd>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/erratum-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/erratum-content-hosts.controller.js
@@ -8,13 +8,14 @@
  * @requires IncrementalUpdate
  * @requires Environment
  * @requires CurrentOrganization
+ * @requires newHostDetailsUI
  *
  * @description
  *   Provides the functionality for the available host collection details action pane.
  */
 angular.module('Bastion.errata').controller('ErratumContentHostsController',
-    ['$scope', 'Nutupane', 'Host', 'IncrementalUpdate', 'Environment', 'CurrentOrganization',
-    function ($scope, Nutupane, Host, IncrementalUpdate, Environment, CurrentOrganization) {
+    ['$scope', 'Nutupane', 'Host', 'IncrementalUpdate', 'Environment', 'CurrentOrganization', 'newHostDetailsUI',
+    function ($scope, Nutupane, Host, IncrementalUpdate, Environment, CurrentOrganization, newHostDetailsUI) {
         var nutupane, params, searchString, nutupaneParams = {
             'overrideAutoLoad': true
         };
@@ -32,6 +33,7 @@ angular.module('Bastion.errata').controller('ErratumContentHostsController',
 
         $scope.nutupane = nutupane;
         $scope.table = nutupane.table;
+        $scope.newHostDetailsUI = newHostDetailsUI;
         $scope.nutupane.searchTransform = function(term) {
             var addition, errataSearchStringAddition = $scope.errataSearchString($scope.restrictInstallable);
             if (errataSearchStringAddition) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-content-hosts.html
@@ -62,9 +62,10 @@
         <tr bst-table-row ng-repeat="contentHost in table.rows" row-select="contentHost"
             ng-controller="ContentHostStatusController">
           <td bst-table-cell>
-            <a ui-sref="content-host.info({hostId: contentHost.id})">
-              {{ contentHost.name }}
-            </a>
+            <span ng-switch="newHostDetailsUI">
+              <a ng-switch-when="true" ng-href="/new/hosts/{{contentHost.name}}/content">{{ contentHost.name }}</a>
+              <a ng-switch-when="false" ui-sref="content-host.info({hostId: contentHost.id})">{{ contentHost.name }}</a>
+            </span>
           </td>
           <td bst-table-cell>{{ contentHost.operatingsystem_name }}</td>
           <td bst-table-cell>{{ contentHost.content_facet_attributes.lifecycle_environment_name }}</td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-add-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-add-hosts.controller.js
@@ -10,13 +10,14 @@
  * @requires Host
  * @requires HostCollection
  * @requires Notification
+ * @requires newHostDetailsUI
  *
  * @description
  *   Provides the functionality for the host collection add content hosts pane.
  */
 angular.module('Bastion.host-collections').controller('HostCollectionAddHostsController',
-    ['$scope', '$state', '$location', 'translate', 'Nutupane', 'CurrentOrganization', 'Host', 'HostCollection', 'Notification',
-    function ($scope, $state, $location, translate, Nutupane, CurrentOrganization, Host, HostCollection, Notification) {
+    ['$scope', '$state', '$location', 'translate', 'Nutupane', 'CurrentOrganization', 'Host', 'HostCollection', 'Notification', 'newHostDetailsUI',
+    function ($scope, $state, $location, translate, Nutupane, CurrentOrganization, Host, HostCollection, Notification, newHostDetailsUI) {
         var contentNutupane, params, nutupaneParams;
 
         params = {
@@ -46,6 +47,7 @@ angular.module('Bastion.host-collections').controller('HostCollectionAddHostsCon
         $scope.table = contentNutupane.table;
         $scope.isAdding = false;
         $scope.table.closeItem = function () {};
+        $scope.newHostDetailsUI = newHostDetailsUI;
 
         $scope.disableAddButton = function () {
             return $scope.table.numSelected === 0 || $scope.isAdding;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-hosts.controller.js
@@ -10,13 +10,14 @@
  * @requires CurrentOrganization
  * @requires Host
  * @requires HostCollection
+ * @requires newHostDetailsUI
  *
  * @description
  *   Provides the functionality for the host collection details action pane.
  */
 angular.module('Bastion.host-collections').controller('HostCollectionHostsController',
-    ['$scope', '$location', 'Notification', 'translate', 'Nutupane', 'CurrentOrganization', 'Host', 'HostCollection',
-    function ($scope, $location, Notification, translate, Nutupane, CurrentOrganization, Host, HostCollection) {
+    ['$scope', '$location', 'Notification', 'translate', 'Nutupane', 'CurrentOrganization', 'Host', 'HostCollection', 'newHostDetailsUI',
+    function ($scope, $location, Notification, translate, Nutupane, CurrentOrganization, Host, HostCollection, newHostDetailsUI) {
         var params, nutupaneParams;
 
         params = {
@@ -46,6 +47,7 @@ angular.module('Bastion.host-collections').controller('HostCollectionHostsContro
         $scope.table = $scope.contentNutupane.table;
         $scope.table.closeItem = function () {};
         $scope.isRemoving = false;
+        $scope.newHostDetailsUI = newHostDetailsUI;
         $scope.contentNutupane.setSearchKey('contentHostSearch');
         $scope.contentNutupane.refresh();
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-add-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-add-hosts.html
@@ -39,9 +39,10 @@
                  ng-change="itemSelected(host)"/>
         </td>
         <td bst-table-cell >
-          <a ui-sref="content-host.info({hostId: host.id})">
-            {{ host.name}}
-          </a>
+          <span ng-switch="newHostDetailsUI">
+            <a ng-switch-when="true" ng-href="/new/hosts/{{host.name}}">{{ host.name }}</a>
+            <a ng-switch-when="false" ui-sref="content-host.info({hostId: host.id})">{{ host.name }}</a>
+          </span>
         </td>
         <td bst-table-cell >{{ host.content_facet_attributes.lifecycle_environment.name}}</td>
         <td bst-table-cell >{{ host.content_facet_attributes.content_view.name}}</td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-hosts-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-hosts-list.html
@@ -39,9 +39,10 @@
                    ng-change="itemSelected(host)"/>
           </td>
           <td bst-table-cell >
-            <a ui-sref="content-host.info({hostId: host.id})">
-              {{ host.name}}
-            </a>
+            <span ng-switch="newHostDetailsUI">
+              <a ng-switch-when="true" ng-href="/new/hosts/{{host.name}}">{{ host.name }}</a>
+              <a ng-switch-when="false" ui-sref="content-host.info({hostId: host.id})">{{ host.name }}</a>
+            </span>
           </td>
           <td bst-table-cell >{{ host.content_facet_attributes.lifecycle_environment.name}}</td>
           <td bst-table-cell >{{ host.content_facet_attributes.content_view.name}}</td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/package.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/package.controller.js
@@ -7,13 +7,14 @@
  * @requires Host
  * @requires CurrentOrganization
  * @requires ApiErrorHandler
+ * @requires newHostDetailsUI
  *
  * @description
  *   Provides the functionality for the package page.
  */
 angular.module('Bastion.packages').controller('PackageController',
-    ['$scope', 'Package', 'Host', 'CurrentOrganization', 'ApiErrorHandler',
-    function ($scope, Package, Host, CurrentOrganization, ApiErrorHandler) {
+    ['$scope', 'Package', 'Host', 'CurrentOrganization', 'ApiErrorHandler', 'newHostDetailsUI', 'newHostDetailsUI',
+    function ($scope, Package, Host, CurrentOrganization, ApiErrorHandler, newHostDetailsUI) {
         $scope.panel = {
             error: false,
             loading: true
@@ -24,6 +25,7 @@ angular.module('Bastion.packages').controller('PackageController',
         }
 
         $scope.installedPackageCount = undefined;
+        $scope.newHostDetailsUI = (newHostDetailsUI === 'true');
 
         $scope.fetchHostCount = function() {
             Host.get({'per_page': 0, 'search': $scope.createSearchString('installed_package'), 'organization_id': CurrentOrganization}, function (data) {
@@ -38,6 +40,10 @@ angular.module('Bastion.packages').controller('PackageController',
 
         $scope.encodedUrl = function(field) {
             return '/content_hosts?search=' + encodeURIComponent($scope.createSearchString(field));
+        };
+
+        $scope.newHostUrl = function(field) {
+            return '/hosts?search=' + encodeURIComponent($scope.createSearchString(field));
         };
 
         $scope.package = Package.get({id: $scope.$stateParams.packageId}, function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-info.html
@@ -9,7 +9,10 @@
       <dd>
         <i class="fa fa-spinner fa-spin" ng-show="installedPackageCount === undefined"></i>
         <span ng-show="installedPackageCount !== undefined">
-          <a href="{{ encodedUrl('installed_package') }}" translate>
+          <a ng-if="newHostDetailsUI" href="{{ newHostUrl('installed_package') }}" translate>
+            {{ installedPackageCount }} Host(s)
+          </a>
+          <a ng-if="!newHostDetailsUI" href="{{ encodedUrl('installed_package') }}" translate>
             {{ installedPackageCount }} Host(s)
           </a>
         </span>
@@ -17,14 +20,20 @@
 
       <dt translate>Applicable To</dt>
       <dd>
-        <a href="{{ encodedUrl('applicable_rpms') }}" translate>
+        <a ng-if="newHostDetailsUI" href="{{ newHostUrl('applicable_rpms') }}" translate>
+          {{ package.hosts_applicable_count }} Host(s)
+        </a>
+        <a ng-if="!newHostDetailsUI" href="{{ encodedUrl('applicable_rpms') }}" translate>
           {{ package.hosts_applicable_count }} Host(s)
         </a>
       </dd>
 
       <dt translate>Upgradable For</dt>
       <dd>
-        <a href="{{ encodedUrl('upgradable_rpms') }}" translate>
+        <a ng-if="newHostDetailsUI" href="{{ newHostUrl('upgradable_rpms') }}" translate>
+          {{ package.hosts_available_count }} Host(s)
+        </a>
+        <a ng-if="!newHostDetailsUI" href="{{ encodedUrl('upgradable_rpms') }}" translate>
           {{ package.hosts_available_count }} Host(s)
         </a>
       </dd>

--- a/engines/bastion_katello/test/activation-keys/details/activation-key-associations.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/details/activation-key-associations.controller.test.js
@@ -40,7 +40,8 @@ describe('Controller: ActivationKeyAssociationsController', function() {
             ActivationKey: ActivationKey,
             Host: Host,
             ContentHostsHelper: {},
-            CurrentOrganization: 'ACME'
+            CurrentOrganization: 'ACME',
+            newHostDetailsUI: 'newHostDetailsUI'
         });
     }));
 

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.test.js
@@ -48,7 +48,8 @@ describe('Controller: ContentHostsBulkErrataModalController', function() {
             HostCollection: HostCollection,
             Nutupane: Nutupane,
             translate: translate,
-            CurrentOrganization: CurrentOrganization
+            CurrentOrganization: CurrentOrganization,
+            newHostDetailsUI: 'newHostDetailsUI'
         });
     }));
 

--- a/engines/bastion_katello/test/debs/details/deb.controller.test.js
+++ b/engines/bastion_katello/test/debs/details/deb.controller.test.js
@@ -23,7 +23,8 @@ describe('Controller: DebController', function() {
             $scope: $scope,
             Deb: Deb,
             Host: Host,
-            CurrentOrganization: currentOrganization
+            CurrentOrganization: currentOrganization,
+            newHostDetailsUI: 'newHostDetailsUI'
         });
     }));
 

--- a/engines/bastion_katello/test/errata/details/erratum-content-hosts.controller.test.js
+++ b/engines/bastion_katello/test/errata/details/erratum-content-hosts.controller.test.js
@@ -71,7 +71,8 @@ describe('Controller: ErratumContentHostsController', function() {
             IncrementalUpdate: IncrementalUpdate,
             Environment: Environment,
             ContentHostBulkAction: ContentHostBulkAction,
-            CurrentOrganization: CurrentOrganization                      
+            CurrentOrganization: CurrentOrganization,
+            newHostDetailsUI: 'newHostDetailsUI'
         });
     }));
 

--- a/engines/bastion_katello/test/host-collections/details/host-collection-add-hosts.controller.test.js
+++ b/engines/bastion_katello/test/host-collections/details/host-collection-add-hosts.controller.test.js
@@ -35,7 +35,8 @@ describe('Controller: HostCollectionAddHostsController', function() {
             translate: function(){},
             HostCollection: HostCollection,
             Host: Host,
-            CurrentOrganization: 'CurrentOrganization'
+            CurrentOrganization: 'CurrentOrganization',
+            newHostDetailsUI: 'newHostDetailsUI'
         });
     }));
 

--- a/engines/bastion_katello/test/host-collections/details/host-collection-hosts.controller.test.js
+++ b/engines/bastion_katello/test/host-collections/details/host-collection-hosts.controller.test.js
@@ -33,7 +33,8 @@ describe('Controller: HostCollectionHostsController', function() {
             translate: function(){},
             HostCollection: HostCollection,
             Host: Host,
-            CurrentOrganization: 'CurrentOrganization'
+            CurrentOrganization: 'CurrentOrganization',
+            newHostDetailsUI: 'newHostDetailsUI'
         });
     }));
 

--- a/engines/bastion_katello/test/packages/details/package.controller.test.js
+++ b/engines/bastion_katello/test/packages/details/package.controller.test.js
@@ -23,7 +23,8 @@ describe('Controller: PackageController', function() {
             $scope: $scope,
             Package: Package,
             Host: Host,
-            CurrentOrganization: currentOrganization
+            CurrentOrganization: currentOrganization,
+            newHostDetailsUI: 'newHostDetailsUI'
         });
     }));
 

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/affectedHosts.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/affectedHosts.js
@@ -67,7 +67,7 @@ const AffectedHosts = ({
         }) => (
           <Tr ouiaId={`${id}`} key={`${id}`}>
             <Td>
-              <a rel="noreferrer" target="_blank" href={urlBuilder(`hosts/${id}`, '')}>{name}</a>
+              <a rel="noreferrer" target="_blank" href={urlBuilder(`new/hosts/${id}`, '')}>{name}</a>
             </Td>
             <Td><EnvironmentLabels environments={environment} /></Td>
           </Tr>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* We had a few lingering links going to the legacy content host ui, this fixes the remaining ones

#### Considerations taken when implementing this change?

* N/A

#### What are the testing steps for this pull request?

* Register a content host with an activation key
* Goto the activation key tab associations and verify the content host ui link goes to the new ui
* Sync a repo that has errata
* Install `katello-host-tools` on the client so errata show up
* On the host collection page, verify the url of the content host goes to the new ui
* Add the content host to a host collection, on the list/remove tab, make sure the host goes to the new ui
* Goto content - errata, check applicable and click an errata, verify the content hosts name link goes to the new ui
* Make sure there are no other lingering links going to the legacy ui