### PR TITLE
Fixes #36156 - Content -> Errata does not display the year for the dates listed under column Updated

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-info.html
@@ -24,10 +24,10 @@
       <dd>{{ errata.severity | errataSeverity }}</dd>
 
       <dt translate>Issued</dt>
-      <dd><short-date-time date="errata.issued" /></dd>
+      <dd><long-date-time date="errata.issued" /></dd>
 
       <dt translate>Last Updated On</dt>
-      <dd><short-date-time date="errata.updated" /></dd>
+      <dd><long-date-time date="errata.updated" /></dd>
 
       <dt translate>Reboot Suggested?</dt>
       <dd>{{ errata.reboot_suggested | booleanToYesNo }}</dd>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
@@ -101,7 +101,7 @@
             <span translate>{{ errata.hosts_applicable_count || 0 }} Applicable, </span>
             <span translate>{{ errata.hosts_available_count || 0 }} Installable</span>
           </td>
-          <td bst-table-cell><short-date-time date="errata.updated" /></td>
+          <td bst-table-cell><long-date-time date="errata.updated" /></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION


#### What are the changes introduced in this pull request?

Errata Issued and Updated dates now show the year.

![image](https://user-images.githubusercontent.com/14796566/223841687-314f256d-223b-4259-bbf6-3182c5803ad2.png)

![image](https://user-images.githubusercontent.com/14796566/223841756-0b16c979-1531-41c0-82e3-27e196cb2181.png)


#### Considerations taken when implementing this change?

I changed every `short-date-time` to `long-date-time` that made sense. Our other uses of `short-date-time` make sense -- users likely won't need the year for thinks like seeing when a task ran.

#### What are the testing steps for this pull request?

Sync some errata and look at both the errata index page and an erratum's details page.