### PR TITLE
Fixes #36147 - Correct the name of the new rake task

### DIFF
--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -12,7 +12,7 @@ module Katello
       if product_provider.redhat_provider?
         false
       else
-        Rails.logger.warn "Found orphaned object with id #{cp_id} in Candlepin. Skipping import into Katello; run rake katello:delete_orphaned_custom_products to remove it from Candlepin."
+        Rails.logger.warn "Found orphaned object with id #{cp_id} in Candlepin. Skipping import into Katello; run rake katello:clean_candlepin_orphaned_products to remove it from Candlepin."
         true
       end
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The Rails logger warning message in https://github.com/Katello/katello/pull/10433 tells you to run a rake task that doesn't exist. This (hopefully) fixes that.

#### What are the testing steps for this pull request?

I mean I guess you could follow the same testing steps from https://github.com/Katello/katello/pull/10433, knock yourself out. Or just verify that the new code and the actual rake task name match ;)
