### PR TITLE
Fixes #36397 - Disabled needs_publish flag for old CVs and CVs with audits cleaned up

### DIFF
--- a/test/models/content_view_component_test.rb
+++ b/test/models/content_view_component_test.rb
@@ -222,24 +222,33 @@ module Katello
     def test_needs_publish
       view1 = create(:katello_content_view)
       view2 = create(:katello_content_view)
+      task = ForemanTasks::Task.create!(:label => 'Actions::Katello::ContentView::Publish', :state => 'stopped',
+                                        :type => 'ForemanTasks::Task::DynflowTask', :result => 'success')
+      cv_history = ::Katello::ContentViewHistory.create!(:katello_content_view_version_id => @composite.latest_version_object.id,
+                                                      :status => 'successful', :task_id => task.id, :user => User.first,
+                                                      :action => "publish")
       assert_equal @composite.needs_publish?, true
       @composite.create_new_version
+      cv_history.update!(katello_content_view_version_id: @composite.latest_version_object.id)
       assert_equal @composite.reload.needs_publish?, false
       version1 = create(:katello_content_view_version, :content_view => view1)
       assert ContentViewComponent.create(:composite_content_view => @composite,
                                          :content_view_version => version1, :latest => false)
       assert_equal @composite.reload.needs_publish?, true
       @composite.create_new_version
+      cv_history.update!(katello_content_view_version_id: @composite.latest_version_object.id)
       assert_equal @composite.reload.needs_publish?, false
       create(:katello_content_view_version, :content_view => view2)
       assert ContentViewComponent.create(:composite_content_view => @composite,
                                          :content_view => view2, :latest => true)
       assert_equal @composite.reload.needs_publish?, true
       @composite.create_new_version
+      cv_history.update!(katello_content_view_version_id: @composite.latest_version_object.id)
       assert_equal @composite.reload.needs_publish?, false
       create(:katello_content_view_version, :content_view => view2, :major => "1000")
       assert_equal @composite.reload.needs_publish?, true
       @composite.create_new_version
+      cv_history.update!(katello_content_view_version_id: @composite.latest_version_object.id)
       assert_equal @composite.reload.needs_publish?, false
     end
   end

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -636,6 +636,24 @@ module Katello
       assert content_view.needs_publish?
     end
 
