### PR TITLE
Fixes #36428 - Don't trigger pulp tasks on ignorable_content updates

### DIFF
--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -406,8 +406,8 @@ module Katello
     end
 
     def pulp_update_needed?
-      changeable_attributes = %w(url unprotected checksum_type docker_upstream_name download_policy mirroring_policy verify_ssl_on_sync
-                                 upstream_username upstream_password ignorable_content retain_package_versions_count
+      changeable_attributes = %w(url unprotected checksum_type docker_upstream_name download_policy verify_ssl_on_sync
+                                 upstream_username upstream_password retain_package_versions_count
                                  ssl_ca_cert_id ssl_client_cert_id ssl_client_key_id http_proxy_policy http_proxy_id download_concurrency)
       changeable_attributes += %w(name container_repository_name include_tags exclude_tags) if docker?
       changeable_attributes += %w(deb_releases deb_components deb_architectures gpg_key_id) if deb?


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Ignorable_content is a param on pulp repository sync API and isn't stored anywhere other than katello. An update to ignorable_content shouldn't trigger unnecessary pulp tasks since we don't actually update anything in pulp. A sync will perform all the required steps to ignore updated list.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a yum repo with Ignore SRPMs and Ignore treeinfo blank.
2. Update either of those values.
3. Monitor the foreman task for Repository::Update
4. There shouldn't be any pulp task steps run in the Repository::Update task.

Ex srpm repo to test srpm is ignored in the next sync: https://fixtures.pulpproject.org/srpm-unsigned/
Ex treeinfo repo to test ignore treeinfo: https://www.keepersecurity.com/kcm/2/el/8/x86_64 (Note: sync will fail without ignoring treeinfo)
Make sure your repo isn't doing an additive sync cause that will not delete srpms that have been synced on repo before.