### PR TITLE
Fixes #36628 - update audit is not created after updating CV name

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -1,7 +1,7 @@
 module Katello
   # rubocop:disable Metrics/ClassLength
   class ContentView < Katello::Model
-    audited :associations => [:repositories, :environments, :filters], :except => [:name, :label, :description]
+    audited :associations => [:repositories, :environments, :filters]
     has_associated_audits
     include Ext::LabelFromName
     include Katello::Authorization::ContentView


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds audit back to name,label,description fields. (label can't be changed but no benefit of excluding it specifically.)
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a CV
2. Update name/description of CV
3. Go to Monitor > Audits
4. Check if an audit record is created for the updates on name/description.