+    def test_audits_cleaned_cv_needs_publish
+      content_view = FactoryBot.build(:katello_content_view, :name => "New CV cleaned audits")
+      content_view.save!
+      content_view.create_new_version
+      content_view.reload
+      content_view.latest_version_object.audits.destroy_all
+      assert_nil content_view.needs_publish?
+    end
+
+    def test_audits_never_created_cv_needs_publish
+      content_view = FactoryBot.build(:katello_content_view, :name => "New CV applied filters nil")
+      content_view.save!
+      content_view.create_new_version
+      content_view.reload
+      content_view.latest_version_object.update!(applied_filters: nil)
+      assert_nil content_view.needs_publish?
+    end
+
     def test_published_cv_needs_publish_on_repositories_update
       org = @organization
       product = create(:katello_product, provider: org.anonymous_provider,

--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
@@ -155,8 +155,12 @@ const ContentViewVersions = ({ cvId, details }) => {
       />,
       <>
         <Link to={`/versions/${versionId}`}>{__('Version ')}{version}</Link>
-        {(latestVersionId === versionId && (needsPublish || needsPublishLocal)) &&
-        <NeedsPublishIcon composite={composite} />
+        {(latestVersionId === versionId &&
+                (needsPublish === null || needsPublish || needsPublishLocal)) &&
+                <NeedsPublishIcon
+                  composite={composite}
+                  determinate={needsPublish !== null || needsPublishLocal}
+                />
         }
         {(filtersApplied) &&
         <FiltersAppliedIcon />

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
@@ -80,8 +80,12 @@ const ContentViewVersionDetailsHeader = ({
         <TextContent>
           <Text ouiaId="cv-version" component={TextVariants.h2}>
             {__('Version ')}{version}
-            {(latestVersionId === id && (needsPublish || needsPublishLocal)) &&
-            <NeedsPublishIcon composite={composite} />
+            {(latestVersionId === id &&
+                    (needsPublish === null || needsPublish || needsPublishLocal)) &&
+                    <NeedsPublishIcon
+                      composite={composite}
+                      determinate={needsPublish !== null || needsPublishLocal}
+                    />
             }
             {(filtersApplied) &&
             <FiltersAppliedIcon />

--- a/webpack/scenes/ContentViews/Publish/CVPublishForm.js
+++ b/webpack/scenes/ContentViews/Publish/CVPublishForm.js
@@ -41,23 +41,25 @@ const CVPublishForm = ({
         title={__('Publish')}
         description={
           <>
-            {!needsPublishAlertDismissed && !(needsPublish || needsPublishLocal) && (
-            <Alert
-              ouiaId="needs-publish-alert"
-              variant="info"
-              isInline
-              title={composite ?
-                __('No available component content view updates') :
-                __('No available repository or filter updates')}
-              actionClose={
-                <AlertActionCloseButton
-                  onClose={() => setNeedsPublishAlertDismissed(true)}
-                />
+            {!needsPublishAlertDismissed &&
+                !(needsPublish === null || needsPublish || needsPublishLocal) &&
+                (
+                <Alert
+                  ouiaId="needs-publish-alert"
+                  variant="info"
+                  isInline
+                  title={composite ?
+                    __('No available component content view updates') :
+                    __('No available repository or filter updates')}
+                  actionClose={
+                    <AlertActionCloseButton
+                      onClose={() => setNeedsPublishAlertDismissed(true)}
+                    />
             }
-              style={{ marginBottom: '24px' }}
-            >
-              <TextContent>{__('Newly published version will be the same as the previous version.')}</TextContent>
-            </Alert>)
+                  style={{ marginBottom: '24px' }}
+                >
+                  <TextContent>{__('Newly published version will be the same as the previous version.')}</TextContent>
+                </Alert>)
             }
             {__('A new version of ')}<b>{composite ? <RegistryIcon /> : <EnterpriseIcon />} {name}</b>
             {__(' will be created and automatically promoted to the ' +

--- a/webpack/scenes/ContentViews/components/NeedsPublishIcon.js
+++ b/webpack/scenes/ContentViews/components/NeedsPublishIcon.js
@@ -3,25 +3,43 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import PropTypes from 'prop-types';
 import { Tooltip } from '@patternfly/react-core';
 import { ArrowCircleUpIcon } from '@patternfly/react-icons';
+import './NeedsPublishIcon.scss';
 
-const NeedsPublishIcon = ({ composite }) => (
+const tooltipContent = (composite, determinate) => {
+  let content = '';
+  if (determinate) {
+    content = composite ? __('Updates available: Component content view versions have been updated.') :
+      __('Updates available: Repositories and/or filters have changed.');
+  } else {
+    content = __('We could not determine if publish is required for the content view. ' +
+        'Audit records may have been cleaned or not created for this version.');
+  }
+  return content;
+};
+
+const NeedsPublishIcon = ({ composite, determinate }) => (
   <Tooltip
     position="auto"
     enableFlip
     entryDelay={400}
-    content={composite ? __('Updates available: Component content view versions have been updated.') :
-      __('Updates available: Repositories and/or filters have changed.')}
+    content={tooltipContent(composite, determinate)}
   >
-    <ArrowCircleUpIcon size="sm" style={{ color: 'var(--pf-global--primary-color--100)', marginLeft: '9px' }} />
+    <ArrowCircleUpIcon
+      id={determinate ? 'determinate-needs-publish' : 'indeterminate-needs-publish'}
+      size="sm"
+      className={determinate ? 'determinate-needs-publish' : 'indeterminate-needs-publish'}
+    />
   </Tooltip>
 );
 
 NeedsPublishIcon.propTypes = {
   composite: PropTypes.bool,
+  determinate: PropTypes.bool,
 };
 
 NeedsPublishIcon.defaultProps = {
   composite: false,
+  determinate: false,
 };
 
 export default NeedsPublishIcon;

--- a/webpack/scenes/ContentViews/components/NeedsPublishIcon.scss
+++ b/webpack/scenes/ContentViews/components/NeedsPublishIcon.scss
@@ -1,0 +1,9 @@
+.determinate-needs-publish {
+  color: var(--pf-global--primary-color--100);
+  margin-left: 9px;
+}
+
+.indeterminate-needs-publish {
+  color: var(--pf-global--disabled-color--200);
+  margin-left: 9px;
+}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Show a disabled needs_publish icon when we can not determine if a CV needs publish or not.
This is the case when:
1. CV is a component CV.
2. CV audits have been cleaned since the last publish.
3. CV version was published pre-upgrade when logic for creating several of the audits were added.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
For a CV version, add a few repositories after publish.
This would mean needs_publish should be true.
Notice active(primary-color) icon next to version on table/version details.
In console> Audit.delete_all
Now the CV versions page should show disabled needs_publish icon with a tooltip text.
The publish wizard shouldn't tell user there are no updates in case of nil (soft-yes) needs_publish