### PR TITLE
Fixes #36338 - display Module streams tab correctly

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -49,8 +49,8 @@ import {
 const moduleStreamSupported = ({ os, version }) =>
   os.match(/RedHat|RHEL|CentOS|Rocky|AlmaLinux|OracleLinux/i) && Number(version) > 7;
 export const hideModuleStreamsTab = ({ hostDetails }) => {
-  const osMatch = hostDetails?.operatingsystem_name?.match(/(\w+) (\d+)/);
-  if (!osMatch) return true;
+  const osMatch = hostDetails?.operatingsystem_name?.match(/(\D+) (\d+)/);
+  if (!osMatch) return false;
   const [, os, version] = osMatch;
   return !(osMatch && moduleStreamSupported({ os, version }));
 };


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Change the regex to parse OS name and version correctly.
Display Module streams tab for OS when regex does not match it.
 
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Verify module stream tab is displayed for hosts that supports module streams.