### PR TITLE
Fixes #36301 - Auto-create content overrides on SCA enable

### DIFF
--- a/app/controllers/katello/api/v2/simple_content_access_controller.rb
+++ b/app/controllers/katello/api/v2/simple_content_access_controller.rb
@@ -26,8 +26,10 @@ module Katello
     api :PUT, "/organizations/:organization_id/simple_content_access/enable",
       N_("Enable simple content access for a manifest")
     param :organization_id, :number, :desc => N_("Organization ID"), :required => true
+    param :auto_create_overrides, :bool, :desc => N_("Automatically create disabled content overrides for custom products which do not have an attached subscription"), :required => false, :default => true
     def enable
-      task = async_task(::Actions::Katello::Organization::SimpleContentAccess::Enable, params[:organization_id])
+      auto_create = params.key?(:auto_create_overrides) ? ::Foreman::Cast.to_bool(params[:auto_create_overrides]) : true
+      task = async_task(::Actions::Katello::Organization::SimpleContentAccess::Enable, params[:organization_id], auto_create_overrides: auto_create)
       respond_for_async :resource => task
     end
 

--- a/app/lib/actions/katello/organization/simple_content_access/enable.rb
+++ b/app/lib/actions/katello/organization/simple_content_access/enable.rb
@@ -3,6 +3,16 @@ module Actions
     module Organization
       module SimpleContentAccess
         class Enable < Toggle
+          def plan(organization_id, auto_create_overrides: true)
+            input[:auto_create_overrides] = auto_create_overrides
+            sequence do
+              if auto_create_overrides
+                plan_action(PrepareContentOverrides, organization_id)
+              end
+              super(organization_id) # puts plan_self inside the sequence
+            end
+          end
+
           def content_access_mode_value
             SIMPLE_CONTENT_ACCESS_ENABLED_VALUE
           end

--- a/app/lib/actions/katello/organization/simple_content_access/prepare_content_overrides.rb
+++ b/app/lib/actions/katello/organization/simple_content_access/prepare_content_overrides.rb
@@ -1,0 +1,36 @@
+module Actions
+  module Katello
+    module Organization
+      module SimpleContentAccess
+        class PrepareContentOverrides < Actions::Base
+          def plan(organization_id)
+            Rails.logger.info "PrepareContentOverrides plan: #{organization_id.inspect}"
+            organization = ::Organization.find(organization_id.to_i)
+            org_name = organization.name
+
+            plan_self(organization_id: organization_id, organization_name: org_name)
+          end
+
+          def run
+            organization = ::Organization.find(input[:organization_id].to_i)
+            migrator = ::Katello::Util::ContentOverridesMigrator.new(organization: organization)
+
+            output[:migrator_result] = migrator.execute_non_sca_overrides!
+          end
+
+          def rescue_strategy
+            Dynflow::Action::Rescue::Skip
+          end
+
+          def humanized_name
+            N_("Prepare content overrides for Simple Content Access")
+          end
+
+          def humanized_input
+            _("for organization %s") % input[:organization_name]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/organization/simple_content_access/toggle.rb
+++ b/app/lib/actions/katello/organization/simple_content_access/toggle.rb
@@ -12,9 +12,15 @@ module Actions
           attr_reader :organization
 
           def plan(organization_id)
-            @organization = ::Organization.find(organization_id)
+            organization = ::Organization.find(organization_id.to_i)
+            input[:organization_name] = organization.name
+            input[:organization_label] = organization.label
             action_subject organization
-            ::Katello::Resources::Candlepin::Owner.update(@organization.label, contentAccessMode: content_access_mode_value)
+            plan_self(organization_id: organization_id)
+          end
+
+          def run
+            ::Katello::Resources::Candlepin::Owner.update(input[:organization_label], contentAccessMode: content_access_mode_value)
           end
 
           def failure_notification(plan)
@@ -28,6 +34,10 @@ module Actions
             task_success_notification.deliver!(
               subject_organization
             )
+          end
+
+          def humanized_input
+            _("for organization %s") % input[:organization_name]
           end
 
           private

