### PR TITLE
Fixes #36461 - 'Remove orphans' task fails on DeleteOrphanAlternateContentSources step

### DIFF
--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -39,6 +39,7 @@ module Katello
 
       def self.api(smart_proxy, repository_type_label)
         repo_type = RepositoryTypeManager.enabled_repository_types[repository_type_label]
+        fail _("%s content type is not enabled." % repository_type_label) unless repo_type
         repo_type.pulp3_api(smart_proxy)
       end
 

--- a/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
+++ b/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
@@ -79,18 +79,19 @@ module Katello
         known_acss = smart_proxy.smart_proxy_alternate_content_sources
         known_acs_hrefs = known_acss.pluck(:alternate_content_source_href) if known_acss.present?
 
-        file_acs_api = ::Katello::Pulp3::Repository.api(smart_proxy, 'file').alternate_content_source_api
-        yum_acs_api = ::Katello::Pulp3::Repository.api(smart_proxy, 'yum').alternate_content_source_api
-
-        orphan_file_acs_hrefs = file_acs_api.list.results.map(&:pulp_href) - known_acs_hrefs
-        orphan_yum_acs_hrefs = yum_acs_api.list.results.map(&:pulp_href) - known_acs_hrefs
-
-        orphan_file_acs_hrefs.each do |orphan_file_acs_href|
-          tasks << file_acs_api.delete(orphan_file_acs_href)
+        if RepositoryTypeManager.enabled_repository_types['file']
+          file_acs_api = ::Katello::Pulp3::Repository.api(smart_proxy, 'file').alternate_content_source_api
+          orphan_file_acs_hrefs = file_acs_api.list.results.map(&:pulp_href) - known_acs_hrefs
+          orphan_file_acs_hrefs.each do |orphan_file_acs_href|
+            tasks << file_acs_api.delete(orphan_file_acs_href)
+          end
         end
-
-        orphan_yum_acs_hrefs.each do |orphan_yum_acs_href|
-          tasks << yum_acs_api.delete(orphan_yum_acs_href)
+        if RepositoryTypeManager.enabled_repository_types['yum']
+          yum_acs_api = ::Katello::Pulp3::Repository.api(smart_proxy, 'yum').alternate_content_source_api
+          orphan_yum_acs_hrefs = yum_acs_api.list.results.map(&:pulp_href) - known_acs_hrefs
+          orphan_yum_acs_hrefs.each do |orphan_yum_acs_href|
+            tasks << yum_acs_api.delete(orphan_yum_acs_href)
+          end
         end
       end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Only triggers orphan ACS cleanup of types enabled on proxy. This is a special case where users diable file plugin on proxy.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. The long way to test this is to disable file content on a proxy.
2. And then try running bundle exec rails katello:delete_orphaned_content
3. You'll see the remove orphan task for proxy fail.
4. On this PR, it should not fail.

A shortcut to test that I used, is to change L82 and 83 of katello/app/services/katello/pulp3/smart_proxy_mirror_repository.rb, replace 'file' with 'file2'
and notice it doesn't fail with this PR.