### PR TITLE
Fixes #36593 - Repository details page shouldn't say 'enabled by default'

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -41,8 +41,8 @@ module Katello
 
     def_param_group :repo do
       param :url, String, :desc => N_("repository source url")
-      param :os_versions, Array,
-            :desc => N_("Identifies whether the repository should be disabled on a client with a non-matching OS version. Pass [] to enable regardless of OS version. Maximum length 1; allowed tags are: %s") % Katello::RootRepository::ALLOWED_OS_VERSIONS.join(', ')
+      param :os_versions, Array, :desc => N_("Identifies whether the repository should be unavailable on a client with a non-matching OS version.
+Pass [] to make repo available for clients regardless of OS version. Maximum length 1; allowed tags are: %s") % Katello::RootRepository::ALLOWED_OS_VERSIONS.join(', ')
       param :gpg_key_id, :number, :desc => N_("id of the gpg key that will be assigned to the new repository"), :allow_nil => true
       param :ssl_ca_cert_id, :number, :desc => N_("Identifier of the content credential containing the SSL CA Cert"), :allow_nil => true
       param :ssl_client_cert_id, :number, :desc => N_("Identifier of the content credential containing the SSL Client Cert"), :allow_nil => true

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -35,7 +35,7 @@
       <dl class="dl-horizontal dl-horizontal-left">
           <dt>
             <span translate>Restrict to architecture</span>
-            <i class="pficon-info" title="{{ 'The repository will be enabled by default on content hosts with the selected architecture.' | translate }}"></i>
+            <i class="pficon-info" title="{{ 'The repository will only be available on content hosts with the selected architecture.' | translate }}"></i>
           </dt>
           <dd bst-edit-select="repository.arch==='noarch'?'No restriction':repository.arch"
               selector="repository.arch"
@@ -45,7 +45,7 @@
 
           <dt>
             <span translate>Restrict to <br />OS version</span>
-            <i class="pficon-info" title="{{ 'The repository will be enabled by default on content hosts with the selected OS version.' | translate }}"></i>
+            <i class="pficon-info" title="{{ 'The repository will only be available on content hosts with the selected OS version.' | translate }}"></i>
           </dt>
           <dd bst-edit-select="repository.os_versions.length ? formatOSVersions() : 'No restriction'"
               selector="selectedOSVersion"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -60,7 +60,7 @@
                 ng-options="arch.id as arch.name for arch in architecture">
         </select>
         <p class="help-block" translate>
-          The repository will be enabled by default on content hosts with the selected architecture.
+          The repository will only be available on content hosts with the selected architecture.
         </p>
       </div>
 
@@ -71,7 +71,7 @@
                 ng-options="tag as tag.name for tag in osVersionsOptions track by tag.id">
         </select>
         <p class="help-block" translate>
-          The repository will be enabled by default on content hosts with the selected OS version.
+          The repository will only be available on content hosts with the selected OS version.
         </p>
       </div>
     </div>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Change wording on repositories views to no longer say repos are enabled by default.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Go to Products > Create new repository
You should see the new message like below: 
![Screenshot from 2023-08-01 14-14-23](https://github.com/Katello/katello/assets/21146741/ce63b96b-8615-49c0-9664-f226bda49fb1)

After creating the repo, go to repo details. The 2 fields should have tooltips with updated messages:
![Screenshot from 2023-08-01 14-13-59](https://github.com/Katello/katello/assets/21146741/e6f4b3cc-5eb1-4521-ae1c-967884b1aec1)


Also updated param description on repo_create. You can check that via hammer or in APIDocs.

Let me know if you see any other places this update should be made.