### PR TITLE
Fixes #36445 - remove extra th element from repository sets page

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -67,7 +67,7 @@ import SelectableDropdown from '../../../../SelectableDropdown';
 import {
   hasRequiredPermissions as can,
   missingRequiredPermissions as cannot,
-  userPermissionsFromHostDetails
+  userPermissionsFromHostDetails,
 } from '../../hostDetailsHelpers';
 
 const viewRepoSets = [

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -64,9 +64,11 @@ import { selectRepositorySetsStatus } from './RepositorySetsSelectors';
 import './RepositorySetsTab.scss';
 import SortableColumnHeaders from '../../../../Table/components/SortableColumnHeaders';
 import SelectableDropdown from '../../../../SelectableDropdown';
-import { hasRequiredPermissions as can,
+import {
+  hasRequiredPermissions as can,
   missingRequiredPermissions as cannot,
-  userPermissionsFromHostDetails } from '../../hostDetailsHelpers';
+  userPermissionsFromHostDetails
+} from '../../hostDetailsHelpers';
 
 const viewRepoSets = [
   'view_hosts', 'view_activation_keys', 'view_products',
@@ -397,7 +399,7 @@ const RepositorySetsTab = () => {
   });
 
   const readOnlyBookmarks =
-  cannot(createBookmarks, userPermissionsFromHostDetails({ hostDetails }));
+    cannot(createBookmarks, userPermissionsFromHostDetails({ hostDetails }));
 
   const dropdownItems = [
     <DropdownItem
@@ -604,7 +606,6 @@ const RepositorySetsTab = () => {
                 pfSortParams={pfSortParams}
                 columnsToSortParams={COLUMNS_TO_SORT_PARAMS}
               />
-              <Th />
               <Th key="action-menu" />
             </Tr>
           </Thead>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Removing the extra th element from the repository sets page
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Steps to Reproduce:
1. Register host
2. Navigate to All hosts->$hostname->Content->Repository sets
3. Check DOM for the table, the number of header columns should be the same as the number of columns in rows