### PR TITLE
Fixes #36270 - Update UI to reflect needs_publish on CV

### DIFF
--- a/webpack/scenes/ContentViews/ContentViewsConstants.js
+++ b/webpack/scenes/ContentViews/ContentViewsConstants.js
@@ -34,6 +34,8 @@ export const MODULE_STREAMS_CONTENT = 'MODULE_STREAMS_CONTENT';
 export const DEB_PACKAGES_CONTENT = 'DEB_PACKAGES_CONTENT';
 export const RPM_PACKAGES_CONTENT = 'RPM_PACKAGES_CONTENT';
 export const FILE_CONTENT = 'FILE_CONTENT';
+export const CONTENT_VIEW_NEEDS_PUBLISH = 'CV_NEEDS_PUBLISH';
+export const CONTENT_VIEW_NEEDS_PUBLISH_RESET = 'CV_NEEDS_PUBLISH_RESET';
 export const generatedContentKey = pluralLabel => `${toUpper(pluralLabel)}_CONTENT`;
 export const cvDetailsKey = cvId => `${CONTENT_VIEWS_KEY}_${cvId}`;
 export const cvDetailsRepoKey = cvId => `${CONTENT_VIEWS_KEY}_REPOSITORIES_${cvId}`;

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewAddModal.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewAddModal.js
@@ -15,6 +15,7 @@ import {
   selectCVDetailError,
 } from '../../Details/ContentViewDetailSelectors';
 import { addComponent } from '../ContentViewDetailActions';
+import { CONTENT_VIEW_NEEDS_PUBLISH } from '../../ContentViewsConstants';
 
 const ComponentContentViewAddModal = ({
   cvId, componentCvId, componentId, latest, show, setIsOpen,
@@ -73,12 +74,12 @@ const ComponentContentViewAddModal = ({
       dispatch(addComponent({
         compositeContentViewId: cvId,
         components: getUpdateParams(),
-      }));
+      }, () => dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH })));
     } else {
       dispatch(addComponent({
         compositeContentViewId: cvId,
         components: getAddParams(),
-      }));
+      }, () => dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH })));
     }
     setIsOpen(false);
   };

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
@@ -30,7 +30,7 @@ import AddedStatusLabel from '../../../../components/AddedStatusLabel';
 import ComponentVersion from './ComponentVersion';
 import ComponentEnvironments from './ComponentEnvironments';
 import ContentViewIcon from '../../components/ContentViewIcon';
-import { ADDED, ALL_STATUSES, NOT_ADDED } from '../../ContentViewsConstants';
+import { ADDED, ALL_STATUSES, CONTENT_VIEW_NEEDS_PUBLISH, NOT_ADDED } from '../../ContentViewsConstants';
 import SelectableDropdown from '../../../../components/SelectableDropdown/SelectableDropdown';
 import '../../../../components/EditableTextInput/editableTextInput.scss';
 import ComponentContentViewAddModal from './ComponentContentViewAddModal';
@@ -92,7 +92,7 @@ const ContentViewComponents = ({ cvId, details }) => {
       dispatch(addComponent({
         compositeContentViewId: cvId,
         components: [{ latest: true, content_view_id: componentCvId }],
-      }));
+      }, () => dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH })));
     }
   }, [cvId, dispatch]);
 
@@ -102,7 +102,7 @@ const ContentViewComponents = ({ cvId, details }) => {
     dispatch(removeComponent({
       compositeContentViewId: cvId,
       component_ids: componentIds,
-    }));
+    }, () => dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH })));
   };
 
   const addBulk = () => {
@@ -116,7 +116,7 @@ const ContentViewComponents = ({ cvId, details }) => {
     dispatch(removeComponent({
       compositeContentViewId: cvId,
       component_ids: [componentIdToRemove],
-    }));
+    }, () => dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH })));
   };
 
   const toggleBulkAction = () => {

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
@@ -229,29 +229,32 @@ export const updateContentView = (cvId, params, handleSuccess) => put({
   },
 });
 
