### PR TITLE
Fixes #36732 - Add a RHEL Lifecycle Status host column

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -483,6 +483,10 @@ module Katello
         @purpose_addons_status_label ||= get_status(::Katello::PurposeAddonsStatus).to_label(options)
       end
 
+      def rhel_lifecycle_global_status
+        @rhel_lifecycle_global_status ||= get_status(::Katello::RhelLifecycleStatus).to_global
+      end
+
       def rhel_lifecycle_status
         @rhel_lifecycle_status ||= get_status(::Katello::RhelLifecycleStatus).status
       end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -272,6 +272,10 @@ Foreman::Plugin.register :katello do
       use_pagelet :hosts_table_column_content, :name
       add_pagelet :hosts_table_column_header, key: :subscription_status, label: _('Subscription status'), sortable: true, class: common_class, width: '10%', export_key: 'subscription_global_status'
       add_pagelet :hosts_table_column_content, key: :subscription_status, class: common_class, callback: ->(host) { host_status_icon(host.subscription_global_status) }
+
+      add_pagelet :hosts_table_column_header, key: :rhel_lifecycle_status, label: _('RHEL Lifecycle status'), sortable: true, class: common_class, width: '10%', export_key: 'rhel_lifecycle_status'
+      add_pagelet :hosts_table_column_content, key: :rhel_lifecycle_status, class: common_class, callback: ->(host) { host_status_icon(host.rhel_lifecycle_global_status) }
+
       add_pagelet :hosts_table_column_header, key: :installable_updates, label: _('Installable updates'), class: common_class, width: '15%',
                   export_data: [:security, :bugfix, :enhancement].map { |kind| CsvExporter::ExportDefinition.new("installable_updates.#{kind}", callback: ->(host) { (host.content_facet_attributes&.errata_counts || {})[kind] }) } +
                                [:rpm, :deb].map { |kind| CsvExporter::ExportDefinition.new("installable_packages.#{kind}", callback: ->(host) { host&.content_facet_attributes&.public_send("upgradable_#{kind}_count".to_sym) || 0 }) }


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds a new  RHEL Lifecycle Status host column in the Host Index page

#### What are the testing steps for this pull request?

- Register rhel host
- Go to Hosts index
- Select Manage Columns and Expand Content
- Notice the new RHEL Lifecycle Status
- Select that
- The Lifecycle status should now show up. 
