### PR TITLE
Fixes #37083 - Remove unused pulp_export_destination setting

### DIFF
--- a/db/migrate/20240123120109_remove_pulp_export_destination_setting.rb
+++ b/db/migrate/20240123120109_remove_pulp_export_destination_setting.rb
@@ -1,0 +1,9 @@
+class RemovePulpExportDestinationSetting < ActiveRecord::Migration[6.1]
+  def up
+    Setting.where(name: 'pulp_export_destination').delete_all
+  end
+
+  def down
+    # no action, seeding on app start should create the object with the default value
+  end
+end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -523,12 +523,6 @@ Foreman::Plugin.register :katello do
         description: N_("Default download policy for Smart Proxy syncs (either 'inherit', immediate', or 'on_demand')"),
         collection: proxy_download_policies
 
-      setting 'pulp_export_destination',
-        type: :string,
-        default: "/var/lib/pulp/katello-export",
-        full_name: N_('Pulp export destination filepath'),
-        description: N_("On-disk location for exported repositories")
-
       setting 'pulpcore_export_destination',
         type: :string,
         default: "/var/lib/pulp/exports",


### PR DESCRIPTION
I noticed this in the current Foreman demo. I haven't checked if it needs a migration yet and doesn't have an issue.

Fixes: a1e037258b17 ("Fixes #32580 - remove most pulp2 actions in planning")