### PR TITLE
Fixes #36512 - Update ids on ssl client key select

### DIFF
--- a/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditCredentials.js
+++ b/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditCredentials.js
@@ -273,11 +273,11 @@ const ACSEditCredentials = ({ onClose, acsId, acsDetails }) => {
             fieldId="client_key"
           >
             <FormSelect
-              ouiaId="sslCAcert-select"
+              ouiaId="ssl_client_key_select"
               isRequired
               value={acsSslClientKey}
               onChange={value => setAcsSslClientKey(value)}
-              aria-label="sslCAcert_select"
+              aria-label="ssl_client_key_select"
             >
               {
                 [


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Go to ACS details > Credentials > Edit
On the modal inspect the "SSL client key" FormSelect option.
Aria-label and ouia-id should be updated as requested.