-export const addComponent = params => put({
+export const addComponent = (params, handleSuccess) => put({
   type: API_OPERATIONS.PUT,
   key: cvAddComponentKey(params.compositeContentViewId),
   url: api.getApiUrl(`/content_views/${params.compositeContentViewId}/content_view_components/${params.components.id ? params.components.id : 'add'}`),
   params: params.components.id ? params.components : params,
+  handleSuccess,
   successToast: () => addComponentSuccessMessage(params.components.id),
   errorToast: error => __(`Something went wrong while adding component! ${getResponseErrorMsgs(error.response)}`),
 });
 
-export const removeComponent = params => put({
+export const removeComponent = (params, handleSuccess) => put({
   type: API_OPERATIONS.PUT,
   key: cvRemoveComponentKey(params.compositeContentViewId),
   url: api.getApiUrl(`/content_views/${params.compositeContentViewId}/content_view_components/remove`),
   params,
+  handleSuccess,
   successToast: () => removeComponentSuccessMessage(params.component_ids.length),
   errorToast: error => __(`Something went wrong while removing component! ${getResponseErrorMsgs(error.response)}`),
 });
 
-export const createContentViewFilter = (cvId, params) => post({
+export const createContentViewFilter = (cvId, params, handleSuccess) => post({
   type: API_OPERATIONS.POST,
   key: CREATE_CONTENT_VIEW_FILTER_KEY,
   url: api.getApiUrl(`/content_view_filters?content_view_id=${cvId}`),
   params,
+  handleSuccess,
   successToast: () => __('Filter created'),
   errorToast: error => __(`Something went wrong while creating the filter! ${getResponseErrorMsgs(error.response)}`),
 });

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailReducer.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailReducer.js
@@ -3,6 +3,8 @@ import {
   UPDATE_CONTENT_VIEW,
   UPDATE_CONTENT_VIEW_FAILURE,
   UPDATE_CONTENT_VIEW_SUCCESS,
+  CONTENT_VIEW_NEEDS_PUBLISH,
+  CONTENT_VIEW_NEEDS_PUBLISH_RESET,
 } from '../ContentViewsConstants';
 
 const initialState = Immutable({
@@ -17,6 +19,10 @@ export default (state = initialState, action) => {
     return state.merge({ updating: false });
   case UPDATE_CONTENT_VIEW_FAILURE:
     return state.set('updating', false);
+  case CONTENT_VIEW_NEEDS_PUBLISH:
+    return state.set('needsPublish', true);
+  case CONTENT_VIEW_NEEDS_PUBLISH_RESET:
+    return state.set('needsPublish', false);
   default:
     return state;
   }

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
@@ -389,3 +389,5 @@ export const selectRemoveCVVersionError = (state, versionId, versionEnvironments
 
 
 export const selectIsCVUpdating = state => state.katello?.contentViewDetails?.updating;
+
+export const selectCVNeedsPublish = state => state.katello?.contentViewDetails?.needsPublish;

--- a/webpack/scenes/ContentViews/Details/Filters/Add/CVFilterAddModal.js
+++ b/webpack/scenes/ContentViews/Details/Filters/Add/CVFilterAddModal.js
@@ -14,7 +14,7 @@ import { selectCreateContentViewFilter, selectCreateContentViewFilterStatus,
   selectCreateContentViewFilterError, selectCreateFilterRule,
   selectCreateFilterRuleError, selectCreateFilterRuleStatus,
   selectRepoTypes, selectRepoTypesStatus } from '../../../Details/ContentViewDetailSelectors';
-import { FILTER_TYPES } from '../../../ContentViewsConstants';
+import { CONTENT_VIEW_NEEDS_PUBLISH, FILTER_TYPES } from '../../../ContentViewsConstants';
 import ContentType from '../ContentType';
 
 const CVFilterAddModal = ({ cvId, onClose }) => {
@@ -46,7 +46,7 @@ const CVFilterAddModal = ({ cvId, onClose }) => {
       cvId,
       {
         name, description, inclusion, type,
-      },
+      }, () => dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH }),
     ));
   };
 

--- a/webpack/scenes/ContentViews/Details/Filters/AffectedRepositories/AffectedRepositoryTable.js
+++ b/webpack/scenes/ContentViews/Details/Filters/AffectedRepositories/AffectedRepositoryTable.js
@@ -28,6 +28,7 @@ import TableWrapper from '../../../../../components/Table/TableWrapper';
 import RepoIcon from '../../Repositories/RepoIcon';
 import SelectableDropdown from '../../../../../components/SelectableDropdown/SelectableDropdown';
 import { hasPermission } from '../../../helpers';
+import { CONTENT_VIEW_NEEDS_PUBLISH } from '../../../ContentViewsConstants';
 
 const allProducts = 'All products';
 
@@ -131,6 +132,7 @@ const AffectedRepositoryTable = ({
       filterId,
       { id: filterId, repository_ids: repositoryIds.concat(repos) }, () => {
         dispatch(getCVFilterDetails(cvId, filterId));
+        dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH });
       },
     ));
   };
@@ -142,7 +144,10 @@ const AffectedRepositoryTable = ({
     dispatch(editCVFilter(
       filterId,
       { id: filterId, repository_ids: deletedRepos },
-      () => dispatch(getCVFilterDetails(cvId, filterId, {})),
+      () => {
+        dispatch(getCVFilterDetails(cvId, filterId, {}));
+        dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH });
+      },
     ));
     if (deletedRepos.length === 0) setShowAffectedRepos(false);
   };

--- a/webpack/scenes/ContentViews/Details/Filters/ArtifactsWithNoErrata.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ArtifactsWithNoErrata.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Switch } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { editCVFilter } from '../ContentViewDetailActions';
+import { CONTENT_VIEW_NEEDS_PUBLISH } from '../../ContentViewsConstants';
 
 export const ArtifactsWithNoErrataRenderer = ({ filterDetails }) => {
   const dispatch = useDispatch();
@@ -18,7 +19,10 @@ export const ArtifactsWithNoErrataRenderer = ({ filterDetails }) => {
   const setArtifactsNoErrata = (checked) => {
     enableArtifactsNoErrata(checked);
     setLoading(true);
-    dispatch(editCVFilter(id, { [artifactAttribute]: checked }, () => setLoading(false)));
+    dispatch(editCVFilter(id, { [artifactAttribute]: checked }, () => {
+      setLoading(false);
+      dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH });
+    }));
   };
   const getLabel = () => {
     switch (true) {

--- a/webpack/scenes/ContentViews/Details/Filters/CVContainerImageFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVContainerImageFilterContent.js
@@ -32,6 +32,7 @@ import { emptyContentTitle,
   emptyContentBody,
   emptySearchTitle,
   emptySearchBody } from './FilterRuleConstants';
+import { CONTENT_VIEW_NEEDS_PUBLISH } from '../../ContentViewsConstants';
 
 const CVContainerImageFilterContent = ({
   cvId, filterId, showAffectedRepos, setShowAffectedRepos, details,
@@ -79,8 +80,10 @@ const CVContainerImageFilterContent = ({
     setBulkActionOpen(false);
     const tagFilterIds =
       rows.filter(row => row.selected).map(selected => selected.id);
-    dispatch(deleteContentViewFilterRules(filterId, tagFilterIds, () =>
-      dispatch(getCVFilterRules(filterId))));
+    dispatch(deleteContentViewFilterRules(filterId, tagFilterIds, () => {
+      dispatch(getCVFilterRules(filterId));
+      dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH });
+    }));
     deselectAll();
   };
 
@@ -110,8 +113,10 @@ const CVContainerImageFilterContent = ({
     {
       title: __('Remove'),
       onClick: (_event, _rowId, { id }) => {
-        dispatch(removeCVFilterRule(filterId, id, () =>
-          dispatch(getCVFilterRules(filterId))));
+        dispatch(removeCVFilterRule(filterId, id, () => {
+          dispatch(getCVFilterRules(filterId));
+          dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH });
+        }));
       },
     },
     {

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
@@ -15,6 +15,7 @@ import { selectCVFilterDetails } from '../ContentViewDetailSelectors';
 import AffectedRepositoryTable from './AffectedRepositories/AffectedRepositoryTable';
 import { editCVFilterRule } from '../ContentViewDetailActions';
 import { hasPermission } from '../../helpers';
+import { CONTENT_VIEW_NEEDS_PUBLISH } from '../../ContentViewsConstants';
 
 export const dateFormat = date => `${(date.getMonth() + 1).toString().padStart(2, '0')}/${date.getDate().toString().padStart(2, '0')}/${date.getFullYear()}`;
 
@@ -68,7 +69,10 @@ const CVErrataDateFilterContent = ({
         types: selectedTypes,
         date_type: dateType,
       },
-      () => push('/filters'),
+      () => {
+        dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH });
+        push('/filters');
+      },
     ));
   };
 

