### PR TITLE
Fixes #36523 - Optimized capsule sync doesn't sync recently published/promoted docker repositories

### DIFF
--- a/app/lib/actions/pulp3/orchestration/repository/generate_metadata.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/generate_metadata.rb
@@ -14,6 +14,8 @@ module Actions
                 plan_self(source_repository_id: options[:source_repository].id, target_repository_id: repository.id, smart_proxy_id: smart_proxy.id)
               elsif publication_content_type && (force_publication || repository.publication_href.nil? || !repository.using_mirrored_metadata?)
                 plan_action(Actions::Pulp3::Repository::CreatePublication, repository, smart_proxy, options)
+              elsif !publication_content_type
+                plan_self(target_repository_id: repository.id, contents_changed: options[:contents_changed], skip_publication: true)
               end
               plan_action(Actions::Pulp3::ContentGuard::Refresh, smart_proxy) unless repository.unprotected
               plan_action(Actions::Pulp3::Repository::RefreshDistribution, repository, smart_proxy, :contents_changed => options[:contents_changed]) if Setting[:distribute_archived_cvv] || repository.environment
@@ -21,13 +23,18 @@ module Actions
           end
 
           def run
-            #we don't have to actually generate a publication, we can reuse the old one
             target_repo = ::Katello::Repository.find(input[:target_repository_id])
-            source_repo = ::Katello::Repository.find(input[:source_repository_id])
-            if (target_repo.publication_href != source_repo.publication_href && smart_proxy.pulp_primary?)
-              target_repo.clear_smart_proxy_sync_histories
+            if input[:skip_publication]
+              #Need to clear smart proxy sync histories for non-publication content_types: docker, ansible collection
+              target_repo.clear_smart_proxy_sync_histories if input[:contents_changed]
+            else
+              #we don't have to actually generate a publication, we can reuse the old one
+              source_repo = ::Katello::Repository.find(input[:source_repository_id])
+              if (target_repo.publication_href != source_repo.publication_href && smart_proxy.pulp_primary?)
+                target_repo.clear_smart_proxy_sync_histories
+              end
+              target_repo.update!(publication_href: source_repo.publication_href)
             end
-            target_repo.update!(publication_href: source_repo.publication_href)
           end
         end
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Clears smart proxy sync history for repositories when content changes on a docker repo/ansible repo. 
#### Considerations taken when implementing this change?
We have logic in capsule sync optimization that clears smart proxy sync history when publication changes on a target repo and that causes optimized capsule sync to pick those up.
We weren't clearing the smart proxy sync history on Docker/ansible content during this because we weren't considering content types that don't have publications.
#### What are the testing steps for this pull request?
Steps to Reproduce:
1. Set "Sync Capsules after content view promotion" to No
2. Create and sync a docker repository.
~~~
Registry URL: https://registry-1.docker.io/
Upstream Repository Name: library/hello-world

# Limit the tag to sync
Include Tags: latest
~~~

3. Create a content view and attach the docker repository to it. Publish and promote the content view.
4. Trigger a optimized capsule sync to sync the CV repositories for the first time to the Capsule.
5. In the docker repository page, include a new tag and sync it.

Include Tags: latest, linux

6. Publish and promote new version of the content view.
7. Trigger a optimized capsule sync again


Actual results:
The optimized capsule sync doesn't sync newly published docker repositories

Expected results:
Optimized capsule sync should sync the newly published docker repositories.
