### PR TITLE
Fixes #36577 - Filter gets applied to all the repository upon removal

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -416,9 +416,12 @@ module Katello
     api :DELETE, "/repositories/:id", N_("Destroy a custom repository")
     param :id, :number, :required => true
     param :remove_from_content_view_versions, :bool, :required => false, :desc => N_("Force delete the repository by removing it from all content view versions")
+    param :delete_empty_repo_filters, :bool, :required => false, :desc => N_("Delete content view filters that have this repository as the last associated repository. Defaults to true. If false, such filters will now apply to all repositories in the content view.")
     def destroy
       sync_task(::Actions::Katello::Repository::Destroy, @repository,
-        remove_from_content_view_versions: ::Foreman::Cast.to_bool(params.fetch(:remove_from_content_view_versions, false)))
+                remove_from_content_view_versions: ::Foreman::Cast.to_bool(params.fetch(:remove_from_content_view_versions, false)),
+                delete_empty_repo_filters: ::Foreman::Cast.to_bool(params.fetch(:delete_empty_repo_filters, true))
+                )
       respond_for_destroy
     end
 

--- a/app/views/katello/api/v2/products/show.json.rabl
+++ b/app/views/katello/api/v2/products/show.json.rabl
@@ -71,6 +71,9 @@ node(:published_content_view_ids) do |product|
   product.published_content_views.map(&:id).uniq
 end
 
+node(:has_last_affected_repo_in_filter) do |product|
+  product.repositories.any? { |repo| repo.filters.any? { |filter| filter.repositories.size == 1 } }
+end
 node :redhat do |product|
   product.redhat?
 end

--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -36,6 +36,24 @@ child :published_in_versions => :content_view_versions do |_version|
   end
 end
 
+child :repository_content_view_filters => :filters do |_filters|
+  node :content_view_filter_id do |object|
+    object.filter.id
+  end
+  node :content_view_filter_name do |object|
+    object.filter.name
+  end
+  node :content_view_id do |object|
+    object.filter.content_view_id
+  end
+  node :content_view_name do |object|
+    object.filter.content_view_name
+  end
+  node :last_affected_repo do |object|
+    object.filter&.repositories&.size == 1
+  end
+end
+
 child :latest_dynflow_sync => :last_sync do |_object|
   attributes :id, :username, :started_at, :ended_at, :state, :result, :progress
 end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-details.controller.js
@@ -66,6 +66,8 @@ angular.module('Bastion.products').controller('ProductDetailsController',
                     readOnlyReason = 'permissions';
                 } else if (product['published_content_view_ids'].length > 0) {
                     readOnlyReason = 'published';
+                } else if (product['has_last_affected_repo_in_filter']) {
+                    readOnlyReason = 'last_affected_repo_on_filter';
                 }
             }
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details.controller.js
@@ -37,14 +37,25 @@
             });
         };
 
+        $scope.repositoryFiltersToDelete = function () {
+            return _.groupBy($scope.repository.filters && $scope.repository.filters.filter(function(filter) {
+                return filter.last_affected_repo === true;
+            }), function(filter) {
+                return filter.content_view_id;
+            });
+        };
+
         $scope.repositoryWrapper = {
             repository: $scope.repository,
             repositoryVersions: {},
-            forceDelete: false
+            repositoryFiltersToDelete: {},
+            forceDeleteCV: false,
+            filterAction: 'delete',
+            showLastFilterDeletion: false
         };
 
