### PR TITLE
Fixes #36378 - Use plugin dsl for gettext

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -149,13 +149,6 @@ module Katello
       Katello::EventDaemon::Runner.register_service(:candlepin_events, Katello::CandlepinEventListener)
       Katello::EventDaemon::Runner.register_service(:katello_events, Katello::EventMonitor::PollerThread)
       Katello::EventDaemon::Runner.register_service(:katello_agent_events, Katello::EventDaemon::Services::AgentEventReceiver) if ::Katello.with_katello_agent?
-      FastGettext.add_text_domain('katello',
-                                    :path => File.expand_path("../../../locale", __FILE__),
-                                    :type => :po,
-                                    :ignore_fuzzy => true,
-                                    :report_warning => false
-                                 )
-      FastGettext.default_text_domain = 'katello'
 
       # Lib Extensions
       ::Foreman::Renderer::Scope::Variables::Base.include Katello::Concerns::RendererExtensions

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -4,7 +4,8 @@ require 'katello/host_status_manager'
 # rubocop:disable Metrics/BlockLength
 
 Foreman::Plugin.register :katello do
-  requires_foreman '>= 2.6'
+  requires_foreman '>= 3.7'
+  register_gettext
 
   sub_menu :top_menu, :content_menu, :caption => N_('Content'),
            :icon => 'fa fa-book', :after => :monitor_menu do


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Switch to a new plugin dsl for registering translations

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Extracting strings should work just the same
