### PR TITLE
Fixes #36782 - Update UI in preparation for SCA-only

### DIFF
--- a/app/views/overrides/organizations/_edit_override.html.erb
+++ b/app/views/overrides/organizations/_edit_override.html.erb
@@ -18,4 +18,8 @@
     tag1 + tag2
   end %>
 
+  <div class="alert alert-warning" role="alert">
+    <%= _('Simple Content Access will be required for all organizations in Katello 4.12.') %>
+  </div>
+
 <% end %>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/content-access-mode-banner.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/content-access-mode-banner.html
@@ -5,6 +5,6 @@ This organization has Simple Content Access enabled.  Hosts are not required to 
 </div>
 <div id="non-sca-banner" bst-alert="warning" ng-if="!simpleContentAccessEnabled">
   <span translate>
-This organization is not using <a target="_blank" href="https://access.redhat.com/articles/simple-content-access">Simple Content Access.</a> Entitlement-based subscription management is deprecated and will be removed in a future version.
+This organization is not using <a target="_blank" href="https://access.redhat.com/articles/simple-content-access">Simple Content Access.</a> Entitlement-based subscription management is deprecated and will be removed in Katello 4.12.
   </span>
 </div>

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -6,6 +6,8 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
 import { isEmpty } from 'lodash';
 import { Grid, Row, Col, Alert } from 'patternfly-react';
+import { Popover, Flex, FlexItem } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import ModalProgressBar from 'foremanReact/components/common/ModalProgressBar';
 import PermissionDenied from 'foremanReact/components/PermissionDenied';
 import ManageManifestModal from './Manifest/';
