### PR TITLE
Fixes #30664 - add Katello support for installable errata reports

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -65,7 +65,8 @@ module Katello
         prepend ::ForemanRemoteExecution::HostExtensions if ::Katello.with_remote_execution?
         prepend Overrides
 
-        delegate :content_source_id, :single_content_view, :single_lifecycle_environment, :default_environment?, :single_content_view_environment?, :multi_content_view_environment?, :kickstart_repository_id, :bound_repositories, to: :content_facet, allow_nil: true
+        delegate :content_source_id, :single_content_view, :single_lifecycle_environment, :default_environment?, :single_content_view_environment?, :multi_content_view_environment?, :kickstart_repository_id, :bound_repositories,
+          :installable_errata, :installable_rpms, to: :content_facet, allow_nil: true
 
         has_many :content_view_environment_content_facets, through: :content_facet, class_name: 'Katello::ContentViewEnvironmentContentFacet'
         has_many :content_view_environments, through: :content_view_environment_content_facets


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds methods to report on installable errata.

#### Considerations taken when implementing this change?
I fixed a bug around the latest RPM check if a host has no applicable RPMs. With no applicable content, the report would error out.

#### What are the testing steps for this pull request?
Test the report templates edited in https://github.com/theforeman/foreman/pull/9662