### PR TITLE
Fixes #36316 - Scope LCE selection to content source and organization

### DIFF
--- a/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
+++ b/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
@@ -36,8 +36,11 @@ KT.hosts.fetchEnvironments = function () {
   select.find('option').remove();
   if (content_source_id) {
     var url = tfm.tools.foremanUrl('/katello/api/capsules/' + content_source_id);
+    var orgId = $('#host_organization_id').val();
     $.get(url, function (content_source) {
       $.each(content_source.lifecycle_environments, function(index, env) {
+    // Don't show environments that aren't in the selected org. See jQuery.each() docs    
+    if (orgId && env.organization_id != orgId) return true;
 	option = $("<option />").val(env.id).text(env.name);
 	select.append(option);
       });

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -275,6 +275,14 @@ module Katello
       host || URI.parse(Setting[:foreman_url]).host
     end
 
+    def get_content_source_id(hostname)
+      proxies = SmartProxy.authorized.filter do |sp|
+        hostname == URI.parse(sp.url).hostname
+      end
+      return nil if proxies.length != 1
+      proxies.first.id
+    end
+
     private
 
     # in case set taxonomy from core was skipped since the User.current was nil at that moment (typically AK was used instead of username/password)
@@ -466,6 +474,8 @@ module Katello
     def update_host_registered_through(host, headers)
       parent_host = get_parent_host(headers)
       host.subscription_facet.update_attribute(:registered_through, parent_host)
+      content_source_id = get_content_source_id(parent_host)
+      host.content_facet.update_attribute(:content_source_id, content_source_id)
     end
 
     def check_registration_services

--- a/app/controllers/katello/api/v2/environments_controller.rb
+++ b/app/controllers/katello/api/v2/environments_controller.rb
@@ -132,6 +132,7 @@ module Katello
 
     api :GET, "/organizations/:organization_id/environments/paths", N_("List environment paths")
     param :organization_id, :number, :desc => N_("organization identifier")
+    param :content_source_id, :number, :desc => N_("Show whether each lifecycle environment is associated with the given Smart Proxy id.")
     param :permission_type, String, :desc => <<-DESC
       The associated permission type. One of (readable | promotable)
       Default: readable
@@ -142,7 +143,10 @@ module Katello
                   else
                     @organization.readable_promotion_paths
                   end
-
+      if params[:content_source_id]
+        @content_source_id = params[:content_source_id].to_i
+        @content_source = SmartProxy.authorized(:view_smart_proxies).find(@content_source_id)
+      end
       paths = env_paths.inject([]) do |result, path|
         result << { :environments => [@organization.library] + path.select(&:readable?) }
       end

--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -326,12 +326,11 @@ module Katello
 
       hosts.each do |host|
         next unless host.content_facet
+        host.content_facet.content_source = content_source
         host.content_facet.assign_single_environment(
           :content_view_id => content_view.id,
           :environment_id => lifecycle_environment.id
         )
-        host.content_facet.content_source = content_source
-
         host.update_candlepin_associations
       end
 

--- a/app/models/katello/content_view_environment_content_facet.rb
+++ b/app/models/katello/content_view_environment_content_facet.rb
@@ -5,5 +5,17 @@ module Katello
 
     validates :content_view_environment_id, presence: true
     validates :content_facet_id, presence: true, unless: :new_record?
+    validate :ensure_valid_content_source
+
+    def ensure_valid_content_source
+      source = self.content_facet&.content_source
+      return if source&.pulp_primary? # pulp_primary smart proxy always has all content
+      env = self.content_view_environment&.environment
+      hostname = self.content_facet&.host&.name
+      return unless [source, env].all? { |x| x.present? }
+      unless source.lifecycle_environments.include?(env)
+        errors.add(:base, _("Host %{hostname}: Cannot add content view environment to content facet. The host's content source '%{content_source}' does not sync lifecycle environment '%{lce}'.") % { hostname: hostname, content_source: source.name, lce: env.name })
+      end
+    end
   end
 end

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -110,7 +110,7 @@ module Katello
           Rails.logger.info("ContentViewEnvironment not found for content view '#{cve.content_view_name}' and environment '#{cve.environment&.name}'; creating a new one.")
         end
         fail _("Unable to create ContentViewEnvironment. Check the logs for more information.") if content_view_environment.nil?
-        
+
         self.content_view_environments = [content_view_environment]
       end
 

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -38,6 +38,7 @@ module Katello
 
       validates_with ::AssociationExistsValidator, attributes: [:content_source]
       validates_with Katello::Validators::GeneratedContentViewValidator
+      validates_associated :content_view_environment_content_facets
       validates :host, :presence => true, :allow_blank => false
 
       attr_accessor :cves_changed
@@ -109,6 +110,7 @@ module Katello
           Rails.logger.info("ContentViewEnvironment not found for content view '#{cve.content_view_name}' and environment '#{cve.environment&.name}'; creating a new one.")
         end
         fail _("Unable to create ContentViewEnvironment. Check the logs for more information.") if content_view_environment.nil?
+        
         self.content_view_environments = [content_view_environment]
       end
 

--- a/app/views/katello/api/v2/environments/show.json.rabl
+++ b/app/views/katello/api/v2/environments/show.json.rabl
@@ -6,6 +6,16 @@ extends 'katello/api/v2/common/org_reference'
 attributes :library
 attributes :registry_name_pattern, :registry_unauthenticated_pull
 
+if @content_source.present?
+  node :content_source do |env|
+    {
+      :name => @content_source.name,
+      :id => @content_source_id,
+      :environment_is_associated => env.content_source_associated?(@content_source)
+    }
+  end
+end
+
 node :prior do |env|
   if env.prior
     {name: env.prior.name, :id => env.prior.id}

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -165,6 +165,7 @@ const ChangeHostCVModal = ({
       {environments?.some(env => env?.content_source?.environment_is_associated === false) &&
         <Alert
           variant="info"
+          ouiaId="disabled-environments-alert"
           isInline
           title={__('Some environments are disabled because they are not associated with the host\'s content source.')}
           style={{ marginBottom: '1rem' }}

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -20,6 +20,7 @@ import ContentViewSelectOption
 import { getCVPlaceholderText } from '../../../../../scenes/ContentViews/components/ContentViewSelect/helpers';
 import { useRexJobPolling } from '../../Tabs/RemoteExecutionHooks';
 import './ChangeHostCVModal.scss';
+import { selectEnvironmentPaths } from '../../../../../scenes/ContentViews/components/EnvironmentPaths/EnvironmentPathSelectors';
 
 const ENV_PATH_OPTIONS = { key: ENVIRONMENT_PATHS_KEY };
 
@@ -29,6 +30,7 @@ const ChangeHostCVModal = ({
   hostEnvId,
   orgId,
   hostId,
+  contentSourceId,
   hostName,
 }) => {
   const [selectedEnvForHost, setSelectedEnvForHost]
@@ -39,12 +41,15 @@ const ChangeHostCVModal = ({
   const [forceProfileUpload, setForceProfileUpload] = useState(false);
   const dispatch = useDispatch();
   const contentViewsInEnvResponse = useSelector(state => selectContentViews(state, `FOR_ENV_${hostEnvId}`));
+  const environmentPathResponse = useSelector(selectEnvironmentPaths);
+  const environments = environmentPathResponse?.results?.map(path => path.environments).flat();
   const { results } = contentViewsInEnvResponse;
   const contentViewsInEnvStatus = useSelector(state => selectContentViewStatus(state, `FOR_ENV_${hostEnvId}`));
   const hostUpdateStatus = useSelector(state => selectAPIStatus(state, HOST_CV_AND_ENV_KEY));
+  const pathsUrl = `/organizations/${orgId}/environments/paths?permission_type=promotable${contentSourceId ? `&content_source_id=${contentSourceId}` : ''}`;
   useAPI( // No TableWrapper here, so we can useAPI from Foreman
     'get',
-    api.getApiUrl(`/organizations/${orgId}/environments/paths?permission_type=promotable`),
+    api.getApiUrl(pathsUrl),
     ENV_PATH_OPTIONS,
   );
   const selectedCVForHostId = results?.find(cv => cv.name === selectedCVForHost)?.id;
@@ -157,11 +162,23 @@ const ChangeHostCVModal = ({
           {__(' to manage and promote content views, or select a different environment.')}
         </Alert>
       }
+      {environments?.some(env => env?.content_source?.environment_is_associated === false) &&
+        <Alert
+          variant="info"
+          isInline
+          title={__('Some environments are disabled because they are not associated with the host\'s content source.')}
+          style={{ marginBottom: '1rem' }}
+        >
+          {__('To enable them, add the environment to the host\'s content source, or ')}
+          <a href={`/change_host_content_source?host_id=${hostId}`}>{__('change the host\'s content source.')}</a>
+        </Alert>
+      }
       <EnvironmentPaths
         userCheckedItems={selectedEnvForHost}
         setUserCheckedItems={handleEnvSelect}
         publishing={false}
         multiSelect={false}
+        hostId={hostId}
         headerText={__('Select environment')}
         isDisabled={hostUpdateStatus === STATUS.PENDING}
       />
@@ -209,6 +226,7 @@ ChangeHostCVModal.propTypes = {
   hostEnvId: PropTypes.number,
   orgId: PropTypes.number.isRequired,
   hostId: PropTypes.number.isRequired,
+  contentSourceId: PropTypes.number,
   hostName: PropTypes.string.isRequired,
 };
 
@@ -216,6 +234,7 @@ ChangeHostCVModal.defaultProps = {
   isOpen: false,
   closeModal: () => {},
   hostEnvId: null,
+  contentSourceId: null,
 };
 
 

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -31,7 +31,7 @@ const requiredPermissions = [
 const HostContentViewDetails = ({
   contentView, lifecycleEnvironment, contentViewVersionId, contentViewDefault,
   contentViewVersion, contentViewVersionLatest, hostId, hostName, orgId, hostEnvId,
-  hostPermissions, permissions,
+  hostPermissions, permissions, contentSourceId,
 }) => {
   let versionLabel = `Version ${contentViewVersion}`;
   if (contentViewVersionLatest) {
@@ -142,6 +142,7 @@ const HostContentViewDetails = ({
           hostId={hostId}
           hostName={hostName}
           hostEnvId={hostEnvId}
+          contentSourceId={contentSourceId}
           orgId={orgId}
           key={`cv-change-modal-${hostId}`}
         />
@@ -156,6 +157,7 @@ const ContentViewDetailsCard = ({ hostDetails }) => {
     return (<HostContentViewDetails
       hostId={hostDetails.id}
       hostName={hostDetails.name}
+      contentSourceId={hostDetails.content_facet_attributes.content_source?.id}
       orgId={hostDetails.organization_id}
       hostEnvId={hostDetails.content_facet_attributes.lifecycle_environment_id}
       hostPermissions={hostDetails.permissions}
@@ -183,6 +185,7 @@ HostContentViewDetails.propTypes = {
   name: PropTypes.string,
   hostId: PropTypes.number,
   hostName: PropTypes.string,
+  contentSourceId: PropTypes.number,
   orgId: PropTypes.number,
   hostEnvId: PropTypes.number,
   hostPermissions: PropTypes.shape({
@@ -202,6 +205,7 @@ HostContentViewDetails.defaultProps = {
   hostId: null,
   hostName: '',
   orgId: null,
+  contentSourceId: null,
   contentViewDefault: false,
   hostPermissions: {},
   permissions: {},
@@ -214,6 +218,9 @@ ContentViewDetailsCard.propTypes = {
     organization_id: PropTypes.number,
     content_facet_attributes: PropTypes.shape({
       lifecycle_environment_id: PropTypes.number,
+      content_source: PropTypes.shape({
+        id: PropTypes.number,
+      }),
       permissions: PropTypes.shape({
         view_content_views: PropTypes.bool,
         view_lifecycle_environments: PropTypes.bool,

--- a/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.js
+++ b/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.js
@@ -54,6 +54,7 @@ const EnvironmentPaths = ({
                     envCheckedInList(env, userCheckedItems) ||
                     envCheckedInList(env, promotedEnvironments)}
                     isDisabled={isDisabled || (publishing && env.library)
+                    || env?.content_source?.environment_is_associated === false
                     || envCheckedInList(env, promotedEnvironments)}
                     className="env-path__labels-with-pointer"
                     key={`${env.id}${index}`}

--- a/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
@@ -188,6 +188,7 @@ const ContentSourceForm = ({
       />
       {envList?.some(env => env?.content_source?.environment_is_associated === false) &&
         <Alert
+          ouiaId="disabled-environments-alert"
           variant="info"
           isInline
           title={__('Some environments are disabled because they are not associated with the selected content source.')}
@@ -221,9 +222,9 @@ const ContentSourceForm = ({
       </ContentViewSelect>
       <ActionGroup style={{ display: 'block' }}>
         <Button
-          ouiaId="generate_button"
           variant="primary"
           id="generate_btn"
+          ouiaId="update-source-button"
           onClick={e => handleSubmit(e)}
           isDisabled={isLoading || !formIsValid() || hostsUpdated}
           isLoading={isLoading}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

1. When assigning a content view environment to a host, check that its lifecycle environment is available on the host's content source, and raise an error if not.
2. On the Create Host page, the 'Lifecycle environment' dropdown showed multiple Library entries if you had multiple organizations. This change scopes the lifecycle environment dropdown so it only shows environments in the currently selected organization.
3. In the environment path selector on the Change Content Source page and Edit content view assignment modal, disable lifecycle environments not available in the host's content source.

![image](https://user-images.githubusercontent.com/22042343/233186598-10c28bb6-8f91-4a70-b292-1e4dc87b5f6e.png)


#### Considerations taken when implementing this change?

I'm separating the commits to hopefully make this more backportable

#### What are the testing steps for this pull request?

If you're ambitious, you can actually set up one or more Smart Proxies with Content  / capsules / content sources / whatever you wanna call 'em.  If not, just edit my code to simulate things :)

Example of simulating:
```rb
--- a/app/views/katello/api/v2/environments/show.json.rabl
+++ b/app/views/katello/api/v2/environments/show.json.rabl
@@ -11,7 +11,7 @@ if @content_source.present?
     {
       :name => @content_source.name,
       :id => @content_source_id,
-      :environment_is_associated => env.content_source_associated?(@content_source)
+      :environment_is_associated => env.name == 'dev' ? false : env.content_source_associated?(@content_source)
     }
   end
 end
```


Verify the following:

1. API error is raised if you try to assign a content view environment to the host, but that lifecycle environment is not associated with the host's content source.
2. On the Create Host page, the lifecycle environment dropdown shows only the currently selected org's environments -- NOT all environments.
3. See item 3 above and make sure that that's happening. Check both locations!! Also notice the pretty info alert
