### PR TITLE
Fixes #36638 - Allow metadata regenerate with --force flag on API/Hammer

### DIFF
--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -142,7 +142,7 @@ module Katello
     def test_republish_repositories
       #force is deprecated and will be removed. Remove this test when that happens
       version = @library_dev_staging_view.versions.first
-      @controller.expects(:async_task).with(::Actions::Katello::ContentViewVersion::RepublishRepositories, version).returns({})
+      @controller.expects(:async_task).with(::Actions::Katello::ContentViewVersion::RepublishRepositories, version, :force => true).returns({})
       put :republish_repositories, params: { :id => version.id, :force => true }
 
       assert_response :success

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -788,7 +788,7 @@ module Katello
       @repository.root.update!(mirroring_policy: Katello::RootRepository::MIRRORING_POLICY_COMPLETE)
       put :republish, params: { :id => @repository.id }
       assert_response 400
-      assert_match "Metadata republishing is not allowed on repositories with the 'Complete Mirroring' mirroring policy.", @response.body
+      assert_match(/Metadata republishing is risky on 'Complete Mirroring' repositories./, @response.body)
     end
 
     def test_republish


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
The plan for Regenerating metadata on "complete_mirroring" is as follows:
a) **Disallowed on the UI** : Republishing on UI on repos and cv versions with complete_mirroring repos will not be allowed.
b) **Allowed in hammer** : only with `--force true`
#### Considerations taken when implementing this change?
We want to discourage users from republishing metadata locally on Pulp for repositories with complete mirroring. Disallowing on UI and only allowing via hammer/api with --force flag makes it so.
#### What are the testing steps for this pull request?
1. Create a yum repo with mirroring policy = Complete Mirroring and another with not mirror complete.
2. Sync the repos, add them to a CV and publish.
3. Check to see that  Republishing Metadata action is disabled on repo with complete mirroring and enabled for the other on the UI.
4. In hammer, you should be able to regenerate metadata on both, however only with --force 1 on complete mirroring repo.
Check `hammer -r repository republish --id $REPO_ID --force false ` vs `hammer -r repository republish --id $REPO_ID --force true`
5. For the CV version, republishing metadata from Version Details > Actions will be disabled. (Since a mirror complete repo exists in the version)
6. Via hammer, you'll get an error message when republishing metadata without force flag.
7. Hammer should allow republishing metadata with --force flag. Check number of sub-actions in the bulk task to make sure all repos get republished with 
`hammer -r content-view version republish-repositories --id $VERSION_ID --force 1` and `hammer -r content-view version republish-repositories --id $VERSION_ID --force 0`
