### PR TITLE
Fixes #36713 - Fix errata workflow in host collections

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
@@ -79,7 +79,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkErrataModalC
         };
 
         $scope.selectedErrataIds = function () {
-            return $scope.table.getSelected();
+            return $scope.nutupane.getAllSelectedResults('errata_id');
         };
 
         $scope.installErrataViaRemoteExecution = function(customize) {
@@ -88,6 +88,10 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkErrataModalC
             $scope.errataActionFormValues.remoteAction = 'errata_install';
             $scope.errataActionFormValues.bulkErrataIds = angular.toJson(errataIds);
             $scope.errataActionFormValues.customize = customize;
+
+            $timeout(function () {
+                angular.element('#errataActionForm').submit();
+            }, 0);
         };
 
         $scope.ok = function () {

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.test.js
@@ -16,6 +16,9 @@ describe('Controller: ContentHostsBulkErrataModalController', function() {
             };
 
             this.enableSelectAllResults = function () {};
+            this.getAllSelectedResults = function() {
+                return [1, 2, 3, 4]
+             };
             this.setParams = function () {}
         };
 
@@ -51,6 +54,7 @@ describe('Controller: ContentHostsBulkErrataModalController', function() {
     }));
 
     it("can install errata on multiple content hosts", function () {
+        $scope.remoteExecutionPresent = true;
         $scope.installErrata();
 
         expect($scope.errataActionFormValues.remoteAction).toEqual('errata_install');


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* I got to trigger happy with removing stuff for katello-agent and removed too much AngularJS stuff, so the errata form never got submitted.
* I was sending an array instead of a hash so once I fixed the errata form, we got a `deep symbolize_keys` error on an array, so corrected my mistake
* Fixed up a test that I broke when I switched to an array instead of a hash

#### Considerations taken when implementing this change?

* Made sure we transitioned to the rex job for all three buttons
* I didn't test the actual rex since I don't have a client setup with it

#### What are the testing steps for this pull request?

* Check out PR
* Have a client with REX working and some errata that are avail to the host
* Add the host to a host collection
* Apply errata through the host collection bulk window and see if the buttons work
