### PR TITLE
Fixes #36035 - Add empty content states for CV repositories

### DIFF
--- a/app/views/katello/api/v2/content_view_repositories/show_all.json.rabl
+++ b/app/views/katello/api/v2/content_view_repositories/show_all.json.rabl
@@ -6,3 +6,9 @@ child @collection[:results] => :results do
   extends 'katello/api/v2/repositories/base'
   node(:added_to_content_view) { |repo| repo.in_content_view?(@content_view) }
 end
+
+if @organization
+  node :org_repository_count do
+    @organization.repositories.count
+  end
+end

--- a/app/views/katello/api/v2/repositories/index.json.rabl
+++ b/app/views/katello/api/v2/repositories/index.json.rabl
@@ -5,3 +5,9 @@ extends "katello/api/v2/common/metadata"
 child @collection[:results] => :results do
   extends "katello/api/v2/repositories/base"
 end
+
+if @organization
+  node :org_repository_count do
+    @organization.repositories.count
+  end
+end

--- a/webpack/__mocks__/foremanReact/Root/Context/ForemanContext.js
+++ b/webpack/__mocks__/foremanReact/Root/Context/ForemanContext.js
@@ -1,2 +1,3 @@
 // eslint-disable-next-line import/prefer-default-export
 export const useForemanSettings = () => ({ perPage: 20 });
+export const useForemanVersion = () => 'nightly';

--- a/webpack/components/Table/EmptyStateMessage.js
+++ b/webpack/components/Table/EmptyStateMessage.js
@@ -92,12 +92,17 @@ const EmptyStateMessage = ({
         {showSecondaryActionAnchor &&
           <EmptyStateSecondaryActions>
             <Button variant="link" ouiaId="empty-state-secondary-action-link">
-              <a href={secondaryActionLink} style={{ textDecoration: 'none' }}>{secondaryActionTitle}</a>
+              {extraTableProps.secondaryActionTargetBlank ? (
+                <a href={secondaryActionLink} target="_blank" rel="noreferrer" style={{ textDecoration: 'none' }} >{secondaryActionTitle}</a>
+              ) : (
+                <a href={secondaryActionLink} style={{ textDecoration: 'none' }} >{secondaryActionTitle}</a>
+              )}
             </Button>
           </EmptyStateSecondaryActions>
         }
 
-        {(showSecondaryActionButton || searchIsActive || !!filtersAreActive) &&
+        {(!showSecondaryActionAnchor &&
+          (showSecondaryActionButton || searchIsActive || !!filtersAreActive)) &&
           <EmptyStateSecondaryActions>
             <Button variant="link" onClick={handleClick} ouiaId="empty-state-secondary-action-router-link">
               {secondaryActionText}

--- a/webpack/components/Table/MainTable.js
+++ b/webpack/components/Table/MainTable.js
@@ -21,7 +21,8 @@ const MainTable = ({
   activeToggleState, unfilteredToggleState, actionButtons, rowsCount,
   children, showPrimaryAction, showSecondaryAction, showSecondaryActionButton, primaryActionLink,
   secondaryActionLink, primaryActionTitle, secondaryActionTitle, secondaryActionTextOverride,
-  resetFilters, updateSearchQuery, requestKey, primaryActionButton, ...extraTableProps
+  resetFilters, updateSearchQuery, requestKey, primaryActionButton, secondaryActionTargetBlank,
+  ...extraTableProps
 }) => {
   const tableHasNoRows = () => {
     if (children) return rowsCount === 0;
@@ -76,7 +77,8 @@ const MainTable = ({
         title={emptyContentTitle}
         body={emptyContentBody}
         happy={happyEmptyContent}
-        search={!happyEmptyContent}
+        search={!happyEmptyContent && !emptyContentOverride}
+        secondaryActionTargetBlank={secondaryActionTargetBlank}
         {...clearSearchProps}
         {...callToActionProps}
       />
@@ -162,6 +164,7 @@ MainTable.propTypes = {
   updateSearchQuery: PropTypes.func,
   requestKey: PropTypes.string,
   primaryActionButton: PropTypes.element,
+  secondaryActionTargetBlank: PropTypes.bool,
 };
 
 MainTable.defaultProps = {
@@ -192,6 +195,7 @@ MainTable.defaultProps = {
   updateSearchQuery: undefined,
   requestKey: '',
   primaryActionButton: undefined,
+  secondaryActionTargetBlank: false,
 };
 
 export default MainTable;

--- a/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewDetailNoReposAdded.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewDetailNoReposAdded.fixtures.json
@@ -1,0 +1,13 @@
+{
+  "total": 0,
+  "subtotal": 0,
+  "page": 1,
+  "per_page": 20,
+  "error": null,
+  "search": null,
+  "sort": {
+    "by": null,
+    "order": null
+  },
+  "results": []
+}

--- a/webpack/utils/useKatelloDocUrl.js
+++ b/webpack/utils/useKatelloDocUrl.js
@@ -1,0 +1,18 @@
+import URI from 'urijs';
+import { useForemanVersion } from 'foremanReact/Root/Context/ForemanContext';
+import { foremanUrl } from 'foremanReact/common/helpers';
+
+// useKatelloDocUrl('Managing_Content, '#Products_and_Repositories_content-management') =>
+// https://docs.theforeman.org/3.7/Managing_Content/index-katello.html#Products_and_Repositories_content-management
+export const useKatelloDocUrl = (guide = 'Managing_Content', hash = '') => {
+  // in dev you'll have to replace the Foreman version in the url with the latest published one
+  const foremanVersion = useForemanVersion();
+  const rootUrl = `https://docs.theforeman.org/${foremanVersion}/`;
+
+  const section = `${guide}/index-katello.html${hash}`;
+
+  const url = new URI({ path: '/links/manual', query: { root_url: rootUrl, section } });
+  return foremanUrl(url.href());
+};
+
+export default useKatelloDocUrl;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This PR improves empty states in the new CV UI for ContentViewRepositories, in the following two situations:

1. When your content view doesn't have any repositories added;
2. When there aren't any repositories in your organization.

It also changes the default view from "All" repositories to "Added," and adds call-to-action buttons & links:

1. Show repositories - switches the view from Added to All
2. Enable Red Hat repositories - link
3. Create a custom product - link

#### Considerations taken when implementing this change?

The "Show repositories" button was originally "Add repositories," but I thought it would be confusing to have two different "Add Repositories" buttons on the screen.

#### What are the testing steps for this pull request?

Test the following scenarios:

1. Empty content view with no repositories added
2. Empty content view in an empty organization with no products or Red Hat repos enabled
3. also make sure I didn't break empty states anywhere else in CV UI or the new host details page

