### PR TITLE
Fixes #36367 - Fix sticky pagination in rh repos

### DIFF
--- a/webpack/scenes/RedHatRepositories/index.scss
+++ b/webpack/scenes/RedHatRepositories/index.scss
@@ -126,7 +126,7 @@
 
 .sticky-pagination {
   position: sticky;
-  top: 60px;
+  top: 0;
   z-index: 2;
   background-color: white;
   padding-top: 10px;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
fix the pagination being too low

#### Considerations taken when implementing this change?
Merge only after https://github.com/theforeman/foreman/pull/9659 is merged

#### What are the testing steps for this pull request?
open Red Hat Repositories and expand a few repos until you can scroll down, when scrolling down the pagination should stick to be above the repo but under the page header
