### PR TITLE
Fixes #36530 - Fix up /katello/api/sync_plans/:sync_plan_id/product…

### DIFF
--- a/app/controllers/katello/api/v2/sync_controller.rb
+++ b/app/controllers/katello/api/v2/sync_controller.rb
@@ -4,7 +4,6 @@ module Katello
     before_action :find_object, :only => [:index]
     before_action :ensure_library, :only => [:index]
 
-    api :GET, "/organizations/:organization_id/products/:product_id/sync", N_("Get status of repo synchronisation for given product")
     api :GET, "/repositories/:repository_id/sync", N_("Get status of synchronisation for given repository")
     def index
       respond_for_async(:resource => @obj.sync_status)

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -947,6 +947,10 @@ module Katello
       content_view.repositories.include? self
     end
 
+    def sync_status
+      return latest_dynflow_sync
+    end
+
     protected
 
     def unit_type_for_removal(type_class = nil)

--- a/app/views/katello/api/v2/sync/index.json.rabl
+++ b/app/views/katello/api/v2/sync/index.json.rabl
@@ -1,1 +1,0 @@
-extends 'katello/api/v2/common/async'

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -484,6 +484,7 @@ Katello::Engine.routes.draw do
         end
 
         api_resources :sync_plans, :only => [:index, :show, :update, :destroy] do
+          api_resources :products, :only => [:index]
           get :auto_complete_search, :on => :collection
           put :sync
         end

--- a/test/controllers/api/v2/sync_controller_test.rb
+++ b/test/controllers/api/v2/sync_controller_test.rb
@@ -22,7 +22,7 @@ module Katello
     end
 
     def test_index
-      Product.any_instance.expects(:sync_status).returns([{}])
+      Product.any_instance.expects(:sync_status).returns([])
 
       get :index, params: { :product_id => @product.cp_id, :organization_id => @organization.id }
       assert_response :success


### PR DESCRIPTION
…s and /katello/api/repositories/:repository_id/sync API endpoints.

Fixed broken ktests

#### What are the changes introduced in this pull request?
Fixed the Katello API endpoints for the following URLs:
```
GET /katello/api/sync_plans/:sync_plan_id/products 	(List of Products for sync plan)
GET /katello/api/repositories/:repository_id/sync 	(Get status of synchronisation for given repository)
```
and removed the endpoint for the following URL:
```
GET /katello/api/organizations/:organization_id/products/:product_id/sync 	(Get status of repo synchronisation for given product)
```
These endpoints broke when certain Pulp 2 functionality was removed from Foreman and Katello. The removed endpoint should no longer appear in the API documentation.

#### Considerations taken when implementing this change?
We believe that nothing is querying the removed endpoint (product lookup via candlepin id and organization). If we for some reason need this functionality, I'd be more than happy to fix it as well.

#### What are the testing steps for this pull request?

1. Create a repository with products and a sync plan. 
2. Go to `<host>/katello/sync_management`. Ensure that running 'Synchronize now' on your repo functions as expected.
3. Go to `<host>/apidoc/v2.html`. Ensure that the first two API endpoints are listed and that the third is not.
4. Using a terminal, run these commands to verify the API endpoints work:
```
curl --user admin:changeme --request GET <host>/katello/api/sync_plans/<sp_id>/products?organization_id=1
curl --user admin:changeme --request GET <host>/katello/api/repositories/<repo_id>/sync
```
5. Ensure the following command fails:
```
curl --user admin:changeme --request GET centos8-katello-devel.redhat.example.com/katello/api/organizations/1/products/1/sync
```
You should expect a big ol' html doc which indicates an invalid route.