### PR TITLE
Fixes #36722 - restore Katello::Ping.packages

### DIFF
--- a/app/models/katello/ping.rb
+++ b/app/models/katello/ping.rb
@@ -2,6 +2,7 @@ module Katello
   class Ping
     OK_RETURN_CODE = 'ok'.freeze
     FAIL_RETURN_CODE = 'FAIL'.freeze
+    PACKAGES = %w(katello candlepin pulp foreman hammer).freeze
 
     class << self
       def services(capsule_id = nil)
@@ -140,6 +141,13 @@ module Katello
         result[:status] = FAIL_RETURN_CODE
         result[:message] = e.message
         result
+      end
+
+      # get package information for katello and its components
+      def packages
+        names = PACKAGES.join("|")
+        packages = `rpm -qa | egrep "#{names}"`
+        packages.split("\n").sort
       end
 
       def pulp_url(capsule_id)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Brings back `Katello::Ping.packages` which was wrongly removed during katello-agent removal.

Instead of removing this, update the package list to not list qpid.

#### Considerations taken when implementing this change?

The data provided is still valuable, so instead of removing it, make it work again.

#### What are the testing steps for this pull request?

Go to `/about` on your Katello installation.
Without the patch, you get a 502, with the patch it works ;-)