### PR TITLE
Fixes #36268 - Audit filter/rules to determine needs_publish

### DIFF
--- a/app/models/katello/concerns/content_view_filter_rule_common.rb
+++ b/app/models/katello/concerns/content_view_filter_rule_common.rb
@@ -6,8 +6,50 @@ module Katello
       included do
         scoped_search on: :id, :complete_value => true
         scoped_search on: :name, :complete_value => true
+        after_create -> { create_audit_record('create') }
+        after_update -> { create_audit_record('update') }
+        before_destroy -> { create_audit_record('destroy') }
 
         validates_lengths_from_database
+      end
+
+      def create_audit_record(action)
+        audit = case action
+                when 'create'
+                  Audit.new(
+                    auditable_type: self.class,
+                    auditable_id: id,
+                    user_id: User.current.id,
+                    user_type: 'User',
+                    audited_changes: self.as_json,
+                    associated_id: filter.content_view.id,
+                    associated_type: filter.content_view.class,
+                    action: action
+                  )
+                when 'update'
+                  Audit.new(
+                    auditable_type: self.class,
+                    auditable_id: id,
+                    user_id: User.current.id,
+                    user_type: 'User',
+                    audited_changes: self.previous_changes,
+                    associated_id: filter.content_view.id,
+                    associated_type: filter.content_view.class,
+                    action: action
+                  )
+                when 'destroy'
+                  Audit.new(
+                    auditable_type: self.class,
+                    auditable_id: id,
+                    user_id: User.current.id,
+                    user_type: 'User',
+                    audited_changes: self.as_json,
+                    associated_id: filter.content_view.id,
+                    associated_type: filter.content_view.class,
+                    action: action
+                  )
+                end
+        audit&.save!
       end
     end
   end

--- a/app/models/katello/content_view_filter.rb
+++ b/app/models/katello/content_view_filter.rb
@@ -1,7 +1,7 @@
 module Katello
   class ContentViewFilter < Katello::Model
     include Authorization::ContentViewFilter
-    audited :associations => [:repositories]
+    audited :associations => [:repositories], :associated_with => :content_view, :except => [:name, :description]
     DOCKER = 'docker'.freeze
     RPM = Rpm::CONTENT_TYPE
     PACKAGE_GROUP   = PackageGroup::CONTENT_TYPE

--- a/app/models/katello/content_view_package_filter_rule.rb
+++ b/app/models/katello/content_view_package_filter_rule.rb
@@ -1,7 +1,6 @@
 module Katello
   class ContentViewPackageFilterRule < Katello::Model
     include ::Katello::Concerns::ContentViewFilterRuleCommon
-
     belongs_to :filter,
                :class_name => "Katello::ContentViewPackageFilter",
                :inverse_of => :package_rules,

--- a/test/models/content_view_docker_filter_rule_test.rb
+++ b/test/models/content_view_docker_filter_rule_test.rb
@@ -12,6 +12,19 @@ module Katello
       refute_empty ContentViewDockerFilterRule.where(:id => @rule)
     end
 
+    def test_audit_creation
+      assert @rule.save!
+      auditable_id = @rule.id
+      rules_audit = Audit.where(auditable_id: auditable_id)
+      assert_equal rules_audit.size, 1
+      @rule.update_attribute(:name, @rule.name + 'updated')
+      rules_audit = Audit.where(auditable_id: auditable_id)
+      assert_equal rules_audit.size, 2
+      @rule.destroy
+      rules_audit = Audit.where(auditable_id: auditable_id)
+      assert_equal rules_audit.size, 3
+    end
+
     def test_create_without_name
       assert_raises(ActiveRecord::RecordInvalid) do
         @rule.name = nil
@@ -23,7 +36,7 @@ module Katello
       @rule.save!
       attrs = FactoryBot.attributes_for(:katello_content_view_docker_filter_rule,
                                          :name => @rule.name)
-
+      ContentViewDockerFilterRule.any_instance.stubs(:create_audit_record).returns({})
       rule_item = ContentViewDockerFilterRule.create(attrs)
       assert rule_item.persisted?
       assert rule_item.save

--- a/test/models/content_view_package_filter_rule_test.rb
+++ b/test/models/content_view_package_filter_rule_test.rb
@@ -12,6 +12,19 @@ module Katello
       refute_empty ContentViewPackageFilterRule.where(:id => @rule)
     end
 
+    def test_audit_creation
+      assert @rule.save!
+      auditable_id = @rule.id
+      rules_audit = Audit.where(auditable_id: auditable_id)
+      assert_equal rules_audit.size, 1
+      @rule.update_attribute(:name, @rule.name + 'updated')
+      rules_audit = Audit.where(auditable_id: auditable_id)
+      assert_equal rules_audit.size, 2
+      @rule.destroy
+      rules_audit = Audit.where(auditable_id: auditable_id)
+      assert_equal rules_audit.size, 3
+    end
+
     def test_create_without_name
       assert_raises(ActiveRecord::RecordInvalid) do
         @rule.name = nil
@@ -23,7 +36,7 @@ module Katello
       @rule.save!
       attrs = FactoryBot.attributes_for(:katello_content_view_package_filter_rule,
                                          :name => @rule.name)
-
+      ContentViewPackageFilterRule.any_instance.stubs(:create_audit_record).returns({})
       rule_item = ContentViewPackageFilterRule.create(attrs)
       assert rule_item.persisted?
       assert rule_item.save


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Audit any changes to filters/filter rules. These audits are then used to determine if the content view needs a publish for changes to reflect on latest version.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a CV.
2. Play around with repos, filters, filter rules on the CV.
3. Verify that cv.needs_publish? gets set whenever there's any changes on filters and filter rules of different content types.