### PR TITLE
Fixes #36501 - Making Environment and Content View info visible on th…

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
@@ -37,8 +37,8 @@
             <span ng-class="getHostStatusIcon(host.subscription_global_status)">
             </span>
           </td>
-          <td bst-table-cell>{{ host.content_facet_attributes.lifecycle_environment_name }}</td>
-          <td bst-table-cell>{{ host.content_facet_attributes.content_view_name || "" }}</td>
+          <td bst-table-cell>{{ host.content_facet_attributes.lifecycle_environment.name }}</td>
+          <td bst-table-cell>{{ host.content_facet_attributes.content_view.name || "" }}</td>
           <td bst-table-cell>{{ host.subscription_facet_attributes.service_level }}</td>
           <td bst-table-cell>{{ host.subscription_facet_attributes.release_version }}</td>
         </tr>


### PR DESCRIPTION
…e Associations Page for Activation Keys

#### What are the changes introduced in this pull request?
Making the info for Lifecycle Environment and Content View available on the Associations Page for Activation Keys
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Checking that the associations page displayed info as intended