### PR TITLE
Fixes #36526 - Add banners warning about katello-agent removal

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/views/katello-agent-notice.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/views/katello-agent-notice.html
@@ -1,7 +1,7 @@
 <section>
   <p bst-alert="warning" >
     <span translate>
-      Katello-agent is deprecated and will be removed in a future release.
+      Katello-agent is deprecated and will be removed in Katello 4.10.
     </span>
   </p>
 </section>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
@@ -15,6 +15,7 @@
  * @requires ContentHostsHelper
  * @requires simpleContentAccessEnabled
  * @requires newHostDetailsUI
+ * @requires BastionConfig
  *
  * @description
  *   Provides the functionality specific to Content Hosts for use with the Nutupane UI pattern.
@@ -22,8 +23,8 @@
  *   within the table.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostsController',
-    ['$scope', '$q', '$state', '$location', '$uibModal', 'translate', 'Nutupane', 'Host', 'HostBulkAction', 'Notification', 'CurrentOrganization', 'ContentHostsHelper', 'ContentHostsModalHelper', '$httpParamSerializer', 'simpleContentAccessEnabled', 'newHostDetailsUI',
-    function ($scope, $q, $state, $location, $uibModal, translate, Nutupane, Host, HostBulkAction, Notification, CurrentOrganization, ContentHostsHelper, ContentHostsModalHelper, $httpParamSerializer, simpleContentAccessEnabled, newHostDetailsUI) {
+    ['$scope', '$q', '$state', '$location', '$uibModal', 'translate', 'Nutupane', 'Host', 'HostBulkAction', 'Notification', 'CurrentOrganization', 'ContentHostsHelper', 'ContentHostsModalHelper', '$httpParamSerializer', 'simpleContentAccessEnabled', 'newHostDetailsUI', 'BastionConfig',
+    function ($scope, $q, $state, $location, $uibModal, translate, Nutupane, Host, HostBulkAction, Notification, CurrentOrganization, ContentHostsHelper, ContentHostsModalHelper, $httpParamSerializer, simpleContentAccessEnabled, newHostDetailsUI, BastionConfig) {
         var nutupane, params, query;
 
         if ($location.search().search) {
@@ -51,6 +52,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsController',
         $scope.nutupane = nutupane;
         $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
         $scope.newHostDetailsUI = newHostDetailsUI;
+        $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
 
         // @TODO begin hack necessary because of foreman API bug http://projects.theforeman.org/issues/13877
         $scope.table.sortBy = function (column) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -5,8 +5,6 @@
   <h3 translate ng-show="selectedErrataOption === 'current'">Installable Errata</h3>
 </div>
 
-<div ng-show="katelloAgentPresent" data-extend-template="common/views/katello-agent-notice.html"></div>
-
 <div ng-hide="host.hasContent()">
   <div data-extend-template="common/views/registration.html"></div>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
@@ -2,7 +2,6 @@
 
 <section ng-hide="denied('edit_hosts', host)" bst-feature-flag="remote_actions">
   <h4 translate>Package Actions</h4>
-  <div ng-show="katelloAgentPresent" data-extend-template="common/views/katello-agent-notice.html"></div>
   <p bst-alert="warning" ng-hide="hostToolingEnabled">
     <span translate>
       Performing host package actions is disabled because Katello is not configured for Remote Execution or Katello Agent.

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
@@ -14,13 +14,14 @@
  * @requires deleteHostOnUnregister
  * @requires ContentHostsHelper
  * @requires simpleContentAccessEnabled
+ * @requires BastionConfig
  *
  * @description
  *   Provides the functionality for the content host details action pane.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostDetailsController',
-    ['$scope', '$state', '$q', '$location', 'translate', 'Host', 'HostSubscription', 'Organization', 'CurrentOrganization', 'Notification', 'MenuExpander', 'ApiErrorHandler', 'deleteHostOnUnregister', 'ContentHostsHelper', 'simpleContentAccessEnabled',
-    function ($scope, $state, $q, $location, translate, Host, HostSubscription, Organization, CurrentOrganization, Notification, MenuExpander, ApiErrorHandler, deleteHostOnUnregister, ContentHostsHelper, simpleContentAccessEnabled) {
+    ['$scope', '$state', '$q', '$location', 'translate', 'Host', 'HostSubscription', 'Organization', 'CurrentOrganization', 'Notification', 'MenuExpander', 'ApiErrorHandler', 'deleteHostOnUnregister', 'ContentHostsHelper', 'simpleContentAccessEnabled', 'BastionConfig',
+    function ($scope, $state, $q, $location, translate, Host, HostSubscription, Organization, CurrentOrganization, Notification, MenuExpander, ApiErrorHandler, deleteHostOnUnregister, ContentHostsHelper, simpleContentAccessEnabled, BastionConfig) {
         $scope.menuExpander = MenuExpander;
 
         $scope.getHostStatusIcon = ContentHostsHelper.getHostStatusIcon;
@@ -36,6 +37,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
 
         $scope.purposeAddonsCount = 0;
         $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
+        $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
 
         $scope.panel = {
             error: false,

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
@@ -54,6 +54,7 @@
 
   <nav data-block="navigation">
     <div content-access-mode-banner></div>
+    <div ng-show="katelloAgentPresent" data-extend-template="common/views/katello-agent-notice.html"></div>
     <ul class="nav nav-tabs">
       <li ng-class="{active: isState('content-host.info')}">
         <a translate

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -66,6 +66,10 @@
     </span>
   </div>
 
+  <span data-block="messages">
+    <div ng-show="katelloAgentPresent" data-extend-template="common/views/katello-agent-notice.html"></div>
+  </span>
+
   <span data-block="no-rows-message" translate>
     You currently don't have any Content Hosts, you can register one by clicking the button on the right and following the instructions.
   </span>

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -44,6 +44,7 @@ import { defaultRemoteActionMethod,
 import SortableColumnHeaders from '../../../../Table/components/SortableColumnHeaders';
 import { useRexJobPolling } from '../RemoteExecutionHooks';
 import { errataStatusContemplation, friendlyErrataStatus } from '../../../../Errata/errataHelpers';
+import KatelloAgentDeprecationAlert from '../../common/KatelloAgentDeprecationAlert';
 
 const recalculateApplicability = ['edit_hosts'];
 const invokeRexJobs = ['create_job_invocations'];
@@ -465,6 +466,9 @@ export const ErrataTab = () => {
   return (
     <div>
       <div id="errata-tab">
+        {defaultRemoteAction === KATELLO_AGENT && (
+          <KatelloAgentDeprecationAlert />
+        )}
         <TableWrapper
           {...{
             metadata,

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -48,6 +48,7 @@ import { defaultRemoteActionMethod,
   userPermissionsFromHostDetails } from '../../hostDetailsHelpers';
 import SortableColumnHeaders from '../../../../Table/components/SortableColumnHeaders';
 import { useRexJobPolling } from '../RemoteExecutionHooks';
+import KatelloAgentDeprecationAlert from '../../common/KatelloAgentDeprecationAlert';
 
 const invokeRexJobs = ['create_job_invocations'];
 const doKatelloAgentActions = ['edit_hosts'];
@@ -491,6 +492,9 @@ export const PackagesTab = () => {
   return (
     <div>
       <div id="packages-tab">
+        {showKatelloAgent && (
+          <KatelloAgentDeprecationAlert />
+        )}
         <TableWrapper
           {...{
             metadata,

--- a/webpack/components/extensions/HostDetails/common/KatelloAgentDeprecationAlert.js
+++ b/webpack/components/extensions/HostDetails/common/KatelloAgentDeprecationAlert.js
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+import {
+  Alert,
+  AlertActionCloseButton,
+} from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+const KatelloAgentDeprecationAlert = () => {
+  const [kAgentAlertShowing, setKAgentAlertShowing] = useState(true);
+
+  return kAgentAlertShowing ? (
+    <Alert
+      variant="warning"
+      className="katello-agent-deprecation-alert"
+      ouiaId="katello-agent-deprecation-alert"
+      isInline
+      title={__('Katello-agent is deprecated and will be removed in Katello 4.10.')}
+      actionClose={<AlertActionCloseButton ouiaId="katello-agent-alert-close-button" onClose={() => setKAgentAlertShowing(false)} />}
+    />
+  ) : null;
+};
+
+export default KatelloAgentDeprecationAlert;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add several banners in the web UI warning users about impending katello-agent removal.
Also, I removed the banners on the content host details / Packages and Errata tabs in favor of a single banner at the top of the page.

![image](https://github.com/Katello/katello/assets/22042343/013bbdec-4df7-4ef4-97c0-3e3b45a20932)
![image](https://github.com/Katello/katello/assets/22042343/4337ad31-bcdc-48a5-afe8-03321da9cc6f)
![image](https://github.com/Katello/katello/assets/22042343/f90c4211-8119-4347-a3f1-65a1e1422cb0)
![image](https://github.com/Katello/katello/assets/22042343/4bfdcc6f-aa86-4403-ad9f-34925d186088)


#### Considerations taken when implementing this change?

I didn't add a single banner at the top of the new host details page because that would require a Foreman code change.

There were already banners on the Content Host Bulk Actions modals for errata and packages.

Can you think of any other places where I should add a banner?

Downstream, "Katello 4.10" will be translated to "Satellite 6.15".

The PF4 banners have a close button which is nice! but the Angular ones don't, sorry!

#### What are the testing steps for this pull request?

In order to see these banners, the UI has to think that you have katello-agent enabled. So, you either have to actually set up katello-agent, or fake it somehow.
