### PR TITLE
Fixes #36654 - Remove dead content_view_solve_dependencies setting

### DIFF
--- a/engines/bastion/app/views/bastion/layouts/assets.html.erb
+++ b/engines/bastion/app/views/bastion/layouts/assets.html.erb
@@ -25,7 +25,6 @@
     angular.module('Bastion').value('deleteHostOnUnregister', angular.fromJson(`<%= Setting[:unregister_delete_host] %>`));
     angular.module('Bastion').value('globalContentProxy', angular.fromJson(`<%= Setting[:content_default_http_proxy].empty? ? nil.to_json : Setting[:content_default_http_proxy].to_json.html_safe %>`));
     angular.module('Bastion').value('entriesPerPage', "<%= Setting[:entries_per_page] %>");
-    angular.module('Bastion').value('contentViewSolveDependencies', "<%= Setting[:content_view_solve_dependencies] %>");
     angular.module('Bastion').constant('BastionConfig', angular.fromJson(`<%= Bastion.config.to_json.html_safe %>`));
     angular.module('Bastion.auth').value('CurrentUser', {
         id: <%= User.current.id %>,

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -612,12 +612,6 @@ Foreman::Plugin.register :katello do
         full_name: N_('Expire soon days'),
         description: N_('The number of days remaining in a subscription before you will be reminded about renewing it.')
 
-      setting 'content_view_solve_dependencies',
-        type: :boolean,
-        default: false,
-        full_name: N_('content view Dependency Solving Default'),
-        description: N_('The default dependency solving value for new content views.')
-
       setting 'host_dmi_uuid_duplicates',
         type: :array,
         default: [],


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

1. Remove the setting `content_view_solve_dependencies`, which was previously used to set whether depsolving was enabled by default for new content views, but now is apparently not used anymore.
2. Remove reference to this setting in bastion_katello

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Verify that the setting "content view Dependency Solving Default" is no longer there
