### PR TITLE
Fixes #36708 - Repair module stream details page breadcrumb bar

### DIFF
--- a/webpack/scenes/ModuleStreams/Details/ModuleStreamDetails.js
+++ b/webpack/scenes/ModuleStreams/Details/ModuleStreamDetails.js
@@ -50,8 +50,7 @@ class ModuleStreamDetails extends Component {
           breadcrumbItems={[
             {
               caption: __('Module Streams'),
-              onClick: () =>
-                this.props.history.push('/module_streams'),
+              url: '/module_streams/',
             },
             {
               caption: `${name} ${stream}`,

--- a/webpack/scenes/ModuleStreams/Details/__tests__/__snapshots__/ModuleStreamDetails.test.js.snap
+++ b/webpack/scenes/ModuleStreams/Details/__tests__/__snapshots__/ModuleStreamDetails.test.js.snap
@@ -109,7 +109,7 @@ exports[`Module stream details page rendering renders with module stream provide
       Array [
         Object {
           "caption": "Module Streams",
-          "onClick": [Function],
+          "url": "/module_streams/",
         },
         Object {
           "caption": "avocado latest",


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
The breadcrumb bar at the top of the module stream details page now has a properly-rendering hyperlink.

#### Considerations taken when implementing this change?
n/a

#### What are the testing steps for this pull request?
1. Launch a Katello instance with valid module streams.
2. Navigate to Content -> Content Types -> Module Streams -> <any stream>
3. The breadcrumb bar in the header should have a visible hyperlink which takes you back to the /module_streams overview page.