### PR TITLE
Fixes #36463 - Authenticate to custom cdn using product certs

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -161,9 +161,10 @@ module Katello
     param :upstream_content_view_label, String, :desc => N_("Upstream Content View Label, default: Default_Organization_View. Relevant only for 'upstream_server' type.")
     param :upstream_lifecycle_environment_label, String, :desc => N_("Upstream Lifecycle Environment, default: Library. Relevant only for 'upstream_server' type.")
     param :ssl_ca_credential_id, Integer, :desc => N_("Content Credential to use for SSL CA. Relevant only for 'upstream_server' type.")
+    param :custom_cdn_auth_enabled, :bool, :desc => N_("If product certificates should be used to authenticate to a custom CDN.")
     def cdn_configuration
       config_keys = [:url, :username, :password, :upstream_organization_label, :ssl_ca_credential_id, :type,
-                     :upstream_lifecycle_environment_label, :upstream_content_view_label]
+                     :upstream_lifecycle_environment_label, :upstream_content_view_label, :custom_cdn_auth_enabled]
       config_params = params.slice(*config_keys).permit!.to_h
 
       task = sync_task(::Actions::Katello::CdnConfiguration::Update, @organization.cdn_configuration, config_params)

--- a/app/lib/katello/resources/cdn.rb
+++ b/app/lib/katello/resources/cdn.rb
@@ -67,6 +67,10 @@ module Katello
             self.new(cdn_configuration.url, options)
           elsif cdn_configuration.custom_cdn?
             options[:ssl_ca_cert] = cdn_configuration.ssl_ca
+            if cdn_configuration.custom_cdn_auth_enabled?
+              options[:ssl_client_cert] = OpenSSL::X509::Certificate.new(product.certificate)
+              options[:ssl_client_key] = OpenSSL::PKey::RSA.new(product.key)
+            end
             self.new(cdn_configuration.url, options)
           else
             options[:username] = cdn_configuration.username

--- a/app/models/katello/cdn_configuration.rb
+++ b/app/models/katello/cdn_configuration.rb
@@ -37,6 +37,10 @@ module Katello
       type == CUSTOM_CDN_TYPE
     end
 
+    def custom_cdn_auth_enabled?
+      custom_cdn_auth_enabled
+    end
+
     def redhat_cdn_url?
       Katello::Resources::CDN::CdnResource.redhat_cdn?(url)
     end

--- a/db/migrate/20230609155411_add_custom_cdn_auth_enabled_to_katello_cdn_configurations.rb
+++ b/db/migrate/20230609155411_add_custom_cdn_auth_enabled_to_katello_cdn_configurations.rb
@@ -1,0 +1,5 @@
+class AddCustomCdnAuthEnabledToKatelloCdnConfigurations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :katello_cdn_configurations, :custom_cdn_auth_enabled, :boolean, default: false
+  end
+end

--- a/test/controllers/api/v2/organizations_controller_test.rb
+++ b/test/controllers/api/v2/organizations_controller_test.rb
@@ -124,9 +124,10 @@ module Katello
       assert_sync_task(::Actions::Katello::CdnConfiguration::Update) do |organization, params|
         assert_equal organization.id, @organization.id
         assert_equal params[:url], url
+        assert_equal params[:custom_cdn_auth_enabled], true
       end
 
-      put(:cdn_configuration, params: { :id => @organization.id, :url => url })
+      put(:cdn_configuration, params: { :id => @organization.id, :url => url, :custom_cdn_auth_enabled => true })
       assert_response :success
     end
 

--- a/test/lib/resources/cdn_test.rb
+++ b/test/lib/resources/cdn_test.rb
@@ -34,4 +34,25 @@ class CdnResourceTest < ActiveSupport::TestCase
       Katello::Resources::CDN::CdnResource.new('http://foo.com')
     end
   end
+
+  def test_custom_cdn_auth
+    organization = taxonomies(:empty_organization)
+    credential = FactoryBot.create(:katello_content_credential, organization: organization)
+    product = ::Katello::Product.find_by(cp_id: 'redhat_empty')
+    attrs = {
+      type: ::Katello::CdnConfiguration::CUSTOM_CDN_TYPE,
+      url: 'http://newcdn.example.com',
+      ssl_ca_credential_id: credential.id,
+      custom_cdn_auth_enabled: true
+    }
+    organization.cdn_configuration.update(attrs)
+    product.expects(:certificate).once.returns('')
+    product.expects(:key).once.returns('')
+    OpenSSL::X509::Certificate.expects(:new).once.returns('mock cert')
+    OpenSSL::PKey::RSA.expects(:new).once.returns('mock key')
+    cdn_resource = Katello::Resources::CDN::CdnResource.create(product: product, cdn_configuration: organization.cdn_configuration)
+    cdn_resource_options = cdn_resource.instance_variable_get(:@options)
+    assert_equal 'mock cert', cdn_resource_options[:ssl_client_cert]
+    assert_equal 'mock key', cdn_resource_options[:ssl_client_key]
+  end
 end

--- a/test/models/cdn_configuration_test.rb
+++ b/test/models/cdn_configuration_test.rb
@@ -51,7 +51,7 @@ module Katello
       assert config.network_sync?
 
       # Now update to custom cdn
-      config.update!(type: ::Katello::CdnConfiguration::CUSTOM_CDN_TYPE)
+      config.update!(type: ::Katello::CdnConfiguration::CUSTOM_CDN_TYPE, custom_cdn_auth_enabled: true)
       assert config.custom_cdn?
       assert_empty config.username
       assert_empty config.password


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds a `custom_cdn_auth_enabled` flag to the organizations API so that a custom cdn configuration can optionally apply product certs + keys for authentication.

#### Considerations taken when implementing this change?


#### What are the testing steps for this pull request?
1) Change the org's CDN configuration to be:
  - Custom CDN
  - URL: https://ru-by-exceptions.cdn.redhat.com
  - SSL CA Cert: copy/paste `katello/ca/redhat-uep.pem`
 
2) Using hammer or the API: `hammer organization configure-cdn --custom-cdn-auth-enabled=true --id 1 --type custom_cdn`

3) Try to enable and sync a red hat repository