### PR TITLE
Fixes #36505 - Add back missing SCA code to release branch

### DIFF
--- a/app/lib/katello/util/content_overrides_migrator.rb
+++ b/app/lib/katello/util/content_overrides_migrator.rb
@@ -12,11 +12,11 @@ module Katello
         ak_errors = create_disabled_overrides_for_non_sca_org_activation_keys(organization: @organization)
 
         total_errors = host_errors + ak_errors
-        finish_message = "Finished creating overrides in non-SCA orgs; #{total_errors == 0 ? "no errors" : "#{pluralize(total_errors, "error")}"}"
+        finish_message = "Finished creating overrides in non-SCA org; #{total_errors == 0 ? "no errors" : "#{pluralize(total_errors, "error")}"}"
         messages = { result: finish_message, errors: total_errors }
         messages[:host_errors] = "Hosts - #{pluralize(host_errors, "error")} creating disabled overrides for unsubscribed content; see log messages above" if host_errors > 0
         messages[:ak_errors] = "Activation keys - #{pluralize(ak_errors, "error")} creating disabled overrides for unsubscribed content; see log messages above" if ak_errors > 0
-        messages[:success_message] = "You may now switch all organizations to Simple Content Access mode without any change in access to content." if total_errors == 0
+        messages[:success_message] = "Organization may now be switched to Simple Content Access mode without any change in access to content." if total_errors == 0
         Rails.logger.info finish_message
         Rails.logger.info messages[:host_errors] if messages[:host_errors]
         Rails.logger.info messages[:ak_errors] if messages[:ak_errors]

--- a/app/models/katello/product_content.rb
+++ b/app/models/katello/product_content.rb
@@ -15,6 +15,10 @@ module Katello
       where(:product_id => Product.redhat.select(:id))
     }
 
+    scope :custom, -> {
+      where.not(:product_id => Product.redhat.select(:id))
+    }
+
     scoped_search :on => :name, :relation => :content
     scoped_search :relation => :product, :on => :name, :rename => :product
     scoped_search :on => :content_type, :relation => :content, :complete_value => true

--- a/app/services/katello/product_content_finder.rb
+++ b/app/services/katello/product_content_finder.rb
@@ -33,6 +33,10 @@ module Katello
       consumable.organization.enabled_product_content_for(roots)
     end
 
+    def custom_content_labels
+      product_content.custom.map { |pc| pc.product.root_repositories.map(&:custom_content_label) }.flatten.uniq
+    end
+
     def self.wrap_with_overrides(product_contents:, overrides:, status: nil)
       pc_with_overrides = product_contents.map { |pc| ProductContentPresenter.new(pc, overrides) }
       if status


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

A few lines of code were left out when backporting https://github.com/Katello/katello/pull/10515 into Katello 4.8 and 4.7. See the redmine issue for details

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Check out the branch
`bundle update`
Register a host in a non-SCA org
Sync some custom content, but do not attach a subscription
Turn on SCA in the org
Look for the output of the `Actions::Katello::Organization::SimpleContentAccess::PrepareContentOverrides` subtask in the Dynflow console under "Enable Simple Content Access"

Before: 

```
# Actions::Katello::Organization::SimpleContentAccess::PrepareContentOverrides (success) [ 0.07s / 0.07s ]
---
migrator_result:
result: Finished creating overrides in non-SCA orgs; 2 errors
errors: 2
host_errors: Hosts - 1 error creating disabled overrides for unsubscribed content;
see log messages above
ak_errors: Activation keys - 1 error creating disabled overrides for unsubscribed
content; see log messages above
```

After: 

```
migrator_result:
  result: Finished creating overrides in non-SCA orgs; no errors
  errors: 0
  success_message: Organization may now be switched to Simple Content Access mode without any change in access to content.
```

Also, in Repository Sets for the host, you'll see a disabled override for your custom repo.
