### PR TITLE
Fixes #36477 - Correctly imports  repos with arch restrictions

### DIFF
--- a/app/lib/actions/katello/content_view_version/auto_create_redhat_repositories.rb
+++ b/app/lib/actions/katello/content_view_version/auto_create_redhat_repositories.rb
@@ -15,7 +15,8 @@ module Actions
             helper.creatable.each do |root|
               plan_action(::Actions::Katello::RepositorySet::EnableRepository,
                             root[:product], root[:content], root[:substitutions],
-                            override_url: root[:override_url])
+                            override_url: root[:override_url],
+                            override_arch: root[:override_arch])
             end
             helper.updatable.each do |root|
               plan_action(::Actions::Katello::Repository::Update, root[:repository], root[:options])

--- a/app/lib/actions/katello/repository_set/enable_repository.rb
+++ b/app/lib/actions/katello/repository_set/enable_repository.rb
@@ -6,7 +6,8 @@ module Actions
           _("Enable")
         end
 
-        def plan(product, content, substitutions, override_url: nil)
+        def plan(product, content, substitutions, override_url: nil,
+                 override_arch: nil)
           mapper = ::Katello::Candlepin::RepositoryMapper.new(product,
                                                                content,
                                                                substitutions)
@@ -15,6 +16,7 @@ module Actions
             fail ::Katello::Errors::ConflictException, _("The repository is already enabled")
           end
           repository = mapper.build_repository
+          repository.root.arch = override_arch if override_arch.present?
           if override_url
             repository.root.url = override_url
             repository.root.download_policy = ::Katello::RootRepository::DOWNLOAD_IMMEDIATE if URI(override_url).scheme == 'file'

--- a/app/services/katello/pulp3/content_view_version/importable_repositories.rb
+++ b/app/services/katello/pulp3/content_view_version/importable_repositories.rb
@@ -29,10 +29,12 @@ module Katello
 
             root = product.root_repositories.find do |r|
               if repo.content&.id && repo.redhat
-                r.content.cp_content_id == repo.content.id &&
+                repo_exists = r.content.cp_content_id == repo.content.id &&
                   r.arch == repo.arch &&
                   r.major == repo.major &&
                   r.minor == repo.minor
+
+                repo_exists || r.label == repo.label
               else
                 r.label == repo.label
               end
@@ -46,11 +48,13 @@ module Katello
                 basearch: repo.arch,
                 releasever: repo.minor
               }
-              creatable << { product: product,
-                             content: product_content,
-                             substitutions: substitutions,
-                             override_url: fetch_feed_url(repo)
-                           }
+              creatable << {
+                product: product,
+                content: product_content,
+                substitutions: substitutions,
+                override_url: fetch_feed_url(repo),
+                override_arch: repo.arch
+              }
             else
               creatable << { repository: product.add_repo(create_repo_params(repo, product)) }
             end


### PR DESCRIPTION
Red Hat repositories incorrectly allow users to set architecture restrictions on the repo details page. This causes issues when exporting and importing these repositories due to the way enablement worked.

#### What are the changes introduced in this pull request?
Initially we went the route of no allowing user to update arch information on a redhat repo. Which would imply that the they'd need to run an upgrade task to correct stuff.

This PR allows for exports and imports for the wrong arch via being smart on enablement. 

#### Considerations taken when implementing this change?
Originally thought of adding some complexity in the behavior by adding a `original arch substitutions` key to the export `metadata.json`. 

But instead decided to go with the simpler "Enable Repo and then override the arch to what comes from the metadata json" approach

#### What are the testing steps for this pull request?
Before you check out the PR
- Enable a couple of redhat repos (suggest something you can quickly sync.)
- Change their architectures
- Set the download policy to immediate 
- Sync them
- Export that repo and try to import it in a new org 
- You should see the task completing successfully but the imported repo has zero content.

After checking out the PR
- Go to the repo details of one of the redhat repos
- Finally reimport the content in a  new org 
- Verify that the content appears correctly.
