### PR TITLE
Refs #36267 - Fix audit query to filter out irrelevant records

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -735,7 +735,7 @@ module Katello
     end
 
     def audited_cv_repositories_since_last_publish
-      audited_repositories = Audit.where(auditable_id: self).filter do |a|
+      audited_repositories = self.audits.filter do |a|
         !a.audited_changes["repository_ids"].nil?
       end
       if latest_version_object
@@ -745,7 +745,7 @@ module Katello
     end
 
     def audited_cv_repository_publications_changed
-      audited_repositories_publication = Audit.where(auditable_id: repositories).filter do |a|
+      audited_repositories_publication = Audit.where(auditable_id: repositories, auditable_type: "Katello::Repository").filter do |a|
         !a.audited_changes["publication_href"].nil?
       end
       if latest_version_object


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
In the initial iteration, the auidts being queried were based on IDs in the auditable_id field. That is not narrow enough and fetches a bunch of audit records with same id, ex: CV id = 1, cvv id= 1, basically any audit record for objects with id=1.

Example false positive that the query detects as a change:

```
cv.audited_cv_repositories_since_last_publish
=> [#<Audited::Audit:0x00005584e7701b80
  id: 85,
  auditable_id: 2,
  auditable_type: "Katello::ContentViewVersion",
  user_id: 4,
  user_type: nil,
  username: "Admin User",
  action: "create",
  audited_changes:
   {"content_view_id"=>2,
    "major"=>1,
    "definition_archive_id"=>nil,
    "minor"=>0,
    "content_counts"=>nil,
    "applied_filters"=>nil,
    "repository_ids"=>[],
    "environment_ids"=>[]},
  version: 1,
  comment: nil,
  associated_id: nil,
  associated_type: nil,
  request_uuid: "1918afe4-a9a7-478f-b714-1826f0758ac5",
  created_at: Thu, 13 Apr 2023 18:25:59.951839000 UTC +00:00,
  remote_address: "192.168.122.1",
  auditable_name: "2",
  associated_name: nil>]

```

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Reset your box. `bundle exec rails katello:reset`
Create a new cv and add some repos to it.
Publish a new version.
In console check: `Katello::ContentView.find(2).needs_publish?`

On a fresh box, both the CV and the 1st version will be id=2. That causes audit records for both to be fetched without this change and cv.needs_publish? will return true instead of false as a result.

With this PR needs_publish? will be false right after the first publish.