### PR TITLE
Opt-in email notifications when {repo sync, cv promote, cv publish, proxy sync} fails

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -2,6 +2,7 @@ module Actions
   module Katello
     module CapsuleContent
       class Sync < ::Actions::EntryAction
+        include ::Actions::ObservableAction
         def resource_locks
           :link
         end

--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -7,7 +7,7 @@ module Actions
           :link
         end
 
-        execution_plan_hooks.use :notify_on_failure, :on => :failure
+        execution_plan_hooks.use :notify_on_failure, :on => [:failure, :paused]
 
         input_format do
           param :name

--- a/app/lib/actions/katello/content_view/promote.rb
+++ b/app/lib/actions/katello/content_view/promote.rb
@@ -4,7 +4,7 @@ module Actions
       class Promote < Actions::EntryAction
         extend ApipieDSL::Class
         include ::Actions::ObservableAction
-        execution_plan_hooks.use :notify_on_failure, :on => :failure
+        execution_plan_hooks.use :notify_on_failure, :on => [:failure, :paused]
 
         def plan(version, environments, is_force = false, description = nil, incremental_update = false)
           action_subject(version.content_view)

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -7,7 +7,7 @@ module Actions
         include ::Actions::ObservableAction
         attr_accessor :version
         execution_plan_hooks.use :trigger_capsule_sync, :on => :success
-        execution_plan_hooks.use :notify_on_failure, :on => :failure
+        execution_plan_hooks.use :notify_on_failure, :on => [:failure, :paused]
 
         # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity
         def plan(content_view, description = "", options = {importing: false, syncable: false}) # rubocop:disable Metrics/PerceivedComplexity

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -7,6 +7,7 @@ module Actions
         include ::Actions::ObservableAction
         attr_accessor :version
         execution_plan_hooks.use :trigger_capsule_sync, :on => :success
+        execution_plan_hooks.use :notify_on_failure, :on => :failure
 
         # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity
         def plan(content_view, description = "", options = {importing: false, syncable: false}) # rubocop:disable Metrics/PerceivedComplexity
@@ -129,6 +130,14 @@ module Actions
             ForemanTasks.async_task(ContentView::CapsuleSync,
                                     view,
                                     environment)
+          end
+        end
+
+        def notify_on_failure(_plan)
+          notification = MailNotification[:content_view_publish_failure]
+          view = ::Katello::ContentView.find(input.fetch(:content_view, {})[:id])
+          notification.users.each do |user|
+            notification.deliver(user: user, content_view: view, task: task)
           end
         end
 

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -8,7 +8,7 @@ module Actions
         include ::Actions::ObservableAction
         middleware.use Actions::Middleware::ExecuteIfContentsChanged
 
-        execution_plan_hooks.use :notify_on_failure, :on => :failure
+        execution_plan_hooks.use :notify_on_failure, :on => [:failure, :paused]
 
         input_format do
           param :id, Integer

--- a/app/mailers/katello/task_mailer.rb
+++ b/app/mailers/katello/task_mailer.rb
@@ -26,5 +26,17 @@ module Katello
         end
       end
     end
+
+    def cv_promote_failure(options)
+      user, @content_view, @task = options.values_at(:user, :content_view, :task)
+
+      ::User.as(user.login) do
+        subject = _("%{label} failed") % { :label => @task.action }
+
+        set_locale_for(user) do
+          mail(:to => user.mail, :subject => subject)
+        end
+      end
+    end
   end
 end

--- a/app/mailers/katello/task_mailer.rb
+++ b/app/mailers/katello/task_mailer.rb
@@ -1,0 +1,18 @@
+module Katello
+  class TaskMailer < ApplicationMailer
+    helper ApplicationHelper
+    include Rails.application.routes.url_helpers
+
+    def repo_sync_failure(options)
+      user, @repo, @task = options.values_at(:user, :repo, :task)
+
+      ::User.as(user.login) do
+        subject = _("Repository %{label} failed to synchronize") % { :label => @repo.label }
+
+        set_locale_for(user) do
+          mail(:to => user.mail, :subject => subject)
+        end
+      end
+    end
+  end
+end

