### PR TITLE
Fixes #36334 - Delete orphaned content units after indexing and improve missing content units error on Pulp 3 copy

### DIFF
--- a/app/lib/actions/katello/content_view/update.rb
+++ b/app/lib/actions/katello/content_view/update.rb
@@ -4,6 +4,30 @@ module Actions
       class Update < Actions::EntryAction
         def plan(content_view, content_view_params)
           action_subject content_view
+          content_view_params = content_view_params.with_indifferent_access
+
+          # If we are removing repositories, remove their filter rules
+          if content_view.filters.present? && content_view.repository_ids.present? && content_view_params.has_key?(:repository_ids)
+            repo_ids_to_remove = content_view.repository_ids - content_view_params[:repository_ids]
+            if repo_ids_to_remove.present?
+              # Only yum-type repositories have by-ID filter rules
+              old_repos = content_view.repositories.yum_type
+              new_repos = ::Katello::Repository.where(id: content_view_params[:repository_ids]).yum_type
+
+              lost_module_stream_ids = (::Katello::ModuleStream.in_repositories(old_repos) -
+                ::Katello::ModuleStream.in_repositories(new_repos)).pluck(:id)
+              ::Katello::ContentViewModuleStreamFilterRule.in_content_views([content_view.id]).where(module_stream_id: lost_module_stream_ids).delete_all
+
+              lost_errata_ids = (::Katello::Erratum.in_repositories(old_repos) -
+                ::Katello::Erratum.in_repositories(new_repos)).pluck(:errata_id)
+              ::Katello::ContentViewErratumFilterRule.in_content_views([content_view.id]).where(errata_id: lost_errata_ids).delete_all
+
+              lost_package_group_hrefs = (::Katello::PackageGroup.in_repositories(old_repos) -
+                ::Katello::PackageGroup.in_repositories(new_repos)).pluck(:pulp_id)
+              ::Katello::ContentViewPackageGroupFilterRule.in_content_views([content_view.id]).where(uuid: lost_package_group_hrefs).delete_all
+            end
+          end
+
           content_view.update!(content_view_params)
         end
       end

--- a/app/lib/actions/katello/content_view/update.rb
+++ b/app/lib/actions/katello/content_view/update.rb
@@ -7,7 +7,7 @@ module Actions
           content_view_params = content_view_params.with_indifferent_access
 
           # If we are removing repositories, remove their filter rules
-          if content_view.filters.present? && content_view.repository_ids.present? && content_view_params.has_key?(:repository_ids)
+          if content_view.filters.present? && content_view.repository_ids.present? && content_view_params.key?(:repository_ids)
             repo_ids_to_remove = content_view.repository_ids - content_view_params[:repository_ids]
             if repo_ids_to_remove.present?
               # Only yum-type repositories have by-ID filter rules

--- a/app/models/katello/concerns/pulp_database_unit.rb
+++ b/app/models/katello/concerns/pulp_database_unit.rb
@@ -167,6 +167,14 @@ module Katello
         where("#{self.table_name}.id in (?) or #{self.table_name}.pulp_id in (?)", id_integers, ids)
       end
 
+      def orphaned
+        if many_repository_associations
+          where.not(:id => repository_association_class.where(:repository_id => ::Katello::Repository.all).select(unit_id_field))
+        else
+          where.not(:repository_id => ::Katello::Repository.all)
+        end
+      end
+
       def in_repositories(repos)
         if many_repository_associations
           where(:id => repository_association_class.where(:repository_id => repos).select(unit_id_field))

--- a/app/models/katello/content_view_erratum_filter_rule.rb
+++ b/app/models/katello/content_view_erratum_filter_rule.rb
@@ -26,6 +26,11 @@ module Katello
         :message => (_("must be one of the following: %s") % DATE_TYPES.join(', '))
       }
 
+    def self.in_content_views(content_view_ids)
+      joins('INNER JOIN katello_content_view_filters ON katello_content_view_erratum_filter_rules.content_view_filter_id = katello_content_view_filters.id').
+        where("katello_content_view_filters.content_view_id IN (#{content_view_ids.join(',')})")
+    end
+
     def filter_has_date_or_type_rule?
       filter.erratum_rules.any? { |rule| rule.start_date || rule.end_date || !rule.types.blank? }
     end

--- a/app/models/katello/content_view_module_stream_filter_rule.rb
+++ b/app/models/katello/content_view_module_stream_filter_rule.rb
@@ -7,5 +7,10 @@ module Katello
                :foreign_key => :content_view_filter_id
     belongs_to :module_stream, :class_name => "Katello::ModuleStream", :inverse_of => :rules
     validates :module_stream_id, :presence => true, :uniqueness => { :scope => :content_view_filter_id }
+
+    def self.in_content_views(content_view_ids)
+      joins('INNER JOIN katello_content_view_filters ON katello_content_view_module_stream_filter_rules.content_view_filter_id = katello_content_view_filters.id').
+        where("katello_content_view_filters.content_view_id IN (#{content_view_ids.join(',')})")
+    end
   end
 end

--- a/app/models/katello/content_view_package_group_filter_rule.rb
+++ b/app/models/katello/content_view_package_group_filter_rule.rb
@@ -8,5 +8,10 @@ module Katello
                :foreign_key => :content_view_filter_id
 
     validates :uuid, :presence => true, :uniqueness => { :scope => :content_view_filter_id }
+
+    def self.in_content_views(content_view_ids)
+      joins('INNER JOIN katello_content_view_filters ON katello_content_view_package_group_filter_rules.content_view_filter_id = katello_content_view_filters.id').
+        where("katello_content_view_filters.content_view_id IN (#{content_view_ids.join(',')})")
+    end
   end
 end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -935,6 +935,7 @@ module Katello
         repository_type.content_types_to_index.each do |type|
           Katello::Logging.time("CONTENT_INDEX", data: {type: type.model_class}) do
             Katello::ContentUnitIndexer.new(content_type: type, repository: self, optimized: !full_index).import_all
+            type.model_class.orphaned.destroy_all
           end
         end
         repository_type.index_additional_data_proc&.call(self)

--- a/app/services/katello/content_unit_indexer.rb
+++ b/app/services/katello/content_unit_indexer.rb
@@ -154,6 +154,7 @@ module Katello
 
     def clean_filter_rules(repo_associations_to_destroy)
       affected_content_view_ids = @repository.content_views.non_default.pluck(:id)
+      return false if affected_content_view_ids.empty?
       case @model_class.to_s
       when 'Katello::ModuleStream'
         module_stream_ids = repo_associations_to_destroy.pluck(:module_stream_id)

