### PR TITLE
Fixes #36584 - Update realtive_path to text in the db from char

### DIFF
--- a/db/migrate/20230710190626_remove_relative_path_limit.rb
+++ b/db/migrate/20230710190626_remove_relative_path_limit.rb
@@ -1,0 +1,5 @@
+class RemoveRelativePathLimit < ActiveRecord::Migration[6.1]
+  def change
+    change_column :katello_repositories, :relative_path, :text
+  end
+end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -237,6 +237,18 @@ module Katello
       assert_equal @fedora_17_x86_64, @fedora_17_x86_64.archived_instance
     end
 
+    def test_long_relative_path
+      # Test to make sure we can have a relative_path bigger than 255 chars
+      repo = Repository.new(:root => katello_root_repositories(:busybox2_root),
+                            :content_view_version => @repo.organization.default_content_view.versions.first,
+                            :environment => @repo.organization.library,
+                            :relative_path => "/Fe34w5KviF38bTCcGy6KIfjor2UBRfdWYSno8xprufnKQMvLT4nwGD8mJ6HkE7t1vqgL6CBhyppgk4ZsVyNJSe1ciZlEk5Wlc0uzqKwIrADqD7Ucl5tN7LtXiThYwk8aF61D5ACtOZQcrblWxxR5TTccNfCWvY41eGAge6mn41fWbwppF2FH0ixQm21UmLvIgLkV5hUfxt2KKgyCkccdSkz3
+                                              IuP9cplkniFmtE7zAPVxD6GZtI8KRHhqUFM9UKzUZFtQlxvggTi6z5QO48963UOJePiz1PGh7lZtUokD4GN")
+      assert repo.save
+
+      assert_equal 347, repo.relative_path.size
+    end
+
     def test_docker_pulp_id
       # for docker repos, the pulp_id should be downcased
       repo = Repository.new(:root => katello_root_repositories(:busybox2_root),


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* In Pulp the `core_distribution` table and column `base_path` is text without a limit so this PR removes the limit from our DB to match pulp
* This was the approach I worked with Ian on and he said go for it.

#### Considerations taken when implementing this change?

* I tested with a rhel7 and centos8-stream box and was able to pull content fine, pulp/candlepin were working fine

#### What are the testing steps for this pull request?

* Create a product with long label name (For example: Community_Extra_Packages_for_Enterprise_Linux_EPEL_debug)
* Create a repository with long label name (Fore example: Community_Extra_Packages_for_Enterprise_Linux_EPEL_8_Modular_x86_64_debug)
* Sync the repository
* Create a content view with label along  Community_Extra_Packages_for_Enterprise_Linux_EPEL_8_Modular_x86_64_debug_100000
* Publish

Without PR you should get `Error => "Validation failed: Relative path is too long (maximum is 255 characters)" `