### PR TITLE
Fixes #36731 - Use facts, not operatingsystem name, to identify RHEL hosts

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -108,8 +108,6 @@ module Katello
         delegate :content_source_id, :single_content_view, :single_lifecycle_environment, :default_environment?, :single_content_view_environment?, :multi_content_view_environment?, :kickstart_repository_id, :bound_repositories,
           :installable_errata, :installable_rpms, to: :content_facet, allow_nil: true
 
-        delegate :rhel_eos_schedule_index, to: :operatingsystem, allow_nil: true
-
         has_many :content_view_environment_content_facets, through: :content_facet, class_name: 'Katello::ContentViewEnvironmentContentFacet'
         has_many :content_view_environments, through: :content_view_environment_content_facets
         has_many :content_views, through: :content_view_environments
@@ -522,6 +520,33 @@ module Katello
       def traces_helpers(search:)
         traces = host_traces.selectable.search_for(search)
         ::Katello::HostTracer.helpers_for(traces)
+      end
+
+      def probably_rhel?
+        # Get the os name from sub-man facts rather than operatingsystem. This is
+        # less likely to have been changed by the user.
+        os_name = facts['distribution::name']
+        # if this fact isn't there, we can ignore it because the host is not "managed"
+        os_name.present? && os_name.start_with?('Red Hat Enterprise Linux')
+      end
+
+      def rhel_eos_schedule_index
+        return nil unless probably_rhel?
+        major = operatingsystem&.major
+        arch_name = architecture&.name
+        return "RHEL#{major}" unless major == "7"
+        case arch_name
+        when "x86_64", nil
+          "RHEL7"
+        when "ppc64le"
+          "RHEL7 (POWER9)"
+        when "aarch64"
+          "RHEL7 (ARM)"
+        when "s390x"
+          "RHEL7 (System z (Structure A))"
+        else
+          "RHEL#{major}"
+        end
       end
 
       def package_names_for_job_template(action:, search:, versions: nil)

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -525,7 +525,7 @@ module Katello
       def probably_rhel?
         # Get the os name from sub-man facts rather than operatingsystem. This is
         # less likely to have been changed by the user.
-        os_name = facts['distribution::name']
+        os_name, = facts('distribution::name').values # only query for that one fact, then get its value
         # if this fact isn't there, we can ignore it because the host is not "managed"
         os_name.present? && os_name.start_with?('Red Hat Enterprise Linux')
       end

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -532,12 +532,10 @@ module Katello
 
       def rhel_eos_schedule_index
         return nil unless probably_rhel?
-        major = operatingsystem&.major
-        arch_name = architecture&.name
+        major = operatingsystem.major
         return "RHEL#{major}" unless major == "7"
+        arch_name = architecture&.name
         case arch_name
-        when "x86_64", nil
-          "RHEL7"
         when "ppc64le"
           "RHEL7 (POWER9)"
         when "aarch64"

--- a/app/models/katello/concerns/operatingsystem_extensions.rb
+++ b/app/models/katello/concerns/operatingsystem_extensions.rb
@@ -44,23 +44,6 @@ module Katello
       def atomic?
         name.match(/.*atomic.*/i)
       end
-
-      def rhel_eos_schedule_index(arch_name: nil)
-        return nil unless name == "RedHat" # using name and not title so we get specifically RHEL, not rebuilds
-        return "RHEL#{major}" unless major == "7"
-        case arch_name
-        when "x86_64", nil
-          "RHEL7"
-        when "ppc64le"
-          "RHEL7 (POWER9)"
-        when "aarch64"
-          "RHEL7 (ARM)"
-        when "s390x"
-          "RHEL7 (System z (Structure A))"
-        else
-          "RHEL#{major}"
-        end
-      end
     end
   end
 end

--- a/app/models/katello/rhel_lifecycle_status.rb
+++ b/app/models/katello/rhel_lifecycle_status.rb
@@ -179,7 +179,7 @@ module Katello
     end
 
     def rhel_eos_schedule_index
-      host&.operatingsystem&.rhel_eos_schedule_index(arch_name: host&.arch&.name)
+      host&.rhel_eos_schedule_index
     end
 
     def to_global(_options = {})