--- a/app/services/katello/content_unit_indexer.rb
+++ b/app/services/katello/content_unit_indexer.rb
@@ -159,20 +159,16 @@ module Katello
       when 'Katello::ModuleStream'
         module_stream_ids = repo_associations_to_destroy.pluck(:module_stream_id)
         filter_rules = ::Katello::ContentViewModuleStreamFilterRule.
-          joins('INNER JOIN katello_content_view_filters ON katello_content_view_module_stream_filter_rules.content_view_filter_id = katello_content_view_filters.id').
-          where("katello_content_view_filters.content_view_id IN (#{affected_content_view_ids.join(',')})").where(module_stream_id: module_stream_ids)
+          in_content_views(affected_content_view_ids).where(module_stream_id: module_stream_ids)
         filter_rules.delete_all
       when 'Katello::Erratum'
         errata_ids = ::Katello::Erratum.where(id: repo_associations_to_destroy.select(:erratum_id)).pluck(:errata_id)
-        filter_rules = ::Katello::ContentViewErratumFilterRule.
-          joins('INNER JOIN katello_content_view_filters ON katello_content_view_erratum_filter_rules.content_view_filter_id = katello_content_view_filters.id').
-          where("katello_content_view_filters.content_view_id IN (#{affected_content_view_ids.join(',')})").where(errata_id: errata_ids)
+        filter_rules = ::Katello::ContentViewErratumFilterRule.in_content_views(affected_content_view_ids).where(errata_id: errata_ids)
         filter_rules.delete_all
       when 'Katello::PackageGroup'
         package_group_uuids = ::Katello::PackageGroup.where(id: repo_associations_to_destroy.select(:package_group_id)).pluck(:pulp_id)
         filter_rules = ::Katello::ContentViewPackageGroupFilterRule.
-          joins('INNER JOIN katello_content_view_filters ON katello_content_view_package_group_filter_rules.content_view_filter_id = katello_content_view_filters.id').
-          where("katello_content_view_filters.content_view_id IN (#{affected_content_view_ids.join(',')})").where(uuid: package_group_uuids)
+          in_content_views(affected_content_view_ids).where(uuid: package_group_uuids)
         filter_rules.delete_all
       else
         return false

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -493,11 +493,26 @@ module Katello
         else
           api.repositories_api.modify(repository_reference.repository_href, add_content_units: content_unit_href)
         end
+      rescue api.client_module::ApiError => e
+        if e.message.include? 'Could not find the following content units'
+          raise ::Katello::Errors::Pulp3Error.new "Content units that do not exist in Pulp were requested to be copied."\
+            " Please run a complete sync on the following repository: #{repository_reference.root_repository.name}. Original error: #{e.message}"
+        else
+          raise e
+        end
       end
 
       def add_content_for_repo(repository_href, content_unit_href)
         content_unit_href = [content_unit_href] unless content_unit_href.is_a?(Array)
         api.repositories_api.modify(repository_href, add_content_units: content_unit_href)
+      rescue api.client_module::ApiError => e
+        if e.message.include? 'Could not find the following content units'
+          raise ::Katello::Errors::Pulp3Error.new "Content units that do not exist in Pulp were requested to be copied."\
+            " Please run a complete sync on the following repository:"\
+            " #{::Katello::Pulp3::RepositoryReference.find_by(repository_href: repository_href).root_repository.name}. Original error: #{e.message}"
+        else
+          raise e
+        end
       end
 
       def unit_keys(uploads)

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -495,7 +495,7 @@ module Katello
         end
       rescue api.client_module::ApiError => e
         if e.message.include? 'Could not find the following content units'
-          raise ::Katello::Errors::Pulp3Error.new "Content units that do not exist in Pulp were requested to be copied."\
+          raise ::Katello::Errors::Pulp3Error, "Content units that do not exist in Pulp were requested to be copied."\
             " Please run a complete sync on the following repository: #{repository_reference.root_repository.name}. Original error: #{e.message}"
         else
           raise e
@@ -507,7 +507,7 @@ module Katello
         api.repositories_api.modify(repository_href, add_content_units: content_unit_href)
       rescue api.client_module::ApiError => e
         if e.message.include? 'Could not find the following content units'
-          raise ::Katello::Errors::Pulp3Error.new "Content units that do not exist in Pulp were requested to be copied."\
+          raise ::Katello::Errors::Pulp3Error, "Content units that do not exist in Pulp were requested to be copied."\
             " Please run a complete sync on the following repository:"\
             " #{::Katello::Pulp3::RepositoryReference.find_by(repository_href: repository_href).root_repository.name}. Original error: #{e.message}"
         else

--- a/app/services/katello/pulp3/repository/docker.rb
+++ b/app/services/katello/pulp3/repository/docker.rb
@@ -67,6 +67,13 @@ module Katello
         def add_content(content_unit_href)
           content_unit_href = [content_unit_href] unless content_unit_href.is_a?(Array)
           api.repositories_api.add(repository_reference.repository_href, content_units: content_unit_href)
+        rescue api.client_module::ApiError => e
+          if e.message.include? 'Could not find the following content units'
+            raise ::Katello::Errors::Pulp3Error.new "Content units that do not exist in Pulp were requested to be copied."\
+              " Please run a complete sync on the following repository: #{repository_reference.root_repository.name}. Original error: #{e.message}"
+          else
+            raise e
+          end
         end
 
         def copy_units_recursively(unit_hrefs, clear_repo = false)

--- a/app/services/katello/pulp3/repository/docker.rb
+++ b/app/services/katello/pulp3/repository/docker.rb
@@ -69,7 +69,7 @@ module Katello
           api.repositories_api.add(repository_reference.repository_href, content_units: content_unit_href)
         rescue api.client_module::ApiError => e
           if e.message.include? 'Could not find the following content units'
-            raise ::Katello::Errors::Pulp3Error.new "Content units that do not exist in Pulp were requested to be copied."\
+            raise ::Katello::Errors::Pulp3Error, "Content units that do not exist in Pulp were requested to be copied."\
               " Please run a complete sync on the following repository: #{repository_reference.root_repository.name}. Original error: #{e.message}"
           else
             raise e

--- a/lib/katello/tasks/upgrades/4.9/clean_orphaned_filter_rules.rake
+++ b/lib/katello/tasks/upgrades/4.9/clean_orphaned_filter_rules.rake
@@ -12,7 +12,7 @@ namespace :katello do
           content_view = rule.filter.content_view
           unless ::Katello::ModuleStream.in_repositories(content_view.repositories)&.pluck(:id)&.include?(rule.module_stream_id)
             rule.delete
