### PR TITLE
Fixes #26434 - rename SystemStatuses component import

### DIFF
--- a/webpack/components/extensions/about/index.js
+++ b/webpack/components/extensions/about/index.js
@@ -3,7 +3,7 @@ import * as actions from './SystemStatusesActions';
 import { selectAllServices, selectStatus } from './SystemStatusesSelectors';
 import reducer from './SystemStatusesReducer';
 
-import FactChart from './SystemStatuses';
+import SystemStatuses from './SystemStatuses';
 
 const mapStateToProps = ({ katelloExtends }) => ({
   services: selectAllServices(katelloExtends),
@@ -16,4 +16,4 @@ export const reducers = { systemServices: reducer };
 export default connect(
   mapStateToProps,
   actions,
-)(FactChart);
+)(SystemStatuses);


### PR DESCRIPTION
probably due to copy&paste, the FactChart name was shown, and while removing that component from core,
I found this reference that should be renamed.

#### What are the changes introduced in this pull request?
rename of the import to the right component

#### Considerations taken when implementing this change?
while removing the FactChart component from core in https://github.com/theforeman/foreman/pull/9695,
I found this reference that should be renamed.

#### What are the testing steps for this pull request?
Check that the SystemStatuses is still rendered properly.
