### PR TITLE
Fixes #36520 - Enforce authorization on capsule syncs

### DIFF
--- a/app/lib/actions/katello/content_view/capsule_sync.rb
+++ b/app/lib/actions/katello/content_view/capsule_sync.rb
@@ -9,7 +9,7 @@ module Actions
         def plan(content_view, environment)
           sequence do
             concurrence do
-              smart_proxies = SmartProxy.with_environment(environment)
+              smart_proxies = SmartProxy.unscoped.with_environment(environment).select { |sp| sp.authorized?(:manage_capsule_content) && sp.authorized?(:view_capsule_content) }
               unless smart_proxies.blank?
                 plan_action(::Actions::BulkAction, ::Actions::Katello::CapsuleContent::Sync, smart_proxies.sort,
                             :content_view_id => content_view.id, :environment_id => environment.id)

--- a/app/lib/actions/katello/repository/capsule_sync.rb
+++ b/app/lib/actions/katello/repository/capsule_sync.rb
@@ -9,7 +9,7 @@ module Actions
         def plan(repo)
           if repo.node_syncable?
             concurrence do
-              smart_proxies = ::SmartProxy.with_environment(repo.environment)
+              smart_proxies = ::SmartProxy.unscoped.with_environment(repo.environment).select { |sp| sp.authorized?(:manage_capsule_content) && sp.authorized?(:view_capsule_content) }
               unless smart_proxies.blank?
                 plan_action(::Actions::BulkAction, ::Actions::Katello::CapsuleContent::Sync, smart_proxies,
                             :repository_id => repo.id)

--- a/app/lib/actions/katello/repository/update_metadata_sync.rb
+++ b/app/lib/actions/katello/repository/update_metadata_sync.rb
@@ -6,7 +6,7 @@ module Actions
           sequence do
             plan_action(Katello::Repository::MetadataGenerate, repository)
             concurrence do
-              ::SmartProxy.with_repo(repository).each do |capsule|
+              (::SmartProxy.unscoped.with_repo(repository).select { |sp| sp.authorized?(:manage_capsule_content) && sp.authorized?(:view_capsule_content) })&.each do |capsule|
                 next if capsule.pulp_primary?
                 plan_action(Katello::CapsuleContent::Sync, capsule, repository_id: repository.id)
               end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Only sync capsules users have permissions on.
#### Considerations taken when implementing this change?
Add scoping and permissions to smart proxies that can be synced by a user.
#### What are the testing steps for this pull request?
User Setup: Create a user created for API use only, selected role is only "sync_repositories"

Steps to reproduce:
Push Content into Repo via cmd `hammer repository upload-content --organization <org> --product <product> --name <reponame> --path <directory_path_to_rpms>`
The capsule content sync task in dynflow triggered by this will error out.

With this PR: 
The capsule content sync task will only start on capsules that user has permissions on.