-            module_stream_count+=1
+            module_stream_count += 1
           end
         end
         puts "#{module_stream_count} orphaned content view module stream filter rules were deleted."
@@ -21,7 +21,7 @@ namespace :katello do
           content_view = rule.filter.content_view
           unless ::Katello::Erratum.in_repositories(content_view.repositories)&.pluck(:errata_id)&.include?(rule.errata_id)
             rule.delete
-            erratum_count+=1
+            erratum_count += 1
           end
         end
         puts "#{erratum_count} orphaned content view erratum filter rules were deleted."
@@ -30,7 +30,7 @@ namespace :katello do
           content_view = rule.filter.content_view
           unless ::Katello::PackageGroup.in_repositories(content_view.repositories)&.pluck(:pulp_id)&.include?(rule.uuid)
             rule.delete
-            package_group_count+=1
+            package_group_count += 1
           end
         end
         puts "#{package_group_count} orphaned content view package group filter rules were deleted."

--- a/lib/katello/tasks/upgrades/4.9/clean_orphaned_filter_rules.rake
+++ b/lib/katello/tasks/upgrades/4.9/clean_orphaned_filter_rules.rake
@@ -1,0 +1,40 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '4.9' do
+      desc "Clean orphaned filter rules that cause Pulp copy errors during content view publishing"
+      task :clean_orphaned_filter_rules => ['environment'] do
+        module_stream_count = 0
+        erratum_count = 0
+        package_group_count = 0
+
+        ::Katello::ContentViewModuleStreamFilterRule.all.each do |rule|
+          # Delete if rule exists in a CV that does not have the matching module stream in its repositories
+          content_view = rule.filter.content_view
+          unless ::Katello::ModuleStream.in_repositories(content_view.repositories)&.pluck(:id)&.include?(rule.module_stream_id)
+            rule.delete
+            module_stream_count+=1
+          end
+        end
+        puts "#{module_stream_count} orphaned content view module stream filter rules were deleted."
+
+        ::Katello::ContentViewErratumFilterRule.all.each do |rule|
+          content_view = rule.filter.content_view
+          unless ::Katello::Erratum.in_repositories(content_view.repositories)&.pluck(:errata_id)&.include?(rule.errata_id)
+            rule.delete
+            erratum_count+=1
+          end
+        end
+        puts "#{erratum_count} orphaned content view erratum filter rules were deleted."
+
+        ::Katello::ContentViewPackageGroupFilterRule.all.each do |rule|
+          content_view = rule.filter.content_view
+          unless ::Katello::PackageGroup.in_repositories(content_view.repositories)&.pluck(:pulp_id)&.include?(rule.uuid)
+            rule.delete
+            package_group_count+=1
+          end
+        end
+        puts "#{package_group_count} orphaned content view package group filter rules were deleted."
+      end
+    end
+  end
+end

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -346,7 +346,6 @@ module ::Actions::Katello::ContentView
     end
 
     it 'deletes old filter rules' do