@@ -195,12 +195,12 @@ module Katello
     end
 
     def to_status
-      self.class.to_status(rhel_eos_schedule_index: self.host&.operatingsystem&.rhel_eos_schedule_index)
+      self.class.to_status(rhel_eos_schedule_index: self.host&.rhel_eos_schedule_index)
     end
 
     # this status is only relevant for RHEL
     def relevant?(_options = {})
-      host&.operatingsystem&.rhel_eos_schedule_index
+      host&.rhel_eos_schedule_index.present?
     end
   end
 end

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -424,18 +424,18 @@ module Katello
     let(:host) { FactoryBot.create(:host, :with_subscription) }
 
     def test_probably_rhel?
-      host.expects(:facts).returns({'distribution::name' => 'Red Hat Enterprise Linux', 'distribution::version' => '7.3'})
+      host.expects(:facts).with('distribution::name').returns({'distribution::name' => 'Red Hat Enterprise Linux'})
       assert host.probably_rhel?
     end
 
     def test_probably_not_rhel
-      host.expects(:facts).returns({'distribution::name' => 'CentOS', 'distribution::version' => '7.3'})
+      host.expects(:facts).with('distribution::name').returns({'distribution::name' => 'CentOS'})
       refute host.probably_rhel?
     end
 
     def test_rhel_eos_schedule_index
       os = Operatingsystem.create!(:name => "RedHat", :major => "7", :minor => "3")
-      host.expects(:facts).at_least_once.returns({'distribution::name' => 'Red Hat Enterprise Linux Server', 'distribution::version' => '7.3'})
+      host.expects(:facts).at_least_once.returns({'distribution::name' => 'Red Hat Enterprise Linux Server'})
       host.operatingsystem = os
       host.architecture = architectures(:x86_64)
       host.architecture.expects(:name).at_least_once.returns("x86_64")
@@ -448,7 +448,7 @@ module Katello
       assert_equal "RHEL7 (System z (Structure A))", host.rhel_eos_schedule_index
 
       os = Operatingsystem.create!(:name => "RedHat", :major => "6", :minor => "3")
-      host.expects(:facts).returns({'distribution::name' => 'Red Hat Enterprise Linux', 'distribution::version' => '6.3'})
+      host.expects(:facts).returns({'distribution::name' => 'Red Hat Enterprise Linux'})
       host.operatingsystem = os
       assert_equal "RHEL6", host.rhel_eos_schedule_index
     end
@@ -456,7 +456,7 @@ module Katello
     def test_rhel_eos_schedule_index_non_rhel
       os = Operatingsystem.create!(:name => "CentOS_Stream", :major => "8", :minor => "")
       host.operatingsystem = os
-      host.expects(:facts).returns({'distribution::name' => 'CentOS Stream', 'distribution::version' => '8'})
+      host.expects(:facts).returns({'distribution::name' => 'CentOS Stream'})
       assert_nil host.rhel_eos_schedule_index
     end
 

--- a/test/models/concerns/operatingsystem_extensions_test.rb
+++ b/test/models/concerns/operatingsystem_extensions_test.rb
@@ -37,21 +37,5 @@ module Katello
       assert_equal "x86_64", os.architectures.first.name
       assert_equal "#{::Operatingsystem::REDHAT_ATOMIC_HOST_DISTRO_NAME} 7.3", os.description
     end
-
-    def test_rhel_eos_schedule_index
-      os = Operatingsystem.create!(:name => "RedHat", :major => "7", :minor => "3")
-      assert_equal "RHEL7", os.rhel_eos_schedule_index
-      assert_equal "RHEL7 (POWER9)", os.rhel_eos_schedule_index(arch_name: "ppc64le")
-      assert_equal "RHEL7 (ARM)", os.rhel_eos_schedule_index(arch_name: "aarch64")
-      assert_equal "RHEL7 (System z (Structure A))", os.rhel_eos_schedule_index(arch_name: "s390x")
-
-      os = Operatingsystem.create!(:name => "RedHat", :major => "6", :minor => "3")
-      assert_equal "RHEL6", os.rhel_eos_schedule_index
-    end
-
-    def test_rhel_eos_schedule_index_non_rhel
-      os = Operatingsystem.create!(:name => "CentOS_Stream", :major => "8", :minor => "3")
-      assert_nil os.rhel_eos_schedule_index
-    end
   end
 end

