### PR TITLE
Fixes #36174 - Added additional context to error messages for certain…

### DIFF
--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -35,7 +35,9 @@ module Katello
     validates :base_url, :subpaths, :upstream_username,
               :upstream_password, if: :simplified?, absence: true
     validates :base_url, if: -> { custom? || rhui? }, presence: true
-    validates :products, if: -> { custom? || rhui? }, absence: true
+    validates :products, if: -> { custom? || rhui? }, absence: {
+      message: "should not be set for any custom or rhui ACS"
+    }
     validates :label, :uniqueness => true
     validates :name, :uniqueness => true, presence: true
     # verify ssl must be validated this way due to presence: <bool> failing on a value of false
@@ -141,13 +143,13 @@ module Katello
       # Simplified ACS's should never have ssl-* params populated
       if simplified?
         if changes.keys.include? "ssl_ca_cert_id"
-          errors.add(:ssl_ca_cert, "must be blank")
+          errors.add(:ssl_ca_cert, "cannot be set for simplified ACS")
         end
         if changes.keys.include? "ssl_client_cert_id"
-          errors.add(:ssl_client_cert, "must be blank")
+          errors.add(:ssl_client_cert, "cannot be set for simplified ACS")
         end
         if changes.keys.include? "ssl_client_key_id"
-          errors.add(:ssl_client_key, "must be blank")
+          errors.add(:ssl_client_key, "cannot be set for simplified ACS")
         end
 
       # Custom and RHUI ACS's should have valid keys where populated

--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -19,9 +19,10 @@ module Katello
     belongs_to :ssl_ca_cert, inverse_of: :ssl_ca_alternate_content_sources, class_name: "Katello::ContentCredential"
     belongs_to :ssl_client_cert, inverse_of: :ssl_client_alternate_content_sources, class_name: "Katello::ContentCredential"
     belongs_to :ssl_client_key, inverse_of: :ssl_key_alternate_content_sources, class_name: "Katello::ContentCredential"
-    # We breakout ssl-* validation into a function to allow for us to set
-    # the object name correctly in complex error messages
+    # We breakout ssl-* and product validation into a function to allow for us
+    # to set the object name correctly in complex error messages
     validate :validate_ssl_ids
+    validate :validate_products
 
     has_many :alternate_content_source_products, dependent: :delete_all, inverse_of: :alternate_content_source,
              class_name: "Katello::AlternateContentSourceProduct"
@@ -35,9 +36,6 @@ module Katello
     validates :base_url, :subpaths, :upstream_username,
               :upstream_password, if: :simplified?, absence: true
     validates :base_url, if: -> { custom? || rhui? }, presence: true
-    validates :products, if: -> { custom? || rhui? }, absence: {
-      message: "cannot be set for custom or rhui ACS"
-    }
     validates :label, :uniqueness => true
     validates :name, :uniqueness => true, presence: true
     # verify ssl must be validated this way due to presence: <bool> failing on a value of false
@@ -163,6 +161,14 @@ module Katello
         if ssl_client_key_id.present? && ssl_client_key.nil?
           errors.add(:ssl_client_key, "with ID '#{ssl_client_key_id}' couldn't be found")
         end
+      end
+    end
+
+    # Check that products are not present for custom or rhui ACS's
+    # Requires complex/custom error message
+    def validate_products
+      if (custom? || rhui?) && products.present?
+        errors.add(:product_ids, "cannot be set for custom or rhui ACS")
       end
     end
   end

--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -36,7 +36,7 @@ module Katello
               :upstream_password, if: :simplified?, absence: true
     validates :base_url, if: -> { custom? || rhui? }, presence: true
     validates :products, if: -> { custom? || rhui? }, absence: {
-      message: "should not be set for any custom or rhui ACS"
+      message: "cannot be set for custom or rhui ACS"
     }
     validates :label, :uniqueness => true
     validates :name, :uniqueness => true, presence: true

--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -40,11 +40,11 @@ module Katello
     # verify ssl must be validated this way due to presence: <bool> failing on a value of false
     validates :verify_ssl, if: -> { custom? || rhui? }, inclusion: {
       in: [true, false],
-      message: "can't be blank"
+      message: "must be provided for custom or rhui ACS"
     }
     validates :verify_ssl, if: :simplified?, inclusion: {
       in: [nil],
-      message: "must be blank"
+      message: "cannot be provided for simplified ACS"
     }
     validates :alternate_content_source_type, inclusion: {
       in: ->(_) { ACS_TYPES },

--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -19,8 +19,7 @@ module Katello
     belongs_to :ssl_ca_cert, inverse_of: :ssl_ca_alternate_content_sources, class_name: "Katello::ContentCredential"
     belongs_to :ssl_client_cert, inverse_of: :ssl_client_alternate_content_sources, class_name: "Katello::ContentCredential"
     belongs_to :ssl_client_key, inverse_of: :ssl_key_alternate_content_sources, class_name: "Katello::ContentCredential"
-    # We breakout ssl-* and product validation into a function to allow for us
-    # to set the object name correctly in complex error messages
+
     validate :validate_ssl_ids
     validate :validate_products
 
@@ -164,8 +163,6 @@ module Katello
       end
     end
 
-    # Check that products are not present for custom or rhui ACS's
-    # Requires complex/custom error message
     def validate_products
       if (custom? || rhui?) && products.present?
         errors.add(:product_ids, "cannot be set for custom or rhui ACS")


### PR DESCRIPTION
… ACS conditions.

#### What are the changes introduced in this pull request?
Changed the 'validation failed' error messages for various alternate content source fields:

- `Validation failed: Ssl ca cert must be blank` -> `Validation failed: Ssl ca cert cannot be set for simplified ACS`
- `Validation failed: Ssl client cert must be blank` -> `Validation failed: Ssl client cert cannot be set for simplified ACS`
- `Validation failed: Ssl client key must be blank` -> `Validation failed: Ssl client key cannot be set for simplified ACS`
- `Validation failed: Products must be blank` -> `Validation failed: Products should not be set for any custom or rhui ACS`

#### Considerations taken when implementing this change?
n/a

#### What are the testing steps for this pull request?
Attempt to create a simplified ACS with the `ssl-ca-cert-id`, `ssl-client-cert-id`, or `ssl-client-key-id` fields populated and note the presence of new error messages. Attempt the same thing with a custom or rhui ACS and setting the `product-ids` field.
