### PR TITLE
Refs #36285 - Revert katello CI to use node 12

### DIFF
--- a/.github/workflows/react_tests.yml
+++ b/.github/workflows/react_tests.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: '14.x'
+        node-version: '12.x'
     # We could update the postinstall action for foreman to look for an environment variable for plugin webpack dirs
     # before kicking off the ruby script to find them, this would eliminate the ruby dep and running `npm i` in Katello.
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Reverting to using node 12 for our pipeline since the dependency error should now be resolved.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
See if React tests are green on this.