### PR TITLE
Fixes #36429 - Add specific release for k-agent removal

### DIFF
--- a/app/controllers/katello/concerns/api/api_controller.rb
+++ b/app/controllers/katello/concerns/api/api_controller.rb
@@ -19,11 +19,11 @@ module Katello
 
       class_methods do
         def katello_agent_deprecation_text
-          N_("NOTE: Katello-agent is deprecated and will be removed in %s. Consider using remote execution instead.") % katello_agent_removal_release
+          N_("WARNING: Katello-agent is deprecated and will be removed in %s. Migrate to remote execution now.") % katello_agent_removal_release
         end
 
         def katello_agent_removal_release
-          N_("a future release")
+          N_("Katello 4.10")
         end
       end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add a specific release (Katello 4.10) to the katello-agent deprecation warning.

#### Considerations taken when implementing this change?

it's finally happening

#### What are the testing steps for this pull request?

attempt a Katello-agent package action thru either Hammer or API
View the new deprecation warning
