### PR TITLE
Fix Module Stream check for Orace Linux

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -47,7 +47,7 @@ import {
 } from '../../hostDetailsHelpers';
 
 const moduleStreamSupported = ({ os, version }) =>
-  os.match(/RedHat|RHEL|CentOS|Rocky|AlmaLinux|OracleLinux/i) && Number(version) > 7;
+  os.match(/RedHat|RHEL|CentOS|Rocky|AlmaLinux|Oracle Linux/i) && Number(version) > 7;
 export const hideModuleStreamsTab = ({ hostDetails }) => {
   const osMatch = hostDetails?.operatingsystem_name?.match(/(\D+) (\d+)/);
   if (!osMatch) return false;


### PR DESCRIPTION
The operatingsystem_name for Oracle is "Oracle Linux Server" and not "OracleLinux".
See e.g. https://github.com/theforeman/foreman/blob/develop/test/unit/katello/rhsm_fact_parser_test.rb#L98