### PR TITLE
Refs #36120 - Add upgrade task to db seeds

### DIFF
--- a/app/lib/katello/util/default_enablement_migrator.rb
+++ b/app/lib/katello/util/default_enablement_migrator.rb
@@ -59,7 +59,7 @@ module Katello
         Organization.all.each do |org|
           next if org.simple_content_access? # subscription attachment is meaningless with SCA
           Rails.logger.info("Creating disabled overrides for unsubscribed content in org #{org.name}")
-          hosts_to_update = org.hosts.where.not(subscription_facet: nil)
+          hosts_to_update = org.hosts.joins(:subscription_facet).where.not("#{Katello::Host::SubscriptionFacet.table_name}.host_id" => nil)
           hosts_to_update.each do |host|
             create_disabled_overrides_for_non_sca(consumable: host.subscription_facet)
           rescue => e

--- a/db/seeds.d/111-upgrade_tasks.rb
+++ b/db/seeds.d/111-upgrade_tasks.rb
@@ -9,6 +9,7 @@ UpgradeTask.define_tasks(:katello) do
     {:name => 'katello:upgrades:4.2:remove_checksum_values'},
     {:name => 'katello:upgrades:4.4:publish_import_cvvs'},
     {:name => 'katello:upgrades:4.8:fix_incorrect_providers'},
-    {:name => 'katello:upgrades:4.8:regenerate_imported_repository_metadata'}
+    {:name => 'katello:upgrades:4.8:regenerate_imported_repository_metadata'},
+    {:name => 'katello:upgrades:4.9:update_custom_products_enablement'}
   ]
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add `rake katello:upgrades:4.9:update_custom_products_enablement` to `db/seeds.d/111-upgrade_tasks.rb`.

#### Considerations taken when implementing this change?

Without this I don't think the task will run on upgrade :sob: 

#### What are the testing steps for this pull request?

:shrug: 
