### PR TITLE
Fixes #36402 - Closing publish task wizard doesn't reset needs_publish local state

### DIFF
--- a/webpack/scenes/ContentViews/Publish/CVPublishFinish.js
+++ b/webpack/scenes/ContentViews/Publish/CVPublishFinish.js
@@ -68,6 +68,7 @@ const CVPublishFinish = ({
             setSaving(false);
           },
         ));
+        dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH_RESET });
       }, () => { setSaving(false); }));
     }
   }, [POLLING_TASK_KEY, currentStep, cvId, description, dispatch, forcePromote,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Updates page to hide needs_publish icon when CV is published and wizard is closed while task is running.
#### Considerations taken when implementing this change?
In case of errors, the icon will not appear and if you skip and resume tasks. This feels like a gap and I am thinking about opening an issue to track that.
#### What are the testing steps for this pull request?
1. Add/remove a filter on a cv. (Do not refresh anytime during the process)
2. Publish and close the wizard while task is running.
3. After the task polling completes, the needs_publish icon shouldn't appear on the latest version.