### PR TITLE
Fixes #36390 - Orphan cleanup on capsules

### DIFF
--- a/app/lib/actions/pulp3/orchestration/orphan_cleanup/remove_orphans.rb
+++ b/app/lib/actions/pulp3/orchestration/orphan_cleanup/remove_orphans.rb
@@ -7,13 +7,13 @@ module Actions
             if proxy.pulp3_enabled?
               sequence do
                 plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanRepositoryVersions, proxy)
-                plan_action(Actions::Pulp3::OrphanCleanup::RemoveOrphans, proxy)
                 if proxy.pulp_mirror?
                   plan_action(Actions::Pulp3::OrphanCleanup::RemoveUnneededRepos, proxy)
                   plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanDistributions, proxy)
                   plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanAlternateContentSources, proxy)
                   plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanRemotes, proxy)
                 end
+                plan_action(Actions::Pulp3::OrphanCleanup::RemoveOrphans, proxy)
               end
             end
           end

--- a/app/services/katello/pulp3/api/core.rb
+++ b/app/services/katello/pulp3/api/core.rb
@@ -168,7 +168,7 @@ module Katello
         end
 
         def delete_orphans
-          [orphans_api.cleanup(PulpcoreClient::OrphansCleanup.new(orphan_protection_time: Setting[:orphan_protection_time]))]
+          [orphans_api.cleanup(PulpcoreClient::OrphansCleanup.new(orphan_protection_time: (smart_proxy.pulp_mirror? ? 0 : Setting[:orphan_protection_time])))]
         end
 
         def delete_remote(remote_href)

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -669,7 +669,7 @@ Foreman::Plugin.register :katello do
         type: :integer,
         default: 1440,
         full_name: N_('Orphaned Content Protection Time'),
-        description: N_('Time in minutes to consider orphan content as orphaned.')
+        description: N_('Time in minutes before content that is not contained within a repository and has not been accessed is considered orphaned.')
 
       setting 'remote_execution_prefer_registered_through_proxy',
         type: :boolean,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Run pulp orphan cleanup after removing other records like unneeded repositories etc which create orphaned content of their own.
Run capsule orphan cleanup with orphan_protection_time as 0.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Set up a capsule assigned to Default organization that also has some repo content (Synced with immediate download policy)
Sync.
Notice files in /var/lib/pulp/media/artifact/*/*
Remove Default Organization from the capsule and run `bundle exec rails katello:delete_orphaned_content`
Notice files in /var/lib/pulp/media/artifact/*/* . It should be empty since all the downloaded content is orphaned.
