### PR TITLE
Fixes #36622 - Mark needs_publish after reindexing

### DIFF
--- a/app/lib/actions/katello/repository/index_content.rb
+++ b/app/lib/actions/katello/repository/index_content.rb
@@ -20,7 +20,6 @@ module Actions
 
           if input[:force_index] || (repo.last_contents_changed >= repo.last_indexed)
             repo.index_content(source_repository: source_repository, full_index: input[:full_index].present?)
-            repo.update(:last_indexed => DateTime.now)
           else
             output[:index_skipped] = true
           end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -939,6 +939,7 @@ module Katello
         end
         repository_type.index_additional_data_proc&.call(self)
       end
+      self.update!(last_indexed: DateTime.now)
       true
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Set needs_publish true when repo is indexed.
#### Considerations taken when implementing this change?
An indexing in katello will now show up as needs_publish=true in the CV. Thanks to optimizations, when repo contents haven't changed, indexing is skipped so in most cases, CV won't set needs_publish=true when contents haven't changed. But if a forced index is run on repo wthout adding new content, CV will have needs_publish true. You can see this by going to console and running: repo.index_content manually. 
#### What are the testing steps for this pull request?
The reproducer steps are a little weird because you need to fake an indexing error in katello to reproduce this.
1: (Fake the error)
In app/models/katello/repository.rb , method index_content add `fail _('Forced error')` as first line. (Downstream requires server restart to reload updates: `foreman-maintain service restart`)
2. Restart the server and create a new yum repo. Do not sync the repo yet.
3. Add new repo to a CV and publish the Content View.
4. Sync the repo. Skip the indexing failure from Dynflow console of the task and let the task finish with warning. You shouldn't see any content in the repo.
5. Publish the CV again.
6. Remove the  `fail _('Forced error')` from  app/models/katello/repository.rb , method index_content
7. Restart server (Downstream requires server restart to reload updates: `foreman-maintain service restart`)
8. Sync the repo now.
9. You should see the CV have the needs_publish icon show up once contents are added correctly in katello.