### PR TITLE
Fixes #36679 - Sort CV versions when adding component views

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -178,6 +178,10 @@ module Katello
       content_view_components.map(&:latest_version).compact.freeze
     end
 
+    def sorted_versions
+      versions.order('created_at DESC')
+    end
+
     # Adds content view components based on the input
     # [{:content_view_version_id=>1, :latest=> false}, {:content_view_id=>1, :latest=> true} ..]
     def add_components(components_to_add)

--- a/app/models/katello/content_view_component.rb
+++ b/app/models/katello/content_view_component.rb
@@ -32,7 +32,7 @@ module Katello
     end
 
     def component_content_view_versions
-      self.content_view&.versions
+      self.content_view&.versions&.order(created_at: :desc)
     end
 
     private

--- a/app/views/katello/api/v2/content_views/base.json.rabl
+++ b/app/views/katello/api/v2/content_views/base.json.rabl
@@ -64,7 +64,7 @@ else
   attributes :repository_ids
 end
 
-child :versions => :versions do
+child :sorted_versions => :versions do
   attributes :id, :version
   attributes :created_at => :published
   attributes :description

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
@@ -54,6 +54,7 @@ const ContentViewComponents = ({ cvId, details }) => {
   const [componentCvEditing, setComponentCvEditing] = useState(null);
   const [componentLatest, setComponentLatest] = useState(false);
   const [componentId, setComponentId] = useState(null);
+  const [componentVersionId, setComponentVersionId] = useState(null);
   const [selectedComponentsToAdd, setSelectedComponentsToAdd] = useState(null);
   const [bulkAdding, setBulkAdding] = useState(false);
   const [bulkActionOpen, setBulkActionOpen] = useState(false);
@@ -86,6 +87,11 @@ const ContentViewComponents = ({ cvId, details }) => {
       setVersionEditing(true);
       setCompositeCvEditing(cvId);
       setComponentCvEditing(componentCvId);
+      if (added) {
+        setComponentVersionId(published?.id);
+      } else {
+        setComponentVersionId(null);
+      }
       setComponentLatest(latest);
       setComponentId(added);
     } else { // if no versions are present, default to always latest and add cv without modal
@@ -297,6 +303,7 @@ const ContentViewComponents = ({ cvId, details }) => {
               componentCvId={componentCvEditing}
               componentId={componentId}
               latest={componentLatest}
+              componentVersionId={componentVersionId}
               show={versionEditing}
               setIsOpen={setVersionEditing}
               aria-label="edit_component_modal"

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.fixtures.json
@@ -128,10 +128,10 @@
       },
       "component_content_view_versions": [
         {
-          "id": 36,
-          "version": "1.0",
-          "description": "Version 1.0",
-          "published_at_words": "5 days"
+          "id": 44,
+          "version": "4.0",
+          "description": "Version 4.0",
+          "published_at_words": "3 days"
         },
         {
           "id": 42,
@@ -140,10 +140,10 @@
           "published_at_words": "4 days"
         },
         {
-          "id": 44,
-          "version": "4.0",
-          "description": "Version 4.0",
-          "published_at_words": "3 days"
+          "id": 36,
+          "version": "1.0",
+          "description": "Version 1.0",
+          "published_at_words": "5 days"
         }
       ]
     },

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.test.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.test.js
@@ -201,7 +201,7 @@ test('Can add published component views to content view with modal', async (done
 
   const addComponentParams = {
     compositeContentViewId: 4,
-    components: [{ content_view_version_id: 85 }],
+    components: [{ content_view_version_id: 13 }],
   };
 
   const addComponentScope = nockInstance

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/publishedContentViewDetails.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/publishedContentViewDetails.fixtures.json
@@ -139,214 +139,60 @@
   "repositories": [],
   "versions": [
     {
-      "id": 52,
-      "version": "1.0",
-      "published": "2021-06-22 06:07:43 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 53,
-      "version": "2.0",
-      "published": "2021-06-22 06:09:02 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 54,
-      "version": "3.0",
-      "published": "2021-06-22 06:09:33 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 55,
-      "version": "4.0",
-      "published": "2021-06-22 06:29:29 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 56,
-      "version": "5.0",
-      "published": "2021-06-22 06:29:56 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 57,
+      "id": 13,
       "version": "6.0",
-      "published": "2021-06-22 06:30:29 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 58,
-      "version": "7.0",
-      "published": "2021-06-22 06:32:10 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 59,
-      "version": "8.0",
-      "published": "2021-06-22 06:38:01 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 60,
-      "version": "9.0",
-      "published": "2021-06-22 06:41:03 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 61,
-      "version": "10.0",
-      "published": "2021-06-22 06:53:06 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 62,
-      "version": "11.0",
-      "published": "2021-06-22 06:55:03 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 63,
-      "version": "12.0",
-      "published": "2021-06-22 06:57:47 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 64,
-      "version": "13.0",
-      "published": "2021-06-22 06:58:13 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 65,
-      "version": "14.0",
-      "published": "2021-06-22 06:58:44 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 66,
-      "version": "15.0",
-      "published": "2021-06-22 07:00:51 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 67,
-      "version": "16.0",
-      "published": "2021-06-22 07:02:35 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 68,
-      "version": "17.0",
-      "published": "2021-06-22 07:03:15 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 69,
-      "version": "18.0",
-      "published": "2021-06-22 07:12:38 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 70,
-      "version": "19.0",
-      "published": "2021-06-22 07:38:55 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 71,
-      "version": "20.0",
-      "published": "2021-06-22 07:39:27 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 72,
-      "version": "21.0",
-      "published": "2021-06-22 08:09:53 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 73,
-      "version": "22.0",
-      "published": "2021-06-22 08:10:23 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 74,
-      "version": "23.0",
-      "published": "2021-06-22 09:24:48 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 75,
-      "version": "24.0",
-      "published": "2021-06-22 09:28:09 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 76,
-      "version": "25.0",
-      "published": "2021-06-22 09:31:50 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 77,
-      "version": "26.0",
-      "published": "2021-06-22 09:33:03 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 78,
-      "version": "27.0",
-      "published": "2021-06-22 09:34:31 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 79,
-      "version": "28.0",
-      "published": "2021-06-22 09:35:00 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 80,
-      "version": "29.0",
-      "published": "2021-06-22 09:35:18 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 81,
-      "version": "30.0",
-      "published": "2021-06-22 10:55:48 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 83,
-      "version": "31.0",
-      "published": "2021-06-22 10:58:09 -1000",
-      "environment_ids": []
-    },
-    {
-      "id": 84,
-      "version": "32.0",
-      "published": "2021-06-22 10:58:37 -1000",
+      "published": "2023-08-11 10:32:48 -0400",
+      "description": "aaa",
       "environment_ids": [
-        8,
-        10,
-        11,
-        12,
-        13
-      ]
+        1
+      ],
+      "filters_applied": false,
+      "published_at_words": "3 days"
     },
     {
-      "id": 85,
-      "version": "33.0",
-      "published": "2021-06-22 11:03:15 -1000",
-      "environment_ids": [
-        1,
-        5,
-        6,
-        7,
-        9
-      ]
+      "id": 12,
+      "version": "5.0",
+      "published": "2023-08-11 10:32:22 -0400",
+      "description": "aa",
+      "environment_ids": [],
+      "filters_applied": false,
+      "published_at_words": "3 days"
+    },
+    {
+      "id": 11,
+      "version": "4.0",
+      "published": "2023-08-11 10:31:12 -0400",
+      "description": "aa",
+      "environment_ids": [],
+      "filters_applied": false,
+      "published_at_words": "3 days"
+    },
+    {
+      "id": 9,
+      "version": "3.0",
+      "published": "2023-08-10 13:47:47 -0400",
+      "description": "ab",
+      "environment_ids": [],
+      "filters_applied": false,
+      "published_at_words": "4 days"
+    },
+    {
+      "id": 8,
+      "version": "2.0",
+      "published": "2023-08-10 13:47:09 -0400",
+      "description": "",
+      "environment_ids": [],
+      "filters_applied": false,
+      "published_at_words": "4 days"
+    },
+    {
+      "id": 7,
+      "version": "1.0",
+      "published": "2023-08-10 13:46:58 -0400",
+      "description": "",
+      "environment_ids": [],
+      "filters_applied": false,
+      "published_at_words": "4 days"
     }
   ],
   "components": [],


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Sorts versions for component CVs in the Composite CV -> Add/Bulk Add/Edit Component CVs modals in descending order.
#### Considerations taken when implementing this change?
Without the sorting, the versions in the component CV add modals are in random order in single add/ and ascending order in bulk modal. 
#### What are the testing steps for this pull request?
Have a few CVs and publish a few versions of each.
Create a composite CV and go to Content view subtab in the Composite CV.
Try single add(row action)/ bulk add(From table action button)/Edit(From pencil icon on added CV row version)
Make sure the versions for component CV in the dropdown are correctly sorted with latest version first down to the earliest version in correct order.