### PR TITLE
Fixes #36343 - Fix migration failure

### DIFF
--- a/db/migrate/20220110223754_update_disconnected_settings.rb
+++ b/db/migrate/20220110223754_update_disconnected_settings.rb
@@ -1,19 +1,23 @@
 class UpdateDisconnectedSettings < ActiveRecord::Migration[6.0]
+  class FakeSetting < Katello::Model
+    self.table_name = 'settings'
+  end
+
   def up
-    setting_disconnected = Setting.find_by(name: 'content_disconnected')
+    setting_disconnected = FakeSetting.find_by(name: 'content_disconnected')
     setting = Setting.find_by(name: 'subscription_connection_enabled')
 
     setting&.update!(
       value: !setting_disconnected&.value
     )
-    Setting.where(:name => 'content_disconnected').delete_all
+    FakeSetting.where(:name => 'content_disconnected').delete_all
   end
 
   def down
     remove_column :katello_cdn_configurations, :airgapped
     setting_disconnected = Setting.find_by(name: 'subscription_connection_enabled')
-    Setting.set('content_disconnected', N_("A server operating in disconnected mode does not communicate with the Red Hat CDN."),
-               !setting_disconnected.value, N_('Disconnected mode'))
+    FakeSetting.set('content_disconnected', N_("A server operating in disconnected mode does not communicate with the Red Hat CDN."),
+                    !setting_disconnected.value, N_('Disconnected mode'))
 
     Setting.where(:name => 'subscription_connection_enabled').delete_all
   end


### PR DESCRIPTION
This fixed a 'single-table inheritance mechanism failed' issue because Setting.find_by() tries to use the inheritance_column category and tries to access Setting::Content. The categories are no longer used in Katello 4.5 (and above).

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
