### PR TITLE
Fixes #36748 - fix usage of deb copy api

### DIFF
--- a/app/services/katello/pulp3/api/apt.rb
+++ b/app/services/katello/pulp3/api/apt.rb
@@ -21,7 +21,7 @@ module Katello
         end
 
         def copy_api
-          PulpDebClient::CopyApi.new(api_client)
+          PulpDebClient::DebCopyApi.new(api_client)
         end
       end
     end

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/repository/apt/copy_units_rewrites_missing_content_error.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/repository/apt/copy_units_rewrites_missing_content_error.yml
@@ -1,0 +1,744 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/1.7.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 11 Jan 2024 12:49:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - b84d2ba9756f48b4b1c45e17aa4a5afe
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 11 Jan 2024 12:49:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?name=debian_9
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 11 Jan 2024 12:49:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '486'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f7fcb4a020dc46c69e4564a569f47060
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ZGViL2FwdC80Y2IwNjFmYS0yNjI5LTQzNGMtOThhMi1iZTRlYzA5ZDM5ODkv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyMy0xMi0yMlQxMzozOToyMy40MDU1MTNa
+        IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ZGViL2FwdC80Y2IwNjFmYS0yNjI5LTQzNGMtOThhMi1iZTRlYzA5ZDM5ODkv
+        dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzRjYjA2
+        MWZhLTI2MjktNDM0Yy05OGEyLWJlNGVjMDlkMzk4OS92ZXJzaW9ucy8wLyIs
+        Im5hbWUiOiJkZWJpYW5fOSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5f
+        cmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsfV19
+    http_version: 
+  recorded_at: Thu, 11 Jan 2024 12:49:17 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/4cb061fa-2629-434c-98a2-be4ec09d3989/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 11 Jan 2024 12:49:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9e6e71c3b4d2430fa97378466f52fdf5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM1NzEzMThkLTNiYTAtNDE5
+        MS05MGU3LWI4NjBiY2EwZmE3My8ifQ==
+    http_version: 
+  recorded_at: Thu, 11 Jan 2024 12:49:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/?name=debian_9
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 11 Jan 2024 12:49:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '1003'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 48c1787d1d484c478922b185a54ac6f3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2RlYi9h
+        cHQvZmJkMzIwN2EtYjg5NC00OTBhLThmOWUtZDk4YTA2OTk5NDU5LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjMtMTItMjJUMTM6Mzk6MjMuMTgyMjA2WiIsIm5h
+        bWUiOiJkZWJpYW5fOSIsInVybCI6Imh0dHA6Ly9mdHAuZGViaWFuLm15bWly
+        cm9yLm9yZy9kZWJpYW4iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6
+        bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwi
+        cHVscF9sYWJlbHMiOnt9LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjMtMTIt
+        MjJUMTM6Mzk6MjMuMTgyMjQwWiIsImRvd25sb2FkX2NvbmN1cnJlbmN5Ijpu
+        dWxsLCJtYXhfcmV0cmllcyI6bnVsbCwicG9saWN5Ijoib25fZGVtYW5kIiwi
+        dG90YWxfdGltZW91dCI6MzYwMC4wLCJjb25uZWN0X3RpbWVvdXQiOjYwLjAs
+        InNvY2tfY29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX3JlYWRfdGltZW91
+        dCI6MzYwMC4wLCJoZWFkZXJzIjpudWxsLCJyYXRlX2xpbWl0IjowLCJoaWRk
+        ZW5fZmllbGRzIjpbeyJuYW1lIjoiY2xpZW50X2tleSIsImlzX3NldCI6ZmFs
+        c2V9LHsibmFtZSI6InByb3h5X3VzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0s
+        eyJuYW1lIjoicHJveHlfcGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfSx7Im5h
+        bWUiOiJ1c2VybmFtZSIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InBhc3N3
+        b3JkIiwiaXNfc2V0IjpmYWxzZX1dLCJkaXN0cmlidXRpb25zIjoic3RyZXRj
+        aCIsImNvbXBvbmVudHMiOiJtYWluIiwiYXJjaGl0ZWN0dXJlcyI6ImFtZDY0
+        Iiwic3luY19zb3VyY2VzIjpmYWxzZSwic3luY191ZGVicyI6ZmFsc2UsInN5
+        bmNfaW5zdGFsbGVyIjpmYWxzZSwiZ3Bna2V5IjoiQURGI0ZDU0ZBU0RGJEAk
+        QFpGRERTRyQjJSMlQURTIiwiaWdub3JlX21pc3NpbmdfcGFja2FnZV9pbmRp
+        Y2VzIjpmYWxzZX1dfQ==
+    http_version: 
+  recorded_at: Thu, 11 Jan 2024 12:49:17 GMT
+- request:
+    method: delete
+    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/fbd3207a-b894-490a-8f9e-d98a06999459/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 11 Jan 2024 12:49:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3af18a63756e4e15a7642efa4fcf7120
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMyYmUzZDNmLTQ2NjktNGYy
+        Mi1hNmM4LWNlZTBiMjA1YzgwOS8ifQ==
+    http_version: 
+  recorded_at: Thu, 11 Jan 2024 12:49:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/3571318d-3ba0-4191-90e7-b860bca0fa73/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.39.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 11 Jan 2024 12:49:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '607'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - f4b79909acb444e0b3e1d0d30e3f3bf9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzU3MTMxOGQtM2Jh
+        MC00MTkxLTkwZTctYjg2MGJjYTBmYTczLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDEtMTFUMTI6NDk6MTcuNTE4OTM5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiI5ZTZlNzFjM2I0ZDI0MzBmYTk3Mzc4NDY2
+        ZjUyZmRmNSIsInN0YXJ0ZWRfYXQiOiIyMDI0LTAxLTExVDEyOjQ5OjE3LjU2
+        NDE1NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDEtMTFUMTI6NDk6MTcuNjY2
+        OTEzWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy8wZjY5M2JmNi00ZjJiLTQwNGEtYmZhYS1hNjFmMzEzMGM3MDIvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvNGNiMDYxZmEtMjYyOS00MzRj
+        LTk4YTItYmU0ZWMwOWQzOTg5LyJdfQ==
+    http_version: 
+  recorded_at: Thu, 11 Jan 2024 12:49:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/32be3d3f-4669-4f22-a6c8-cee0b205c809/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.39.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 11 Jan 2024 12:49:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '602'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - cfd25570a1e24837847c4c2ee49e290f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzJiZTNkM2YtNDY2
+        OS00ZjIyLWE2YzgtY2VlMGIyMDVjODA5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDEtMTFUMTI6NDk6MTcuNjM2NTk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwibG9nZ2luZ19jaWQiOiIzYWYxOGE2Mzc1NmU0ZTE1YTc2NDJlZmE0
+        ZmNmNzEyMCIsInN0YXJ0ZWRfYXQiOiIyMDI0LTAxLTExVDEyOjQ5OjE3LjY5
+        OTc2MloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDEtMTFUMTI6NDk6MTcuNzIz
+        NTM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29y
+        a2Vycy80MTdhZTY1NC1kYTk3LTQyYjUtYjYwMC00NTA1YzJlOGY4YzMvIiwi
+        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
+        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9h
+        cGkvdjMvcmVtb3Rlcy9kZWIvYXB0L2ZiZDMyMDdhLWI4OTQtNDkwYS04Zjll
+        LWQ5OGEwNjk5OTQ1OS8iXX0=
+    http_version: 
+  recorded_at: Thu, 11 Jan 2024 12:49:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?name=debian_9
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 11 Jan 2024 12:49:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 904fffcb0c234070b4ed25c93540df57
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 11 Jan 2024 12:49:17 GMT
+- request:
+    method: get
+    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_9_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 11 Jan 2024 12:49:17 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 449f2fc25bb940839ab50d556b343c40
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 11 Jan 2024 12:49:17 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiZGViaWFuXzkiLCJ1cmwiOiJodHRwOi8vZnRwLmRlYmlhbi5t
+        eW1pcnJvci5vcmcvZGViaWFuIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2Nl
+        cnQiOm51bGwsImNsaWVudF9rZXkiOm51bGwsInRsc192YWxpZGF0aW9uIjp0
+        cnVlLCJwcm94eV91cmwiOm51bGwsInByb3h5X3VzZXJuYW1lIjpudWxsLCJw
+        cm94eV9wYXNzd29yZCI6bnVsbCwidXNlcm5hbWUiOm51bGwsInBhc3N3b3Jk
+        IjpudWxsLCJwb2xpY3kiOiJvbl9kZW1hbmQiLCJ0b3RhbF90aW1lb3V0Ijoz
+        NjAwLCJjb25uZWN0X3RpbWVvdXQiOjYwLCJzb2NrX2Nvbm5lY3RfdGltZW91
+        dCI6NjAsInNvY2tfcmVhZF90aW1lb3V0IjozNjAwLCJyYXRlX2xpbWl0Ijow
+        LCJkaXN0cmlidXRpb25zIjoic3RyZXRjaCIsImNvbXBvbmVudHMiOiJtYWlu
+        IiwiYXJjaGl0ZWN0dXJlcyI6ImFtZDY0IiwiZ3Bna2V5IjoiQURGI0ZDU0ZB
+        U0RGJEAkQFpGRERTRyQjJSMlQURTIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 11 Jan 2024 12:49:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/deb/apt/7428c0dc-03e9-4ad5-bb10-15616324fcd3/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '951'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 774b144c49f24f91b7a041d29821a1ac
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9kZWIvYXB0Lzc0
+        MjhjMGRjLTAzZTktNGFkNS1iYjEwLTE1NjE2MzI0ZmNkMy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI0LTAxLTExVDEyOjQ5OjE4LjAyMTQ4MVoiLCJuYW1lIjoi
+        ZGViaWFuXzkiLCJ1cmwiOiJodHRwOi8vZnRwLmRlYmlhbi5teW1pcnJvci5v
+        cmcvZGViaWFuIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGws
+        InRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBf
+        bGFiZWxzIjp7fSwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTAxLTExVDEy
+        OjQ5OjE4LjAyMTQ5NloiLCJkb3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwi
+        bWF4X3JldHJpZXMiOm51bGwsInBvbGljeSI6Im9uX2RlbWFuZCIsInRvdGFs
+        X3RpbWVvdXQiOjM2MDAuMCwiY29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2Nr
+        X2Nvbm5lY3RfdGltZW91dCI6NjAuMCwic29ja19yZWFkX3RpbWVvdXQiOjM2
+        MDAuMCwiaGVhZGVycyI6bnVsbCwicmF0ZV9saW1pdCI6MCwiaGlkZGVuX2Zp
+        ZWxkcyI6W3sibmFtZSI6ImNsaWVudF9rZXkiLCJpc19zZXQiOmZhbHNlfSx7
+        Im5hbWUiOiJwcm94eV91c2VybmFtZSIsImlzX3NldCI6ZmFsc2V9LHsibmFt
+        ZSI6InByb3h5X3Bhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoi
+        dXNlcm5hbWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwYXNzd29yZCIs
+        ImlzX3NldCI6ZmFsc2V9XSwiZGlzdHJpYnV0aW9ucyI6InN0cmV0Y2giLCJj
+        b21wb25lbnRzIjoibWFpbiIsImFyY2hpdGVjdHVyZXMiOiJhbWQ2NCIsInN5
+        bmNfc291cmNlcyI6ZmFsc2UsInN5bmNfdWRlYnMiOmZhbHNlLCJzeW5jX2lu
+        c3RhbGxlciI6ZmFsc2UsImdwZ2tleSI6IkFERiNGQ1NGQVNERiRAJEBaRkRE
+        U0ckIyUjJUFEUyIsImlnbm9yZV9taXNzaW5nX3BhY2thZ2VfaW5kaWNlcyI6
+        ZmFsc2V9
+    http_version: 
+  recorded_at: Thu, 11 Jan 2024 12:49:18 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJuYW1lIjoiZGViaWFuXzkifQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 11 Jan 2024 12:49:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/deb/apt/31ce65a2-3252-47b2-8188-242ea96f96d4/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '434'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 28049a17ee4c44508a66e6424a9aa186
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
+        cHQvMzFjZTY1YTItMzI1Mi00N2IyLTgxODgtMjQyZWE5NmY5NmQ0LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDEtMTFUMTI6NDk6MTguMjQzODA1WiIsInZl
+        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
+        cHQvMzFjZTY1YTItMzI1Mi00N2IyLTgxODgtMjQyZWE5NmY5NmQ0L3ZlcnNp
+        b25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8zMWNlNjVhMi0z
+        MjUyLTQ3YjItODE4OC0yNDJlYTk2Zjk2ZDQvdmVyc2lvbnMvMC8iLCJuYW1l
+        IjoiZGViaWFuXzkiLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9f
+        dmVyc2lvbnMiOm51bGwsInJlbW90ZSI6bnVsbH0=
+    http_version: 
+  recorded_at: Thu, 11 Jan 2024 12:49:18 GMT
+- request:
+    method: post
+    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/31ce65a2-3252-47b2-8188-242ea96f96d4/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2RlYi9hcHQvYWFhYWFhYWEtYWFhYS1hYWFhLWFhYWEtYWFhYWFhYWFh
+        YWFhLyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Thu, 11 Jan 2024 12:49:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '123'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1ecff421a08442e78eaf9c6c4ad59183
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos8-katello-devel-stable.example.com
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      base64_string: |
+        WyJDb3VsZCBub3QgZmluZCB0aGUgZm9sbG93aW5nIGNvbnRlbnQgdW5pdHM6
+        IFsnL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0L2FhYWFhYWFh
+        LWFhYWEtYWFhYS1hYWFhLWFhYWFhYWFhYWFhYS8nXSJd
+    http_version: 
+  recorded_at: Thu, 11 Jan 2024 12:49:18 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/repository/apt_vcr/create_remote_with_http_proxy_creds.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/repository/apt_vcr/create_remote_with_http_proxy_creds.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/deb/apt/
+    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/
     body:
       encoding: UTF-8
       base64_string: |
