### PR TITLE
Fixes #36489 - Change the field id of activation key field

### DIFF
--- a/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/ActivationKeys.test.js.snap
+++ b/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/ActivationKeys.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ActivationKeys renders 1`] = `
 <FormGroup
-  fieldId="reg_katello_ak"
+  fieldId="activation_keys_field"
   helperText="From host group: "
   helperTextInvalid={
     <a
@@ -36,7 +36,7 @@ exports[`ActivationKeys renders 1`] = `
     favoritesLabel="Favorites"
     hasInlineFilter={false}
     hasPlaceholderStyle={false}
-    id="reg_katello_ak"
+    id="activation_keys_field"
     inlineFilterPlaceholderText={null}
     inputAutoComplete="off"
     inputIdPrefix=""
@@ -58,7 +58,7 @@ exports[`ActivationKeys renders 1`] = `
     onSelect={[Function]}
     onToggle={[Function]}
     onTypeaheadInputChanged={null}
-    ouiaId="reg-katello-ak"
+    ouiaId="activation-keys-field"
     ouiaSafe={true}
     placeholderText="No Activation keys to select"
     position="left"

--- a/webpack/components/extensions/RegistrationCommands/fields/ActivationKeys.js
+++ b/webpack/components/extensions/RegistrationCommands/fields/ActivationKeys.js
@@ -45,7 +45,7 @@ const ActivationKeys = ({
   return (
     <FormGroup
       label={__('Activation Keys')}
-      fieldId="reg_katello_ak"
+      fieldId="activation_keys_field"
       helperText={hostGroupActivationKeys && sprintf('From host group: %s', hostGroupActivationKeys)}
       helperTextInvalid={activationKeys?.length === 0 ? <a href="/activation_keys/new">{__('Create new activation key')}</a> : __('No Activation Keys selected')}
       validated={validateAKField(hostGroupId, pluginValues?.activationKeys, hostGroupActivationKeys)}
@@ -53,14 +53,14 @@ const ActivationKeys = ({
       isRequired
     >
       <Select
-        ouiaId="reg-katello-ak"
+        ouiaId="activation-keys-field"
         selections={selectedKeys}
         variant={SelectVariant.typeaheadMulti}
         onToggle={() => setIsOpen(!isOpen)}
         onSelect={onSelect}
         onClear={() => updatePluginValues([])}
         isOpen={isOpen}
-        id="reg_katello_ak"
+        id="activation_keys_field"
         className="without_select2"
         isDisabled={isLoading || activationKeys?.length === 0}
         placeholderText={activationKeys?.length === 0 ? __('No Activation keys to select') : ''}


### PR DESCRIPTION
The field id was named incorrectly, it was reg_katello_ak but it can't include "katello" in it. 
