### PR TITLE
Fixes #36648 - Show desc and publish date on component CV add/edit modal

### DIFF
--- a/app/views/katello/api/v2/content_view_components/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_components/show.json.rabl
@@ -29,5 +29,8 @@ child :latest_version => :content_view_version do
 end
 
 child :component_content_view_versions => :component_content_view_versions do
-  attributes :id, :version
+  attributes :id, :version, :description
+  node :published_at_words do |version|
+    time_ago_in_words(version.created_at)
+  end
 end

--- a/app/views/katello/api/v2/content_views/base.json.rabl
+++ b/app/views/katello/api/v2/content_views/base.json.rabl
@@ -67,8 +67,12 @@ end
 child :versions => :versions do
   attributes :id, :version
   attributes :created_at => :published
+  attributes :description
   attributes :environment_ids
   attributes :filters_applied? => :filters_applied
+  node :published_at_words do |version|
+    time_ago_in_words(version.created_at)
+  end
 end
 
 if params.key?(:include_permissions)

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewAddModal.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewAddModal.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Flex, Modal, ModalVariant, Select,
+  Flex, Modal, ModalVariant, Select, SelectVariant,
   SelectOption, Checkbox, Form, FormGroup,
   ActionGroup, Button, Tooltip,
 } from '@patternfly/react-core';
