### PR TITLE
Fixes #36410 - Set needs_publish to true for versions published with a failed task

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -787,7 +787,14 @@ module Katello
       published_component_version_ids.compact.uniq.sort != unpublished_component_version_ids.compact.uniq.sort
     end
 
+    def last_publish_task_success?
+      last_publish_result = latest_version_object&.history&.publish&.first&.task&.result
+      return last_publish_result&.equal?('success')
+    end
+
     def needs_publish?
+      return true unless latest_version_object
+      return nil unless last_publish_task_success?
       return composite_cv_components_changed? if composite?
       audited_cv_repositories_since_last_publish.present? || audited_cv_repository_changed.present? ||
         audited_cv_filters_changed.present? || audited_cv_filter_rules_changed.present?


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
When a publish task ends in a failed state, we can not determine if all repository contents were successfully snapshotted in the CV.
In such a case, we should fall back on the indeterminate needs_publish value of null instead of determinate true/false.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create and publish a CV with a modular repo and some modules selected in an include filter
2. In console, update one of the module streams in include filter href to junk value
3. Publish the CV again.
4. The publish will fail. In dynflow console, skip the failed step and resume the task. Task will end in warning state.
5. Check if needs_publish is returned as null for the CV in the API.