### PR TITLE
Fixes #36634 - Fail when wrong/missing ids are passed to bulk ACS actions

### DIFF
--- a/app/controllers/katello/api/v2/alternate_content_sources_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/alternate_content_sources_bulk_actions_controller.rb
@@ -54,6 +54,12 @@ module Katello
     def find_alternate_content_sources
       params.require(:ids)
       @alternate_content_sources = AlternateContentSource.readable.where(id: params[:ids])
+      unless params[:ids].size == @alternate_content_sources.size
+        missing_ids = params[:ids].map(&:to_s) - @alternate_content_sources.pluck(:id)&.map(&:to_s)
+        msg = "Could not find alternate content sources with id: #{missing_ids} . You either do not have required permissions"\
+                ", or these alternate content sources do not exist."
+        fail HttpErrors::UnprocessableEntity, msg
+      end
     end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fail when invalid ids are passed to ACS bulk actions
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Try bulk actions like below with invalid IDs:

`hammer alternate-content-source bulk refresh --ids 1,2,3`
or 
`hammer alternate-content-source bulk destroy --ids 1,2,3`