### PR TITLE
Refs #35573 - Improve UX when enabling Tracer

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -8,6 +8,9 @@ module Katello
       HOST_TOOLS_PACKAGE_NAME = 'katello-host-tools'.freeze
       HOST_TOOLS_TRACER_PACKAGE_NAME = 'katello-host-tools-tracer'.freeze
       SUBSCRIPTION_MANAGER_PACKAGE_NAME = 'subscription-manager'.freeze
+      ALL_TRACER_PACKAGE_NAMES = [ "python-#{HOST_TOOLS_TRACER_PACKAGE_NAME}",
+                                   "python3-#{HOST_TOOLS_TRACER_PACKAGE_NAME}",
+                                   HOST_TOOLS_TRACER_PACKAGE_NAME ].freeze
 
       belongs_to :kickstart_repository, :class_name => "::Katello::Repository", :inverse_of => :kickstart_content_facets
       belongs_to :content_source, :class_name => "::SmartProxy", :inverse_of => :content_facets
@@ -304,12 +307,12 @@ module Katello
       end
 
       def tracer_installed?
-        self.host.installed_packages.where("#{Katello::InstalledPackage.table_name}.name" => [ "python-#{HOST_TOOLS_TRACER_PACKAGE_NAME}",
-                                                                                               "python3-#{HOST_TOOLS_TRACER_PACKAGE_NAME}",
-                                                                                               HOST_TOOLS_TRACER_PACKAGE_NAME ]).any? ||
-          self.host.installed_debs.where("#{Katello::InstalledDeb.table_name}.name" => [ "python-#{HOST_TOOLS_TRACER_PACKAGE_NAME}",
-                                                                                         "python3-#{HOST_TOOLS_TRACER_PACKAGE_NAME}",
-                                                                                         HOST_TOOLS_TRACER_PACKAGE_NAME ]).any?
+        self.host.installed_packages.where("#{Katello::InstalledPackage.table_name}.name" => ALL_TRACER_PACKAGE_NAMES).any? ||
+          self.host.installed_debs.where("#{Katello::InstalledDeb.table_name}.name" => ALL_TRACER_PACKAGE_NAMES).any?
+      end
+
+      def tracer_rpm_available?
+        ::Katello::Rpm.yum_installable_for_host(self.host).where(name: ALL_TRACER_PACKAGE_NAMES).any?
       end
 
       def host_tools_installed?

--- a/app/views/katello/api/v2/content_facet/show.json.rabl
+++ b/app/views/katello/api/v2/content_facet/show.json.rabl
@@ -25,6 +25,10 @@ child :content_facet => :content_facet_attributes do
     content_facet.tracer_installed?
   end
 
+  node :katello_tracer_rpm_available do |content_facet|
+    content_facet.tracer_rpm_available?
+  end
+
   user = User.current # current_user is not available here
   child :permissions do
     node(:view_lifecycle_environments) { user.can?("view_lifecycle_environments") }

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.js
@@ -9,17 +9,24 @@ import {
   Dropdown,
   DropdownItem,
   DropdownToggle,
+  Text,
+  TextContent,
+  TextList,
+  TextListItem,
+  Alert,
 } from '@patternfly/react-core';
