### PR TITLE
Fixes #36157 - reuse pulpcore registry manifest headers

### DIFF
--- a/test/controllers/api/registry/registry_proxies_controller_test.rb
+++ b/test/controllers/api/registry/registry_proxies_controller_test.rb
@@ -13,6 +13,7 @@ module Katello
       @rpm_repo = katello_repositories(:fedora_17_x86_64)
       @tag = katello_docker_tags(:one)
       @digest = 'sha256:somedigest'
+      @length = '0'
     end
 
     def setup_permissions
@@ -398,7 +399,7 @@ module Katello
 
       it "pull manifest - success" do
         manifest = '{"mediaType":"MEDIATYPE"}'
-        manifest.stubs(:headers).returns({docker_content_digest: @digest})
+        manifest.stubs(:headers).returns({docker_content_digest: @digest, content_length: @length, content_type: 'MEDIATYPE'})
         @controller.stubs(:registry_authorize).returns(true)
         @controller.stubs(:find_readable_repository).returns(@docker_repo)
         Resources::Registry::Proxy.stubs(:get).returns(manifest)
@@ -417,7 +418,7 @@ module Katello
       it "pull manifest - HTTPS Header" do
         #production installs include an HTTPS: 'on' header, which needs to be removed
         manifest = '{"mediaType":"MEDIATYPE"}'
-        manifest.stubs(:headers).returns({docker_content_digest: @digest})
+        manifest.stubs(:headers).returns({docker_content_digest: @digest, content_length: @length, content_type: 'MEDIATYPE'})
         @controller.stubs(:registry_authorize).returns(true)
         @controller.stubs(:find_readable_repository).returns(@docker_repo)
 
@@ -443,7 +444,7 @@ module Katello
 
       it "pull manifest - HTTP Header - v1+json" do
         manifest = '{}'
-        manifest.stubs(:headers).returns({docker_content_digest: @digest})
+        manifest.stubs(:headers).returns({docker_content_digest: @digest, content_length: @length, content_type: 'MEDIATYPE'})
         @controller.stubs(:registry_authorize).returns(true)
         @controller.stubs(:find_readable_repository).returns(@docker_repo)
         Resources::Registry::Proxy.stubs(:get).returns(manifest)
@@ -454,14 +455,14 @@ module Katello
         get :pull_manifest, params: { repository: @docker_repo.name, tag: @tag.name }
         assert_response 200
         assert_equal(manifest, response.body)
-        assert_includes response.header['Content-Type'], 'application/vnd.docker.distribution.manifest.v1+json'
+        assert_includes response.header['Content-Type'], 'MEDIATYPE'
         assert_equal response.header['Content-Length'], '0'
         assert_equal @digest, response.header['Docker-Content-Digest']
       end
 
       it "pull manifest - HTTP Header - with signatures" do
         manifest = '{"signatures": [{"signature":"...."}]}'
-        manifest.stubs(:headers).returns({docker_content_digest: @digest})
+        manifest.stubs(:headers).returns({docker_content_digest: @digest, content_length: @length, content_type: 'MEDIATYPE'})
         @controller.stubs(:registry_authorize).returns(true)
         @controller.stubs(:find_readable_repository).returns(@docker_repo)
         Resources::Registry::Proxy.stubs(:get).returns(manifest)
@@ -472,14 +473,14 @@ module Katello
         get :pull_manifest, params: { repository: @docker_repo.name, tag: @tag.name }
         assert_response 200
         assert_equal(manifest, response.body)
-        assert_equal response.header['Content-Length'], '0'
-        assert_includes response.header['Content-Type'], 'application/vnd.docker.distribution.manifest.v1+prettyjws'
+        assert_equal response.header['Content-Length'], @length
+        assert_includes response.header['Content-Type'], 'MEDIATYPE'
         assert_equal @digest, response.header['Docker-Content-Digest']
       end
 
       it "pull manifest no login - success" do
         manifest = '{"mediaType":"MEDIATYPE"}'
-        manifest.stubs(:headers).returns({docker_content_digest: @digest})
+        manifest.stubs(:headers).returns({docker_content_digest: @digest, content_length: @length, content_type: 'MEDIATYPE'})
 
         @controller.stubs(:registry_authorize).returns(true)
         @controller.stubs(:find_readable_repository).returns(@docker_repo)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Stops Katello from calculating container manifest pull headers. Trust the headers coming from Pulp during manifest pull.

#### Considerations taken when implementing this change?
The old code is very likely due to Pulp 2 times. Ina from Pulp mentioned we should be able to trust their headers.

#### What are the testing steps for this pull request?
1) Try to sync and pull quay.io/riadh_hamdi/ceph-zabbix:latest
2) Try other container images and ensure you can pull them.