### PR TITLE
Fixes #36221 - Allow removing products with empty URL repos from ACS

### DIFF
--- a/app/lib/actions/katello/alternate_content_source/update.rb
+++ b/app/lib/actions/katello/alternate_content_source/update.rb
@@ -71,7 +71,7 @@ module Actions
               products_to_disassociate.each do |product|
                 product.repositories.library.with_type(acs.content_type).each do |repo|
                   smart_proxy_acs = ::Katello::SmartProxyAlternateContentSource.find_by(alternate_content_source_id: acs.id, smart_proxy_id: smart_proxy.id, repository_id: repo.id)
-                  plan_action(Pulp3::Orchestration::AlternateContentSource::Delete, smart_proxy_acs)
+                  plan_action(Pulp3::Orchestration::AlternateContentSource::Delete, smart_proxy_acs) if smart_proxy_acs.present?
                 end
               end
             end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Check for presence of ACSSmartProxy before planning delete task
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Create a product.
Create a yum repository with URL, sync and everything you'd do normally.
Create another yum repo without a URL.

Create a simplified ACS and add the product to it.
Try removing that product from the ACS. It fails without this PR cause we don't create SmartProxyACS records for empty URL repos.