### PR TITLE
Fixes #36528 - handle integer hash keys in katello-agent actions

### DIFF
--- a/app/lib/actions/katello/agent_action.rb
+++ b/app/lib/actions/katello/agent_action.rb
@@ -14,8 +14,10 @@ module Actions
 
       def plan(host, options)
         action_subject(host, :hostname => host.name, :content => options[:content])
-
-        dispatch_history_id = options.dig(:dispatch_histories, host.id.to_s) || ::Katello::Agent::Dispatcher.create_histories(
+        # options[:dispatch_histories] keys might be strings or integers
+        dispatch_history_id = options.dig(:dispatch_histories, host.id.to_s) ||
+        options.dig(:dispatch_histories, host.id.to_i) ||
+          ::Katello::Agent::Dispatcher.create_histories(
           host_ids: [host.id]
         ).first.id
 
@@ -44,7 +46,6 @@ module Actions
             history.dynflow_execution_plan_id = suspended_action.execution_plan_id
             history.dynflow_step_id = suspended_action.step_id
             history.save!
-
             dispatch_message(history) unless input[:bulk]
 
             schedule_timeout(timeout, optional: true)

--- a/app/lib/actions/katello/bulk_agent_action.rb
+++ b/app/lib/actions/katello/bulk_agent_action.rb
@@ -21,7 +21,10 @@ module Actions
 
       def spawn_plans
         args = input[:args].first
-        histories = ::Katello::Agent::DispatchHistory.where(id: args[:dispatch_histories].slice(*current_batch.map(&:to_s)).values)
+        # args[:dispatch_histories] keys are numeric host ids; they may be integer or string
+        # Hash#slice will return a filtered hash only with the specified keys, and ignore keys that don't exist
+        possible_keys = [*current_batch.map(&:to_i), *current_batch.map(&:to_s)]
+        histories = ::Katello::Agent::DispatchHistory.where(id: args[:dispatch_histories].slice(*possible_keys).values)
         ::Katello::Agent::Dispatcher.dispatch(
           args[:type].to_sym,
           histories,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

For some reason, `args[:dispatch_histories]` is ending up with integer keys, but the code was expecting string keys. This caused no sub-plans to be created for any Katello-agent bulk action.

I changed the code to handle both string and integer hash keys. After doing this, I noticed that the action would succeed on the host, but the task would still fail:

```
RuntimeError

Host did not respond within 20 seconds. The task has been cancelled. Is katello-agent installed and goferd running on the Host?
```

This was because `Katello::AgentAction#plan` was still expecting `options[:dispatch_histories]` to have string keys. I changed that to handle both string and integer as well.

#### Considerations taken when implementing this change?

Originally I had just changed `.to_s` to `.to_i`, but realized I don't necessarily know for sure all the code paths that create `Katello::Agent::DispatchHistory`s. Figured it was safer to handle both data types.

#### What are the testing steps for this pull request?

Set up katello-agent:

```
sudo foreman-installer \
--scenario katello-devel \
--katello-devel-modulestream-nodejs=14\
--foreman-proxy-content-enable-katello-agent=true
```

Administer > Settings > Content > Use remote execution by default > No

Enable the RH Client repo
Install katello-agent on a host

Test basic setup: Hosts > All Hosts > your host > Packages > kebab > Install packages > Install "via katello-agent"
Task should succeed.

Test bulk actions:
Hosts > Content Hosts > Select your host (you don't need more than one) > Select action > Manage Packages > type a package name > Install > via katello-agent

Before: Task fails and Dynflow console for the task shows no subplans.
After: Task succeeds with no errors. Bulk action shows sub-plans for each host.

