### PR TITLE
Fixes #36333 - Calculate needs_publish for composite content views

### DIFF
--- a/test/models/content_view_component_test.rb
+++ b/test/models/content_view_component_test.rb
@@ -218,5 +218,29 @@ module Katello
       refute component.valid?
       assert component.errors.full_messages.first =~ error_message
     end
+
+    def test_needs_publish
+      view1 = create(:katello_content_view)
+      view2 = create(:katello_content_view)
+      assert_equal @composite.needs_publish?, true
+      @composite.create_new_version
+      assert_equal @composite.reload.needs_publish?, false
+      version1 = create(:katello_content_view_version, :content_view => view1)
+      assert ContentViewComponent.create(:composite_content_view => @composite,
+                                         :content_view_version => version1, :latest => false)
+      assert_equal @composite.reload.needs_publish?, true
+      @composite.create_new_version
+      assert_equal @composite.reload.needs_publish?, false
+      create(:katello_content_view_version, :content_view => view2)
+      assert ContentViewComponent.create(:composite_content_view => @composite,
+                                         :content_view => view2, :latest => true)
+      assert_equal @composite.reload.needs_publish?, true
+      @composite.create_new_version
+      assert_equal @composite.reload.needs_publish?, false
+      create(:katello_content_view_version, :content_view => view2, :major => "1000")
+      assert_equal @composite.reload.needs_publish?, true
+      @composite.create_new_version
+      assert_equal @composite.reload.needs_publish?, false
+    end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Calculate needs_publish for composite content views
#### Considerations taken when implementing this change?
The reasons a composite content view (CCV) would need a publish are:
1. CCV has no published versions.
2. A component CV was added/removed to the CCV.
3. A component CV added with `Always update to latest version` set to true got a new version published.
4. A component CV was updated to edit version associated with CCV or set to update to latest when earlier CCV version was published with an older version.
#### What are the testing steps for this pull request?

Test the above paths that would need a publish on CCV and make sure the needs_publish returns the correct value for both Composite and component CVs.
