### PR TITLE
Fixes #36102 - Use HTTP proxy switch is non-functional for custom and rhui ACS's

### DIFF
--- a/app/services/katello/pulp3/alternate_content_source.rb
+++ b/app/services/katello/pulp3/alternate_content_source.rb
@@ -61,7 +61,6 @@ module Katello
         if acs.content_type == ::Katello::Repository::FILE_TYPE && acs.subpaths.empty? && !remote_options[:url].end_with?('/PULP_MANIFEST')
           remote_options[:url] = acs.base_url + '/PULP_MANIFEST'
         end
-        # If not using http proxies, set proxy options to nil
         unless acs.use_http_proxies
           remote_options[:proxy_url] = nil
           remote_options[:proxy_username] = nil

--- a/app/services/katello/pulp3/alternate_content_source.rb
+++ b/app/services/katello/pulp3/alternate_content_source.rb
@@ -61,6 +61,12 @@ module Katello
         if acs.content_type == ::Katello::Repository::FILE_TYPE && acs.subpaths.empty? && !remote_options[:url].end_with?('/PULP_MANIFEST')
           remote_options[:url] = acs.base_url + '/PULP_MANIFEST'
         end
+        # If not using http proxies, set proxy options to nil
+        unless acs.use_http_proxies
+          remote_options[:proxy_url] = nil
+          remote_options[:proxy_username] = nil
+          remote_options[:proxy_password] = nil
+        end
         remote_options.merge!(username: acs&.upstream_username, password: acs&.upstream_password)
         remote_options.merge!(ssl_remote_options)
       end

--- a/test/actions/pulp3/orchestration/alternate_content_source_update_test.rb
+++ b/test/actions/pulp3/orchestration/alternate_content_source_update_test.rb
@@ -3,13 +3,20 @@ require 'katello_test_helper'
 module ::Actions::Pulp3
   class AlternateContentSourceUpdateTest < ActiveSupport::TestCase
     include Katello::Pulp3Support
+    include Katello::Util::HttpProxy
 
     def setup
       @primary = SmartProxy.pulp_primary
+      @repository = katello_repositories(:rhel_6_x86_64)
       @yum_acs = katello_alternate_content_sources(:yum_alternate_content_source)
       @file_acs = katello_alternate_content_sources(:file_alternate_content_source)
+      @simplified_acs = katello_alternate_content_sources(:yum_simplified_alternate_content_source)
+      @simplified_acs.products << @repository.product
+      @rhui_acs = katello_alternate_content_sources(:yum_alternate_content_source_rhui)
       @yum_acs.save!
       @file_acs.save!
+      @simplified_acs.save!
+      @rhui_acs.save!
       ::Katello::Pulp3::AlternateContentSource.any_instance.stubs(:test_remote_name).returns('test-remote')
     end
 
@@ -25,6 +32,18 @@ module ::Actions::Pulp3
             ::Actions::Pulp3::Orchestration::AlternateContentSource::Delete, smart_proxy_acs)
       end
       @file_acs.reload
+
+      @simplified_acs.smart_proxy_alternate_content_sources.each do |smart_proxy_acs|
+        ForemanTasks.sync_task(
+            ::Actions::Pulp3::Orchestration::AlternateContentSource::Delete, smart_proxy_acs)
+      end
+      @simplified_acs.reload
+
+      @rhui_acs.smart_proxy_alternate_content_sources.each do |smart_proxy_acs|
+        ForemanTasks.sync_task(
+            ::Actions::Pulp3::Orchestration::AlternateContentSource::Delete, smart_proxy_acs)
+      end
+      @rhui_acs.reload
     end
 
     def test_yum_update
@@ -64,6 +83,68 @@ module ::Actions::Pulp3
       pulp_remote = @file_acs.backend_service(@primary).get_remote
       assert_equal @file_acs.base_url + '/PULP_MANIFEST', pulp_remote.url
       assert_equal [''], pulp_acs.paths
