### PR TITLE
Fixes #36178 - Add repository type column to Repo Sets

### DIFF
--- a/app/models/katello/content.rb
+++ b/app/models/katello/content.rb
@@ -11,6 +11,15 @@ module Katello
     scoped_search :relation => :products, :on => :name, :rename => :product_name, :complete_value => true
     scoped_search :on => :label, :rename => :content_label, :complete_value => true
     scoped_search :on => :cp_content_id, :complete_value => true
+    scoped_search :on => :id, :rename => :redhat, :ext_method => :search_by_redhat, :complete_value => { :true => true, :false => false }, :only_explicit => true
+
+    def self.search_by_redhat(_key, _operator, value)
+      conditions = Arel.sql(value == 'true' ? "#{Provider.table_name}.provider_type = 'Red Hat'" : "#{Provider.table_name}.provider_type != 'Red Hat'")
+      {
+        :conditions => conditions, :order => "#{Product.table_name}.name",
+        :joins => {:product_contents => {:product => :provider}}
+      }
+    end
 
     after_update :update_repository_names, :if => :propagate_name_change?
 

--- a/app/models/katello/product_content.rb
+++ b/app/models/katello/product_content.rb
@@ -29,6 +29,16 @@ module Katello
     scoped_search :on => :name, :relation => :product, :rename => :product_name
     scoped_search :on => :id, :relation => :product, :rename => :product_id, :only_explicit => true
     scoped_search :on => :label, :relation => :content, :rename => :content_label
+    scoped_search :on => :id, :rename => :redhat, :ext_method => :search_by_redhat, :complete_value => { :true => true, :false => false }, :only_explicit => true
+
+    def self.search_by_redhat(_key, _operator, value)
+      conditions = Arel.sql(value == 'true' ? "#{Provider.table_name}.provider_type = 'Red Hat'" : "#{Provider.table_name}.provider_type != 'Red Hat'")
+      {
+        :conditions => conditions, :order => "#{Product.table_name}.name",
+        :include => :product,
+        :joins => {:product => :provider}
+      }
+    end
 
     def self.content_table_name
       Katello::Content.table_name

--- a/app/services/katello/product_content_finder.rb
+++ b/app/services/katello/product_content_finder.rb
@@ -37,7 +37,7 @@ module Katello
       product_content.custom.map { |pc| pc.product.root_repositories.map(&:custom_content_label) }.flatten.uniq
     end
 
-    def self.wrap_with_overrides(product_contents:, overrides:, status: nil)
+    def self.wrap_with_overrides(product_contents:, overrides:, status: nil, repository_type: nil)
       pc_with_overrides = product_contents.map { |pc| ProductContentPresenter.new(pc, overrides) }
       if status
         pc_with_overrides.keep_if do |pc|
@@ -46,6 +46,11 @@ module Katello
           else
             pc.status[:status] == status
           end
+        end
+      end
+      if %w(custom redhat).include?(repository_type)
+        pc_with_overrides.keep_if do |pc|
+          pc.product.send("#{repository_type}?".to_sym) # pc.product.redhat? || pc.product.custom?
         end
       end
       pc_with_overrides

--- a/app/views/katello/api/v2/repository_sets/show.json.rabl
+++ b/app/views/katello/api/v2/repository_sets/show.json.rabl
@@ -63,3 +63,9 @@ node :enabled_content_override do |pc|
     override&.computed_value
   end
 end
+
+node :redhat do |pc|
+  if pc&.product&.respond_to? :redhat?
+    pc.product.redhat?
+  end
+end

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsConstants.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsConstants.js
@@ -20,3 +20,19 @@ export const PARAM_TO_FRIENDLY_NAME = {
   disabled: __('Disabled'),
   overridden: __('Overridden'),
 };
+
+export const PROVIDER_TYPES = {
+  CUSTOM: __('Custom'),
+  REDHAT: __('Red Hat'),
+};
+
+export const PROVIDER_TYPE_TO_PARAM = {
+  [PROVIDER_TYPES.CUSTOM]: 'custom',
+  [PROVIDER_TYPES.REDHAT]: 'redhat',
+};
+
+export const PROVIDER_TYPE_PARAM_TO_FRIENDLY_NAME = {
+  custom: __('Custom'),
+  redhat: __('Red Hat'),
+};
+


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

1. Add a _Repository type_ column to the Repository Sets tab in the new host details page. This column is sortable and will show whether a repo is a Red Hat or custom repo.
2. Move the 'Restricted to OS version / arch' labels to this new column.
3. Add a _Repository type_ dropdown, so you can filter results to just custom or just Red Hat repos.
4. Add a `repository_type` URL param, so you can add `repository_type=custom` to the end of the URL and the dropdown will be pre-selected for you.
5. Fix the bug I mention below.

#### Considerations taken when implementing this change?

I noticed that if you have repo sets filtered, and use Select All, it would behave as if the selection were unfiltered. Fixing this proved impossible with the Status dropdown*, so I ended up disabling select all for Status. But you can still use the checkbox to select the page. For repository type, I did fix it, but had to add some crazy scoped search custom external methods in a couple places.

*This is due to the complexities around content overrides and how they're not an actual model in our DB that can be queried.

#### What are the testing steps for this pull request?

1. Click around and make sure adding and removing overrides works as expected, especially when using the Select All checkbox with filters.
2. Also make sure pagination, Select All, and filter dropdowns work together as expected.
