### PR TITLE
Fixes #36278 - Use hostgroup os refresh path in hostgroup edit

### DIFF
--- a/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
+++ b/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
@@ -125,7 +125,7 @@ KT.hosts.toggle_installation_medium = function(content_view_id) {
       content_view_id = KT.hosts.getSelectedContentView();
     }
 
-    if ($('#hostgroup_parent_id').length > 0) {
+    if ($('#hostgroup_operatingsystem_id').data('type') == 'hostgroup') {
       lifecycle_environment_id = KT.hosts.getSelectedEnvironment();
       content_source_id = $('#content_source_id').val();
       architecture_id = $('#hostgroup_architecture_id').val();


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Previously the code path taken to update OS when one of the katello fields was changed was determined based on presence of dom element matching #hostgroup_parent_id. However, this element was only present if the user was editing a hostgroup and had more than one hostgroup visible in the current context.

The refresh should now get triggered if data-type of element matching #hostgroup_operatingsystem_id is hostgroup which should be a more reliable indicator.

#### What are the testing steps for this pull request?
1) Have two LFEs
2) Have a content view
3) Have an OS with available 
4) Promote the content view to both LFEs
5) Create a hostgroup, assign one of the LFEs, the CV, architecture and OS to it
6) Edit the hostgroup, change its LFE

You should see a request being done to /hostgroups/os_selected.

Without this patch, this should only happen if you have multiple hostgroups.