+    end
+
+    # Test that all ACS types update their http_proxy information correctly when use_http_proxies flag is toggled
+    def test_http_proxy_url_update
+      proxy = FactoryBot.create(:http_proxy)
+      proxy.update!(url: "https://test_url", username: "foo", password: "bar")
+
+      # We stub this function so that simplified ACS remote options don't query candlepin
+      ::Katello::Pulp3::Repository::Yum.any_instance.stubs(:remote_options).returns(
+        remote_options = {
+          tls_validation: @rhui_acs.verify_ssl,
+          name: "test_name",
+          url: @rhui_acs.base_url,
+          policy: 'on_demand',
+          proxy_url: "https://bad_url",
+          proxy_username: "bad_username",
+          proxy_password: "bad_password",
+          total_timeout: 8675309
+        }
+      )
+
+      @file_acs.update!(use_http_proxies: true)
+      ::Katello::SmartProxyAlternateContentSource.create(alternate_content_source_id: @file_acs.id, smart_proxy_id: @primary.id)
+      @file_acs.smart_proxy_alternate_content_sources.first.backend_service.smart_proxy.update!(http_proxy_id: proxy.id)
+      remote_options = @file_acs.smart_proxy_alternate_content_sources.first.backend_service.remote_options
+      assert_equal remote_options[:proxy_url], proxy.url
+      assert_equal remote_options[:proxy_username], proxy.username
+      assert_equal remote_options[:proxy_password], proxy.password
+
+      @file_acs.update(use_http_proxies: false)
+      remote_options = @file_acs.smart_proxy_alternate_content_sources.first.backend_service.remote_options
+      assert_nil remote_options[:proxy_url]
+      assert_nil remote_options[:proxy_username]
+      assert_nil remote_options[:proxy_password]
+
+      @rhui_acs.update!(use_http_proxies: true)
+      ::Katello::SmartProxyAlternateContentSource.create(alternate_content_source_id: @rhui_acs.id, smart_proxy_id: @primary.id)
+      @rhui_acs.smart_proxy_alternate_content_sources.first.backend_service.smart_proxy.update!(http_proxy_id: proxy.id)
+      remote_options = @rhui_acs.smart_proxy_alternate_content_sources.first.backend_service.remote_options
+      assert_equal remote_options[:proxy_url], proxy.url
+      assert_equal remote_options[:proxy_username], proxy.username
+      assert_equal remote_options[:proxy_password], proxy.password
+
+      @rhui_acs.update(use_http_proxies: false)
+      remote_options = @rhui_acs.smart_proxy_alternate_content_sources.first.backend_service.remote_options
+      assert_nil remote_options[:proxy_url]
+      assert_nil remote_options[:proxy_username]
+      assert_nil remote_options[:proxy_password]
+
+      @simplified_acs.update!(use_http_proxies: true)
+      ::Katello::SmartProxyAlternateContentSource.create(alternate_content_source_id: @simplified_acs.id, smart_proxy_id: @primary.id, repository_id: @repository.id) # has repo
+      @simplified_acs.smart_proxy_alternate_content_sources.first.backend_service.smart_proxy.update!(http_proxy_id: proxy.id)
+      remote_options = @simplified_acs.smart_proxy_alternate_content_sources.first.backend_service.remote_options
+      assert_equal remote_options[:proxy_url], proxy.url
+      assert_equal remote_options[:proxy_username], proxy.username
+      assert_equal remote_options[:proxy_password], proxy.password
+
+      @simplified_acs.update(use_http_proxies: false)
+      remote_options = @simplified_acs.smart_proxy_alternate_content_sources.first.backend_service.remote_options
+      assert_nil remote_options[:proxy_url]
+      assert_nil remote_options[:proxy_username]
+      assert_nil remote_options[:proxy_password]
     end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Like simplified alternate content sources, custom and RHUI-type ACS's will now respect the `use_http_proxies` flag when configured with smart proxy parameters. Additionally, tests have been added to check whether this functionality occurs for both creating and updating the `use_http_proxies` flag on all three ACS types.

#### Considerations taken when implementing this change?
n/a

#### What are the testing steps for this pull request?
1. Create a custom-type ACS with an assigned smart proxy. Set the use HTTP proxies flag to true.
2. Verify that toggling "Use HTTP proxies" works using pulp:
    - Open the Katello console.
    - Input `::Katello::AlternateContentSource.find_by(id:<your_acs_id>).smart_proxy_alternate_content_sources`.
    - Locate the `remote_href` field and copy the existing string.
    - Paste that string into a pulp command: `pulp show --href <remote_href>`
    - Note the `proxy_url` field will be populated by your smart proxy's location
    - Toggle "Use HTTP Proxies" to off in the Foreman GUI (Alternate Content Sources -> ACS Name -> Smart Proxies -> Edit)
    - Rerun the previous pulp command
    - Note that the `proxy_url` field is now `null`
3. Verify that toggling "Use HTTP proxies" works using squid and tail:
    - Ensure squid is running
    - Run `sudo tail -f /var/log/squid/access.log` to follow local traffic requests
    - Toggle "Use HTTP proxies" back to on and save.
    - Click the "Refresh source" button, noting that a refresh request appears in the squid log.
    - Toggle "Use HTTP proxies" off and save.
    - Click the "Refresh source" button, noting that no new requests appear.
4. Repeat the above testing steps with a simplified ACS; they use different logic than custom and rhui so will need to be checked separately. Note that refreshing a simplified ACS will output more than one request in the squid log (but should still request nothing when `use_http_proxies` is false).