--- a/app/mailers/katello/task_mailer.rb
+++ b/app/mailers/katello/task_mailer.rb
@@ -38,5 +38,17 @@ module Katello
         end
       end
     end
+
+    def proxy_sync_failure(options)
+      user, @environment, @repo, @content_view, @task, @smart_proxy = options.values_at(:user, :environment, :repository, :content_view, :task, :smart_proxy)
+
+      ::User.as(user.login) do
+        subject = _("%{label} failed") % { :label => @task.action }
+
+        set_locale_for(user) do
+          mail(:to => user.mail, :subject => subject)
+        end
+      end
+    end
   end
 end

--- a/app/mailers/katello/task_mailer.rb
+++ b/app/mailers/katello/task_mailer.rb
@@ -14,5 +14,17 @@ module Katello
         end
       end
     end
+
+    def cv_publish_failure(options)
+      user, @content_view, @task = options.values_at(:user, :content_view, :task)
+
+      ::User.as(user.login) do
+        subject = _("%{label} failed") % { :label => @task.action }
+
+        set_locale_for(user) do
+          mail(:to => user.mail, :subject => subject)
+        end
+      end
+    end
   end
 end

--- a/app/views/katello/task_mailer/cv_promote_failure.html.erb
+++ b/app/views/katello/task_mailer/cv_promote_failure.html.erb
@@ -1,0 +1,31 @@
+<p>
+  <%= _("%{label} failed.") % { :label => @task.action } %>
+</p>
+
+<div class="dashboard">
+  <table>
+    <tr>
+      <td><%= _('Content view') %></td>
+      <td><%= link_to @content_view.name, "#{katello_url}content_views/#{@content_view.id}" %></td>
+    </tr>
+    <tr>
+      <td><%= _('Task ID') %></td>
+      <td><%= link_to @task.id, foreman_tasks_task_url(@task.id) %></td>
+    </tr>
+    <tr>
+      <td><%= _('Task state') %></td>
+      <td><%= @task.state %></td>
+    </tr>
+    <tr>
+      <td><%= _('Task result') %></td>
+      <td><%= @task.result %></td>
+    </tr>
+  </table>
+
+  Errors:
+  <ul>
+  <% @task.execution_plan.errors.each do |error| %>
+    <li><%= error.exception_class %>: <%= error.message %></li>
+  <% end %>
+  </ul>
+</div>

--- a/app/views/katello/task_mailer/cv_promote_failure.text.erb
+++ b/app/views/katello/task_mailer/cv_promote_failure.text.erb
@@ -1,0 +1,13 @@
+<%= _("%{label} failed.") % { :label => @task.action } %>
+
+<%= _('Content view ID') %>: <%= @content_view.id %>
+<%= _('Content view name') %>: <%= @content_view.name %>
+<%= _('Task ID') %>: <%= @task.id %>
+<%= _('Task state') %>: <%= @task.state %>
+<%= _('Task result') %>: <%= @task.result %>
+<%= _('Task details') %>: <%= foreman_tasks_task_url(@task) %>
+
+Errors:
+<% @task.execution_plan.errors.each do |error| %>
+- <%= error.exception_class %>: <%= error.message %>
+<% end %>

--- a/app/views/katello/task_mailer/cv_publish_failure.html.erb
+++ b/app/views/katello/task_mailer/cv_publish_failure.html.erb
@@ -1,0 +1,31 @@
+<p>
+  <%= _("%{label} failed.") % { :label => @task.action } %>
+</p>
+
+<div class="dashboard">
+  <table>
+    <tr>
+      <td><%= _('Content view') %></td>
+      <td><%= link_to @content_view.name, "#{katello_url}content_views/#{@content_view.id}" %></td>
+    </tr>
+    <tr>
+      <td><%= _('Task ID') %></td>
+      <td><%= link_to @task.id, foreman_tasks_task_url(@task.id) %></td>
+    </tr>
+    <tr>
+      <td><%= _('Task state') %></td>
+      <td><%= @task.state %></td>
+    </tr>
+    <tr>
+      <td><%= _('Task result') %></td>
+      <td><%= @task.result %></td>
+    </tr>
+  </table>
+
+  Errors:
+  <ul>
+  <% @task.execution_plan.errors.each do |error| %>
+    <li><%= error.exception_class %>: <%= error.message %></li>
+  <% end %>
+  </ul>
+</div>

