### PR TITLE
Fixes #36758 - Add content counts to capsule content view UI

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -145,23 +145,12 @@ module Katello
               translated_counts[::Katello::Pulp3::PulpContentUnit.katello_name_from_pulpcore_name(name, repo)] = count
             end
           end
-          new_content_counts[:content_view_versions][repo.content_view_version_id] ||= { repositories: {}, cv_version_content_counts: {}}
-          new_content_counts[:content_view_versions][repo.content_view_version_id][:repositories][repo.id] = translated_counts
-          new_content_counts = aggregated_cv_version_count!(repo.content_view_version_id, new_content_counts, translated_counts)
+          new_content_counts[:content_view_versions][repo.content_view_version_id] ||= { repositories: {}}
+          # Store counts on capsule of archived repos which are reused across environment copies
+          # of the archived repo corresponding to each environment CV version is promoted to.
+          new_content_counts[:content_view_versions][repo.content_view_version_id][:repositories][repo.content_view_version.archived_repos.find_by(library_instance_id: repo.library_instance_id)&.id] = translated_counts
         end
         update(content_counts: new_content_counts)
-      end
-
-      def aggregated_cv_version_count!(cv_version_id, cvv_content_counts, repo_counts)
-        repo_counts.keys.each do |content_type|
-          cvv_content_counts[:content_view_versions][cv_version_id][:cv_version_content_counts][content_type] =
-            if cvv_content_counts[:content_view_versions][cv_version_id][:cv_version_content_counts][content_type]
-              cvv_content_counts[:content_view_versions][cv_version_id][:cv_version_content_counts][content_type] + repo_counts[content_type]
-            else
-              repo_counts[content_type]
-            end
-        end
-        cvv_content_counts
       end
 
       def sync_container_gateway

--- a/app/services/katello/pulp3/ansible_collection.rb
+++ b/app/services/katello/pulp3/ansible_collection.rb
@@ -2,7 +2,7 @@ module Katello
   module Pulp3
     class AnsibleCollection < PulpContentUnit
       include LazyAccessor
-      PULPCORE_CONTENT_TYPE = "ansible.collection".freeze
+      PULPCORE_CONTENT_TYPE = "ansible.collection_version".freeze
 
       def self.content_api
         PulpAnsibleClient::ContentCollectionVersionsApi.new(Katello::Pulp3::Api::AnsibleCollection.new(SmartProxy.pulp_primary!).api_client)

--- a/app/views/foreman/smart_proxies/_content_tab.html.erb
+++ b/app/views/foreman/smart_proxies/_content_tab.html.erb
@@ -1,5 +1,3 @@
 <%= javascript_include_tag *webpack_asset_paths('katello', extension: 'js') %>
-
-<br />
 <% @smartProxyId= @smart_proxy.id %>
 <%= react_component('Content', smartProxyId: @smartProxyId,)  %>

