### PR TITLE
Refs #36493 - Add new AK details page

### DIFF
--- a/engines/bastion/app/views/bastion/layouts/assets.html.erb
+++ b/engines/bastion/app/views/bastion/layouts/assets.html.erb
@@ -33,6 +33,7 @@
     });
     angular.module('Bastion.auth').value('Permissions', angular.fromJson(`<%= User.current.cached_roles.collect { |role| role.permissions }.flatten.to_json.html_safe %>`));
     angular.module('Bastion').value('newHostDetailsUI', "<%= Setting[:host_details_ui] %>");
+    angular.module('Bastion').value('experimentalLabsSetting', "<%= Setting[:lab_features] %>");
   </script>
   <% Bastion.plugins.each do |name, plugin| %>
     <%= include_plugin_js(plugin) %>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-keys.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-keys.controller.js
@@ -8,6 +8,7 @@
  * @requires Nutupane
  * @requires ActivationKey
  * @requires CurrentOrganization
+ * @requires experimentalLabsSetting
  *
  * @description
  *   Provides the functionality specific to activation keys for use with the Nutupane UI pattern.
@@ -15,8 +16,8 @@
  *   within the table.
  */
 angular.module('Bastion.activation-keys').controller('ActivationKeysController',
-    ['$scope', '$location', 'translate', 'Nutupane', 'ActivationKey', 'CurrentOrganization',
-    function ($scope, $location, translate, Nutupane, ActivationKey, CurrentOrganization) {
+    ['$scope', '$location', 'translate', 'Nutupane', 'ActivationKey', 'CurrentOrganization', 'experimentalLabsSetting',
+    function ($scope, $location, translate, Nutupane, ActivationKey, CurrentOrganization, experimentalLabsSetting) {
 
         var params = {
             'organization_id': CurrentOrganization,
@@ -30,5 +31,6 @@ angular.module('Bastion.activation-keys').controller('ActivationKeysController',
         $scope.controllerName = 'katello_activation_keys';
         nutupane.primaryOnly = true;
         $scope.table = nutupane.table;
+        $scope.experimentalLabsSetting = experimentalLabsSetting;
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/views/activation-keys.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/views/activation-keys.html
@@ -35,9 +35,14 @@
       <tbody>
       <tr bst-table-row ng-repeat="activationKey in table.rows">
         <td bst-table-cell>
-          <a ui-sref="activation-key.info({activationKeyId: activationKey.id})">
-            {{ activationKey.name }}
-          </a>
+          <span ng-switch="experimentalLabsSetting">
+            <a ng-switch-when="true" ng-href="/labs/activation_keys/{{activationKey.id}}">
+              {{ activationKey.name }}
+            </a>
+            <a ng-switch-when="false" ui-sref="activation-key.info({activationKeyId: activationKey.id})">
+              {{ activationKey.name }}
+            </a>
+          </span>
           <i class="fa fa-chevron-right selected-icon" ng-show="activationKey.selected"></i>
         </td>
         <td bst-table-cell>{{ activationKey | activationKeyConsumedFilter }}</td>

--- a/engines/bastion_katello/test/activation-keys/activation-keys.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/activation-keys.controller.test.js
@@ -24,7 +24,8 @@ describe('Controller: ActivationKeysController', function() {
             translate: function(){},
             Nutupane: Nutupane,
             ActivationKey: ActivationKey,
-            CurrentOrganization: 'CurrentOrganization'
+            CurrentOrganization: 'CurrentOrganization',
+            experimentalLabsSetting: false
         });
     }));
 

--- a/webpack/containers/Application/config.js
+++ b/webpack/containers/Application/config.js
@@ -3,6 +3,7 @@ import Repos from '../../scenes/RedHatRepositories';
 import Subscriptions from '../../scenes/Subscriptions';
 import UpstreamSubscriptions from '../../scenes/Subscriptions/UpstreamSubscriptions/index';
 import SubscriptionDetails from '../../scenes/Subscriptions/Details';
+import ActivationKeyDetails from '../../scenes/ActivationKeys/Details/ActivationKeyDetails';
 import SetOrganization from '../../components/SelectOrg/SetOrganization';
 import WithOrganization from '../../components/WithOrganization/withOrganization';
 import ModuleStreams from '../../scenes/ModuleStreams';
@@ -28,6 +29,10 @@ export const links = [
   {
     path: 'subscriptions/add',
     component: WithOrganization(withHeader(UpstreamSubscriptions, { title: __('Add Subscriptions') })),
+  },
+  {
+    path: 'labs/activation_keys/:id',
+    component: WithOrganization(withHeader(ActivationKeyDetails, { title: __('Activation key details') })),
   },
   {
     // eslint-disable-next-line no-useless-escape

--- a/webpack/scenes/ActivationKeys/Details/ActivationKeyDetails.js
+++ b/webpack/scenes/ActivationKeys/Details/ActivationKeyDetails.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const ActivationKeyDetails = ({ match }) => <div>ActivationKeyDetails { match?.params?.id } </div>;
+
+export default ActivationKeyDetails;
+
+ActivationKeyDetails.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      id: PropTypes.string,
+    }),
+  }),
+};
+
+ActivationKeyDetails.defaultProps = {
+  match: {},
+};

--- a/webpack/scenes/ActivationKeys/Details/index.js
+++ b/webpack/scenes/ActivationKeys/Details/index.js
@@ -1,0 +1,3 @@
+import ActivationKeyDetails from './ActivationKeyDetails';
+
+export default ActivationKeyDetails;


### PR DESCRIPTION
  also includes routes and links from AK list page

#### What are the changes introduced in this pull request?

* Add a new route at `/labs/activation_keys/:id` with a (more or less) blank page
* Change links from AK list page to go to the new page, depending on `Setting[:lab_features]`

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Try links from AK list page with the setting both on and off.
