### PR TITLE
Fixes #36674 - don't update Candlepin consumer when force-reregistering

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -61,6 +61,10 @@ module Katello
         self.cves_changed = true
       end
 
+      def mark_cves_unchanged
+        self.cves_changed = false
+      end
+
       def cves_changed?
         cves_changed
       end

--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -317,6 +317,8 @@ module Katello
           host.content_facet.uuid = nil
           host.content_facet.content_view_environments = []
           host.content_facet.save!
+          Rails.logger.debug "remove_host_artifacts: marking CVEs unchanged to prevent backend update"
+          host.content_facet.mark_cves_unchanged
           host.content_facet.calculate_and_import_applicability
         end
 

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -261,7 +261,7 @@ module Katello
       def test_registration_existing_host
         @host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @content_view,
                                    :lifecycle_environment => @library, :organization => @content_view.organization)
-        @host.expects(:update_candlepin_associations).twice
+        @host.expects(:update_candlepin_associations)
         ::Katello::Resources::Candlepin::Consumer.expects(:destroy)
         ::Katello::Host::SubscriptionFacet.any_instance.expects(:update_hypervisor).twice
         ::Katello::Host::SubscriptionFacet.any_instance.expects(:update_guests).twice
@@ -291,7 +291,6 @@ module Katello
         @host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @content_view,
                                    :lifecycle_environment => @library, :organization => @content_view.organization)
         ::Katello.expects(:with_katello_agent?).returns(true)
-        @host.expects(:update_candlepin_associations)
         ::Katello::Resources::Candlepin::Consumer.expects(:destroy)
         ::Katello::EventQueue.expects(:push_event)
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Mark CVEs unchanged in `remove_host_artifacts`. This prevents `backend_update_needed?` from erroneously returning `true` during the process of host removal.

This was manifesting when you do a force reregister with subscription-manager without having consumer certs.


#### Considerations taken when implementing this change?

I considered passing around some sort of `destroying_host?` variable instead, but that seemed like too many hops to me, and reminded me of React prop drilling.

#### What are the testing steps for this pull request?

```
rm -rf /etc/pki/consumer/*
subscription-manager register --force --username=admin --password=changeme --org=Default_Organization --environment=Library
```

**Before**: The first attempt fails with 
```
Registering to: centos8-katello-devel-stable.example.com:443/rhsm
Unit 547cf5fd-3ff0-44d9-b26c-5944bbbb9fbd has been deleted (HTTP error code 410: Gone)
```

The second attempt succeeds.

**After**: All attempts succeed.

also test other registration flows and make sure nothing is broken

