### PR TITLE
Fixes #36237 - Add associated hosts to activation key

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -87,6 +87,7 @@ module Katello
     api :GET, "/activation_keys/:id", N_("Show an activation key")
     param :id, :number, :desc => N_("ID of the activation key"), :required => true
     param :organization_id, :number, :desc => N_("organization identifier"), :required => false
+    param :show_hosts, :bool, :desc => N_("Show hosts associated to an activation key"), :required => false
     def show
       respond(:resource => @activation_key)
     end

--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -83,6 +83,10 @@ module Katello
       subscription_facet_activation_keys.count
     end
 
+    def hosts
+      subscription_facets.map(&:host)
+    end
+
     def related_resources
       self.organization
     end

--- a/app/views/katello/api/v2/activation_keys/base.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/base.json.rabl
@@ -32,6 +32,12 @@ child :products => :products do |_product|
   attributes :id, :name
 end
 
+if ::Foreman::Cast.to_bool(params.fetch(:show_hosts, false))
+  child :hosts do
+    attributes :id, :name
+  end
+end
+
 child :host_collections => :host_collections do
   attributes :id
   attributes :name

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -171,6 +171,11 @@ module Katello
       assert @dev_key.valid?
     end
 
+    def test_hosts_mapping
+      total_hosts = hosts
+      assert_equal 6, total_hosts.count
+    end
+
     def test_products
       pool_one = katello_pools(:pool_one)
       cp_pools = [{'id' => pool_one.cp_id}]


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Added a method named `hosts` to the activation key model to return a mapping of the hosts used by it. The way we do it in the UI is calling the hosts controller and passing in the activation key, hammer is dumb and can't do that unless I make a host command to do that. Since the BZ wanted to see the hosts used by the key, this made more sense.

#### Considerations taken when implementing this change?

* N/A

#### What are the testing steps for this pull request?

* Check out Hammer PR: https://github.com/Katello/hammer-cli-katello/pull/884
* Create an activation key
* Register a host with an activation key
* run `hammer activation-key info --id X` and see if it shows the associated host