### PR TITLE
Fixes #36608 - Fix customizing discovered hosts / use safe navigation for content facet in host_managed_extensions

### DIFF
--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -4,6 +4,18 @@ module Katello
       "kt_activation_keys"
     end
 
+    def edit_action?
+      params[:action] == 'edit'
+    end
+
+    def cv_lce_disabled?
+      edit_action? && !using_discovered_hosts_page?
+    end
+
+    def using_discovered_hosts_page?
+      controller.controller_name == "discovered_hosts"
+    end
+
     def using_hostgroups_page?
       controller.controller_name == "hostgroups"
     end
@@ -164,7 +176,7 @@ module Katello
 
       views = []
       if lifecycle_environment
-        views = Katello::ContentView.in_environment(lifecycle_environment).readable.order(:name)
+        views = Katello::ContentView.in_environment(lifecycle_environment).ignore_generated.readable.order(:name)
         views |= [content_view] if content_view.present? && content_view.in_environment?(lifecycle_environment)
       elsif content_view
         views = [content_view]

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -1,5 +1,6 @@
 module Katello
   module Concerns
+    # rubocop:disable Metrics/ModuleLength
     module HostManagedExtensions
       extend ActiveSupport::Concern
       include Katello::KatelloUrlsHelper
@@ -10,11 +11,17 @@ module Katello
           if attrs[:content_facet_attributes]
             cv_id = attrs[:content_facet_attributes].delete(:content_view_id)
             lce_id = attrs[:content_facet_attributes].delete(:lifecycle_environment_id)
+            # Running validations on a host will clear out any existing errors, and then
+            # validate all attributes. As we know, running update or save will run validations.
+            # Since we've just removed two attributes that may
+            # have caused an error, we need to save those so we can explicitly validate
+            # them below in add_back_cve_errors.
+            @pending_cve_attrs = { content_view_id: cv_id, lifecycle_environment_id: lce_id }
             if cv_id && lce_id
               cve = content_facet&.assign_single_environment(content_view_id: cv_id, lifecycle_environment_id: lce_id)
               Rails.logger.warn "Couldn't assign content view environment; host has no content facet" if cve.blank?
+              @pending_cve_attrs = {}
             end
-
             if (cv_id.present? && lce_id.blank?) || (cv_id.blank? && lce_id.present?)
               errors.add(:base, _("Content view and lifecycle environment must be provided together"))
             end
@@ -27,8 +34,7 @@ module Katello
         end
 
         def update(attrs)
-          return super if self.content_facet.blank?
-          check_cve_attributes(attrs)
+          check_cve_attributes(attrs) unless self.content_facet.blank?
           super
         end
 
@@ -59,7 +65,7 @@ module Katello
             end
             attributes['content_facet_attributes'] = facet_attrs
           else
-            Rails.logger.info "Hostgroup has content view and lifecycle environment assigned; using those"
+            Rails.logger.debug "Hostgroup has content view and lifecycle environment assigned; using those"
           end
           attributes
         end
@@ -124,6 +130,8 @@ module Katello
         has_many :hypervisor_pools, :class_name => '::Katello::Pool', :foreign_key => :hypervisor_id, :dependent => :nullify
 
         before_validation :correct_kickstart_repository
+        after_validation :add_back_cve_errors
+        after_update :clear_pending_cve_attributes
         before_update :check_host_registration, :if => proc { organization_id_changed? }
 
         after_validation :queue_reset_content_host_status
@@ -151,6 +159,16 @@ module Katello
         scoped_search :relation => :content_views, :on => :id, :complete_value => true, :rename => :content_view_id, :only_explicit => true
 
         scoped_search relation: :pools, on: :pools_expiring_in_days, ext_method: :find_with_expiring_pools, only_explicit: true
+
+        def add_back_cve_errors
+          if @pending_cve_attrs&.[](:content_view_id).present? || @pending_cve_attrs&.[](:lifecycle_environment_id).present?
+            check_cve_attributes({ content_facet_attributes: @pending_cve_attrs })
+          end
+        end
+
+        def clear_pending_cve_attributes
+          @pending_cve_attrs = {}
+        end
 
         def self.find_with_expiring_pools(_key, _operator, days_from_now)
           host_ids = with_pools_expiring_in_days(days_from_now).ids

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -11,7 +11,8 @@ module Katello
             cv_id = attrs[:content_facet_attributes].delete(:content_view_id)
             lce_id = attrs[:content_facet_attributes].delete(:lifecycle_environment_id)
             if cv_id && lce_id
