### PR TITLE
Fixes #36272 - Fix the documentation link to create manifest

### DIFF
--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
@@ -100,8 +100,8 @@ class ManageManifestModal extends Component {
       header: __('There is no Manifest History to display.'),
       description: __('Import a Manifest using the manifest tab above.'),
       documentation: {
-        label: __('Learn more about adding Subscription Manifests'),
-        url: 'http://redhat.com',
+        label: __('Learn more about adding Subscription Manifests '),
+        url: 'https://access.redhat.com/solutions/3410771',
       },
     });
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fixed the documentation link to guide customers to create a new manifest. 
Fixed spacing issue between Manifests and documentation words.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
