### PR TITLE
Refs #36526 - Remove duplicate katello-agent banners from content host Packages tab

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
@@ -1,7 +1,6 @@
 <span page-title ng-model="host">{{ 'Packages for: ' | translate }} {{ host.name }}</span>
 
 <h3 translate>Applicable Packages</h3>
-<div ng-show="katelloAgentPresent" data-extend-template="common/views/katello-agent-notice.html"></div>
 
 <section ng-hide="denied('edit_hosts', host)" bst-feature-flag="remote_actions">
   <p bst-alert="warning" ng-hide="hostToolingEnabled">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-installed.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-installed.html
@@ -2,8 +2,6 @@
 
 <h3 translate>Installed Packages</h3>
 
-<div ng-show="katelloAgentPresent" data-extend-template="common/views/katello-agent-notice.html"></div>
-
 <section ng-hide="denied('edit_hosts', host)" bst-feature-flag="remote_actions">
   <p bst-alert="warning" ng-hide="hostToolingEnabled">
     <span translate>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

In https://github.com/Katello/katello/pull/10626 I missed removing two banners. This results in two banners being displayed on the Applicable and Installed Packages pages -- we only need one.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

See previous PR for testing steps