@@ -22,7 +22,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0/ruby
+      - OpenAPI-Generator/3.0.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -35,13 +35,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 Nov 2023 19:44:41 GMT
+      - Thu, 11 Jan 2024 12:49:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/deb/apt/018bab50-cec5-7cc0-bdf9-f789de17158f/"
+      - "/pulp/api/v3/remotes/deb/apt/12644d79-c993-4513-b085-59713754e9a5/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -54,25 +54,23 @@ http_interactions:
       - nosniff
       Referrer-Policy:
       - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
       Correlation-Id:
-      - 991e57cb8a804126a2f4ad0adeb623ed
+      - 1f252e0174bc48c7878c3e556a6f49aa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9kZWIvYXB0LzAx
-        OGJhYjUwLWNlYzUtN2NjMC1iZGY5LWY3ODlkZTE3MTU4Zi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDIzLTExLTA3VDE5OjQ0OjQxLjY3MDI0NloiLCJuYW1lIjoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9kZWIvYXB0LzEy
+        NjQ0ZDc5LWM5OTMtNDUxMy1iMDg1LTU5NzEzNzU0ZTlhNS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI0LTAxLTExVDEyOjQ5OjE2LjYwMDUyNFoiLCJuYW1lIjoi
         RGViaWFuIDkgYW1kNjQtdGVzdCIsInVybCI6Imh0dHA6Ly9mdHAuZGViaWFu
         Lm15bWlycm9yLm9yZy9kZWJpYW4iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRf
         Y2VydCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6
         Imh0dHBzOi8vbXl0ZXN0LmNvbSIsInB1bHBfbGFiZWxzIjp7fSwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDIzLTExLTA3VDE5OjQ0OjQxLjY3MDI2OFoiLCJk