--- a/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
@@ -22,6 +22,7 @@ import { emptyContentTitle,
   emptyContentBody,
   emptySearchTitle,
   emptySearchBody } from './FilterRuleConstants';
+import { CONTENT_VIEW_NEEDS_PUBLISH } from '../../ContentViewsConstants';
 
 const CVRpmFilterContent = ({
   cvId, filterId, inclusion, showAffectedRepos, setShowAffectedRepos, details,
@@ -115,8 +116,10 @@ const CVRpmFilterContent = ({
     {
       title: __('Remove'),
       onClick: (_event, _rowId, { id }) => {
-        dispatch(removeCVFilterRule(filterId, id, () =>
-          dispatch(getCVFilterRules(filterId))));
+        dispatch(removeCVFilterRule(filterId, id, () => {
+          dispatch(getCVFilterRules(filterId));
+          dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH });
+        }));
       },
     },
     {
@@ -139,8 +142,10 @@ const CVRpmFilterContent = ({
     setBulkActionOpen(false);
     const rpmFilterIds =
       rows.filter(row => row.selected).map(selected => selected.id);
-    dispatch(deleteContentViewFilterRules(filterId, rpmFilterIds, () =>
-      dispatch(getCVFilterRules(filterId))));
+    dispatch(deleteContentViewFilterRules(filterId, rpmFilterIds, () => {
+      dispatch(getCVFilterRules(filterId));
+      dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH });
+    }));
     deselectAll();
   };
 

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetailsHeader.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetailsHeader.js
@@ -20,8 +20,7 @@ import {
 } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { useDispatch } from 'react-redux';
-import {
-  getCVFilterDetails,
+import getContentViewDetails, {
   editCVFilter,
   deleteContentViewFilter,
 } from '../ContentViewDetailActions';
@@ -32,6 +31,7 @@ import { hasPermission } from '../../helpers';
 import { typeName } from './ContentType';
 import ActionableDetail from '../../../../components/ActionableDetail';
 import { ArtifactsWithNoErrataRenderer } from './ArtifactsWithNoErrata';
+import { CONTENT_VIEW_NEEDS_PUBLISH } from '../../ContentViewsConstants';
 
 const ContentViewFilterDetailsHeader = ({
   cvId, filterId, filterDetails, setShowAffectedRepos, details,
@@ -58,7 +58,7 @@ const ContentViewFilterDetailsHeader = ({
       { [attribute]: val },
       () => {
         setLoading(false);
-        dispatch(getCVFilterDetails(cvId, filterId));
+        dispatch(getContentViewDetails(cvId));
       },
       () => setLoading(false),
     ));
@@ -70,6 +70,7 @@ const ContentViewFilterDetailsHeader = ({
       ouiaId="cv-filter-delete"
       onClick={() => {
         dispatch(deleteContentViewFilter(filterId, () => {
+          dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH });
           push(`/content_views/${cvId}#/filters/`);
         }));
       }}

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
@@ -22,6 +22,7 @@ import ContentType from './ContentType';
 import CVFilterAddModal from './Add/CVFilterAddModal';
 import { hasPermission } from '../../helpers';
 import InactiveText from '../../components/InactiveText';
+import { CONTENT_VIEW_NEEDS_PUBLISH } from '../../ContentViewsConstants';
 
 const ContentViewFilters = ({ cvId, details }) => {
   const dispatch = useDispatch();
@@ -83,6 +84,7 @@ const ContentViewFilters = ({ cvId, details }) => {
     const filterIds = rows.filter(({ selected }) => selected).map(({ id }) => id);
     dispatch(deleteContentViewFilters(cvId, filterIds, () =>
       dispatch(getContentViewFilters(cvId, {}))));
+    dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH });
   };
 
   useEffect(() => {
@@ -103,6 +105,7 @@ const ContentViewFilters = ({ cvId, details }) => {
       onClick: (_event, _rowId, { id }) => {
         dispatch(deleteContentViewFilter(id, () =>
           dispatch(getContentViewFilters(cvId, {}))));
+        dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH });
       },
     },
   ];

--- a/webpack/scenes/ContentViews/Details/Filters/Rules/ContainerTag/AddEditContainerTagRuleModal.js
+++ b/webpack/scenes/ContentViews/Details/Filters/Rules/ContainerTag/AddEditContainerTagRuleModal.js
@@ -6,6 +6,7 @@ import { Modal, ModalVariant, Form, FormGroup, ActionGroup, Button } from '@patt
 import { addCVFilterRule, editCVFilterRule, getCVFilterRules } from '../../../ContentViewDetailActions';
 import { orgId } from '../../../../../../services/api';
 import SearchText from '../../../../../../components/Search/SearchText';
+import { CONTENT_VIEW_NEEDS_PUBLISH } from '../../../../ContentViewsConstants';
 
 const AddEditContainerTagRuleModal = ({
   onClose, filterId, selectedFilterRuleData, repositoryIds,
@@ -24,13 +25,19 @@ const AddEditContainerTagRuleModal = ({
       dispatch(editCVFilterRule(
         filterId,
         { id, name: tagName },
-        () => dispatch(getCVFilterRules(filterId)),
+        () => {
+          dispatch(getCVFilterRules(filterId));
+          dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH });
+        },
       ));
     } else {
       dispatch(addCVFilterRule(
         filterId,
         { name: tagName },
-        () => dispatch(getCVFilterRules(filterId)),
+        () => {
+          dispatch(getCVFilterRules(filterId));
+          dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH });
+        },
       ));
     }
     onClose();

--- a/webpack/scenes/ContentViews/Details/Filters/Rules/Package/AddEditPackageRuleModal.js
+++ b/webpack/scenes/ContentViews/Details/Filters/Rules/Package/AddEditPackageRuleModal.js
@@ -14,6 +14,7 @@ import {
 } from '../../../ContentViewDetailSelectors';
 import { orgId } from '../../../../../../services/api';
 import SearchText from '../../../../../../components/Search/SearchText';
+import { CONTENT_VIEW_NEEDS_PUBLISH } from '../../../../ContentViewsConstants';
 
 const AddEditPackageRuleModal = ({
   filterId, onClose, selectedFilterRuleData, repositoryIds,
@@ -109,6 +110,7 @@ const AddEditPackageRuleModal = ({
           onClose();
         },
       ));
+    dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH });
   };
 
 

