### PR TITLE
Fixes #36613 - Enclose Content subtabs in a section

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/ContentTab/index.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ContentTab/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
-import { Tabs, Tab, TabTitleText } from '@patternfly/react-core';
+import { Tabs, Tab, TabTitleText, PageSection } from '@patternfly/react-core';
 import { useSelector } from 'react-redux';
 import { selectAPIResponse } from 'foremanReact/redux/API/APISelectors';
 import SecondaryTabRoutes from './SecondaryTabsRoutes';
@@ -14,8 +14,13 @@ const ContentTab = ({ location: { pathname } }) => {
   const filteredTabs =
     SECONDARY_TABS?.filter(tab => !tab.hideTab?.({ hostDetails })) ?? [];
   return (
-    <>
+    <PageSection
+      variant="light"
+      padding={{ default: 'noPadding' }}
+      className="host-content-tabs-section"
+    >
       <Tabs
+        id="host-content-tabs"
         ouiaId="host-content-tabs"
         className="margin-0-24"
         onSelect={(evt, subTab) => hashHistory.push(subTab)}
@@ -32,7 +37,8 @@ const ContentTab = ({ location: { pathname } }) => {
         ))}
       </Tabs>
       <SecondaryTabRoutes />
-    </>
+    </PageSection>
+
   );
 };
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

On the new host details page, if you click Content > Packages (or Module streams or Repository sets, but for some reason not Errata) the Content subtabs bar simply disappears. The elements are still on the page; they actually have a height of 0px. I'm guessing this is something to do with the recent navigation changes in Foreman.

I fixed this by ~adding a min-height to the Content subtabs~ enclosing the tabs in a `<PageSection>` like Foreman does for its host detail tabs.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

click around and make sure nothing disappears
