### PR TITLE
Remove remote_execution_by_default setting

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -131,8 +131,7 @@ module Katello
       validate_content(params[:add_content])
       resolve_dependencies = params.fetch(:resolve_dependencies, true)
       task = async_task(::Actions::Katello::ContentView::IncrementalUpdates, @content_view_version_environments, @composite_version_environments,
-                        params[:add_content], resolve_dependencies, hosts, params[:description],
-                        Setting[:remote_execution_by_default] && ::Katello.with_remote_execution?)
+                        params[:add_content], resolve_dependencies, hosts, params[:description])
       respond_for_async :resource => task
     end
 

--- a/app/lib/actions/katello/content_view/incremental_updates.rb
+++ b/app/lib/actions/katello/content_view/incremental_updates.rb
@@ -4,8 +4,8 @@ module Actions
       class IncrementalUpdates < Actions::EntryAction
         include Helpers::Presenter
 
-        def plan(version_environments, composite_version_environments, content, dep_solve, hosts, description,
-                use_remote_execution = false)
+        def plan(version_environments, composite_version_environments, content, dep_solve, hosts, description) # rubocop:disable Metrics/MethodLength
+          use_remote_execution = true # TODO: remove this when we remove katello-agent dynflow actions
           old_new_version_map = {}
           output_for_version_ids = []
 

--- a/app/views/katello/api/v2/content_facet/show.json.rabl
+++ b/app/views/katello/api/v2/content_facet/show.json.rabl
@@ -33,10 +33,6 @@ child :content_facet => :content_facet_attributes do
     Katello.with_katello_agent?
   end
 
-  node :remote_execution_by_default do
-    Katello.remote_execution_by_default?
-  end
-
   user = User.current # current_user is not available here
   child :permissions do
     node(:view_lifecycle_environments) { user.can?("view_lifecycle_environments") }

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -247,7 +247,7 @@ module Katello
   end
 
   def self.remote_execution_by_default?
-    self.with_katello_agent? ? Setting['remote_execution_by_default'] : true
+    true
   end
 
   def self.with_ansible?

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -575,12 +575,6 @@ Foreman::Plugin.register :katello do
         full_name: N_('Sync Sock Read Timeout'),
         description: N_("The maximum number of seconds that Pulp can take to download a file, not counting connection time.")
 
-      setting 'remote_execution_by_default',
-        type: :boolean,
-        default: false,
-        full_name: N_('Use remote execution by default'),
-        description: N_("If this is enabled, remote execution is used instead of katello-agent for remote actions")
-
       setting 'unregister_delete_host',
         type: :boolean,
         default: false,

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -263,7 +263,7 @@ module Katello
       errata_id = Katello::Erratum.first.pulp_id
       @controller.expects(:async_task).with(::Actions::Katello::ContentView::IncrementalUpdates,
                                             [{:content_view_version => version, :environments => [@beta]}], [],
-                                            {'errata_ids' => [errata_id]}, true, [], nil, false).returns({})
+                                            {'errata_ids' => [errata_id]}, true, [], nil).returns({})
 
       put :incremental_update, params: { :content_view_version_environments => [{:content_view_version_id => version.id, :environment_ids => [@beta.id]}], :add_content => {:errata_ids => [errata_id]}, :resolve_dependencies => true }
 
@@ -276,7 +276,7 @@ module Katello
       deb_id = Katello::Deb.first.id
       @controller.expects(:async_task).with(::Actions::Katello::ContentView::IncrementalUpdates,
                                             [{:content_view_version => version, :environments => [@beta]}], [],
-                                            {'errata_ids' => [errata_id], 'deb_ids' => [deb_id]}, true, [], nil, false).returns({})
+                                            {'errata_ids' => [errata_id], 'deb_ids' => [deb_id]}, true, [], nil).returns({})
 
       put :incremental_update, params: { :content_view_version_environments => [{:content_view_version_id => version.id, :environment_ids => [@beta.id]}], :add_content => {:errata_ids => [errata_id], :deb_ids => [deb_id]}, :resolve_dependencies => true }
 
@@ -288,7 +288,7 @@ module Katello
       errata_id = Katello::Erratum.first.pulp_id
       @controller.expects(:async_task).with(::Actions::Katello::ContentView::IncrementalUpdates,
                                             [{:content_view_version => version, :environments => []}], [],
-                                            {'errata_ids' => [errata_id]}, true, [], nil, false).returns({})
+                                            {'errata_ids' => [errata_id]}, true, [], nil).returns({})
 
       put :incremental_update, params: { :content_view_version_environments => [{:content_view_version_id => version.id, :environment_ids => []}], :update_hosts => {:included => {:search => ''}}, :add_content => {:errata_ids => [errata_id]}, :resolve_dependencies => true }
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Remove the setting 'Use remote execution by default'
* Everywhere in the code that used it, change behavior to use remote execution no matter what

#### Considerations taken when implementing this change?

Should probably wait to merge this one until any UI changes that depend on it are merged.

#### What are the testing steps for this pull request?

- Test incremental updates via REX and make sure nothing is broken
- Test legacy content host UI and ensure it always uses REX and nothing is broken
- Test new host details page and ensure it always uses REX and nothing is broken
- on new host details page > Content > Packages > kebab > Install packages, ensure 'via Katello agent' option is NOT listed

