### PR TITLE
Fixes #36739 - Product without any repo is added to a Sync Plan regardless the error message

### DIFF
--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -34,6 +34,7 @@ module Katello
     validates_lengths_from_database :except => [:label]
     validates :provider_id, :presence => true
     validate :ensure_provider_type_matches_id
+    validate :ensure_no_sync_plans_on_empty_product
     validates_with Validators::KatelloNameFormatValidator, :attributes => :name
     validates_with Validators::KatelloLabelFormatValidator, :attributes => :label
     validates_with Validators::ProductUniqueAttributeValidator, :attributes => :name
@@ -261,6 +262,13 @@ module Katello
       return if errors[:provider_id].any?
       if provider.redhat_provider? && ::Katello::Glue::Candlepin::Product.custom_product_id?(cp_id)
         errors.add(:base, _("Cannot associate a Red Hat provider with a custom product"))
+      end
+    end
+
+    def ensure_no_sync_plans_on_empty_product
+      return if sync_plan_id.nil?
+      if redhat? && !enabled?
+        errors.add(:base, _("Cannot add disabled Red Hat product %s to sync plan!") % name)
       end
     end
   end

--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -24,6 +24,7 @@ module Katello
     validate :validate_sync_date
     validate :product_enabled
     validate :custom_cron_interval_expression
+    validates_associated :products
     validates_with Validators::KatelloNameFormatValidator, :attributes => :name
 
     before_destroy :cancel_recurring_logic
@@ -55,7 +56,7 @@ module Katello
 
     def product_enabled
       products.each do |product|
-        errors.add :base, _("Cannot add product %s because it is disabled.") % product.name unless product.enabled?
+        errors.add :base, _("Cannot add product %s because it is disabled.") % product.name if (product.redhat? && !product.enabled?)
       end
     end
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-add-products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-add-products.controller.js
@@ -57,7 +57,7 @@ angular.module('Bastion.sync-plans').controller('SyncPlanAddProductsController',
 
                 error = function (response) {
                     deferred.reject(response.data.errors);
-                    Notification.setErrorMessage(response.data.errors.base);
+                    Notification.setErrorMessage(response.data.displayMessage);
                     $scope.table.working = false;
                 };
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create an empty product.
2. Try adding empty product to sync plan
3. You should see an error message and product should not get added to sync plan.

Before PR: You'll see an error but the sync plan gets updated despite the error message.