### PR TITLE
Fixes #36196 - upstream auth migration should refer to root

### DIFF
--- a/db/migrate/20230119003859_ensure_repo_username_password_nil_not_blank.rb
+++ b/db/migrate/20230119003859_ensure_repo_username_password_nil_not_blank.rb
@@ -2,7 +2,7 @@ class EnsureRepoUsernamePasswordNilNotBlank < ActiveRecord::Migration[6.1]
   def change
     ::Katello::Repository.library.each do |repo|
       if repo.upstream_username == '' && repo.upstream_password == ''
-        repo.update(upstream_username: nil, upstream_password: nil)
+        repo.root.update(upstream_username: nil, upstream_password: nil)
       end
     end
   end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fixes the migration so it doesn't fail with `ActiveModel::UnknownAttributeError: unknown attribute 'upstream_username' for Katello::Repository.`

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1) Comment out `validate :ensure_valid_upstream_authorization` in `app/models/katello/root_repository.rb`
2) Give some library repository an empty string for upstream username AND upstream password

```ruby
repo = ::Katello::Repository.library.first
repo.root.update!(upstream_username: '', upstream_password: '')

#should both be ''
repo.upstream_username
repo.upstream_password
```

3) Rerun the migration (since your dev environment likely already ran it)

```
bundle exec rake db:migrate:redo VERSION=20230119003859
```

Lastly, ensure that the repository had its upstream username and password fixed.
