### PR TITLE
Fixes #36500 - Optimize DockerMetaTag query and CV version deletion to run a single invocation of the method

### DIFF
--- a/app/lib/actions/katello/content_view_environment/destroy.rb
+++ b/app/lib/actions/katello/content_view_environment/destroy.rb
@@ -8,19 +8,20 @@ module Actions
           content_view = cv_env.content_view
           environment = cv_env.environment
           content_view.check_remove_from_environment!(environment) unless organization_destroy
-
+          docker_cleanup = false
           sequence do
             concurrence do
               unless skip_repo_destroy
                 content_view.repos(environment).each do |repo|
                   # no need to update the content view environment since it's
                   # getting destroyed so skip_environment_update
-                  plan_action(Repository::Destroy, repo, skip_environment_update: true)
+                  plan_action(Repository::Destroy, repo, skip_environment_update: true, docker_cleanup: false)
+                  docker_cleanup ||= repo.docker?
                 end
               end
             end
             plan_action(Candlepin::Environment::Destroy, cp_id: cv_env.cp_id) unless organization_destroy
-            plan_self(:id => cv_env.id)
+            plan_self(:id => cv_env.id, :docker_cleanup => docker_cleanup)
           end
         end
 
@@ -31,6 +32,7 @@ module Actions
           else
             cv_env.destroy!
           end
+          ::Katello::DockerMetaTag.cleanup_tags if input[:docker_cleanup]
         end
       end
     end

--- a/app/lib/actions/katello/content_view_version/destroy.rb
+++ b/app/lib/actions/katello/content_view_version/destroy.rb
@@ -7,22 +7,26 @@ module Actions
 
           destroy_env_content = !options.fetch(:skip_destroy_env_content, false)
           repos = destroy_env_content ? version.repositories : version.archived_repos
+          docker_cleanup = false
 
           sequence do
             concurrence do
               repos.each do |repo|
                 repo_options = options.clone
+                repo_options[:docker_cleanup] = false
                 plan_action(Repository::Destroy, repo, repo_options)
+                docker_cleanup ||= repo.docker?
               end
             end
           end
 
-          plan_self(:id => version.id)
+          plan_self(:id => version.id, :docker_cleanup => docker_cleanup)
         end
 
         def finalize
           version = ::Katello::ContentViewVersion.find_by(id: input[:id])
           version&.destroy!
+          ::Katello::DockerMetaTag.cleanup_tags if input[:docker_cleanup]
         end
       end
     end

--- a/app/models/katello/docker_meta_tag.rb
+++ b/app/models/katello/docker_meta_tag.rb
@@ -134,7 +134,9 @@ module Katello
     end
 
     def self.cleanup_tags
-      self.where("id not in (?) OR (schema2_id IS NULL AND schema1_id IS NULL)", Katello::RepositoryDockerMetaTag.pluck(:docker_meta_tag_id) + [0]).delete_all
+      #Cleanup RepositoryMetaTag for nil schema meta tags
+      RepositoryDockerMetaTag.where(docker_meta_tag: where(schema1: nil, schema2: nil)).delete_all
+      self.where.not(id: RepositoryDockerMetaTag.select(:docker_meta_tag_id)).or(where(schema1: nil, schema2: nil)).delete_all
     end
 
     def self.import_meta_tags(repositories)

--- a/test/actions/katello/content_view_version/destroy_test.rb
+++ b/test/actions/katello/content_view_version/destroy_test.rb
@@ -16,7 +16,7 @@ module Katello::Host
       let(:action) { create_action action_class }
 
       it 'plans with default values' do
-        options = {:skip_environment_check => true}
+        options = {:skip_environment_check => true, :docker_cleanup => false}
         plan_action(action, @version, options)
 
         @version.repositories.each do |repo|


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
1. Avoid using pluck in Metatag cleanup.
2. Adds RepoMetaTag deletion before cleanup of schema_id = nil records to prevent foreign key violation failures.
3. Don't call metatag cleanup on repo destroy of every docker repo during CV version deletion or remove from environment.
4. Add metatag cleanup to finalize of those 2 actions directly so it runs once on each invocation.
5. Deleting CV version in environments calls both and hence metatag cleanup runs twice for that.
Once for removing CV from environment and once for deleting CV version itself
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Add several docker repos to a CV and publish/promote few versions.
2. Delete a version, make sure docker_cleanup param is set to false in repo_destroy finalize action spawned by CV version delete.
3. Test other actions like CV remove from env, Cv version delete, CV delete, repo delete etc. to make sure metatag cleanup doesn't happen every repo, rather only in finalize of parent actions like CVE delete or CVV delete.