--- a/app/views/katello/task_mailer/cv_publish_failure.text.erb
+++ b/app/views/katello/task_mailer/cv_publish_failure.text.erb
@@ -1,0 +1,13 @@
+<%= _("%{label} failed.") % { :label => @task.action } %>
+
+<%= _('Content view ID') %>: <%= @content_view.id %>
+<%= _('Content view name') %>: <%= @content_view.name %>
+<%= _('Task ID') %>: <%= @task.id %>
+<%= _('Task state') %>: <%= @task.state %>
+<%= _('Task result') %>: <%= @task.result %>
+<%= _('Task details') %>: <%= foreman_tasks_task_url(@task) %>
+
+Errors:
+<% @task.execution_plan.errors.each do |error| %>
+- <%= error.exception_class %>: <%= error.message %>
+<% end %>

--- a/app/views/katello/task_mailer/proxy_sync_failure.html.erb
+++ b/app/views/katello/task_mailer/proxy_sync_failure.html.erb
@@ -1,0 +1,45 @@
+<p>
+  <%= _("%{label} failed.") % { :label => @task.action } %>
+</p>
+
+<div class="dashboard">
+  <table>
+    <% if @environment %>
+    <tr>
+      <td><%= _('Environment') %></td>
+      <td><%= link_to @environment.name, "#{katello_url}lifecycle_environments/#{@environment.id}" %></td>
+    </tr>
+    <% end %>
+    <% if @content_view %>
+    <tr>
+      <td><%= _('Content view') %></td>
+      <td><%= link_to @content_view.name, "#{katello_url}content_views/#{@content_view.id}" %></td>
+    </tr>
+    <% end %>
+    <% if @repo %>
+    <tr>
+      <td><%= _('Repository') %></td>
+      <td><%= link_to @repo.name, "#{katello_url}products/#{@repo.product.id}/repositories/#{@repo.id}" %></td>
+    </tr>
+    <% end %>
+    <tr>
+      <td><%= _('Task ID') %></td>
+      <td><%= link_to @task.id, foreman_tasks_task_url(@task.id) %></td>
+    </tr>
+    <tr>
+      <td><%= _('Task state') %></td>
+      <td><%= @task.state %></td>
+    </tr>
+    <tr>
+      <td><%= _('Task result') %></td>
+      <td><%= @task.result %></td>
+    </tr>
+  </table>
+
+  Errors:
+  <ul>
+  <% @task.execution_plan.errors.each do |error| %>
+    <li><%= error.exception_class %>: <%= error.message %></li>
+  <% end %>
+  </ul>
+</div>

--- a/app/views/katello/task_mailer/proxy_sync_failure.text.erb
+++ b/app/views/katello/task_mailer/proxy_sync_failure.text.erb
@@ -1,0 +1,25 @@
+<%= _("%{label} failed.") % { :label => @task.action } %>
+
+<%= _('Smart proxy ID') %>: <%= @smart_proxy.id %>
+<%= _('Smart proxy name') %>: <%= @smart_proxy.name %>
+<% if @environment %>
+<%= _('Environment ID') %>: <%= @environment&.id %>
+<%= _('Environment name') %>: <%= @environment&.name %>
+<% end %>
+<% if @content_view %>
+<%= _('Content view ID') %>: <%= @content_view&.id %>
+<%= _('Content view name') %>: <%= @content_view&.name %>
+<% end %>
+<% if @repo %>
+<%= _('Repository ID') %>: <%= @repo&.id %>
+<%= _('Repository name') %>: <%= @repo&.name %>
+<% end %>
+<%= _('Task ID') %>: <%= @task.id %>
+<%= _('Task state') %>: <%= @task.state %>
+<%= _('Task result') %>: <%= @task.result %>
+<%= _('Task details') %>: <%= foreman_tasks_task_url(@task) %>
+
+Errors:
+<% @task.execution_plan.errors.each do |error| %>
+- <%= error.exception_class %>: <%= error.message %>
+<% end %>

