### PR TITLE
Fixes #36599 - Add hostname to hypervisor task with validation error

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -121,6 +121,8 @@ module Katello
 
         has_many :hypervisor_pools, :class_name => '::Katello::Pool', :foreign_key => :hypervisor_id, :dependent => :nullify
 
+        validates :name, format: { with: Net::Validations::HOST_REGEXP, message: _("%{value} can contain only lowercase letters, numbers, dashes and dots.") }
+
         before_validation :correct_kickstart_repository
         before_update :check_host_registration, :if => proc { organization_id_changed? }
 

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -106,7 +106,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
   def test_create_with_permitted_attributes
     cf_attrs = {:content_view_id => @content_view.id, :lifecycle_environment_id => @environment.id}
     sf_attrs = {:purpose_addons => ["Addon"]}
-    attrs = @host.clone.attributes.merge("name" => "contenthost", "content_facet_attributes" => cf_attrs, "subscription_facet_attributes" => sf_attrs).compact!
+    attrs = @host.clone.attributes.merge("name" => "contenthost.example.com", "content_facet_attributes" => cf_attrs, "subscription_facet_attributes" => sf_attrs).compact!
 
     assert_difference('Host.unscoped.count') do
       post :create, params: attrs
@@ -119,7 +119,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
                 :lifecycle_environment_id => @environment.id,
                 :uuid => "thisshouldntbeabletobesetbyuser"
                }
-    attrs = @host.clone.attributes.merge("name" => "contenthost1", "content_facet_attributes" => cf_attrs).compact!
+    attrs = @host.clone.attributes.merge("name" => "contenthost1.example.com", "content_facet_attributes" => cf_attrs).compact!
 
     post :create, params: attrs
     assert_response :success # the uuid is simply filtered out which allows the host to be still saved

