### PR TITLE
Fixes #36146 - Fail export validation on zero repository versions

### DIFF
--- a/app/lib/actions/pulp3/orchestration/content_view_version/syncable_export.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/syncable_export.rb
@@ -18,7 +18,6 @@ module Actions
 
           def plan(content_view_version:,
                    smart_proxy:,
-                   fail_on_missing_content: false,
                    destination_server:,
                    from_content_view_version:)
             format = ::Katello::Pulp3::ContentViewVersion::Export::SYNCABLE

--- a/app/lib/actions/pulp3/orchestration/content_view_version/syncable_export.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/syncable_export.rb
@@ -29,7 +29,6 @@ module Actions
                   from_content_view_version: from_content_view_version,
                   format: format,
                   destination_server: destination_server)
-              export_service.validate!(fail_on_missing_content: fail_on_missing_content)
               base_path = export_service.generate_exporter_path
               export_service.repositories.each do |repository|
                 action_output = plan_action(::Actions::Pulp3::ContentViewVersion::CreateExporter,

--- a/app/services/katello/pulp3/content_view_version/export_validation_error.rb
+++ b/app/services/katello/pulp3/content_view_version/export_validation_error.rb
@@ -1,7 +1,7 @@
 module Katello
   module Pulp3
     module ContentViewVersion
-      class ExportValidationError < HttpErrors::BadRequest; end
+      class ExportValidationError < StandardError; end
     end
   end
 end

--- a/app/services/katello/pulp3/content_view_version/export_validator.rb
+++ b/app/services/katello/pulp3/content_view_version/export_validator.rb
@@ -25,7 +25,7 @@ module Katello
           if repos.empty?
             fail ExportValidationError,
                  _("NOTE: Content view version '%{content_view} %{current}'"\
-                   " does not have any exportable repositories. At least one repository among"\
+                   " does not have any exportable repositories. At least one repository with"\
                    " any of the following types"\
                    " is required to be able to export: '%{exportable_types}'." %
                    { content_view: content_view_version.content_view.name,

--- a/test/services/katello/pulp3/content_view_version/export_test.rb
+++ b/test/services/katello/pulp3/content_view_version/export_test.rb
@@ -175,6 +175,14 @@ module Katello
             assert_match(/Specify an export chunk size less than 1_000_000 GB/, exception.message)
           end
 
+          it "fails on validate! if content view has no repos" do
+            export = setup_environment(version: :library_no_filter_view_version_1)
+            exception = assert_raises(::Katello::Pulp3::ContentViewVersion::ExportValidationError) do
+              export.validate!(fail_on_missing_content: false, validate_incremental: false, chunk_size: 1e6)
+            end
+            assert_match(/does not have any exportable repositories/, exception.message)
+          end
+
           it "Picks the right repos for syncable" do
             proxy = SmartProxy.pulp_primary
             SmartProxy.any_instance.stubs(:pulp_primary).returns(proxy)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
It checks if the  content view version to export has any exportable repositories and fails if is does not.

#### Considerations taken when implementing this change?
Original bug had the user try this for incremental exports but allowing export of a version with no content does not make any sense.

#### What are the testing steps for this pull request?

- Create a CVV with repo
- Remove the repo from the CV and republish
- Try doing a complete export on both 
- Version 1.0 should work fine.
- Version 2.0 should fail with
```
$ hammer content-export complete version --id=11
Could not export the content view version:
  NOTE: Content view version 'boo 2.0'. does not have any exportable repositories. At least one repository of the following types  is required to be able to export: 'yum', 'file', 'ansible_collection', 'docker'.
```