-
       content_view.repositories << repository
       module_stream = katello_module_streams(:river)
       erratum = repository.errata.find_by(pulp_id: 'partylikeits1999')

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/docker_tag/copy_units_rewrites_missing_content_error.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/docker_tag/copy_units_rewrites_missing_content_error.yml
@@ -1,0 +1,903 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.14.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:15:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '589'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - fd85430fe7344cf099db23030d37fad1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        Y29udGFpbmVyL2NvbnRhaW5lci83YzA0NGIxMC1hMzJmLTQxM2YtYmMxYS0w
+        MjlkYWI1OTM2ZTUvIiwicHVscF9jcmVhdGVkIjoiMjAyMy0wNS0wMlQyMDox
+        NToxMy4zNDcxNDRaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci83YzA0NGIxMC1hMzJm
+        LTQxM2YtYmMxYS0wMjlkYWI1OTM2ZTUvdmVyc2lvbnMvIiwicHVscF9sYWJl
+        bHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9jb250YWluZXIvY29udGFpbmVyLzdjMDQ0YjEwLWEzMmYt
+        NDEzZi1iYzFhLTAyOWRhYjU5MzZlNS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJE
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwi
+        ZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxs
+        LCJyZW1vdGUiOm51bGwsIm1hbmlmZXN0X3NpZ25pbmdfc2VydmljZSI6bnVs
+        bH1dfQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:15:45 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/7c044b10-a32f-413f-bc1a-029dab5936e5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.14.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:15:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 21a339ff20e148c79df1ddcdc6092166
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA0ZjVlNTFmLWM1NGEtNDA1
+        OS05YThmLWY3OTI0NjllNzEzNi8ifQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:15:45 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.14.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:15:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '913'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6379c6e1d9ca408a91facb61de91dc34
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2NvbnRh
+        aW5lci9jb250YWluZXIvYzVmNTQ3NDctMzA4OS00ZDcxLWE1MTgtODZkZjYz
+        MjJhNzk5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjMtMDUtMDJUMjA6MTU6MTMu
+        MTUzNDUxWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0
+        LXB1bHAzX0RvY2tlcl8xIiwidXJsIjoiaHR0cHM6Ly9yZWdpc3RyeS0xLmRv
+        Y2tlci5pby8iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwi
+        dGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwicHVscF9s
+        YWJlbHMiOnt9LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjMtMDUtMDJUMjA6
+        MTU6MTMuMTUzNDY3WiIsImRvd25sb2FkX2NvbmN1cnJlbmN5IjpudWxsLCJt
+        YXhfcmV0cmllcyI6bnVsbCwicG9saWN5IjoiaW1tZWRpYXRlIiwidG90YWxf
+        dGltZW91dCI6MzYwMC4wLCJjb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tf
+        Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX3JlYWRfdGltZW91dCI6MzYw
+        MC4wLCJoZWFkZXJzIjpudWxsLCJyYXRlX2xpbWl0IjowLCJoaWRkZW5fZmll
+        bGRzIjpbeyJuYW1lIjoiY2xpZW50X2tleSIsImlzX3NldCI6ZmFsc2V9LHsi
+        bmFtZSI6InByb3h5X3VzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1l
+        IjoicHJveHlfcGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJ1
+        c2VybmFtZSIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InBhc3N3b3JkIiwi
+        aXNfc2V0IjpmYWxzZX1dLCJ1cHN0cmVhbV9uYW1lIjoiZmVkb3JhL3NzaCIs
+        ImluY2x1ZGVfdGFncyI6bnVsbCwiZXhjbHVkZV90YWdzIjpudWxsLCJzaWdz
+        dG9yZSI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:15:45 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/c5f54747-3089-4d71-a518-86df6322a799/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.14.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:15:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - c81965d8c2f84de2b1e244205c33e148
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJhNjAzMzhiLTdmYTktNDVh
+        ZC04ZWQ4LTk1MjE2MjAxNTc1NS8ifQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:15:45 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/tasks/04f5e51f-c54a-4059-9a8f-f792469e7136/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.22.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:15:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '619'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - cbbb016a03dd42309fd92b9ffa2f9c6a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDRmNWU1MWYtYzU0
+        YS00MDU5LTlhOGYtZjc5MjQ2OWU3MTM2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjMtMDUtMDJUMjA6MTU6NDUuNzE3MjM3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIyMWEzMzlmZjIwZTE0OGM3OWRmMWRkY2Rj
+        NjA5MjE2NiIsInN0YXJ0ZWRfYXQiOiIyMDIzLTA1LTAyVDIwOjE1OjQ1Ljc4
+        NzQ0MloiLCJmaW5pc2hlZF9hdCI6IjIwMjMtMDUtMDJUMjA6MTU6NDUuODQ1
+        MTcyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy83YTE0NDNhZS0zMGZlLTQ1ZTUtYjQ0Ny04YWIyZDM4ODZjMjQvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvN2MwNDRi
+        MTAtYTMyZi00MTNmLWJjMWEtMDI5ZGFiNTkzNmU1LyJdfQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:15:46 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/tasks/2a60338b-7fa9-45ad-8ed8-952162015755/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.22.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:15:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '614'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 382aaf3fee2948138068a863fe6584de
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMmE2MDMzOGItN2Zh
+        OS00NWFkLThlZDgtOTUyMTYyMDE1NzU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjMtMDUtMDJUMjA6MTU6NDUuOTE4ODMwWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiJjODE5NjVkOGMyZjg0ZGUyYjFlMjQ0MjA1
+        YzMzZTE0OCIsInN0YXJ0ZWRfYXQiOiIyMDIzLTA1LTAyVDIwOjE1OjQ1Ljk2
+        Njc2NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjMtMDUtMDJUMjA6MTU6NDYuMDAy
+        OTIwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy83ZTk1ZjY2Yy03OWJmLTQ0MWQtODYzNC0yNWU5M2ZjMGExYzkvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9jb250YWluZXIvY29udGFpbmVyL2M1ZjU0NzQ3LTMw
+        ODktNGQ3MS1hNTE4LTg2ZGY2MzIyYTc5OS8iXX0=
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:15:46 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.14.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:15:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7d1f9e06195340889d23276293497a71
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:15:46 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.14.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:15:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ff409c09a89d4073ab245bbe01eff4ab
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:15:46 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.14.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:15:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 02c8b604d7c94eba9428170a425e53fe
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:15:46 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.14.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:15:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 872480445960434699130b54bedd869f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:15:46 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.14.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:15:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4e7ac49f14ba49088f977bea0ea61561
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:15:46 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/container/container/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.14.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:15:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - e77c1fe79a7d405b9e4805471982e4b6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:15:46 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/container/container/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2NrZXIuaW8v
+        IiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsImNsaWVudF9r
+        ZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51
+        bGwsInByb3h5X3VzZXJuYW1lIjpudWxsLCJwcm94eV9wYXNzd29yZCI6bnVs
+        bCwidXNlcm5hbWUiOm51bGwsInBhc3N3b3JkIjpudWxsLCJwb2xpY3kiOiJp
+        bW1lZGlhdGUiLCJ0b3RhbF90aW1lb3V0IjozNjAwLCJjb25uZWN0X3RpbWVv
+        dXQiOjYwLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6NjAsInNvY2tfcmVhZF90
+        aW1lb3V0IjozNjAwLCJyYXRlX2xpbWl0IjowLCJ1cHN0cmVhbV9uYW1lIjoi
+        ZmVkb3JhL3NzaCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.14.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:15:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/container/container/2a16ce81-f8b9-4dea-8114-0e44ba333252/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '861'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - ab0f56d5b7e945038d9fb1a14c6be4b7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9jb250YWluZXIv
+        Y29udGFpbmVyLzJhMTZjZTgxLWY4YjktNGRlYS04MTE0LTBlNDRiYTMzMzI1
+        Mi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDIzLTA1LTAyVDIwOjE1OjQ2LjcyNTcx
+        NloiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxw
+        M19Eb2NrZXJfMSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2NrZXIu
+        aW8vIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192
+        YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxz
+        Ijp7fSwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDIzLTA1LTAyVDIwOjE1OjQ2
+        LjcyNTczNFoiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3Jl
+        dHJpZXMiOm51bGwsInBvbGljeSI6ImltbWVkaWF0ZSIsInRvdGFsX3RpbWVv
+        dXQiOjM2MDAuMCwiY29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5l
+        Y3RfdGltZW91dCI6NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2MDAuMCwi
+        aGVhZGVycyI6bnVsbCwicmF0ZV9saW1pdCI6MCwiaGlkZGVuX2ZpZWxkcyI6
+        W3sibmFtZSI6ImNsaWVudF9rZXkiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUi
+        OiJwcm94eV91c2VybmFtZSIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InBy
+        b3h5X3Bhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoidXNlcm5h
+        bWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwYXNzd29yZCIsImlzX3Nl
+        dCI6ZmFsc2V9XSwidXBzdHJlYW1fbmFtZSI6ImZlZG9yYS9zc2giLCJpbmNs
+        dWRlX3RhZ3MiOm51bGwsImV4Y2x1ZGVfdGFncyI6bnVsbCwic2lnc3RvcmUi
+        Om51bGx9
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:15:46 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.14.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:15:46 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/container/container/4bafdca7-bfe0-4738-aa0d-cbffa24db486/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '537'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4210a39428a34a21a8a6da5bd0ba7dcb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NvbnRh
+        aW5lci9jb250YWluZXIvNGJhZmRjYTctYmZlMC00NzM4LWFhMGQtY2JmZmEy
+        NGRiNDg2LyIsInB1bHBfY3JlYXRlZCI6IjIwMjMtMDUtMDJUMjA6MTU6NDYu
+        OTY0NDMxWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2NvbnRhaW5lci9jb250YWluZXIvNGJhZmRjYTctYmZlMC00NzM4
+        LWFhMGQtY2JmZmEyNGRiNDg2L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7
+        fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvY29udGFpbmVyL2NvbnRhaW5lci80YmFmZGNhNy1iZmUwLTQ3Mzgt
+        YWEwZC1jYmZmYTI0ZGI0ODYvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGVmYXVs
+        dF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsImRlc2Ny
+        aXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVt
+        b3RlIjpudWxsLCJtYW5pZmVzdF9zaWduaW5nX3NlcnZpY2UiOm51bGx9
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:15:46 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/container/container/4bafdca7-bfe0-4738-aa0d-cbffa24db486/add/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb250ZW50X3VuaXRzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        Y29udGFpbmVyL2NvbnRhaW5lci9hYWFhYWFhYS1hYWFhLWFhYWEtYWFhYS1h
+        YWFhYWFhYWFhYWEvIl19
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.14.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:15:47 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '135'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 653ff66bef10431b9bd210694254f27f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      base64_string: |
+        WyJDb3VsZCBub3QgZmluZCB0aGUgZm9sbG93aW5nIGNvbnRlbnQgdW5pdHM6
+        IFsnL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jb250YWluZXIvY29udGFp
+        bmVyL2FhYWFhYWFhLWFhYWEtYWFhYS1hYWFhLWFhYWFhYWFhYWFhYS8nXSJd
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:15:47 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/repository/yum/copy_units_rewrites_missing_content_error.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/repository/yum/copy_units_rewrites_missing_content_error.yml
@@ -1,0 +1,793 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/?name=Fedora_17
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.19.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:11:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '681'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5a62cfeb923249b092221463c936ed45
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9kNThmZDY4MC0yMzc1LTRiMjItYWY2Ny0wYzA2NGEzNjc0ZDUv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMy0wNS0wMlQyMDoxMDoyMC44NzIxODla
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        cnBtL3JwbS9kNThmZDY4MC0yMzc1LTRiMjItYWY2Ny0wYzA2NGEzNjc0ZDUv
+        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2Q1OGZk
+        NjgwLTIzNzUtNGIyMi1hZjY3LTBjMDY0YTM2NzRkNS92ZXJzaW9ucy8wLyIs
+        Im5hbWUiOiJGZWRvcmFfMTciLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWlu
+        X3JlcG9fdmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxp
+        c2giOmZhbHNlLCJtZXRhZGF0YV9zaWduaW5nX3NlcnZpY2UiOm51bGwsInJl
+        dGFpbl9wYWNrYWdlX3ZlcnNpb25zIjowLCJtZXRhZGF0YV9jaGVja3N1bV90
+        eXBlIjpudWxsLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOm51bGwsImdwZ2No
+        ZWNrIjowLCJyZXBvX2dwZ2NoZWNrIjowLCJzcWxpdGVfbWV0YWRhdGEiOmZh
+        bHNlfV19
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:11:38 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/d58fd680-2375-4b22-af67-0c064a3674d5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.19.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:11:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 50621f12766140d59c3ea84e23118063
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY3NDMyYjJmLWU4N2ItNDA1
+        NS05ZWY3LWUzNmMxNDdjYmRlNy8ifQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:11:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/?name=Fedora_17
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.19.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:11:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '793'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8a318db07c554b5bb6e803a93391b3ef
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
+        cG0vMTYzZWYxMWUtMWNjZC00MmY3LWFmOTAtZDUwMDVhYTRkZWM2LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjMtMDUtMDJUMjA6MTA6MjAuNjc3Mjc2WiIsIm5h
+        bWUiOiJGZWRvcmFfMTciLCJ1cmwiOiJodHRwOi8vbXlyZXBvLmNvbSIsImNh
+        X2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlv
+        biI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVscyI6e30sInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyMy0wNS0wMlQyMDoxMDoyMC42NzcyOTVa
+        IiwiZG93bmxvYWRfY29uY3VycmVuY3kiOm51bGwsIm1heF9yZXRyaWVzIjpu
+        dWxsLCJwb2xpY3kiOiJvbl9kZW1hbmQiLCJ0b3RhbF90aW1lb3V0IjozNjAw
+        LjAsImNvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19jb25uZWN0X3RpbWVv
+        dXQiOjYwLjAsInNvY2tfcmVhZF90aW1lb3V0IjozNjAwLjAsImhlYWRlcnMi
+        Om51bGwsInJhdGVfbGltaXQiOjAsImhpZGRlbl9maWVsZHMiOlt7Im5hbWUi
+        OiJjbGllbnRfa2V5IiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicHJveHlf
+        dXNlcm5hbWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwcm94eV9wYXNz
+        d29yZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InVzZXJuYW1lIiwiaXNf
+        c2V0IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQiLCJpc19zZXQiOmZhbHNl
+        fV0sInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:11:38 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/163ef11e-1ccd-42f7-af90-d5005aa4dec6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.19.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:11:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8c9c51f75a2f44858f30d5f504965ffe
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRhODZlZWVjLWY4NGItNDg2
+        Yi1iZjBkLWQyZmUzZDE2YmE3My8ifQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:11:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/tasks/67432b2f-e87b-4055-9ef7-e36c147cbde7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.22.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:11:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '607'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 169759ca85ed4826b1904084652176f3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNjc0MzJiMmYtZTg3
+        Yi00MDU1LTllZjctZTM2YzE0N2NiZGU3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjMtMDUtMDJUMjA6MTE6MzguNTQyODg2WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI1MDYyMWYxMjc2NjE0MGQ1OWMzZWE4NGUy
+        MzExODA2MyIsInN0YXJ0ZWRfYXQiOiIyMDIzLTA1LTAyVDIwOjExOjM4LjU5
+        OTgyOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjMtMDUtMDJUMjA6MTE6MzguNjU1
+        NzE0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy83OGM4MmY1My1jMDAwLTQ4MjItODg1OS0xZjBlYmEwMmFkZGUvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vZDU4ZmQ2ODAtMjM3NS00YjIy
+        LWFmNjctMGMwNjRhMzY3NGQ1LyJdfQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:11:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/tasks/4a86eeec-f84b-486b-bf0d-d2fe3d16ba73/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.22.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:11:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '602'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 72730a296d4943b3a8cdd88cf937c0cb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNGE4NmVlZWMtZjg0
+        Yi00ODZiLWJmMGQtZDJmZTNkMTZiYTczLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjMtMDUtMDJUMjA6MTE6MzguNjczNDcxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI4YzljNTFmNzVhMmY0NDg1OGYzMGQ1ZjUw
+        NDk2NWZmZSIsInN0YXJ0ZWRfYXQiOiIyMDIzLTA1LTAyVDIwOjExOjM4Ljcx
+        MjgwN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjMtMDUtMDJUMjA6MTE6MzguNzU3
+        NzAyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy84ZTBkZTVmNS1hMTU2LTRiYjUtOGM1YS1kYzhlMDMzZjQxMjYvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzE2M2VmMTFlLTFjY2QtNDJmNy1hZjkw
+        LWQ1MDA1YWE0ZGVjNi8iXX0=
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:11:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?name=Fedora_17
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.19.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:11:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2d74167ff7384bcca12b7b0ad4dc27d2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:11:38 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/library/fedora_17_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.19.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:11:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5af96a26159b4db28e44767509cb7600
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:11:38 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRmVkb3JhXzE3IiwidXJsIjoiaHR0cDovL215cmVwby5jb20i
+        LCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwiY2xpZW50X2tl
+        eSI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVs
+        bCwicHJveHlfdXNlcm5hbWUiOm51bGwsInByb3h5X3Bhc3N3b3JkIjpudWxs
+        LCJ1c2VybmFtZSI6bnVsbCwicGFzc3dvcmQiOm51bGwsInBvbGljeSI6Im9u
+        X2RlbWFuZCIsInRvdGFsX3RpbWVvdXQiOjM2MDAsImNvbm5lY3RfdGltZW91
+        dCI6NjAsInNvY2tfY29ubmVjdF90aW1lb3V0Ijo2MCwic29ja19yZWFkX3Rp
+        bWVvdXQiOjM2MDAsInJhdGVfbGltaXQiOjB9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.19.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:11:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/rpm/rpm/306b43a5-6448-4f64-a173-8382b0a9dfa1/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '741'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - d35cd33268554d25b9eff89ab7696649
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzMw
+        NmI0M2E1LTY0NDgtNGY2NC1hMTczLTgzODJiMGE5ZGZhMS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDIzLTA1LTAyVDIwOjExOjM5LjExNDcyMVoiLCJuYW1lIjoi
+        RmVkb3JhXzE3IiwidXJsIjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0
+        IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRy
+        dWUsInByb3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMiOnt9LCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjMtMDUtMDJUMjA6MTE6MzkuMTE0NzQxWiIsImRv
+        d25sb2FkX2NvbmN1cnJlbmN5IjpudWxsLCJtYXhfcmV0cmllcyI6bnVsbCwi
+        cG9saWN5Ijoib25fZGVtYW5kIiwidG90YWxfdGltZW91dCI6MzYwMC4wLCJj
+        b25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfY29ubmVjdF90aW1lb3V0Ijo2
+        MC4wLCJzb2NrX3JlYWRfdGltZW91dCI6MzYwMC4wLCJoZWFkZXJzIjpudWxs
+        LCJyYXRlX2xpbWl0IjowLCJoaWRkZW5fZmllbGRzIjpbeyJuYW1lIjoiY2xp
+        ZW50X2tleSIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InByb3h5X3VzZXJu
+        YW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicHJveHlfcGFzc3dvcmQi
+        LCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJ1c2VybmFtZSIsImlzX3NldCI6
+        ZmFsc2V9LHsibmFtZSI6InBhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX1dLCJz
+        bGVzX2F1dGhfdG9rZW4iOm51bGx9
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:11:39 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRmVkb3JhXzE3IiwicmV0YWluX3BhY2thZ2VfdmVyc2lvbnMi
+        OjB9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.19.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:11:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/rpm/rpm/5b2c9511-433d-4c35-b438-85a693d41ed8/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '629'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f68a8a63b0b04861b41b3cfa2563e681
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vNWIyYzk1MTEtNDMzZC00YzM1LWI0MzgtODVhNjkzZDQxZWQ4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjMtMDUtMDJUMjA6MTE6MzkuMjg3MzQ1WiIsInZl
+        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
+        cG0vNWIyYzk1MTEtNDMzZC00YzM1LWI0MzgtODVhNjkzZDQxZWQ4L3ZlcnNp
+        b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS81YjJjOTUxMS00
+        MzNkLTRjMzUtYjQzOC04NWE2OTNkNDFlZDgvdmVyc2lvbnMvMC8iLCJuYW1l
+        IjoiRmVkb3JhXzE3IiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBv
+        X3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpm
+        YWxzZSwibWV0YWRhdGFfc2lnbmluZ19zZXJ2aWNlIjpudWxsLCJyZXRhaW5f
+        cGFja2FnZV92ZXJzaW9ucyI6MCwibWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6
+        bnVsbCwicGFja2FnZV9jaGVja3N1bV90eXBlIjpudWxsLCJncGdjaGVjayI6
+        MCwicmVwb19ncGdjaGVjayI6MCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZX0=
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:11:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/content/rpm/packageenvironments/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5b2c9511-433d-4c35-b438-85a693d41ed8/versions/0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.19.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:11:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4774bb5af0ab4a82afa354d8959841cd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:11:39 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/content/rpm/modulemd_defaults/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/rpm/rpm/5b2c9511-433d-4c35-b438-85a693d41ed8/versions/0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.19.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:11:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 860e116e1d8540efa1a4a7997d5b6bb2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:11:39 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/repositories/rpm/rpm/5b2c9511-433d-4c35-b438-85a693d41ed8/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL3JwbS9ycG0vYWFhYWFhYWEtYWFhYS1hYWFhLWFhYWEtYWFhYWFhYWFh
+        YWFhLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.19.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Tue, 02 May 2023 20:11:39 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '123'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7f8f6f7e558f4824a82c1b5767d0b20e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel.cannolo.example.com
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      base64_string: |
+        WyJDb3VsZCBub3QgZmluZCB0aGUgZm9sbG93aW5nIGNvbnRlbnQgdW5pdHM6
+        IFsnL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtL2FhYWFhYWFh
+        LWFhYWEtYWFhYS1hYWFhLWFhYWFhYWFhYWFhYS8nXSJd
+    http_version: 
+  recorded_at: Tue, 02 May 2023 20:11:39 GMT
+recorded_with: VCR 3.0.3

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -124,7 +124,6 @@ module Katello
                                    :errata_id => @enhancement.errata_id)
       @repo.errata << @enhancement
       content_type = Katello::RepositoryTypeManager.find_content_type('erratum')
