### PR TITLE
Fixes #35722 - Selector to enable/disable custom/rh repos

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-repository-sets.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-repository-sets.controller.js
@@ -27,10 +27,26 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyRepositorySet
         $scope.nutupane = new Nutupane(RepositorySet, params);
         $scope.nutupane.primaryOnly = true;
         $scope.table = $scope.nutupane.table;
+        $scope.repositoryTypes = {
+            redhat: translate("Red Hat"),
+            custom: translate("Custom")
+        };
+
+        $scope.repositoryType = { value: ""};
+
         $scope.contentAccessModes = {
             contentAccessModeAll: $scope.simpleContentAccessEnabled,
             contentAccessModeEnv: false
         };
+
+        $scope.selectRepositoryType = function () {
+            delete $scope.nutupane.table.params['repository_type'];
+            if (!_.isEmpty($scope.repositoryType.value)) {
+                $scope.nutupane.table.params['repository_type'] = $scope.repositoryType.value;
+            }
+            $scope.nutupane.refresh();
+        };
+
         $scope.toggleFilters = function () {
             $scope.nutupane.table.params['content_access_mode_env'] = $scope.contentAccessModes.contentAccessModeEnv;
             $scope.nutupane.table.params['content_access_mode_all'] = $scope.contentAccessModes.contentAccessModeAll || $scope.simpleContentAccessEnabled;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-repository-sets.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-repository-sets.controller.js
@@ -32,7 +32,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyRepositorySet
             custom: translate("Custom")
         };
 
