### PR TITLE
Fixes #36733 - Disable published redhat repo disable button

### DIFF
--- a/webpack/redux/reducers/RedHatRepositories/enabled.fixtures.js
+++ b/webpack/redux/reducers/RedHatRepositories/enabled.fixtures.js
@@ -55,6 +55,7 @@ export const requestSuccessResponse = Immutable({
         ],
       },
       last_sync: null,
+      content_view_versions: [],
       content_counts: {
         docker_manifest: 0,
         docker_manifest_list: 0,
@@ -95,6 +96,7 @@ export const requestSuccessResponse = Immutable({
         ],
       },
       last_sync: null,
+      content_view_versions: [1],
       content_counts: {
         docker_manifest: 0,
         docker_manifest_list: 0,
@@ -128,6 +130,7 @@ export const successState = Immutable({
       productId: 20,
       releasever: '7.0',
       type: 'yum',
+      canDisable: true,
     },
     {
       arch: 'x86_64',
@@ -139,6 +142,7 @@ export const successState = Immutable({
       productId: 20,
       releasever: '7.1',
       type: 'yum',
+      canDisable: false,
     },
   ],
   searchIsActive: false,

--- a/webpack/redux/reducers/RedHatRepositories/enabled.js
+++ b/webpack/redux/reducers/RedHatRepositories/enabled.js
@@ -31,6 +31,7 @@ const mapRepo = (repo) => {
     orphaned: repo.product.orphaned,
     contentId: parseInt(repo.content_id, 10),
     productId: parseInt(repo.product.id, 10),
+    canDisable: repo.content_view_versions.length === 0,
   });
 };
 

--- a/webpack/scenes/RedHatRepositories/RedHatRepositoriesPage.js
+++ b/webpack/scenes/RedHatRepositories/RedHatRepositoriesPage.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
 import { Grid, Row, Col } from 'react-bootstrap';
 import { Skeleton, Alert } from '@patternfly/react-core';
-import { Button } from 'patternfly-react';
+import { Button, FieldLevelHelp } from 'patternfly-react';
 import { translate as __ } from 'foremanReact/common/I18n';
 import PermissionDenied from 'foremanReact/components/PermissionDenied';
 import { LoadingState } from '../../components/LoadingState';
@@ -96,6 +96,7 @@ class RedHatRepositoriesPage extends Component {
           <Col sm={6} className="enabled-repositories-container">
             <h2>
               {__('Enabled Repositories')}
+              <FieldLevelHelp content={__('Only repositories not published in a content view can be disabled. Published repositories must be deleted from the repository details page.')} />
               <Button
                 ouiaId="export-csv-button"
                 className="pull-right"

--- a/webpack/scenes/RedHatRepositories/__tests__/__snapshots__/RedHatRepositoriesPage.test.js.snap
+++ b/webpack/scenes/RedHatRepositories/__tests__/__snapshots__/RedHatRepositoriesPage.test.js.snap
@@ -81,6 +81,12 @@ exports[`RedHatRepositories page should render 1`] = `
     >
       <h2>
         Enabled Repositories
+        <FieldLevelHelp
+          buttonClass=""
+          content="Only repositories not published in a content view can be disabled. Published repositories must be deleted from the repository details page."
+          placement="top"
+          rootClose={true}
+        />
         <Button
           active={false}
           block={false}

--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepository.js
@@ -62,7 +62,7 @@ class EnabledRepository extends Component {
 
   render() {
     const {
-      name, id, type, orphaned, label,
+      name, id, type, orphaned, label, canDisable,
     } = this.props;
 
     return (
@@ -73,6 +73,7 @@ class EnabledRepository extends Component {
             loading={this.props.loading}
             disableTooltipId={this.disableTooltipId}
             disableRepository={this.disableRepository}
+            canDisable={canDisable}
           />
         }
         leftContent={<RepositoryTypeIcon id={id} type={type} />}
@@ -106,6 +107,7 @@ EnabledRepository.propTypes = {
   loading: PropTypes.bool,
   releasever: PropTypes.string,
   orphaned: PropTypes.bool,
+  canDisable: PropTypes.bool,
   setRepositoryDisabled: PropTypes.func.isRequired,
   loadEnabledRepos: PropTypes.func.isRequired,
   disableRepository: PropTypes.func.isRequired,
@@ -116,6 +118,7 @@ EnabledRepository.defaultProps = {
   orphaned: false,
   search: {},
   loading: false,
+  canDisable: true,
 };
 
 export default EnabledRepository;

--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepositoryContent.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepositoryContent.js
@@ -4,21 +4,29 @@ import cx from 'classnames';
 import { Spinner, OverlayTrigger, Tooltip } from 'patternfly-react';
 import { translate as __ } from 'foremanReact/common/I18n';
 
-const EnabledRepositoryContent = ({ loading, disableTooltipId, disableRepository }) => (
+const EnabledRepositoryContent = ({
+  loading, disableTooltipId, disableRepository, canDisable,
+}) => (
   <Spinner loading={loading} inline>
     <OverlayTrigger
-      overlay={<Tooltip id={disableTooltipId}>{__('Disable')}</Tooltip>}
+      overlay={<Tooltip id={disableTooltipId}>{canDisable ? __('Disable') : __('Cannot be disabled because it is part of a published content view')}</Tooltip>}
       placement="bottom"
       trigger={['hover', 'focus']}
       rootClose={false}
     >
       <button
         onClick={disableRepository}
-        style={{
+        style={canDisable ? {
           backgroundColor: 'initial',
           border: 'none',
           color: '#0388ce',
-        }}
+        } : {
+          backgroundColor: 'initial',
+          border: 'none',
+          color: '#d2d2d2',
+        }
+      }
+        disabled={!canDisable}
       >
         <i className={cx('fa-2x', 'fa fa-minus-circle')} />
       </button>
@@ -30,6 +38,7 @@ EnabledRepositoryContent.propTypes = {
   loading: PropTypes.bool.isRequired,
   disableTooltipId: PropTypes.string.isRequired,
   disableRepository: PropTypes.func.isRequired,
+  canDisable: PropTypes.bool.isRequired,
 };
 
 export default EnabledRepositoryContent;

--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository/__tests__/EnabledRepositoryContent.test.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository/__tests__/EnabledRepositoryContent.test.js
@@ -12,6 +12,7 @@ describe('Enabled Repositories Content Component', () => {
       loading
       disableTooltipId="disable-1"
       disableRepository={mockCallBack}
+      canDisable={false}
     />);
   });
 

--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository/__tests__/__snapshots__/EnabledRepository.test.js.snap
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository/__tests__/__snapshots__/EnabledRepository.test.js.snap
@@ -4,6 +4,7 @@ exports[`Enabled Repositories Component should render 1`] = `
 <ListViewItem
   actions={
     <EnabledRepositoryContent
+      canDisable={true}
       disableRepository={[Function]}
       disableTooltipId="disable-1"
       loading={false}

--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository/__tests__/__snapshots__/EnabledRepositoryContent.test.js.snap
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository/__tests__/__snapshots__/EnabledRepositoryContent.test.js.snap
@@ -16,7 +16,7 @@ exports[`Enabled Repositories Content Component should render 1`] = `
         id="disable-1"
         placement="right"
       >
-        Disable
+        Cannot be disabled because it is part of a published content view
       </Tooltip>
     }
     placement="bottom"
@@ -29,12 +29,13 @@ exports[`Enabled Repositories Content Component should render 1`] = `
     }
   >
     <button
+      disabled={true}
       onClick={[MockFunction]}
       style={
         Object {
           "backgroundColor": "initial",
           "border": "none",
-          "color": "#0388ce",
+          "color": "#d2d2d2",
         }
       }
     >


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Disable disable button on Redhat repositories page when repo has been published to a content view version and can not be disabled.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1. Enable a redhat repo
2. Add it to a CV and publish a version
3. Go to Redhat repository page. Verify that the disable button is disabled.