### PR TITLE
Fixes #36346 - DELETE request now returns deleted object for ACS

### DIFF
--- a/app/views/katello/api/v2/common/destroy.json.rabl
+++ b/app/views/katello/api/v2/common/destroy.json.rabl
@@ -1,1 +1,2 @@
-object false
+object @resource
+extends "katello/api/v2/%s/show" % controller_name

--- a/app/views/katello/api/v2/host_subscriptions/show.json.rabl
+++ b/app/views/katello/api/v2/host_subscriptions/show.json.rabl
@@ -1,0 +1,1 @@
+object false


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
When sending a DELETE HTTP request on an alternate content source, the ACS's contents will now be returned upon deletion.

#### Considerations taken when implementing this change?
n/a

#### What are the testing steps for this pull request?

1. Create any ACS.
2. Delete the ACS via curl, noting that the ACS's contents are now returned upon deletion:
```
curl -sku admin:changeme -H "Content-type: application/json" -X DELETE https://<host>/katello/api/alternate_content_sources/<ACS id>
```