-      service_class = content_type.pulp3_service_class
       indexer = Katello::ContentUnitIndexer.new(content_type: content_type, repository: @repo)
       repo_associations = ::Katello::RepositoryErratum.where(erratum_id: [@bugfix.id, @enhancement.id], repository_id: @repo.id)
       filter.content_view.update(organization_id: @repo.organization.id)

--- a/test/models/module_stream_test.rb
+++ b/test/models/module_stream_test.rb
@@ -11,6 +11,29 @@ module Katello
       @module_stream_artifact_boat = katello_module_stream_artifacts(:boat)
     end
 
+    def test_clean_filter_rules
+      filter = FactoryBot.build(:katello_content_view_module_stream_filter, :inclusion => true)
+      river_rule = FactoryBot.create(:katello_content_view_module_stream_filter_rule,
+                                   :filter => filter,
+                                   :module_stream_id => @module_stream_river.id)
+      empty_rule = FactoryBot.create(:katello_content_view_module_stream_filter_rule,
+                                   :filter => filter,
+                                   :module_stream_id => @module_stream_empty.id)
+      content_type = Katello::RepositoryTypeManager.find_content_type('module_stream')
+      service_class = content_type.pulp3_service_class
+      indexer = Katello::ContentUnitIndexer.new(content_type: content_type, repository: @fedora_repo)
+      repo_associations = ::Katello::RepositoryErratum.where(module_stream_id: @module_stream_empty.id, repository_id: @fedora_repo.id)
+      filter.content_view.update(organization_id: @fedora_repo.organization.id)
+      filter.content_view.repositories << @fedora_repo
+
+      indexer.clean_filter_rules(repo_associations)
+      river_rule.reload
+      assert_raises ActiveRecord::RecordNotFound do
+        empty_rule.reload
+      end
+    end
+  end
+
     def test_repositories_relation
       assert_includes @module_stream_river.repositories, @fedora_repo
     end