@@ -204,7 +206,7 @@ class SubscriptionsPage extends Component {
     const emptyStateData = isManifestImported
       ? {
         header: __('There are no Subscriptions to display'),
-        description: __('Add Subscriptions using the Add Subscriptions button.'),
+        description: __('Add subscriptions using the Add Subscriptions button.'),
         action: {
           title: __('Add subscriptions'),
           url: 'subscriptions/add',
@@ -212,7 +214,7 @@ class SubscriptionsPage extends Component {
       }
       : {
         header: __('There are no Subscriptions to display'),
-        description: __('Import a Manifest to manage your Entitlements.'),
+        description: __('Import a subscription manifest to give hosts access to Red Hat content.'),
         action: {
           onClick: () => openManageManifestModal(),
           title: __('Import a Manifest'),
@@ -220,26 +222,50 @@ class SubscriptionsPage extends Component {
       };
 
     const SCAAlert = (
-      <Alert ouiaId="sca-alert" type={simpleContentAccess ? 'info' : 'warning'}>
+      <Alert ouiaId="sca-alert" type="warning">
         <FormattedMessage
           id="sca-alert"
           values={{
-            subscriptionsService: <a href={SUBSCRIPTIONS_SERVICE_DOC_URL} target="_blank" rel="noreferrer">{__('Subscriptions service')}</a>,
-            br: <br />,
             scaLink: <a href={SCA_URL} target="_blank" rel="noreferrer">{__('Simple Content Access')}</a>,
           }}
-          defaultMessage={simpleContentAccess ? __(`This organization has Simple Content Access enabled.
-          Hosts are not required to have subscriptions attached to access repositories.
-          {br}
-          Learn more about your overall subscription usage with the {subscriptionsService}.`) : __('This organization is not using {scaLink}. Entitlement-based subscription management is deprecated and will be removed in a future version.')}
+          defaultMessage={__('This organization is not using {scaLink}. Entitlement-based subscription management is deprecated and will be removed in Katello 4.12.')}
         />
       </Alert>
+    );
+
+    const SCAPopoverContent = (
+      <FormattedMessage
+        id="sca-popover-content"
+        values={{
+          br: <br />,
+          subscriptionsService: <a href={SUBSCRIPTIONS_SERVICE_DOC_URL} target="_blank" rel="noreferrer">{__('Subscriptions service')}</a>,
+        }}
+        defaultMessage={__(`This page shows the subscriptions available from this organization's subscription manifest.
+        {br}
+        Learn more about your overall subscription usage with the {subscriptionsService}.`)}
+      />
     );
     return (
       <Grid bsClass="container-fluid">
         <Row>
           <Col sm={12}>
-            <h1>{__('Subscriptions')}</h1>
+            <Flex alignItems={{ default: 'alignItemsBaseline' }}>
+              <FlexItem>
+                <h1>{__('Subscriptions')}</h1>
+              </FlexItem>
+              {isManifestImported && (
+              <FlexItem>
+                <Popover
+                  aria-label="sca-popover"
+                  bodyContent={SCAPopoverContent}
+                >
+                  <span style={{ cursor: 'pointer', position: 'relative', top: '-0.2em' }}>
+                    <OutlinedQuestionCircleIcon>Toggle popover</OutlinedQuestionCircleIcon>
+                  </span>
+                </Popover>
+              </FlexItem>
+              )}
+            </Flex>
 
             <SubscriptionsToolbar
               canManageSubscriptionAllocations={canManageSubscriptionAllocations}
@@ -274,7 +300,7 @@ class SubscriptionsPage extends Component {
             />
 
             <div id="subscriptions-table" className="modal-container">
-              {!this.props.organization?.loading && SCAAlert}
+              {!this.props.organization?.loading && !simpleContentAccess ? SCAAlert : null}
               <SubscriptionsTable
                 canManageSubscriptionAllocations={canManageSubscriptionAllocations}
                 loadSubscriptions={this.props.loadSubscriptions}

--- a/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsPage.test.js.snap
+++ b/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsPage.test.js.snap
@@ -25,9 +25,19 @@ exports[`subscriptions page should render 1`] = `
       componentClass="div"
       sm={12}
     >
-      <h1>
-        Subscriptions
-      </h1>
+      <Flex
+        alignItems={
+          Object {
+            "default": "alignItemsBaseline",
+          }
+        }
+      >
+        <FlexItem>
+          <h1>
+            Subscriptions
+          </h1>
+        </FlexItem>
+      </Flex>
       <SubscriptionsToolbar
         autocompleteQueryParams={
           Object {
@@ -71,24 +81,16 @@ exports[`subscriptions page should render 1`] = `
           type="warning"
         >
           <FormattedMessage
-            defaultMessage="This organization is not using {scaLink}. Entitlement-based subscription management is deprecated and will be removed in a future version."
+            defaultMessage="This organization is not using {scaLink}. Entitlement-based subscription management is deprecated and will be removed in Katello 4.12."
             id="sca-alert"
             values={
               Object {
-                "br": <br />,
                 "scaLink": <a
                   href="https://access.redhat.com/articles/simple-content-access"
                   rel="noreferrer"
                   target="_blank"
                 >
                   Simple Content Access
-                </a>,
-                "subscriptionsService": <a
-                  href="https://access.redhat.com/documentation/en-us/subscription_central/2021/html-single/getting_started_with_the_subscriptions_service/index"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  Subscriptions service
                 </a>,
               }
             }
@@ -102,7 +104,7 @@ exports[`subscriptions page should render 1`] = `
                 "onClick": [Function],
                 "title": "Import a Manifest",
               },
-              "description": "Import a Manifest to manage your Entitlements.",
+              "description": "Import a subscription manifest to give hosts access to Red Hat content.",
               "header": "There are no Subscriptions to display",
             }
           }


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add UI messaging in preparation for the retirement of entitlement mode in Katello 4.12.

![image](https://github.com/Katello/katello/assets/22042343/1326a60a-4fd4-4316-9929-7dd597a6e029)

![image](https://github.com/Katello/katello/assets/22042343/d0e1bcf6-bcaf-4dc2-8adb-bcab200f9b6d)

![image](https://github.com/Katello/katello/assets/22042343/e4e8729f-fa70-4969-a117-ff59a6dffeac)

![image](https://github.com/Katello/katello/assets/22042343/6a728c8e-9159-4608-ae67-b6ff8986c25d)

![image](https://github.com/Katello/katello/assets/22042343/659aff30-9bbf-4409-a830-c7e6cfd94468)


#### Considerations taken when implementing this change?

Once the branding plugin is updated, "Katello 4.12" will translate to "Satellite 6.16" downstream.

#### What are the testing steps for this pull request?

Check all of the following locations:

* Non-SCA Banner messages updated with specific Katello version (4.12) on
   * Subscriptions page
   * Legacy Content Host details page
   * Activation Key details page
 * Organization Edit screen has a message next to the SCA checkbox
 * SCA Banner message (Subscriptions service link) updated per UX guidance:
 * For SCA organizations, banner will be removed
 * The second sentence ("Learn more about your subscription usage..."), with the link to the Subscriptions service, will appear inside a Popover. This popover will be accessed by clicking a question mark icon (?) to the right of the "Subscriptions" title/header.
 * The question mark icon / popover is not visible for organizations with no manifest imported.
 * Also, adjusted some wording for Subscriptions page empty states.

