### PR TITLE
Refs #36178 - fix Clear Filters on Repo Sets tab

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -317,6 +317,7 @@ const RepositorySetsTab = () => {
 
   const resetFilters = () => {
     setStatusSelected(STATUS_LABEL);
+    setRepoTypeSelected(REPO_TYPE_LABEL);
     if (emptyContent) setToggleGroupState(SHOW_ALL);
   };
   useEffect(() => {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

I forgot to add `setRepoTypeSelected(REPO_TYPE_LABEL);` to the `resetFilters` function. This breaks the "Clear filters" link.

#### Considerations taken when implementing this change?

I considered that I'm an idiot

#### What are the testing steps for this pull request?

Filter the repo sets tab Repository Type -> Custom on a host that has no custom repositories
Click the 'Clear filters' link

It should work