--- a/test/models/module_stream_test.rb
+++ b/test/models/module_stream_test.rb
@@ -12,6 +12,7 @@ module Katello
     end
 
     def test_clean_filter_rules
+      ::Katello::RepositoryModuleStream.create!(module_stream_id: @module_stream_empty.id, repository_id: @fedora_repo.id)
       filter = FactoryBot.build(:katello_content_view_module_stream_filter, :inclusion => true)
       river_rule = FactoryBot.create(:katello_content_view_module_stream_filter_rule,
                                    :filter => filter,
@@ -19,20 +20,18 @@ module Katello
       empty_rule = FactoryBot.create(:katello_content_view_module_stream_filter_rule,
                                    :filter => filter,
                                    :module_stream_id => @module_stream_empty.id)
-      content_type = Katello::RepositoryTypeManager.find_content_type('module_stream')
-      service_class = content_type.pulp3_service_class
+      content_type = Katello::RepositoryTypeManager.find_content_type('modulemd')
       indexer = Katello::ContentUnitIndexer.new(content_type: content_type, repository: @fedora_repo)
-      repo_associations = ::Katello::RepositoryErratum.where(module_stream_id: @module_stream_empty.id, repository_id: @fedora_repo.id)
+      repo_associations = ::Katello::RepositoryModuleStream.where(module_stream_id: @module_stream_empty.id, repository_id: @fedora_repo.id)
       filter.content_view.update(organization_id: @fedora_repo.organization.id)
       filter.content_view.repositories << @fedora_repo
-
       indexer.clean_filter_rules(repo_associations)
+
       river_rule.reload
       assert_raises ActiveRecord::RecordNotFound do
         empty_rule.reload
       end
     end
-  end
 
     def test_repositories_relation
       assert_includes @module_stream_river.repositories, @fedora_repo

--- a/test/models/package_group_test.rb
+++ b/test/models/package_group_test.rb
@@ -1,4 +1,5 @@
 require 'katello_test_helper'
+require 'pry-byebug'
 
 module Katello
   class PackageGroupTest < ActiveSupport::TestCase
@@ -34,6 +35,29 @@ module Katello
 
     def test_search_by_repository
       assert_includes PackageGroup.search_for('repository = "Fedora 17 x86_64"'), @mammals_pg
+    end
+
+    def test_clean_filter_rules
+      filter = FactoryBot.build(:katello_content_view_package_group_filter, :inclusion => true)
+      server_rule = FactoryBot.create(:katello_content_view_package_group_filter_rule,
+                                   :filter => filter,
+                                   :uuid => @server_pg.pulp_id)
+      mammals_rule = FactoryBot.create(:katello_content_view_package_group_filter_rule,
+                                   :filter => filter,
+                                   :uuid => @mammals_pg.pulp_id)
+      content_type = Katello::RepositoryTypeManager.find_content_type('package_group')
+      service_class = content_type.pulp3_service_class
+      indexer = Katello::ContentUnitIndexer.new(content_type: content_type, repository: @repo)
+      repo_associations = ::Katello::RepositoryPackageGroup.where(package_group_id: @mammals_pg.id, repository_id: @repo.id)
+      filter.content_view.update(organization_id: @repo.organization.id)
+      filter.content_view.repositories << @repo
+
+      indexer.clean_filter_rules(repo_associations)
+      server_rule.reload
+      binding.pry
+      assert_raises ActiveRecord::RecordNotFound do
+        mammals_rule.reload
+      end
     end
   end
 end

--- a/test/models/package_group_test.rb
+++ b/test/models/package_group_test.rb
@@ -1,5 +1,4 @@
 require 'katello_test_helper'
-require 'pry-byebug'
 
 module Katello
   class PackageGroupTest < ActiveSupport::TestCase
@@ -46,7 +45,6 @@ module Katello
                                    :filter => filter,
                                    :uuid => @mammals_pg.pulp_id)
       content_type = Katello::RepositoryTypeManager.find_content_type('package_group')