+        YXN0X3VwZGF0ZWQiOiIyMDI0LTAxLTExVDEyOjQ5OjE2LjYwMDU1NloiLCJk
         b3dubG9hZF9jb25jdXJyZW5jeSI6bnVsbCwibWF4X3JldHJpZXMiOm51bGws
         InBvbGljeSI6Im9uX2RlbWFuZCIsInRvdGFsX3RpbWVvdXQiOjM2MDAuMCwi
         Y29ubmVjdF90aW1lb3V0Ijo2MC4wLCJzb2NrX2Nvbm5lY3RfdGltZW91dCI6
@@ -88,10 +86,10 @@ http_interactions:
         ZXkiOiJBREYjRkNTRkFTREYkQCRAWkZERFNHJCMlIyVBRFMiLCJpZ25vcmVf
         bWlzc2luZ19wYWNrYWdlX2luZGljZXMiOmZhbHNlfQ==
     http_version: 
-  recorded_at: Tue, 07 Nov 2023 19:44:41 GMT
+  recorded_at: Thu, 11 Jan 2024 12:49:16 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel.cannolo.example.com/pulp/api/v3/remotes/deb/apt/018bab50-cec5-7cc0-bdf9-f789de17158f/
+    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/12644d79-c993-4513-b085-59713754e9a5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -99,7 +97,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.0.0/ruby
+      - OpenAPI-Generator/3.0.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -112,7 +110,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 Nov 2023 19:44:41 GMT
+      - Thu, 11 Jan 2024 12:49:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -129,19 +127,17 @@ http_interactions:
       - nosniff
       Referrer-Policy:
       - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
       Correlation-Id:
