### PR TITLE
Fixes #36462 - check for presence of content facet before assigning CVE

### DIFF
--- a/app/controllers/katello/concerns/content_facet_hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/content_facet_hosts_controller_extensions.rb
@@ -6,7 +6,7 @@ module Katello
         before_action :set_up_content_view_environment, only: [:update]
 
         def set_up_content_view_environment
-          return unless params[:host] && params[:host][:content_facet_attributes]
+          return unless @host&.content_facet.present? && params[:host]&.[](:content_facet_attributes)&.present?
           cv_id = params[:host][:content_facet_attributes].delete(:content_view_id)
           env_id = params[:host][:content_facet_attributes].delete(:lifecycle_environment_id)
           Rails.logger.info "set_up_content_view_environment: cv_id=#{cv_id}, env_id=#{env_id}"

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -25,6 +25,7 @@ module Katello
         end
 
         def update(attrs)
+          return super if self.content_facet.blank?
           check_cve_attributes(attrs)
           super
         end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Sometimes in Katello we assume that all hosts have content facets. We should stop doing that.

Specifically in this case, the host edit page will try to inherit content facet attributes from a hostgroup without first checking if the host has a content facet.

Before assigning a content view environment based on the deprecated `content_view_id` and `lifecycle_environment_id`  attributes, we should check if the content facet actually exists.

#### Considerations taken when implementing this change?

same as https://github.com/Katello/katello/pull/10595 and https://github.com/Katello/katello/pull/10600 ugh I'm getting tired of saying this

#### What are the testing steps for this pull request?

Create a hostgroup with CV and LCE
Create a host (Hosts > Create Host) - I did it by syncing a kickstart repo
In rails console, remove the host's content facet (verify that `myhost.content_facet` returns `nil`)
Edit the host and attempt to add/remove the hostgroup (you may have to fill in other required fields, it's a pain I know sorry)

Before patch: 

```
NoMethodError (undefined method `assign_single_environment' for nil:NilClass):
13:38:08 rails.1   |  a198b8f9 |   
13:38:08 rails.1   |  a198b8f9 | /home/vagrant/katello/app/models/katello/concerns/host_managed_extensions.rb:14:in `update'

```

After patch: host is edited without error
