### PR TITLE
Fixes #35324 - Reset Syspurpose modal state on BreadcrumbSwitcher host switch

### DIFF
--- a/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeCard.js
@@ -31,7 +31,7 @@ import { hasRequiredPermissions, hostIsNotRegistered } from '../../hostDetailsHe
 
 const SystemPurposeCard = ({ hostDetails }) => {
   const showEditButton = hasRequiredPermissions(['edit_hosts'], hostDetails?.permissions);
-  const orgId = hostDetails.organization_id;
+  const { organization_id: orgId, name: hostName } = hostDetails;
   const subscriptionFacetAttributes = hostDetails?.subscription_facet_attributes;
   const {
     purposeRole, purposeUsage, purposeAddons, releaseVersion, serviceLevel,
@@ -137,10 +137,11 @@ const SystemPurposeCard = ({ hostDetails }) => {
           </DescriptionList>
           {showEditButton && (
             <SystemPurposeEditModal
+              key={hostName}
               isOpen={editing}
               orgId={orgId}
               closeModal={() => setEditing(false)}
-              hostName={hostDetails.name}
+              hostName={hostName}
               hostId={hostDetails.id}
               {...sysPurposeProps}
             />


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Pass a `key` to the `SystemPurposeEditModal`. This will cause its local state to be reset when switching hosts with the breadcrumb switcher. See https://beta.reactjs.org/learn/preserving-and-resetting-state#resetting-a-form-with-a-key

#### Considerations taken when implementing this change?

I also considered having the key be `id` but I think it doesn't matter

#### What are the testing steps for this pull request?

Setup: Have two hosts with content. 

1. Go to Hosts > All Hosts and click on one of them
2. Click Edit on the System Purpose card and change some values, then click Save
3. The card will update. Click Edit again and notice that the form is prefilled with the values you saved.
4. Switch hosts using the breadcrumb switcher.
5. Click Edit on the System Purpose card.

Before this change: The prefilled values on the SystemPurposeEditModal form are those of the previous host.
After this change: The prefilled values on the form are those of the new host. You can switch between hosts freely and the modal's values always reflect the current host.

