### PR TITLE
Fixes #36750 - Add aggregated CV version content counts to count field and return via API

### DIFF
--- a/app/views/katello/api/v2/capsule_content/sync_status.json.rabl
+++ b/app/views/katello/api/v2/capsule_content/sync_status.json.rabl
@@ -43,7 +43,8 @@ child @lifecycle_environments => :lifecycle_environments do
           :up_to_date => @capsule.repos_pending_sync(env, content_view).empty?,
           :counts => {
             :repositories => ::Katello::ContentViewVersion.in_environment(env).find_by(:content_view => content_view)&.archived_repos&.count
-          }
+          },
+          :content_counts => @capsule.content_counts
         }
         attributes
       end

--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -102,6 +102,24 @@ module Katello
               ostree_repo.id.to_s => {"ostree_ref" => 30 },
               deb_repo.id.to_s => { "deb" => 987 },
               python_repo.id.to_s => { "python_package" => 42 }
+            },
+            "cv_version_content_counts" =>
+            {  "erratum" => 4,
+               "srpm" => 1,
+               "rpm" => 31,
+               "rpm.modulemd" => 7,
+               "rpm.modulemd_defaults" => 3,
+               "package_group" => 7,
+               "rpm.packagecategory" => 1,
+               "file" => 100,
+               "ansible_collection" => 802,
+               "container.blob" => 30,
+               "docker_manifest_list" => 1,
+               "docker_manifest" => 9,
+               "docker_tag" => 5,
+               "ostree_ref" => 30,
+               "deb" => 987,
+               "python_package" => 42
             }
           }
         }


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds aggregated cv_version content count to smart proxy content counts and adds the content counts to API.
#### Considerations taken when implementing this change?
We need aggregated cv_version content counts to easily display on UI and the aggregated count on the API is good information to have about the synced CV version.
#### What are the testing steps for this pull request?
Add some repositories of different content types to the CV and publish and promote to an env tied to a smart proxy. 
Check the API call for smart_proxy/:id.. You can check this in the network tab when you go to smart proxy details page.
The API return should have a cv_version_content_counts key with aggregated counts of all content types.  