### PR TITLE
Fixes #36328 - display short host name in Content Hosts page

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.routes.js
@@ -51,7 +51,7 @@ angular.module('Bastion.content-hosts').config(['$stateProvider', function ($sta
         controller: 'ContentHostDetailsInfoController',
         templateUrl: 'content-hosts/details/views/content-host-info.html',
         ncyBreadcrumb: {
-            label: "{{ host.name }}",
+            label: "{{ host.display_name }}",
             parent: 'content-hosts'
         }
     })

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-debs-actions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-debs-actions.html
@@ -1,4 +1,4 @@
-<span page-title ng-model="host">{{ 'Packages for: ' | translate }} {{ host.name }}</span>
+<span page-title ng-model="host">{{ 'Packages for: ' | translate }} {{ host.display_name }}</span>
 
 <section ng-hide="denied('edit_hosts', host)" bst-feature-flag="remote_actions">
   <h4 translate>Package Actions</h4>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-debs-applicable.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-debs-applicable.html
@@ -1,4 +1,4 @@
-<span page-title ng-model="host">{{ 'Deb Packages for: ' | translate }} {{ host.name }}</span>
+<span page-title ng-model="host">{{ 'Deb Packages for: ' | translate }} {{ host.display_name }}</span>
 
 <h3 translate>Applicable Deb Packages</h3>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-debs-installed.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-debs-installed.html
@@ -1,4 +1,4 @@
-<span page-title ng-model="host">{{ 'Packages for: ' | translate }} {{ host.name }}</span>
+<span page-title ng-model="host">{{ 'Packages for: ' | translate }} {{ host.display_name }}</span>
 
 <section ng-hide="denied('edit_hosts', host)" bst-feature-flag="remote_actions">
   <p bst-alert="info" ng-hide="remoteExecutionPresent">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -1,4 +1,4 @@
-<span page-title ng-model="host">{{ 'Errata for: ' | translate }} {{ host.name }}</span>
+<span page-title ng-model="host">{{ 'Errata for: ' | translate }} {{ host.display_name }}</span>
 
 <div bst-feature-flag="remote_actions">
   <h3 translate ng-hide="selectedErrataOption === 'current'">Applicable Errata</h3>
@@ -53,8 +53,8 @@
 
     <span data-block="list-actions" ng-hide="contentHost.readonly">
       <div bst-modal="applySelected()" model="host">
-        <div data-block="modal-header" translate>Apply Errata to Content Host "{{host.name}}"?</div>
-        <div data-block="modal-body" translate>Are you sure you want to apply Errata to content host "{{ host.name }}"?</div>
+        <div data-block="modal-header" translate>Apply Errata to Content Host "{{host.displayname}}"?</div>
+        <div data-block="modal-body" translate>Are you sure you want to apply Errata to content host "{{ host.displayname }}"?</div>
         <span data-block="modal-confirm-button">
           <button class="btn btn-primary" ng-click="ok()">
             <span translate>Apply</span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-module-streams.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-module-streams.html
@@ -1,4 +1,4 @@
-<span page-title ng-model="host">{{ 'Module Streams for: ' | translate }} {{ host.name }}</span>
+<span page-title ng-model="host">{{ 'Module Streams for: ' | translate }} {{ host.display_name }}</span>
 <div bst-feature-flag="remote_actions">
   <h3 translate ng-hide="selectedModuleStreamOption === 'available'">Available Module Streams</h3>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
@@ -1,4 +1,4 @@
-<span page-title ng-model="host">{{ 'Packages for: ' | translate }} {{ host.name }}</span>
+<span page-title ng-model="host">{{ 'Packages for: ' | translate }} {{ host.display_name }}</span>
 
 <section ng-hide="denied('edit_hosts', host)" bst-feature-flag="remote_actions">
   <h4 translate>Package Actions</h4>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
@@ -1,4 +1,4 @@
-<span page-title ng-model="host">{{ 'Packages for: ' | translate }} {{ host.name }}</span>
+<span page-title ng-model="host">{{ 'Packages for: ' | translate }} {{ host.display_name }}</span>
 
 <h3 translate>Applicable Packages</h3>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-installed.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-installed.html
@@ -1,4 +1,4 @@
-<span page-title ng-model="host">{{ 'Packages for: ' | translate }} {{ host.name }}</span>
+<span page-title ng-model="host">{{ 'Packages for: ' | translate }} {{ host.display_name }}</span>
 
 <h3 translate>Installed Packages</h3>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-traces.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-traces.html
@@ -1,4 +1,4 @@
-<span page-title ng-model="host">{{ 'Traces for: ' | translate }} {{ host.name }}</span>
+<span page-title ng-model="host">{{ 'Traces for: ' | translate }} {{ host.display_name }}</span>
 
 <div ng-hide="host.hasContent()">
   <div data-extend-template="common/views/registration.html"></div>
@@ -39,9 +39,9 @@
   <div data-extend-template="layouts/partials/table.html">
     <span data-block="list-actions" ng-hide="contentHost.readonly">
       <div bst-modal="performViaRemoteExecution(false)" model="host">
-        <div data-block="modal-header" translate>Restart Services on Content Host "{{host.name}}"?</div>
+        <div data-block="modal-header" translate>Restart Services on Content Host "{{host.displayname}}"?</div>
         <div data-block="modal-body">
-          <span translate>Are you sure you want to restart services on content host "{{ host.name }}"?</span>
+          <span translate>Are you sure you want to restart services on content host "{{ host.displayname }}"?</span>
           <span ng-show="host.rebootRequired()">
             <strong translate>Resolving the selected Traces will reboot this host.</strong>
           </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-add-host-collections.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-add-host-collections.controller.js
@@ -46,7 +46,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostAddHostCollection
 
             success = function (response) {
                 Notification.setSuccessMessage(translate('Added %x host collections to content host "%y".')
-                    .replace('%x', $scope.table.numSelected).replace('%y', host.name));
+                    .replace('%x', $scope.table.numSelected).replace('%y', host.display_name));
                 $scope.table.working = false;
                 $scope.table.selectAll(false);
                 nutupane.refresh();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-host-collections.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-host-collections.controller.js
@@ -45,7 +45,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostHostCollectionsCo
 
             success = function (response) {
                 var message = translate('Removed %x host collections from content host "%y".')
-                    .replace('%x', $scope.table.numSelected).replace('%y', host.name);
+                    .replace('%x', $scope.table.numSelected).replace('%y', host.display_name);
 
                 Notification.setSuccessMessage(message);
                 $scope.table.working = false;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
@@ -1,4 +1,4 @@
-<span page-title ng-model="host">{{ 'Add Subscriptions for Content Host:' | translate }} {{ host.name }}</span>
+<span page-title ng-model="host">{{ 'Add Subscriptions for Content Host:' | translate }} {{ host.display_name }}</span>
 
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
@@ -1,8 +1,8 @@
-<span page-title ng-model="host">{{ 'Content Host:' | translate }} {{ host.name }}</span>
+<span page-title ng-model="host">{{ 'Content Host:' | translate }} {{ host.display_name }}</span>
 
 <div data-extend-template="layouts/details-page-with-breadcrumbs.html">
   <header data-block="header" translate>
-    {{ host.name }}
+    {{ host.display_name }}
   </header>
 
   <nav data-block="item-actions">
@@ -15,7 +15,7 @@
 
     <div bst-modal="unregisterContentHost(host)" model="host">
       <div data-block="modal-header" translate>
-        Unregister Host "{{host.name}}"?
+        Unregister Host "{{host.display_name}}"?
       </div>
       <div data-block="modal-body">
         <p translate>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-host-collections.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-host-collections.html
@@ -1,4 +1,4 @@
-<span page-title ng-model="host">{{ 'Host Collections for:' | translate }} {{ host.name }}</span>
+<span page-title ng-model="host">{{ 'Host Collections for:' | translate }} {{ host.display_name }}</span>
 
 <h4 translate>Host Collection Management</h4>
 <nav>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -1,4 +1,4 @@
-<span page-title ng-model="host">{{ 'Content Host' | translate }} {{ host.name }}</span>
+<span page-title ng-model="host">{{ 'Content Host' | translate }} {{ host.display_name }}</span>
 
 <div ng-hide="host.hasSubscription()">
   <div data-extend-template="common/views/registration.html"></div>
@@ -79,7 +79,7 @@
 
         <dt ng-show="host.subscription_facet_attributes.virtual_host" translate>Virtual Host</dt>
         <dd ng-show="host.subscription_facet_attributes.virtual_host">
-          <a ui-sref="content-host.info({hostId: host.subscription_facet_attributes.virtual_host.id })">{{ host.subscription_facet_attributes.virtual_host.name }}</a>
+          <a ui-sref="content-host.info({hostId: host.subscription_facet_attributes.virtual_host.id })">{{ host.subscription_facet_attributes.virtual_host.display_name }}</a>
         </dd>
       </dl>
 
@@ -359,7 +359,7 @@
 
       <dl class="dl-horizontal dl-horizontal-left">
         <dt translate>Hostname</dt>
-        <dd>{{ host.name }}</dd>
+        <dd>{{ host.displayname }}</dd>
 
         <dt translate>IPv4 Address</dt>
         <dd>{{ host.facts["network::ipv4_address"] }}</dd>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-provisioning-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-provisioning-info.html
@@ -1,4 +1,4 @@
-<span page-title ng-model="host">{{ 'Content Host' | translate }} {{ host.name }}</span>
+<span page-title ng-model="host">{{ 'Content Host' | translate }} {{ host.display_name }}</span>
 
 <div data-extend-template="layouts/two-column-details.html">
   <div data-block="left-column">
@@ -8,7 +8,7 @@
       <dt translate>Name</dt>
       <dd>
         <a href="/hosts/{{ host.name }}">
-          {{ host.name }}
+          {{ host.display_name }}
         </a>
       </dd>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
@@ -1,4 +1,4 @@
-<span page-title ng-model="host">{{ 'Subscriptions for Content Host:' | translate }} {{ host.name }}</span>
+<span page-title ng-model="host">{{ 'Subscriptions for Content Host:' | translate }} {{ host.display_name }}</span>
 
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions.html
@@ -1,4 +1,4 @@
-<span page-title ng-model="host">{{ 'Subscriptions for: ' | translate }} {{ host.name }}</span>
+<span page-title ng-model="host">{{ 'Subscriptions for: ' | translate }} {{ host.display_name }}</span>
 
 <div ng-hide="host.hasSubscription()">
   <div data-extend-template="common/views/registration.html"></div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -104,9 +104,9 @@
             ng-controller="ContentHostStatusController">
           <td bst-table-cell>
             <span ng-switch="newHostDetailsUI">
-              <a ng-switch-when="true" ng-if="host.subscription_facet_attributes.uuid" ng-href="/new/hosts/{{host.name}}/content">{{ host.name }}</a>
-              <a ng-switch-when="true" ng-if="!host.subscription_facet_attributes.uuid" ng-href="/new/hosts/{{host.name}}">{{ host.name}}</a>
-              <a ng-switch-when="false" ui-sref="content-host.info({hostId: host.id})">{{ host.name }}</a>
+              <a ng-switch-when="true" ng-if="host.subscription_facet_attributes.uuid" ng-href="/new/hosts/{{host.name}}/content">{{ host.display_name }}</a>
+              <a ng-switch-when="true" ng-if="!host.subscription_facet_attributes.uuid" ng-href="/new/hosts/{{host.name}}">{{ host.display_name }}</a>
+              <a ng-switch-when="false" ui-sref="content-host.info({hostId: host.id})">{{ host.display_name }}</a>
             </span>
           </td>
           <td bst-table-cell ng-hide="simpleContentAccessEnabled">


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Display host's FQDN or short name based on setting `display_fqdn_for_hosts` in `Content Hosts` page.

#### Considerations taken when implementing this change?
Depends on https://github.com/theforeman/foreman/pull/9613

#### What are the testing steps for this pull request?
Make sure https://github.com/theforeman/foreman/pull/9613 is available in your testing environment.
Verify the host name displayed in `Content Hosts` page is based on setting `display_fqdn_for_hosts`