### PR TITLE
Fixes #36524 - RegistrationManager expects an array for content_view_environments to register

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -81,7 +81,7 @@ module Katello
     def create
       rhsm_params = params_to_rhsm_params
 
-      host = Katello::RegistrationManager.process_registration(rhsm_params, @content_view_environment)
+      host = Katello::RegistrationManager.process_registration(rhsm_params, [@content_view_environment])
       host.reload
       ::Katello::Host::SubscriptionFacet.update_facts(host, rhsm_params[:facts]) unless rhsm_params[:facts].blank?
 

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -158,7 +158,7 @@ module Katello
       content_view_environment = ContentViewEnvironment.find(katello_content_view_environments(:library_default_view_environment).id)
       Resources::Candlepin::Consumer.stubs(:get)
 
-      ::Katello::RegistrationManager.expects(:process_registration).with(expected_consumer_params, content_view_environment).returns(@host)
+      ::Katello::RegistrationManager.expects(:process_registration).with(expected_consumer_params, [content_view_environment]).returns(@host)
       post(:create,
         params: {
           :lifecycle_environment_id => content_view_environment.environment_id,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
`Katello::RegistrationManager.process_registration` expects an array for [content_view_environments](https://github.com/Katello/katello/blob/f3dba82d5f35f679c0f7906cf07e211a716b6785/app/services/katello/registration_manager.rb#L17) to register a host.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
```hammer host subscription register --name 'tester' --organization-id 1 --content-view-id 2 --lifecycle-environment-id 2```

Before
``` undefined method `each' for #<Katello::ContentViewEnvironment:0x00007efec2e62cc0>```

After
```Host successfully registered.```