### PR TITLE
Fixes #36137 - Catch content_view_id and LCE id before Rails update

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -6,6 +6,20 @@ module Katello
       include ForemanTasks::Concerns::ActionSubject
 
       module Overrides
+        def update(attrs)
+          if attrs[:content_facet_attributes]
+            cv_id = attrs[:content_facet_attributes].delete(:content_view_id)
+            lce_id = attrs[:content_facet_attributes].delete(:lifecycle_environment_id)
+            if cv_id && lce_id
+              content_facet.assign_single_environment(content_view_id: cv_id, lifecycle_environment_id: lce_id)
+            end
+            if (cv_id.present? && lce_id.blank?) || (cv_id.blank? && lce_id.present?)
+              fail "content_view_id and lifecycle_environment_id must be provided together"
+            end
+          end
+          super
+        end
+
         def validate_media?
           (content_source_id.blank? || (content_facet && content_facet.kickstart_repository.blank?)) && super
         end

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -97,6 +97,13 @@ module Katello
         )
       end
     end
+
+    def test_update_with_blank_lifecycle_environment
+      host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @library_view, :lifecycle_environment => @library)
+      assert_raises(RuntimeError, "content_view_id and lifecycle_environment_id must be provided together") do
+        host.update(content_facet_attributes: {content_view_id: @view.id, lifecycle_environment_id: nil})
+      end
+    end
   end
 
   class HostManagedExtensionsUpdateTest < HostManagedExtensionsTestBase


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The hosts controller in Foreman passes through all attributes with `@host.update(attributes)`. This causes problems with attributes that no longer exist on content hosts, such as `content_view_id` and `lifecycle_environment_id`.

This adds a method that overrides `Host::Managed#update` to account for that.

#### Considerations taken when implementing this change?

Theoretically this fix is only temporary, until we finish building out the multi CV feature and stop sending these params to the backend.

#### What are the testing steps for this pull request?

See steps in the Redmine issue.
