### PR TITLE
Fixes #36302 - Add option to skip dep solving during inc update in the UI

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
@@ -77,7 +77,7 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
                 };
 
                 params['content_view_version_environments'] = [];
-                params['resolve_dependencies'] = true;
+                params['resolve_dependencies'] = !$scope.noDepSolve;
 
                 //get a list of unique content view version ids with their environments
                 angular.forEach($scope.updates, function (update) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
@@ -118,6 +118,13 @@
 
     <div class="checkbox" ng-show="updates.length > 0">
       <label>
+        <input name="noDepSolve" ng-model="noDepSolve" type="checkbox"/>
+        <span translate>Skip dependency solving for a significant speed increase. If the update cannot be applied to the host, delete the incremental content view version and retry the application with dependency solving turned on.</span>
+      </label>
+    </div>
+
+    <div class="checkbox" ng-show="updates.length > 0">
+      <label>
         <input name="applyErrata" ng-model="applyErrata" type="checkbox"/>
         <span translate>Apply Errata to Content Hosts immediately after publishing.</span>
       </label>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Adds a checkbox to skip dependency solving during incremental update in the UI.

#### Considerations taken when implementing this change?

This was determined to be the best way to speed up incremental update for users.

To the reviewer: how does the wording sound?

#### What are the testing steps for this pull request?

1) Subscribe a host to a content view version with errata filtered out.
2) Apply some errata that were filtered out. First, skip dependency solving with the new checkbox.
3) See that dependency solving `false` is sent to Pulp in the MultiCopyContents Dynflow.
4) Apply the errata again (after promoting the original CVV  to Library) using dependency solving this time.
5) Check that dependency solving is `true` this time.