### PR TITLE
Fixes #36151 - Add RHEL 9 kickstart appstream/baseos as recommended repos

### DIFF
--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -11,7 +11,9 @@ const repoTypeSearchQueryMap = {
 
 const recommendedRepositoriesRHEL = [
   'rhel-9-for-x86_64-baseos-rpms',
+  'rhel-9-for-x86_64-baseos-kickstart',
   'rhel-9-for-x86_64-appstream-rpms',
+  'rhel-9-for-x86_64-appstream-kickstart',
   'rhel-8-for-x86_64-baseos-rpms',
   'rhel-8-for-x86_64-baseos-kickstart',
   'rhel-8-for-x86_64-appstream-rpms',


### PR DESCRIPTION

#### What are the changes introduced in this pull request?
Add `rhel-9-for-x86_64-appstream-kickstart` and `rhel-9-for-x86_64-baseos-kickstart` as recommended repositories.


#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1. `Red Hat Enterprise Linux 9 for x86_64 - AppStream (Kickstart)`
2. `Red Hat Enterprise Linux 9 for x86_64 - BaseOS (Kickstart)`
should be included in the recommended repositories list when searching with `Kickstart` repo type
