### PR TITLE
Fixes #36100 - check arch when looking for package upgrades

### DIFF
--- a/test/presenters/host_package_presenter_test.rb
+++ b/test/presenters/host_package_presenter_test.rb
@@ -7,7 +7,7 @@ module Katello
       @rpm = katello_rpms(:one)
     end
 
-    let(:installed_package) { Katello::InstalledPackage.create(name: @rpm.name, nvra: @rpm.nvra, version: @rpm.version, release: @rpm.release, nvrea: @rpm.nvrea) }
+    let(:installed_package) { Katello::InstalledPackage.create(name: @rpm.name, nvra: @rpm.nvra, version: @rpm.version, release: @rpm.release, nvrea: @rpm.nvrea, arch: @rpm.arch) }
     let(:new_version) { 'one-1.2-5.el7.x86_64' }
 
     test "with set upgradable_version" do
@@ -29,10 +29,23 @@ module Katello
     test "with_latest" do
       host = katello_content_facets(:content_facet_one).host
       host.content_facet.bound_repositories << @repo
-      @rpm.update(version: '1.2', nvra: new_version, release: '5')
+      update = Katello::Rpm.create(name: 'one', pulp_id: 'one-new-uuid', version: '1.2', nvra: new_version, release: '5', arch: 'x86_64')
+      ::Katello::Rpm.stubs(:installable_for_hosts).returns(Katello::Rpm.where(id: update.id))
       presenter = HostPackagePresenter.with_latest([installed_package], host).first
 
       assert_equal presenter.upgradable_versions, [new_version]
+      assert_equal presenter.name, installed_package.name
+      assert_equal presenter.rpm_id, @rpm.id
+    end
+
+    test "with arch" do
+      host = katello_content_facets(:content_facet_one).host
+      host.content_facet.bound_repositories << @repo
+      update = Katello::Rpm.create(name: 'one', pulp_id: 'one-new-uuid', version: '1.2', nvra: 'one-1.2-5.el7.noarch', release: '5', arch: 'noarch')
+      ::Katello::Rpm.stubs(:installable_for_hosts).returns(Katello::Rpm.where(id: update.id))
+      presenter = HostPackagePresenter.with_latest([installed_package], host).first
+
+      assert_nil presenter.upgradable_versions
       assert_equal presenter.name, installed_package.name
       assert_equal presenter.rpm_id, @rpm.id
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Package upgradable versions should be based on architecture.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1. Get a rocky Linux box.
2. Sync repo: https://mirrors.rockylinux.org/mirrorlist?arch=x86_64&repo=BaseOS-8
3. Be able to install `expat.i686`,  `expat.x86_64`, `zlib.i686` or `zlib.x86_64` as you want.
