### PR TITLE
Fixes #36721 - Correctly handles provisioning with HG on discovered hosts page

### DIFF
--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -35,7 +35,7 @@ module Katello
     end
 
     def use_install_media(host, options = {})
-      return true if host&.errors && host.errors.include?(:medium_id)
+      return true if host&.errors && host.errors.include?(:medium_id) && host.medium.present?
       kickstart_repository_id(host, options).blank?
     end
 

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -29,8 +29,8 @@ module Katello
         end
 
         def attributes=(attrs)
-          super
           check_cve_attributes(attrs) unless self.content_facet.blank?
+          super
         end
 
         def update(attrs)

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -29,8 +29,8 @@ module Katello
         end
 
         def attributes=(attrs)
-          check_cve_attributes(attrs)
           super
+          check_cve_attributes(attrs) unless self.content_facet.blank?
         end
 
         def update(attrs)

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -29,7 +29,7 @@ module Katello
         end
 
         def attributes=(attrs)
-          check_cve_attributes(attrs) #unless self.content_facet.blank?
+          check_cve_attributes(attrs) unless self.content_facet.blank?
           super
         end
 

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -29,7 +29,7 @@ module Katello
         end
 
         def attributes=(attrs)
-          check_cve_attributes(attrs) unless self.content_facet.blank?
+          check_cve_attributes(attrs) #unless self.content_facet.blank?
           super
         end
 

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -93,12 +93,13 @@ module Katello
         content_view_environments&.first&.lifecycle_environment
       end
 
+      # rubocop:disable Metrics/CyclomaticComplexity
       def assign_single_environment(
         content_view_id: nil, lifecycle_environment_id: nil, environment_id: nil,
         content_view: nil, lifecycle_environment: nil, environment: nil
       )
         lifecycle_environment_id ||= environment_id || lifecycle_environment&.id || environment&.id || self.single_lifecycle_environment&.id
-        content_view_id ||= content_view&.id  || self.single_content_view&.id
+        content_view_id ||= content_view&.id || self.single_content_view&.id
 
         unless lifecycle_environment_id
           fail _("Lifecycle environment must be specified")

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -97,8 +97,8 @@ module Katello
         content_view_id: nil, lifecycle_environment_id: nil, environment_id: nil,
         content_view: nil, lifecycle_environment: nil, environment: nil
       )
-        lifecycle_environment_id ||= environment_id || lifecycle_environment&.id || environment&.id
-        content_view_id ||= content_view&.id
+        lifecycle_environment_id ||= environment_id || lifecycle_environment&.id || environment&.id || self.single_lifecycle_environment&.id
+        content_view_id ||= content_view&.id  || self.single_content_view&.id
 
         unless lifecycle_environment_id
           fail _("Lifecycle environment must be specified")

--- a/app/views/overrides/activation_keys/_host_media_type_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_media_type_select.html.erb
@@ -1,9 +1,17 @@
-<% media_selection = using_hostgroups_page? ? use_install_media(@hostgroup) : use_install_media(@host, :selected_host_group => @hostgroup)
+<%
+   if using_discovered_hosts_page?
+     media_selection =  use_install_media(@host, :selected_host_group => @host&.hostgroup)
+     kickstart_options = kickstart_repository_options(@host, :selected_host_group => @host&.hostgroup)
+   elsif using_hostgroups_page?
+     media_selection =  use_install_media(@hostgroup)
+     kickstart_options = kickstart_repository_options(@hostgroup)
+   else
+    media_selection = use_install_media(@host, :selected_host_group => @hostgroup)
+     kickstart_options = kickstart_repository_options(@host, :selected_host_group => @hostgroup)
+   end
    install_media_radio  = media_selection ? 'checked="checked"':''
    synced_content_radio  = media_selection ? '' : 'checked="checked"'
    install_media_disabled = os_media.empty? ? 'disabled = true' : ''
-
-   kickstart_options = using_hostgroups_page? ? kickstart_repository_options(@hostgroup) : kickstart_repository_options(@host, :selected_host_group => @hostgroup)
    synced_content_disabled = kickstart_options.empty? ? 'disabled = true' : ''
 %>
 

--- a/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
@@ -7,7 +7,7 @@
      kickstart_options = kickstart_repository_options(@hostgroup)
    else
      kickstart_repo_id = kickstart_repository_id(@host, :selected_host_group => @hostgroup)
-     kickstart_options = kickstart_repository_options(@hostgroup)
+     kickstart_options = kickstart_repository_options(@host, :selected_host_group => @hostgroup)
    end
 
    kickstart_repo_id = 'unset' if kickstart_repo_id.blank?

--- a/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
@@ -1,11 +1,19 @@
 <%
-kickstart_repo_id = using_hostgroups_page? ? kickstart_repository_id(@hostgroup) : kickstart_repository_id(@host, :selected_host_group => @hostgroup)
-kickstart_repo_id = 'unset' if kickstart_repo_id.blank?
-host = using_hostgroups_page? ? @hostgroup : @host
-kickstart_options = kickstart_repository_options(host, :selected_host_group => @hostgroup)
-ks_repo_select_id =  using_hostgroups_page? ? :host_group_kickstart_repository_id : :host_kickstart_repository_id
-ks_repo_select_name =  using_hostgroups_page? ? 'hostgroup[kickstart_repository_id]' : 'host[content_facet_attributes][kickstart_repository_id]'
-ks_repo_select_attr = using_hostgroups_page? ? 'kickstart_repository' : 'content_facet.kickstart_repository'
+   if using_discovered_hosts_page?
+     kickstart_repo_id = kickstart_repository_id(@host, :selected_host_group => @host&.hostgroup)
+     kickstart_options = kickstart_repository_options(@host, :selected_host_group => @host&.hostgroup)
+   elsif using_hostgroups_page?
+     kickstart_repo_id = kickstart_repository_id(@host, :selected_host_group => @host&.hostgroup)
+     kickstart_options = kickstart_repository_options(@hostgroup)
+   else
+     kickstart_repo_id = kickstart_repository_id(@host, :selected_host_group => @hostgroup)
+     kickstart_options = kickstart_repository_options(@hostgroup)
+   end
+
+   kickstart_repo_id = 'unset' if kickstart_repo_id.blank?
+   ks_repo_select_id =  using_hostgroups_page? ? :host_group_kickstart_repository_id : :host_kickstart_repository_id
+   ks_repo_select_name =  using_hostgroups_page? ? 'hostgroup[kickstart_repository_id]' : 'host[content_facet_attributes][kickstart_repository_id]'
+   ks_repo_select_attr = using_hostgroups_page? ? 'kickstart_repository' : 'content_facet.kickstart_repository'
 %>
 
 <% spinner_path = asset_path('spinner.gif') %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
We now correctly set the KS repository options when applying a host group to a discovered host. Prior to this PR the Synced Content would show up as disabled and would not get populated.

#### Considerations taken when implementing this change?
This pr exclusively checks if its on the discovered hosts page and asks the host's hostgroup's kickstart repository id to be chosen when initially populated.

#### What are the testing steps for this pull request?
1. Sync a KS repo
2. Create a HG with the appropriate CV, LCE, OS, ARCH and KS repo
3. Add a discovered host
4. Try to apply the HG to the Discovered Host.

Actual
- You notice that synced media is disabled and not selectable

Expected
-  Synced media is appropriately populated.