### PR TITLE
Fixes #36352 - Add metadata_expire attribute for custom yum repos

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -71,7 +71,7 @@ module Katello
       param :http_proxy_id, :number, :desc => N_("ID of a HTTP Proxy")
       param :arch, String, :desc => N_("Architecture of content in the repository")
       param :retain_package_versions_count, :number, :desc => N_("The maximum number of versions of each package to keep.")
-
+      param :metadata_expire, :number, :desc => N_("Time to expire yum metadata in seconds. Only relevant for custom yum repositories.")
       RepositoryTypeManager.generic_remote_options(defined_only: true).each do |option|
         param option.name, option.type, :desc => N_(option.description)
       end
@@ -580,7 +580,7 @@ module Katello
     # rubocop:disable Metrics/CyclomaticComplexity
     def repository_params
       keys = [:download_policy, :mirroring_policy, :sync_policy, :arch, :verify_ssl_on_sync, :upstream_password,
-              :upstream_username, :download_concurrency, :upstream_authentication_token,
+              :upstream_username, :download_concurrency, :upstream_authentication_token, :metadata_expire,
               {:os_versions => []}, :deb_releases, :deb_components, :deb_architectures, :description,
               :http_proxy_policy, :http_proxy_id, :retain_package_versions_count, {:ignorable_content => []}
              ]
@@ -620,7 +620,8 @@ module Katello
     def construct_repo_from_params(repo_params) # rubocop:disable Metrics/AbcSize
       root = @product.add_repo(repo_params.slice(:label, :name, :description, :url, :content_type, :arch, :unprotected,
                                                             :gpg_key, :ssl_ca_cert, :ssl_client_cert, :ssl_client_key,
-                                                            :checksum_type, :download_policy, :http_proxy_policy).to_h.with_indifferent_access)
+                                                            :checksum_type, :download_policy, :http_proxy_policy,
+                                                            :metadata_expire).to_h.with_indifferent_access)
       root.docker_upstream_name = repo_params[:docker_upstream_name] if repo_params[:docker_upstream_name]
       if root.docker?
         if repo_params[:docker_tags_whitelist].present?

--- a/app/lib/actions/candlepin/product/content_update.rb
+++ b/app/lib/actions/candlepin/product/content_update.rb
@@ -12,6 +12,7 @@ module Actions
           param :content_url
           param :gpg_key_url
           param :owner
+          param :metadata_expire
         end
 
         def run
@@ -25,7 +26,7 @@ module Actions
                      arches: input[:arches] || '',
                      requiredTags: input[:os_versions],
                      label: input[:label],
-                     metadataExpire: 1,
+                     metadataExpire: input[:metadata_expire] || 1,
                      vendor: ::Katello::Provider::CUSTOM)
         end
       end

--- a/app/lib/actions/katello/repository/update.rb
+++ b/app/lib/actions/katello/repository/update.rb
@@ -31,7 +31,8 @@ module Actions
                         :label => content.label,
                         :type => root.content_type,
                         :arches => root.format_arches,
-                        :os_versions => root.os_versions&.join(',')
+                        :os_versions => root.os_versions&.join(','),
+                        :metadata_expire => root.metadata_expire
                       )
 
             content.update!(name: root.name,

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -28,6 +28,7 @@ glue(@resource.root) do
   attributes :http_proxy_id
   attributes :http_proxy_name
   attributes :retain_package_versions_count
+  attributes :metadata_expire
 
   node :http_proxy do
     attributes :id => @resource.root&.http_proxy&.id, :name => @resource.root&.http_proxy&.name, :policy => @resource.root&.http_proxy_policy

--- a/db/migrate/20230503190626_add_metadata_expire_to_root.rb
+++ b/db/migrate/20230503190626_add_metadata_expire_to_root.rb
@@ -1,0 +1,5 @@
+class AddMetadataExpireToRoot < ActiveRecord::Migration[6.1]
+  def change
+    add_column :katello_root_repositories, :metadata_expire, :integer
+  end
+end

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -70,6 +70,21 @@ module Katello
       assert_valid @root
     end
 
+    def test_valid_metadata_expire
+      @root.content_type = 'yum'
+      @root.metadata_expire = ::Katello::RootRepository::MAX_EXPIRE_TIME + 1
+      refute_valid @root
+
+      @root.metadata_expire = 0
+      refute_valid @root
+
+      @root.metadata_expire = 100
+      assert_valid @root
+
+      @root.content_type = "docker"
+      refute_valid @root
+    end
+
     def test_non_yum_retain_package_version_counts
       @root.content_type = 'docker'
       @root.retain_package_versions_count = 2


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Default value for custom yum repo metadata expiration is 1. This means every yum transaction will check on its entitlements, accessible repositories etc if the yum cache is more than a second old.  This works for most cases but may be not ideal for high latency environments. 

This PR provides a clear way to setup  metadata expiration values for custom yum repositories . 
- Added a new metadata expire column to root repository
- This value will be used to set on the repository content in Candlepin.
- Added API controllers
- Added validations (Must be yum and custom, must be >0 and < 86400s =24 hours)

#### Considerations taken when implementing this change?
We were trying to solve [Community Issue](https://community.theforeman.org/t/yum-commands-are-very-slow/30174/17 ) 

Initially we were going to do a rake task to set the metadata expiry. But repository update will reset that back to 1. So had to go to this approach

#### What are the testing steps for this pull request?

- Checkout PR
- `bundle exec rake db:migrate`
- Create a Custom Yum repo and a content host consuming it
- Check the redhat repo file on the content host and make sure the `metadata_expire` value is set to 1
- Now update this via hammer or api => `hammer repository update --id=10 --metadata-expire=1000`
- On your content host `subscription-manager refresh`
-  check your redhat repo and make sure the `metadata_expire` value is set to 1000
- Make sure you are not able to update repository if its redhat or non yum. Also check for boundary conditions (>0, <=86400)
