### PR TITLE
Add an internal API for Katello Event Queue and Candlepin Events

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,21 @@
+# Katello Architecture
+
+## Event Queue
+The Event Queue enables asynchronous event processing with a few other requirements:
+
+### Requirements
+
+#### Deduplication
+Certain operations in Katello may trigger a flurry of events that would cause the same operation to be executed several times in a row. One example is generating Content Host Errata applicability. When an action triggering applicability generation occurs, an event is placed on the queue. Several applicability events may be queued for the same host in a brief period. The next time the Event Queue is drained it will calculate applicability for that host only once and remove the duplicate events afterward since their action has already been completed.
+
+#### Scheduling
+Certain operations need to happen at some point in the future from the time an event is queued. Events can be marked with a timestamp indicating when they should be handled. Until that point they'll remain untouched in the queue. One example of this is removal of a Content Host's Qpid queue (Katello Agent) which happens ten minutes after unregistering. If the host re-registers in that window its queue will be preserved.
+
+#### Retrying
+Certain events which might fail can be marked as needing to be retried. The functionality works on top of event scheduling. Each event can configure its retry wait individually. The Event Queue controls the total elapsed time that any event can be retried but doesn't limit the number of retries in that window.
+
+### Operation
+The Event Queue is drained by the Event Daemon which is different subsystem. Draining occurs every three seconds. The drain interval was chosen to strike a balance between timely handling of events and gaining benefit from deduplication. The Daemon runs the Event Queue [here](https://github.com/Katello/katello/blob/master/app/services/katello/event_monitor/poller_thread.rb).
+
+### Implementation
+The logic is consolidated in the [Event Queue Service](https://github.com/Katello/katello/blob/master/app/services/katello/event_queue.rb). It ultimately controls all ingress/egress of the [Katello::Event](https://github.com/Katello/katello/blob/master/app/models/katello/event.rb) table. All events must be [registered](https://github.com/Katello/katello/blob/master/lib/katello/engine.rb#L225-L230) in order to be processed.

--- a/app/controllers/katello/api/internal/candlepin_events_controller.rb
+++ b/app/controllers/katello/api/internal/candlepin_events_controller.rb
@@ -1,0 +1,21 @@
+module Katello
+  module Api
+    module Internal
+      class CandlepinEventsController < ::Katello::Api::InternalApiController
+        before_action :authorize_foreman_client
+
+        def handle
+          event = OpenStruct.new(params.slice(:subject, :content))
+          handler = ::Katello::Candlepin::EventHandler.new(Katello.internal_events_logger)
+          handler.handle(event)
+        end
+
+        def heartbeat
+          if params[:status].present?
+            Rails.cache.write(::Katello::Ping::CANDLEPIN_EVENTS_CACHE_KEY, params[:status], expires_in: 1.minute)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/katello/api/internal/event_queue_controller.rb
+++ b/app/controllers/katello/api/internal/event_queue_controller.rb
@@ -8,6 +8,17 @@ module Katello
           EventQueue.reset_in_progress
         end
 
+        def subscribe
+          subscription = Katello::EventQueue::Subscription.new
+          result = subscription.wait
+
+          if result
+            render json: 'ok'
+          else
+            head :no_content
+          end
+        end
+
         def next
           event = ::Katello::EventQueue.next_event
 

--- a/app/controllers/katello/api/internal/event_queue_controller.rb
+++ b/app/controllers/katello/api/internal/event_queue_controller.rb
@@ -1,0 +1,34 @@
+module Katello
+  module Api
+    module Internal
+      class EventQueueController < ::Katello::Api::InternalApiController
+        before_action :authorize_foreman_client
+
+        def reset
+          EventQueue.reset_in_progress
+        end
+
+        def next
+          event = ::Katello::EventQueue.next_event
+
+          unless event
+            return head :no_content
+          end
+
+          ::User.as_anonymous_admin do
+            handler = Katello::EventQueue::Handler.new(event)
+            handler.handle
+          end
+
+          render json: { event: event }
+        end
+
+        def heartbeat
+          if params[:status].present?
+            Rails.cache.write(::Katello::Ping::CANDLEPIN_EVENTS_CACHE_KEY, params[:status], expires_in: 1.minute)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/katello/api/internal_api_controller.rb
+++ b/app/controllers/katello/api/internal_api_controller.rb
@@ -1,0 +1,17 @@
+module Katello
+  module Api
+    class InternalApiController < ApplicationController
+      skip_before_action :verify_authenticity_token
+      skip_before_action :require_login
+      skip_before_action :session_expiry
+      skip_before_action :authorize
+
+      private
+
+      def authorize_foreman_client
+        client_cert = ::Foreman::ClientCertificate.new(request: request)
+        render json: nil, status: :forbidden unless client_cert.verified?
+      end
+    end
+  end
+end

--- a/app/lib/katello/event_queue/handler.rb
+++ b/app/lib/katello/event_queue/handler.rb
@@ -1,0 +1,34 @@
+module Katello
+  class EventQueue
+    class Handler
+      def initialize(event, logger = EventQueue.logger)
+        @event = event
+        @event_instance = ::Katello::EventQueue.create_instance(@event)
+        @logger = logger
+      end
+
+      def handle
+        Katello::Logging.time("katello event handled") do |data|
+          data[:type] = @event.event_type
+          data[:object_id] = @event.object_id
+          data[:expired] = false
+          data[:rescheduled] = false
+
+          begin
+            @event_instance.run
+          ensure
+            if @event_instance.try(:retry)
+              result = ::Katello::EventQueue.reschedule_event(@event)
+              if result == :expired
+                @logger.warn("event_queue_event_expired: type=#{@event.event_type} object_id=#{@event.object_id}")
+              elsif !result.nil?
+                @logger.warn("event_queue_rescheduled: type=#{@event.event_type} object_id=#{@event.object_id}")
+              end
+            end
+            ::Katello::EventQueue.clear_events(@event.event_type, @event.object_id, @event.created_at)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/katello/event_queue/subscription.rb
+++ b/app/lib/katello/event_queue/subscription.rb
@@ -1,0 +1,26 @@
+module Katello
+  class EventQueue
+    class Subscription
+      TIMEOUT = 120 # Base this on httpd timeout?
+
+      def wait
+        start = Time.zone.now
+        loop do
+          if Katello.shutting_down?
+            Rails.logger.info "Canceling event queue subscription due to shutdown."
+            return
+          end
+
+          return true if Katello::EventQueue.runnable_events.any?
+
+          elapsed = Time.zone.now - start
+          break if elapsed > TIMEOUT
+
+          sleep 2
+        end
+
+        nil
+      end
+    end
+  end
+end

--- a/app/services/katello/event_queue.rb
+++ b/app/services/katello/event_queue.rb
@@ -12,6 +12,10 @@ module Katello
       end
     end
 
+    def self.logger
+      ::Foreman::Logging.logger('katello/katello_events')
+    end
+
     def self.queue_depth
       ::Katello::Event.all.size
     end

--- a/config/routes/api/internal.rb
+++ b/config/routes/api/internal.rb
@@ -5,6 +5,7 @@ Katello::Engine.routes.draw do
         match '/heartbeat' => 'event_queue#heartbeat', via: :post
         match '/next' => 'event_queue#next', via: :post
         match '/reset' => 'event_queue#reset', via: :post
+        match '/subscribe' => 'event_queue#subscribe', via: :get
       end
 
       scope path: :candlepin_events, as: :candlepin_events do

--- a/config/routes/api/internal.rb
+++ b/config/routes/api/internal.rb
@@ -1,0 +1,16 @@
+Katello::Engine.routes.draw do
+  scope module: :api, path: :api do
+    scope module: :internal, path: :internal do
+      scope path: :event_queue, as: :event_queue do
+        match '/heartbeat' => 'event_queue#heartbeat', via: :post
+        match '/next' => 'event_queue#next', via: :post
+        match '/reset' => 'event_queue#reset', via: :post
+      end
+
+      scope path: :candlepin_events, as: :candlepin_events do
+        match '/handle' => 'candlepin_events#handle', via: :post
+        match '/heartbeat' => 'candlepin_events#heartbeat', via: :post
+      end
+    end
+  end
+end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -262,4 +262,8 @@ module Katello
   def self.with_ansible?
     Foreman::Plugin.installed?("foreman_ansible")
   end
+
+  def self.shutting_down?
+    ::Puma::Server.current.shutting_down?
+  end
 end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -121,6 +121,7 @@ module Katello
 
     initializer "katello.paths", :before => :sooner_routes_load do |app|
       app.routes_reloader.paths << "#{Katello::Engine.root}/config/routes/api/v2.rb"
+      app.routes_reloader.paths << "#{Katello::Engine.root}/config/routes/api/internal.rb"
       app.routes_reloader.paths << "#{Katello::Engine.root}/config/routes/api/rhsm.rb"
       app.routes_reloader.paths << "#{Katello::Engine.root}/config/routes/api/registry.rb"
       app.routes_reloader.paths.unshift("#{Katello::Engine.root}/config/routes/overrides.rb")
@@ -244,6 +245,14 @@ module Katello
 
   def self.with_katello_agent?
     !!SETTINGS.dig(:katello, :agent, :enabled)
+  end
+
+  def self.with_event_daemon?
+    !!SETTINGS.dig(:katello, :event_daemon, :enabled)
+  end
+
+  def self.internal_events_logger
+    ::Foreman::Logging.logger('katello/internal_events')
   end
 
   def self.remote_execution_by_default?

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -242,6 +242,7 @@ Foreman::Plugin.register :katello do
   logger :registry_proxy, :enabled => true
   logger :katello_events, :enabled => true
   logger :candlepin_events, :enabled => true
+  logger :internal_events, :enabled => true
   logger :agent, :enabled => true
 
   widget 'errata_widget', :name => 'Latest Errata', :sizey => 1, :sizex => 6

--- a/test/controllers/api/internal/candlepin_events_controller_test.rb
+++ b/test/controllers/api/internal/candlepin_events_controller_test.rb
@@ -1,0 +1,24 @@
+require "katello_test_helper"
+
+module Katello
+  class Api::Internal::CandlepinEventsControllerTest < ActionController::TestCase
+    def setup
+      setup_engine_routes
+      stub_foreman_client_auth
+    end
+
+    def test_handle_ok
+      event = { subject: '', content: '{}' }
+
+      post :handle, params: event
+
+      assert_response :success
+    end
+
+    def test_heartbeat
+      post :heartbeat
+
+      assert_response :success
+    end
+  end
+end

--- a/test/controllers/api/internal/event_queue_controller_test.rb
+++ b/test/controllers/api/internal/event_queue_controller_test.rb
@@ -1,0 +1,33 @@
+require 'katello_test_helper'
+require 'support/event_queue_support'
+
+module Katello
+  class Api::Internal::EventQueueController::TestCase < ActionController::TestCase
+    include Katello::EventQueueSupport
+
+    def setup
+      setup_engine_routes
+      stub_foreman_client_auth
+    end
+
+    def test_next
+      Katello::Event.create!(event_type: MockEvent::EVENT_TYPE, object_id: 1)
+
+      post :next
+
+      assert_response :success
+    end
+
+    def test_next_empty_queue
+      post :next
+
+      assert_response :no_content
+    end
+
+    def test_heartbeat
+      post :heartbeat
+
+      assert_response :success
+    end
+  end
+end

--- a/test/models/ping_test.rb
+++ b/test/models/ping_test.rb
@@ -17,6 +17,7 @@ module Katello
                          "versions" => {"platform_version" => "2.9.1"
                           }
                         }
+      Katello.stubs(:with_event_daemon?).returns(true)
     end
 
     def test_ping_with_errors

--- a/test/services/katello/event_queue_test.rb
+++ b/test/services/katello/event_queue_test.rb
@@ -1,30 +1,12 @@
 require 'katello_test_helper'
+require 'support/event_queue_support'
 
 module Katello
   class EventQueueTest < ActiveSupport::TestCase
-    class MockEvent
-      EVENT_TYPE = 'mock_event'.freeze
-      def initialize(*)
-      end
-
-      def self.retry_seconds
-        300
-      end
-    end
-
-    class MockEventWithMetadata
-      EVENT_TYPE = 'mock_event_with_metadata'.freeze
-      attr_accessor :metadata
-
-      def initialize(*)
-        yield(self) if block_given?
-      end
-    end
+    include Katello::EventQueueSupport
 
     def setup
       @type = MockEvent::EVENT_TYPE
-      EventQueue.register_event(@type, MockEvent)
-      EventQueue.register_event(MockEventWithMetadata::EVENT_TYPE, MockEventWithMetadata)
     end
 
     def test_create_instance

--- a/test/support/controller_support.rb
+++ b/test/support/controller_support.rb
@@ -3,6 +3,10 @@ require "#{Katello::Engine.root}/test/support/auth_support"
 module ControllerSupport
   include Katello::AuthorizationSupportMethods
 
+  def stub_foreman_client_auth
+    ::Foreman::ClientCertificate.any_instance.expects(:verified?).returns true
+  end
+
   def check_permission(permission:, action:, request:, organizations:, authorized: true, expect_404: false)
     permissions = permission.is_a?(Array) ? permission : [permission]
 

--- a/test/support/event_queue_support.rb
+++ b/test/support/event_queue_support.rb
@@ -1,0 +1,28 @@
+module Katello
+  module EventQueueSupport
+    class MockEvent
+      EVENT_TYPE = 'mock_event'.freeze
+      def initialize(*)
+      end
+
+      def run
+      end
+
+      def self.retry_seconds
+        300
+      end
+    end
+
+    class MockEventWithMetadata
+      EVENT_TYPE = 'mock_event_with_metadata'.freeze
+      attr_accessor :metadata
+
+      def initialize(*)
+        yield(self) if block_given?
+      end
+    end
+
+    EventQueue.register_event(MockEvent::EVENT_TYPE, MockEvent)
+    EventQueue.register_event(MockEventWithMetadata::EVENT_TYPE, MockEventWithMetadata)
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The news has spread like wildfire that Katello 4.10 will be the release which removes Katello Agent, leaving only two subsystems - Event Queue and Candlepin Events - using the EventDaemon thing that runs those services inside the Puma process. Now could be the right time to move away from the EventDaemon completely and do something a little more _normal_ in terms of how these services fit into the bigger picture.

#### Considerations taken when implementing this change?

- Remove the need for the Katello Event Daemon
- Use an established pattern (API) to allow event queue and candlepin events to be processed
- A new repository tentatively called `katello_events` will house the Ruby code that calls these APIs. The two services therein can be installed on the system using systemd ie `systemctl start/stop/restart/status katello-event-queue` and `systemctl start/stop/restart/status katello-candlepin-events`
- Does nothing to EventDaemon or Katello Agent itself. Those can be cleaned up whenever the time is right.

#### What are the testing steps for this pull request?

- Check out this PR
- Follow the steps in the README of https://github.com/jturel/katello_events (the instructions assume checkout is in /home/vagrant)
- Set Katello "with_event_daemon" to false:
```
[vagrant@centos8-katello-devel foreman]$ grep event_daemon ~/foreman/config/settings.plugins.d/katello.yaml -A1
  :event_daemon:
    :enabled: false
```
- start katello
- `systemctl start katello-candlepin-events` (check it's running with `status`)
- `systemctl start katello-event-queue` (check it's running with `status`)
- Register a system with subman which exercises both of these. You can see the activity in the logs:
```
[vagrant@centos8-katello-devel foreman]$ ack "api/internal" log/development.log 
2023-08-05T15:59:40 [I|app|46f1df7f] Started POST "/api/internal/event_queue/next" for 192.168.122.191 at 2023-08-05 15:59:40 +0000
2023-08-05T15:59:41 [I|app|49c0ffd5] Started POST "/api/internal/event_queue/heartbeat" for 192.168.122.191 at 2023-08-05 15:59:41 +0000
2023-08-05T15:59:45 [I|app|c8e8e077] Started POST "/api/internal/event_queue/next" for 192.168.122.191 at 2023-08-05 15:59:51 +0000
2023-08-05T15:59:52 [I|app|883ddd76] Started POST "/api/internal/event_queue/heartbeat" for 192.168.122.191 at 2023-08-05 15:59:52 +0000
2023-08-05T15:59:54 [I|app|b8328d6e] Started POST "/api/internal/event_queue/next" for 192.168.122.191 at 2023-08-05 15:59:54 +0000
2023-08-05T15:59:57 [I|app|0bb633f9] Started POST "/api/internal/candlepin_events/heartbeat" for 192.168.122.191 at 2023-08-05 15:59:57 +0000
2023-08-05T15:59:57 [I|app|d7615ed5] Started POST "/api/internal/event_queue/next" for 192.168.122.191 at 2023-08-05 15:59:57 +0000
2023-08-05T16:00:03 [I|app|d913349f] Started POST "/api/internal/event_queue/heartbeat" for 192.168.122.191 at 2023-08-05 16:00:03 +0000
2023-08-05T16:00:06 [I|app|c7c5d367] Started POST "/api/internal/event_queue/next" for 192.168.122.191 at 2023-08-05 16:00:06 +0000
2023-08-05T16:00:16 [I|app|7fff6325] Started POST "/api/internal/event_queue/heartbeat" for 192.168.122.191 at 2023-08-05 16:00:16 +0000
2023-08-05T16:00:18 [I|app|2b0aabd0] Started POST "/api/internal/candlepin_events/handle" for 192.168.122.191 at 2023-08-05 16:00:18 +0000
2023-08-05T16:00:18 [I|app|caec1fdc] Started POST "/api/internal/candlepin_events/handle" for 192.168.122.191 at 2023-08-05 16:00:18 +0000
2023-08-05T16:00:19 [I|app|61c4a269] Started POST "/api/internal/event_queue/next" for 192.168.122.191 at 2023-08-05 16:00:19 +0000
2023-08-05T16:00:23 [I|app|ac0a597d] Started POST "/api/internal/event_queue/next" for 192.168.122.191 at 2023-08-05 16:00:23 +0000
```

These services should be resilient to things like Katello going down, or returning unexpected status codes from the API so be clever in trying to break it!

**Known Issues**
- Ping API is not reporting OK
- Logging could be improved
- ???