### PR TITLE
Fixes #36442 - Capsule is auto-synced on CV promotion

### DIFF
--- a/app/lib/actions/katello/content_view/promote_to_environment.rb
+++ b/app/lib/actions/katello/content_view/promote_to_environment.rb
@@ -55,7 +55,7 @@ module Actions
 
         def trigger_capsule_sync(_execution_plan)
           environment = ::Katello::KTEnvironment.find(input[:environment_id])
-          if !input[:incremental_update] && sync_proxies?(environment)
+          if !input[:incremental_update] && sync_proxies?(environment) && Setting[:foreman_proxy_content_auto_sync]
             ForemanTasks.async_task(ContentView::CapsuleSync,
                                     ::Katello::ContentView.find(input[:content_view_id]),
                                     environment)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Check the value for setting: Sync Smart Proxies after content view promotion
2. Promote a CV to an env that has a capsule attached.
3. The capsule sync task should get triggered after promotion based on the value of that setting.