--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
@@ -30,6 +30,7 @@ import BulkDeleteModal from './BulkDelete/BulkDeleteModal';
 import { selectEnvironmentPathsStatus } from '../../components/EnvironmentPaths/EnvironmentPathSelectors';
 import PublishContentViewWizard from '../../Publish/PublishContentViewWizard';
 import CVVersionCompare from './Compare/CVVersionCompare';
+import NeedsPublishIcon from '../../components/NeedsPublishIcon';
 
 const ContentViewVersions = ({ cvId, details }) => {
   const response = useSelector(state => selectCVVersions(state, cvId));
@@ -56,7 +57,9 @@ const ContentViewVersions = ({ cvId, details }) => {
   const [removingFromEnv, setRemovingFromEnv] = useState(false);
   const [deleteVersion, setDeleteVersion] = useState(false);
   const [currentStep, setCurrentStep] = useState(1);
-  const { permissions } = details;
+  const {
+    permissions, needs_publish: needsPublish, composite, latest_version_id: latestVersionId,
+  } = details;
   const [kebabOpen, setKebabOpen] = useState(false);
   const hasActionPermissions = hasPermission(permissions, 'promote_or_remove_content_views');
   const hasPublishCvPermissions = hasPermission(permissions, 'publish_content_views');
@@ -147,7 +150,12 @@ const ContentViewVersions = ({ cvId, details }) => {
         isChecked={isSelected(versionId)}
         onChange={selected => selectOne(selected, versionId)}
       />,
-      <Link to={`/versions/${versionId}`}>{__('Version ')}{version}</Link>,
+      <>
+        <Link to={`/versions/${versionId}`}>{__('Version ')}{version}</Link>
+        {(latestVersionId === versionId && needsPublish) &&
+        <NeedsPublishIcon composite={composite} />
+        }
+      </>,
       <ContentViewVersionEnvironments {...{ environments }} />,
       Number(packageCount) ?
         <a href={urlBuilder(`content_views/${cvId}#/versions/${versionId}/packages`, '')}>{packageCount}</a> :
@@ -384,6 +392,9 @@ ContentViewVersions.propTypes = {
   cvId: PropTypes.number.isRequired,
   details: PropTypes.shape({
     permissions: PropTypes.shape({}),
+    needs_publish: PropTypes.bool,
+    composite: PropTypes.bool,
+    latest_version_id: PropTypes.number,
   }).isRequired,
 };
 

--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
@@ -19,7 +19,7 @@ import {
   selectCVVersions,
   selectCVVersionsStatus,
   selectCVVersionsError,
-  selectCVDetails,
+  selectCVDetails, selectCVNeedsPublish,
 } from '../ContentViewDetailSelectors';
 import getEnvironmentPaths from '../../components/EnvironmentPaths/EnvironmentPathActions';
 import ContentViewVersionPromote from '../Promote/ContentViewVersionPromote';
@@ -60,6 +60,7 @@ const ContentViewVersions = ({ cvId, details }) => {
   const {
     permissions, needs_publish: needsPublish, composite, latest_version_id: latestVersionId,
   } = details;
+  const needsPublishLocal = useSelector(state => selectCVNeedsPublish(state));
   const [kebabOpen, setKebabOpen] = useState(false);
   const hasActionPermissions = hasPermission(permissions, 'promote_or_remove_content_views');
   const hasPublishCvPermissions = hasPermission(permissions, 'publish_content_views');
@@ -152,7 +153,7 @@ const ContentViewVersions = ({ cvId, details }) => {
       />,
       <>
         <Link to={`/versions/${versionId}`}>{__('Version ')}{version}</Link>
-        {(latestVersionId === versionId && needsPublish) &&
+        {(latestVersionId === versionId && (needsPublish || needsPublishLocal)) &&
         <NeedsPublishIcon composite={composite} />
         }
       </>,

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
   Button,
@@ -25,6 +25,7 @@ import RemoveCVVersionWizard from '../Delete/RemoveCVVersionWizard';
 import ActionableDetail from '../../../../../components/ActionableDetail';
 import BulkDeleteModal from '../BulkDelete/BulkDeleteModal';
 import NeedsPublishIcon from '../../../components/NeedsPublishIcon';
+import { selectCVNeedsPublish } from '../../ContentViewDetailSelectors';
 
 const ContentViewVersionDetailsHeader = ({
   versionDetails,
@@ -38,6 +39,7 @@ const ContentViewVersionDetailsHeader = ({
   const {
     version, description, environments, content_view_id: cvId, id,
   } = versionDetails;
+  const needsPublishLocal = useSelector(state => selectCVNeedsPublish(state));
   const dispatch = useDispatch();
   useEffect(
     () => {
@@ -77,7 +79,9 @@ const ContentViewVersionDetailsHeader = ({
         <TextContent>
           <Text ouiaId="cv-version" component={TextVariants.h2}>
             {__('Version ')}{version}
-            {(latestVersionId === id && needsPublish) && <NeedsPublishIcon composite={composite} />}
+            {(latestVersionId === id && (needsPublish || needsPublishLocal)) &&
+            <NeedsPublishIcon composite={composite} />
+            }
           </Text>
 
         </TextContent>
@@ -118,8 +122,10 @@ const ContentViewVersionDetailsHeader = ({
           />
         </TextContent>
         <Flex>
-          {environments?.map(({ name, id: envId }) =>
-            <FlexItem key={name}><Label isTruncated color="purple" href={`/lifecycle_environments/${envId}`}>{name}</Label></FlexItem>)}
+          {environments?.map(({ name, id: envId }) => (
+            <FlexItem key={name}>
+              <Label isTruncated color="purple" href={`/lifecycle_environments/${envId}`}>{name}</Label>
+            </FlexItem>))}
         </Flex>
       </GridItem>
       {promoting &&

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
@@ -24,11 +24,14 @@ import getEnvironmentPaths from '../../../components/EnvironmentPaths/Environmen
 import RemoveCVVersionWizard from '../Delete/RemoveCVVersionWizard';
 import ActionableDetail from '../../../../../components/ActionableDetail';
 import BulkDeleteModal from '../BulkDelete/BulkDeleteModal';
+import NeedsPublishIcon from '../../../components/NeedsPublishIcon';
 
 const ContentViewVersionDetailsHeader = ({
   versionDetails,
   onEdit,
-  details: { permissions },
+  details: {
+    permissions, latest_version_id: latestVersionId, needs_publish: needsPublish, composite,
+  },
   loading,
 }) => {
   const history = useHistory();
@@ -72,7 +75,11 @@ const ContentViewVersionDetailsHeader = ({
     <Grid className="margin-0-24">
       <GridItem sm={6} >
         <TextContent>
-          <Text ouiaId="cv-version" component={TextVariants.h2}>{__('Version ')}{version}</Text>
+          <Text ouiaId="cv-version" component={TextVariants.h2}>
+            {__('Version ')}{version}
+            {(latestVersionId === id && needsPublish) && <NeedsPublishIcon composite={composite} />}
+          </Text>
+
         </TextContent>
       </GridItem>
       <GridItem sm={6} style={{ display: 'flex' }}>
@@ -169,6 +176,9 @@ ContentViewVersionDetailsHeader.propTypes = {
   onEdit: PropTypes.func.isRequired,
   details: PropTypes.shape({
     permissions: PropTypes.shape({}),
+    needs_publish: PropTypes.bool,
+    composite: PropTypes.bool,
+    latest_version_id: PropTypes.number,
   }).isRequired,
   loading: PropTypes.bool.isRequired,
 };

--- a/webpack/scenes/ContentViews/Publish/CVPublishFinish.js
+++ b/webpack/scenes/ContentViews/Publish/CVPublishFinish.js
@@ -20,7 +20,7 @@ import { selectTaskPoll, selectTaskPollStatus } from '../Details/ContentViewDeta
 import { publishContentView } from '../ContentViewsActions';
 import Loading from '../../../components/Loading';
 import EmptyStateMessage from '../../../components/Table/EmptyStateMessage';
-import { cvVersionTaskPollingKey } from '../ContentViewsConstants';
+import { CONTENT_VIEW_NEEDS_PUBLISH_RESET, cvVersionTaskPollingKey } from '../ContentViewsConstants';
 import { clearPollTaskData, startPollingTask, stopPollingTask, toastTaskFinished } from '../../Tasks/TaskActions';
 import getContentViewDetails from '../Details/ContentViewDetailActions';
 
@@ -84,6 +84,7 @@ const CVPublishFinish = ({
       dispatch(clearPollTaskData(POLLING_TASK_KEY));
       dispatch(getContentViewDetails(cvId));
       dispatch(toastTaskFinished(pollResponse));
+      dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH_RESET });
       history.push(`/content_views/${cvId}#/versions/${cvvID || ''}`);
       onClose();
     }

--- a/webpack/scenes/ContentViews/Publish/CVPublishForm.js
+++ b/webpack/scenes/ContentViews/Publish/CVPublishForm.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
 import {
@@ -10,6 +11,7 @@ import EnvironmentPaths from '../components/EnvironmentPaths/EnvironmentPaths';
 import ComponentEnvironments from '../Details/ComponentContentViews/ComponentEnvironments';
 import './cvPublishForm.scss';
 import WizardHeader from '../components/WizardHeader';
+import { selectCVNeedsPublish } from '../Details/ContentViewDetailSelectors';
 
 const CVPublishForm = ({
   description,
@@ -25,6 +27,7 @@ const CVPublishForm = ({
 }) => {
   const [alertDismissed, setAlertDismissed] = useState(false);
   const [needsPublishAlertDismissed, setNeedsPublishAlertDismissed] = useState(false);
+  const needsPublishLocal = useSelector(state => selectCVNeedsPublish(state));
 
   const checkPromote = (checked) => {
     if (!checked) {
@@ -38,7 +41,7 @@ const CVPublishForm = ({
         title={__('Publish')}
         description={
           <>
-            {!needsPublishAlertDismissed && !needsPublish && (
+            {!needsPublishAlertDismissed && !(needsPublish || needsPublishLocal) && (
             <Alert
               ouiaId="needs-publish-alert"
               variant="info"
@@ -53,7 +56,7 @@ const CVPublishForm = ({
             }
               style={{ marginBottom: '24px' }}
             >
-              <TextContent>{__('Newly published version will be the same as previous version.')}</TextContent>
+              <TextContent>{__('Newly published version will be the same as the previous version.')}</TextContent>
             </Alert>)
             }
             {__('A new version of ')}<b>{composite ? <RegistryIcon /> : <EnterpriseIcon />} {name}</b>

--- a/webpack/scenes/ContentViews/Publish/CVPublishForm.js
+++ b/webpack/scenes/ContentViews/Publish/CVPublishForm.js
@@ -15,7 +15,7 @@ const CVPublishForm = ({
   description,
   setDescription,
   details: {
-    name, composite, next_version: nextVersion,
+    name, composite, next_version: nextVersion, needs_publish: needsPublish,
   },
   userCheckedItems,
   setUserCheckedItems,
@@ -24,6 +24,7 @@ const CVPublishForm = ({
   forcePromote,
 }) => {
   const [alertDismissed, setAlertDismissed] = useState(false);
+  const [needsPublishAlertDismissed, setNeedsPublishAlertDismissed] = useState(false);
 
   const checkPromote = (checked) => {
     if (!checked) {
@@ -36,11 +37,31 @@ const CVPublishForm = ({
       <WizardHeader
         title={__('Publish')}
         description={
-          <>{__('A new version of ')}<b>{composite ? <RegistryIcon /> : <EnterpriseIcon />} {name}</b>
+          <>
+            {!needsPublishAlertDismissed && !needsPublish && (
+            <Alert
+              ouiaId="needs-publish-alert"
+              variant="info"
+              isInline
+              title={composite ?
+                __('No available component content view updates') :
+                __('No available repository or filter updates')}
+              actionClose={
+                <AlertActionCloseButton
+                  onClose={() => setNeedsPublishAlertDismissed(true)}
+                />
+            }
+              style={{ marginBottom: '24px' }}
+            >
+              <TextContent>{__('Newly published version will be the same as previous version.')}</TextContent>
+            </Alert>)
+            }
+            {__('A new version of ')}<b>{composite ? <RegistryIcon /> : <EnterpriseIcon />} {name}</b>
             {__(' will be created and automatically promoted to the ' +
               'Library environment. You can promote to other environments as well. ')
             }
-          </>}
+          </>
+      }
       />
       <TextContent>
         <Text ouiaId="next-version-text" component={TextVariants.h3}>
@@ -115,6 +136,7 @@ CVPublishForm.propTypes = {
       PropTypes.number,
       PropTypes.string,
     ]).isRequired,
+    needs_publish: PropTypes.bool,
   }).isRequired,
 };
 

--- a/webpack/scenes/ContentViews/Publish/cvPublishForm.scss
+++ b/webpack/scenes/ContentViews/Publish/cvPublishForm.scss
@@ -7,3 +7,7 @@
   grid-gap: 16px;
   flex-direction: column;
 }
+
+.pf-c-content h4 {
+  margin-top: 0px;
+}

--- a/webpack/scenes/ContentViews/components/NeedsPublishIcon.js
+++ b/webpack/scenes/ContentViews/components/NeedsPublishIcon.js
@@ -9,10 +9,10 @@ const NeedsPublishIcon = ({ composite }) => (
     position="auto"
     enableFlip
     entryDelay={400}
-    content={composite ? __('Available updates in component content views.') :
-      __('Audited updates on repositories and/or filters available.')}
+    content={composite ? __('Updates available: Component content view versions have been updated.') :
+      __('Updates available: Repositories and/or filters have changed.')}
   >
-    <ArrowCircleUpIcon size="sm" style={{ color: '#0066CC', margin: '0 9px' }} />
+    <ArrowCircleUpIcon size="sm" style={{ color: 'var(--pf-global--primary-color--100)', margin: '0 9px' }} />
   </Tooltip>
 );
 

--- a/webpack/scenes/ContentViews/components/NeedsPublishIcon.js
+++ b/webpack/scenes/ContentViews/components/NeedsPublishIcon.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { translate as __ } from 'foremanReact/common/I18n';
+import PropTypes from 'prop-types';
+import { Tooltip } from '@patternfly/react-core';
+import { ArrowCircleUpIcon } from '@patternfly/react-icons';
+
+const NeedsPublishIcon = ({ composite }) => (
+  <Tooltip
+    position="auto"
+    enableFlip
+    entryDelay={400}
+    content={composite ? __('Available updates in component content views.') :
+      __('Audited updates on repositories and/or filters available.')}
+  >
+    <ArrowCircleUpIcon size="sm" style={{ color: '#0066CC', margin: '0 9px' }} />
+  </Tooltip>
+);
+
+NeedsPublishIcon.propTypes = {
+  composite: PropTypes.bool,
+};
+
+NeedsPublishIcon.defaultProps = {
+  composite: false,
+};
+
+export default NeedsPublishIcon;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Update CV UI to reflect needs_publish flag and add icons to versions and notice to publish wizard.
#### Considerations taken when implementing this change?
We have many pages where we avoid reloading the store from API for CV to avoid a refresh of the page. On such components, added a local store variable to reflect needs_publish based on UI actions.
Caveat: Repository level updates like content changes will need a refresh as there's no way to track that on the UI alone.
#### What are the testing steps for this pull request?
Play around with CV versions and check if the needs_publish icon shows up against the latest version. Also test the publish wizard to see if notice explaining that a publish is not needed shows up when needs_publish is false.