### PR TITLE
Fixes #36506 - allow installable errata counts in safe mode

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -375,7 +375,8 @@ module Katello
       class Jail < ::Safemode::Jail
         allow :applicable_deb_count, :applicable_module_stream_count, :applicable_rpm_count, :content_source, :content_source_id, :content_source_name,
               :errata_counts, :id, :kickstart_repository, :kickstart_repository_id, :kickstart_repository_name,
-              :upgradable_deb_count, :upgradable_module_stream_count, :upgradable_rpm_count, :uuid
+              :upgradable_deb_count, :upgradable_module_stream_count, :upgradable_rpm_count, :uuid,
+              :installable_security_errata_count, :installable_bugfix_errata_count, :installable_enhancement_errata_count
       end
     end
   end


### PR DESCRIPTION
Allow installable errata counts in safe mode for foreman reporting.