### PR TITLE
Fixes #36581 - Treat indeterminate/nil needs_publish as true in the API

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -258,7 +258,8 @@ module Katello
         fail HttpErrors::BadRequest, _("Both major and minor parameters have to be used to override a CV version")
       end
 
-      if (::Foreman::Cast.to_bool(params[:publish_only_if_needed]) && !@content_view.needs_publish?)
+      cv_needs_publish = @content_view.needs_publish?
+      if (::Foreman::Cast.to_bool(params[:publish_only_if_needed]) && !cv_needs_publish.nil? && !cv_needs_publish)
         fail HttpErrors::BadRequest, _("Content view does not need a publish since there are no audited changes since the last publish." \
                                      " Pass check_needs_publish parameter as false if you don't want to check if content view needs a publish.")
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
When users pass true for `publish-only-if-needed` param, we should let them publish cv where needs_publish? value is indeterminate(nil). This is consistent with UI behavior where we don't provide a notice to users when publishing a CV if needs_publish is true/indeterminate. 
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a CV.
2. Publish.
3. hammer -r content-view publish --id $id --publish-only-if-needed true
4. You will see a message saying no changes to publish.
```
Could not publish the content view:
  Content view does not need a publish since there are no audited changes since the last publish. Pass check_needs_publish parameter as false if you don't want to check if content view needs a publish.
```
5. In console, run `Audit.delete_all` . This creates the indeterminate state for us where we lose audits of all changes.
6. Publish from hammer with command above. It should let you publish CV.