### PR TITLE
Fixes #36589 - Added ability to refresh all alternate content sources…

### DIFF
--- a/app/controllers/katello/api/v2/alternate_content_sources_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/alternate_content_sources_bulk_actions_controller.rb
@@ -1,6 +1,6 @@
 module Katello
   class Api::V2::AlternateContentSourcesBulkActionsController < Api::V2::ApiController
-    before_action :find_alternate_content_sources
+    before_action :find_alternate_content_sources, except: [:refresh_all_alternate_content_sources]
 
     api :PUT, '/alternate_content_sources/bulk/destroy', N_('Destroy one or more alternate content sources')
     param :ids, Array, desc: N_('List of alternate content source IDs'), required: true
@@ -25,6 +25,21 @@ module Katello
       if refreshable_alternate_content_sources.empty?
         msg = _("Unable to refresh any alternate content source. You either do not have the permission to"\
                 " refresh, or none of the alternate content sources exist.")
+        fail HttpErrors::UnprocessableEntity, msg
+      else
+        task = async_task(::Actions::BulkAction,
+                          ::Actions::Katello::AlternateContentSource::Refresh,
+                          refreshable_alternate_content_sources)
+        respond_for_async resource: task
+      end
+    end
+
+    api :POST, '/alternate_content_sources/bulk/refresh_all', N_("Refresh all alternate content sources")
+    def refresh_all_alternate_content_sources
+      refreshable_alternate_content_sources = AlternateContentSource.editable
+      if refreshable_alternate_content_sources.empty?
+        msg = _("Unable to refresh any alternate content source. You either do"\
+          " not have the permission to refresh, or no alternate content sources exist.")
         fail HttpErrors::UnprocessableEntity, msg
       else
         task = async_task(::Actions::BulkAction,

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -353,6 +353,8 @@ Katello::Engine.routes.draw do
         ##############################
         ##############################
 
+        match '/alternate_content_sources/bulk/refresh_all' => 'alternate_content_sources_bulk_actions#refresh_all_alternate_content_sources', :via => :post
+
         api_resources :alternate_content_sources, :only => [], :constraints => { :id => /[0-9a-zA-Z\-_.]*/ } do
           collection do
             match '/bulk/destroy' => 'alternate_content_sources_bulk_actions#destroy_alternate_content_sources', :via => :put

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -404,7 +404,7 @@ module Katello
       @plugin.permission :edit_alternate_content_sources,
                          {
                            'katello/api/v2/alternate_content_sources' => [:update, :refresh],
-                           'katello/api/v2/alternate_content_sources_bulk_actions' => [:refresh_alternate_content_sources]
+                           'katello/api/v2/alternate_content_sources_bulk_actions' => [:refresh_alternate_content_sources, :refresh_all_alternate_content_sources]
                          },
                          :resource_type => 'Katello::AlternateContentSource',
                          :finder_scope => :editable


### PR DESCRIPTION
… using API POST call at /alternate_content_sources/bulk/refresh_all

#### What are the changes introduced in this pull request?
Sending a POST request to `http://centos8-katello-devel.redhat.example.com/katello/api/alternate_content_sources/bulk/refresh_all` will refresh all alternate content sources. This is the first half of the implementation of #36589 (adding refresh all support to hammer); the remaining changes will need to be made on hammer's end to support bulk actions.

#### Considerations taken when implementing this change?
n/a

#### What are the testing steps for this pull request?
Create a Katello instance with no alternate content sources. Run the following command to request to refresh all ACS's:
```
curl --request POST --user admin:changeme -H "Content-type: application/json" http://<host>/katello/api/alternate_content_sources/bulk/refresh_all

```
Since there are no ACS's, the command should fail:
```
{"displayMessage":"Unable to refresh any alternate content source. You either do not have the permission to refresh, or no alternate content sources exist.","errors":["Unable to refresh any alternate content source. You either do not have the permission to refresh, or no alternate content sources exist."]}
```
Now add a few alternate content sources and monitor the last refreshed time (I used the web UI). Run the same command as before:
```
curl --request POST --user admin:changeme -H "Content-type: application/json" http://<host>/katello/api/alternate_content_sources/bulk/refresh_all
```
The alternate content sources should all have been refreshed.