-import { CaretDownIcon } from '@patternfly/react-icons';
+import { CaretDownIcon, ArrowRightIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { useSelector } from 'react-redux';
 import { selectAPIResponse } from 'foremanReact/redux/API/APISelectors';
 import { katelloPackageInstallUrl } from '../customizedRexUrlHelpers';
 import { KATELLO_TRACER_PACKAGE } from './HostTracesConstants';
+import './EnableTracerModal.scss';
 
-const EnableTracerModal = ({ isOpen, setIsOpen, triggerJobStart }) => {
+const EnableTracerModal = ({
+  isOpen, setIsOpen, triggerJobStart, tracerRpmAvailable,
+}) => {
   const title = __('Enable Tracer');
-  const body = __('Enabling will install the katello-host-tools-tracer package on the host.');
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [buttonLoading, setButtonLoading] = useState(false);
   const toggleDropdownOpen = () => setIsDropdownOpen(prev => !prev);
@@ -41,6 +48,57 @@ const EnableTracerModal = ({ isOpen, setIsOpen, triggerJobStart }) => {
     triggerJobStart();
     handleClose();
   };
+
+  const body = (
+    <TextContent>
+      <Text ouiaId="enable-tracer-modal-text" id="enable-tracer-modal-p">
+        {__('Enabling Tracer requires installing the katello-host-tools-tracer package on the host.')}
+      </Text>
+      {!tracerRpmAvailable && (
+        <>
+          <Alert
+            ouiaId="enable-tracer-modal-prereq-text"
+            variant="warning"
+            isInline
+            title={__('Before continuing, ensure that all of the following prerequisites are met:')}
+          />
+          <TextList className="enable-tracer-modal-prereq-list">
+            <TextListItem>
+              {__('The Foreman Client repository is enabled. ')}
+              <a onClick={() => setButtonLoading(true)} href="/redhat_repositories" id="enable-tracer-enable-red-hat-repos-link">
+                {__('Enable Red Hat repositories')}
+              </a>
+              <ArrowRightIcon />
+            </TextListItem>
+            <TextListItem>
+              {__('The Foreman Client repository is synced. ')}
+              <a onClick={() => setButtonLoading(true)} href="/katello/sync_management" id="enable-tracer-sync-status-link">
+                {__('View sync status')}
+              </a>
+              <ArrowRightIcon />
+            </TextListItem>
+            <TextListItem>
+              {__('The Foreman Client repository is available in the host\'s content view environment(s). ')}
+              <a onClick={() => setButtonLoading(true)} href="/content_views" id="enable-tracer-cv-link">
+                {__('View content views')}
+              </a>
+              <ArrowRightIcon />
+            </TextListItem>
+            <TextListItem id="enable-repo-sets-p">
+              {__('The Foreman Client repository set is enabled for the host. ')}
+              <a onClick={() => setButtonLoading(true)} href="#/Content/Repository%20sets" id="enable-tracer-reposets-link">
+                {__('Enable repository sets')}
+              </a>
+              <ArrowRightIcon />
+            </TextListItem>
+            <TextListItem>
+              {__('Remote execution is enabled.')}
+            </TextListItem>
+          </TextList>
+        </>
+      )}
+    </TextContent>
+  );
 
   const dropdownItems = dropdownOptions.map(text => (
     <DropdownItem key={`option_${text}`} ouiaId={`option_${text}`} onClick={() => setSelectedOption(text)}>{text}</DropdownItem>
@@ -86,7 +144,7 @@ const EnableTracerModal = ({ isOpen, setIsOpen, triggerJobStart }) => {
       variant={ModalVariant.small}
       title={title}
       ouiaId="enable-tracer-modal"
-      width="28em"
+      width="46em"
       isOpen={isOpen}
       onClose={handleClose}
       actions={[
@@ -96,7 +154,14 @@ const EnableTracerModal = ({ isOpen, setIsOpen, triggerJobStart }) => {
     >
       <Flex direction={{ default: 'column' }}>
         <FlexItem>{body}</FlexItem>
-        <FlexItem><div>{__('Select a provider to install katello-host-tools-tracer')}</div></FlexItem>
+        <FlexItem>
+          <TextContent>
+            <Text ouiaId="enable-tracer-modal-provider-text">
+              {tracerRpmAvailable ? __('Select a provider to install katello-host-tools-tracer') :
+                __('Once the prerequisites are met, select a provider to install katello-host-tools-tracer')}
+            </Text>
+          </TextContent>
+        </FlexItem>
         <FlexItem>
           <Dropdown
             ouiaId="enable-tracer-modal-dropdown"
@@ -126,6 +191,7 @@ EnableTracerModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   setIsOpen: PropTypes.func.isRequired,
   triggerJobStart: PropTypes.func.isRequired,
+  tracerRpmAvailable: PropTypes.bool.isRequired,
 };
 
 export default EnableTracerModal;

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.scss
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.scss
@@ -1,0 +1,16 @@
+.pf-c-content {
+  ul {
+      margin-top: 1rem;
+      li svg {
+        margin-right: 0.3rem;
+        margin-left: 0.3rem;
+      }
+      }
+  #enable-tracer-modal-p {
+    width: 32rem;
+  }
+}
+
+#enable-repo-sets-p {
+  width: 28rem;
+}

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesEnabler.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesEnabler.js
@@ -53,7 +53,7 @@ EnableTracerButton.propTypes = {
   pollingStarted: PropTypes.bool.isRequired,
 };
 
-const TracesEnabler = ({ hostname }) => {
+const TracesEnabler = ({ hostname, tracerRpmAvailable }) => {
   const title = __('Traces are not enabled');
   const enablingTitle = __('Traces are being enabled');
   const body = __('Traces help administrators identify applications that need to be restarted after a system is patched.');
@@ -91,9 +91,11 @@ const TracesEnabler = ({ hostname }) => {
         </Flex>
       </EmptyStateBody>
       <EnableTracerModal
+        key={hostname}
         isOpen={enableTracerModalOpen}
         setIsOpen={setEnableTracerModalOpen}
         triggerJobStart={triggerJobStart}
+        tracerRpmAvailable={tracerRpmAvailable}
       />
     </EmptyState>
   );
@@ -101,6 +103,7 @@ const TracesEnabler = ({ hostname }) => {
 
 TracesEnabler.propTypes = {
   hostname: PropTypes.string.isRequired,
+  tracerRpmAvailable: PropTypes.bool.isRequired,
 };
 
 export default TracesEnabler;

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
@@ -36,6 +36,7 @@ const TracesTab = () => {
   } = hostDetails;
   const showActions = can(invokeRexJobs, userPermissionsFromHostDetails({ hostDetails }));
   const showEnableTracer = (contentFacetAttributes?.katello_tracer_installed === false);
+  const tracerRpmAvailable = contentFacetAttributes?.katello_tracer_rpm_available;
   const emptyContentTitle = showActions ? __('No applications to restart') : __('Traces not available');
   const tracesNotAvailBody = showEnableTracer ? __('Traces may be enabled by a user with the appropriate permissions.') :
     __('Traces will be shown here to a user with the appropriate permissions.');
@@ -180,7 +181,9 @@ const TracesTab = () => {
 
   ) : null;
   const status = useSelector(state => selectHostTracesStatus(state));
-  if (showEnableTracer && showActions) return <TracesEnabler hostname={hostname} />;
+  if (showEnableTracer && showActions) {
+    return <TracesEnabler hostname={hostname} tracerRpmAvailable={tracerRpmAvailable} />;
+  }
 
   if (!hostId) return <Skeleton />;
 

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
@@ -31,6 +31,7 @@ const tracerNotInstalledResponse = {
   ...tracerInstalledResponse,
   content_facet_attributes: {
     katello_tracer_installed: false,
+    katello_tracer_rpm_available: false,
   },
 };
 
@@ -393,6 +394,30 @@ describe('Without tracer installed', () => {
     expect(queryByText('via remote execution')).not.toBeInTheDocument();
 
     assertNockRequest(jobInvocationScope, done);
+  });
+
+  test('Detects if tracer package is not available to install', async () => {
+    const { getByText, queryByText }
+      = renderWithRedux(<TracesTab />, renderOptions(false));
+
+    await patientlyWaitFor(() => expect(queryByText('Traces are not enabled')).toBeInTheDocument());
+    const enableTracesButton = getByText('Enable Traces');
+    enableTracesButton.click();
+
+    expect(getByText('Before continuing, ensure that all of the following prerequisites are met:')).toBeInTheDocument();
+  });
+
+  test('Detects when tracer package is available to install', async () => {
+    tracerNotInstalledResponse.content_facet_attributes.katello_tracer_rpm_available = true;
+
+    const { getByText, queryByText }
+      = renderWithRedux(<TracesTab />, renderOptions(false));
+
+    await patientlyWaitFor(() => expect(queryByText('Traces are not enabled')).toBeInTheDocument());
+    const enableTracesButton = getByText('Enable Traces');
+    enableTracesButton.click();
+
+    expect(queryByText('Before continuing, ensure that all of the following prerequisites are met:')).not.toBeInTheDocument();
   });
 
   test('Can enable tracer via customized remote execution', async () => {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Detect if the `katello-host-tools-tracer` package can be installed on the host.

If it's available, and REX is working, then things should go smoothly when you click 'Enable Tracer.'  But if it's not available, one of two things is the case:

1. One or more of the prerequisites to install the package have not been met; _or_
2. All the prerequisites have been met, but the host hasn't yet uploaded a new package profile and recalculated the installed / available package list.

Because of no. 2 above, we're never 100% sure that clicking 'Enable Tracer' is going to fail. But we can _at least_ remind you about the prerequisites if we're showing that the package isn't yet available.

So, if the package isn't listed in the host's `yum_installable` packages, we show this:
![image](https://github.com/Katello/katello/assets/22042343/043ac354-bd6d-453a-9ac5-710e214ae58f)

And if it is, we skip all of that and show this:
![image](https://github.com/Katello/katello/assets/22042343/d8463ca4-2305-497f-84d7-63a98363a9f9)


#### Considerations taken when implementing this change?

Originally I wanted to do a lot of this for you automatically. But it turned out to be more complex than you might think, since we'd have to do it

* across different OS versions
* across different arches
* also, the repository names & labels are different upstream vs. downstream

So I settled on this compromise.

#### What are the testing steps for this pull request?

Test with two hosts, neither of which has katello-host-tools-tracer installed

* one which has the repo available and enabled
* one which does not