-      - a4d3f7f279e5475e8a3a4b392811872a
+      - e231eac11033495490897e5f83c55a30
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel.cannolo.example.com
+      - 1.1 centos8-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGJhYjUwLWNmMWMtNzQy
-        MS1iZTZkLTM5MWE0NWE1MGJmZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFjZDc4MWY0LTkxODUtNGU2
+        YS1hMGFiLWE4YWQ5NzA2YWE4MS8ifQ==
     http_version: 
-  recorded_at: Tue, 07 Nov 2023 19:44:41 GMT
+  recorded_at: Thu, 11 Jan 2024 12:49:16 GMT
 recorded_with: VCR 3.0.3

--- a/test/services/katello/pulp3/repository/apt/apt_test.rb
+++ b/test/services/katello/pulp3/repository/apt/apt_test.rb
@@ -12,6 +12,20 @@ module Katello
             @proxy = SmartProxy.pulp_primary
           end
 
+          def test_copy_units_does_not_clear_repo_during_composite_merger
+            service = Katello::Pulp3::Repository::Apt.new(@repo, @proxy)
+            service.expects(:remove_all_content).never
+            service.copy_units([], false)
+          end
+
+          def test_copy_units_rewrites_missing_content_error
+            fake_content_href = '/pulp/api/v3/repositories/deb/apt/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/'
+            service = Katello::Pulp3::Repository::Apt.new(@repo, @proxy)
+            create_repo(@repo, @proxy)
+            error = assert_raises(::Katello::Errors::Pulp3Error) { service.copy_units([fake_content_href], false) }
+            assert_match(/Please run `foreman-rake katello:delete_orphaned_content` to fix the following repository: Debian 9 amd64./, error.message)
+          end
+
           def test_remote_options
             @repo.root.url = "http://foo.com/bar/"
             service = Katello::Pulp3::Repository::Apt.new(@repo, @proxy)

