### PR TITLE
Fixes #36176 - Show N/A for empty product list

### DIFF
--- a/webpack/scenes/AlternateContentSources/Details/ACSExpandableDetails.js
+++ b/webpack/scenes/AlternateContentSources/Details/ACSExpandableDetails.js
@@ -286,6 +286,9 @@ const ACSExpandableDetails = ({ expandedId }) => {
                       <a href={urlBuilder(`products/${product?.id}`, '')}><b>{product?.name}</b></a>
                     </ListItem>
                   ))}
+                {products?.length === 0 &&
+                <InactiveText text="N/A" />
+                }
               </List>
             </ExpandableSection>
           </StackItem>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
We show N/A for empty values on ACS details panel. Products should behave the same.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a simplified ACS with some product.
2. Edit the ACS to remove all products.
3. Details panel > Products should display N/A instead of blank.