### PR TITLE
Fixes #36288 - Wrong listing of Content Views which contain Files

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -22,6 +22,8 @@ module Katello
     param :organization_id, :number, :desc => N_("Organization identifier")
     param :include_applied_filters, :bool, :desc => N_("Whether or not to return filters applied to the content view version"), :required => false
     param :triggered_by_id, :number, :desc => N_("Filter composite versions whose publish was triggered by the specified component version"), :required => false
+    param :file_id, :number, :desc => N_("Filter content view versions that contain the file")
+    param :nondefault, :bool, :desc => N_("Filter out default content views"), :required => false
     param_group :search, Api::V2::ApiController
     add_scoped_search_description_for(ContentViewVersion)
     def index
@@ -36,10 +38,12 @@ module Katello
       versions = ContentViewVersion.readable
       versions = versions.triggered_by(params[:triggered_by_id]) if params[:triggered_by_id]
       versions = versions.with_organization_id(params[:organization_id]) if params[:organization_id]
+      versions = versions.non_default_view if ::Foreman::Cast.to_bool(params[:nondefault])
       versions = versions.where(:content_view_id => @view.id) if @view
       versions = versions.for_version(version_number) if version_number
       versions = versions.in_environment(@environment) if @environment
       versions = versions.component_of(params[:composite_version_id]) if params[:composite_version_id]
+      versions = versions.contains_file(params[:file_id]) if params[:file_id]
       versions
     end
 

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -106,6 +106,10 @@ module Katello
       name
     end
 
+    def self.contains_file(file_unit_id)
+      where(id: Katello::Repository.where(id: Katello::RepositoryFileUnit.where(file_unit_id: file_unit_id).select(:repository_id)).select(:content_view_version_id))
+    end
+
     def ansible_collections
       AnsibleCollection.in_repositories(archived_repos)
     end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/files/details/file-content-views.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/files/details/file-content-views.controller.js
@@ -11,7 +11,8 @@
         var contentViewsNutupane,
             params = {
                 'file_id': $scope.$stateParams.fileId,
-                'organization_id': CurrentOrganization
+                'organization_id': CurrentOrganization,
+                'nondefault': true
             };
 
         contentViewsNutupane = new Nutupane(ContentViewVersion, params);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/files/details/views/file-content-views.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/files/details/views/file-content-views.html
@@ -24,7 +24,7 @@
       <tbody>
         <tr bst-table-row ng-repeat="version in table.rows">
           <td bst-table-cell>
-            <a ui-sref="content-view.info({contentViewId: version.content_view.id})">
+            <a href="/content_views/{{version.content_view.id}}">
               {{ version.content_view.name }}
             </a>
           </td>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add file_id as a param to cv version API as bastion expects the API call to accept the parameter
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create and sync file repo.
2. Create some CVs with and some without file repo and publish a few versions.
3. Go to Menu > Content > Files > One of the file units > Content views tab

Before PR:
Views shows all CV versions in the system. No file filter applied.
After PR:
Only CV versions that contain file unit are shown.