--- a/test/services/katello/pulp3/repository/apt/copy_units_test.rb
+++ b/test/services/katello/pulp3/repository/apt/copy_units_test.rb
@@ -1,0 +1,122 @@
+require 'katello_test_helper'
+
+module Katello
+  module Service
+    class Repository
+      class AptCopyUnitsTest < ::ActiveSupport::TestCase
+        include Katello::Pulp3Support
+
+        def setup
+          @mock_smart_proxy = mock('smart_proxy')
+          @mock_smart_proxy.stubs(:pulp3_support?).returns(true)
+          @mock_smart_proxy.stubs(:pulp2_preferred_for_type?).returns(false)
+          @repo = katello_repositories(:debian_10_amd64)
+
+          @repo_service = @repo.backend_service(@mock_smart_proxy)
+        end
+
+        def test_copy_api_data_dup_does_deep_copy
+          data = PulpDebClient::Copy.new
+          data.config = [
+            { source_repo_version: "a source repo",
+              dest_repo: "a dest repo",
+              content: ["1", "2", "3"],
+              dest_base_version: 0 },
+            { source_repo_version: "another source repo",
+              dest_repo: "another dest repo",
+              content: ["4", "5", "6"],
+              dest_base_version: 1 }
+          ]
+          data.dependency_solving = false
+
+          data_dup = @repo_service.copy_api_data_dup(data)
+
+          refute data.equal?(data_dup)
+        end
+
+        def test_copy_api_data_dup_clears_content
+          data = PulpDebClient::Copy.new
+          data.config = [
+            { source_repo_version: "a source repo",
+              dest_repo: "a dest repo",
+              content: ["1", "2", "3"],
+              dest_base_version: 0 },
+            { source_repo_version: "another source repo",
+              dest_repo: "another dest repo",
+              content: ["4", "5", "6"],
+              dest_base_version: 1 }
+          ]
+          data.dependency_solving = false
+
+          data.config.first[:content] = []
+          data.config.second[:content] = []
+
+          data_dup = @repo_service.copy_api_data_dup(data)
+
+          assert_equal data, data_dup
+        end
+
+        def test_copy_content_chunked_limits_units_copied
+          data = PulpDebClient::Copy.new
+          data.config = []
+
+          content = []
+          30_001.times { |i| content << i }
+
+          3.times { data.config << { content: content } }
+
+          mock_api = "test"
+          Katello::Pulp3::Api::Apt.any_instance.expects(:copy_api).returns(mock_api).times(12)
+          mock_api.stubs(:copy_content).returns("copied")
+
+          @repo_service.copy_content_chunked(data)
+        end
+
+        def test_copy_content_chunked_copies_correct_units
+          data = PulpDebClient::Copy.new
+          data.config = []
+
+          mock_api = "test"
+          Katello::Pulp3::Api::Apt.any_instance.expects(:copy_api).returns(mock_api).times(4)
+
+          3.times do
+            data.config << {
+              source_repo_version: "repo version",
+              dest_repo: "dest repo",
+              content: []
+            }
+          end
+          data.config[0][:content] = (0..9_999).to_a
+          data.config[1][:content] = (10_000..19_999).to_a
+          data.config[2][:content] = (20_000..30_000).to_a
+
+          mock_api.expects(:copy_content).returns("task").once.with do |value|
+            value.config == [{source_repo_version: "repo version", dest_repo: "dest repo", content: (0..9_999).to_a},
+                             {source_repo_version: "repo version", dest_repo: "dest repo", content: []},
+                             {source_repo_version: "repo version", dest_repo: "dest repo", content: []}]
+          end
+
+          mock_api.expects(:copy_content).returns("task").once.with do |value|
+            value.config == [{source_repo_version: "repo version", dest_repo: "dest repo", content: []},
+                             {source_repo_version: "repo version", dest_repo: "dest repo", content: (10_000..19_999).to_a},
+                             {source_repo_version: "repo version", dest_repo: "dest repo", content: []}]
+          end
+
+          mock_api.expects(:copy_content).returns("task").once.with do |value|
+            value.config == [{source_repo_version: "repo version", dest_repo: "dest repo", content: []},
+                             {source_repo_version: "repo version", dest_repo: "dest repo", content: []},
+                             {source_repo_version: "repo version", dest_repo: "dest repo", content: (20_001..30_000).to_a}]
+          end
+
+          mock_api.expects(:copy_content).returns("task").once.with do |value|
+            value.config == [{source_repo_version: "repo version", dest_repo: "dest repo", content: []},
+                             {source_repo_version: "repo version", dest_repo: "dest repo", content: []},
+                             {source_repo_version: "repo version", dest_repo: "dest repo", content: [20_000]}]
+          end
+
+          @repo_service.copy_content_chunked(data)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pulp-Deb does not support dependency-solving.

Also we should use the correct name of the copy-api class.