### PR TITLE
Fixes #36623 - Add buttons and other UX improvements to change content source

### DIFF
--- a/webpack/scenes/ContentViews/components/ContentViewSelect/helpers.js
+++ b/webpack/scenes/ContentViews/components/ContentViewSelect/helpers.js
@@ -8,7 +8,7 @@ export const getCVPlaceholderText = ({
   cvSelectOptions = [],
 }) => {
   if (contentSourceId === '') return __('Select a content source first');
-  if (environments.length === 0) return __('Select an environment first');
+  if (environments.length === 0) return __('Select a lifecycle environment first');
   if (contentViewsStatus === STATUS.PENDING) return __('Loading...');
   if (contentViewsStatus === STATUS.ERROR) return __('Error loading content views');
   if (cvSelectOptions.length === 0) return __('No content views available');

--- a/webpack/scenes/Hosts/ChangeContentSource/actions.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/actions.js
@@ -17,18 +17,20 @@ export const getFormData = (hostIds, search) => (post({
   errorToast: () => __('Something went wrong while getting the data. See the logs for more information'),
 }));
 
-export const changeContentSource = (environmentId, contentViewId, contentSourceId, hostIds) =>
-  put({
-    key: CHANGE_CONTENT_SOURCE,
-    url: foremanUrl('/api/v2/hosts/bulk/change_content_source'),
-    params: {
-      environment_id: environmentId,
-      content_view_id: contentViewId,
-      content_source_id: contentSourceId,
-      host_ids: hostIds,
-    },
-    errorToast: () => __('Something went wrong while updating the content source. See the logs for more information'),
-  });
+export const changeContentSource =
+  (environmentId, contentViewId, contentSourceId, hostIds, handleSuccess) =>
+    put({
+      key: CHANGE_CONTENT_SOURCE,
+      url: foremanUrl('/api/v2/hosts/bulk/change_content_source'),
+      params: {
+        environment_id: environmentId,
+        content_view_id: contentViewId,
+        content_source_id: contentSourceId,
+        host_ids: hostIds,
+      },
+      errorToast: () => __('Something went wrong while updating the content source. See the logs for more information'),
+      handleSuccess,
+    });
 
 export const getProxy = id =>
   get({

--- a/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { FormattedMessage } from 'react-intl';
 import { useSelector } from 'react-redux';
 import {
   ActionGroup,
@@ -11,6 +12,7 @@ import {
   SelectOption,
   SelectVariant,
   TextContent,
+  Text,
 } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import PropTypes from 'prop-types';
@@ -109,6 +111,7 @@ const ContentSourceForm = ({
   const envList = environmentPathResponse?.results?.map(path => path.environments).flat();
   const [csSelectOpen, setCSSelectOpen] = useState(false);
   const [cvSelectOpen, setCVSelectOpen] = useState(false);
+  const hostCount = contentHosts.length;
 
   const handleCSSelect = (_event, selection) => {
     handleContentSource(selection);
@@ -123,10 +126,10 @@ const ContentSourceForm = ({
   const formIsValid = () => (!!environments &&
     !!contentViewName &&
     !!contentSourceId &&
-    contentHosts.length !== 0);
+    hostCount !== 0);
 
   const contentSourcesIsDisabled = (isLoading || contentSources.length === 0 ||
-    contentHosts.length === 0);
+    hostCount === 0);
   const environmentIsDisabled = (isLoading || environments === [] ||
     contentSourceId === '');
   const viewIsDisabled = (isLoading || contentViews.length === 0 ||
@@ -153,7 +156,7 @@ const ContentSourceForm = ({
       isHorizontal
     >
       <Grid hasGutter className="margin-top-16">
-        {(contentHosts.length === 0 && !isLoading) && (
+        {(hostCount === 0 && !isLoading) && (
 
         <GridItem span={7}>
           <Alert
@@ -226,6 +229,29 @@ const ContentSourceForm = ({
           env={environments[0]}
         />))}
       </ContentViewSelect>
+      <TextContent>
+        <Text
+          ouiaId="ccs-options-description"
+        >
+          <FormattedMessage
+            defaultMessage={__('After configuring Foreman, configuration must also be updated on {hosts}. Choose one of the following options to update {hosts}:')}
+            values={{
+              hosts: (
+                <FormattedMessage
+                  defaultMessage="{count, plural, one {{singular}} other {# {plural}}}"
+                  values={{
+                    count: hostCount,
+                    singular: __('the host'),
+                    plural: __('hosts'),
+                  }}
+                  id="ccs-options-i18n"
+                />
+              ),
+            }}
+            id="ccs-options-description-i18n"
+          />
+        </Text>
+      </TextContent>
       <ActionGroup style={{ display: 'block' }}>
         <Button
           variant="primary"

--- a/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
@@ -96,6 +96,7 @@ const ContentSourceForm = ({
   contentHosts,
   isLoading,
   hostsUpdated,
+  showTemplate,
 }) => {
   const pathsUrl = `/organizations/${orgId()}/environments/paths?permission_type=promotable${contentSourceId ? `&content_source_id=${contentSourceId}` : ''}`;
   useAPI( // No TableWrapper here, so we can useAPI from Foreman
@@ -203,7 +204,7 @@ const ContentSourceForm = ({
         setUserCheckedItems={handleEnvironment}
         publishing={false}
         multiSelect={false}
-        headerText={__('Environment')}
+        headerText={__('Lifecycle environment')}
         isDisabled={environmentIsDisabled || hostsUpdated}
       />
       <ContentViewSelect
@@ -230,12 +231,23 @@ const ContentSourceForm = ({
           variant="primary"
           id="generate_btn"
           ouiaId="update-source-button"
-          onClick={e => handleSubmit(e)}
+          onClick={e => handleSubmit(e, { shouldRedirect: true })}
           isDisabled={isLoading || !formIsValid() || hostsUpdated}
           isLoading={isLoading}
         >
-          {__('Update')}
+          {__('Run job invocation')}
         </Button>
+        <Button
+          variant="secondary"
+          id="generate_btn"
+          ouiaId="update-source-button"
+          onClick={showTemplate}
+          isDisabled={isLoading || !formIsValid() || hostsUpdated}
+          isLoading={isLoading}
+        >
+          {__('Update hosts manually')}
+        </Button>
+
       </ActionGroup>
     </Form>);
 };
@@ -253,6 +265,7 @@ ContentSourceForm.propTypes = {
   contentHosts: PropTypes.arrayOf(PropTypes.shape({})),
   isLoading: PropTypes.bool,
   hostsUpdated: PropTypes.bool,
+  showTemplate: PropTypes.func.isRequired,
 };
 
 ContentSourceForm.defaultProps = {

--- a/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceTemplate.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceTemplate.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { FormattedMessage } from 'react-intl';
 import {
   Alert,
   Grid,
@@ -15,7 +16,7 @@ import PropTypes from 'prop-types';
 
 import { copyToClipboard } from '../helpers';
 
-const ContentSourceTemplate = ({ template }) => {
+const ContentSourceTemplate = ({ template, hostCount }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isCopied, setCopied] = useState(false);
 
@@ -50,11 +51,45 @@ const ContentSourceTemplate = ({ template }) => {
         <Alert
           ouiaId="host-configuration-alert"
           variant="warning"
-          title={__('Configuration still must be updated on hosts')}
+          title={
+            <FormattedMessage
+              defaultMessage={__('Configuration still must be updated on {hosts}')}
+              values={{
+                hosts: (
+                  <FormattedMessage
+                    defaultMessage="{count, plural, one {{singular}} other {# {plural}}}"
+                    values={{
+                      count: hostCount,
+                      singular: __('the host'),
+                      plural: __('hosts'),
+                    }}
+                    id="ccs-status-i18n"
+                  />
+                ),
+              }}
+              id="ccs-status-description-i18n"
+            />
+          }
           className="margin-top-20"
           isInline
         >
-          {__('To finish the process of changing hosts\' content source, run the following script manually on the host(s).')}
+          <FormattedMessage
+            defaultMessage={__('To finish the process of changing the content source, run the following script manually on {hosts}.')}
+            values={{
+              hosts: (
+                <FormattedMessage
+                  defaultMessage="{count, plural, one {{singular}} other {{plural}}}"
+                  values={{
+                    count: hostCount,
+                    singular: __('the host'),
+                    plural: __('the hosts'),
+                  }}
+                  id="ccs-status2-i18n"
+                />
+              ),
+            }}
+            id="ccs-status2-description-i18n"
+          />
         </Alert>
 
       </GridItem>
@@ -81,10 +116,12 @@ const ContentSourceTemplate = ({ template }) => {
 
 ContentSourceTemplate.propTypes = {
   template: PropTypes.string,
+  hostCount: PropTypes.number,
 };
 
 ContentSourceTemplate.defaultProps = {
   template: '',
+  hostCount: 1,
 };
 
 export default ContentSourceTemplate;

--- a/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceTemplate.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceTemplate.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { FormattedMessage } from 'react-intl';
 import {
   Alert,
   Grid,
@@ -16,7 +15,7 @@ import PropTypes from 'prop-types';
 
 import { copyToClipboard } from '../helpers';
 
-const ContentSourceTemplate = ({ template, jobInvocationPath }) => {
+const ContentSourceTemplate = ({ template }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isCopied, setCopied] = useState(false);
 
@@ -42,19 +41,20 @@ const ContentSourceTemplate = ({ template, jobInvocationPath }) => {
     <Grid>
       <GridItem span={7}>
         <Alert
+          ouiaId="host-server-content-source-complete"
+          variant="info"
+          title={__('Configuration updated on Foreman')}
+          className="margin-top-20"
+          isInline
+        />
+        <Alert
           ouiaId="host-configuration-alert"
           variant="warning"
-          title={__('Host configurations are not updated yet')}
+          title={__('Configuration still must be updated on hosts')}
           className="margin-top-20"
           isInline
         >
-          <FormattedMessage
-            id="ccs_alert"
-            values={{
-              link: <a href={jobInvocationPath}>{__('run job invocation')}</a>,
-            }}
-            defaultMessage={jobInvocationPath ? __('To update the selected host configuration, {link}, or update hosts manually in the next section.') : __('To update the selected host configuration, update hosts manually in the next section.')}
-          />
+          {__('To finish the process of changing hosts\' content source, run the following script manually on the host(s).')}
         </Alert>
 
       </GridItem>
@@ -81,12 +81,10 @@ const ContentSourceTemplate = ({ template, jobInvocationPath }) => {
 
 ContentSourceTemplate.propTypes = {
   template: PropTypes.string,
-  jobInvocationPath: PropTypes.string,
 };
 
 ContentSourceTemplate.defaultProps = {
   template: '',
-  jobInvocationPath: '',
 };
 
 export default ContentSourceTemplate;

--- a/webpack/scenes/Hosts/ChangeContentSource/index.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/index.js
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
-import { Alert, Grid, GridItem, PageSection, Title, Text } from '@patternfly/react-core';
+import { Alert, Grid, GridItem, PageSection, Title, Text, TextContent } from '@patternfly/react-core';
 
 import { translate as __ } from 'foremanReact/common/I18n';
 import { foremanUrl } from 'foremanReact/common/helpers';
@@ -57,7 +57,8 @@ const ChangeContentSourcePage = () => {
   const [redirect, setRedirect] = useState(false);
 
   const contentViewId = contentViews?.find(cv => cv.name === contentViewName)?.id;
-  const noHostSpecified = getHostIds(urlParams.host_id).length === 0 && urlParams.searchParam === '';
+  const hostIds = useMemo(() => getHostIds(urlParams.host_id), [urlParams.host_id]);
+  const noHostSpecified = (hostIds.length === 0 && urlParams.searchParam === '');
   const environmentId = selectedEnvironment[0]?.id;
 
   const redirectToJobInvocationForm = () => setRedirect(true);
@@ -117,8 +118,8 @@ const ChangeContentSourcePage = () => {
     }
   };
   useEffect(() => {
-    dispatch(getFormData(getHostIds(urlParams.host_id), urlParams.searchParam));
-  }, [dispatch, urlParams.host_id, urlParams.searchParam]);
+    dispatch(getFormData(hostIds, urlParams.searchParam));
+  }, [dispatch, hostIds, urlParams.searchParam]);
 
   if (redirect && jobInvocationPath) {
     window.location.assign(jobInvocationPath); // redirect to job invocation wizard
@@ -148,9 +149,11 @@ const ChangeContentSourcePage = () => {
             >
               {__('Change host content source')}
             </Title>
-            <Text ouiaId="change-content-source-description" id="ccs-description">
-              {__('Changing a host\'s content source will change the Smart Proxy from which the host gets its content.')}
-            </Text>
+            <TextContent>
+              <Text ouiaId="change-content-source-description" id="ccs-description">
+                {__('Changing a host\'s content source will change the Smart Proxy from which the host gets its content.')}
+              </Text>
+            </TextContent>
           </GridItem>
           {noHostSpecified &&
             <GridItem span={7}>
@@ -186,7 +189,7 @@ const ChangeContentSourcePage = () => {
             />
           </> }
           { (apiChangeStatus === STATUS.RESOLVED && shouldShowTemplate) &&
-          <ContentSourceTemplate template={template} /> }
+          <ContentSourceTemplate template={template} hostCount={contentHosts.length} /> }
         </Grid>
       </PageSection>
     </>

--- a/webpack/scenes/Hosts/ChangeContentSource/styles.scss
+++ b/webpack/scenes/Hosts/ChangeContentSource/styles.scss
@@ -17,3 +17,8 @@
 .set-select-width {
   width: 60%
 }
+
+#ccs-description {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add buttons to the Change Content Source screen so it's less confusing.

![image](https://github.com/Katello/katello/assets/22042343/87799d02-1866-41dc-8f88-d6e77b98c416)

When you click either of the buttons, the content source is updated on the Foreman / Satellite server.

In the case of 'Run job invocation', you are then redirected to the job wizard.
In the case of 'Update hosts manually', the following is presented:

![image](https://github.com/Katello/katello/assets/22042343/c0ea0f9c-c8ac-4194-a36a-287d9e3bfc40)

Other changes:

* Add a description blurb explaining why you might want to change a content source
* Change 'Environment' to 'Lifecycle environment'. I feel like 'Environment' can mean too many things, and want to start getting away from using it to describe lifecycle environments.



#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

You should be able to test this without actually setting up multiple content sources.
