### PR TITLE
Fixes #36164 - Incremental imports create proper publication

### DIFF
--- a/app/lib/actions/pulp3/orchestration/content_view_version/copy_version_units_to_library.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/copy_version_units_to_library.rb
@@ -13,7 +13,7 @@ module Actions
                                                     mirror: content_view_version.content_view.generated?)
                   plan_action(Actions::Pulp3::Repository::SaveVersion, repo.library_instance)
                   plan_action(Katello::Repository::IndexContent, id: repo.library_instance_id)
-                  plan_action(Katello::Repository::MetadataGenerate, repo.library_instance, :force => true)
+                  plan_action(Katello::Repository::MetadataGenerate, repo.library_instance, force_publication: true)
                 end
               end
             end

--- a/db/seeds.d/111-upgrade_tasks.rb
+++ b/db/seeds.d/111-upgrade_tasks.rb
@@ -8,7 +8,7 @@ UpgradeTask.define_tasks(:katello) do
     {:name => 'katello:upgrades:4.1:reupdate_content_import_export_perms'},
     {:name => 'katello:upgrades:4.2:remove_checksum_values'},
     {:name => 'katello:upgrades:4.4:publish_import_cvvs'},
-    {:name => 'katello:upgrades:4.8:fix_incorrect_providers'}
+    {:name => 'katello:upgrades:4.8:fix_incorrect_providers'},
     {:name => 'katello:upgrades:4.8:regenerate_imported_repository_metadata'}
   ]
 end

--- a/db/seeds.d/111-upgrade_tasks.rb
+++ b/db/seeds.d/111-upgrade_tasks.rb
@@ -9,5 +9,6 @@ UpgradeTask.define_tasks(:katello) do
     {:name => 'katello:upgrades:4.2:remove_checksum_values'},
     {:name => 'katello:upgrades:4.4:publish_import_cvvs'},
     {:name => 'katello:upgrades:4.8:fix_incorrect_providers'}
+    {:name => 'katello:upgrades:4.8:regenerate_imported_repository_metadata'}
   ]
 end

--- a/lib/katello/tasks/upgrades/4.8/regenerate_imported_repository_metadata.rake
+++ b/lib/katello/tasks/upgrades/4.8/regenerate_imported_repository_metadata.rake
@@ -5,7 +5,7 @@ namespace :katello do
       task :regenerate_imported_repository_metadata => ["dynflow:client", "environment"] do
         User.current = User.anonymous_admin #set a user for orchestration
         versions = Katello::ContentViewVersionImportHistory.all.map(&:content_view_version)
-        repo_ids = versions.map do |ver|
+        repos = versions.map do |ver|
            rps = if ver.default?
                    ver.repositories
                   else
@@ -14,12 +14,11 @@ namespace :katello do
            rps.exportable
               .map(&:library_instance_or_self)
               .select(&:using_mirrored_metadata?)
-              .map(&:id)
         end.flatten.uniq
 
-        if repo_ids.any?
+        if repos.any?
           task = ForemanTasks.async_task(::Actions::Katello::Repository::BulkMetadataGenerate,
-                                  ::Katello::Repository.where(id: repo_ids),
+                                  repos,
                                   force_publication: true)
           puts "Refreshing #{repo_ids.count} repositories.  You can monitor these on task id #{task.id}\n"
         else

--- a/lib/katello/tasks/upgrades/4.8/regenerate_imported_repository_metadata.rake
+++ b/lib/katello/tasks/upgrades/4.8/regenerate_imported_repository_metadata.rake
@@ -23,7 +23,7 @@ namespace :katello do
                                          ::Actions::Katello::Repository::MetadataGenerate,
                                          repos,
                                          force_publication: true)
-          puts "Refreshing #{repo_ids.count} repositories.  You can monitor these on task id #{task.id}\n"
+          puts "Refreshing #{repos.count} repositories. You can monitor these on task id #{task.id}\n"
         else
           puts "No repositories found for regeneration."
         end

--- a/lib/katello/tasks/upgrades/4.8/regenerate_imported_repository_metadata.rake
+++ b/lib/katello/tasks/upgrades/4.8/regenerate_imported_repository_metadata.rake
@@ -6,20 +6,23 @@ namespace :katello do
         User.current = User.anonymous_admin #set a user for orchestration
         versions = Katello::ContentViewVersionImportHistory.all.map(&:content_view_version)
         repos = versions.map do |ver|
