### PR TITLE
Fixes #36540 - Accurately checks custom product enablement upgrade task

### DIFF
--- a/lib/katello/tasks/upgrades/4.9/update_custom_products_enablement.rake
+++ b/lib/katello/tasks/upgrades/4.9/update_custom_products_enablement.rake
@@ -3,6 +3,7 @@ namespace :katello do
     namespace '4.9' do
       desc "Update custom products enablement"
       task :update_custom_products_enablement => ['environment'] do
+        next unless ::Katello::ProductContent.custom.where(enabled: true).exists?
         migrator = Katello::Util::DefaultEnablementMigrator.new
         migrator.execute!
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This commit tries to address the issues listed [here](https://community.theforeman.org/t/katello-4-9-custom-products-changes-with-sca/33763/10)


PR for Issue #36120 changed default enablement for custom repos. By default all custom repos got disabled in candlepin. However a migration task was provided to add overrides for existing custom repos.

We needed a way for the custom product enablement upgrade task to only run if needed without having to rely on `UpgradeTask.needing_run` 

This commit checks if there are any custom product content who's enablement is set to true. This implies that upgrade rake task update_custom_products_enablement has not run and hence the task can be run.

#### Considerations taken when implementing this change?
Multiple approaches were thought of but the current product enablement check makes the most sense

#### What are the testing steps for this pull request?
- Create a few custom repositories.
- `bundle exec rake katello:upgrades:4.9:update_custom_products_enablement` should not change the enablement of anything. 
- Now update the enablement for that product content in candlepin and katello
- `bundle exec rake katello:upgrades:4.9:update_custom_products_enablement` should now run and change the enablement of of the repo to false 