### PR TITLE
Fixes #36362 - Reporting results of docker v2 repo discovery

### DIFF
--- a/app/lib/katello/repo_discovery.rb
+++ b/app/lib/katello/repo_discovery.rb
@@ -62,7 +62,9 @@ module Katello
         # Note: v2 endpoint does not support search
         request_params[:url] = "#{@uri}v2/_catalog"
         results = RestClient::Request.execute(request_params)
-        @found = JSON.parse(results)['repositories']
+        JSON.parse(results)['repositories'].each do |result|
+          @found << result
+        end
       end
       @found.sort!
     end


### PR DESCRIPTION
A Repository Discovery with custom container images URL <https://registry.fedoraproject.org/> (which does not support the v1 API) reported "No discovered repositories".