### PR TITLE
Fixes #36515 - Don't show promote out of order for in-order envs

### DIFF
--- a/webpack/scenes/ContentViews/Details/Promote/ContentViewVersionPromote.js
+++ b/webpack/scenes/ContentViews/Details/Promote/ContentViewVersionPromote.js
@@ -92,10 +92,10 @@ const ContentViewVersionPromote = ({
   );
 
   const isValid = useCallback((env) => {
-    if (!env.prior) return true;
+    if (!env.prior || versionEnvironments.some(item => item.id === env.prior.id)) return true;
     if (!isChecked(prior(env))) return false;
     return isValid(prior(env));
-  }, [prior, isChecked]);
+  }, [prior, isChecked, versionEnvironments]);
 
   useDeepCompareEffect(() => {
     setForcePromote(userCheckedItems.filter(item => !isValid(item)));

--- a/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersionsLatestEnvironment.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersionsLatestEnvironment.fixtures.json
@@ -55,9 +55,9 @@
           "activation_key_count": 0
         },
         {
-          "id": 2,
-          "name": "dev1",
-          "label": "dev1",
+          "id": 3,
+          "name": "test",
+          "label": "test",
           "publish_date": "4 days",
           "permissions": {
             "readable": true,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
If the env to be promoted to has prior env checked or already promoted to, even if the prior promoted env is out of order, don't show out of order warning
#### Considerations taken when implementing this change?
Scenarios in issue
#### What are the testing steps for this pull request?
Consider a promotion like this:
![Screenshot from 2023-06-16 13-57-57](https://github.com/Katello/katello/assets/21146741/61b863d9-7d65-41e7-a634-09f5f68397ff)
Env qa is now considered 'in-order' because version is already published to previous env test (which was out of order, notice missing env dev). We don't have to consider test being out of order anymore. As a result qa is in-order. If you uncheck qa, check prod, prod is still out of order. Hope that makes sense.. :) 