### PR TITLE
Fixes #36514 - Update ids on ACS edit product modal action buttons

### DIFF
--- a/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditProducts.js
+++ b/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditProducts.js
@@ -88,8 +88,8 @@ const ACSEditProducts = ({ onClose, acsId, acsDetails }) => {
         />
         <ActionGroup>
           <Button
-            ouiaId="edit-acs-details-submit"
-            aria-label="edit_acs_details"
+            ouiaId="edit-acs-products-submit"
+            aria-label="edit-acs-products"
             variant="primary"
             isDisabled={saving}
             isLoading={saving}
@@ -97,7 +97,12 @@ const ACSEditProducts = ({ onClose, acsId, acsDetails }) => {
           >
             {__('Edit')}
           </Button>
-          <Button ouiaId="edit-acs-smart-proxies-cancel" variant="link" onClick={onClose}>
+          <Button
+            ouiaId="edit-acs-products-cancel"
+            aria-label="edit-acs-products-cancel"
+            variant="link"
+            onClick={onClose}
+          >
             {__('Cancel')}
           </Button>
         </ActionGroup>

--- a/webpack/scenes/AlternateContentSources/Details/__tests__/ACSEdits.test.js
+++ b/webpack/scenes/AlternateContentSources/Details/__tests__/ACSEdits.test.js
@@ -229,9 +229,9 @@ test('Can edit products in a simplified ACS details edit modal', async (done) =>
   // Can open modal
   await patientlyWaitFor(() => {
     expect(queryAllByText('Edit')).toHaveLength(4);
-    expect(getByLabelText('edit_acs_details')).toBeInTheDocument();
+    expect(getByLabelText('edit-acs-products')).toBeInTheDocument();
   });
-  const saveButton = getByLabelText('edit_acs_details');
+  const saveButton = getByLabelText('edit-acs-products');
   fireEvent.click(saveButton);
   // can close modal
   await patientlyWaitFor(() => {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Create a simplified ACS with some products.
Go to ACS details > Edit products > Inspect Save and cancel buttons and ensure aria-label and ouia-ids are correctly updated.