### PR TITLE
Fixes #36459 - Hide import_only and generated fields on CV

### DIFF
--- a/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
+++ b/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Form, FormGroup, TextInput, TextArea, Checkbox, ActionGroup, Button, Tile, Grid, GridItem } from '@patternfly/react-core';
 import { createContentView } from '../ContentViewsActions';
 import { selectCreateContentViews, selectCreateContentViewStatus, selectCreateContentViewError } from './ContentViewCreateSelectors';
-import { LabelDependencies, LabelAutoPublish, LabelImportOnly } from './ContentViewFormComponents';
+import { LabelDependencies, LabelAutoPublish } from './ContentViewFormComponents';
 import ContentViewIcon from '../components/ContentViewIcon';
 import './CreateContentViewForm.scss';
 
@@ -19,7 +19,6 @@ const CreateContentViewForm = ({ setModalOpen }) => {
   const [composite, setComposite] = useState(false);
   const [component, setComponent] = useState(true);
   const [autoPublish, setAutoPublish] = useState(false);
-  const [importOnly, setImportOnly] = useState(false);
   const [dependencies, setDependencies] = useState(false);
   const [redirect, setRedirect] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -59,7 +58,6 @@ const CreateContentViewForm = ({ setModalOpen }) => {
       composite,
       solve_dependencies: dependencies,
       auto_publish: (autoPublish && composite),
-      import_only: importOnly,
     }));
   };
 
