### PR TITLE
Fixes #36612 - Fix file repo link on product repo page

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
@@ -168,9 +168,9 @@
 
             <span ng-show="repository.content_type == 'file'">
               <div>
-                <span translate>
+                <a translate ui-sref="product.repository.manage-content.files({productId: product.id, repositoryId: repository.id})">
                   {{ repository.content_counts.file || 0 }} Files
-                </span>
+                </a>
               </div>
             </span>
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Fixed the file link in the product repo page

![prfile](https://github.com/Katello/katello/assets/1518655/de90bf96-3a16-4767-a008-614d10595407)


#### What are the testing steps for this pull request?

* Check out the PR
* Create a file repo in a custom product
* Upload a file
* Goto Product > Repositories and see if the content(file) has a link to the file contents