-      service_class = content_type.pulp3_service_class
       indexer = Katello::ContentUnitIndexer.new(content_type: content_type, repository: @repo)
       repo_associations = ::Katello::RepositoryPackageGroup.where(package_group_id: @mammals_pg.id, repository_id: @repo.id)
       filter.content_view.update(organization_id: @repo.organization.id)
@@ -54,7 +52,6 @@ module Katello
 
       indexer.clean_filter_rules(repo_associations)
       server_rule.reload
-      binding.pry
       assert_raises ActiveRecord::RecordNotFound do
         mammals_rule.reload
       end

--- a/test/models/pulp_database_unit_test.rb
+++ b/test/models/pulp_database_unit_test.rb
@@ -17,5 +17,17 @@ module Katello
 
       assert_empty ::Katello::YumMetadataFile.methods.grep(/complete_for/)
     end
+
+    def test_orphaned
+      river = katello_module_streams(:river)
+      river.repository_module_streams.destroy_all
+      one = katello_module_streams(:one)
+      unless one.repositories.include?(katello_repositories(:fedora_17_x86_64))
+        fail 'Ensure that one.repositories includes :fedora_17_x86_64'
+      end
+
+      assert ::Katello::ModuleStream.orphaned.include?(river)
+      refute ::Katello::ModuleStream.orphaned.include?(one)
+    end
   end
 end