--- a/test/models/rhel_lifecycle_status_test.rb
+++ b/test/models/rhel_lifecycle_status_test.rb
@@ -70,7 +70,7 @@ module Katello
     def test_to_status_full_support
       os.hosts << host
       host.operatingsystem.update(:name => "RedHat", :major => "9", :minor => "0")
-      host.operatingsystem.expects(:rhel_eos_schedule_index).returns(release)
+      host.expects(:rhel_eos_schedule_index).returns(release)
       Katello::RhelLifecycleStatus.expects(:approaching_end_of_category).returns({})
       fake_full_support_end_date(Date.today + 2.years)
       fake_maintenance_support_end_date(Date.today + 10.years)
@@ -81,7 +81,7 @@ module Katello
     def test_to_status_maintenance_support
       os.hosts << host
       host.operatingsystem.update(:name => "RedHat", :major => "9", :minor => "0")
-      host.operatingsystem.expects(:rhel_eos_schedule_index).returns(release)
+      host.expects(:rhel_eos_schedule_index).returns(release)
       fake_full_support_end_date(Date.today - 1.year)
       fake_maintenance_support_end_date(Date.today + 2.years)
       fake_extended_support_end_date(Date.today + 10.years)
@@ -91,7 +91,7 @@ module Katello
     def test_to_status_approaching_end_of_support
       os.hosts << host
       host.operatingsystem.update(:name => "RedHat", :major => "9", :minor => "0")
-      host.operatingsystem.expects(:rhel_eos_schedule_index).returns(release)
+      host.expects(:rhel_eos_schedule_index).returns(release)
       Katello::RhelLifecycleStatus.expects(:approaching_end_of_category).returns({ 'extended_support' => Date.today + 2.days })
       assert_equal Katello::RhelLifecycleStatus::APPROACHING_END_OF_SUPPORT, status.to_status
     end
@@ -99,7 +99,7 @@ module Katello
     def test_to_status_extended_support
       os.hosts << host
       host.operatingsystem.update(:name => "RedHat", :major => "9", :minor => "0")
-      host.operatingsystem.expects(:rhel_eos_schedule_index).returns(release)
+      host.expects(:rhel_eos_schedule_index).returns(release)
       fake_full_support_end_date(Date.today - 5.years)
       fake_maintenance_support_end_date(Date.today - 3.years)
       fake_extended_support_end_date(Date.today + 2.years)
@@ -109,7 +109,7 @@ module Katello
     def test_to_status_support_ended
       os.hosts << host
       host.operatingsystem.update(:name => "RedHat", :major => "9", :minor => "0")
-      host.operatingsystem.expects(:rhel_eos_schedule_index).returns(release)
+      host.expects(:rhel_eos_schedule_index).returns(release)
       fake_full_support_end_date(Date.today - 5.years)
       fake_maintenance_support_end_date(Date.today - 3.years)
       fake_extended_support_end_date(Date.today - 1.year)
@@ -149,13 +149,12 @@ module Katello
     end
 
     def test_relevant
-      os.hosts << host
+      host.expects(:rhel_eos_schedule_index).returns('RHEL9')
       assert status.relevant?
     end
 
     def test_relevant_non_rhel
-      os.update(:name => "CentOS_Stream")
-      os.hosts << host
+      host.expects(:rhel_eos_schedule_index).returns(nil)
       refute status.relevant?
     end
   end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When determining the host status for RHEL lifecycle, do what's described in the PR title.

#### Considerations taken when implementing this change?

We now rely on sub-man facts instead of operatingsystem name, which is a bit more reliable. These facts won't be present for "unmanaged" hosts, but that's okay because we only care about managed hosts.

#### What are the testing steps for this pull request?

In rails console, run
```
Host.all.each(&:refresh_statuses)
```

Then check all host statuses and make sure they are still as expected.
