### PR TITLE
Fixes #36123 - Can't force delete when repo is in syncable exports

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -101,7 +101,7 @@ module Katello
                                    :library_export_syncable,
                                    :repository_export_syncable])
     }
-    scope :generated_for_library, -> { where(:generated_for => [:library_export, :library_import]) }
+    scope :generated_for_library, -> { where(:generated_for => [:library_export, :library_import, :library_export_syncable]) }
 
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :organization_id, :complete_value => true, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
@@ -157,11 +157,11 @@ module Katello
     end
 
     def generated_for_repository?
-      generated_for_repository_export? || generated_for_repository_import?
+      generated_for_repository_export? || generated_for_repository_import? || generated_for_repository_export_syncable?
     end
 
     def generated_for_library?
-      generated_for_library_export? || generated_for_library_import?
+      generated_for_library_export? || generated_for_library_import? || generated_for_library_export_syncable?
     end
 
     def content_host_count


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Create a yum repo (repo_to_export) and sync.
Create a CV, add the repo and publish
Run the following exports for library, the repo and content view version in hammer:
```
hammer content-export complete library --organization="Default Organization"
hammer content-export complete library --organization="Default Organization" --format=syncable
hammer content-export complete repository --name="repo_to_export" --product="product_name" --organization="Default Organization"
hammer content-export complete repository --name="repo_to_export" --product="prod" --organization="Default Organization" --format=syncable
hammer content-export complete version --content-view="cv_to_export" --version=1.0 --organization="Default Organization"
hammer content-export complete version --content-view="cv_to_export" --version=1.0 --organization="Default Organization" --format=syncable
```
Try deleting the repo from the UI and confirm deletion from versions in the confirmation modal.
Monitor the task.

Expected result: The repository and all the version repositories should get deleted successfully.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
