### PR TITLE
Fixes #36563 - Remove orphaned content unit cleanup from index_content

### DIFF
--- a/app/lib/actions/katello/orphan_cleanup/remove_orphaned_content_units.rb
+++ b/app/lib/actions/katello/orphan_cleanup/remove_orphaned_content_units.rb
@@ -1,0 +1,32 @@
+module Actions
+  module Katello
+    module OrphanCleanup
+      class RemoveOrphanedContentUnits < Actions::Base
+        def plan(options = {})
+          plan_self(id: options[:repo_id], destroy_all: options[:destroy_all])
+        end
+
+        def run
+          content_types_to_index = []
+          if input[:destroy_all]
+            ::Katello::RepositoryTypeManager.enabled_repository_types.each_value do |repo_type|
+              content_types_to_index << repo_type.content_types_to_index
+            end
+          elsif input[:id]
+            repo = ::Katello::Repository.find(input[:id])
+            content_types_to_index = repo.repository_type.content_types_to_index
+          else
+            fail "Pass either a repository to determine content type or destroy_all to destroy all orphaned content units"
+          end
+          content_types_to_index.flatten.each do |type|
+            type.model_class.orphaned.destroy_all
+          end
+        end
+
+        def rescue_strategy
+          Dynflow::Action::Rescue::Skip
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/orphan_cleanup/remove_orphaned_content_units.rb
+++ b/app/lib/actions/katello/orphan_cleanup/remove_orphaned_content_units.rb
@@ -2,24 +2,14 @@ module Actions
   module Katello
     module OrphanCleanup
       class RemoveOrphanedContentUnits < Actions::Base
-        def plan(options = {})
-          plan_self(id: options[:repo_id], destroy_all: options[:destroy_all])
-        end
-
         def run
-          content_types_to_index = []
-          if input[:destroy_all]
-            ::Katello::RepositoryTypeManager.enabled_repository_types.each_value do |repo_type|
-              content_types_to_index << repo_type.content_types_to_index
-            end
-          elsif input[:id]
-            repo = ::Katello::Repository.find(input[:id])
-            content_types_to_index = repo.repository_type.content_types_to_index
-          else
-            fail "Pass either a repository to determine content type or destroy_all to destroy all orphaned content units"
+          models = []
+
+          ::Katello::RepositoryTypeManager.enabled_repository_types.each_value do |repo_type|
+            models << repo_type.content_types_to_index
           end
-          content_types_to_index.flatten.each do |type|
-            type.model_class.orphaned.destroy_all
+          models.flatten.each do |content_type|
+            content_type.model_class.orphaned.destroy_all
           end
         end
 

--- a/app/lib/actions/katello/orphan_cleanup/remove_orphans.rb
+++ b/app/lib/actions/katello/orphan_cleanup/remove_orphans.rb
@@ -9,7 +9,7 @@ module Actions
           sequence do
             if proxy.pulp_primary?
               ::Katello::RootRepository.orphaned.destroy_all
-              plan_action(RemoveOrphanedContentUnits, destroy_all: true)
+              plan_action(RemoveOrphanedContentUnits)
             end
             if proxy.pulp3_enabled?
               plan_action(

--- a/app/lib/actions/katello/repository/index_content.rb
+++ b/app/lib/actions/katello/repository/index_content.rb
@@ -31,10 +31,6 @@ module Actions
             output[:new_content][content_type.label] = new_count - initial_counts[content_type.label]
           end
         end
-
-        def finalize
-          ForemanTasks.async_task(OrphanCleanup::RemoveOrphanedContentUnits, {repo_id: input[:id]})
-        end
       end
     end
   end

--- a/app/lib/actions/katello/repository/index_content.rb
+++ b/app/lib/actions/katello/repository/index_content.rb
@@ -31,6 +31,10 @@ module Actions
             output[:new_content][content_type.label] = new_count - initial_counts[content_type.label]
           end
         end
+
+        def finalize
+          ForemanTasks.async_task(OrphanCleanup::RemoveOrphanedContentUnits, {repo_id: input[:id]})
+        end
       end
     end
   end

--- a/app/models/katello/concerns/pulp_database_unit.rb
+++ b/app/models/katello/concerns/pulp_database_unit.rb
@@ -169,9 +169,9 @@ module Katello
 
       def orphaned
         if many_repository_associations
-          where.not(:id => repository_association_class.where(:repository_id => ::Katello::Repository.all).select(unit_id_field))
+          where.not(:id => repository_association_class.select(unit_id_field))
         else
-          where.not(:repository_id => ::Katello::Repository.all)
+          where.not(:repository_id => ::Katello::Repository.select(:id))
         end
       end
 

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -935,7 +935,6 @@ module Katello
         repository_type.content_types_to_index.each do |type|
           Katello::Logging.time("CONTENT_INDEX", data: {type: type.model_class}) do
             Katello::ContentUnitIndexer.new(content_type: type, repository: self, optimized: !full_index).import_all
-            type.model_class.orphaned.destroy_all
           end
         end
         repository_type.index_additional_data_proc&.call(self)

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -130,7 +130,7 @@ module Katello
       where(:http_proxy_policy => RootRepository::USE_SELECTED_HTTP_PROXY).
       where(:http_proxy_id => http_proxy_id)
     }
