### PR TITLE
Fixes #36256 - Allow user to force profile upload when changing host content view

### DIFF
--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.scss
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.scss
@@ -1,0 +1,3 @@
+#force-profile-upload-checkbox {
+  margin-top: 0.16rem;
+}

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/HostContentViewActions.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/HostContentViewActions.js
@@ -2,6 +2,7 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import { API_OPERATIONS, put } from 'foremanReact/redux/API';
 import { errorToast } from '../../../../../scenes/Tasks/helpers';
 import { foremanApi } from '../../../../../services/api';
+import { runCommand } from '../../Tabs/RemoteExecutionActions';
 import HOST_CV_AND_ENV_KEY from './HostContentViewConstants';
 
 const updateHostContentViewAndEnvironment = (params, hostId, handleSuccess, handleError) => put({
@@ -14,6 +15,13 @@ const updateHostContentViewAndEnvironment = (params, hostId, handleSuccess, hand
   errorToast,
   params,
 });
+
+export const runSubmanRepos =
+  (hostname, handleSuccess) => runCommand({
+    hostname,
+    command: 'subscription-manager repos',
+    handleSuccess,
+  });
 
 export default updateHostContentViewAndEnvironment;
 

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
@@ -17,6 +17,13 @@ const baseParams = ({ feature, hostname, inputs = {} }) => ({
   },
 });
 
+const runCommandParams = ({ hostname, command }) =>
+  baseParams({
+    hostname,
+    inputs: { command },
+    feature: REX_FEATURES.RUN_COMMAND,
+  });
+
 // used when we know the package name
 const katelloPackageInstallParams = ({ hostname, packageName }) =>
   baseParams({
@@ -103,6 +110,18 @@ export const startPollingJob = ({
 export const stopPollingJob = ({ key }) => stopInterval(pollJobKey(key));
 
 // JOB INVOCATIONS
+export const runCommand = ({ hostname, command, handleSuccess }) => post({
+  type: API_OPERATIONS.POST,
+  key: REX_JOB_INVOCATIONS_KEY,
+  url: foremanApi.getApiUrl('/job_invocations'),
+  params: runCommandParams({ hostname, command }),
+  handleSuccess: (response) => {
+    showRexToast(response);
+    if (handleSuccess) handleSuccess(response);
+  },
+  errorToast,
+});
+
 export const installPackage = ({ hostname, packageName, handleSuccess }) => post({
   type: API_OPERATIONS.POST,
   key: REX_JOB_INVOCATIONS_KEY,
@@ -190,3 +209,4 @@ export const moduleStreamAction = ({ hostname, action, moduleSpec }) => post({
   handleSuccess: showRexToast,
   errorToast,
 });
+

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionConstants.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionConstants.js
@@ -9,4 +9,5 @@ export const REX_FEATURES = {
   KATELLO_HOST_TRACER_RESOLVE: 'katello_host_tracer_resolve',
   KATELLO_HOST_ERRATA_INSTALL_BY_SEARCH: 'katello_errata_install_by_search',
   KATELLO_HOST_MODULE_STREAM_ACTION: 'katello_module_stream_action',
+  RUN_COMMAND: 'run_script',
 };


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When changing a host's content view, normally the host's package and errata information isn't updated until the next package action or host check-in. This PR adds a checkbox allowing the user to force that update immediately, by running a subscription-manager command on the host via remote execution.

https://www.awesomescreenshot.com/video/16089294?key=99f6cd115d69a6ed97698284c4074dfe

#### Considerations taken when implementing this change?

Does this also require a change to the 'Change content source' workflow? I don't think so, because the job invocation that it provides already includes 'subscription-manager facts' which also updates the host. But double-check this to be safe :)


#### What are the testing steps for this pull request?

Check out the Foreman Remote Execution PR: https://github.com/theforeman/foreman_remote_execution/pull/803

Load the updated job template: In rails console, run

```
ForemanInternal.all.first.destroy
```

Then run `bundle exec rails db:seed` and restart the server.

Check out this PR and go to the new host detail page > Content view card > Edit content view assignment

Test the following:

1. REX job is started when you check the checkbox and click Save
2. Content view card is updated with the new content view at the beginning of REX job
3. You receive a toast notification when the job is completed
4. On the errata card, Installable errata (NOT applicable errata) will update when the REX job completes
5. The Recent Communication card will update with the new "Last check-in" time
6. None of this happens when you don't check the checkbox