--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -45,6 +45,7 @@ const TableWrapper = ({
   emptySearchBody,
   hideSearch,
   alwaysHideToolbar,
+  hidePagination,
   nodesBelowSearch,
   bookmarkController,
   readOnlyBookmarks,
@@ -59,7 +60,7 @@ const TableWrapper = ({
   const { pageRowCount } = getPageStats({ total, page, perPage });
   const unresolvedStatus = !!allTableProps?.status && allTableProps.status !== STATUS.RESOLVED;
   const unresolvedStatusOrNoRows = unresolvedStatus || pageRowCount === 0;
-  const showPagination = !unresolvedStatusOrNoRows;
+  const showPagination = !unresolvedStatusOrNoRows && !hidePagination;
   const filtersAreActive = activeFilters?.length &&
     !isEqual(new Set(activeFilters), new Set(allTableProps.defaultFilters));
   const hideToolbar = alwaysHideToolbar || (!searchQuery && !filtersAreActive &&
@@ -308,6 +309,7 @@ TableWrapper.propTypes = {
   emptySearchBody: PropTypes.string,
   hideSearch: PropTypes.bool,
   alwaysHideToolbar: PropTypes.bool,
+  hidePagination: PropTypes.bool,
   nodesBelowSearch: PropTypes.node,
   bookmarkController: PropTypes.string,
   readOnlyBookmarks: PropTypes.bool,
@@ -338,6 +340,7 @@ TableWrapper.defaultProps = {
   emptySearchBody: __('Try changing your search settings.'),
   hideSearch: false,
   alwaysHideToolbar: false,
+  hidePagination: false,
   nodesBelowSearch: null,
   bookmarkController: undefined,
   readOnlyBookmarks: false,

--- a/webpack/scenes/Content/ContentConfig.js
+++ b/webpack/scenes/Content/ContentConfig.js
@@ -16,6 +16,7 @@ export default [
       singularLowercase: __('Python package'),
       pluralLabel: 'python_packages',
       singularLabel: 'python_package',
+      capsuleCountLabel: 'python_package',
     },
     columnHeaders: [
       { title: __('Name'), getProperty: unit => (<a href={urlBuilder(`content/python_packages/${unit?.id}`, '')}>{unit?.name}</a>) },
@@ -81,6 +82,7 @@ export default [
       singularLowercase: __('OSTree ref'),
       pluralLabel: 'ostree_refs',
       singularLabel: 'ostree_ref',
+      capsuleCountLabel: 'ostree_ref',
     },
     columnHeaders: [
       { title: __('Name'), getProperty: unit => (<a href={urlBuilder(`content/ostree_refs/${unit?.id}`, '')}>{unit?.name}</a>) },
@@ -142,6 +144,7 @@ export default [
       singularLowercase: __('Ansible collection'),
       pluralLabel: 'ansible_collections',
       singularLabel: 'ansible_collection',
+      capsuleCountLabel: 'ansible_collection',
     },
     columnHeaders: [
       { title: __('Name'), getProperty: unit => (<a href={urlBuilder(`content/ansible_collections/${unit?.id}`, '')}>{unit?.name}</a>) },

--- a/webpack/scenes/SmartProxy/AdditionalCapsuleContent.js
+++ b/webpack/scenes/SmartProxy/AdditionalCapsuleContent.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ContentConfig from '../Content/ContentConfig';
+
+const AdditionalCapsuleContent = ({ counts }) => {
+  const {
+    deb: debPackageCount = 0,
+    docker_manifest: dockerManifestCount = 0,
+    docker_tag: dockerTagCount = 0,
+    file: fileCount = 0,
+    erratum: errataCount = 0,
+    package_group: packageGroup = 0,
+    'rpm.modulemd': moduleStreamCount = 0,
+  } = counts;
+
+  const contentConfigTypes = ContentConfig.filter(({ names: { capsuleCountLabel } }) =>
+    !!counts[`${capsuleCountLabel}`])
+    .map(({
+      names: {
+        capsuleCountLabel, pluralLowercase,
+      },
+    }) => {
+      const countParam = `${capsuleCountLabel}`;
+      const count = counts[countParam];
+      return {
+        pluralLowercase,
+        count,
+      };
+    });
+
+  return (
+    <>
+      {errataCount > 0 &&
+      <>
+        {`${errataCount} Errata`}<br />
+      </>
+            }
+      {moduleStreamCount > 0 &&
+      <>
+        {`${moduleStreamCount} Module streams`}<br />
+      </>
+            }
+      {packageGroup > 0 &&
+      <>
+        {`${packageGroup} Package groups`}<br />
+      </>
+            }
+      {dockerTagCount > 0 &&
+      <>
+        {`${dockerTagCount} Container tags`}<br />
+      </>
+            }
+      {dockerManifestCount > 0 &&
+      <>
+        {`${dockerManifestCount} Container manifests`}<br />
+      </>
+            }
+      {fileCount > 0 &&
+      <>
+        {`${fileCount} Files`}<br />
+      </>
+            }
+      {debPackageCount > 0 &&
+      <>
+        {`${debPackageCount} Debian packages`}<br />
+      </>}
+      {contentConfigTypes?.length > 0 &&
+                contentConfigTypes.map(({ count, pluralLowercase }) => (
+                  <React.Fragment key={pluralLowercase}>
+                    {`${count} ${pluralLowercase}`}<br />
+                  </React.Fragment>))
+            }
+    </>
+  );
+};
+
+AdditionalCapsuleContent.propTypes = {
+  counts: PropTypes.shape({
+    deb: PropTypes.number,
+    docker_manifest: PropTypes.number,
+    docker_tag: PropTypes.number,
+    file: PropTypes.number,
+    erratum: PropTypes.number,
+    package_group: PropTypes.number,
+    'rpm.modulemd': PropTypes.number,
+  }),
+};
+
+AdditionalCapsuleContent.defaultProps = {
+  counts: {},
+};
+
+export default AdditionalCapsuleContent;

--- a/webpack/scenes/SmartProxy/Content.js
+++ b/webpack/scenes/SmartProxy/Content.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import SmartProxyContentTable from './SmartProxyContentTable';
+import SmartProxyExpandableTable from './SmartProxyExpandableTable';
 
 const Content = ({ smartProxyId }) => (
-  <SmartProxyContentTable smartProxyId={smartProxyId} />
+  <SmartProxyExpandableTable smartProxyId={smartProxyId} />
 );
 
 Content.propTypes = {

--- a/webpack/scenes/SmartProxy/ExpandableCvDetails.js
+++ b/webpack/scenes/SmartProxy/ExpandableCvDetails.js
@@ -1,31 +1,34 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { TableComposable, Thead, Tr, Th, Tbody, Td, TableVariant } from '@patternfly/react-table';
+import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
 import LongDateTime from 'foremanReact/components/common/dates/LongDateTime';
 import { urlBuilder } from 'foremanReact/common/urlHelpers';
 import ContentViewIcon from '../ContentViews/components/ContentViewIcon';
+import { useSet } from '../../components/Table/TableHooks';
+import ExpandedSmartProxyRepositories from './ExpandedSmartProxyRepositories';
 
-const ExpandableCvDetails = ({ contentViews }) => {
+const ExpandableCvDetails = ({ contentViews, counts }) => {
   const columnHeaders = [
     __('Content view'),
     __('Last published'),
-    __('Repositories'),
     __('Synced to smart proxy'),
   ];
+  const { content_counts: contentCounts } = counts;
+  const expandedTableRows = useSet([]);
+  const tableRowIsExpanded = id => expandedTableRows.has(id);
 
   return (
     <TableComposable
-      variant={TableVariant.compact}
       aria-label="expandable-content-views"
       ouiaId="expandable-content-views"
     >
       <Thead>
         <Tr ouiaId="column-headers">
+          <Th />
           {columnHeaders.map(col => (
             <Th
-              modifier="fitContent"
               key={col}
             >
               {col}
@@ -33,15 +36,22 @@ const ExpandableCvDetails = ({ contentViews }) => {
           ))}
         </Tr>
       </Thead>
-      <Tbody>
-        {contentViews.map((cv) => {
-          const {
-            id, name: cvName, composite, up_to_date: upToDate, counts,
-          } = cv;
-          const { repositories } = counts;
-          const upToDateVal = upToDate ? <CheckCircleIcon /> : <TimesCircleIcon />;
-          return (
-            <Tr key={cv.name} ouiaId={cv.name}>
+      {contentViews.map((cv, rowIndex) => {
+        const {
+          id, name: cvName, composite, up_to_date: upToDate, cvv_id: version, repositories,
+        } = cv;
+        const upToDateVal = upToDate ? <CheckCircleIcon /> : <TimesCircleIcon />;
+        const isExpanded = tableRowIsExpanded(version);
+        return (
+          <Tbody key={`${id} + ${version}`}isExpanded={isExpanded}>
+            <Tr key={version} ouiaId={cv.name}>
+              <Td
+                expand={{
+                  rowIndex,
+                  isExpanded,
+                  onToggle: (_event, _rInx, isOpen) => expandedTableRows.onToggle(isOpen, version),
+                }}
+              />
               <Td>
                 <ContentViewIcon
                   composite={composite}
@@ -49,12 +59,20 @@ const ExpandableCvDetails = ({ contentViews }) => {
                 />
               </Td>
               <Td><LongDateTime date={cv.last_published} showRelativeTimeTooltip /></Td>
-              <Td>{repositories}</Td>
               <Td>{upToDateVal}</Td>
             </Tr>
-          );
-        })}
-      </Tbody>
+            <Tr key="child_row" ouiaId={`ContentViewTableRowChild-${id}`} isExpanded={isExpanded}>
+              <Td colSpan={12}>
+                <ExpandedSmartProxyRepositories
+                  contentCounts={contentCounts?.content_view_versions[version]?.repositories}
+                  repositories={repositories}
+                />
+              </Td>
+            </Tr>
+          </Tbody>
+        );
+      })}
+
     </TableComposable>
 
   );
@@ -62,10 +80,16 @@ const ExpandableCvDetails = ({ contentViews }) => {
 
 ExpandableCvDetails.propTypes = {
   contentViews: PropTypes.arrayOf(PropTypes.shape({})),
+  counts: PropTypes.shape({
+    content_counts: PropTypes.shape({
+      content_view_versions: PropTypes.shape({}),
+    }),
+  }),
 };
 
 ExpandableCvDetails.defaultProps = {
   contentViews: [],
+  counts: {},
 };
 
 export default ExpandableCvDetails;

--- a/webpack/scenes/SmartProxy/ExpandableCvDetails.js
+++ b/webpack/scenes/SmartProxy/ExpandableCvDetails.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { TableComposable, Thead, Tr, Th, Tbody, Td, TableVariant } from '@patternfly/react-table';
+import { CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
+import LongDateTime from 'foremanReact/components/common/dates/LongDateTime';
+import { urlBuilder } from 'foremanReact/common/urlHelpers';
+import ContentViewIcon from '../ContentViews/components/ContentViewIcon';
+
+const ExpandableCvDetails = ({ contentViews }) => {
+  const columnHeaders = [
+    __('Content view'),
+    __('Last published'),
+    __('Repositories'),
+    __('Synced to smart proxy'),
+  ];
+
+  return (
+    <TableComposable
+      variant={TableVariant.compact}
+      aria-label="expandable-content-views"
+      ouiaId="expandable-content-views"
+    >
+      <Thead>
+        <Tr ouiaId="column-headers">
+          {columnHeaders.map(col => (
+            <Th
+              modifier="fitContent"
+              key={col}
+            >
+              {col}
+            </Th>
+          ))}
+        </Tr>
+      </Thead>
+      <Tbody>
+        {contentViews.map((cv) => {
+          const {
+            id, name: cvName, composite, up_to_date: upToDate, counts,
+          } = cv;
+          const { repositories } = counts;
+          const upToDateVal = upToDate ? <CheckCircleIcon /> : <TimesCircleIcon />;
+          return (
+            <Tr key={cv.name} ouiaId={cv.name}>
+              <Td>
+                <ContentViewIcon
+                  composite={composite}
+                  description={<a href={cv.default ? urlBuilder('products', '') : urlBuilder('content_views', '', id)}>{cvName}</a>}
+                />
+              </Td>
+              <Td><LongDateTime date={cv.last_published} showRelativeTimeTooltip /></Td>
+              <Td>{repositories}</Td>
+              <Td>{upToDateVal}</Td>
+            </Tr>
+          );
+        })}
+      </Tbody>
+    </TableComposable>
+
+  );
+};
+
+ExpandableCvDetails.propTypes = {
+  contentViews: PropTypes.arrayOf(PropTypes.shape({})),
+};
+
+ExpandableCvDetails.defaultProps = {
+  contentViews: [],
+};
+
+export default ExpandableCvDetails;

--- a/webpack/scenes/SmartProxy/ExpandedSmartProxyRepositories.js
+++ b/webpack/scenes/SmartProxy/ExpandedSmartProxyRepositories.js
@@ -1,0 +1,56 @@
+/* eslint-disable react/no-array-index-key */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { DataList, DataListItem, DataListItemRow, DataListItemCells, DataListCell } from '@patternfly/react-core';
+import AdditionalCapsuleContent from './AdditionalCapsuleContent';
+
+const ExpandedSmartProxyRepositories = ({ contentCounts, repositories }) => {
+  const getRepositoryNameById = id => (repositories.find(repo =>
+    Number(repo.id) === Number(id)) || {}).name;
+
+  const dataListCellLists = (repo) => {
+    const cellList = [];
+    /* eslint-disable max-len */
+    cellList.push(<DataListCell key={`${repo.id}-name`}><span>{getRepositoryNameById(repo)}</span></DataListCell>);
+    cellList.push(<DataListCell key={`${repo.id}-rpm`}><span>{contentCounts[repo].rpm ? `${contentCounts[repo].rpm} Packages` : 'N/A'}</span></DataListCell>);
+    cellList.push(<DataListCell key={`${repo.id}-count`}><AdditionalCapsuleContent counts={contentCounts[repo]} /></DataListCell>);
+    /* eslint-enable max-len */
+    return cellList;
+  };
+  return (
+    <DataList aria-label="Expanded repository details" isCompact>
+      <DataListItem key="headers" >
+        <DataListItemRow>
+          <DataListItemCells dataListCells={[
+            <DataListCell key="primary content">
+              <b>{__('Repositories')}</b>
+            </DataListCell>,
+            <DataListCell key="Packages"><b>{__('Packages')}</b></DataListCell>,
+            <DataListCell key="Additional Content"><b>{__('Additional Content')}</b></DataListCell>,
+          ]}
+          />
+        </DataListItemRow>
+      </DataListItem>
+      {Object.keys(contentCounts).map((repo, index) => (
+        <DataListItem key={`${repo.id}-${index}`}>
+          <DataListItemRow>
+            <DataListItemCells dataListCells={dataListCellLists(repo)} />
+          </DataListItemRow>
+        </DataListItem>
+      ))}
+    </DataList>
+  );
+};
+
+ExpandedSmartProxyRepositories.propTypes = {
+  contentCounts: PropTypes.shape({}),
+  repositories: PropTypes.arrayOf(PropTypes.shape({})),
+};
+
+ExpandedSmartProxyRepositories.defaultProps = {
+  contentCounts: {},
+  repositories: [{}],
+};
+
+export default ExpandedSmartProxyRepositories;

--- a/webpack/scenes/SmartProxy/SmartProxyExpandableTable.js
+++ b/webpack/scenes/SmartProxy/SmartProxyExpandableTable.js
@@ -1,0 +1,109 @@
+import React, { useState, useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { Thead, Tbody, Th, Tr, Td } from '@patternfly/react-table';
+import getSmartProxyContent from './SmartProxyContentActions';
+import {
+  selectSmartProxyContent,
+  selectSmartProxyContentStatus,
+  selectSmartProxyContentError,
+} from './SmartProxyContentSelectors';
+import { useSet } from '../../components/Table/TableHooks';
+import TableWrapper from '../../components/Table/TableWrapper';
+import ExpandableCvDetails from './ExpandableCvDetails';
+
+const SmartProxyExpandableTable = ({ smartProxyId }) => {
+  const response = useSelector(selectSmartProxyContent);
+  const status = useSelector(selectSmartProxyContentStatus);
+  const error = useSelector(selectSmartProxyContentError);
+  const [searchQuery, updateSearchQuery] = useState('');
+  const expandedTableRows = useSet([]);
+  const tableRowIsExpanded = id => expandedTableRows.has(id);
+  let metadata = {};
+  const {
+    lifecycle_environments: results,
+  } = response;
+  if (results) {
+    metadata = { total: results.length, subtotal: results.length };
+  }
+  const columnHeaders = [
+    __('Environment'),
+  ];
+  const fetchItems = useCallback(() => getSmartProxyContent({ smartProxyId }), [smartProxyId]);
+
+  const emptyContentTitle = __('No content views yet');
+  const emptyContentBody = __('You currently have no content views to display');
+  const emptySearchTitle = __('No matching content views found');
+  const emptySearchBody = __('Try changing your search settings.');
+  const alwaysHideToolbar = true;
+  const hidePagination = true;
+  return (
+    <TableWrapper
+      {...{
+        error,
+        metadata,
+        emptyContentTitle,
+        emptyContentBody,
+        emptySearchTitle,
+        emptySearchBody,
+        searchQuery,
+        updateSearchQuery,
+        fetchItems,
+        alwaysHideToolbar,
+        hidePagination,
+      }}
+      ouiaId="capsule-content-table"
+      autocompleteEndpoint=""
+      status={status}
+    >
+      <Thead>
+        <Tr ouiaId="cvTableHeaderRow">
+          <Th key="expand-carat" />
+          {columnHeaders.map(col => (
+            <Th
+              key={col}
+            >
+              {col}
+            </Th>
+          ))}
+        </Tr>
+      </Thead>
+      {
+        results?.map((env, rowIndex) => {
+          const { name, id, content_views: contentViews } = env;
+          const isExpanded = tableRowIsExpanded(id);
+          return (
+            <Tbody isExpanded={isExpanded} key={id}>
+              <Tr key={id} ouiaId={`EnvRow-${id}`}>
+                <Td
+                  expand={{
+                    rowIndex,
+                    isExpanded,
+                    onToggle: (_event, _rInx, isOpen) =>
+                      expandedTableRows.onToggle(isOpen, id),
+                  }}
+                />
+                <Td>{name}</Td>
+              </Tr>
+              <Tr key="child_row" ouiaId={`ContentViewTableRowChild-${id}`} isExpanded={isExpanded}>
+                <Td colSpan={2}>
+                  <ExpandableCvDetails contentViews={contentViews} />
+                </Td>
+              </Tr>
+            </Tbody>
+          );
+        })
+      }
+    </TableWrapper >
+  );
+};
+
+SmartProxyExpandableTable.propTypes = {
+  smartProxyId: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string, // The API can sometimes return strings
+  ]).isRequired,
+};
+
+export default SmartProxyExpandableTable;

--- a/webpack/scenes/SmartProxy/SmartProxyExpandableTable.js
+++ b/webpack/scenes/SmartProxy/SmartProxyExpandableTable.js
@@ -71,7 +71,9 @@ const SmartProxyExpandableTable = ({ smartProxyId }) => {
       </Thead>
       {
         results?.map((env, rowIndex) => {
-          const { name, id, content_views: contentViews } = env;
+          const {
+            name, id, content_views: contentViews, counts,
+          } = env;
           const isExpanded = tableRowIsExpanded(id);
           return (
             <Tbody isExpanded={isExpanded} key={id}>
@@ -88,7 +90,7 @@ const SmartProxyExpandableTable = ({ smartProxyId }) => {
               </Tr>
               <Tr key="child_row" ouiaId={`ContentViewTableRowChild-${id}`} isExpanded={isExpanded}>
                 <Td colSpan={2}>
-                  <ExpandableCvDetails contentViews={contentViews} />
+                  <ExpandableCvDetails contentViews={contentViews} counts={counts} />
                 </Td>
               </Tr>
             </Tbody>

--- a/webpack/scenes/SmartProxy/__tests__/SmartProxyContentTest.js
+++ b/webpack/scenes/SmartProxy/__tests__/SmartProxyContentTest.js
@@ -3,7 +3,7 @@ import { renderWithRedux, patientlyWaitFor } from 'react-testing-lib-wrapper';
 
 import { nockInstance, assertNockRequest } from '../../../test-utils/nockWrapper';
 import api from '../../../services/api';
-import SmartProxyContentTable from '../SmartProxyContentTable';
+import SmartProxyExpandableTable from '../SmartProxyExpandableTable';
 
 const smartProxyContentData = require('./SmartProxyContentResult.fixtures.json');
 
@@ -11,7 +11,7 @@ const smartProxyContentPath = api.getApiUrl('/capsules/1/content/sync');
 
 const smartProxyContent = { ...smartProxyContentData };
 
-const contentTable = <SmartProxyContentTable smartProxyId={1} />;
+const contentTable = <SmartProxyExpandableTable smartProxyId={1} />;
 
 test('Can display Smart proxy content table', async (done) => {
   const detailsScope = nockInstance
@@ -19,13 +19,12 @@ test('Can display Smart proxy content table', async (done) => {
     .query(true)
     .reply(200, smartProxyContent);
 
-  const { getByText, getAllByLabelText } = renderWithRedux(contentTable);
+  const { getByText, getAllByText, getAllByLabelText } = renderWithRedux(contentTable);
   await patientlyWaitFor(() => expect(getByText('Environment')).toBeInTheDocument());
-  expect(getByText('Content view')).toBeInTheDocument();
-  expect(getByText('Type')).toBeInTheDocument();
-  expect(getByText('Last published')).toBeInTheDocument();
-  expect(getByText('Repositories')).toBeInTheDocument();
-  expect(getByText('Synced to smart proxy')).toBeInTheDocument();
+  expect(getAllByText('Content view')[0]).toBeInTheDocument();
+  expect(getAllByText('Last published')[0]).toBeInTheDocument();
+  expect(getAllByText('Repositories')[0]).toBeInTheDocument();
+  expect(getAllByText('Synced to smart proxy')[0]).toBeInTheDocument();
   expect(getAllByLabelText('Details')[0]).toHaveAttribute('aria-expanded', 'false');
   getAllByLabelText('Details')[0].click();
   expect(getAllByLabelText('Details')[0]).toHaveAttribute('aria-expanded', 'true');


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add UI bits for capsule content redesigned page with content counts.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Add some CVs to environments tied to a capsule and run a sync.
2. Check to see if content counts show up on the UI.

Have added all necessary changes to commits here for easier testing.