### PR TITLE
Fixes #36503 - Updated needed perms for download_debug_certificate

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -180,11 +180,14 @@ module Katello
     protected
 
     def action_permission
-      if %w(download_debug_certificate redhat_provider repo_discover cdn_configuration
-            cancel_repo_discover).include?(params[:action])
-        :edit
-      elsif params[:action] == "releases"
+      if params[:action] == "releases"
         :view
+      elsif params[:action] == "download_debug_certificate" &&
+          Organization.find(params[:id]).authorized?(:export_content)
+        :view
+      elsif %w(download_debug_certificate redhat_provider repo_discover cdn_configuration
+               cancel_repo_discover).include?(params[:action])
+        :edit
       else
         super
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
To download a debug certificate one needed to have edit_organization permission. 
However this causes issues in an ISS Network Sync scenario we need the downstream server to be able to download debug certificate from upstream. Ideally we do not want the downstream user to be able update organization information in the upstream server (so no edit org perms) 

This PR relaxes the rule for downloading debug certificates.  If user can
- view_organization
- export_content
They can then download the debug certificates

#### Considerations taken when implementing this change?
I was initially thinking `view_organization` should be enough to download debug certificate. But the debug certs gives users powers to pull in all content (including protected.) 
So need something stronger than view_org but lesser than edit_org. As a compromise I feel having export_content and view_organizations (both org level permissions) makes it amply clear that you want to download debug certificate for exporting content.

#### What are the testing steps for this pull request?
Create a role with
-  view_organizations
-  view_products
-  view_lifecycle_environments
-  view_content_views
-  export_content
 
* Create a user with this role.

From a 2nd foreman server try to pull content from this server using network sync using the above user.
Prior to this PR
* Network sync should not work

After PR:
* Network sync should work and you should be able to pull content.

Alternately you can also test this PR along
Create a role with
-  view_organizations
- export_content
Create a user with the above role

Try the following curl command 

Before PR

``` bash
$ curl -u user:changeme https://`hostname`/katello/api/v2/organizations/1/download_debug_certificate
{
  "error": {"message":"Resource organization not found by id '1'"}
}
```

After
 ```
$ curl -u user:changeme https://`hostname`/katello/api/v2/organizations/1/download_debug_certificate
-----BEGIN PRIVATE KEY-----
<.....>
```