@@ -166,17 +164,6 @@ const CreateContentViewForm = ({ setModalOpen }) => {
             label={LabelDependencies()}
             isChecked={dependencies}
             onChange={checked => setDependencies(checked)}
-          />
-        </FormGroup>}
-      {!composite &&
-        <FormGroup isInline fieldId="importOnly">
-          <Checkbox
-            id="importOnly"
-            ouiaId="importOnly"
-            name="importOnly"
-            label={LabelImportOnly()}
-            isChecked={importOnly}
-            onChange={checked => setImportOnly(checked)}
           />
         </FormGroup>}
       {composite &&

--- a/webpack/scenes/ContentViews/Create/__tests__/createContentView.test.js
+++ b/webpack/scenes/ContentViews/Create/__tests__/createContentView.test.js
@@ -24,7 +24,6 @@ const createDetails = {
   composite: false,
   solve_dependencies: false,
   auto_publish: false,
-  import_only: false,
 };
 
 const createdCVDetails = { ...cvCreateData };
@@ -78,7 +77,6 @@ test('Displays dependent fields correctly', () => {
   expect(getByText('Content view')).toBeInTheDocument();
   expect(getByText('Solve dependencies')).toBeInTheDocument();
   expect(queryByText('Auto publish')).not.toBeInTheDocument();
-  expect(getByText('Import only')).toBeInTheDocument();
 
   // label auto_set
   fireEvent.change(getByLabelText('input_name'), { target: { value: '123 2123' } });
@@ -88,13 +86,11 @@ test('Displays dependent fields correctly', () => {
   fireEvent.click(getByLabelText('composite_tile'));
   expect(queryByText('Solve dependencies')).not.toBeInTheDocument();
   expect(getByText('Auto publish')).toBeInTheDocument();
-  expect(queryByText('Import only')).not.toBeInTheDocument();
 
   // display Solve Dependencies when Component CV
   fireEvent.click(getByLabelText('component_tile'));
   expect(getByText('Solve dependencies')).toBeInTheDocument();
   expect(queryByText('Auto publish')).not.toBeInTheDocument();
-  expect(getByText('Import only')).toBeInTheDocument();
 });
 
 test('Validates label field', () => {

--- a/webpack/scenes/ContentViews/Details/ContentViewDetails.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetails.js
@@ -105,39 +105,47 @@ export default () => {
     generated_for: generatedFor, import_only: importOnly,
   } = details;
   const generatedContentView = generatedFor !== 'none';
-  const tabs = [
-    {
-      key: 'details',
-      title: __('Details'),
-      content: <ContentViewInfo {...{ cvId, details }} />,
-    },
-    {
-      key: 'versions',
-      title: __('Versions'),
-      content: <ContentViewVersionsRoutes {...{ cvId, details }} />,
-    },
-    ...composite ? [{
-      key: 'contentviews',
-      title: __('Content views'),
-      content: <ContentViewComponents {...{ cvId, details }} />,
-    }] : [{
-      key: 'repositories',
-      title: __('Repositories'),
-      content: <ContentViewRepositories {...{ cvId, details }} />,
-    },
-    !(importOnly || generatedContentView) &&
-    {
-      key: 'filters',
-      title: __('Filters'),
-      content: <ContentViewFilterRoutes {...{ cvId, details }} />,
-    }],
-    {
-      key: 'history',
-      title: __('History'),
-      content: <ContentViewHistories cvId={cvId} />,
-    },
-  ];
+  const detailsTab = {
+    key: 'details',
+    title: __('Details'),
+    content: <ContentViewInfo {...{ cvId, details }} />,
+  };
+  const versionsTab = {
+    key: 'versions',
+    title: __('Versions'),
+    content: <ContentViewVersionsRoutes {...{ cvId, details }} />,
+  };
+  const contentViewsTab = {
+    key: 'contentviews',
+    title: __('Content views'),
+    content: <ContentViewComponents {...{ cvId, details }} />,
+  };
+  const repositoriesTab = {
+    key: 'repositories',
+    title: __('Repositories'),
+    content: <ContentViewRepositories {...{ cvId, details }} />,
+  };
+  const filtersTab = {
+    key: 'filters',
+    title: __('Filters'),
+    content: <ContentViewFilterRoutes {...{ cvId, details }} />,
+  };
+  const historyTab = {
+    key: 'history',
+    title: __('History'),
+    content: <ContentViewHistories cvId={cvId} />,
+  };
 
+  /* eslint-disable no-nested-ternary */
+  const tabs = [
+    detailsTab,
+    versionsTab,
+    ...(composite ? [contentViewsTab] :
+      ((importOnly || generatedContentView) ?
+        [repositoriesTab] : [repositoriesTab, filtersTab])),
+    historyTab,
+  ];
+  /* eslint-enable no-nested-ternary */
 
   return (
     <>

--- a/webpack/scenes/ContentViews/Details/ContentViewInfo.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewInfo.js
@@ -111,32 +111,38 @@ const ContentViewInfo = ({ cvId, details }) => {
             boolean
             {...{ currentAttribute, setCurrentAttribute }}
           />)}
-        <TextListItem component={TextListItemVariants.dt}>
-          {LabelImportOnly()}
-        </TextListItem>
-        <TextListItem component={TextListItemVariants.dd} className="foreman-spaced-list">
-          <Switch
-            id="import_only_switch"
-            ouiaId="import_only_switch"
-            aria-label="import_only_switch"
-            isChecked={importOnly}
-            className="foreman-spaced-list"
-            disabled
-          />
-        </TextListItem>
-        <TextListItem component={TextListItemVariants.dt}>
-          {LabelGenerated()}
-        </TextListItem>
-        <TextListItem component={TextListItemVariants.dd} className="foreman-spaced-list">
-          <Switch
-            id="generated_by_export_switch"
-            ouiaId="generated_by_export_switch"
-            aria-label="generated_by_export_switch"
-            isChecked={generatedContentView}
-            className="foreman-spaced-list"
-            disabled
-          />
-        </TextListItem>
+        {importOnly &&
+          <>
+            <TextListItem component={TextListItemVariants.dt}>
+              {LabelImportOnly()}
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd} className="foreman-spaced-list">
+              <Switch
+                id="import_only_switch"
+                ouiaId="import_only_switch"
+                aria-label="import_only_switch"
+                isChecked={importOnly}
+                className="foreman-spaced-list"
+                disabled
+              />
+            </TextListItem>
+          </>}
+        {generatedContentView &&
+          <>
+            <TextListItem component={TextListItemVariants.dt}>
+              {LabelGenerated()}
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd} className="foreman-spaced-list">
+              <Switch
+                id="generated_by_export_switch"
+                ouiaId="generated_by_export_switch"
+                aria-label="generated_by_export_switch"
+                isChecked={generatedContentView}
+                className="foreman-spaced-list"
+                disabled
+              />
+            </TextListItem>
+          </>}
       </TextList>
     </TextContent>
   );

--- a/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
+++ b/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
@@ -351,7 +351,6 @@ test('Displays Create Content View and opens modal with Form', async () => {
   expect(queryByText('Content view')).not.toBeInTheDocument();
   expect(queryByText('Solve dependencies')).not.toBeInTheDocument();
   expect(queryByText('Auto publish')).not.toBeInTheDocument();
-  expect(queryByText('Import only')).not.toBeInTheDocument();
 
   getByLabelText('create_content_view').click();
 
@@ -362,7 +361,6 @@ test('Displays Create Content View and opens modal with Form', async () => {
   expect(getByText('Content view')).toBeInTheDocument();
   expect(getByText('Solve dependencies')).toBeInTheDocument();
   expect(queryByText('Auto publish')).not.toBeInTheDocument();
-  expect(getByText('Import only')).toBeInTheDocument();
 });
 
 /* eslint-enable no-useless-escape */


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
1. Set up tabs better. (On master, for generated CVs, there's a hidden tab which still shows up as clickable where filters tab would be)
2. Hide import_only and generated fields on CV details when false
3. Remove import_only from CV create form.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a CV from UI. You shouldn't see the import only flag
2. On the created CV, you shouldn't see import_only or generated fields.
3. Export library environment. Make sure you see the disabled generated flag.
4. Import the library environment to a staellite and ensure you see the disabled import_only flag set to true on the UI.