### PR TITLE
Fixes #36420 - Correct aria-label for description

### DIFF
--- a/webpack/scenes/AlternateContentSources/Details/ACSExpandableDetails.js
+++ b/webpack/scenes/AlternateContentSources/Details/ACSExpandableDetails.js
@@ -144,7 +144,7 @@ const ACSExpandableDetails = ({ expandedId }) => {
                   {__('Description')}
                 </TextListItem>
                 <TextListItem
-                  aria-label="name_text_value"
+                  aria-label="description_text_value"
                   component={TextListItemVariants.dd}
                 >
                   {description || <InactiveText text="N/A" />}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Correct aria-label of description field value on ACS details.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1. Go to ACS details page.
2. Inspect description value in the details.
3. Check if aria-label changed to description_text_value