-        $scope.updateForceDelete = function () {
-            $scope.repositoryWrapper.forceDelete = !($scope.repositoryWrapper.forceDelete);
+        $scope.updateForceDeleteCV = function () {
+            $scope.repositoryWrapper.forceDeleteCV = !($scope.repositoryWrapper.forceDeleteCV);
         };
 
         $scope.product = Product.get({id: $scope.$stateParams.productId}, function () {
@@ -71,6 +82,8 @@
             $scope.page.loading = false;
             $scope.repositoryWrapper.repository = $scope.repository;
             $scope.repositoryWrapper.repositoryVersions = $scope.repositoryVersions();
+            $scope.repositoryWrapper.repositoryFiltersToDelete = $scope.repositoryFiltersToDelete();
+            $scope.repositoryWrapper.showLastFilterDeletion = Object.keys($scope.repositoryWrapper.repositoryFiltersToDelete).length !== 0;
         }, function (response) {
             $scope.page.loading = false;
             ApiErrorHandler.handleGETRequestErrors(response, $scope);
@@ -152,7 +165,7 @@
                 Notification.setSuccessMessage(translate('Repository "%s" successfully deleted').replace('%s', repositoryName));
             };
 
-            Repository.remove({id: repository.id}, success, errorHandler);
+            Repository.remove({id: repository.id, 'delete_orphaned_filters': ($scope.repositoryWrapper.filterAction === 'delete')}, success, errorHandler);
         };
 
         $scope.canRemove = function (repo, product) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-details.html
@@ -95,11 +95,11 @@
         </li>
       </ul>
 
-      <div bst-modal="removeRepository(repository)" model="repositoryWrapper">
+      <div bst-modal="removeRepository(repository, filterAction)" model="repositoryWrapper">
         <div data-block="modal-header" translate>Remove Repository {{ repositoryWrapper.repository.name }}?</div>
         <div data-block="modal-body">
             <div ng-show="repositoryWrapper.repository.content_view_versions.length !== 0" style="margin-bottom: 1em">
-                <span translate>Repository will also be removed from the following published content view versions!</span>
+                <b><span translate>Repository will also be removed from the following published content view versions!</span></b>
                 <table class="table table-striped table-bordered" style="margin-top: 1em">
                     <thead>
                         <tr>
@@ -127,13 +127,62 @@
             </div>
             <input type="checkbox"
                    ng-show="repositoryWrapper.repository.content_view_versions.length !== 0"
-                   ng-model="repositoryWrapper.forceDelete"
-                   ng-change="updateForceDelete()"/>
-            <span translate> Are you sure you want to remove repository {{ repositoryWrapper.repository.name }} from all content views?</span>
+                   ng-model="repositoryWrapper.forceDeleteCV"
+                   ng-change="updateForceDeleteCV()"/>
+            <span translate
+                  ng-show="repositoryWrapper.repository.content_view_versions.length !== 0"
+                  style="margin-bottom: 2em"
+            >
+                Are you sure you want to remove repository {{ repositoryWrapper.repository.name }} from all content views?
+            </span>
+            <div ng-show="repositoryWrapper.showLastFilterDeletion" style="margin-top: 1em; margin-bottom: 1em">
+                <b><span translate> The filters below have this repository as the last affected repository!</span></b>
+                <table class="table table-striped table-bordered" style="margin-top: 1em">
+                    <thead>
+                        <tr>
+                            <th translate>Content View</th>
+                            <th translate>Filters</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                      <tr ng-repeat="filters in repositoryWrapper.repositoryFiltersToDelete">
+                        <td class="align-center">
+                            <a href="/content_views/{{filters[0]['content_view_id']}}/" target="_blank">
+                                {{filters[0]['content_view_name']}}
+                            </a>
+                        </td>
+                        <td class="align-center">
+                            <div ng-repeat="filter in filters">
+                                <a href="/content_views/{{filter['content_view_id']}}#/filters/{{filter['content_view_filter_id']}}" target="_blank">
+                                    {{filter['content_view_filter_name']}}
+                                </a>
+                            </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                </table>
+                <div class="radio">
+                    <label>
+                      <input type="radio" ng-model="repositoryWrapper.filterAction" value="delete" />
+                      <span translate>
+                        Delete filters
+                      </span>
+                    </label>
+                </div>
+                <div class="radio">
+                    <label>
+                      <input type="radio" ng-model="repositoryWrapper.filterAction" value="applyAll" />
+                      <span translate>
+                        Make filters apply to all repositories in the content view
+                      </span>
+                    </label>
+              </div>
+            </div>
         </div>
           <div data-block="modal-footer">
             <span data-block="modal-confirm-button">
-              <button class="btn btn-danger" ng-disabled="repositoryWrapper.repository.content_view_versions.length !== 0 && !repositoryWrapper.forceDelete" ng-click="ok()">
+              <button class="btn btn-danger" ng-disabled="(repositoryWrapper.repository.content_view_versions.length !== 0 &&
+              !repositoryWrapper.forceDeleteCV)" ng-click="ok()">
                 <span translate>Delete</span>
               </button>
             </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
