### PR TITLE
Fixes #36140 - Remove all references to mirror_on_sync

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -7,7 +7,7 @@ module Katello
       generic_repo_wrap_params << option.name
     end
 
-    repo_wrap_params = RootRepository.attribute_names + [:mirror_on_sync] + generic_repo_wrap_params
+    repo_wrap_params = RootRepository.attribute_names + generic_repo_wrap_params
 
     wrap_parameters :repository, :include => repo_wrap_params
 
@@ -55,7 +55,6 @@ module Katello
       param :exclude_tags, Array, :desc => N_("Comma-separated list of tags to exclude when syncing a container image repository. Default: any tag ending in \"-source\"")
       param :download_policy, ["immediate", "on_demand"], :desc => N_("download policy for yum, deb, and docker repos (either 'immediate' or 'on_demand')")
       param :download_concurrency, :number, :desc => N_("Used to determine download concurrency of the repository in pulp3. Use value less than 20. Defaults to 10")
-      param :mirror_on_sync, :bool, :desc => N_("true if this repository when synced has to be mirrored from the source and stale rpms removed (Deprecated)")
       param :mirroring_policy, Katello::RootRepository::MIRRORING_POLICIES, :desc => N_("Policy to set for mirroring content.  Must be one of %s.") % RootRepository::MIRRORING_POLICIES
       param :verify_ssl_on_sync, :bool, :desc => N_("if true, Katello will verify the upstream url's SSL certifcates are signed by a trusted CA")
       param :upstream_username, String, :desc => N_("Username of the upstream repository user used for authentication")
@@ -580,7 +579,7 @@ module Katello
 
     # rubocop:disable Metrics/CyclomaticComplexity
     def repository_params
-      keys = [:download_policy, :mirror_on_sync, :mirroring_policy, :sync_policy, :arch, :verify_ssl_on_sync, :upstream_password,
+      keys = [:download_policy, :mirroring_policy, :sync_policy, :arch, :verify_ssl_on_sync, :upstream_password,
               :upstream_username, :download_concurrency, :upstream_authentication_token,
               {:os_versions => []}, :deb_releases, :deb_components, :deb_architectures, :description,
               :http_proxy_policy, :http_proxy_id, :retain_package_versions_count, {:ignorable_content => []}
@@ -604,8 +603,7 @@ module Katello
         keys += [:url, :gpg_key_id, :ssl_ca_cert_id, :ssl_client_cert_id, :ssl_client_key_id, :unprotected, :name,
                  :checksum_type]
       end
-      to_return = params.require(:repository).permit(*keys).to_h.with_indifferent_access
-      handle_mirror_on_sync(to_return)
+      params.require(:repository).permit(*keys).to_h.with_indifferent_access
     end
 
     def get_content_credential(repo_params, content_type)
@@ -663,19 +661,6 @@ module Katello
       root
     end
     # rubocop:enable Metrics/CyclomaticComplexity,Metrics/MethodLength
-
-    def handle_mirror_on_sync(repo_params)
-      if !repo_params.key?(:mirroring_policy) && repo_params.key?(:mirror_on_sync)
-        ::Foreman::Deprecation.api_deprecation_warning("mirror_on_sync is deprecated in favor of mirroring_policy.  It will be removed in Katello 4.8.")
-        if ::Foreman::Cast.to_bool(repo_params[:mirror_on_sync])
-          repo_params[:mirroring_policy] = Katello::RootRepository::MIRRORING_POLICY_CONTENT
-        else
-          repo_params[:mirroring_policy] = Katello::RootRepository::MIRRORING_POLICY_ADDITIVE
-        end
-      end
-      repo_params.delete(:mirror_on_sync)
-      repo_params
-    end
 
     def error_on_rh_product
       fail HttpErrors::BadRequest, _("Red Hat products cannot be manipulated.") if @product.redhat?

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -424,20 +424,6 @@ module Katello
       assert_template 'api/v2/common/create'
     end
 
-    def test_create_with_mirror_on_sync_true
-      mirror_on_sync = true
-      run_test_individual_attribute(:mirror_on_sync => mirror_on_sync) do |_, repo|
-        repo.root.expects(:mirroring_policy=).with(::Katello::RootRepository::MIRRORING_POLICY_CONTENT)
-      end
-    end
-
-    def test_create_with_mirror_on_sync_false
-      mirror_on_sync = false
-      run_test_individual_attribute(:mirror_on_sync => mirror_on_sync) do |_, repo|
-        repo.root.expects(:mirroring_policy=).with(::Katello::RootRepository::MIRRORING_POLICY_ADDITIVE)
-      end
-    end
-
     def test_create_with_mirroring_policy
       run_test_individual_attribute(:mirroring_policy => ::Katello::RootRepository::MIRRORING_POLICY_CONTENT) do |_, repo|
         repo.root.expects(:mirroring_policy=).with(::Katello::RootRepository::MIRRORING_POLICY_CONTENT)
@@ -657,13 +643,13 @@ module Katello
       put :update, params: { :id => repo.id, :mirroring_policy => ::Katello::RootRepository::MIRRORING_POLICY_COMPLETE }
     end
 
-    def test_update_with_mirror_on_sync
+    def test_update_with_mirroring_policy
       repo = katello_repositories(:fedora_17_unpublished)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
         refute_includes attributes.keys, :mirror_on_sync
         assert_equal ::Katello::RootRepository::MIRRORING_POLICY_ADDITIVE, attributes[:mirroring_policy]
       end
-      put :update, params: { :id => repo.id, :mirror_on_sync => false }
+      put :update, params: { :id => repo.id, :mirroring_policy => ::Katello::RootRepository::MIRRORING_POLICY_ADDITIVE }
     end
 
     def test_update_with_retain_package_versions_count


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Removes all usages of mirror_on_sync
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Checkout this PR and test repository creation, updates, sync etc.
In hammer try `hammer -r repository create --help` and `hammer -r repository update --help` to make sure mirror_on_sync is no longer a recognized option.