--- a/test/controllers/foreman/hosts_controller_test.rb
+++ b/test/controllers/foreman/hosts_controller_test.rb
@@ -53,7 +53,7 @@ class HostsControllerTest < ActionController::TestCase
   test 'empty content facet parameters are removed' do
     orig_cves = @host.content_facet.content_view_environment_ids.to_a
     post :create, params: { :host => {
-      :name => 'test_content',
+      :name => 'test-content',
       :content_facet_attributes => {
         :lifecycle_environment_id => "",
         :content_source_id => ""

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -6,7 +6,7 @@ module Katello
     let(:dev) { katello_environments(:dev) }
     let(:view)  { katello_content_views(:library_dev_view) }
     let(:environment) { katello_environments(:library) }
-    let(:empty_host) { ::Host::Managed.create!(:name => 'foobar', :managed => false) }
+    let(:empty_host) { ::Host::Managed.create!(:name => 'foobar.example.com', :managed => false) }
     let(:host) do
       FactoryBot.create(:host,
                         :with_content,
@@ -58,7 +58,7 @@ module Katello
 
     def test_audit_for_content_facet
       org = taxonomies(:empty_organization)
-      host1 = ::Host::Managed.create!(:name => 'foohost', :managed => false, :organization_id => org.id)
+      host1 = ::Host::Managed.create!(:name => 'foohost.example.com', :managed => false, :organization_id => org.id)
       content_facet1 = Katello::Host::ContentFacet.create!(
         :content_view_id => view.id, :lifecycle_environment_id => library.id, :host => host1
       )

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -7,7 +7,7 @@ module Katello
     let(:dev) { katello_environments(:dev) }
     let(:view)  { katello_content_views(:library_dev_view) }
     let(:activation_key) { katello_activation_keys(:simple_key) }
-    let(:empty_host) { ::Host::Managed.create!(:name => 'foobar', :managed => false) }
+    let(:empty_host) { ::Host::Managed.create!(:name => 'foobar.example.com', :managed => false) }
     let(:basic_subscription) { katello_subscriptions(:basic_subscription) }
     let(:host_one) { hosts(:one) }
     let(:host) do
@@ -462,7 +462,7 @@ module Katello
     end
 
     def test_audit_for_subscription_facet
-      sample_host = ::Host::Managed.create!(:name => 'foohost', :managed => false, :organization_id => org.id)
+      sample_host = ::Host::Managed.create!(:name => 'foohost.example.com', :managed => false, :organization_id => org.id)
       subfacet1 = Katello::Host::SubscriptionFacet.create!(:host => sample_host)
 
       recent_audit = Audit.where(auditable_id: subfacet1.id).last

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -28,7 +28,7 @@ module Katello
         @activation_key.host_collections.delete_all
       end
 
-      let(:rhsm_params) { {:name => 'foobar', :facts => @facts, :type => 'system'} }
+      let(:rhsm_params) { {:name => 'foobar.example.com', :facts => @facts, :type => 'system'} }
 
       class ValidateHostsTest < ActiveSupport::TestCase
         def setup
@@ -204,7 +204,7 @@ module Katello
       end
 
       def test_registration
-        new_host = ::Host::Managed.new(:name => 'foobar', :managed => false, :organization => @library.organization)
+        new_host = ::Host::Managed.new(:name => 'foobar.example.com', :managed => false, :organization => @library.organization)
 
         ::Katello::RegistrationManager.expects(:get_uuid).returns("fake-uuid-from-katello")
 
@@ -220,7 +220,7 @@ module Katello
       end
 
       def test_registration_activation_key
-        new_host = ::Host::Managed.new(:name => 'foobar', :managed => false, :organization => @host_collection.organization)
+        new_host = ::Host::Managed.new(:name => 'foobar.example.com', :managed => false, :organization => @host_collection.organization)
         cvpe = Katello::ContentViewEnvironment.where(:content_view_id => @activation_key.content_view, :environment_id => @activation_key.environment).first
 
         ::Katello::RegistrationManager.expects(:get_uuid).returns("fake-uuid-from-katello")
@@ -244,8 +244,8 @@ module Katello
 
       def test_registration_with_host_collection_max_hosts_exceeded
         @activation_key.host_collections << @one_host_limit_host_collection
-        existing_host = ::Host::Managed.create(:name => 'alreadyhere', :managed => false, :organization => @one_host_limit_host_collection.organization)
-        new_host = ::Host::Managed.new(:name => 'foobar', :managed => false, :organization => @one_host_limit_host_collection.organization)
+        existing_host = ::Host::Managed.create(:name => 'alreadyhere.example.com', :managed => false, :organization => @one_host_limit_host_collection.organization)
+        new_host = ::Host::Managed.new(:name => 'foobar.example.com', :managed => false, :organization => @one_host_limit_host_collection.organization)
         cvpe = Katello::ContentViewEnvironment.where(:content_view_id => @activation_key.content_view, :environment_id => @activation_key.environment).first
         @one_host_limit_host_collection.hosts << existing_host
         assert_equal 1, @one_host_limit_host_collection.hosts.count
@@ -353,7 +353,7 @@ module Katello
       end
 
       def test_registration_dead_candlepin
-        new_host = ::Host::Managed.new(:name => 'foobar', :managed => false, :organization => @library.organization)
+        new_host = ::Host::Managed.new(:name => 'foobar.example.com', :managed => false, :organization => @library.organization)
 
         ::Host.expects(:find).returns(new_host)
         new_host.expects(:destroy)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* In `Actions::Katello::Host::Hypervisors` returned the name of the hypervisor hostname reporting in instead of just `hostname`
* Returned an error like Foreman's validation citing the RFCs around hostnames
* Fixed a test that was failing because of my added validation

#### Considerations taken when implementing this change?

* Wrote the `create_host_for_hypervisor` method in a `begin/rescue` statement so that if the host does not have any issues we just move along like normal.

#### What are the testing steps for this pull request?

* Check out PR
* Install `virt-who` with `dnf`
* Create a `virt-who` config file in `/etc/virt-who.d/` I called mine `fake.conf` Here is what mine looks like:
```bash
[fakevirt]
type=fake
file=/tmp/fake.json
is_hypervisor=True
owner=Default_Organization
hypervisor_id=$&
```

* Now in `/tmp` create a `fake.json` that looks like this
```json
{
        "hypervisors": [{
                "uuid": "$&",
                "guests": [{
                                "guestId": "a8f73be7-c6a9-4c2a-8590-0ec2457c975d",
                                "state": 1
                        },
                        {
                                "guestId": "3e62be70-2365-4b53-8d2c-84c89cc1373a",
                                "state": 1
                        },
                        {
                                "guestId": "a746244b-125a-4f09-80bd-c043413a9153",
                                "state": 1
                        },
                        {       "guestId": "b5e07903-f5d8-44e6-b2dd-922743c402e2",
                                "state": 1
                        },
                        {       "guestId": "be263884-7c5c-4d02-a268-0cfadef3c6b4",
                                "state": 1
                        },
                        {       "guestId": "da172ae4-1b82-4900-975b-17ed24553f09",
                                "state": 1
                        },
                        {       "guestId": "ecf50029-a084-4c0e-813b-51f6b977f2f1",
                                "state": 1
                        }
                ]
        }]
}
```
* Register your system running virt-who to your devel box ( I just used my own devel box to register to itself)
* Start up `virt-who` 
  * `systemctl start virt-who`
* Check in the production log to make sure you see the new error `InvalidVirtWhoHost` with the hostname `virt-who-xxx` like so
`ESC[32m2023-07-12T20:51:33ESC[0m [ESC[31mEESC[0m|ESC[36mbacESC[0m|7f084d2d] The hostname virt-who-$&-1 can contain only lowercase letters, numbers, dashes and dots according to RFC921, RFC952 and RFC1123 (Katello::Errors::InvalidVirtWhoHost)`