@@ -45,7 +45,10 @@
       <div data-block="modal-body"
            translate
            translate-n="table.numSelected"
-           translate-plural="Are you sure you want to remove {{ table.getSelected().length }} repositories?">
+           translate-plural="Repositories that are published in content view
+                             versions or are the last affected repository in a content view filter will be skipped. You can delete those from the repository details page.
+                             "
+      >
         Are you sure you want to remove the {{ table.getSelected()[0].name }} repository?
       </div>
     </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-details.html
@@ -46,6 +46,11 @@
                  tooltip-animation="false"
                  tooltip-append-to-body="true">
               </i>
+              <i class="fa fa-question-circle" ng-switch-when="last_affected_repo_on_filter"
+                 uib-tooltip="{{ 'You cannot remove this product because it has repositories that are the last affected repository on content view filters' | translate }}"
+                 tooltip-animation="false"
+                 tooltip-append-to-body="true">
+              </i>
             </span>
           </span>
         </li>

--- a/engines/bastion_katello/test/products/details/repositories/details/repository-details.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/details/repository-details.controller.test.js
@@ -211,7 +211,7 @@ describe('Controller: RepositoryDetailsController', function() {
           });
   });
 
-    it('should provide a way to view orphaned filters on a repository', function() {
+    it('should provide a way to view empty-repo filters on a repository', function() {
         repository.id = 1;
         repository.filters = [
             {

--- a/engines/bastion_katello/test/products/details/repositories/details/repository-details.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/details/repository-details.controller.test.js
@@ -149,7 +149,15 @@ describe('Controller: RepositoryDetailsController', function() {
 
     it('should provide a way to remove a repository', function() {
         repository.id = 1;
-
+        repository.filters = [
+            {
+                "content_view_filter_id": 1,
+                "content_view_filter_name": "test",
+                "content_view_id": 38,
+                "content_view_name": "test",
+                "last_affected_repo": true
+            }
+        ];
         spyOn($scope, 'transitionTo');
 
         $scope.removeRepository(repository);
@@ -202,4 +210,63 @@ describe('Controller: RepositoryDetailsController', function() {
               }]
           });
   });
+
+    it('should provide a way to view orphaned filters on a repository', function() {
+        repository.id = 1;
+        repository.filters = [
+            {
+                "content_view_filter_id": 1,
+                "content_view_filter_name": "test",
+                "content_view_id": 38,
+                "content_view_name": "test",
+                "last_affected_repo": true
+            },
+            {
+                "content_view_filter_id": 2,
+                "content_view_filter_name": "test2",
+                "content_view_id": 38,
+                "content_view_name": "test",
+                "last_affected_repo": false
+            },
+            {
+                "content_view_filter_id": 3,
+                "content_view_filter_name": "test3",
+                "content_view_id": 38,
+                "content_view_name": "test",
+                "last_affected_repo": true
+            },
+            {
+                "content_view_filter_id": 4,
+                "content_view_filter_name": "test4",
+                "content_view_id": 39,
+                "content_view_name": "test",
+                "last_affected_repo": true
+            }
+        ];
+        expect($scope.repositoryFiltersToDelete()).toEqual(
+            {
+                38: [{
+                    content_view_filter_id: 1,
+                    content_view_filter_name: 'test',
+                    content_view_id: 38,
+                    content_view_name: 'test',
+                    last_affected_repo: true
+                },
+                {
+                    content_view_filter_id: 3,
+                    content_view_filter_name: 'test3',
+                    content_view_id: 38,
+                    content_view_name: 'test',
+                    last_affected_repo: true
+                }
+                ],
+                39: [{
+                    content_view_filter_id: 4,
+                    content_view_filter_name: 'test4',
+                    content_view_id: 39,
+                    content_view_name: 'test',
+                    last_affected_repo: true
+                }]
+            });
+    });
 });


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a couple of repos and add them to filters.
2. Go to repo > Remove repository
3. You should see a section in the deletion confirmation modal if the repo is the last repo that a filter is applied to.
4. You should be able to choose to delete the filter/or make it apply to all repositories in the CV depending on your selection.
5. This section shouldn't appear for repos that are not the last affected repo in any filters.