### PR TITLE
Fixes #36521 - raise an error with invalid manifest

### DIFF
--- a/app/models/katello/candlepin/repository_mapper.rb
+++ b/app/models/katello/candlepin/repository_mapper.rb
@@ -56,6 +56,7 @@ module Katello
       end
 
       def substitutor
+        fail _("Manifest does not have a valid subscription") if product.cdn_resource.nil?
         product.cdn_resource.substitutor
       end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Export a Red Hat repository
2. Go to your disconnected Satellite and remove all subscriptions from your manifest (DO NOT DELETE THE MANIFEST, JUST LET IT EMPTY)
3. Try importing the Red hat repository exported in step 1

Before:
```
Could not import the archive.:
undefined method `substitutor' for nil:NilClass
```
After
```
Could not import the archive.:
  Manifest does not have a valid subscription
```