### PR TITLE
Fixes #36649 - Remove katello-agent out of legacy UI

### DIFF
--- a/engines/bastion_katello/README.md
+++ b/engines/bastion_katello/README.md
@@ -7,7 +7,8 @@ The only real difference, as far as the user is concerned, is that the applicati
 # Running tests:
 
 ```
-sudo yum -y install npm chromium-headless chromium
+sudo dnf -y install epel-release epel-next-release
+sudo dnf -y install npm chromium-headless chromium
 cd ./engines/bastion_katello
 sudo npm install -g grunt-cli
 npm install

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
@@ -24,21 +24,6 @@
 angular.module('Bastion.content-hosts').controller('ContentHostsBulkErrataModalController',
     ['$scope', '$http', '$location', '$window', '$timeout', '$uibModalInstance', 'HostBulkAction', 'HostCollection', 'Nutupane', 'CurrentOrganization', 'Erratum', 'Notification', 'BastionConfig', 'hostIds', 'newHostDetailsUI',
     function ($scope, $http, $location, $window, $timeout, $uibModalInstance, HostBulkAction, HostCollection, Nutupane, CurrentOrganization, Erratum, Notification, BastionConfig, hostIds, newHostDetailsUI) {
-        function installParams() {
-            var params = hostIds;
-            params['content_type'] = 'errata';
-            params.content = _.map($scope.table.getSelected(), 'errata_id');
-
-            if ($scope.nutupane.table.allResultsSelected) {
-                params['install_all'] = true;
-            } else {
-                params['install_all'] = false;
-            }
-
-            params['organization_id'] = CurrentOrganization;
-            return params;
-        }
-
         function fetchErratum(errataId) {
             $scope.erratum = Erratum.get({id: errataId, 'organization_id': CurrentOrganization});
         }
@@ -55,8 +40,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkErrataModalC
         $scope.table.initialLoad = false;
         $scope.initialLoad = true;
         $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
-        $scope.remoteExecutionByDefault = BastionConfig.remoteExecutionByDefault;
-        $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
         $scope.allHostsSelected = hostIds.allResultsSelected;
         $scope.hostToolingEnabled = BastionConfig.hostToolingEnabled;
         $scope.newHostDetailsUI = newHostDetailsUI;
@@ -92,43 +75,19 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkErrataModalC
         };
 
         $scope.installErrata = function () {
-            if ($scope.remoteExecutionByDefault) {
-                $scope.installErrataViaRemoteExecution();
-
-            } else {
-                $scope.installErrataViaKatelloAgent(false);
-            }
-        };
-
-        $scope.installErrataViaKatelloAgent = function () {
-            var params = installParams();
-            HostBulkAction.installContent(params,
-              function (data) {
-                  $scope.nutupane.invalidate();
-                  $scope.ok();
-                  $scope.transitionTo('content-hosts.bulk-task', {taskId: data.id});
-              },
-              function (response) {
-                  angular.forEach(response.data.errors, function (error) {
-                      Notification.setErrorMessage(error);
-                  });
-              });
+            $scope.installErrataViaRemoteExecution();
         };
 
         $scope.selectedErrataIds = function () {
-            return $scope.nutupane.getAllSelectedResults('errata_id');
+            return $scope.table.getSelected();
         };
 
         $scope.installErrataViaRemoteExecution = function(customize) {
             var errataIds = $scope.selectedErrataIds();
-            $scope.errataActionFormValues.bulkErrataIds = angular.toJson(errataIds);
 
             $scope.errataActionFormValues.remoteAction = 'errata_install';
+            $scope.errataActionFormValues.bulkErrataIds = angular.toJson(errataIds);
             $scope.errataActionFormValues.customize = customize;
-
-            $timeout(function () {
-                angular.element('#errataActionForm').submit();
-            }, 0);
         };
 
         $scope.ok = function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-module-streams-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-module-streams-modal.controller.js
@@ -34,7 +34,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkModuleStream
         $scope.moduleStreamsNutupane.primaryOnly = true;
         $scope.table = $scope.moduleStreamsNutupane.table;
         $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
-        $scope.remoteExecutionByDefault = BastionConfig.remoteExecutionByDefault;
 
         $scope.moduleStreamActionFormValues = {
             authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, ''),

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-packages-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-packages-modal.controller.js
@@ -21,32 +21,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkPackagesModa
     ['$scope', '$location', '$timeout', '$window', '$uibModalInstance', 'HostBulkAction', 'CurrentOrganization', 'translate', 'Notification', 'BastionConfig', 'hostIds',
     function ($scope, $location, $timeout, $window, $uibModalInstance, HostBulkAction, CurrentOrganization, translate, Notification, BastionConfig, hostIds) {
 
-        function successMessage(type) {
-            var messages = {
-                install: translate("Successfully scheduled package installation"),
-                update: translate("Successfully scheduled package update"),
-                remove: translate("Successfully scheduled package removal"),
-                "update all": translate("Successfully scheduled an update of all packages")
-            };
-            return messages[type];
-        }
-
-        function installParams() {
-            var params = hostIds;
-            params['content_type'] = $scope.content.contentType;
-            if ($scope.content.action === "update all") {
-                params['update_all'] = true;
-                params.content = null;
-            } else {
-                params.content = $scope.content.content.split(/ *, */);
-            }
-            params['organization_id'] = CurrentOrganization;
-            return params;
-        }
-
         $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
-        $scope.remoteExecutionByDefault = BastionConfig.remoteExecutionByDefault;
-        $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
         $scope.hostToolingEnabled = BastionConfig.hostToolingEnabled;
 
         $scope.packageActionFormValues = {
@@ -74,46 +49,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkPackagesModa
         };
 
         $scope.performContentAction = function () {
-            if ($scope.remoteExecutionByDefault) {
-                $scope.performViaRemoteExecution();
-            } else {
-                $scope.performViaKatelloAgent();
-            }
-        };
-
-        $scope.performViaKatelloAgent = function (action, actionInput) {
-            var success, error, params;
-
-            if (action) {
-                $scope.content.action = action;
-            }
-
-            if (actionInput) {
-                $scope.content.actionInput = actionInput;
-            }
-
-            $scope.content.confirm = false;
-
-            success = function () {
-                Notification.setSuccessMessage(successMessage($scope.content.action));
-            };
-
-            error = function (response) {
-                angular.forEach(response.data.errors, function (responseError) {
-                    Notification.setErrorMessage(responseError);
-                });
-            };
-
-            params = installParams();
-            if ($scope.content.action === "install") {
-                HostBulkAction.installContent(params, success, error);
-            } else if ($scope.content.action === "update") {
-                HostBulkAction.updateContent(params, success, error);
-            } else if ($scope.content.action === "remove") {
-                HostBulkAction.removeContent(params, success, error);
-            } else if ($scope.content.action === "update all") {
-                HostBulkAction.updateContent(params, success, error);
-            }
+            $scope.performViaRemoteExecution();
         };
 
         $scope.performViaRemoteExecution = function(action, customize) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
@@ -27,11 +27,10 @@
       </div>
     </div>
 
-    <div ng-show="katelloAgentPresent" data-extend-template="common/views/katello-agent-notice.html"></div>
     <div bst-feature-flag="remote_actions">
       <p bst-alert="warning" ng-hide="hostToolingEnabled">
         <span translate>
-          Performing host package actions is disabled because Katello is not configured for Remote Execution or Katello Agent.
+          Performing host package actions is disabled because Katello is not configured for Remote Execution.
           </span>
       </p>
     </div>
@@ -58,7 +57,6 @@
           </button>
 
           <ul uib-dropdown-menu class="dropdown-menu-right" role="menu" aria-labelledby="use-remote-execution">
-            <li ng-show="katelloAgentPresent" role="presentation"><a ng-click="installErrataViaKatelloAgent()" role="menuitem" translate>via Katello agent</a></li>
             <li role="presentation"><a ng-click="installErrataViaRemoteExecution(false)" role="menuitem" translate>via remote execution</a></li>
             <li role="presentation"><a ng-click="installErrataViaRemoteExecution(true)" role="menuitem" translate>via remote execution - customize first</a></li>
           </ul>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-packages-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-packages-modal.html
@@ -8,11 +8,10 @@
       </div>
     </div>
 
-    <div ng-show="katelloAgentPresent" data-extend-template="common/views/katello-agent-notice.html"></div>
     <div bst-feature-flag="remote_actions">
       <p bst-alert="warning" ng-hide="hostToolingEnabled">
         <span translate>
-          Performing host package actions is disabled because Katello is not configured for Remote Execution or Katello Agent.
+          Performing host package actions is disabled because Katello is not configured for Remote Execution.
           </span>
       </p>
       <p bst-alert="warning">
@@ -38,7 +37,6 @@
         <span class="caret"></span>
       </button>
       <ul uib-dropdown-menu role="menu" aria-labelledby="install-use-remote-execution">
-        <li ng-show="katelloAgentPresent" role="presentation"><a ng-click="performViaKatelloAgent('update all', content)" role="menuitem" tabindex="-1" href="#" translate>via Katello Agent</a></li>
         <li role="presentation"><a ng-click="performViaRemoteExecution('update all', false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
         <li role="presentation"><a ng-click="performViaRemoteExecution('update all', true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
       </ul>
@@ -99,7 +97,6 @@
           <span class="caret"></span>
         </button>
         <ul uib-dropdown-menu role="menu" aria-labelledby="install-use-remote-execution">
-          <li ng-show="katelloAgentPresent" role="presentation"><a ng-click="performViaKatelloAgent('install', content)" role="menuitem" tabindex="-1" href="#" translate>via Katello Agent</a></li>
           <li role="presentation"><a ng-click="performViaRemoteExecution('install', false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
           <li role="presentation"><a ng-click="performViaRemoteExecution('install', true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
         </ul>
@@ -121,7 +118,6 @@
           <span class="caret"></span>
         </button>
         <ul uib-dropdown-menu role="menu" aria-labelledby="update-use-remote-execution">
-          <li ng-show="katelloAgentPresent" role="presentation"><a ng-click="performViaKatelloAgent('update', content)" role="menuitem" tabindex="-1" href="#" translate>via Katello Agent</a></li>
           <li role="presentation"><a ng-click="performViaRemoteExecution('update', false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
           <li role="presentation"><a ng-click="performViaRemoteExecution('update', true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
         </ul>
@@ -142,7 +138,6 @@
           <span class="caret"></span>
         </button>
         <ul uib-dropdown-menu role="menu" aria-labelledby="remove-use-remote-execution">
-          <li ng-show="katelloAgentPresent" role="presentation"><a ng-click="performViaKatelloAgent('remove', content)" role="menuitem" tabindex="-1" href="#" translate>via Katello Agent</a></li>
           <li role="presentation"><a ng-click="performViaRemoteExecution('remove', false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
           <li role="presentation"><a ng-click="performViaRemoteExecution('remove', true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
         </ul>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
@@ -15,7 +15,6 @@
  * @requires ContentHostsHelper
  * @requires simpleContentAccessEnabled
  * @requires newHostDetailsUI
- * @requires BastionConfig
  *
  * @description
  *   Provides the functionality specific to Content Hosts for use with the Nutupane UI pattern.
@@ -23,8 +22,8 @@
  *   within the table.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostsController',
-    ['$scope', '$q', '$state', '$location', '$uibModal', 'translate', 'Nutupane', 'Host', 'HostBulkAction', 'Notification', 'CurrentOrganization', 'ContentHostsHelper', 'ContentHostsModalHelper', '$httpParamSerializer', 'simpleContentAccessEnabled', 'newHostDetailsUI', 'BastionConfig',
-    function ($scope, $q, $state, $location, $uibModal, translate, Nutupane, Host, HostBulkAction, Notification, CurrentOrganization, ContentHostsHelper, ContentHostsModalHelper, $httpParamSerializer, simpleContentAccessEnabled, newHostDetailsUI, BastionConfig) {
+    ['$scope', '$q', '$state', '$location', '$uibModal', 'translate', 'Nutupane', 'Host', 'HostBulkAction', 'Notification', 'CurrentOrganization', 'ContentHostsHelper', 'ContentHostsModalHelper', '$httpParamSerializer', 'simpleContentAccessEnabled', 'newHostDetailsUI',
+    function ($scope, $q, $state, $location, $uibModal, translate, Nutupane, Host, HostBulkAction, Notification, CurrentOrganization, ContentHostsHelper, ContentHostsModalHelper, $httpParamSerializer, simpleContentAccessEnabled, newHostDetailsUI) {
         var nutupane, params, query;
 
         if ($location.search().search) {
@@ -52,7 +51,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostsController',
         $scope.nutupane = nutupane;
         $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
         $scope.newHostDetailsUI = newHostDetailsUI;
-        $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
 
         // @TODO begin hack necessary because of foreman API bug http://projects.theforeman.org/issues/13877
         $scope.table.sortBy = function (column) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-debs-applicable.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-debs-applicable.controller.js
@@ -30,7 +30,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDebsApplicableCon
             return $scope.getSelectedDebs().join(' ');
         };
 
-        $scope.performDefaultUpdateAction = function () {
+        $scope.performRexUpdate = function () {
             $scope.performViaRemoteExecution('packageUpdate', $scope.getRemoteExecutionCommand(), false);
         };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
@@ -42,8 +42,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
         };
 
         $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
-        $scope.remoteExecutionByDefault = BastionConfig.remoteExecutionByDefault;
-        $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
         $scope.hostToolingEnabled = BastionConfig.hostToolingEnabled;
         $scope.errataActionFormValues = {
             authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, '')
@@ -124,15 +122,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
             return $scope.nutupane.getAllSelectedResults('errata_id');
         };
 
-        $scope.performViaKatelloAgent = function () {
-            var errataIds = $scope.selectedErrataIds();
-            HostErratum.apply({id: $scope.host.id, 'bulk_errata_ids': angular.toJson(errataIds)},
-                               function (task) {
-                                    $scope.table.selectAll(false);
-                                    $scope.transitionTo('content-host.tasks.details', {taskId: task.id});
-                                });
-        };
-
         $scope.performViaRemoteExecution = function(customize) {
             var errataIds = $scope.selectedErrataIds();
 
@@ -148,11 +137,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
         };
 
         $scope.applySelected = function () {
-            if ($scope.remoteExecutionByDefault) {
-                $scope.performViaRemoteExecution(false);
-            } else {
-                $scope.performViaKatelloAgent();
-            }
+            $scope.performViaRemoteExecution(false);
         };
 
         $scope.nutupane.enableSelectAllResults();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-module-streams.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-module-streams.controller.js
@@ -29,7 +29,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostModuleStreamsCont
         $scope.table = $scope.moduleStreamsNutupane.table;
 
         $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
-        $scope.remoteExecutionByDefault = BastionConfig.remoteExecutionByDefault;
         $scope.moduleStreamActionFormValues = {
             authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, ''),
             remoteAction: 'module_stream_action'

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-actions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-actions.controller.js
@@ -12,7 +12,6 @@
 angular.module('Bastion.content-hosts').controller('ContentHostPackagesActionsController',
     ['$scope', '$location', 'BastionConfig', function ($scope, $location, BastionConfig) {
         var packageName = $location.search().package_name;
-        $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
         $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
         $scope.hostToolingEnabled = BastionConfig.hostToolingEnabled;
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-applicable.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-applicable.controller.js
@@ -19,7 +19,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesApplicabl
     function ($scope, $timeout, $window, Package, HostPackage, translate, Nutupane, BastionConfig) {
         var packagesNutupane, openEventInfo;
 
-        $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
         $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
         $scope.hostToolingEnabled = BastionConfig.hostToolingEnabled;
 
@@ -35,16 +34,8 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesApplicabl
             return $scope.getSelectedPackages().join(' ');
         };
 
-        $scope.getKatelloAgentCommand = function () {
-            return $scope.getSelectedPackages().join(',');
-        };
-
-        $scope.performDefaultUpdateAction = function () {
-            if ($scope.remoteExecutionByDefault) {
-                $scope.performViaRemoteExecution('packageUpdate', $scope.getRemoteExecutionCommand(), false);
-            } else {
-                $scope.performViaKatelloAgent('packageUpdate', $scope.getKatelloAgentCommand());
-            }
+        $scope.performRexUpdate = function () {
+            $scope.performViaRemoteExecution('packageUpdate', $scope.getRemoteExecutionCommand(), false);
         };
 
         packagesNutupane = new Nutupane(Package, {'host_id': $scope.$stateParams.hostId, 'packages_restrict_upgradable': true});

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-installed.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-installed.controller.js
@@ -18,8 +18,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesInstalled
     function ($scope, $timeout, $window, HostPackage, translate, Nutupane, BastionConfig) {
         var packagesNutupane;
         $scope.controllerName = 'katello_host_installed_packages';
-
-        $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
         $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
         $scope.hostToolingEnabled = BastionConfig.hostToolingEnabled;
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages.controller.js
@@ -16,8 +16,6 @@
 angular.module('Bastion.content-hosts').controller('ContentHostPackagesController',
     ['$scope', '$timeout', '$window', 'HostPackage', 'translate', 'Nutupane', 'BastionConfig', 'Notification',
     function ($scope, $timeout, $window, HostPackage, translate, Nutupane, BastionConfig, Notification) {
-        var packageActions;
-
         $scope.openEventInfo = function (event) {
             // when the event has label defined, it means it comes
             // from foreman-tasks
@@ -38,7 +36,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesControlle
 
         $scope.working = false;
         $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
-        $scope.remoteExecutionByDefault = BastionConfig.remoteExecutionByDefault;
         $scope.packageActionFormValues = {
             authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, '')
         };
@@ -49,22 +46,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesControlle
         };
 
         $scope.performPackageAction = function (actionType, term) {
-            if ($scope.remoteExecutionByDefault) {
-                $scope.performViaRemoteExecution(actionType, term, false);
-            } else {
-                $scope.performViaKatelloAgent(actionType, term);
-            }
-        };
-
-        $scope.performViaKatelloAgent = function (actionType, term) {
-            var terms = [];
-            if (term === '') {
-                packageActions.updateAll();
-            } else {
-                terms = term.split(/ *, */);
-                packageActions[actionType](terms);
-            }
-            $scope.working = true;
+            $scope.performViaRemoteExecution(actionType, term, false);
         };
 
         $scope.performViaRemoteExecution = function(actionType, term, customize) {
@@ -80,25 +62,5 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesControlle
             }, 0);
         };
 
-        packageActions = {
-            updateAll: function () {
-                HostPackage.updateAll({id: $scope.host.id}, $scope.openEventInfo, $scope.errorHandler);
-            },
-            packageInstall: function (termList) {
-                HostPackage.install({id: $scope.host.id, packages: termList}, $scope.openEventInfo, $scope.errorHandler);
-            },
-            packageUpdate: function (termList) {
-                HostPackage.update({id: $scope.host.id, packages: termList}, $scope.openEventInfo, $scope.errorHandler);
-            },
-            packageRemove: function (termList) {
-                HostPackage.remove({id: $scope.host.id, packages: termList}, $scope.openEventInfo, $scope.errorHandler);
-            },
-            groupInstall: function (termList) {
-                HostPackage.install({id: $scope.host.id, groups: termList}, $scope.openEventInfo, $scope.errorHandler);
-            },
-            groupRemove: function (termList) {
-                HostPackage.remove({id: $scope.host.id, groups: termList}, $scope.openEventInfo, $scope.errorHandler);
-            }
-        };
     }
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-debs-applicable.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-debs-applicable.html
@@ -14,11 +14,11 @@
 
   <div data-block="list-actions" bst-feature-flag="remote_actions">
     <div ng-hide="denied('edit_hosts', host)" class="nutupane-actions fr">
-      <form ng-submit="performDefaultUpdateAction()" role="form">
+      <form ng-submit="performRexUpdate()" role="form">
 
         <span uib-dropdown class="btn-group">
           <button class="btn btn-primary" type="button"
-                  ng-click="performDefaultUpdateAction()"
+                  ng-click="performRexUpdate()"
                   ng-hide="denied('edit_hosts', host)"
                   ng-disabled="working || table.numSelected === 0"
                   translate>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -78,7 +78,6 @@
               <span class="caret"></span>
             </button>
             <ul uib-dropdown-menu role="menu" aria-labelledby="use-remote-execution">
-              <li ng-show="katelloAgentPresent" role="presentation"><a ng-click="performViaKatelloAgent()" role="menuitem" tabindex="-1" href="#" translate>via Katello agent</a></li>
               <li role="presentation"><a ng-click="performViaRemoteExecution(false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
               <li role="presentation"><a ng-click="performViaRemoteExecution(true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
             </ul>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
@@ -48,7 +48,6 @@
                 <span class="caret"></span>
               </button>
               <ul uib-dropdown-menu role="menu" aria-labelledby="use-remote-execution">
-                <li ng-show="katelloAgentPresent" role="presentation"><a ng-click="performViaKatelloAgent(packageAction.actionType, packageAction.term)" role="menuitem" tabindex="-1" href="#" translate>via Katello agent</a></li>
                 <li role="presentation"><a ng-click="performViaRemoteExecution(packageAction.actionType, packageAction.term, false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
                 <li role="presentation"><a ng-click="performViaRemoteExecution(packageAction.actionType, packageAction.term, true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
               </ul>
@@ -59,7 +58,7 @@
         <div class="form-group">
           <button class="btn btn-default" type="button"
                   translate
-                  ng-disabled="working || (!remoteExecutionPresent && !katelloAgentPresent)"
+                  ng-disabled="working || !remoteExecutionPresent"
                   ng-click="updateAll()">
             Update All Packages
           </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
@@ -22,11 +22,11 @@
 
   <div data-block="list-actions" bst-feature-flag="remote_actions">
     <div ng-hide="denied('edit_hosts', host)" class="nutupane-actions fr">
-      <form ng-submit="performDefaultUpdateAction()" role="form">
+      <form ng-submit="performRexUpdate()" role="form">
 
         <span uib-dropdown class="btn-group">
           <button class="btn btn-primary" type="button"
-                  ng-click="performDefaultUpdateAction()"
+                  ng-click="performRexUpdate()"
                   ng-hide="denied('edit_hosts', host)"
                   ng-disabled="working || table.numSelected === 0 || !hostToolingEnabled"
                   translate>
@@ -39,7 +39,6 @@
             <span class="caret"></span>
           </button>
           <ul uib-dropdown-menu role="menu" aria-labelledby="use-remote-execution">
-            <li ng-show="katelloAgentPresent" role="presentation"><a ng-click="performViaKatelloAgent('packageUpdate', getKatelloAgentCommand())" role="menuitem" tabindex="-1" href="#" translate>via Katello agent</a></li>
             <li role="presentation"><a ng-click="performViaRemoteExecution('packageUpdate', getRemoteExecutionCommand(), false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
             <li role="presentation"><a ng-click="performViaRemoteExecution('packageUpdate', getRemoteExecutionCommand(), true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
           </ul>
@@ -48,7 +47,7 @@
         <button class="btn btn-default"
                 type="button"
                 translate
-                ng-disabled="working || (!remoteExecutionPresent && !katelloAgentPresent)"
+                ng-disabled="working || !remoteExecutionPresent"
                 ng-click="updateAll()">
           Update All Packages
         </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
@@ -14,14 +14,13 @@
  * @requires deleteHostOnUnregister
  * @requires ContentHostsHelper
  * @requires simpleContentAccessEnabled
- * @requires BastionConfig
  *
  * @description
  *   Provides the functionality for the content host details action pane.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostDetailsController',
-    ['$scope', '$state', '$q', '$location', 'translate', 'Host', 'HostSubscription', 'Organization', 'CurrentOrganization', 'Notification', 'MenuExpander', 'ApiErrorHandler', 'deleteHostOnUnregister', 'ContentHostsHelper', 'simpleContentAccessEnabled', 'BastionConfig',
-    function ($scope, $state, $q, $location, translate, Host, HostSubscription, Organization, CurrentOrganization, Notification, MenuExpander, ApiErrorHandler, deleteHostOnUnregister, ContentHostsHelper, simpleContentAccessEnabled, BastionConfig) {
+    ['$scope', '$state', '$q', '$location', 'translate', 'Host', 'HostSubscription', 'Organization', 'CurrentOrganization', 'Notification', 'MenuExpander', 'ApiErrorHandler', 'deleteHostOnUnregister', 'ContentHostsHelper', 'simpleContentAccessEnabled',
+    function ($scope, $state, $q, $location, translate, Host, HostSubscription, Organization, CurrentOrganization, Notification, MenuExpander, ApiErrorHandler, deleteHostOnUnregister, ContentHostsHelper, simpleContentAccessEnabled) {
         $scope.menuExpander = MenuExpander;
 
         $scope.getHostStatusIcon = ContentHostsHelper.getHostStatusIcon;
@@ -37,7 +36,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
 
         $scope.purposeAddonsCount = 0;
         $scope.simpleContentAccessEnabled = simpleContentAccessEnabled;
-        $scope.katelloAgentPresent = BastionConfig.katelloAgentPresent;
 
         $scope.panel = {
             error: false,

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
@@ -54,7 +54,6 @@
 
   <nav data-block="navigation">
     <div content-access-mode-banner></div>
-    <div ng-show="katelloAgentPresent" data-extend-template="common/views/katello-agent-notice.html"></div>
     <ul class="nav nav-tabs">
       <li ng-class="{active: isState('content-host.info')}">
         <a translate

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -51,20 +51,6 @@
           </button>
         </dd>
 
-        <dt bst-feature-flag="remote_actions" ng-show="katelloAgentPresent">
-          <span translate>Katello Agent</span>
-        </dt>
-        <dd bst-feature-flag="remote_actions" ng-show="katelloAgentPresent">
-          <span ng-show="host.content_facet_attributes.katello_agent_installed">
-            <span class="{{ getHostStatusIcon(0) }}"></span>
-            <span translate>Installed</span>
-          </span>
-          <span ng-hide="host.content_facet_attributes.katello_agent_installed">
-            <span class="{{ getHostStatusIcon(1) }}"></span>
-            <span translate>Not installed</span>
-          </span>
-        </dd>
-
         <dt ng-show="host.subscription_facet_attributes.virtual_guests" translate>Virtual Guests</dt>
         <dd ng-show="host.subscription_facet_attributes.virtual_guests">
           <a ng-href="/content_hosts?search={{virtualGuestIds(host)}}"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -66,10 +66,6 @@
     </span>
   </div>
 
-  <span data-block="messages">
-    <div ng-show="katelloAgentPresent" data-extend-template="common/views/katello-agent-notice.html"></div>
-  </span>
-
   <span data-block="no-rows-message" translate>
     You currently don't have any Content Hosts, you can register one by clicking the button on the right and following the instructions.
   </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
@@ -43,7 +43,6 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
             $scope.applyingErrata = false;
 
             $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
-            $scope.remoteExecutionByDefault = BastionConfig.remoteExecutionByDefault;
             $scope.errataActionFormValues = {
                 authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, ''),
                 errata: IncrementalUpdate.getErrataIds().join(','),
@@ -144,7 +143,7 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
             $scope.confirmApply = function() {
                 $scope.applyingErrata = true;
                 if ($scope.updates.length === 0) {
-                    if ($scope.remoteExecutionPresent && $scope.remoteExecutionByDefault) {
+                    if ($scope.remoteExecutionPresent) {
                         angular.element('#errataActionForm').submit();
                     } else {
                         applyErrata();

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.test.js
@@ -5,9 +5,6 @@ describe('Controller: ContentHostsBulkErrataModalController', function() {
     beforeEach(module('Bastion.content-hosts', 'Bastion.test-mocks'));
 
     beforeEach(function() {
-        HostBulkAction = {
-            installContent: function() {}
-        };
         translate = function() {};
         CurrentOrganization = 'foo';
         selectedErrata = [1, 2, 3, 4]
@@ -54,16 +51,11 @@ describe('Controller: ContentHostsBulkErrataModalController', function() {
     }));
 
     it("can install errata on multiple content hosts", function () {
-        spyOn(HostBulkAction, 'installContent');
         $scope.installErrata();
 
-        expect(HostBulkAction.installContent).toHaveBeenCalledWith(
-            _.extend(hostIds, {
-                content_type: 'errata',
-                content: [1, 2, 3]
-            }),
-            jasmine.any(Function), jasmine.any(Function)
-        );
+        expect($scope.errataActionFormValues.remoteAction).toEqual('errata_install');
+        expect($scope.errataActionFormValues.bulkHostIds).toBe(angular.toJson({ included: { ids: [1,2,3] }}));
+        expect($scope.errataActionFormValues.bulkErrataIds).toBe(angular.toJson( [1,2,3,4] ));
     });
 
     it("provides a function for closing the modal", function () {

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-packages-modal.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-packages-modal.controller.test.js
@@ -53,115 +53,85 @@ describe('Controller: ContentHostsBulkPackagesModalController', function() {
     it("can install packages on multiple content hosts", function() {
         $scope.content = {
             action: 'install',
-            contentType: 'package',
-            content: 'zip, zsh, xterm'
+            contentType: 'package'
         };
 
+        $scope.remoteExecutionPresent = true;
         spyOn(HostBulkAction, 'installContent');
         $scope.performContentAction();
 
-        expect(HostBulkAction.installContent).toHaveBeenCalledWith(
-            _.extend({}, hostIds, {
-                content_type: $scope.content.contentType,
-                content: $scope.content.content.split(/ *, */)
-            }),
-            jasmine.any(Function), jasmine.any(Function)
-        );
+        expect($scope.packageActionFormValues.remoteAction).toEqual('package_install');
+        expect($scope.packageActionFormValues.bulkHostIds).toBe(angular.toJson({ included: { ids: [1,2,3] }}));
     });
 
     it("can update packages on multiple content hosts", function() {
         $scope.content = {
             action: 'update',
             contentType: 'package',
-            content: 'zip, zsh, xterm'
         };
 
+        $scope.remoteExecutionPresent = true;
         spyOn(HostBulkAction, 'updateContent');
         $scope.performContentAction();
 
-        expect(HostBulkAction.updateContent).toHaveBeenCalledWith(
-            _.extend({}, hostIds, {
-                content_type: $scope.content.contentType,
-                content: $scope.content.content.split(/ *, */)
-            }),
-            jasmine.any(Function), jasmine.any(Function)
-        );
+        expect($scope.packageActionFormValues.remoteAction).toEqual('package_update');
+        expect($scope.packageActionFormValues.bulkHostIds).toBe(angular.toJson({ included: { ids: [1,2,3] }}));
     });
 
     it("can remove packages on multiple content hosts", function() {
         $scope.content = {
             action: 'remove',
             contentType: 'package',
-            content: 'zip, zsh, xterm'
         };
 
+        $scope.remoteExecutionPresent = true;
         spyOn(HostBulkAction, 'removeContent');
         $scope.performContentAction();
 
-        expect(HostBulkAction.removeContent).toHaveBeenCalledWith(
-            _.extend({}, hostIds, {
-                content_type: $scope.content.contentType,
-                content: $scope.content.content.split(/ *, */)
-            }),
-            jasmine.any(Function), jasmine.any(Function)
-        );
+        expect($scope.packageActionFormValues.remoteAction).toEqual('package_remove');
+        expect($scope.packageActionFormValues.bulkHostIds).toBe(angular.toJson({ included: { ids: [1,2,3] }}));
     });
 
     it("can install package groups on multiple content hosts", function() {
         $scope.content = {
             action: 'install',
-            contentType: 'package_group',
-            content: 'Backup Client, Development Tools'
+            contentType: 'package_group'
         };
 
+        $scope.remoteExecutionPresent = true;
         spyOn(HostBulkAction, 'installContent');
         $scope.performContentAction();
 
-        expect(HostBulkAction.installContent).toHaveBeenCalledWith(
-            _.extend({}, hostIds, {
-                content_type: $scope.content.contentType,
-                content: $scope.content.content.split(/ *, */)
-            }),
-            jasmine.any(Function), jasmine.any(Function)
-        );
+        expect($scope.packageActionFormValues.remoteAction).toEqual('group_install');
+        expect($scope.packageActionFormValues.bulkHostIds).toBe(angular.toJson({ included: { ids: [1,2,3] }}));
     });
 
     it("can update package groups on multiple content hosts", function() {
         $scope.content = {
             action: 'update',
-            contentType: 'package_group',
-            content: 'Backup Client, Development Tools'
+            contentType: 'package_group'
         };
 
+        $scope.remoteExecutionPresent = true;
         spyOn(HostBulkAction, 'updateContent');
         $scope.performContentAction();
 
-        expect(HostBulkAction.updateContent).toHaveBeenCalledWith(
-            _.extend({}, hostIds, {
-                content_type: $scope.content.contentType,
-                content: $scope.content.content.split(/ *, */)
-            }),
-            jasmine.any(Function), jasmine.any(Function)
-        );
+        expect($scope.packageActionFormValues.remoteAction).toEqual('group_update');
+        expect($scope.packageActionFormValues.bulkHostIds).toBe(angular.toJson({ included: { ids: [1,2,3] }}));
     });
 
     it("can remove package groups on multiple content hosts", function() {
         $scope.content = {
             action: 'remove',
-            contentType: 'package_group',
-            content: 'Backup Client, Development Tools'
+            contentType: 'package_group'
         };
 
+        $scope.remoteExecutionPresent = true;
         spyOn(HostBulkAction, 'removeContent');
         $scope.performContentAction();
 
-        expect(HostBulkAction.removeContent).toHaveBeenCalledWith(
-            _.extend({}, hostIds, {
-                content_type: $scope.content.contentType,
-                content: $scope.content.content.split(/ *, */)
-            }),
-            jasmine.any(Function), jasmine.any(Function)
-        );
+        expect($scope.packageActionFormValues.remoteAction).toEqual('group_remove');
+        expect($scope.packageActionFormValues.bulkHostIds).toBe(angular.toJson({ included: { ids: [1,2,3] }}));
     });
 
     it("provides a function for closing the modal", function () {

--- a/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
@@ -103,20 +103,9 @@ describe('Controller: ContentHostErrataController', function() {
         expect($scope.controllerName).toBe("katello_errata");
     });
 
-    it("provide a way to apply errata", function() {
-        var bulk_errata_ids = angular.toJson({included: { ids: [mockErratum.errata_id], params: {} }});
-
-        spyOn(HostErratum, "apply").and.callThrough();
-        spyOn($scope.table, "selectAll");
-        spyOn($scope, "transitionTo");
-        $scope.applySelected();
-        expect(HostErratum.apply).toHaveBeenCalledWith({id: host.id, bulk_errata_ids: bulk_errata_ids}, jasmine.any(Function));
-        expect($scope.transitionTo).toHaveBeenCalledWith('content-host.tasks.details', {taskId: mockTask.id});
-        expect($scope.table.selectAll).toHaveBeenCalledWith(false);
-    });
-
     it("can apply errata with remote execution", function() {
-        $scope.remoteExecutionByDefault = true;
+        // Removed the test to apply errata because this one now covers it with REX being the only way
+        $scope.remoteExecutionPresent = true;
 
         $scope.applySelected();
 

--- a/engines/bastion_katello/test/content-hosts/content/content-host-packages-applicable.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-packages-applicable.controller.test.js
@@ -37,7 +37,6 @@ describe('Controller: ContentHostPackagesApplicableController', function() {
         $scope.openEventInfo = function(){};
         $scope.errorHandler = function(){};
         $scope.performViaRemoteExecution = function() {};
-        $scope.performViaKatelloAgent = function() {};
         Package = $injector.get('MockResource').$new();
 
 
@@ -60,18 +59,10 @@ describe('Controller: ContentHostPackagesApplicableController', function() {
         expect($scope.getSelectedPackages()[0]).toBe("foo-3-14.noarch");
     });
 
-    it("performs default action as appropriate for katello agent", function() {
-        spyOn($scope, 'performViaKatelloAgent');
-        $scope.remoteExecutionByDefault = false;
-        $scope.performDefaultUpdateAction();
-
-        expect($scope.performViaKatelloAgent).toHaveBeenCalledWith('packageUpdate', $scope.getKatelloAgentCommand());
-    });
-
     it("performs default action as appropriate for rex", function() {
         spyOn($scope, 'performViaRemoteExecution');
-        $scope.remoteExecutionByDefault = true;
-        $scope.performDefaultUpdateAction();
+        $scope.remoteExecutionPresent = true;
+        $scope.performRexUpdate();
 
         expect($scope.performViaRemoteExecution).toHaveBeenCalledWith('packageUpdate', $scope.getRemoteExecutionCommand(), false);
     });

--- a/engines/bastion_katello/test/content-hosts/content/content-host-packages.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-packages.controller.test.js
@@ -58,43 +58,35 @@ describe('Controller: ContentHostPackagesController', function() {
     });
 
     it("performs a package update", function() {
-        spyOn(HostPackage, 'update');
+        $scope.remoteExecutionPresent = true;
         $scope.performPackageAction('packageUpdate', 'foo');
-        expect(HostPackage.update).toHaveBeenCalledWith({id: mockHost.id, packages: ["foo"]},
-                                                          jasmine.any(Function), jasmine.any(Function));
-        expect($scope.working).toBe(true);
+        expect($scope.packageActionFormValues.package).toBe('foo');
+        expect($scope.packageActionFormValues.remoteAction).toBe('packageUpdate');
+        expect($scope.packageActionFormValues.bulkHostIds).toBe(angular.toJson({ included: { ids: [23434] }}));
+        expect($scope.packageActionFormValues.customize).toBe(false);
     });
 
     it("performs a package update with multiple packages", function() {
-        spyOn(HostPackage, 'update');
-        $scope.performPackageAction('packageUpdate', 'foo, bar');
-        expect(HostPackage.update).toHaveBeenCalledWith({id: mockHost.id, packages: ["foo", "bar"]},
-                                                          jasmine.any(Function), jasmine.any(Function));
-        expect($scope.working).toBe(true);
+        $scope.remoteExecutionPresent = true;
+        $scope.performPackageAction('packageUpdate', 'foo bar');
+        expect($scope.packageActionFormValues.package).toBe('foo bar');
+        expect($scope.packageActionFormValues.remoteAction).toBe('packageUpdate');
+        expect($scope.packageActionFormValues.bulkHostIds).toBe(angular.toJson({ included: { ids: [23434] }}));
+        expect($scope.packageActionFormValues.customize).toBe(false);
     });
 
     it("performs a package group install", function() {
-        spyOn(HostPackage, 'install');
+        $scope.remoteExecutionPresent = true;
         $scope.performPackageAction('groupInstall', 'bigGroup');
-        expect(HostPackage.install).toHaveBeenCalledWith({id: mockHost.id, groups: ["bigGroup"]},
-                                                          jasmine.any(Function), jasmine.any(Function));
-        expect($scope.working).toBe(true);
-    });
-
-    it("provides a way to upgrade all packages", function() {
-        $scope.katelloAgentPresent = true;
-        $scope.remoteExecutionPresent = false;
-        $scope.remoteExecutionByDefault = false;
-        spyOn(HostPackage, "updateAll");
-        $scope.updateAll();
-        expect(HostPackage.updateAll).toHaveBeenCalledWith({id: mockHost.id}, jasmine.any(Function),
-            jasmine.any(Function));
-        expect($scope.working).toBe(true);
+        expect($scope.packageActionFormValues.package).toBe('bigGroup');
+        expect($scope.packageActionFormValues.remoteAction).toBe('groupInstall');
+        expect($scope.packageActionFormValues.bulkHostIds).toBe(angular.toJson({ included: { ids: [23434] }}));
+        expect($scope.packageActionFormValues.customize).toBe(false);
     });
 
     it("provides a way to upgrade all packages via remoteExecution", function() {
+        // Removed the test to update all packages because this one now covers it with REX being the only way
         $scope.remoteExecutionPresent = true;
-        $scope.remoteExecutionByDefault = true;
         spyOn(HostPackage, "updateAll");
         $scope.updateAll();
         expect(HostPackage.updateAll).not.toHaveBeenCalled();
@@ -106,21 +98,12 @@ describe('Controller: ContentHostPackagesController', function() {
 
     it("performs a package install via remoteExecution", function() {
         $scope.remoteExecutionPresent = true;
-        $scope.remoteExecutionByDefault = true;
         spyOn(HostPackage, 'install');
         $scope.performPackageAction('packageInstall', 'foo, bar, baz');
         expect(HostPackage.install).not.toHaveBeenCalled();
         expect($scope.packageActionFormValues.package).toEqual('foo bar baz');
         expect($scope.packageActionFormValues.remoteAction).toEqual('packageInstall');
         expect($scope.packageActionFormValues.bulkHostIds).toEqual('{"included":{"ids":[' + mockHost.id + ']}}');
-        expect($scope.working).toBe(true);
-    });
-
-    it("performs a multi package install via katello agent", function() {
-        spyOn(HostPackage, 'install');
-        $scope.performPackageAction('packageInstall', 'foo, bar, baz');
-        expect(HostPackage.install).toHaveBeenCalledWith({id: mockHost.id, packages: ["foo","bar","baz"]},
-                                                          jasmine.any(Function), jasmine.any(Function));
         expect($scope.working).toBe(true);
     });
 });

--- a/engines/bastion_katello/test/errata/apply-errata.controller.test.js
+++ b/engines/bastion_katello/test/errata/apply-errata.controller.test.js
@@ -6,7 +6,7 @@ describe('Controller: ApplyErrataController', function() {
 
     beforeEach(inject(function($injector, $window) {
         $controller = $injector.get('$controller'),
-        BastionConfig = { remoteExecutionPresent: false, remoteExecutionByDefault: false }
+        BastionConfig = { remoteExecutionPresent: false }
         $window.AUTH_TOKEN = 'secret_token';
 
         translate = function (string) {
@@ -81,7 +81,7 @@ describe('Controller: ApplyErrataController', function() {
 
     it("can apply errata with remote execution", function () {
         var bulkContentHosts;
-        dependencies.BastionConfig = { remoteExecutionPresent: true, remoteExecutionByDefault: true }
+        dependencies.BastionConfig = { remoteExecutionPresent: true }
 
         bulkContentHosts = {
             included: {


### PR DESCRIPTION
Will fill this out when I get the tests green, pushing up to see the mess that I caused. Locally there is like 13 failures.

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Todo:
- [x] Put back rex in carrot menu
- [x] (Update performDefaultUpdateAction function name)
- [x] (Remove bulk errata kagent stuff)
- [x] (Fix Tests after fixing last 2 items)