### PR TITLE
Fixes #36670 - Events incorrectly marked as In Progress

### DIFF
--- a/app/services/katello/event_queue.rb
+++ b/app/services/katello/event_queue.rb
@@ -34,8 +34,16 @@ module Katello
     end
 
     def self.mark_in_progress(event)
-      ::Katello::Event.where(:in_progress => false, :object_id => event.object_id, :event_type => event.event_type).
-                       update_all(:in_progress => true)
+      query = ::Katello::Event.where(
+        in_progress: false,
+        object_id: event.object_id,
+        event_type: event.event_type
+      )
+
+      # Don't mark future events as in progress!
+      query = query.where('process_after <= ?', event.process_after) if event.process_after
+
+      query.update_all(in_progress: true)
     end
 
     def self.reset_in_progress


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Fixes an issue with events having an `process_after` date being incorrectly marked in progress, but not being handled.

#### Considerations taken when implementing this change?

Try not to break stuff

#### What are the testing steps for this pull request?

I found this in the context of the DeleteHostAgentQueue event, but it could affect others. I think other events using the retry mechanism should be considered - ie was this bug benefiting or hurting their behavior inadvertently.

Easily tested by using subman to register your local Katello:
- Register twice, back to back (or at least in the 10 minute window where the DeleteHostAgentQueue event is waiting to fire)
- Check Katello::Event.all and see the two events with future process_after dates
- Go make a coffee / come back in 11 minutes
- Look at Katello::Event.all - the first event was handled, but the second is still there and marked in_progress

I'm not familiar with the entire impact of this bug, but it's definitely not desired. These events will eventually be processed but not until the Event Daemon is restarted ie Katello is restarted :(