-           rps = if ver.default?
-                   ver.repositories
-                  else
-                    ver.archived_repos
-                  end
-           rps.exportable
-              .map(&:library_instance_or_self)
-              .select(&:using_mirrored_metadata?)
-        end.flatten.uniq
+          rps = if ver.default?
+                  ver.repositories
+                else
+                  ver.archived_repos
+                end
+          rps.exportable
+            .map(&:library_instance_or_self)
+            .select(&:using_mirrored_metadata?)
+        end
+        repos.flatten!
+        repos.uniq!
 
         if repos.any?
-          task = ForemanTasks.async_task(::Actions::Katello::Repository::BulkMetadataGenerate,
-                                  repos,
-                                  force_publication: true)
+          task = ForemanTasks.async_task(::Actions::BulkAction,
+                                         ::Actions::Katello::Repository::MetadataGenerate,
+                                         repos,
+                                         force_publication: true)
           puts "Refreshing #{repo_ids.count} repositories.  You can monitor these on task id #{task.id}\n"
         else
           puts "No repositories found for regeneration."

--- a/lib/katello/tasks/upgrades/4.8/regenerate_imported_repository_metadata.rake
+++ b/lib/katello/tasks/upgrades/4.8/regenerate_imported_repository_metadata.rake
@@ -1,0 +1,31 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '4.8' do
+      desc "Regenerates metadata for library repositories that were imported"
+      task :regenerate_imported_repository_metadata => ["dynflow:client", "environment"] do
+        User.current = User.anonymous_admin #set a user for orchestration
+        versions = Katello::ContentViewVersionImportHistory.all.map(&:content_view_version)
+        repo_ids = versions.map do |ver|
+           rps = if ver.default?
+                   ver.repositories
+                  else
+                    ver.archived_repos
+                  end
+           rps.exportable
+              .map(&:library_instance_or_self)
+              .select(&:using_mirrored_metadata?)
+              .map(&:id)
+        end.flatten.uniq
+
+        if repo_ids.any?
+          task = ForemanTasks.async_task(::Actions::Katello::Repository::BulkMetadataGenerate,
+                                  ::Katello::Repository.where(id: repo_ids),
+                                  force_publication: true)
+          puts "Refreshing #{repo_ids.count} repositories.  You can monitor these on task id #{task.id}\n"
+        else
+          puts "No repositories found for regeneration."
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fixes an issue with incremental imports, which correctly updates the database and ui counts but does not create a new publication when that data is copied to the library

#### Considerations taken when implementing this change?
The `force` variable in MetadataGenerate got renamed to `force_publication` at some point. This updates the import action to now use that,

#### What are the testing steps for this pull request?
On the export server

- Enable a RH Repo (recommend `Red Hat Ansible Engine 2 for RHEL 8 x86_64 RPMs`)
- Update its download policy to immediate
- sync
- Create a content view version
- Add this repository
- Add rpm excludes filter to filter out `sshpass`
- Publish
- Update the rpm excludes filter now to filter out `sshpassnothere` instead of `sshpass`
- Publish again
- Export version one with `hammer content-export complete version --id=<...>`
- Export version two as incremental  with `hammer content-export incremental version --id=<...>`

Import Side
-----------------
- Create  a new org
- import manifest
- Import version 1 of the exported content - `hammer content-import version --id=<> --path=<>`
- create an activation key to use Library
- Go to Repository sets for the AK and make sure the Ansible repo is enabled 
- Register a rhel8 host to that key
- On the host run `dnf clean all && dnf repolist -v` 
- You should see the number of packages for ansible repo listed as 57
- Import version 2 of the exported content - `hammer content-import version --id=<> --path=<>`
- On the host run `dnf clean all && dnf repolist -v` 

Before PR
- You should see the number of packages for ansible repo still listed as 57


After PR
- Delete the  import version2 in the cv and import version 2 again
- On the host run `dnf clean all && dnf repolist -v` 
- You should see the number of packages for ansible repo still listed as 58
