### PR TITLE
Fixes #36736 - Correct memory fact on HW properties card

### DIFF
--- a/webpack/components/extensions/HostDetails/DetailsTabCards/HwPropertiesCard.js
+++ b/webpack/components/extensions/HostDetails/DetailsTabCards/HwPropertiesCard.js
@@ -10,6 +10,7 @@ import {
   Text,
   TextVariants,
 } from '@patternfly/react-core';
+import { number_to_human_size as NumberToHumanSize } from 'number_helpers';
 import CardTemplate from 'foremanReact/components/HostDetails/Templates/CardItem/CardTemplate';
 import { TranslatedPlural } from '../../../Table/components/TranslatedPlural';
 import { hostIsNotRegistered } from '../hostDetailsHelpers';
@@ -43,7 +44,7 @@ const HwPropertiesCard = ({ isExpandedGlobal, hostDetails }) => {
   const coreSocket = facts?.['cpu::core(s)_per_socket'];
   const reportedFacts = propsToCamelCase(hostDetails?.reported_data || {});
   const totalDisks = reportedFacts?.disksTotal;
-  const memory = facts?.['dmi::memory::maximum_capacity'];
+  const memory = facts?.['memory::memtotal'];
 
   return (
     <CardTemplate
@@ -71,7 +72,9 @@ const HwPropertiesCard = ({ isExpandedGlobal, hostDetails }) => {
         </DescriptionListGroup>
         <DescriptionListGroup>
           <DescriptionListTerm>{__('RAM')}</DescriptionListTerm>
-          <DescriptionListDescription>{memory}</DescriptionListDescription>
+          <DescriptionListDescription>{NumberToHumanSize(memory*1024, {
+          strip_insignificant_zeros: true, precision: 2
+        })}</DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>
           <HostDisks totalDisks={totalDisks} />
@@ -89,7 +92,7 @@ HwPropertiesCard.propTypes = {
       cpuCount: PropTypes.number,
       cpuSockets: PropTypes.number,
       coreSocket: PropTypes.number,
-      memory: PropTypes.string,
+      memory: PropTypes.number,
     }),
     reported_data: PropTypes.shape({
       totalDisks: PropTypes.number,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* We had the wrong param to grab the RAM on the HW properties card so wrong info was being shown
* Corrected to the right value
* This came out of this support thread https://community.theforeman.org/t/hosts-ram-details-buggy/35050/5?u=cintrix84

#### Considerations taken when implementing this change?

* N/A

#### What are the testing steps for this pull request?

* Register a client with 4GB of ram and it should show 5GB (might work with libvirt if not I can give you a test client and test devel box to try it against)
* Apply PR
* Refresh the page and it should show the correct amount.