### PR TITLE
add packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -25,7 +25,7 @@ actions:
     - bash -c "ls -1t ./katello-*.gem | head -n 1"
   fix-spec-file:
     - 'bash -c "sed -i \"s/Source0:.*/Source0: ${PACKIT_PROJECT_ARCHIVE}/\" rubygem-katello.spec"'
-    - bash -c 'sed -i "/global release/a%global nightly $PACKIT_RPMSPEC_RELEASE" rubygem-katello.spec'
+    - bash -c 'sed -i "/global release/a%global nightly ${PACKIT_RPMSPEC_RELEASE:1}" rubygem-katello.spec'
 
 jobs:
   - job: copr_build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,43 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rubygem-katello.spec
+
+# add or remove files that should be synced
+files_to_sync:
+    - rubygem-katello.spec
+    - .packit.yaml
+
+# name in upstream package repository or registry (e.g. in PyPI)
+upstream_package_name: katello
+# downstream (Fedora) RPM package name
+downstream_package_name: rubygem-katello
+
+upstream_tag_template: "{version}"
+
+actions:
+  post-upstream-clone:
+    - "wget https://raw.githubusercontent.com/theforeman/foreman-packaging/rpm/develop/packages/katello/rubygem-katello/rubygem-katello.spec -O rubygem-katello.spec"
+    - "sed -i '/%global prerelease/d' rubygem-katello.spec"
+  get-current-version:
+    - "sed -i 's/-master//' lib/katello/version.rb"
+    - ruby -rrubygems -e 'puts Gem::Specification::load(Dir.glob("*.gemspec").first).version'
+  create-archive:
+    - gem build katello.gemspec
+    - bash -c "ls -1t ./katello-*.gem | head -n 1"
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      centos-stream-8:
+        additional_modules: "katello:el8,nodejs:12"
+        additional_repos:
+          - http://koji.katello.org/releases/yum/foreman-nightly/el8/x86_64/
+          - http://yum.theforeman.org/plugins/nightly/el8/x86_64/
+          - http://yum.theforeman.org/katello/nightly/katello/el8/x86_64/
+    module_hotfixes: true
+
+srpm_build_deps:
+  - wget
+  - rubygems

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,13 +18,14 @@ upstream_tag_template: "{version}"
 actions:
   post-upstream-clone:
     - "wget https://raw.githubusercontent.com/theforeman/foreman-packaging/rpm/develop/packages/katello/rubygem-katello/rubygem-katello.spec -O rubygem-katello.spec"
-    - "sed -i '/%global prerelease/d' rubygem-katello.spec"
   get-current-version:
-    - "sed -i 's/-master//' lib/katello/version.rb"
     - ruby -rrubygems -e 'puts Gem::Specification::load(Dir.glob("*.gemspec").first).version'
   create-archive:
     - gem build katello.gemspec
     - bash -c "ls -1t ./katello-*.gem | head -n 1"
+  fix-spec-file:
+    - 'bash -c "sed -i \"s/Source0:.*/Source0: ${PACKIT_PROJECT_ARCHIVE}/\" rubygem-katello.spec"'
+    - bash -c 'sed -i "/global release/a%global nightly $PACKIT_RPMSPEC_RELEASE" rubygem-katello.spec'
 
 jobs:
   - job: copr_build


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

adds support for packit (see https://community.theforeman.org/t/packit-for-foreman-get-production-rpms-from-prs/32412)

#### Considerations taken when implementing this change?

none

#### What are the testing steps for this pull request?

spin up a box
```
# dnf copr enable packit/katello-katello-<PR_NUMBER> centos-stream-8-x86_64
# dnf upgrade rubygem-katello
```
should give you a .rpm build of Katello from a PR :)