-    scope :orphaned, -> { where.not(id: Katello::Repository.pluck(:root_id).uniq) }
+    scope :orphaned, -> { where.not(id: Katello::Repository.select(:root_id)) }
     scope :redhat, -> { joins(:provider).merge(Katello::Provider.redhat) }
     scope :custom, -> { where.not(:id => self.redhat) }
     delegate :redhat?, :provider, :organization, to: :product

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -497,7 +497,8 @@ module Katello
       rescue api.client_module::ApiError => e
         if e.message.include? 'Could not find the following content units'
           raise ::Katello::Errors::Pulp3Error, "Content units that do not exist in Pulp were requested to be copied."\
-            " Please run a complete sync on the following repository: #{repository_reference.root_repository.name}. Original error: #{e.message}"
+             " Please run `foreman-rake katello:delete_orphaned_content` to fix the following repository:"\
+            " #{repository_reference.root_repository.name}. Original error: #{e.message}"
         else
           raise e
         end
@@ -509,7 +510,7 @@ module Katello
       rescue api.client_module::ApiError => e
         if e.message.include? 'Could not find the following content units'
           raise ::Katello::Errors::Pulp3Error, "Content units that do not exist in Pulp were requested to be copied."\
-            " Please run a complete sync on the following repository:"\
+            " Please run `foreman-rake katello:delete_orphaned_content` to fix the following repository:"\
             " #{::Katello::Pulp3::RepositoryReference.find_by(repository_href: repository_href).root_repository.name}. Original error: #{e.message}"
         else
           raise e

--- a/app/services/katello/pulp3/repository/docker.rb
+++ b/app/services/katello/pulp3/repository/docker.rb
@@ -70,7 +70,7 @@ module Katello
         rescue api.client_module::ApiError => e
           if e.message.include? 'Could not find the following content units'
             raise ::Katello::Errors::Pulp3Error, "Content units that do not exist in Pulp were requested to be copied."\
-              " Please run a complete sync on the following repository: #{repository_reference.root_repository.name}. Original error: #{e.message}"
+              " Please run `foreman-rake katello:delete_orphaned_content` to fix the following repository: #{repository_reference.root_repository.name}. Original error: #{e.message}"
           else
             raise e
           end

--- a/test/actions/katello/orphan_cleanup/remove_orphaned_content_units_test.rb
+++ b/test/actions/katello/orphan_cleanup/remove_orphaned_content_units_test.rb
@@ -8,14 +8,7 @@ module Katello
     def test_orphaned_content_task_destroys_orphans
       rpm = katello_rpms(:one)
       rpm.repository_rpms.destroy_all
-      ForemanTasks.sync_task(Actions::Katello::OrphanCleanup::RemoveOrphanedContentUnits, {repo_id: @rhel6.id})
-      assert_raises(ActiveRecord::RecordNotFound) { rpm.reload }
-    end
-
-    def test_orphaned_content_task_destroy_all
-      rpm = katello_rpms(:one)
-      rpm.repository_rpms.destroy_all
-      ForemanTasks.sync_task(Actions::Katello::OrphanCleanup::RemoveOrphanedContentUnits, {destroy_all: true})
+      ForemanTasks.sync_task(Actions::Katello::OrphanCleanup::RemoveOrphanedContentUnits)
       assert_raises(ActiveRecord::RecordNotFound) { rpm.reload }
     end
   end