-        $scope.repositoryType = { value: ""};
+        $scope.repositoryType = {};
 
         $scope.contentAccessModes = {
             contentAccessModeAll: $scope.simpleContentAccessEnabled,

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-repository-sets.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-repository-sets.html
@@ -15,13 +15,15 @@
       <input type="checkbox" ng-model="contentAccessModes.contentAccessModeAll" ng-change="toggleFilters()"/>
       <span translate>Show All</span>
     </label>
-    <label style="border-right: 1px solid #d1d1d1; padding-right: 15px;"
+    <label style="border-right: 1px solid #d1d1d1; padding-right: 15px;margin-bottom:0.3rem"
             class="checkbox-inline"
             title="{{ 'Limit Repository Sets to only those available in this Activation Key\'s Lifecycle  Environment' | translate }}">
       <input type="checkbox" ng-model="contentAccessModes.contentAccessModeEnv" ng-change="toggleFilters()"/>
       <span translate>Limit to Environment</span>
     </label>
-    <span style="padding-left: 15px;">
+
+    <label style="padding-left: 15px;font-weight: normal;">
+      <span style="margin-right: 1rem;" translate>Repository type</span>
       <select
               id="repositoryTypes"
               name="repositoryTypes"
@@ -29,9 +31,9 @@
               ng-options="id as name for (id, name) in repositoryTypes"
               ng-change="selectRepositoryType()"
               >
-          <option value=""></option>
+          <option value="">{{'All' | translate}}</option>
       </select>
-    </span>
+    </label>
   </div>
 
   <div data-block="list-actions">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-repository-sets.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-repository-sets.html
@@ -15,15 +15,14 @@
       <input type="checkbox" ng-model="contentAccessModes.contentAccessModeAll" ng-change="toggleFilters()"/>
       <span translate>Show All</span>
     </label>
-    <label style="border-right: 1px solid #d1d1d1; padding-right: 15px;margin-bottom:0.3rem"
-            class="checkbox-inline"
+    <label  class="checkbox-inline limit-to-environment-label"
             title="{{ 'Limit Repository Sets to only those available in this Activation Key\'s Lifecycle  Environment' | translate }}">
       <input type="checkbox" ng-model="contentAccessModes.contentAccessModeEnv" ng-change="toggleFilters()"/>
       <span translate>Limit to Environment</span>
     </label>
 
-    <label style="padding-left: 15px;font-weight: normal;">
-      <span style="margin-right: 1rem;" translate>Repository type</span>
+    <label class="repository-type-label">
+      <span translate>Repository type</span>
       <select
               id="repositoryTypes"
               name="repositoryTypes"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-repository-sets.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-repository-sets.html
@@ -19,6 +19,15 @@
       <input type="checkbox" ng-model="contentAccessModes.contentAccessModeEnv" ng-change="toggleFilters()"/>
       <span translate>Limit to Environment</span>
     </label>
+
+    <select id="repositoryTypes"
+            name="repositoryTypes"
+            ng-model="repositoryType.value"
+            ng-options="id as name for (id, name) in repositoryTypes"
+            ng-change="selectRepositoryType()"
+            >
+        <option value=""></option>
+    </select>
   </div>
 
   <div data-block="list-actions">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-repository-sets.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-repository-sets.html
@@ -15,19 +15,23 @@
       <input type="checkbox" ng-model="contentAccessModes.contentAccessModeAll" ng-change="toggleFilters()"/>
       <span translate>Show All</span>
     </label>
-    <label class="checkbox-inline" title="{{ 'Limit Repository Sets to only those available in this Activation Key\'s Lifecycle Environment' | translate }}">
+    <label style="border-right: 1px solid #d1d1d1; padding-right: 15px;"
+            class="checkbox-inline"
+            title="{{ 'Limit Repository Sets to only those available in this Activation Key\'s Lifecycle  Environment' | translate }}">
       <input type="checkbox" ng-model="contentAccessModes.contentAccessModeEnv" ng-change="toggleFilters()"/>
       <span translate>Limit to Environment</span>
     </label>
-
-    <select id="repositoryTypes"
-            name="repositoryTypes"
-            ng-model="repositoryType.value"
-            ng-options="id as name for (id, name) in repositoryTypes"
-            ng-change="selectRepositoryType()"
-            >
-        <option value=""></option>
-    </select>
+    <span style="padding-left: 15px;">
+      <select
+              id="repositoryTypes"
+              name="repositoryTypes"
+              ng-model="repositoryType.value"
+              ng-options="id as name for (id, name) in repositoryTypes"
+              ng-change="selectRepositoryType()"
+              >
+          <option value=""></option>
+      </select>
+    </span>
   </div>
 
   <div data-block="list-actions">

--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/activation_keys.scss
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/activation_keys.scss
@@ -1,0 +1,13 @@
+.limit-to-environment-label {
+  border-right: 1px solid #d1d1d1;
+  padding-right: 15px;
+  margin-bottom:0.3rem
+}
+
+.repository-type-label {
+  padding-left: 15px;
+  font-weight: normal;
+  span {
+    margin-right: 0.4rem;
+  }
+}

--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.scss
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.scss
@@ -7,6 +7,7 @@
   @import "subscriptions";
   @import "host_subscriptions";
   @import "docker";
+  @import "activation_keys";
 
   a {
     &.confined-text {

--- a/engines/bastion_katello/test/activation-keys/details/activation-key-repository-sets.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/details/activation-key-repository-sets.controller.test.js
@@ -188,6 +188,15 @@ describe('Controller: ActivationKeyRepositorySetsController', function () {
             expect($scope.nutupane.table.params['content_access_mode_all']).toEqual($scope.contentAccessModes.contentAccessModeAll);
         });
     });
+
+    describe("can select repository type", function () {
+        it("correctly sets the repo params for redhat", function () {
+            $scope.repositoryType["value"] = "redhat";
+            $scope.selectRepositoryType();
+            expect($scope.nutupane.table.params['repository_type']).toEqual("redhat");
+        });
+    });
+
 });
 
 describe('Controller: ActivationKeyRepositorySetsControllerWithSCA', function () {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds a Repository Type selector to AK repo-sets page. This will enable one select/deselect all  custom/rh repos and add override. 

#### Considerations taken when implementing this change?
Initially thought of using scoped search. Sounds like the backend api already has code to handle this so no scoped search.


#### What are the testing steps for this pull request?

- Enable some RH Repos
- Create some custom repos
- Create Activation Key pointing to Library/Default CV
- Go to Activation Key repository sets page
- You should see a drop down after the "limit to environment" checkbox.
- Select Redhat/Custom/blank  and make sure the items are filtered correctly. 