@@ -69,7 +69,7 @@ const ComponentContentViewAddModal = ({
 
   const updateLatest = (checked) => {
     setFormLatest(checked);
-    if (checked) setSelected(options[0]);
+    if (checked) setSelected(options[0]?.value);
   };
 
   const onSubmit = () => {
@@ -108,6 +108,7 @@ const ComponentContentViewAddModal = ({
       >
         <FormGroup label={__('Version')} isRequired fieldId="version">
           <Select
+            variant={SelectVariant.typeahead}
             selections={selected}
             isDisabled={formLatest || options.length === 1}
             onSelect={(event, value) => { setSelected(value); setCvVersionSelectOpen(false); }}
@@ -117,6 +118,8 @@ const ComponentContentViewAddModal = ({
             onToggle={isExpanded => setCvVersionSelectOpen(isExpanded)}
             aria-label="CvVersion"
             ouiaId="select-cv-version"
+            menuAppendTo="parent"
+            maxHeight="20rem"
           >
             {options.map(option => (
               <SelectOption

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewAddModal.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewAddModal.js
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Flex, Modal, ModalVariant, FormSelect,
-  FormSelectOption, Checkbox, Form, FormGroup,
+  Flex, Modal, ModalVariant, Select,
+  SelectOption, Checkbox, Form, FormGroup,
   ActionGroup, Button, Tooltip,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
@@ -37,6 +37,7 @@ const ComponentContentViewAddModal = ({
   const [options, setOptions] = useState([]);
   const [formLatest, setFormLatest] = useState(componentId ? latest : false);
   const [selected, setSelected] = useState(null);
+  const [cvVersionSelectOpen, setCvVersionSelectOpen] = useState(false);
   const versionsLoading = componentStatus === STATUS.PENDING;
 
   useEffect(() => {
@@ -44,7 +45,9 @@ const ComponentContentViewAddModal = ({
       const { name, versions } = componentDetails;
       const versionMutable = versions;
       setCvName(name);
-      const opt = versionMutable.map(item => ({ value: item.id, label: __(`Version ${item.version}`) }));
+      const opt = versionMutable.map(item => ({
+        value: item.id, label: __(`Version ${item.version}`), description: item.description, publishedAtWords: __(` (${item.published_at_words} ago)`),
+      }));
       setOptions([...opt].reverse());
       setSelected(opt.slice(-1)[0].value);
     }
@@ -104,20 +107,27 @@ const ComponentContentViewAddModal = ({
       }}
       >
         <FormGroup label={__('Version')} isRequired fieldId="version">
-          <FormSelect
-            value={selected}
+          <Select
+            selections={selected}
             isDisabled={formLatest || options.length === 1}
-            onChange={value => setSelected(value)}
+            onSelect={(event, value) => { setSelected(value); setCvVersionSelectOpen(false); }}
             id="horzontal-form-title"
             name="horizontal-form-title"
+            isOpen={cvVersionSelectOpen}
+            onToggle={isExpanded => setCvVersionSelectOpen(isExpanded)}
             aria-label="CvVersion"
             ouiaId="select-cv-version"
           >
-            {options.map((option, index) => (
-              // eslint-disable-next-line react/no-array-index-key
-              <FormSelectOption key={index} value={option.value} label={option.label} />
+            {options.map(option => (
+              <SelectOption
+                key={option.value}
+                value={option.value}
+                description={option.description}
+              >
+                <>{option.label}{option.publishedAtWords}</>
+              </SelectOption>
             ))}
-          </FormSelect>
+          </Select>
         </FormGroup>
         <FormGroup fieldId="latest">
           <Flex style={{ display: 'inline-flex' }}>

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewBulkAddModal.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewBulkAddModal.js
@@ -2,7 +2,7 @@ import React, { useState, useMemo } from 'react';
 import { last } from 'lodash';
 import PropTypes from 'prop-types';
 import {
-  Flex, Modal, ModalVariant, Select,
+  Flex, Modal, ModalVariant, Select, SelectVariant,
   SelectOption, Checkbox, Form, FormGroup,
   ActionGroup, Button, Card, CardTitle, CardBody, Tooltip,
 } from '@patternfly/react-core';
@@ -67,14 +67,20 @@ const ComponentContentViewBulkAddModal = ({ cvId, rowsToAdd, onClose }) => {
       }}
       >
         {Object.keys(versionSelectOptions).sort().map(componentCvName => (
-          <Card ouiaId="componentCvName" key={componentCvName}>
+          <Card
+            ouiaId="componentCvName"
+            aria-label="componentCvName"
+            key={componentCvName}
+          >
             <CardTitle aria-label={componentCvName}>{componentCvName}</CardTitle>
             <CardBody>
               <FormGroup label={__('Version')} isRequired fieldId="version">
                 <Select
+                  variant={SelectVariant.typeahead}
                   selections={selectedVersion[componentCvName]}
                   ouiaId="select-version"
-                  isDisabled={versionSelectOptions[componentCvName].length <= 1}
+                  isDisabled={versionSelectOptions[componentCvName].length <= 1 ||
+                      selectedComponentLatest[componentCvName]}
                   onSelect={(__event, value) => {
                     setSelectedVersion({ ...selectedVersion, ...{ [componentCvName]: value } });
                     setCvVersionSelectOpen('');
@@ -85,6 +91,8 @@ const ComponentContentViewBulkAddModal = ({ cvId, rowsToAdd, onClose }) => {
                   id={`horzontal-form-title-${componentCvName}-${cvVersionSelectOpen[componentCvName]}`}
                   name="horizontal-form-title"
                   aria-label={`version-select-${componentCvName}`}
+                  menuAppendTo="parent"
+                  maxHeight="20rem"
                 >
                   {versionSelectOptions[componentCvName].map(version => (
                     <SelectOption

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewBulkAddModal.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewBulkAddModal.js
@@ -2,8 +2,8 @@ import React, { useState, useMemo } from 'react';
 import { last } from 'lodash';
 import PropTypes from 'prop-types';
 import {
-  Flex, Modal, ModalVariant, FormSelect,
-  FormSelectOption, Checkbox, Form, FormGroup,
+  Flex, Modal, ModalVariant, Select,
+  SelectOption, Checkbox, Form, FormGroup,
   ActionGroup, Button, Card, CardTitle, CardBody, Tooltip,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
@@ -16,6 +16,8 @@ const ComponentContentViewBulkAddModal = ({ cvId, rowsToAdd, onClose }) => {
   const [versionSelectOptions, setVersionSelectOptions] = useState({});
   const [selectedVersion, setSelectedVersion] = useState({});
   const [selectedComponentLatest, setSelectedComponentLatest] = useState({});
+  const [cvVersionSelectOpen, setCvVersionSelectOpen] = useState('');
+
 
   useMemo(() => {
     const versionSelect = {};
@@ -69,21 +71,32 @@ const ComponentContentViewBulkAddModal = ({ cvId, rowsToAdd, onClose }) => {
             <CardTitle aria-label={componentCvName}>{componentCvName}</CardTitle>
             <CardBody>
               <FormGroup label={__('Version')} isRequired fieldId="version">
-                <FormSelect
-                  value={selectedVersion[componentCvName]}
+                <Select
+                  selections={selectedVersion[componentCvName]}
                   ouiaId="select-version"
                   isDisabled={versionSelectOptions[componentCvName].length <= 1}
-                  onChange={value =>
-                    setSelectedVersion({ ...selectedVersion, ...{ [componentCvName]: value } })}
-                  id={`horzontal-form-title-${componentCvName}`}
+                  onSelect={(__event, value) => {
+                    setSelectedVersion({ ...selectedVersion, ...{ [componentCvName]: value } });
+                    setCvVersionSelectOpen('');
+                  }
+                  }
+                  isOpen={cvVersionSelectOpen === componentCvName}
+                  onToggle={isExpanded => setCvVersionSelectOpen(isExpanded ? componentCvName : '')}
+                  id={`horzontal-form-title-${componentCvName}-${cvVersionSelectOpen[componentCvName]}`}
                   name="horizontal-form-title"
                   aria-label={`version-select-${componentCvName}`}
                 >
-                  {versionSelectOptions[componentCvName].map((version, index) => (
-                    // eslint-disable-next-line react/no-array-index-key
-                    <FormSelectOption aria-label={`${componentCvName}-${version.version}`} key={index} value={version.id} label={`${__('Version')} ${version.version}`} />
+                  {versionSelectOptions[componentCvName].map(version => (
+                    <SelectOption
+                      key={`${componentCvName}-${version.version}`}
+                      aria-label={`${componentCvName}-${version.version}`}
+                      value={version.id}
+                      description={version.description}
+                    >
+                      <>{`${__('Version')} ${version.version}`}{__(` (${version.published_at_words} ago)`)}</>
+                    </SelectOption>
                   ))}
-                </FormSelect>
+                </Select>
               </FormGroup>
               <FormGroup style={{ marginTop: '1em' }}>
                 <Flex style={{ display: 'inline-flex' }}>

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.fixtures.json
@@ -63,7 +63,7 @@
       "content_view_version": null
     },
     {
-      "latest": true,
+      "latest": false,
       "id": null,
       "description": "Description_no_version",
       "created_at": null,

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.fixtures.json
@@ -13,6 +13,7 @@
     {
       "latest": true,
       "id": 28,
+      "description": "Description_28",
       "created_at": "2021-06-29 11:11:23 -0400",
       "updated_at": "2021-06-29 11:11:23 -0400",
       "composite_content_view": {
@@ -38,6 +39,7 @@
     {
       "latest": true,
       "id": 23,
+      "description": "Description_23",
       "created_at": "2021-06-29 10:25:52 -0400",
       "updated_at": "2021-06-29 10:25:52 -0400",
       "composite_content_view": {
@@ -63,6 +65,7 @@
     {
       "latest": true,
       "id": null,
+      "description": "Description_no_version",
       "created_at": null,
       "updated_at": null,
       "composite_content_view": {
@@ -126,15 +129,21 @@
       "component_content_view_versions": [
         {
           "id": 36,
-          "version": "1.0"
+          "version": "1.0",
+          "description": "Version 1.0",
+          "published_at_words": "5 days"
         },
         {
           "id": 42,
-          "version": "3.0"
+          "version": "3.0",
+          "description": "Version 3.0",
+          "published_at_words": "4 days"
         },
         {
           "id": 44,
-          "version": "4.0"
+          "version": "4.0",
+          "description": "Version 4.0",
+          "published_at_words": "3 days"
         }
       ]
     },

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.test.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.test.js
@@ -321,7 +321,7 @@ test('Can bulk add component views to content view with modal', async (done) => 
 
   const addComponentParams = {
     compositeContentViewId: 4,
-    components: [{ content_view_version_id: 44 }, { latest: true, content_view_id: 9 }],
+    components: [{ content_view_version_id: 42 }, { latest: true, content_view_id: 9 }],
   };
 
   const addComponentScope = nockInstance
@@ -346,9 +346,10 @@ test('Can bulk add component views to content view with modal', async (done) => 
   fireEvent.click(getByLabelText('bulk_add_components'));
   await patientlyWaitFor(() => {
     expect(getAllByText('Add content views')[1]).toBeInTheDocument();
+    expect(queryByText('Version 4.0 (3 days ago)')).toBeInTheDocument();
   });
-  fireEvent.click(getByLabelText('version-select-cv-10'));
-  fireEvent.click(getByLabelText('cv-10-3.0'));
+  fireEvent.click(queryByText('Version 4.0 (3 days ago)'));
+  fireEvent.click(queryByText('Version 3.0'));
 
   fireEvent.click(getByLabelText('add_components'));
   await patientlyWaitFor(() => {

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.test.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.test.js
@@ -329,7 +329,7 @@ test('Can bulk add component views to content view with modal', async (done) => 
     .reply(200, {});
 
   const {
-    getAllByText, getByLabelText, queryByText,
+    getAllByText, getByLabelText, queryByText, getAllByRole,
   } = renderWithRedux(
     <ContentViewComponents cvId={4} details={cvDetails} />,
     renderOptions,
@@ -346,9 +346,9 @@ test('Can bulk add component views to content view with modal', async (done) => 
   fireEvent.click(getByLabelText('bulk_add_components'));
   await patientlyWaitFor(() => {
     expect(getAllByText('Add content views')[1]).toBeInTheDocument();
-    expect(queryByText('Version 4.0 (3 days ago)')).toBeInTheDocument();
+    expect(getAllByRole('textbox')[0]).toHaveValue('Version 4.0 (3 days ago)');
   });
-  fireEvent.click(queryByText('Version 4.0 (3 days ago)'));
+  fireEvent.click(getAllByRole('textbox')[0]);
   fireEvent.click(queryByText('Version 3.0'));
 
   fireEvent.click(getByLabelText('add_components'));


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add 'published_at' in version label when selecting component CV version to add to composite CV.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Create some content views and publish. Add descriptions to some/all when publishing. You can also edit desc on published versions.
Create a composite content view and play around with adding/editing/bulk adding components to the composite CV.
Make sure all three(single add/edit and bulk add) look like sketch here: 
![Screenshot from 2023-08-07 15-03-31](https://github.com/Katello/katello/assets/21146741/3bd82648-02bd-4054-b3cb-3255c07a98c8)
