### PR TITLE
Fixes # 36623 - Add buttons to change content source screen

### DIFF
--- a/app/controllers/katello/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/hosts_controller_extensions.rb
@@ -91,7 +91,7 @@ module Katello
                                       .distinct
 
           if Katello.with_remote_execution?
-            template_id = JobTemplate.find_by(name: 'Change content source')&.id
+            template_id = JobTemplate.find_by(name: 'Configure host for new content source')&.id
             job_invocation_path = new_job_invocation_path(template_id: template_id, host_ids: content_hosts.map { |h| h[:id] }) if template_id
           end
 

--- a/webpack/scenes/Hosts/ChangeContentSource/actions.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/actions.js
@@ -17,18 +17,20 @@ export const getFormData = (hostIds, search) => (post({
   errorToast: () => __('Something went wrong while getting the data. See the logs for more information'),
 }));
 
-export const changeContentSource = (environmentId, contentViewId, contentSourceId, hostIds) =>
-  put({
-    key: CHANGE_CONTENT_SOURCE,
-    url: foremanUrl('/api/v2/hosts/bulk/change_content_source'),
-    params: {
-      environment_id: environmentId,
-      content_view_id: contentViewId,
-      content_source_id: contentSourceId,
-      host_ids: hostIds,
-    },
-    errorToast: () => __('Something went wrong while updating the content source. See the logs for more information'),
-  });
+export const changeContentSource =
+  (environmentId, contentViewId, contentSourceId, hostIds, handleSuccess) =>
+    put({
+      key: CHANGE_CONTENT_SOURCE,
+      url: foremanUrl('/api/v2/hosts/bulk/change_content_source'),
+      params: {
+        environment_id: environmentId,
+        content_view_id: contentViewId,
+        content_source_id: contentSourceId,
+        host_ids: hostIds,
+      },
+      errorToast: () => __('Something went wrong while updating the content source. See the logs for more information'),
+      handleSuccess,
+    });
 
 export const getProxy = id =>
   get({

--- a/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
@@ -96,6 +96,7 @@ const ContentSourceForm = ({
   contentHosts,
   isLoading,
   hostsUpdated,
+  showTemplate,
 }) => {
   const pathsUrl = `/organizations/${orgId()}/environments/paths?permission_type=promotable${contentSourceId ? `&content_source_id=${contentSourceId}` : ''}`;
   useAPI( // No TableWrapper here, so we can useAPI from Foreman
@@ -203,7 +204,7 @@ const ContentSourceForm = ({
         setUserCheckedItems={handleEnvironment}
         publishing={false}
         multiSelect={false}
-        headerText={__('Environment')}
+        headerText={__('Lifecycle environment')}
         isDisabled={environmentIsDisabled || hostsUpdated}
       />
       <ContentViewSelect
@@ -230,12 +231,23 @@ const ContentSourceForm = ({
           variant="primary"
           id="generate_btn"
           ouiaId="update-source-button"
-          onClick={e => handleSubmit(e)}
+          onClick={e => handleSubmit(e, { shouldRedirect: true })}
           isDisabled={isLoading || !formIsValid() || hostsUpdated}
           isLoading={isLoading}
         >
-          {__('Update')}
+          {__('Run job invocation')}
         </Button>
+        <Button
+          variant="secondary"
+          id="generate_btn"
+          ouiaId="update-source-button"
+          onClick={showTemplate}
+          isDisabled={isLoading || !formIsValid() || hostsUpdated}
+          isLoading={isLoading}
+        >
+          {__('Update hosts manually')}
+        </Button>
+
       </ActionGroup>
     </Form>);
 };
@@ -253,6 +265,7 @@ ContentSourceForm.propTypes = {
   contentHosts: PropTypes.arrayOf(PropTypes.shape({})),
   isLoading: PropTypes.bool,
   hostsUpdated: PropTypes.bool,
+  showTemplate: PropTypes.func.isRequired,
 };
 
 ContentSourceForm.defaultProps = {

--- a/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceTemplate.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceTemplate.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { FormattedMessage } from 'react-intl';
 import {
   Alert,
   Grid,
@@ -16,7 +15,7 @@ import PropTypes from 'prop-types';
 
 import { copyToClipboard } from '../helpers';
 
-const ContentSourceTemplate = ({ template, jobInvocationPath }) => {
+const ContentSourceTemplate = ({ template }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isCopied, setCopied] = useState(false);
 
@@ -42,19 +41,20 @@ const ContentSourceTemplate = ({ template, jobInvocationPath }) => {
     <Grid>
       <GridItem span={7}>
         <Alert
+          ouiaId="host-server-content-source-complete"
+          variant="info"
+          title={__('Configuration updated on Foreman')}
+          className="margin-top-20"
+          isInline
+        />
+        <Alert
           ouiaId="host-configuration-alert"
           variant="warning"
-          title={__('Host configurations are not updated yet')}
+          title={__('Configuration still must be updated on hosts')}
           className="margin-top-20"
           isInline
         >
-          <FormattedMessage
-            id="ccs_alert"
-            values={{
-              link: <a href={jobInvocationPath}>{__('run job invocation')}</a>,
-            }}
-            defaultMessage={jobInvocationPath ? __('To update the selected host configuration, {link}, or update hosts manually in the next section.') : __('To update the selected host configuration, update hosts manually in the next section.')}
-          />
+          {__('To finish the process of changing hosts\' content source, run the following script manually on the host(s).')}
         </Alert>
 
       </GridItem>
@@ -81,12 +81,10 @@ const ContentSourceTemplate = ({ template, jobInvocationPath }) => {
 
 ContentSourceTemplate.propTypes = {
   template: PropTypes.string,
-  jobInvocationPath: PropTypes.string,
 };
 
 ContentSourceTemplate.defaultProps = {
   template: '',
-  jobInvocationPath: '',
 };
 
 export default ContentSourceTemplate;

--- a/webpack/scenes/Hosts/ChangeContentSource/styles.scss
+++ b/webpack/scenes/Hosts/ChangeContentSource/styles.scss
@@ -17,3 +17,8 @@
 .set-select-width {
   width: 60%
 }
+
+#ccs-description {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add buttons to the Change Content Source screen so it's less confusing.

![image](https://github.com/Katello/katello/assets/22042343/87799d02-1866-41dc-8f88-d6e77b98c416)

When you click either of the buttons, the content source is updated on the Foreman / Satellite server.

In the case of 'Run job invocation', you are then redirected to the job wizard.
In the case of 'Update hosts manually', the following is presented:

![image](https://github.com/Katello/katello/assets/22042343/2186155e-d456-4a51-ba1c-ada4a55e15ce)


Other changes:

* Add a description blurb explaining why you might want to change a content source
* Change 'Environment' to 'Lifecycle environment'. I feel like 'Environment' can mean too many things, and want to start getting away from using it to describe lifecycle environments.



#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

You should be able to test this without actually setting up multiple content sources.
