### PR TITLE
Fixes #36510 - Update aria-label and ouia-id on edit credential modal

### DIFF
--- a/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditCredentials.js
+++ b/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditCredentials.js
@@ -314,8 +314,8 @@ const ACSEditCredentials = ({ onClose, acsId, acsDetails }) => {
         />
         <ActionGroup>
           <Button
-            ouiaId="edit-acs-details-submit"
-            aria-label="edit_acs_details"
+            ouiaId="edit-acs-credentials-submit"
+            aria-label="edit_acs_credentials"
             variant="primary"
             isDisabled={saving}
             isLoading={saving}
@@ -323,7 +323,12 @@ const ACSEditCredentials = ({ onClose, acsId, acsDetails }) => {
           >
             {__('Edit')}
           </Button>
-          <Button ouiaId="edit-acs-details-cancel" variant="link" onClick={onClose}>
+          <Button
+            ouiaId="edit-acs-credentials-cancel"
+            aria-label="edit-acs-credentials-cancel"
+            variant="link"
+            onClick={onClose}
+          >
             {__('Cancel')}
           </Button>
         </ActionGroup>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Update aria-label and ouia-id of submit/cancel buttons as recommended.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Go to ACS details > Edit credential > Inspect Submit and Cancel buttons and make sure ouia-id and aria-labels are updated as requested by automation.