### PR TITLE
Fixes #36290 - Add docker image name to cvv compare

### DIFF
--- a/app/models/katello/docker_meta_tag.rb
+++ b/app/models/katello/docker_meta_tag.rb
@@ -31,6 +31,10 @@ module Katello
       repositories.first
     end
 
+    def upstream_name
+      repository.docker_upstream_name
+    end
+
     def self.search_by_repo_name(_key, operator, value)
       conditions = sanitize_sql_for_conditions(["#{Katello::RootRepository.table_name}.name #{operator} ?", value_to_sql(operator, value)])
       query = self.joins(:repositories => :root).where(conditions).select('id')

--- a/app/views/katello/api/v2/docker_tags/_base.json.rabl
+++ b/app/views/katello/api/v2/docker_tags/_base.json.rabl
@@ -22,6 +22,10 @@ child :repositories => :repositories do
   attributes :id, :name, :full_path
 end
 
+node :upstream_name do |item|
+  item.upstream_name
+end
+
 child :product => :product do
   attributes :id, :name
 end

--- a/test/models/docker_meta_tag_test.rb
+++ b/test/models/docker_meta_tag_test.rb
@@ -36,6 +36,12 @@ module Katello
       assert_equal 8, @tag_schema2.related_tags.count
     end
 
+    def test_upstream_name
+      tag = DockerMetaTag.create!(:name => @tag_schema2.name, :schema1 => @tag_schema2, :repositories => [@repo])
+
+      assert_equal tag.upstream_name, @repo.docker_upstream_name
+    end
+
     def test_with_uuid
       meta_one = DockerMetaTag.create!(:name => @tag_schema1.name, :schema1 => @tag_schema1, :repositories => [@repo])
       DockerMetaTag.create!(:name => @tag_schema2.name, :schema2 => @tag_schema2, :repositories => [@repo])

--- a/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareConfig.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareConfig.js
@@ -367,7 +367,14 @@ export default ({
             return __('Schema Version 2');
           },
         },
-        { title: __('Product Name'), getProperty: item => item?.product?.name },
+        {
+          title: __('Product'),
+          getProperty: item => (
+            <a href={urlBuilder(`products/${item?.product?.id}`, '')}>
+              {item?.product?.name}
+            </a>),
+        },
+        { title: __('Image'), getProperty: item => item?.upstream_name },
         { title: __(`Version ${versionOne}`), getProperty: item => compareContent(item, versionOneId) },
         { title: __(`Version ${versionTwo}`), getProperty: item => compareContent(item, versionTwoId) },
       ],

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
@@ -330,7 +330,14 @@ export default ({ cvId, versionId }) => [
           return __('Schema Version 2');
         },
       },
-      { title: __('Product Name'), getProperty: item => item?.product?.name },
+      {
+        title: __('Product'),
+        getProperty: item => (
+          <a href={urlBuilder(`products/${item?.product?.id}`, '')}>
+            {item?.product?.name}
+          </a>),
+      },
+      { title: __('Image'), getProperty: item => item?.upstream_name },
     ],
   },
   ...ContentConfig.map(({


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Added a new method to the `docker_meta_tag` model to pull the image name from the repo
* Added a unit test around the new model method
* Added the image name to the content view compare docker tags page
* Renamed `Product Name` to `Product` so it looked better in the table with the added image name
* Made Product link back to the actual product instead of it being just a label

#### Considerations taken when implementing this change?

* None

#### What are the testing steps for this pull request?
1. Create a product, create two or more different docker repositories, choose various tags in 'Include tags' (e.g. "latest, stable"), sync repositories
2. Create a Content view, add repositories created in previous step, publish two Content view versions
3. Compare the two Content view versions and go to "Container tags"
4. Verify that you can see the image name and that product is a link now.