### PR TITLE
Fixes #36474 - Fix docker content CV links

### DIFF
--- a/webpack/scenes/ContentViews/Details/Repositories/ContentCounts.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/ContentCounts.js
@@ -12,9 +12,9 @@ const repoLabels = {
   erratum: ['errata', 'erratum', 'errata'], // need to handle link, its $URL/errata?repositoryId=107
   deb: ['deb packages', 'deb package', 'debs'],
   ansible_collection: ['Ansible collections', 'Ansible collection', 'ansible_collections'],
-  docker_manifest: ['container manifests', 'container manifest', 'content/docker_manifests'],
-  docker_manifest_list: ['container manifest lists', 'container manifest list', 'content/docker_manifest_lists'],
-  docker_tag: ['container tags', 'container tag', 'content/docker_tags'],
+  docker_manifest: ['container manifests', 'container manifest', 'docker_manifests'],
+  docker_manifest_list: ['container manifest lists', 'container manifest list', 'docker_manifest_lists'],
+  docker_tag: ['container tags', 'container tag', 'docker_tags'],
   file: ['files', 'file', 'content/files'],
   package_group: ['package groups', 'package group', 'package_groups'],
   srpm: ['source RPMs', 'source RPM', 'source_rpms'], // no link?


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fixing links to content for docker repos in content view details

#### What are the testing steps for this pull request?
1. Sync a container repository on the Satellite.
2. Create a CV or use a existing CV.
3. Navigate to the Repositories page on the CV.
   WebUI : Content --> Content View --> Select CV --> Repositories tab --> Click
on any of the link in Content column for the container repository.

