### PR TITLE
Fixes #36289 - Hidden CV version number in CVv comparison

### DIFF
--- a/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareTable.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareTable.js
@@ -71,6 +71,7 @@ const CVVersionCompareTable = ({
           {columnHeaders.map(({ title }) =>
             (
               <Th
+                modifier="wrap"
                 key={`${title}-header`}
                 sort={sortConfig[title] ? pfSortParams(title) : undefined}
               >


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Steps to Reproduce:
1. Sync a repository that contains some erratas (e.g. RHEL8 BaseOS)
2. Create a Content view, add repositories from previous step, publish at least two Content view versions
3. Compare the two Content view versions and go to "Errata"

Actual results:
Some erratas have too long Title and Type so headers of other columns get shortened. Headers of last two columns that should show the compared versions are shortened to "Version...", so the version numbers are not visible.

Expected results:
The version numbers should be always visible.

Before change:
![Before_PR](https://user-images.githubusercontent.com/21146741/231226743-6f7cb84f-c783-403c-a949-cee7e27e83f9.png)

After change:
![After_PR](https://user-images.githubusercontent.com/21146741/231226768-0e870fbd-9a9a-4b19-bf56-a1adce0642eb.png)