--- a/app/views/katello/task_mailer/repo_sync_failure.html.erb
+++ b/app/views/katello/task_mailer/repo_sync_failure.html.erb
@@ -1,0 +1,35 @@
+<p>
+  <%= _("%{label} failed.") % { :label => @task.action } %>
+</p>
+
+<div class="dashboard">
+  <table>
+    <tr>
+      <td><%= _('Repository') %></td>
+      <td><%= link_to @repo.label, "#{katello_url}products/#{@repo.product.id}/repositories/#{@repo.id}" %></td>
+    </tr>
+    <tr>
+      <td><%= _('Product') %></td>
+      <td><%= link_to @repo.product.label, "#{katello_url}products/#{@repo.product.id}" %></td>
+    </tr>
+    <tr>
+      <td><%= _('Task ID') %></td>
+      <td><%= link_to @task.id, foreman_tasks_task_url(@task.id) %></td>
+    </tr>
+    <tr>
+      <td><%= _('Task state') %></td>
+      <td><%= @task.state %></td>
+    </tr>
+    <tr>
+      <td><%= _('Task result') %></td>
+      <td><%= @task.result %></td>
+    </tr>
+  </table>
+
+  Errors:
+  <ul>
+  <% @task.execution_plan.errors.each do |error| %>
+    <li><%= error.exception_class %>: <%= error.message %></li>
+  <% end %>
+  </ul>
+</div>

--- a/app/views/katello/task_mailer/repo_sync_failure.text.erb
+++ b/app/views/katello/task_mailer/repo_sync_failure.text.erb
@@ -1,0 +1,15 @@
+<%= _("%{label} failed.") % { :label => @task.action } %>
+
+<%= _('Repo ID') %>: <%= @repo.id %>
+<%= _('Repo label') %>: <%= @repo.label %>
+<%= _('Product ID') %>: <%= @repo.product.id %>
+<%= _('Product label') %>: <%= @repo.product.label %>
+<%= _('Task ID') %>: <%= @task.id %>
+<%= _('Task state') %>: <%= @task.state %>
+<%= _('Task result') %>: <%= @task.result %>
+<%= _('Task details') %>: <%= foreman_tasks_task_url(@task) %>
+
+Errors:
+<% @task.execution_plan.errors.each do |error| %>
+- <%= error.exception_class %>: <%= error.message %>
+<% end %>

--- a/db/seeds.d/106-mail_notifications.rb
+++ b/db/seeds.d/106-mail_notifications.rb
@@ -9,6 +9,7 @@ User.as(::User.anonymous_api_admin.login) do
   N_('Host errata advisory')
   N_('Sync errata')
   N_('Promote errata')
+  N_('Repository sync failure')
 
   # Mail Notifications
   notifications = [
@@ -39,6 +40,13 @@ User.as(::User.anonymous_api_admin.login) do
      :method => 'subscription_expiry',
      :subscription_type => 'report',
      :queryable => true
+    },
+
+    {:name => :repository_sync_failure,
+     :description => N_('A notification about failed repository sync'),
+     :mailer => 'Katello::TaskMailer',
+     :method => 'repo_sync_failure',
+     :subscription_type => 'alert',
     }
   ]
 

--- a/db/seeds.d/106-mail_notifications.rb
+++ b/db/seeds.d/106-mail_notifications.rb
@@ -49,28 +49,28 @@ User.as(::User.anonymous_api_admin.login) do
      :description => N_('A notification about failed repository sync'),
      :mailer => 'Katello::TaskMailer',
      :method => 'repo_sync_failure',
