### PR TITLE
Fixes #36621 - Update name of job template to new name

### DIFF
--- a/app/controllers/katello/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/hosts_controller_extensions.rb
@@ -91,7 +91,7 @@ module Katello
                                       .distinct
 
           if Katello.with_remote_execution?
-            template_id = JobTemplate.find_by(name: 'Change content source')&.id
+            template_id = JobTemplate.find_by(name: 'Configure host for new content source')&.id
             job_invocation_path = new_job_invocation_path(template_id: template_id, host_ids: content_hosts.map { |h| h[:id] }) if template_id
           end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

`app/controllers/katello/concerns/hosts_controller_extensions.rb` had a hard-coded reference to the job template named "Change content source". In https://github.com/Katello/katello/pull/10652 this template was renamed to "Configure host for new content source," which breaks the Change Content Source form.

#### Considerations taken when implementing this change?

I also considered changing it to look up the template by remote execution feature, but something was wrong with my REX job template setup and I don't seem to have the right feature registered.

#### What are the testing steps for this pull request?

Hosts > All Hosts > Click on your host > kebab > Change Content Source

Choose a content source, LCE and content view and click Submit
Make sure the resulting banner has a link to the job invocation:

![image](https://github.com/Katello/katello/assets/22042343/b4d340cd-d837-463e-803f-580afe126fdd)