--- a/test/models/pulp_database_unit_test.rb
+++ b/test/models/pulp_database_unit_test.rb
@@ -26,8 +26,8 @@ module Katello
         fail 'Ensure that one.repositories includes :fedora_17_x86_64'
       end
 
-      assert ::Katello::ModuleStream.orphaned.include?(river)
-      refute ::Katello::ModuleStream.orphaned.include?(one)
+      assert_includes ::Katello::ModuleStream.orphaned, river
+      refute_includes ::Katello::ModuleStream.orphaned, one
     end
   end
 end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -710,6 +710,15 @@ module Katello
       assert_includes Repository.with_errata([errata]), @rhel6
     end
 
+    def test_index_content_destroys_orphans
+      rpm = katello_rpms(:one)
+      ::Katello::ContentUnitIndexer.any_instance.stubs(:import_all).returns(true)
+      ::Katello::Repository.any_instance.stubs(:import_distribution_data).returns(true)
+      rpm.repository_rpms.destroy_all
+      @rhel6.index_content
+      assert_raises(ActiveRecord::RecordNotFound) { rpm.reload }
+    end
+
     def test_index_content_ordering
       repo_type = @rhel6.repository_type
       SmartProxy.stubs(:pulp_primary).returns(SmartProxy.pulp_primary)

--- a/test/services/katello/pulp3/docker_tag_test.rb
+++ b/test/services/katello/pulp3/docker_tag_test.rb
@@ -29,7 +29,7 @@ module Katello
           fake_content_href = '/pulp/api/v3/repositories/container/container/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/'
           service = Katello::Pulp3::Repository::Docker.new(@repo, @primary)
           error = assert_raises(::Katello::Errors::Pulp3Error) { service.add_content(fake_content_href) }
-          assert_match /Please run a complete sync on the following repository: Pulp3 Docker 1./, error.message
+          assert_match(/Please run a complete sync on the following repository: Pulp3 Docker 1./, error.message)
         end
 
         def test_index_on_sync
@@ -69,6 +69,8 @@ module Katello
           meta_tag = @repo.docker_meta_tags.find_by(name: 'latest')
           dummy_cv_repo = ::Katello::Repository.find_by(pulp_id: 'Default_Organization-Test-busybox-dev')
           repo_meta_tag = ::Katello::RepositoryDockerMetaTag.create(docker_meta_tag_id: meta_tag.id, repository_id: dummy_cv_repo.id)
+          dummy_cv_repo.docker_manifests << repo_meta_tag.docker_meta_tag.schema2.docker_taggable
+          dummy_cv_repo.docker_tags << meta_tag.schema2
 
           @repo.root.update(:include_tags => ['doesntexist'])
           @repo.backend_service(SmartProxy.pulp_primary).refresh_if_needed

--- a/test/services/katello/pulp3/docker_tag_test.rb
+++ b/test/services/katello/pulp3/docker_tag_test.rb
@@ -25,6 +25,13 @@ module Katello
           assert_equal ::Katello::DockerManifest.find_by(id: ::Katello::DockerTag.first.docker_taggable_id).digest, "sha256:a6ecbb1553353a08936f50c275b010388ed1bd6d9d84743c7e8e7468e2acd82e"
         end
 
+        def test_copy_units_rewrites_missing_content_error
+          fake_content_href = '/pulp/api/v3/repositories/container/container/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/'
+          service = Katello::Pulp3::Repository::Docker.new(@repo, @primary)
+          error = assert_raises(::Katello::Errors::Pulp3Error) { service.add_content(fake_content_href) }
+          assert_match /Please run a complete sync on the following repository: Pulp3 Docker 1./, error.message
+        end
+
         def test_index_on_sync
           Katello::DockerTag.destroy_all
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}

--- a/test/services/katello/pulp3/repository/yum/yum_test.rb
+++ b/test/services/katello/pulp3/repository/yum/yum_test.rb
@@ -23,7 +23,7 @@ module Katello
             service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
             create_repo(@repo, @proxy)
             error = assert_raises(::Katello::Errors::Pulp3Error) { service.copy_units(@repo, [fake_content_href], false) }
-            assert_match /Please run a complete sync on the following repository: Fedora 17 x86_64./, error.message
+            assert_match(/Please run a complete sync on the following repository: Fedora 17 x86_64./, error.message)
           end
 
           def test_append_proxy_cacert

--- a/test/services/katello/pulp3/repository/yum/yum_test.rb
+++ b/test/services/katello/pulp3/repository/yum/yum_test.rb
@@ -18,6 +18,14 @@ module Katello
             service.copy_units(@repo, [], false)
           end
 
+          def test_copy_units_rewrites_missing_content_error
+            fake_content_href = '/pulp/api/v3/repositories/rpm/rpm/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/'
+            service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
+            create_repo(@repo, @proxy)
+            error = assert_raises(::Katello::Errors::Pulp3Error) { service.copy_units(@repo, [fake_content_href], false) }
+            assert_match /Please run a complete sync on the following repository: Fedora 17 x86_64./, error.message
+          end
+
           def test_append_proxy_cacert
             service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
             http_proxy = FactoryBot.create(:http_proxy, :url => 'http://foo.com:1000',


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Ensures that content units belonging to no repositories are destroyed at repo indexing time.  This is necessary because content units that have been removed from Pulp can still remain attached to content view filters, which will cause blocking errors at CV publish time.

I also improved the error returned from Pulp that occurs when trying to copy units that don't exist.

Note that I didn't rewrite the special rpm copy API error. In testing, I found that the rpm copy API ignores content units that don't exist.

#### Considerations taken when implementing this change?
I considered if content units should be destroyed during content unit importing, or perhaps if units could be disassociated from filters instead. Finding the filter relations at sync time would be too query-intensive. Determining the content units to remove during `ContentUnitIndexer.import_all` would require searching other repositories to find out if it's truly orphaned, which I ended up doing higher up in the stack anyway.

#### What are the testing steps for this pull request?
1) Create a content view with some module streams and container image tags
2) Make filters that filter in those tags and module streams
3) Modify the pulp_hrefs for some module stream and some container image tag to be something that doesn't exist in Pulp
4) Try publishing the CV. You should see a failed task in Dynflow with the error message rewrite that this PR implements.
5) Perform a complete sync on the related repositories.
6) The publish should now work. I think you'll have to skip the failing Dynflow task and try the publish again.

Also, try verifying that orphaned content units are indeed destroyed using something other than module streams and container image tags.