### PR TITLE
Fixes #36695 - remove docker_tags_whitelist

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -50,7 +50,6 @@ Pass [] to make repo available for clients regardless of OS version. Maximum len
       param :unprotected, :bool, :desc => N_("true if this repository can be published via HTTP")
       param :checksum_type, String, :desc => N_("Checksum of the repository, currently 'sha1' & 'sha256' are supported")
       param :docker_upstream_name, String, :desc => N_("Name of the upstream docker repository")
-      param :docker_tags_whitelist, Array, :desc => N_("Comma-separated list of tags to sync for Container Image repository (Deprecated)"), :deprecated => true
       param :include_tags, Array, :desc => N_("Comma-separated list of tags to sync for a container image repository")
       param :exclude_tags, Array, :desc => N_("Comma-separated list of tags to exclude when syncing a container image repository. Default: any tag ending in \"-source\"")
       param :download_policy, ["immediate", "on_demand"], :desc => N_("download policy for yum, deb, and docker repos (either 'immediate' or 'on_demand')")
@@ -588,7 +587,7 @@ Alternatively, use the 'force' parameter to regenerate metadata locally. On the 
               {:os_versions => []}, :deb_releases, :deb_components, :deb_architectures, :description,
               :http_proxy_policy, :http_proxy_id, :retain_package_versions_count, {:ignorable_content => []}
              ]
-      keys += [{:docker_tags_whitelist => []}, {:include_tags => []}, {:exclude_tags => []}, :docker_upstream_name] if params[:action] == 'create' || @repository&.docker?
+      keys += [{:include_tags => []}, {:exclude_tags => []}, :docker_upstream_name] if params[:action] == 'create' || @repository&.docker?
       keys += [:ansible_collection_requirements, :ansible_collection_auth_url, :ansible_collection_auth_token] if params[:action] == 'create' || @repository&.ansible_collection?
       keys += [:label, :content_type] if params[:action] == "create"
 
@@ -628,11 +627,7 @@ Alternatively, use the 'force' parameter to regenerate metadata locally. On the 
                                                             :metadata_expire).to_h.with_indifferent_access)
       root.docker_upstream_name = repo_params[:docker_upstream_name] if repo_params[:docker_upstream_name]
       if root.docker?
-        if repo_params[:docker_tags_whitelist].present?
-          root.include_tags = repo_params.fetch(:docker_tags_whitelist, [])
-        else
-          root.include_tags = repo_params.fetch(:include_tags, [])
-        end
+        root.include_tags = repo_params.fetch(:include_tags, [])
       end
       root.exclude_tags = repo_params.fetch(:exclude_tags, ['*-source']) if root.docker?
       root.verify_ssl_on_sync = ::Foreman::Cast.to_bool(repo_params[:verify_ssl_on_sync]) if repo_params.key?(:verify_ssl_on_sync)

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -178,7 +178,7 @@ module Katello
              :upstream_authentication_token, :deb_releases,
              :deb_components, :deb_architectures, :ssl_ca_cert_id, :ssl_ca_cert, :ssl_client_cert, :ssl_client_cert_id,
              :ssl_client_key_id, :os_versions, :ssl_client_key, :ignorable_content, :description, :include_tags, :exclude_tags,
-             :docker_tags_whitelist, :ansible_collection_requirements, :ansible_collection_auth_url, :ansible_collection_auth_token,
+             :ansible_collection_requirements, :ansible_collection_auth_url, :ansible_collection_auth_token,
              :http_proxy_policy, :http_proxy_id, :to => :root
 
     delegate :content_id, to: :root, allow_nil: true

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -3,7 +3,6 @@ module Katello
   class RootRepository < Katello::Model
     audited :except => [:content_id]
     serialize :ignorable_content
-    serialize :docker_tags_whitelist
     serialize :include_tags
     serialize :exclude_tags
     serialize :os_versions
@@ -358,11 +357,6 @@ module Katello
 
     def content
       Katello::Content.find_by(:cp_content_id => self.content_id, :organization_id => self.product.organization_id)
-    end
-
-    # For API support during deprecation period.
-    def docker_tags_whitelist
-      include_tags
     end
 
     def docker?

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -7,7 +7,6 @@ extends 'katello/api/v2/repositories/base'
 glue(@resource.root) do
   attributes :content_type
   attributes :docker_upstream_name
-  attributes :docker_tags_whitelist
   attributes :include_tags
   attributes :exclude_tags
   attributes :verify_ssl_on_sync


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Removes remaining traces of docker_tags_whitelist

#### Considerations taken when implementing this change?
Should only be backported to 4.10. 4.9 and below need this attribute to work.

#### What are the testing steps for this pull request?
1) Ensure that docker_tags_whitelist cannot be updated on a repository
2) Ensure updating include_tags and exclude_tags on a container repo still work.