### PR TITLE
Fixes #35976 - Fix ACS SSL key content credential association.

### DIFF
--- a/app/views/katello/api/v2/content_credentials/show.json.rabl
+++ b/app/views/katello/api/v2/content_credentials/show.json.rabl
@@ -39,7 +39,7 @@ child :ssl_client_alternate_content_sources => :ssl_client_alternate_content_sou
   attributes :id, :name
 end
 
-child :ssl_client_key_alternate_content_sources => :ssl_client_key_alternate_content_sources do
+child :ssl_key_alternate_content_sources => :ssl_key_alternate_content_sources do
   attributes :id, :name
 end
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/views/content-credentials.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/views/content-credentials.html
@@ -50,7 +50,7 @@
         </td>
         <td bst-table-cell class="number-cell">{{ contentCredential.ssl_ca_alternate_content_sources.length +
           contentCredential.ssl_client_alternate_content_sources.length +
-          contentCredential.ssl_client_key_alternate_content_sources.length || 0 }}
+          contentCredential.ssl_key_alternate_content_sources.length || 0 }}
       </td>
       </tr>
       </tbody>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* I had the naming wrong of the rabl when I made the initial pr. Fixed the rabl and the html for the ACS main UI.

#### Considerations taken when implementing this change?

* Made sure nothing broke

#### What are the testing steps for this pull request?

* Check out PR
* Create an SSL cert, key, ca. Let me know if you want what I used or just fill it with dummy data
* Create an ACS and associate the ssl stuff to it
* Visit content credentials and make sure the key shows 1 acs
* Click on the key, and goto ACS and verify it shows the correct ACS

Before:

![acs_association_before](https://user-images.githubusercontent.com/1518655/230465054-810a83c7-70f8-43e9-880f-c734d1838029.jpeg)
![acs_main_before](https://user-images.githubusercontent.com/1518655/230465055-27e39713-ffa3-40a6-b8f9-f3de930ad928.jpeg)

After:

![acs_association_after](https://user-images.githubusercontent.com/1518655/230465072-dcd4a994-f524-44b5-8847-fed52a03ea7b.jpeg)
![acs_main_after](https://user-images.githubusercontent.com/1518655/230465075-f6d73994-b1b3-4fae-95b5-1a9a5affca0d.jpeg)
