### PR TITLE
Fixes #36601 - Error when autoprovision/provision for a discovered host

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -41,7 +41,7 @@ module Katello
         end
 
         def apply_inherited_attributes(attributes, initialized = true)
-          attributes = super(attributes, initialized)
+          attributes = super(attributes, initialized) || {}
           facet_attrs = attributes['content_facet_attributes']
           return attributes if facet_attrs.blank?
           cv_id = facet_attrs['content_view_id']


### PR DESCRIPTION
Foreman throws an error `undefined method `html_safe' for nil:NilClass` when auto-provision/provision is initiated for a discovered host without selecting a host group.

#### What are the changes introduced in this pull request?
Safe check for `nil` attributes in `apply_inherited_attributes`

#### Considerations taken when implementing this change?
Provisioning discovered host without selecting a host group

#### What are the testing steps for this pull request?
* Enable foreman-discovery plugin
* Create a discovered host (see https://github.com/theforeman/foreman_discovery/pull/606)
* Try to provision host without selecting a host group