### PR TITLE
Fixes #36690 - Validate *all* products before saving to sync plans

### DIFF
--- a/app/controllers/katello/api/v2/sync_plans_controller.rb
+++ b/app/controllers/katello/api/v2/sync_plans_controller.rb
@@ -8,6 +8,7 @@ module Katello
                                                                :add_products, :remove_products]
     before_action :set_organization, :only => [:update, :show, :destroy, :sync,
                                                :add_products, :remove_products]
+    before_action :validate_sync_plan_products, :only => [:update, :add_products, :remove_products]
 
     def_param_group :sync_plan do
       param :name, String, :desc => N_("sync plan name"), :required => true, :action_aware => true
@@ -126,6 +127,10 @@ module Katello
 
     def set_organization
       @organization ||= @sync_plan.try(:organization)
+    end
+
+    def validate_sync_plan_products
+      @sync_plan.validate_and_update_products force_update: true
     end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds a validate_and_update_products method to sync plans which runs a complete validation of all products of sync plan to remove any possible invalid products left around due to errors in product deletion/repository disable actions etc for any reason. 
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
To test, you'll have to create invalid data to reproduce the error. To do so, you'll need to disable a validation on sync plans model.
1. Comment out the line `validate :product_enabled` like `#validate :product_enabled`
2. Restart the server.
3. Make sure your org has a valid subscription and create a sync plan (Menu > Content> Sync Plans) to run the following steps on. 
4.In foreman-rake console:
Do this:
```
sync_plan = Katello::SyncPlan.first
sync_plan.product_ids = [1,2,3,4]
sync_plan.save!
```
5. Uncomment the  `#validate :product_enabled` like  `validate :product_enabled`
6. Restart server
7. Try enabling a couple redhat products (Content > Redhat repositories > Enable some random products, don't have to sync or anything) and adding them to the sync plan above.
8. See the error on master branch.
9. With changes above, you should be able to correct the sync plan and see messages in foreman log when sync plan is updated.