### PR TITLE
Fixes #36498 - Don't try to unset a host's CV/LCE when inheriting from hostgroup

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -33,10 +33,10 @@ module Katello
         def apply_inherited_attributes(attributes, initialized = true)
           attributes = super(attributes, initialized)
           facet_attrs = attributes['content_facet_attributes']
-          return attributes unless facet_attrs
+          return attributes if facet_attrs.blank?
           cv_id = facet_attrs['content_view_id']
           lce_id = facet_attrs['lifecycle_environment_id']
-          if cv_id.blank? || lce_id.blank?
+          if initialized && (cv_id.blank? || lce_id.blank?)
             if cv_id.blank?
               Rails.logger.info "Hostgroup has no content view assigned; using host's existing content view"
               facet_attrs['content_view_id'] = content_facet&.single_content_view&.id

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -30,6 +30,28 @@ module Katello
           inherited_attrs
         end
 
+        def apply_inherited_attributes(attributes, initialized = true)
+          attributes = super(attributes, initialized)
+          facet_attrs = attributes['content_facet_attributes']
+          return attributes unless facet_attrs
+          cv_id = facet_attrs['content_view_id']
+          lce_id = facet_attrs['lifecycle_environment_id']
+          if cv_id.blank? || lce_id.blank?
+            if cv_id.blank?
+              Rails.logger.info "Hostgroup has no content view assigned; using host's existing content view"
+              facet_attrs['content_view_id'] = content_facet&.single_content_view&.id
+            end
+            if lce_id.blank?
+              Rails.logger.info "Hostgroup has no lifecycle environment assigned; using host's existing lifecycle environment"
+              facet_attrs['lifecycle_environment_id'] = content_facet&.single_lifecycle_environment&.id
+            end
+            attributes['content_facet_attributes'] = facet_attrs
+          else
+            Rails.logger.info "Hostgroup has content view and lifecycle environment assigned; using those"
+          end
+          attributes
+        end
+
         def smart_proxy_ids
           ids = super
           ids << content_source_id

--- a/test/controllers/foreman/hosts_controller_test.rb
+++ b/test/controllers/foreman/hosts_controller_test.rb
@@ -59,7 +59,7 @@ class HostsControllerTest < ActionController::TestCase
         :content_source_id => ""
       }
     } }, session: set_session_user
-    assert_equal orig_cves, @host.content_facet.content_view_environment_ids
+    assert_equal_arrays orig_cves, @host.content_facet.content_view_environment_ids
   end
 
   context 'csv' do


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Redefines Foreman's `apply_inherited_attributes` method (from `Host::Managed`) to address the case where either `content_view_id` or `lifecycle_environment_id` are blank. Since they must now be provided together, having a hostgroup where only one of them is set causes problems.

#### Considerations taken when implementing this change?

This whole issue should go away once we make the same multi-CV changes to `Hostgroup::ContentFacet` that have already been made to `Host::ContentFacet`.

#### What are the testing steps for this pull request?

Create a hostgroup with CV and LCE
Edit the hostgroup and remove the LCE (click the X)
Go to one of your hosts and click Edit
Assign the host to the hostgroup and click Submit


Before patch: an error `content_view_id and lifecycle_environment_id must be provided together`
After patch: no errors


Click around other host and hostgroup edit flows and make sure nothing is broken
- host assigned to hostgroup with no CV and no LCE
- host assigned to hostgroup with both CV and LCE
- host not assigned to hostgroup

