### PR TITLE
consume katello repo from koji when doing packit builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -36,7 +36,7 @@ jobs:
         additional_repos:
           - http://koji.katello.org/releases/yum/foreman-nightly/el8/x86_64/
           - http://yum.theforeman.org/plugins/nightly/el8/x86_64/
-          - http://yum.theforeman.org/katello/nightly/katello/el8/x86_64/
+          - http://koji.katello.org/releases/yum/katello-nightly/katello/el8/x86_64/
     module_hotfixes: true
 
 srpm_build_deps:


### PR DESCRIPTION
otherwise dependencies are sometimes out of date if nightly is red

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
