### PR TITLE
Fixes #36513 - Update ids on action buttons in ACS smart proxy edit modal

### DIFF
--- a/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditSmartProxies.js
+++ b/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditSmartProxies.js
@@ -118,8 +118,8 @@ const ACSEditSmartProxies = ({ onClose, acsId, acsDetails }) => {
         </FormGroup>
         <ActionGroup>
           <Button
-            ouiaId="edit-acs-details-submit"
-            aria-label="edit_acs_details"
+            ouiaId="edit-acs-smart-proxies-submit"
+            aria-label="edit-acs-smart-proxies"
             variant="primary"
             isDisabled={saving}
             isLoading={saving}
@@ -127,7 +127,12 @@ const ACSEditSmartProxies = ({ onClose, acsId, acsDetails }) => {
           >
             {__('Edit')}
           </Button>
-          <Button ouiaId="edit-acs-smart-proxies-cancel" variant="link" onClick={onClose}>
+          <Button
+            ouiaId="edit-acs-smart-proxies-cancel"
+            aria-label="edit-acs-smart-proxies-cancel"
+            variant="link"
+            onClick={onClose}
+          >
             {__('Cancel')}
           </Button>
         </ActionGroup>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Create an ACS. 
On details > Smart Proxies > Edit
Inspect action buttons for save/cancel and ensure the ouia-ids and aria-label are updated.