### PR TITLE
Fixes #36162 - Better error message when trying to export unsynced immediate repo

### DIFF
--- a/app/lib/actions/pulp3/content_view_version/export.rb
+++ b/app/lib/actions/pulp3/content_view_version/export.rb
@@ -24,6 +24,14 @@ module Actions
                                                    .create_export(input[:exporter_data],
                                                                         chunk_size: input[:chunk_size])
         end
+
+        def rescue_external_task(error)
+          if error.is_a?(::Katello::Errors::Pulp3Error) && error.message.match?(/Remote artifacts cannot be exported/)
+            fail ::Katello::Errors::Pulp3ExportError, "Failed to export: One or more repositories needs to be synced (with Immediate download policy.)"
+          else
+            super
+          end
+        end
       end
     end
   end

--- a/app/lib/actions/pulp3/orchestration/content_view_version/export_repository.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/export_repository.rb
@@ -28,7 +28,7 @@ module Actions
           end
 
           def run
-            output[:export_history_id] = input[:export_action_output][:export_history_id]
+            output[:export_history_id] = input[:export_action_output]&.[](:export_history_id)
           end
 
           def humanized_name

--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -110,6 +110,7 @@ module Katello
 
     class Pulp3Error < StandardError; end
     class Pulp3MigrationError < StandardError; end
+    class Pulp3ExportError < StandardError; end
 
     class PulpError < StandardError
       def self.from_task(task)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Turns this:
```
[............................................................................................................................................] [100%]
Error: Remote artifacts cannot be exported.
undefined method `first' for nil:NilClass
```

into this:
```
[..........................................................................................................................................             ] [92%]
Error: Failed to export: One or more repositories needs to be synced (with Immediate download policy.)
```


#### Considerations taken when implementing this change?


#### What are the testing steps for this pull request?

Create and sync a repository - On Demand
Change the repository download policy to Immediate - but don't resync

```
hammer content-export complete repository --product-id 313 --name "Zoo Repo"
```

