### PR TITLE
Fixes #36787 - Delete oprhan content task doesn't remove orphaned remotes in the Capsule

### DIFF
--- a/app/services/katello/pulp3/api/core.rb
+++ b/app/services/katello/pulp3/api/core.rb
@@ -224,7 +224,7 @@ module Katello
           remotes_api.list(args).results
         end
 
-        def remotes_list_all(_smart_proxy, options)
+        def remotes_list_all(_smart_proxy, options = {})
           self.class.fetch_from_list do |page_opts|
             remotes_api.list(page_opts.merge(options))
           end

--- a/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
+++ b/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
@@ -102,7 +102,7 @@ module Katello
         acs_remotes = Katello::SmartProxyAlternateContentSource.pluck(:remote_href)
         pulp3_enabled_repo_types.each do |repo_type|
           api = repo_type.pulp3_api(smart_proxy)
-          remotes = api.remotes_list
+          remotes = api.remotes_list_all(smart_proxy)
 
           remotes.each do |remote|
             if !repo_names.include?(remote.name) && !acs_remotes.include?(remote.pulp_href)

--- a/test/services/katello/pulp3/smart_proxy_repository_test.rb
+++ b/test/services/katello/pulp3/smart_proxy_repository_test.rb
@@ -24,7 +24,7 @@ module Katello
 
         smart_proxy_mirror_repo.expects(:pulp3_enabled_repo_types).once.returns([::Katello::RepositoryTypeManager.find(:yum)])
         ::Katello::SmartProxyHelper.any_instance.expects(:combined_repos_available_to_capsule).once.returns([fedora, rhel6])
-        ::Katello::Pulp3::Api::Yum.any_instance.expects(:remotes_list).once.returns(pulp_remotes)
+        ::Katello::Pulp3::Api::Yum.any_instance.expects(:remotes_list_all).once.returns(pulp_remotes)
         ::Katello::Pulp3::Api::Yum.any_instance.expects(:delete_remote).once.with(rhel7_href).returns('rhel-7-gone')
 
         assert_equal ['rhel-7-gone'], smart_proxy_mirror_repo.delete_orphan_remotes


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Delete *all* orphaned remotes on capsule when deleting orphaned content.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create >100 repositories
2. Add and publish the repo to a CV version tied to an env on a capsule.
3. Sync capsule.
4. Edit capsule to remove the env.
5. Run "bundle exec rails katello:delete_orphaned_content" and make sure all remotes are deleted on capsule.
You can check that using pulp-cli from your server with:
"pulp --profile=proxy rpm remote list"