### PR TITLE
Fixes #36142 - Allow reclaim space without explicitly setting Organization

### DIFF
--- a/app/lib/actions/pulp3/repository/reclaim_space.rb
+++ b/app/lib/actions/pulp3/repository/reclaim_space.rb
@@ -4,7 +4,7 @@ module Actions
       class ReclaimSpace < Pulp3::AbstractAsyncTask
         def plan(repo, smart_proxy = SmartProxy.pulp_primary)
           action_subject(repo)
-          repository_hrefs = ::Katello::Pulp3::RepositoryReference.default_cv_repository_hrefs([repo], Organization.current || repositories.first.organization)
+          repository_hrefs = ::Katello::Pulp3::RepositoryReference.default_cv_repository_hrefs([repo], repo.organization)
           plan_self(repository_hrefs: repository_hrefs, smart_proxy_id: smart_proxy.id)
         end
 

--- a/test/actions/pulp3/repository/reclaim_space_test.rb
+++ b/test/actions/pulp3/repository/reclaim_space_test.rb
@@ -5,21 +5,8 @@ module ::Actions::Pulp3::Repository
     include Katello::Pulp3Support
 
     def setup
-      set_organization(Organization.find_by(label: 'Empty_Organization'))
-      @primary = SmartProxy.pulp_primary
-      @repo = katello_repositories(:fedora_17_x86_64)
-      @repo2 = katello_repositories(:fedora_17_x86_64_duplicate)
-      @repo3 = katello_repositories(:feedless_fedora_17_x86_64)
-      @cv_repo = katello_repositories(:fedora_17_library_library_view)
-
-      @repo = create_repo(@repo, @primary)
-      @repo2 = create_repo(@repo2, @primary)
-      @repo3 = create_repo(@repo3, @primary)
-      @cv_repo = create_repo(@cv_repo, @primary)
-
+      @repo = create_repo(katello_repositories(:fedora_17_x86_64), SmartProxy.pulp_primary)
       @repo.root.update(download_policy: 'on_demand')
-      @repo2.root.update(download_policy: 'on_demand')
-      @repo3.root.update(download_policy: 'immediate')
     end
 
     def test_repository_has_space_reclaimed


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Allows running reclaim space without relying on the Organization being set. Previously this used `Organization.current` and had `repositories.first.organization` as a fallback, however the fallback was broken. Since https://github.com/Katello/katello/pull/9952 we pass the `repo` to the task directly, so now we can simply use `repo.organization` as the definitive approach to determine the organization to use for the task.

#### Considerations taken when implementing this change?

To test this, I removed defining the organization in the test case setup. The repo should get created now with any current organization, and the task should properly determine the organization from the repo object.

I also removed other setup steps that are no longer used.

#### What are the testing steps for this pull request?

Create a repository. Install hammer. Test with `hammer repository reclaim-space --id 1 --organization-id 1`
