### PR TITLE
Fixes #36504 - Use assign_single_environment in bulk action

### DIFF
--- a/app/lib/actions/katello/host/update_content_view.rb
+++ b/app/lib/actions/katello/host/update_content_view.rb
@@ -4,8 +4,10 @@ module Actions
       class UpdateContentView < Actions::EntryAction
         def plan(host, content_view_id, lifecycle_environment_id)
           if host.content_facet
-            host.content_facet.content_view = ::Katello::ContentView.find(content_view_id)
-            host.content_facet.lifecycle_environment = ::Katello::KTEnvironment.find(lifecycle_environment_id)
+            host.content_facet.assign_single_environment(
+              content_view_id: content_view_id,
+              lifecycle_environment_id: lifecycle_environment_id
+            )
             host.update_candlepin_associations
             plan_self(:hostname => host.name)
           else


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The Content host bulk action "Change Lifecycle Environment" was still trying to do `.content_view = ` and `.lifecycle_environment = `. These methods no longer exist. This updates the code to use `assign_single_environment`.

#### Considerations taken when implementing this change?

wow that bulk action UI is baaaad...

#### What are the testing steps for this pull request?

Hosts > Content Hosts > Select one or more content hosts > Actions > Change Lifecycle Environment
Pick an environment and content view
Click Submit and then Yes (not Done lol)

Before: Task will pause with warning; Dynflow subplan will show error `undefined method `content_view=' for #<Katello::Host::ContentFacet>`

After: Task completes successfully.