### PR TITLE
Fixes #36373 - Add metadata expire option for custom repo to UI

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
@@ -232,6 +232,11 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                 $scope.save($scope.repository);
             };
 
+            $scope.clearMetadataExpire = function () {
+                $scope.repository['metadata_expire'] = null;
+                $scope.save($scope.repository);
+            };
+
             $scope.clearAnsibleCollectionAuth = function () {
                 $scope.repository['ansible_collection_auth_url'] = null;
                 $scope.repository['ansible_collection_auth_token'] = null;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -25,6 +25,11 @@
 
       <dt translate>Type</dt>
       <dd>{{ repository.content_type }}</dd>
+      <dt ng-if="product.redhat != true" translate>Metadata Expiration (Seconds)</dt>
+      <dd bst-edit-number="repository.metadata_expire" on-save="save(repository)" readonly="product.redhat || denied('edit_products', product)"
+          deletable="repository.metadata_expire !== null"
+          on-delete="clearMetadataExpire()">
+      </dd>
     </dl>
 
     <div class="divider"></div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -39,6 +39,16 @@
         </select>
       </div>
 
+      <div ng-show="repository.content_type === 'yum'" bst-form-group label="{{ 'Metadata Expiration (Seconds)' | translate }}">
+        <input id="metadataexpire"
+               name="metadataexire"
+               ng-model="repository.metadata_expire"
+               type="number"
+               min="1"
+               placeholder="default value is 1"
+               required/>
+      </div>
+
     </div>
 
     <div ng-show="repository.content_type === 'yum'">

--- a/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
@@ -117,6 +117,14 @@ describe('Controller: RepositoryDetailsInfoController', function() {
         expect($scope.repository["ansible_collection_auth_exists"]).toBe(false);
     });
 
+    it('should clear the metadata_expire on clearMetadataExpire', function() {
+        spyOn($scope, 'save');
+        $scope.repository["metadata_expire"] = "500";
+        $scope.clearMetadataExpire($scope.repository);
+        expect($scope.save).toHaveBeenCalledWith($scope.repository);
+        expect($scope.repository["metadata_expire"]).toBe(null);
+    });
+
     it('should save the repository successfully', function() {
         spyOn(Notification, 'setSuccessMessage');
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Add the ability to see and edit the metadata expire that this pr introduced https://github.com/Katello/katello/pull/10544
* Only will show up and be editable with Custom repos

#### What are the testing steps for this pull request?
* Create a custom repo and set the metadata expiration
* View the repo details and check if you can see and edit the custom repo metadata expire
* View a RH repo to make sure the value is hidden