--- a/app/lib/katello/util/content_overrides_migrator.rb
+++ b/app/lib/katello/util/content_overrides_migrator.rb
@@ -1,0 +1,98 @@
+module Katello
+  module Util
+    class ContentOverridesMigrator # used in Actions::Katello::Organization::SimpleContentAccess::PrepareContentOverrides
+      include ActionView::Helpers::TextHelper
+
+      def initialize(organization:)
+        @organization = organization
+      end
+
+      def execute_non_sca_overrides!
+        host_errors = create_disabled_overrides_for_non_sca_org_hosts(organization: @organization)
+        ak_errors = create_disabled_overrides_for_non_sca_org_activation_keys(organization: @organization)
+
+        total_errors = host_errors + ak_errors
+        finish_message = "Finished creating overrides in non-SCA orgs; #{total_errors == 0 ? "no errors" : "#{pluralize(total_errors, "error")}"}"
+        messages = { result: finish_message, errors: total_errors }
+        messages[:host_errors] = "Hosts - #{pluralize(host_errors, "error")} creating disabled overrides for unsubscribed content; see log messages above" if host_errors > 0
+        messages[:ak_errors] = "Activation keys - #{pluralize(ak_errors, "error")} creating disabled overrides for unsubscribed content; see log messages above" if ak_errors > 0
+        messages[:success_message] = "You may now switch all organizations to Simple Content Access mode without any change in access to content." if total_errors == 0
+        Rails.logger.info finish_message
+        Rails.logger.info messages[:host_errors] if messages[:host_errors]
+        Rails.logger.info messages[:ak_errors] if messages[:ak_errors]
+        Rails.logger.info messages[:success_message] if messages[:success_message]
+        messages
+      end
+
+      def create_disabled_overrides_for_non_sca(consumable:)
+        content_finder = ::Katello::ProductContentFinder.new(
+                match_subscription: false,
+                match_environment: false,
+                consumable: consumable
+              )
+        subscribed_content_finder = ::Katello::ProductContentFinder.new(
+          match_subscription: true,
+          match_environment: false,
+          consumable: consumable
+        )
+        candlepin_resource = consumable.is_a?(::Katello::Host::SubscriptionFacet) ? ::Katello::Resources::Candlepin::Consumer : ::Katello::Resources::Candlepin::ActivationKey
+        consumable_id = consumable.is_a?(::Katello::Host::SubscriptionFacet) ? consumable.uuid : consumable.cp_id
+        repos_with_existing_overrides = candlepin_resource.content_overrides(consumable_id).map do |override|
+          override[:contentLabel]
+        end
+        unsubscribed_content = content_finder.custom_content_labels - subscribed_content_finder.custom_content_labels - repos_with_existing_overrides
+        new_overrides = unsubscribed_content.map do |repo_label|
+          ::Katello::ContentOverride.new(
+            repo_label,
+            { name: "enabled", value: "0" } # Override to disabled
+          )
+        end
+        return if new_overrides.blank?
+        if consumable.is_a? ::Katello::Host::SubscriptionFacet
+          ::Katello::Resources::Candlepin::Consumer.update_content_overrides(
+            consumable.uuid,
+            new_overrides.map(&:to_entitlement_hash)
+          )
+        else
+          ::Katello::Resources::Candlepin::ActivationKey.update_content_overrides(
+            consumable.cp_id,
+            new_overrides.map(&:to_entitlement_hash)
+          )
+        end
+      end
+
+      def create_disabled_overrides_for_non_sca_org_hosts(organization:)
+        errors = 0
+        fail _("Organization must be specified") if organization.blank?
+        return 0 if organization.simple_content_access? # subscription attachment is meaningless with SCA
+        Rails.logger.info("Hosts - Creating disabled overrides for unsubscribed content in organization #{organization.name}")
+        # only registered hosts with content!
+        hosts_to_update = organization.hosts.joins(:subscription_facet).where.not("#{Katello::Host::SubscriptionFacet.table_name}.host_id" => nil)
+        hosts_to_update.each do |host|
+          create_disabled_overrides_for_non_sca(consumable: host.subscription_facet)
+        rescue => e
+          errors += 1
+          Rails.logger.error("Failed to update host #{host.name}: #{e.message}")
+          Rails.logger.debug e.backtrace.join("\n")
+        end
+        errors
+      end
+
+      def create_disabled_overrides_for_non_sca_org_activation_keys(organization:)
+        errors = 0
+        fail _("Organization must be specified") if organization.blank?
+        return 0 if organization.simple_content_access? # subscription attachment is meaningless with SCA
+        Rails.logger.info("Activation keys - Creating disabled overrides for unsubscribed content in organization #{organization.name}")
+        aks_to_update = organization.activation_keys
+        aks_to_update.each do |ak|
+          create_disabled_overrides_for_non_sca(consumable: ak)
+        rescue => e
+          errors += 1
+          Rails.logger.error("Failed to update activation key #{ak.name}: #{e.message}")
+          Rails.logger.debug e.backtrace.join("\n")
+        end
+        errors
+      end
+    end
+  end
+end


### PR DESCRIPTION
(cherry picked from commit 729739222bc9b507f5b05f2ea1facf813c1c0ab8)

See https://github.com/Katello/katello/pull/10515 for description