### PR TITLE
Fixes #36285 - Update katello CI to use node 14

### DIFF
--- a/.github/workflows/react_tests.yml
+++ b/.github/workflows/react_tests.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: '14.x'
     # We could update the postinstall action for foreman to look for an environment variable for plugin webpack dirs
     # before kicking off the ruby script to find them, this would eliminate the ruby dep and running `npm i` in Katello.
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Update katello CI react tests to use node 14.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