--- a/test/actions/katello/orphan_cleanup/remove_orphaned_content_units_test.rb
+++ b/test/actions/katello/orphan_cleanup/remove_orphaned_content_units_test.rb
@@ -1,0 +1,22 @@
+require 'katello_test_helper'
+module Katello
+  class RemoveOrphanedContentUnitsTest < ActiveSupport::TestCase
+    def setup
+      @rhel6 = Repository.find(katello_repositories(:rhel_6_x86_64).id)
+    end
+
+    def test_orphaned_content_task_destroys_orphans
+      rpm = katello_rpms(:one)
+      rpm.repository_rpms.destroy_all
+      ForemanTasks.sync_task(Actions::Katello::OrphanCleanup::RemoveOrphanedContentUnits, {repo_id: @rhel6.id})
+      assert_raises(ActiveRecord::RecordNotFound) { rpm.reload }
+    end
+
+    def test_orphaned_content_task_destroy_all
+      rpm = katello_rpms(:one)
+      rpm.repository_rpms.destroy_all
+      ForemanTasks.sync_task(Actions::Katello::OrphanCleanup::RemoveOrphanedContentUnits, {destroy_all: true})
+      assert_raises(ActiveRecord::RecordNotFound) { rpm.reload }
+    end
+  end
+end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -710,15 +710,6 @@ module Katello
       assert_includes Repository.with_errata([errata]), @rhel6
     end
 
-    def test_orphaned_content_task_destroys_orphans
-      rpm = katello_rpms(:one)
-      ::Katello::ContentUnitIndexer.any_instance.stubs(:import_all).returns(true)
-      ::Katello::Repository.any_instance.stubs(:import_distribution_data).returns(true)
-      rpm.repository_rpms.destroy_all
-      ForemanTasks.sync_task(Actions::Katello::OrphanCleanup::RemoveOrphanedContentUnits, {repo_id: @rhel6.id})
-      assert_raises(ActiveRecord::RecordNotFound) { rpm.reload }
-    end
-
     def test_index_content_ordering
       repo_type = @rhel6.repository_type
       SmartProxy.stubs(:pulp_primary).returns(SmartProxy.pulp_primary)

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -710,12 +710,12 @@ module Katello
       assert_includes Repository.with_errata([errata]), @rhel6
     end
 
-    def test_index_content_destroys_orphans
+    def test_orphaned_content_task_destroys_orphans
       rpm = katello_rpms(:one)
       ::Katello::ContentUnitIndexer.any_instance.stubs(:import_all).returns(true)
       ::Katello::Repository.any_instance.stubs(:import_distribution_data).returns(true)
       rpm.repository_rpms.destroy_all
-      @rhel6.index_content
+      ForemanTasks.sync_task(Actions::Katello::OrphanCleanup::RemoveOrphanedContentUnits, {repo_id: @rhel6.id})
       assert_raises(ActiveRecord::RecordNotFound) { rpm.reload }
     end
 

--- a/test/services/katello/pulp3/docker_tag_test.rb
+++ b/test/services/katello/pulp3/docker_tag_test.rb
@@ -29,7 +29,7 @@ module Katello
           fake_content_href = '/pulp/api/v3/repositories/container/container/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/'
           service = Katello::Pulp3::Repository::Docker.new(@repo, @primary)
           error = assert_raises(::Katello::Errors::Pulp3Error) { service.add_content(fake_content_href) }
-          assert_match(/Please run a complete sync on the following repository: Pulp3 Docker 1./, error.message)
+          assert_match(/Please run `foreman-rake katello:delete_orphaned_content` to fix the following repository: Pulp3 Docker 1./, error.message)
         end
 
         def test_index_on_sync

--- a/test/services/katello/pulp3/repository/yum/yum_test.rb
+++ b/test/services/katello/pulp3/repository/yum/yum_test.rb
@@ -23,7 +23,7 @@ module Katello
             service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
             create_repo(@repo, @proxy)
             error = assert_raises(::Katello::Errors::Pulp3Error) { service.copy_units(@repo, [fake_content_href], false) }
-            assert_match(/Please run a complete sync on the following repository: Fedora 17 x86_64./, error.message)
+            assert_match(/Please run `foreman-rake katello:delete_orphaned_content` to fix the following repository: Fedora 17 x86_64./, error.message)
           end
 
           def test_append_proxy_cacert


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Move remove content unit orphan deletion to async task to avoid increasing indexing times which impacts both syncs and publishes.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Sync a repo. You should see the task: "Remove orphaned content units" run after completion of sync or publish CV actions asynchronously.