### PR TITLE
Fixes #36484 - Add :view_params permission to 'Register hosts' role

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -748,7 +748,7 @@ Foreman::Plugin.register :katello do
     :attach_subscriptions, :view_host_collections,
     :view_organizations, :view_lifecycle_environments, :view_products,
     :view_locations, :view_domains, :view_architectures,
-    :view_operatingsystems, :view_smart_proxies
+    :view_operatingsystems, :view_smart_proxies, :view_params
   ]
 
   role 'Content Importer', [


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
 Add `:view_params` permission to the 'Register hosts' role

#### Considerations taken when implementing this change?
Global Registration using a user with the `Register Hosts` role ignores all the setup options (host parameters)

#### What are the testing steps for this pull request?
1. Create a user with the `Register Hosts` role.
2. Using the new user, generate a global registration command with all the Setup options set to No.
3. Execute the command on the client.

**Actual results:** REX & insights client is installed, params have the value `true`
**Expected result:** The opposite