### PR TITLE
Fixes #36184 - Content view dropdown shouldn't be conditionally rendered

### DIFF
--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -97,7 +97,7 @@ const ChangeHostCVModal = ({
 
   const cvPlaceholderText = getCVPlaceholderText({
     environments: selectedEnvForHost,
-    contentViews: contentViewsInEnv,
+    cvSelectOptions: contentViewsInEnv,
     contentViewsStatus: contentViewsInEnvStatus,
   });
 

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -163,8 +163,14 @@ const ChangeHostCVModal = ({
         placeholderText={cvPlaceholderText}
       >
         {(contentViewsInEnv.length !== 0 && selectedEnvForHost.length !== 0) &&
-            contentViewsInEnv?.map(cv =>
-              <ContentViewSelectOption key={cv.id} cv={cv} env={selectedEnvForHost[0]} />)}
+            contentViewsInEnv?.map(cv => (
+              <ContentViewSelectOption
+                key={cv.id}
+                value={cv.name}
+                cv={cv}
+                env={selectedEnvForHost[0]}
+              />
+            ))}
       </ContentViewSelect>
     </Modal>
   );

--- a/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignActivationKeysForm.js
+++ b/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignActivationKeysForm.js
@@ -10,6 +10,7 @@ import CVDeleteContext from '../CVDeleteContext';
 import EnvironmentPaths from '../../components/EnvironmentPaths/EnvironmentPaths';
 import AffectedActivationKeys from '../../Details/Versions/Delete/affectedActivationKeys';
 import ContentViewSelect from '../../components/ContentViewSelect/ContentViewSelect';
+import { getCVPlaceholderText, shouldDisableCVSelect } from '../../components/ContentViewSelect/helpers';
 
 const CVDeletionReassignActivationKeysForm = () => {
   const dispatch = useDispatch();
@@ -78,6 +79,20 @@ const CVDeletionReassignActivationKeysForm = () => {
     setCVSelectOpen(false);
   };
 
+  const placeholderText = getCVPlaceholderText({
+    contentSourceId: null,
+    environments: selectedEnvForAK,
+    contentViewsStatus: contentViewsInEnvStatus,
+    contentViews: cvSelectOptions,
+  });
+
+  const disableCVSelect = shouldDisableCVSelect({
+    contentSourceId: null,
+    environments: selectedEnvForAK,
+    contentViewsStatus: contentViewsInEnvStatus,
+    contentViews: cvSelectOptions,
+  });
+
   return (
     <>
       <EnvironmentPaths
@@ -87,19 +102,17 @@ const CVDeletionReassignActivationKeysForm = () => {
         headerText={__('Select lifecycle environment')}
         multiSelect={false}
       />
-      {!cvInEnvLoading && selectedEnvForAK.length > 0 &&
-        <ContentViewSelect
-          selections={selectedCVForAK}
-          onSelect={onSelect}
-          onClear={onClear}
-          isOpen={cvSelectOpen}
-          isDisabled={cvSelectOptions.length === 0}
-          onToggle={isExpanded => setCVSelectOpen(isExpanded)}
-          placeholderText={(cvSelectOptions.length === 0) ? __('No content views available') : __('Select a content view')}
-        >
-          {cvSelectOptions}
-        </ContentViewSelect>
-      }
+      <ContentViewSelect
+        selections={selectedCVForAK}
+        onSelect={onSelect}
+        onClear={onClear}
+        isOpen={cvSelectOpen}
+        isDisabled={disableCVSelect}
+        onToggle={isExpanded => setCVSelectOpen(isExpanded)}
+        placeholderText={placeholderText}
+      >
+        {cvSelectOptions}
+      </ContentViewSelect>
       <ExpandableSection
         toggleText={showActivationKeys ?
           'Hide activation keys' :

--- a/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignActivationKeysForm.js
+++ b/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignActivationKeysForm.js
@@ -83,14 +83,14 @@ const CVDeletionReassignActivationKeysForm = () => {
     contentSourceId: null,
     environments: selectedEnvForAK,
     contentViewsStatus: contentViewsInEnvStatus,
-    contentViews: cvSelectOptions,
+    cvSelectOptions,
   });
 
   const disableCVSelect = shouldDisableCVSelect({
     contentSourceId: null,
     environments: selectedEnvForAK,
     contentViewsStatus: contentViewsInEnvStatus,
-    contentViews: cvSelectOptions,
+    cvSelectOptions,
   });
 
   return (

--- a/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignHostsForm.js
+++ b/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignHostsForm.js
@@ -84,14 +84,14 @@ const CVDeletionReassignHostsForm = () => {
     contentSourceId: null,
     environments: selectedEnvForHost,
     contentViewsStatus: contentViewsInEnvStatus,
-    contentViews: cvSelectOptions,
+    cvSelectOptions,
   });
 
   const disableCVSelect = shouldDisableCVSelect({
     contentSourceId: null,
     environments: selectedEnvForHost,
     contentViewsStatus: contentViewsInEnvStatus,
-    contentViews: cvSelectOptions,
+    cvSelectOptions,
   });
 
 

--- a/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignHostsForm.js
+++ b/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignHostsForm.js
@@ -10,6 +10,7 @@ import CVDeleteContext from '../CVDeleteContext';
 import EnvironmentPaths from '../../components/EnvironmentPaths/EnvironmentPaths';
 import AffectedHosts from '../../Details/Versions/Delete/affectedHosts';
 import ContentViewSelect from '../../components/ContentViewSelect/ContentViewSelect';
+import { getCVPlaceholderText, shouldDisableCVSelect } from '../../components/ContentViewSelect/helpers';
 
 
 const CVDeletionReassignHostsForm = () => {
@@ -79,6 +80,21 @@ const CVDeletionReassignHostsForm = () => {
     setCVSelectOpen(false);
   };
 
+  const placeholderText = getCVPlaceholderText({
+    contentSourceId: null,
+    environments: selectedEnvForHost,
+    contentViewsStatus: contentViewsInEnvStatus,
+    contentViews: cvSelectOptions,
+  });
+
+  const disableCVSelect = shouldDisableCVSelect({
+    contentSourceId: null,
+    environments: selectedEnvForHost,
+    contentViewsStatus: contentViewsInEnvStatus,
+    contentViews: cvSelectOptions,
+  });
+
+
   return (
     <>
       <EnvironmentPaths
@@ -88,19 +104,17 @@ const CVDeletionReassignHostsForm = () => {
         headerText={__('Select lifecycle environment')}
         multiSelect={false}
       />
-      {selectedEnvForHost.length > 0 &&
-        <ContentViewSelect
-          selections={selectedCVForHosts}
-          onSelect={onSelect}
-          onClear={onClear}
-          isOpen={cvSelectOpen}
-          isDisabled={cvSelectOptions.length === 0}
-          onToggle={isExpanded => setCVSelectOpen(isExpanded)}
-          placeholderText={(cvSelectOptions.length === 0) ? __('No content views available') : __('Select a content view')}
-        >
-          {cvSelectOptions}
-        </ContentViewSelect>
-      }
+      <ContentViewSelect
+        selections={selectedCVForHosts}
+        onSelect={onSelect}
+        onClear={onClear}
+        isOpen={cvSelectOpen}
+        isDisabled={disableCVSelect}
+        onToggle={isExpanded => setCVSelectOpen(isExpanded)}
+        placeholderText={placeholderText}
+      >
+        {cvSelectOptions}
+      </ContentViewSelect>
       <ExpandableSection
         toggleText={showHosts ? 'Hide hosts' : 'Show hosts'}
         onToggle={expanded => setShowHosts(expanded)}

--- a/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignActivationKeys.js
+++ b/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignActivationKeys.js
@@ -4,7 +4,6 @@ import React, {
 } from 'react';
 
 import { translate as __ } from 'foremanReact/common/I18n';
-import { STATUS } from 'foremanReact/constants';
 import { first } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import {
@@ -38,6 +37,7 @@ import {
   getNumberOfActivationKeys,
 } from '../BulkDeleteHelpers';
 import ContentViewSelect from '../../../../components/ContentViewSelect/ContentViewSelect';
+import { getCVPlaceholderText, shouldDisableCVSelect } from '../../../../components/ContentViewSelect/helpers';
 
 export default () => {
   const dispatch = useDispatch();
@@ -52,7 +52,6 @@ export default () => {
   const { results = [] } = useSelector(selectContentViews);
   const { content_view: { id: cvId } } = first(versions);
   const contentViewsInEnvStatus = useSelector(selectContentViewStatus);
-  const cvInEnvLoading = contentViewsInEnvStatus === STATUS.PENDING;
   const [toggleCVSelect, setToggleCVSelect] = useState(false);
 
   const numberOfActivationKeys = getNumberOfActivationKeys(versions);
@@ -88,18 +87,19 @@ export default () => {
         {name}
       </SelectOption>));
 
-  const placeHolder = (() => {
-    switch (true) {
-    case cvInEnvLoading && !!selectedEnvForAK.length:
-      return __('Loading...');
-    case selectedEnvForAK.length === 0:
-      return __('Select an environment above');
-    case selectOptions.length > 0:
-      return __('Select a content view');
-    default:
-      return __('No content views available');
-    }
-  })();
+  const placeholderText = getCVPlaceholderText({
+    contentSourceId: null,
+    environments: selectedEnvForAK,
+    contentViewsStatus: contentViewsInEnvStatus,
+    contentViews: results,
+  });
+
+  const disableCVSelect = shouldDisableCVSelect({
+    contentSourceId: null,
+    environments: selectedEnvForAK,
+    contentViewsStatus: contentViewsInEnvStatus,
+    contentViews: results,
+  });
 
   const setUserCheckedItems = (value) => {
     setSelectedCVForAK(null);
@@ -178,8 +178,8 @@ export default () => {
         selections={selectedCVForAK}
         onSelect={onSelect}
         onClear={onClear}
-        isDisabled={cvInEnvLoading || !selectOptions?.length || !selectedEnvForAK?.length}
-        placeholderText={placeHolder}
+        isDisabled={disableCVSelect}
+        placeholderText={placeholderText}
         isOpen={toggleCVSelect}
         onToggle={setToggleCVSelect}
         menuAppendTo={() => document.body}

--- a/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignActivationKeys.js
+++ b/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignActivationKeys.js
@@ -91,14 +91,14 @@ export default () => {
     contentSourceId: null,
     environments: selectedEnvForAK,
     contentViewsStatus: contentViewsInEnvStatus,
-    contentViews: results,
+    cvSelectOptions: selectOptions,
   });
 
   const disableCVSelect = shouldDisableCVSelect({
     contentSourceId: null,
     environments: selectedEnvForAK,
     contentViewsStatus: contentViewsInEnvStatus,
-    contentViews: results,
+    cvSelectOptions: selectOptions,
   });
 
   const setUserCheckedItems = (value) => {

--- a/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignHosts.js
+++ b/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignHosts.js
@@ -4,7 +4,6 @@ import React, {
 } from 'react';
 
 import { translate as __ } from 'foremanReact/common/I18n';
-import { STATUS } from 'foremanReact/constants';
 import { first } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import {
@@ -39,6 +38,7 @@ import {
   getNumberOfHosts,
 } from '../BulkDeleteHelpers';
 import ContentViewSelect from '../../../../components/ContentViewSelect/ContentViewSelect';
+import { getCVPlaceholderText, shouldDisableCVSelect } from '../../../../components/ContentViewSelect/helpers';
 
 export default () => {
   const dispatch = useDispatch();
@@ -55,7 +55,6 @@ export default () => {
   const { results = [] } = useSelector(selectContentViews);
   const { content_view: { name: cvName, id: cvId } } = first(versions);
   const contentViewsInEnvStatus = useSelector(selectContentViewStatus);
-  const cvInEnvLoading = contentViewsInEnvStatus === STATUS.PENDING;
   const [toggleCVSelect, setToggleCVSelect] = useState(false);
 
   const numberOfHosts = getNumberOfHosts(versions);
@@ -92,18 +91,12 @@ export default () => {
         {name}
       </SelectOption>));
 
-  const placeHolder = (() => {
-    switch (true) {
-    case cvInEnvLoading && !!selectedEnvForHosts.length:
-      return __('Loading...');
-    case selectedEnvForHosts.length === 0:
-      return __('Select an environment above');
-    case selectOptions.length > 0:
-      return __('Select a content view');
-    default:
-      return __('No content views available');
-    }
-  })();
+  const placeholderText = getCVPlaceholderText({
+    contentSourceId: null,
+    environments: selectedEnvForHosts,
+    contentViewsStatus: contentViewsInEnvStatus,
+    contentViews: results,
+  });
 
   const setUserCheckedItems = (value) => {
     setSelectedCVForHosts(null);
@@ -130,6 +123,13 @@ export default () => {
     }
     setToggleCVSelect(false);
   };
+
+  const disableCVSelect = shouldDisableCVSelect({
+    contentSourceId: null,
+    environments: selectedEnvForHosts,
+    contentViewsStatus: contentViewsInEnvStatus,
+    contentViews: results,
+  });
 
   const contentHostHref =
     `/content_hosts?search=content_view = ${cvName} AND ( ${versionEnvironments.map(({ name }) =>
@@ -206,8 +206,8 @@ export default () => {
         selections={selectedCVForHosts}
         onSelect={onSelect}
         onClear={onClear}
-        isDisabled={cvInEnvLoading || !selectOptions?.length || !selectedEnvForHosts?.length}
-        placeholderText={placeHolder}
+        isDisabled={disableCVSelect}
+        placeholderText={placeholderText}
         isOpen={toggleCVSelect}
         onToggle={setToggleCVSelect}
         menuAppendTo={() => document.body}

--- a/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignHosts.js
+++ b/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignHosts.js
@@ -95,7 +95,7 @@ export default () => {
     contentSourceId: null,
     environments: selectedEnvForHosts,
     contentViewsStatus: contentViewsInEnvStatus,
-    contentViews: results,
+    cvSelectOptions: selectOptions,
   });
 
   const setUserCheckedItems = (value) => {
@@ -128,7 +128,7 @@ export default () => {
     contentSourceId: null,
     environments: selectedEnvForHosts,
     contentViewsStatus: contentViewsInEnvStatus,
-    contentViews: results,
+    cvSelectOptions: selectOptions,
   });
 
   const contentHostHref =

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignActivationKeysForm.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignActivationKeysForm.js
@@ -10,6 +10,7 @@ import { selectContentViewError, selectContentViews, selectContentViewStatus } f
 import AffectedActivationKeys from '../affectedActivationKeys';
 import DeleteContext from '../DeleteContext';
 import ContentViewSelect from '../../../../components/ContentViewSelect/ContentViewSelect';
+import { getCVPlaceholderText, shouldDisableCVSelect } from '../../../../components/ContentViewSelect/helpers';
 
 const CVReassignActivationKeysForm = () => {
   const dispatch = useDispatch();
@@ -87,6 +88,20 @@ const CVReassignActivationKeysForm = () => {
     setCVSelectOpen(false);
   };
 
+  const placeholderText = getCVPlaceholderText({
+    contentSourceId: null,
+    environments: selectedEnvForAK,
+    contentViewsStatus: contentViewsInEnvStatus,
+    contentViews: contentViewsInEnvResponse,
+  });
+
+  const disableCVSelect = shouldDisableCVSelect({
+    contentSourceId: null,
+    environments: selectedEnvForAK,
+    contentViewsStatus: contentViewsInEnvStatus,
+    contentViews: contentViewsInEnvResponse,
+  });
+
   return (
     <>
       <EnvironmentPaths
@@ -96,19 +111,17 @@ const CVReassignActivationKeysForm = () => {
         headerText={__('Select lifecycle environment')}
         multiSelect={false}
       />
-      {!cvInEnvLoading && selectedEnvForAK.length > 0 &&
-        <ContentViewSelect
-          selections={selectedCVForAK}
-          onSelect={onSelect}
-          onClear={onClear}
-          isOpen={cvSelectOpen}
-          isDisabled={cvSelectOptions.length === 0}
-          onToggle={isExpanded => setCVSelectOpen(isExpanded)}
-          placeholderText={(cvSelectOptions.length === 0) ? __('No content views available') : __('Select a content view')}
-        >
-          {cvSelectOptions}
-        </ContentViewSelect>
-      }
+      <ContentViewSelect
+        selections={selectedCVForAK}
+        onSelect={onSelect}
+        onClear={onClear}
+        isOpen={cvSelectOpen}
+        isDisabled={disableCVSelect}
+        onToggle={isExpanded => setCVSelectOpen(isExpanded)}
+        placeholderText={placeholderText}
+      >
+        {cvSelectOptions}
+      </ContentViewSelect>
       <ExpandableSection
         toggleText={showActivationKeys ?
           'Hide activation keys' :

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignActivationKeysForm.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignActivationKeysForm.js
@@ -92,14 +92,14 @@ const CVReassignActivationKeysForm = () => {
     contentSourceId: null,
     environments: selectedEnvForAK,
     contentViewsStatus: contentViewsInEnvStatus,
-    contentViews: contentViewsInEnvResponse,
+    cvSelectOptions,
   });
 
   const disableCVSelect = shouldDisableCVSelect({
     contentSourceId: null,
     environments: selectedEnvForAK,
     contentViewsStatus: contentViewsInEnvStatus,
-    contentViews: contentViewsInEnvResponse,
+    cvSelectOptions,
   });
 
   return (

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignHostsForm.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignHostsForm.js
@@ -91,14 +91,14 @@ const CVReassignHostsForm = () => {
     contentSourceId: null,
     environments: selectedEnvForHost,
     contentViewsStatus: contentViewsInEnvStatus,
-    contentViews: contentViewsInEnvResponse,
+    cvSelectOptions,
   });
 
   const disableCVSelect = shouldDisableCVSelect({
     contentSourceId: null,
     environments: selectedEnvForHost,
     contentViewsStatus: contentViewsInEnvStatus,
-    contentViews: contentViewsInEnvResponse,
+    cvSelectOptions,
   });
 
   return (

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignHostsForm.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignHostsForm.js
@@ -10,6 +10,7 @@ import { selectContentViewError, selectContentViews, selectContentViewStatus } f
 import AffectedHosts from '../affectedHosts';
 import DeleteContext from '../DeleteContext';
 import ContentViewSelect from '../../../../components/ContentViewSelect/ContentViewSelect';
+import { getCVPlaceholderText, shouldDisableCVSelect } from '../../../../components/ContentViewSelect/helpers';
 
 const CVReassignHostsForm = () => {
   const dispatch = useDispatch();
@@ -86,6 +87,20 @@ const CVReassignHostsForm = () => {
     setCVSelectOpen(false);
   };
 
+  const placeholderText = getCVPlaceholderText({
+    contentSourceId: null,
+    environments: selectedEnvForHost,
+    contentViewsStatus: contentViewsInEnvStatus,
+    contentViews: contentViewsInEnvResponse,
+  });
+
+  const disableCVSelect = shouldDisableCVSelect({
+    contentSourceId: null,
+    environments: selectedEnvForHost,
+    contentViewsStatus: contentViewsInEnvStatus,
+    contentViews: contentViewsInEnvResponse,
+  });
+
   return (
     <>
       <EnvironmentPaths
@@ -95,23 +110,21 @@ const CVReassignHostsForm = () => {
         headerText={__('Select lifecycle environment')}
         multiSelect={false}
       />
-      {selectedEnvForHost.length > 0 &&
-        <ContentViewSelect
-          onClear={onClear}
-          selections={selectedCVForHosts}
-          onSelect={onSelect}
-          isOpen={cvSelectOpen}
-          isDisabled={cvSelectOptions.length === 0}
-          onToggle={isExpanded => setCVSelectOpen(isExpanded)}
-          id="selectCV"
-          ouiaId="selectCV"
-          name="selectCV"
-          aria-label="selectCV"
-          placeholderText={(cvSelectOptions.length === 0) ? __('No content views available') : __('Select a content view')}
-        >
-          {cvSelectOptions}
-        </ContentViewSelect>
-      }
+      <ContentViewSelect
+        onClear={onClear}
+        selections={selectedCVForHosts}
+        onSelect={onSelect}
+        isOpen={cvSelectOpen}
+        isDisabled={disableCVSelect}
+        onToggle={isExpanded => setCVSelectOpen(isExpanded)}
+        id="selectCV"
+        ouiaId="selectCV"
+        name="selectCV"
+        aria-label="selectCV"
+        placeholderText={placeholderText}
+      >
+        {cvSelectOptions}
+      </ContentViewSelect>
       <ExpandableSection
         toggleText={showHosts ? 'Hide hosts' : 'Show hosts'}
         onToggle={expanded => setShowHosts(expanded)}

--- a/webpack/scenes/ContentViews/components/ContentViewSelect/ContentViewSelect.js
+++ b/webpack/scenes/ContentViews/components/ContentViewSelect/ContentViewSelect.js
@@ -30,11 +30,12 @@ const ContentViewSelect = ({
 ContentViewSelect.propTypes = {
   headerText: PropTypes.string,
   onClear: PropTypes.func.isRequired,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
 };
 
 ContentViewSelect.defaultProps = {
   headerText: __('Select content view'),
+  children: [],
 };
 
 export default ContentViewSelect;

--- a/webpack/scenes/ContentViews/components/ContentViewSelect/ContentViewSelectOption.js
+++ b/webpack/scenes/ContentViews/components/ContentViewSelect/ContentViewSelectOption.js
@@ -44,10 +44,10 @@ export const relevantVersionObjFromCv = (cv, env) => { // returns the entire ver
 export const relevantVersionFromCv = (cv, env) =>
     relevantVersionObjFromCv(cv, env)?.version; // returns the version text e.g. "1.0"
 
-const ContentViewSelectOption = ({ cv, env }) => (
+const ContentViewSelectOption = ({ cv, env, value }) => (
   <SelectOption
     key={cv.id}
-    value={`${cv.name}`}
+    value={value}
   >
     <Flex
       direction={{ default: 'row', sm: 'row' }}
@@ -82,6 +82,7 @@ ContentViewSelectOption.propTypes = {
   env: PropTypes.shape({
     id: PropTypes.number.isRequired,
   }).isRequired,
+  value: PropTypes.string.isRequired,
 };
 
 export default ContentViewSelectOption;

--- a/webpack/scenes/ContentViews/components/ContentViewSelect/helpers.js
+++ b/webpack/scenes/ContentViews/components/ContentViewSelect/helpers.js
@@ -5,13 +5,13 @@ export const getCVPlaceholderText = ({
   contentSourceId = null,
   environments = [],
   contentViewsStatus = STATUS.PENDING,
-  contentViews = [],
+  cvSelectOptions = [],
 }) => {
   if (contentSourceId === '') return __('Select a content source first');
   if (environments.length === 0) return __('Select an environment first');
   if (contentViewsStatus === STATUS.PENDING) return __('Loading...');
   if (contentViewsStatus === STATUS.ERROR) return __('Error loading content views');
-  if (contentViews.length === 0) return __('No content views available');
+  if (cvSelectOptions.length === 0) return __('No content views available');
   return __('Select a content view');
 };
 
@@ -19,13 +19,13 @@ export const shouldDisableCVSelect = ({
   contentSourceId = null,
   environments = [],
   contentViewsStatus = STATUS.PENDING,
-  contentViews = [],
+  cvSelectOptions = [],
 }) => {
   if (contentSourceId === '') return true;
   if (environments.length === 0) return true;
   if (contentViewsStatus === STATUS.PENDING) return true;
   if (contentViewsStatus === STATUS.ERROR) return true;
-  if (contentViews.length === 0) return true;
+  if (cvSelectOptions.length === 0) return true;
   return false;
 };
 

--- a/webpack/scenes/ContentViews/components/ContentViewSelect/helpers.js
+++ b/webpack/scenes/ContentViews/components/ContentViewSelect/helpers.js
@@ -1,0 +1,32 @@
+import { STATUS } from 'foremanReact/constants';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+export const getCVPlaceholderText = ({
+  contentSourceId = null,
+  environments = [],
+  contentViewsStatus = STATUS.PENDING,
+  contentViews = [],
+}) => {
+  if (contentSourceId === '') return __('Select a content source first');
+  if (environments.length === 0) return __('Select an environment first');
+  if (contentViewsStatus === STATUS.PENDING) return __('Loading...');
+  if (contentViewsStatus === STATUS.ERROR) return __('Error loading content views');
+  if (contentViews.length === 0) return __('No content views available');
+  return __('Select a content view');
+};
+
+export const shouldDisableCVSelect = ({
+  contentSourceId = null,
+  environments = [],
+  contentViewsStatus = STATUS.PENDING,
+  contentViews = [],
+}) => {
+  if (contentSourceId === '') return true;
+  if (environments.length === 0) return true;
+  if (contentViewsStatus === STATUS.PENDING) return true;
+  if (contentViewsStatus === STATUS.ERROR) return true;
+  if (contentViews.length === 0) return true;
+  return false;
+};
+
+export default getCVPlaceholderText;

--- a/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
@@ -22,6 +22,7 @@ import EnvironmentPaths from '../../../../scenes/ContentViews/components/Environ
 import ContentViewSelect from '../../../../scenes/ContentViews/components/ContentViewSelect/ContentViewSelect';
 import ContentViewSelectOption from '../../../../scenes/ContentViews/components/ContentViewSelect/ContentViewSelectOption';
 import { selectContentViewsStatus } from '../selectors';
+import { getCVPlaceholderText, shouldDisableCVSelect } from '../../../ContentViews/components/ContentViewSelect/helpers';
 
 const ENV_PATH_OPTIONS = { key: ENVIRONMENT_PATHS_KEY };
 
@@ -126,6 +127,20 @@ const ContentSourceForm = ({
   const viewIsDisabled = (isLoading || contentViews.length === 0 ||
     contentSourceId === '' || environments === []);
 
+  const cvPlaceholderText = getCVPlaceholderText({
+    contentSourceId,
+    environments,
+    contentViewsStatus,
+    contentViews,
+  });
+
+  const disableCVSelect = shouldDisableCVSelect({
+    contentSourceId,
+    environments,
+    contentViewsStatus,
+    contentViews,
+  });
+
   return (
     <Form
       onSubmit={e => handleSubmit(e)}
@@ -174,22 +189,20 @@ const ContentSourceForm = ({
         headerText={__('Environment')}
         isDisabled={environmentIsDisabled || hostsUpdated}
       />
-      {environments.length > 0 && contentViewsStatus !== STATUS.PENDING &&
-        <ContentViewSelect
-          selections={contentViewName}
-          onClear={() => handleContentView(null)}
-          onSelect={handleCVSelect}
-          isOpen={cvSelectOpen}
-          isDisabled={viewIsDisabled || hostsUpdated}
-          onToggle={isExpanded => setCVSelectOpen(isExpanded)}
-          headerText={__('Content view')}
-          ouiaId="SelectContentView"
-          className="set-select-width"
-          placeholderText={(contentViews.length === 0) ? __('No content views available') : __('Select a content view')}
-        >
-          {contentViews?.map(cv => <ContentViewSelectOption key={`${cv.id}`} cv={cv} env={environments[0]} />)}
-        </ContentViewSelect>
-        }
+      <ContentViewSelect
+        selections={contentViewName}
+        onClear={() => handleContentView(null)}
+        onSelect={handleCVSelect}
+        isOpen={cvSelectOpen}
+        isDisabled={viewIsDisabled || hostsUpdated || disableCVSelect}
+        onToggle={isExpanded => setCVSelectOpen(isExpanded)}
+        headerText={__('Content view')}
+        ouiaId="SelectContentView"
+        className="set-select-width"
+        placeholderText={cvPlaceholderText}
+      >
+        {!environmentIsDisabled && contentViews?.map(cv => <ContentViewSelectOption key={`${cv.id}`} cv={cv} env={environments[0]} />)}
+      </ContentViewSelect>
       <ActionGroup style={{ display: 'block' }}>
         <Button
           variant="primary"

--- a/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
@@ -201,7 +201,7 @@ const ContentSourceForm = ({
         className="set-select-width"
         placeholderText={cvPlaceholderText}
       >
-        {!environmentIsDisabled && contentViews?.map(cv => <ContentViewSelectOption key={`${cv.id}`} cv={cv} env={environments[0]} />)}
+        {!environmentIsDisabled && contentViews?.map(cv => <ContentViewSelectOption key={`${cv.id}`} value={`${cv.name}`} cv={cv} env={environments[0]} />)}
       </ContentViewSelect>
       <ActionGroup style={{ display: 'block' }}>
         <Button

--- a/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
@@ -131,14 +131,14 @@ const ContentSourceForm = ({
     contentSourceId,
     environments,
     contentViewsStatus,
-    contentViews,
+    cvSelectOptions: contentViews,
   });
 
   const disableCVSelect = shouldDisableCVSelect({
     contentSourceId,
     environments,
     contentViewsStatus,
-    contentViews,
+    cvSelectOptions: contentViews,
   });
 
   return (


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

In the places where a CV / LCE selector is used, it was confusing for the content view dropdown not to appear until you selected a lifecycle environment. This changes it so that the content view dropdown is disabled, not invisible.

#### Considerations taken when implementing this change?

There's still a lot of code duplicated in the eight places we use this selector. I decided against refactoring it more here, but I think this should eventually become a `<ContentViewEnvironmentSelector>` component.

#### What are the testing steps for this pull request?

Check all of the following and ensure that (a) the Content view dropdown is _visible_ and disabled at first; (b) everything still works as expected:

1. Hosts > All Hosts > host details > Content View card > Edit content view assignment
2. Hosts > All Hosts > host details > kebab > Change content source
3. CVDeletionReassignActivationKeysForm
4. CVDeletionReassignHostsForm
5. CV version bulk delete ReassignActivationKeys
6. CV version bulk delete ReassignHosts
7. CV Version delete ReassignActivationKeysForm
8. CV Version delete ReassignHostsForm

https://www.awesomescreenshot.com/video/15775405?key=d0d030566b4ced1c7bbc2168838bff5e



