### PR TITLE
Refs #36100 - fix package applicability for multiple architectures

### DIFF
--- a/app/services/katello/applicability/applicable_content_helper.rb
+++ b/app/services/katello/applicability/applicable_content_helper.rb
@@ -133,13 +133,13 @@ module Katello
       end
 
       def newest_distinct_installed_packages_query
-        "SELECT DISTINCT ON (katello_installed_packages.name) katello_installed_packages.id " \
+        "SELECT DISTINCT ON (katello_installed_packages.name, katello_installed_packages.arch) katello_installed_packages.id " \
           "FROM katello_installed_packages INNER JOIN " \
           "katello_host_installed_packages ON " \
           "katello_installed_packages.id = " \
           "katello_host_installed_packages.installed_package_id " \
           "WHERE katello_host_installed_packages.host_id = " \
-          "#{content_facet.host.id} ORDER BY katello_installed_packages.name, katello_installed_packages.evr DESC"
+          "#{content_facet.host.id} ORDER BY katello_installed_packages.name, katello_installed_packages.arch, katello_installed_packages.evr DESC"
       end
 
       def applicable_differences

--- a/test/fixtures/models/katello_rpms.yml
+++ b/test/fixtures/models/katello_rpms.yml
@@ -69,3 +69,28 @@ one_two:
   arch:     x86_64
   filename: one-1.2.rpm
   nvra:     one-1.0-2.el7.x86_64
+
+one_i686:
+  name:     one
+  pulp_id:     one-i686-uuid
+  epoch:    0
+  version:  1.0
+  release:  1.el7
+  version_sortable: 01-1.01-0
+  release_sortable: 01-1.$el.01-7
+  arch:     i686
+  filename: one-i686-1.1.rpm
+  nvra:     one-1.0-1.el7.i686
+  modular: false
+
+one_i686_two:
+  name:     one
+  pulp_id:     one-i686-uuid-two
+  epoch:    0
+  version:  1.0
+  release:  2.el7
+  version_sortable: 01-1.01-0
+  release_sortable: 01-2.$el.01-7
+  arch:     i686
+  filename: one-i686-1.2.rpm
+  nvra:     one-1.0-2.el7.i686


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Package upgradable versions should be based on architecture.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Be able to upgrade `expat.i686` or `expat.x86_64` on RHEL8.