### PR TITLE
Fixes #36684 - allow single_content_view in ContentFacet::Jail

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -380,7 +380,8 @@ module Katello
         allow :applicable_deb_count, :applicable_module_stream_count, :applicable_rpm_count, :content_source, :content_source_id, :content_source_name,
               :errata_counts, :id, :kickstart_repository, :kickstart_repository_id, :kickstart_repository_name,
               :upgradable_deb_count, :upgradable_module_stream_count, :upgradable_rpm_count, :uuid,
-              :installable_security_errata_count, :installable_bugfix_errata_count, :installable_enhancement_errata_count
+              :installable_security_errata_count, :installable_bugfix_errata_count, :installable_enhancement_errata_count,
+              :single_content_view, :single_lifecycle_environment
       end
     end
   end

--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -278,7 +278,7 @@ module Katello
       prop_group :katello_basic_props, Katello::Model, meta: { friendly_name: 'Katello Environment' }
     end
     class Jail < ::Safemode::Jail
-      allow :name, :label
+      allow :id, :name, :label
     end
 
     private


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Allow single_content_view in ContentFacet::Jail

Otherwise the Ansible Inventory report template doesn't render properly when Safe Mode is on.

Same for single_lifecycle_environment and KTEnvironment#id.

#### Considerations taken when implementing this change?

none

#### What are the testing steps for this pull request?

1. have a Katello with at least one system that has a content facet and safe mode on
2. render the "Ansible Inventory" report and it should not fail anymore