### PR TITLE
Fixes #36545 - Correcting apidoc for reclaim_space endpoint of smart-…

### DIFF
--- a/app/controllers/katello/api/v2/capsule_content_controller.rb
+++ b/app/controllers/katello/api/v2/capsule_content_controller.rb
@@ -87,7 +87,7 @@ module Katello
       end
     end
 
-    api :POST, '/capsules/:id/reclaim_space', N_('Reclaim space from all On Demand repositories on a smart proxy')
+    api :POST, '/capsules/:id/content/reclaim_space', N_('Reclaim space from all On Demand repositories on a smart proxy')
     param :id, :number, :required => true, :desc => N_('Id of the smart proxy')
     def reclaim_space
       find_capsule(true)


### PR DESCRIPTION

#### What are the changes introduced in this pull request?

Modification of APIDOC to include the right reclaim_space endpoint for external smart-proxies

#### Considerations taken when implementing this change?

When we invoke the "Reclaim Space" action from WebUI for any external smart-proxies, that triggers the right API call as expected. 

But navigating to the API doc, we can see reclaim_space endpoint is not mentioned correctly and results in failure if used as mentioned.


#### What are the testing steps for this pull request?

1. Build a setup with an external smart-proxy included
2. Sync some repos in main Katello server with Immediate download policy
3. Change the download policy of external smart-proxy to Immediate and sync the external smart-proxy 
4. Change the download policy back to On_Demand for the external smart-proxy
5. Check the apidoc for Capsule Content --> Reclaim Space and notice `POST /katello/api/capsules/:id/reclaim_space` is mentioned. 
6. Use the API to trigger the "ReclaimSpace" task and it should immediately show some failure as mentioned in [BZ 2218179](https://bugzilla.redhat.com/show_bug.cgi?id=2218179)
7. Apply the fix from PR and restart the katello instance 
8. Repeat step 5 and notice the corrected endpoint `POST /katello/api/capsules/:id/content/reclaim_space`
9. Repeat step 6 and that should successfully trigger the expected task