### PR TITLE
Fixes #36516 - Add trailing / to CV RPM search autocomplete endpoint

### DIFF
--- a/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareConfig.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareConfig.js
@@ -137,7 +137,7 @@ export default ({
         selectRPMPackagesComparison(state, versionOneId, versionTwoId, viewBy),
       statusSelector: state =>
         selectRPMPackagesComparisonStatus(state, versionOneId, versionTwoId, viewBy),
-      autocompleteEndpoint: 'katello/api/v2/packages',
+      autocompleteEndpoint: '/katello/api/v2/packages',
       bookmarkController: 'katello_content_view_components',
       fetchItems: params => getRPMPackagesComparison(
         versionOneId,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

There is a bug in Content views -> <content-view> -> Versions -> compare 2 versions -> RPM packages, the search box, which makes it not show the autocompletion.
I searched a bit in the code and found that the RPM packages part is missing the trailing / compared to the others.
This makes the autocompletion work.

#### Considerations taken when implementing this change?

I looked for side-effects, but didn't see any. So it does just this fix.

#### What are the testing steps for this pull request?

I setup a forklift devel system with the 3.7/4.8 repos (and this change, on top of KATELLO-4.8), without this change it doesn't show up:
![image](https://github.com/Katello/katello/assets/42647570/a54a7fc7-b3eb-4944-a4b3-678dfb59a907)

As I tested it there, might be a candidate for backporting as well.
Thanks!