### PR TITLE
Fixes #36497 - Allow unsetting GPG and SSL keys

### DIFF
--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -17,10 +17,10 @@ module Katello
 
     def_param_group :product do
       param :description, String, :desc => N_("Product description")
-      param :gpg_key_id, :number, :desc => N_("Identifier of the GPG key")
-      param :ssl_ca_cert_id, :number, :desc => N_("Idenifier of the SSL CA Cert")
-      param :ssl_client_cert_id, :number, :desc => N_("Identifier of the SSL Client Cert")
-      param :ssl_client_key_id, :number, :desc => N_("Identifier of the SSL Client Key")
+      param :gpg_key_id, :number, :desc => N_("Identifier of the GPG key"), :allow_nil => true
+      param :ssl_ca_cert_id, :number, :desc => N_("Idenifier of the SSL CA Cert"), :allow_nil => true
+      param :ssl_client_cert_id, :number, :desc => N_("Identifier of the SSL Client Cert"), :allow_nil => true
+      param :ssl_client_key_id, :number, :desc => N_("Identifier of the SSL Client Key"), :allow_nil => true
       param :sync_plan_id, :number, :desc => N_("Plan numeric identifier"), :allow_nil => true
     end
 

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -43,10 +43,10 @@ module Katello
       param :url, String, :desc => N_("repository source url")
       param :os_versions, Array,
             :desc => N_("Identifies whether the repository should be disabled on a client with a non-matching OS version. Pass [] to enable regardless of OS version. Maximum length 1; allowed tags are: %s") % Katello::RootRepository::ALLOWED_OS_VERSIONS.join(', ')
-      param :gpg_key_id, :number, :desc => N_("id of the gpg key that will be assigned to the new repository")
-      param :ssl_ca_cert_id, :number, :desc => N_("Identifier of the content credential containing the SSL CA Cert")
-      param :ssl_client_cert_id, :number, :desc => N_("Identifier of the content credential containing the SSL Client Cert")
-      param :ssl_client_key_id, :number, :desc => N_("Identifier of the content credential containing the SSL Client Key")
+      param :gpg_key_id, :number, :desc => N_("id of the gpg key that will be assigned to the new repository"), :allow_nil => true
+      param :ssl_ca_cert_id, :number, :desc => N_("Identifier of the content credential containing the SSL CA Cert"), :allow_nil => true
+      param :ssl_client_cert_id, :number, :desc => N_("Identifier of the content credential containing the SSL Client Cert"), :allow_nil => true
+      param :ssl_client_key_id, :number, :desc => N_("Identifier of the content credential containing the SSL Client Key"), :allow_nil => true
       param :unprotected, :bool, :desc => N_("true if this repository can be published via HTTP")
       param :checksum_type, String, :desc => N_("Checksum of the repository, currently 'sha1' & 'sha256' are supported")
       param :docker_upstream_name, String, :desc => N_("Name of the upstream docker repository")


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Without `allow_nil: true` API clients don't know they can update this parameter to `nil` to unset it again.

#### Considerations taken when implementing this change?

I want a working API :)

#### What are the testing steps for this pull request?

Using FAM, run the following playbook:

```yaml
- name: issue 36497
  hosts: localhost
  become: no
  gather_facts: no
  tasks:
    - name: "create key"
      theforeman.foreman.content_credential:
        username: "admin"
        password: "changeme"
        server_url: "https://foreman.example.com/"
        validate_certs: false
        name: "RPM-GPG-KEY-my-repo"
        content_type: gpg_key
        organization: "Default Organization"
        content: "lol test"
    - name: product with key
      theforeman.foreman.product:
        username: "admin"
        password: "changeme"
        server_url: "https://foreman.example.com/"
        validate_certs: false
        name: "lol prod"
        organization: "Default Organization"
        gpg_key: "RPM-GPG-KEY-my-repo"
    - name: product without key
      theforeman.foreman.product:
        username: "admin"
        password: "changeme"
        server_url: "https://foreman.example.com/"
        validate_certs: false
        name: "lol prod"
        organization: "Default Organization"
        gpg_key: ""
```

Without the patch, the execution will fail with:

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Error while performing update on products: gpg_key_id can't be None"}
```