### PR TITLE
Fixes #36303 - disable scopes on CV publish errata calc

### DIFF
--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -113,15 +113,8 @@ module Actions
           version.add_applied_filters!
           # update errata applicability counts for all hosts in the CV & Library
           unless input[:skip_promotion]
-            content_view = ::Katello::ContentView.find(input[:content_view_id])
-            lifecycle_environment = ::Katello::KTEnvironment.find(input[:environment_id])
-            ::Katello::Host::ContentFacet.in_content_views_and_environments(
-              content_views: [content_view],
-              lifecycle_environments: [lifecycle_environment]
-            ).each do |facet|
-              facet.update_applicability_counts
-              facet.update_errata_status
-            end
+            environment = ::Katello::KTEnvironment.find(input[:environment_id])
+            ::Katello::ContentView.find(input[:content_view_id]).update_host_statuses(environment)
           end
 
           history = ::Katello::ContentViewHistory.find(input[:history_id])

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -652,12 +652,16 @@ module Katello
     end
 
     def check_orphaned_content_facets!(environments: [])
-      ::Katello::Host::ContentFacet.in_content_views_and_environments(
-        content_views: [self],
-        lifecycle_environments: environments
-      ).each do |facet|
-        unless facet.host
-          fail _("Orphaned content facets for deleted hosts exist for the content view and environment. Please run rake task : katello:clean_orphaned_facets and try again!")
+      Location.no_taxonomy_scope do
+        User.as_anonymous_admin do
+          ::Katello::Host::ContentFacet.in_content_views_and_environments(
+            content_views: [self],
+            lifecycle_environments: environments
+          ).each do |facet|
+            unless facet.host
+              fail _("Orphaned content facets for deleted hosts exist for the content view and environment. Please run rake task : katello:clean_orphaned_facets and try again!")
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Disable user and location scopes when calculating errata applicability after publishing a content view.

This also fix false positive orphaned content facet detection.