-              content_facet.assign_single_environment(content_view_id: cv_id, lifecycle_environment_id: lce_id)
+              cve = content_facet&.assign_single_environment(content_view_id: cv_id, lifecycle_environment_id: lce_id)
+              Rails.logger.warn "Couldn't assign content view environment; host has no content facet" if cve.blank?
             end
             if (cv_id.present? && lce_id.blank?) || (cv_id.blank? && lce_id.present?)
               fail "content_view_id and lifecycle_environment_id must be provided together"
@@ -42,7 +43,7 @@ module Katello
 
         def apply_inherited_attributes(attributes, initialized = true)
           attributes = super(attributes, initialized) || {}
-          facet_attrs = attributes['content_facet_attributes']
+          facet_attrs = attributes&.[]('content_facet_attributes')
           return attributes if facet_attrs.blank?
           cv_id = facet_attrs['content_view_id']
           lce_id = facet_attrs['lifecycle_environment_id']

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -14,8 +14,9 @@ module Katello
               cve = content_facet&.assign_single_environment(content_view_id: cv_id, lifecycle_environment_id: lce_id)
               Rails.logger.warn "Couldn't assign content view environment; host has no content facet" if cve.blank?
             end
+
             if (cv_id.present? && lce_id.blank?) || (cv_id.blank? && lce_id.present?)
-              fail "content_view_id and lifecycle_environment_id must be provided together"
+              errors.add(:base, _("Content view and lifecycle environment must be provided together"))
             end
           end
         end

--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -5,9 +5,8 @@
     option.kt-cv  { margin-left: 1em; }
 </style>
 <% spinner_path = asset_path('spinner.gif') %>
-<% edit_action = params[:action] == 'edit' %>
 
-<% if edit_action && !using_hostgroups_page? %>
+<% if edit_action? && !using_hostgroups_page? && !using_discovered_hosts_page? %>
   <div style="margin-left: 270px">
     <%= link_to _("Change content source"), "/change_host_content_source?host_id=#{@host.id}" %>
   </div>
@@ -22,7 +21,7 @@
     select_tag cs_select_id, content_source_options(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path},
                :class => 'form-control',  :name => cs_select_name
   else
-    select_tag cs_select_id, content_source_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cs_select_name, :disabled => edit_action
+    select_tag cs_select_id, content_source_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cs_select_name, :disabled => cv_lce_disabled?
   end
 end %>
 
@@ -35,7 +34,7 @@ end %>
     select_tag env_select_id, lifecycle_environment_options(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)),
                :class => 'form-control',  :name => env_select_name
   else
-    select_tag env_select_id, lifecycle_environment_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name, :disabled => edit_action
+    select_tag env_select_id, lifecycle_environment_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name, :disabled =>  cv_lce_disabled?
   end
 end %>
 
@@ -47,6 +46,6 @@ end %>
     select_tag cv_select_id,  content_views_for_host(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :data => {"spinner_path" => spinner_path},
                :class => 'form-control',  :name => cv_select_name
   else
-    select_tag cv_select_id,  content_views_for_host(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cv_select_name, :disabled => edit_action
+    select_tag cv_select_id,  content_views_for_host(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cv_select_name, :disabled =>  cv_lce_disabled?
   end
 end %>

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -100,9 +100,9 @@ module Katello
 
     def test_update_with_blank_lifecycle_environment
       host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @library_view, :lifecycle_environment => @library)
-      assert_raises(RuntimeError, "content_view_id and lifecycle_environment_id must be provided together") do
-        host.update(content_facet_attributes: {content_view_id: @view.id, lifecycle_environment_id: nil})
-      end
+      refute host.update(content_facet_attributes: {content_view_id: @view.id, lifecycle_environment_id: nil})
+      refute_valid host
+      assert_equal host.errors[:base].first, "Content view and lifecycle environment must be provided together"
     end
 
     def test_check_cve_attributes_removes_cv_and_lce


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Fix some safe navigation errors around customizing discovered hosts.

#### Considerations taken when implementing this change?

I wasn't able to reproduce the original issue in https://bugzilla.redhat.com/show_bug.cgi?id=2069324 (non-inheritance of CV and LCE). But I did find these other issues.

#### What are the testing steps for this pull request?

1. Create a normal HG (not nested) with all information.

2. Discover the host:

Check out `foreman_discovery` repo and add to your `.local.rb`
`bundle install` and run migrations

Create a fake discovered host:

```
cd foreman_discovery/extra
./discover-host
# or if necessary, ./discover-host --url https://<your-server-fqdn>
```


4. Go to Hosts >> Discovered Hosts >> Click on Provision >> Select Host group >> Customize Host

Before: You'll get a silly error
![image](https://github.com/Katello/katello/assets/22042343/02aed63a-4d9c-408f-8d07-ad95d2dd5922)

After: 

- You shouldn't get an error
- Lifecycle environment and content view should be correctly inherited from the hostgroup
