### PR TITLE
Fixes #36562 - Clear RootRepo checksum if on_demand repo

### DIFF
--- a/db/migrate/20220228173251_remove_drpm_from_ignorable_content.rb
+++ b/db/migrate/20220228173251_remove_drpm_from_ignorable_content.rb
@@ -6,6 +6,7 @@ class RemoveDrpmFromIgnorableContent < ActiveRecord::Migration[6.0]
       else
         root.ignorable_content = []
       end
+      root.checksum_type = nil if root.download_policy == ::Katello::RootRepository::DOWNLOAD_ON_DEMAND
       root.save!
     end
   end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Upgrade migration to clear checksum_type from RootRepositories for repos with on_demand download policy, before saving the repos.

#### Considerations taken when implementing this change?

In certain cases where users are upgrading their instance from a very old version of katello (at some point they either have done **validate content sync** or due to some other really weird reason), They may have a few on_demand repos left with some checksum_type set. But as this combination should not exist and can fail the [RemoveDrpmFromIgnorableContent](https://github.com/Katello/katello/blob/master/db/migrate/20220228173251_remove_drpm_from_ignorable_content.rb) migration, we want to unset the checksum_type for such repos before executing `root.save!`

#### What are the testing steps for this pull request?

* Install Katello 4.4
* Enable a few repos ( having on_demand download policy )
* Use a DB query like this to set a specific checksum_type for them i.e. 
```
echo "update katello_root_repositories set checksum_type = 'sha256' where content_type='yum' ;" | su - postgres -c "psql foreman"
```
* Upgrade to 4.5 and observe the failure during db:migrate
* Apply the changes from this PR
* Re-run db:migrate and it should be successful 
* Re-run the upgrade and that should be completed successfully as well. 