-     :subscription_type => 'alert',
+     :subscription_type => 'alert'
     },
 
     {:name => :content_view_publish_failure,
      :description => N_('A notification about failed content view publish'),
      :mailer => 'Katello::TaskMailer',
      :method => 'cv_publish_failure',
-     :subscription_type => 'alert',
+     :subscription_type => 'alert'
     },
 
     {:name => :content_view_promote_failure,
      :description => N_('A notification about failed content view promotion'),
      :mailer => 'Katello::TaskMailer',
      :method => 'cv_promote_failure',
-     :subscription_type => 'alert',
+     :subscription_type => 'alert'
     },
 
     {:name => :proxy_sync_failure,
      :description => N_('A notification about failed proxy sync'),
      :mailer => 'Katello::TaskMailer',
      :method => 'proxy_sync_failure',
-     :subscription_type => 'alert',
+     :subscription_type => 'alert'
     }
   ]
 

--- a/db/seeds.d/106-mail_notifications.rb
+++ b/db/seeds.d/106-mail_notifications.rb
@@ -10,6 +10,7 @@ User.as(::User.anonymous_api_admin.login) do
   N_('Sync errata')
   N_('Promote errata')
   N_('Repository sync failure')
+  N_('Content view publish failure')
 
   # Mail Notifications
   notifications = [
@@ -46,6 +47,13 @@ User.as(::User.anonymous_api_admin.login) do
      :description => N_('A notification about failed repository sync'),
      :mailer => 'Katello::TaskMailer',
      :method => 'repo_sync_failure',
+     :subscription_type => 'alert',
+    },
+
+    {:name => :content_view_publish_failure,
+     :description => N_('A notification about failed content view publish'),
+     :mailer => 'Katello::TaskMailer',
+     :method => 'cv_publish_failure',
      :subscription_type => 'alert',
     }
   ]

--- a/db/seeds.d/106-mail_notifications.rb
+++ b/db/seeds.d/106-mail_notifications.rb
@@ -12,6 +12,7 @@ User.as(::User.anonymous_api_admin.login) do
   N_('Repository sync failure')
   N_('Content view publish failure')
   N_('Content view promote failure')
+  N_('Proxy sync failure')
 
   # Mail Notifications
   notifications = [
@@ -62,6 +63,13 @@ User.as(::User.anonymous_api_admin.login) do
      :description => N_('A notification about failed content view promotion'),
      :mailer => 'Katello::TaskMailer',
      :method => 'cv_promote_failure',
+     :subscription_type => 'alert',
+    },
+
+    {:name => :proxy_sync_failure,
+     :description => N_('A notification about failed proxy sync'),
+     :mailer => 'Katello::TaskMailer',
+     :method => 'proxy_sync_failure',
      :subscription_type => 'alert',
     }
   ]

--- a/db/seeds.d/106-mail_notifications.rb
+++ b/db/seeds.d/106-mail_notifications.rb
@@ -11,6 +11,7 @@ User.as(::User.anonymous_api_admin.login) do
   N_('Promote errata')
   N_('Repository sync failure')
   N_('Content view publish failure')
+  N_('Content view promote failure')
 
   # Mail Notifications
   notifications = [
@@ -54,6 +55,13 @@ User.as(::User.anonymous_api_admin.login) do
      :description => N_('A notification about failed content view publish'),
      :mailer => 'Katello::TaskMailer',
      :method => 'cv_publish_failure',
+     :subscription_type => 'alert',
+    },
+
+    {:name => :content_view_promote_failure,
+     :description => N_('A notification about failed content view promotion'),
+     :mailer => 'Katello::TaskMailer',
+     :method => 'cv_promote_failure',
      :subscription_type => 'alert',
     }
   ]


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Opt-in email notifications when {repo sync, cv promote, cv publish, proxy sync} fails

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1) Subscribe to each of the things mentioned above
2) Make them fail. In general `raise "HALT"` somewhere in the action works pretty well, but it cannot happen before action_subject is called

TODO:
- [x] redmine
