### PR TITLE
Fixes #36440 - Redefine #attributes= to hijack old content facet attributes

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -6,7 +6,7 @@ module Katello
       include ForemanTasks::Concerns::ActionSubject
 
       module Overrides
-        def update(attrs)
+        def check_cve_attributes(attrs)
           if attrs[:content_facet_attributes]
             cv_id = attrs[:content_facet_attributes].delete(:content_view_id)
             lce_id = attrs[:content_facet_attributes].delete(:lifecycle_environment_id)
@@ -17,6 +17,15 @@ module Katello
               fail "content_view_id and lifecycle_environment_id must be provided together"
             end
           end
+        end
+
+        def attributes=(attrs)
+          check_cve_attributes(attrs)
+          super
+        end
+
+        def update(attrs)
+          check_cve_attributes(attrs)
           super
         end
 

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -104,6 +104,24 @@ module Katello
         host.update(content_facet_attributes: {content_view_id: @view.id, lifecycle_environment_id: nil})
       end
     end
+
+    def test_check_cve_attributes_removes_cv_and_lce
+      host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @library_view, :lifecycle_environment => @library)
+      host_attrs = host.attributes.deep_clone
+      host_attrs[:content_facet_attributes] = {content_view_id: @view.id, lifecycle_environment_id: @library.id}
+      # check_cve_attributes should remove the content_view_id and lifecycle_environment_id
+      # so the following should not error
+      host.attributes = host_attrs
+    end
+
+    def test_check_cve_attributes
+      host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @library_view, :lifecycle_environment => @library)
+      host_attrs = host.attributes.deep_clone
+      host_attrs[:content_facet_attributes] = {content_view_id: @view.id, lifecycle_environment_id: @library.id}
+      host.check_cve_attributes(host_attrs)
+      refute host_attrs.key?(:content_view_id)
+      refute host_attrs.key?(:lifecycle_environment_id)
+    end
   end
 
   class HostManagedExtensionsUpdateTest < HostManagedExtensionsTestBase


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When updating a host using the `Api::V2::HostController`, Foreman doesn't call `@host.update` - instead, it does

```rb
@host.attributes = host_attributes(host_params, @host)
...
@host.save
```

The consequence of this is that the host's `update` method redefined in `host_managed_extensions` was never getting called. This is what removed the old deprecated content facet attributes `content_view_id` and `lifecycle_environment_id`, so as a consequence, those attributes were still present when Foreman called `@host.attributes=`. Turns out the `#attributes=` method checks and validates all the nested attributes, so when we try to include imaginary ones like `content_view_id`, it would throw an error:

```
Backtrace for 'Action failed' error (ActiveModel::UnknownAttributeError): unknown attribute 'content_view_id' for Katello::Host::ContentFacet.
```

With this change, the `attributes=` method of `Host::Managed` gets the same enhancement that `update` already had. This will hopefully prevent this problem until we can properly finish the multi-CV related work.

#### Considerations taken when implementing this change?

Just like https://github.com/Katello/katello/pull/10595, this issue should go away completely when we update `Hostgroup::ContentFacet` to truly handle multiple content views.

#### What are the testing steps for this pull request?

Create a hostgroup and assign both CV and LCE
Assign a host to it
Update the host via hammer (this is important because hammer will use the API hosts controller, not the regular one) and include a hostgroup update:

```
hammer host update --id 5 --lifecycle-environment-id 1 --content-view-id 2 --hostgroup "My hostgroup"
```

Before: you should get the error above in the Rails log, and Hammer will complain:

```
Could not update the host:
  Internal Server Error: the server was unable to finish the request. This may be caused by unavailability of some required service, incorrect API call or a server-side bug. There may be more information in the server's logs.
```

After:

```
Host updated.
```
