### PR TITLE
Fixes #36631 - add file:// to ACS path types

### DIFF
--- a/webpack/scenes/AlternateContentSources/Create/Steps/AcsUrlPaths.js
+++ b/webpack/scenes/AlternateContentSources/Create/Steps/AcsUrlPaths.js
@@ -21,7 +21,7 @@ const AcsUrlPaths = () => {
 
   const baseURLplaceholder = acsType === 'rhui' ?
     'https://rhui-server.example.com/pulp/content' :
-    'http:// or https://';
+    'http://, https:// or file://';
   const helperTextInvalid = acsType === 'rhui' ?
     'http://rhui-server.example.com/pulp/content or https://rhui-server.example.com/pulp/content' :
     'http://, https:// or file://';

--- a/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditURLPaths.js
+++ b/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditURLPaths.js
@@ -16,7 +16,7 @@ const ACSEditURLPaths = ({ onClose, acsId, acsDetails }) => {
   const urlValidated = (acsUrl === '' || isValidUrl(acsUrl, acsType)) ? 'default' : 'error';
   const baseURLplaceholder = acsType === 'rhui' ?
     'https://rhui-server.example.com/pulp/content' :
-    'http:// or https://';
+    'http://, https:// or file://';
   const helperTextInvalid = acsType === 'rhui' ?
     'http://rhui-server.example.com/pulp/content or https://rhui-server.example.com/pulp/content' :
     'http://, https:// or file://';


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds file:// to the list of suggested path types for ACSs.

#### Considerations taken when implementing this change?
...
#### What are the testing steps for this pull request?
Create and edit an ACS. In the greyed out empty-text for the base URLs, ensure that `file://` is there.

![image](https://github.com/Katello/katello/assets/14796566/b8f24af5-2f22-4747-b341-8a6b2bdc8806)

