### PR TITLE
Fixes #36435 - Make metadata_expire an optional field

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -25,11 +25,6 @@
 
       <dt translate>Type</dt>
       <dd>{{ repository.content_type }}</dd>
-      <dt ng-if="product.redhat != true" translate>Metadata Expiration (Seconds)</dt>
-      <dd bst-edit-number="repository.metadata_expire" on-save="save(repository)" readonly="product.redhat || denied('edit_products', product)"
-          deletable="repository.metadata_expire !== null"
-          on-delete="clearMetadataExpire()">
-      </dd>
     </dl>
 
     <div class="divider"></div>
@@ -56,6 +51,14 @@
               selector="selectedOSVersion"
               options="osVersionsOptions()"
               on-save="save(repository)">
+          </dd>
+
+          <dt ng-if="product.redhat != true" translate>Metadata Expiration (Seconds)</dt>
+          <dd bst-edit-number="repository.metadata_expire" on-save="save(repository)" readonly="product.redhat || denied('edit_products', product)"
+              deletable="repository.metadata_expire !== null"
+              on-delete="clearMetadataExpire()"
+              min="1"
+          >
           </dd>
       </dl>
       <div class="divider"></div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -46,7 +46,7 @@
                type="number"
                min="1"
                placeholder="default value is 1"
-               required/>
+               />
       </div>
 
     </div>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Go to create new repository
2. Select type Yum and fill in fields other than metadata_expire.
3. You should be able to save the repository.

On the details view for the repository
1. Metadata expire field is now under Publishing Settings section and also lowest value you can set is 1 similar to on the new repository page.