### PR TITLE
Fixes #36712 - Add true select all to errata legacy UI

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.controller.js
@@ -35,6 +35,7 @@ angular.module('Bastion.errata').controller('ErrataController',
         }
 
         nutupane = $scope.nutupane = new Nutupane(Erratum, params);
+        nutupane.enableSelectAllResults();
         $scope.controllerName = 'katello_errata';
         $scope.table = nutupane.table;
         $scope.removeRow = nutupane.removeRow;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
@@ -59,6 +59,7 @@
   </div>
 
   <div data-block="table">
+    <div data-extend-template="layouts/select-all-results.html"></div>
     <table class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
       <thead>
         <tr bst-table-head row-select>

--- a/engines/bastion_katello/test/errata/errata.controller.test.js
+++ b/engines/bastion_katello/test/errata/errata.controller.test.js
@@ -22,6 +22,7 @@ describe('Controller: ErrataController', function() {
                 showColumns: function() {}
             };
             this.get = function() {};
+            this.enableSelectAllResults = function () {};
             this.setParams = function (params) {};
             this.getParams = function (params) { return {}; };
             this.refresh = function () {};


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Adding a select all option in the errata legacy UI when you start to select errata on the table

![prerrata](https://github.com/Katello/katello/assets/1518655/6c75c4cb-b8e4-4868-a72d-7303ad8cfbe8)

#### Considerations taken when implementing this change?

* It looks like Bastion does not keep track of records selected when switching pages in the pagination on multiple pages so this is as close to fixing it as I can. I can raise a Redmine issue to try and fix the other areas, but outside of the scope of this PR

#### What are the testing steps for this pull request?

* Sync some repos that have errata in them
* Goto content - Errata and select a few and see if the new select all works
* Change the tab to the next table page and make sure they are all selected still
* Click apply and see if it takes you to the next screen without an error