### PR TITLE
Fixes #36667 - Hammer host update should fail non-existent LCE

### DIFF
--- a/app/controllers/katello/concerns/content_facet_hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/content_facet_hosts_controller_extensions.rb
@@ -9,14 +9,12 @@ module Katello
           return unless @host&.content_facet.present? && params[:host]&.[](:content_facet_attributes)&.present?
           cv_id = params[:host][:content_facet_attributes].delete(:content_view_id)
           env_id = params[:host][:content_facet_attributes].delete(:lifecycle_environment_id)
-          Rails.logger.info "set_up_content_view_environment: cv_id=#{cv_id}, env_id=#{env_id}"
-          if (cv_id.present? && env_id.present?)
-            @host.content_facet.assign_single_environment(
-              lifecycle_environment_id: env_id,
-              content_view_id: cv_id
-            )
-            Rails.logger.info "set_up_content_view_environment: done"
-          end
+          Rails.logger.info "#{__method__}: cv_id=#{cv_id}, env_id=#{env_id}"
+          @host.content_facet.assign_single_environment(
+            lifecycle_environment_id: env_id,
+            content_view_id: cv_id
+          )
+          Rails.logger.info "#{__method__}: done"
         end
       end
     end

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -71,6 +71,44 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_equal target_cve, host.content_facet.content_view_environments.first
   end
 
+  def test_host_update_with_env_only
+    host = FactoryBot.create(:host, :with_content, :with_subscription,
+                              :content_view => @content_view, :lifecycle_environment => @environment)
+    put :update, params: {
+      :id => host.id,
+      :content_facet_attributes => {
+        :lifecycle_environment_id => @dev.id
+      }
+    }, session: set_session_user
+    assert_response :error
+  end
+
+  def test_host_update_with_cv_only
+    host = FactoryBot.create(:host, :with_content, :with_subscription,
+                              :content_view => @content_view, :lifecycle_environment => @environment)
+    put :update, params: {
+      :id => host.id,
+      :content_facet_attributes => {
+        :content_view_id => @cv2.id
+      }
+    }, session: set_session_user
+    assert_response :error
+  end
+
+  def test_host_update_with_invalid_env
+    host = FactoryBot.create(:host, :with_content, :with_subscription,
+                              :content_view => @content_view, :lifecycle_environment => @environment)
+    @dev.destroy
+    put :update, params: {
+      :id => host.id,
+      :content_facet_attributes => {
+        :content_view_id => @cv2.id,
+        :lifecycle_environment_id => @dev.id
+      }
+    }, session: set_session_user
+    assert_response :error
+  end
+
   def test_with_subscriptions
     host = FactoryBot.create(:host, :with_subscription)
     host_index_and_show(host)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fixed a bug with hammer host update when `--lifecycle-environment-id` or `--content-view-id` is missing.
  
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Have a host registered to the Satellite
2. Run `hammer host update --id <host_id> --lifecycle-environment-id 999999`

**Before** 
`Host updated.`

**After**
```
$ hammer host update --id 3 --lifecycle-environment-id 999999
[ERROR 2023-08-09T22:00:25 Exception] Content view must be specified
```
```
$ hammer host update --id 3 --content-view-id 1111
[ERROR 2023-08-09T22:01:34 Exception] Lifecycle environment must be specified
```
```
$ hammer host update --id 3 --lifecycle-environment-id 999999 --content-view-id 888
[ERROR 2023-08-09T21:06:19 Exception] Validation failed: Content view environments must have both a content view and an environment
```
```
$ hammer -d host update --id 3 --lifecycle-environment-id 999999 --content-view-id 1
[ERROR 2023-08-09T21:58:09 Exception] Validation failed: Content view environments must have both a content view and an environment, Default_Organization_View could not be promoted to  because the conte     nt view and the environment are not in the same organization!
```


