### PR TITLE
Fixes #36529 - CV page needs refresh to get the current filters state

### DIFF
--- a/webpack/scenes/ContentViews/Details/ContentViewDetails.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetails.js
@@ -37,7 +37,7 @@ import { hasPermission } from '../helpers';
 import CopyContentViewModal from '../Copy/CopyContentViewModal';
 import ContentViewDeleteWizard from '../Delete/ContentViewDeleteWizard';
 import EmptyStateMessage from '../../../components/Table/EmptyStateMessage';
-import { cvVersionTaskPollingKey } from '../ContentViewsConstants';
+import { CONTENT_VIEW_NEEDS_PUBLISH_RESET, cvVersionTaskPollingKey } from '../ContentViewsConstants';
 import { clearPollTaskData, stopPollingTask } from '../../Tasks/TaskActions';
 
 export default () => {
@@ -73,6 +73,7 @@ export default () => {
 
   useEffect(() => {
     dispatch(getContentViewDetails(cvId));
+    dispatch({ type: CONTENT_VIEW_NEEDS_PUBLISH_RESET });
   }, [cvId, dispatch]);
 
 

--- a/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersions.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersions.test.js
@@ -13,6 +13,7 @@ import contentViewTaskResponseData from './contentViewTaskResponse.fixtures.json
 import cvDetailData from '../../../../ContentViews/__tests__/mockDetails.fixtures.json';
 import environmentPathsData from '../../../Publish/__tests__/environmentPaths.fixtures.json';
 import cvIndexData from '../../../__tests__/contentViewList.fixtures.json';
+import contentViewFilterData from '../../Filters/__tests__/contentViewFilters.fixtures.json';
 
 const cvPromotePath = api.getApiUrl('/content_view_versions/10/promote');
 const cvIndexPath = api.getApiUrl('/content_views');
@@ -34,6 +35,7 @@ const renderOptions = {
 const cvVersions = api.getApiUrl('/content_view_versions');
 const autocompleteUrl = '/content_view_versions/auto_complete_search';
 const taskPollingUrl = '/foreman_tasks/api/tasks/6b900ff8-62bb-42ac-8c45-da86b7258520';
+const cvFiltersPath = api.getApiUrl('/content_view_filters?content_view_id=5');
 
 let firstVersion;
 let envScope;
@@ -330,6 +332,10 @@ test('Shows call-to-action when there are no versions', async (done) => {
     .query(true)
     .reply(200, environmentPathsData);
 
+  const filterScope = nockInstance
+    .get(cvFiltersPath)
+    .reply(200, contentViewFilterData);
+
   const { getByText, queryByText } = renderWithRedux(
     withCVRoute(<ContentViewVersions cvId={5} details={cvDetailData} />),
     renderOptions,
@@ -347,6 +353,7 @@ test('Shows call-to-action when there are no versions', async (done) => {
   assertNockRequest(scopeWizard);
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope);
+  assertNockRequest(filterScope);
   act(done);
 });
 

--- a/webpack/scenes/ContentViews/Details/__tests__/contentViewDetails.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/__tests__/contentViewDetails.fixtures.json
@@ -7,6 +7,7 @@
   "latest_version": "5.0",
   "auto_publish": false,
   "solve_dependencies": false,
+  "needs_publish": false,
   "generated_for": "none",
   "repository_ids": [
     58,

--- a/webpack/scenes/ContentViews/Publish/CVPublishReview.js
+++ b/webpack/scenes/ContentViews/Publish/CVPublishReview.js
@@ -15,16 +15,20 @@ import InactiveText from '../components/InactiveText';
 import ComponentEnvironments from '../Details/ComponentContentViews/ComponentEnvironments';
 import { selectEnvironmentPaths, selectEnvironmentPathsStatus } from '../components/EnvironmentPaths/EnvironmentPathSelectors';
 import WizardHeader from '../components/WizardHeader';
+import { selectCVFilters, selectCVFiltersStatus } from '../Details/ContentViewDetailSelectors';
 
 const CVPublishReview = ({
   details: {
-    id, name, composite, filtered, next_version: nextVersion,
+    id, name, composite, next_version: nextVersion,
   },
   userCheckedItems,
 }) => {
   const environmentPathResponse = useSelector(selectEnvironmentPaths);
   const environmentPathStatus = useSelector(selectEnvironmentPathsStatus);
+  const cvFiltersResponse = useSelector(state => selectCVFilters(state, id));
+  const cvFiltersStatus = useSelector(state => selectCVFiltersStatus(state, id));
   const environmentPathLoading = environmentPathStatus === STATUS.PENDING;
+  const cvFiltersLoading = cvFiltersStatus === STATUS.PENDING;
 
   const promotedToEnvironments = useMemo(() => {
     if (!environmentPathLoading) {
@@ -34,6 +38,14 @@ const CVPublishReview = ({
     }
     return [];
   }, [environmentPathResponse, environmentPathLoading, userCheckedItems]);
+
+  const filtered = useMemo(() => {
+    if (!cvFiltersLoading) {
+      const { results } = cvFiltersResponse || {};
+      return results.length > 0;
+    }
+    return [];
+  }, [cvFiltersResponse, cvFiltersLoading]);
 
   return (
     <>
@@ -94,7 +106,6 @@ CVPublishReview.propTypes = {
     ]).isRequired,
     name: PropTypes.string.isRequired,
     composite: PropTypes.bool.isRequired,
-    filtered: PropTypes.bool.isRequired,
     next_version: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.string,

--- a/webpack/scenes/ContentViews/Publish/PublishContentViewWizard.js
+++ b/webpack/scenes/ContentViews/Publish/PublishContentViewWizard.js
@@ -14,6 +14,7 @@ import {
 } from '../components/EnvironmentPaths/EnvironmentPathSelectors';
 import { stopPollingTask } from '../../Tasks/TaskActions';
 import { cvVersionTaskPollingKey } from '../ContentViewsConstants';
+import { getContentViewFilters } from '../Details/ContentViewDetailActions';
 
 const PublishContentViewWizard = ({
   details, show, onClose,
@@ -29,6 +30,7 @@ const PublishContentViewWizard = ({
   const environmentPathResponse = useSelector(selectEnvironmentPaths);
   const environmentPathStatus = useSelector(selectEnvironmentPathsStatus);
   const environmentPathLoading = environmentPathStatus === STATUS.PENDING;
+
 
   const steps = [
     {
@@ -71,8 +73,9 @@ const PublishContentViewWizard = ({
   useEffect(
     () => {
       dispatch(getEnvironmentPaths());
+      dispatch(getContentViewFilters(cvId, {}));
     },
-    [dispatch],
+    [dispatch, cvId],
   );
 
   const envPathFlat = useMemo(() => {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
1. Reload cv filters on publish screen when wizard is opened to get accurate state of filters on the CV.
2. Needs_publish is now reset if you move from one CV to another.

#### What are the testing steps for this pull request?
1. Go to a CV without filters.
2. Go to filters tab. Create a new filter.
3. Hit Publish new version button and go to Review step. You should see the notice that filters will be applied.
4. Publish.
5. Go back to filters tab. Delete the single filter and hit publish.
6. You should not see the warning now.

Small bug fix with needs_publish UI:
Have 2 CVs with some published versions in the box. Make sure none need publish at the moment. (Aka no needs_publish icon on the version)
1. Go to a CV and create a new filter.
2. Go to versions tab and see that needs_publish icon is shown.
3. Go to another CV and make sure the needs_publish icon is not shown.