### PR TITLE
Fixes #36202 - ACS page shows loading spinner forever

### DIFF
--- a/webpack/scenes/AlternateContentSources/MainTable/ACSTable.js
+++ b/webpack/scenes/AlternateContentSources/MainTable/ACSTable.js
@@ -107,6 +107,7 @@ const ACSTable = () => {
   const onBulkDelete = (ids) => {
     setDeleting(true);
     dispatch(bulkDeleteACS({ ids }, () => {
+      setDeleting(false);
       if (acsId && ids.has(Number(acsId))) {
         push('/alternate_content_sources');
       } else {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Ensure refresh of page after bulk delete request responds.
#### Considerations taken when implementing this change?

The page reloads after the API responds with success on planning of the bulk tasks. That doesn't ensure that all child tasks have been planned as well. The page displays the current state of data it receives, it's possible not all records deleted in bulk, have been deleted in the backend. The reloaded page will still have these ACSs on the UI. A refresh on the page after the bulk task completes will bring the data on the page up to date with backend.

There's a bigger change that could be possible here to track the bulk task. It's not immediately obvious to me how we track child tasks that haven't been planned yet. But I can file an issue to dig deeper into that.

#### What are the testing steps for this pull request?
Bulk delete some ACSs.
Page should refresh and you should see a notification with link to bulk task.