### PR TITLE
Fixes #36604 - Manifest delete confirmation should be SCA-aware

### DIFF
--- a/webpack/scenes/Subscriptions/Manifest/DeleteManifestModalText.js
+++ b/webpack/scenes/Subscriptions/Manifest/DeleteManifestModalText.js
@@ -1,29 +1,46 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
 
-const question = __('Are you sure you want to delete the manifest?');
-const note = __(`Note: Deleting a subscription manifest is STRONGLY discouraged.
-                 Deleting a manifest will:`);
-const l1 = __('Delete all subscriptions that are attached to running hosts.');
-const l2 = __('Delete all subscriptions attached to activation keys.');
-const l3 = __('Disable Red Hat Insights.');
-const l4 = __(`Require you to upload the subscription-manifest and re-attach
-               subscriptions to hosts and activation keys.`);
-const debug = __(`This action should only be taken in extreme circumstances or
-                  for debugging purposes.`);
-
-const DeleteManifestModalText = () => (
+const DeleteManifestModalText = ({ simpleContentAccess }) => (
   <React.Fragment>
-    <p>{question}</p>
-    <p>{note}</p>
-    <ul className="list-aligned">
-      <li>{l1}</li>
-      <li>{l2}</li>
-      <li>{l3}</li>
-      <li>{l4}</li>
-    </ul>
-    <p>{debug}</p>
+    <p>{__('Are you sure you want to delete the manifest?')}</p>
+    {simpleContentAccess && (
+      <>
+        <p>{__('Note: Deleting a subscription manifest is STRONGLY discouraged.')}</p>
+        <p>{__('This action should only be taken for debugging purposes.')}</p>
+      </>
+    )}
+    {!simpleContentAccess && (
+      <>
+        <p>
+          {__(`Note: Deleting a subscription manifest is STRONGLY discouraged.
+        Deleting a manifest will:`)}
+        </p>
+        <ul className="list-aligned">
+          <li>{__('Delete all subscriptions that are attached to running hosts.')}</li>
+          <li>{__('Delete all subscriptions attached to activation keys.')}</li>
+          <li>{__('Disable Red Hat Insights.')}</li>
+          <li>
+            {__(`Require you to upload the subscription-manifest and re-attach
+              subscriptions to hosts and activation keys.`)}
+          </li>
+        </ul>
+        <p>
+          {__(`This action should only be taken in extreme circumstances or
+              for debugging purposes.`)}
+        </p>
+      </>
+    )}
   </React.Fragment>
 );
+
+DeleteManifestModalText.propTypes = {
+  simpleContentAccess: PropTypes.bool,
+};
+
+DeleteManifestModalText.defaultProps = {
+  simpleContentAccess: false,
+};
 
 export default DeleteManifestModalText;

--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
@@ -84,6 +84,7 @@ class ManageManifestModal extends Component {
       disabledReason,
       canImportManifest,
       canDeleteManifest,
+      simpleContentAccess,
       isManifestImported,
       canEditOrganizations,
       taskInProgress,
@@ -196,7 +197,7 @@ class ManageManifestModal extends Component {
                             }
                           </div>
                           <ForemanModal title={__('Confirm delete manifest')} id={DELETE_MANIFEST_MODAL_ID}>
-                            <DeleteManifestModalText />
+                            <DeleteManifestModalText simpleContentAccess={simpleContentAccess} />
                             <ForemanModal.Footer>
                               <Button ouiaId="cancel-button" bsStyle="default" onClick={this.hideDeleteManifestModal}>
                                 {__('Cancel')}
@@ -282,6 +283,7 @@ ManageManifestModal.propTypes = {
   }).isRequired,
   canImportManifest: PropTypes.bool,
   canDeleteManifest: PropTypes.bool,
+  simpleContentAccess: PropTypes.bool,
   isManifestImported: PropTypes.bool,
   deleteManifestModalExists: PropTypes.bool,
   canEditOrganizations: PropTypes.bool,
@@ -309,6 +311,7 @@ ManageManifestModal.defaultProps = {
   disabledReason: '',
   canImportManifest: false,
   canDeleteManifest: false,
+  simpleContentAccess: true,
   isManifestImported: false,
   deleteManifestModalExists: false,
   canEditOrganizations: false,

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -264,6 +264,7 @@ class SubscriptionsPage extends Component {
               canImportManifest={canImportManifest}
               canDeleteManifest={canDeleteManifest}
               canEditOrganizations={canEditOrganizations}
+              simpleContentAccess={simpleContentAccess}
               taskInProgress={!!task}
               disableManifestActions={disableManifestActions}
               disabledReason={this.getDisabledReason()}

--- a/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsPage.test.js.snap
+++ b/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsPage.test.js.snap
@@ -64,6 +64,7 @@ exports[`subscriptions page should render 1`] = `
         disableManifestActions={true}
         disabledReason="This is disabled because no connection could be made to the upstream Manifest."
         refresh={[Function]}
+        simpleContentAccess={false}
         taskInProgress={false}
         upload={[Function]}
       />


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

In the Delete Manifest confirmation modal, most of the words are no longer relevant if you're using SCA. Update the wording of the `<DeleteManifestModalText>` to remove outdated wording.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Subscriptions > Manage Manifest > Delete > look at the wording for an SCA org vs. a non-SCA org with manifest imported.
