### PR TITLE
Fixes #36586 - pin ostree bindings below 2.1.1

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -60,7 +60,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "pulp_rpm_client", ">= 3.19.0", "< 3.20.0"
   gem.add_dependency "pulp_certguard_client", "< 2.0"
   gem.add_dependency "pulp_python_client", ">= 3.8.0", "< 3.9"
-  gem.add_dependency "pulp_ostree_client"
+  gem.add_dependency "pulp_ostree_client", "< 2.1.1"
 
   # UI
   gem.add_dependency "deface", '>= 1.0.2', '< 2.0.0'


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Pins the ostree client version to before 2.1.0.

As of 2.1.0, there is a new hidden distribution attribute that is breaking the VCRs.

#### Considerations taken when implementing this change?
Re-recording the VCRs to fix this would be incorrect because Katello's packaged version of pulp ostree likely does not support the hidden distribution feature.

#### What are the testing steps for this pull request?
See the tests pass.