### PR TITLE
Fixes #36790 - Show recalculate action in happy empty state

### DIFF
--- a/webpack/components/Table/EmptyStateMessage.js
+++ b/webpack/components/Table/EmptyStateMessage.js
@@ -54,16 +54,19 @@ const EmptyStateMessage = ({
   const clearSearch = useSelector(selectSearchBarClearSearch);
   const showSecondaryActionAnchor = showSecondaryAction && secondaryActionLink;
   const handleClick = () => {
+    const shouldReload = (searchIsActive || filtersAreActive);
     if (searchIsActive) {
       clearSearch();
     }
     if (filtersAreActive || showSecondaryActionButton) {
       resetFilters();
     }
-    dispatch({
-      type: `${requestKey}_REQUEST`,
-      key: requestKey,
-    });
+    if (shouldReload) {
+      dispatch({
+        type: `${requestKey}_REQUEST`,
+        key: requestKey,
+      });
+    }
   };
 
   const actionButton = primaryActionButton ?? (

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -106,6 +106,11 @@ export const ErrataTab = () => {
     setToggleGroupState(APPLICABLE);
   };
 
+  const recalculateErrata = () => {
+    setIsBulkActionOpen(false);
+    dispatch(regenerateApplicability(hostId));
+  };
+
   let resetFilters = resetFiltersOnly;
   let secondaryActionTextOverride;
   let emptyContentTitle;
@@ -114,6 +119,8 @@ export const ErrataTab = () => {
   case 'All up to date':
     emptyContentTitle = __('All up to date');
     emptyContentBody = __('No action is needed because there are no applicable errata for this host.');
+    resetFilters = recalculateErrata;
+    secondaryActionTextOverride = __('Recalculate');
     break;
   case 'Needed':
     emptyContentTitle = __('No matching errata found');
@@ -265,11 +272,6 @@ export const ErrataTab = () => {
   const bulkCustomizedRexUrl = () => errataInstallUrl({
     hostname, search: (selectedCount > 0) ? fetchBulkParams() : '',
   });
-
-  const recalculateErrata = () => {
-    setIsBulkActionOpen(false);
-    dispatch(regenerateApplicability(hostId));
-  };
 
   const showActions = can(invokeRexJobs, userPermissions);
 
@@ -447,7 +449,7 @@ export const ErrataTab = () => {
             secondaryActionTextOverride,
           }
           }
-          showSecondaryActionButton={neededErrata}
+          showSecondaryActionButton={neededErrata || showRecalculate}
           happyEmptyContent={allUpToDate}
           ouiaId="host-errata-table"
           additionalListeners={[


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Adds a "Recalculate" link to the "happy" empty state for ErrataTab.

There's no change in functionality for this action (for now), so you're going to have to just wait for the task to complete and then refresh the browser. It doesn't poll the task like it does for REX jobs.


![image](https://github.com/Katello/katello/assets/22042343/830ef693-9e75-4ae9-bc22-93d9fdf046d2)


#### Considerations taken when implementing this change?

I first just brought back the table toolbar, but it looked super ugly with the disabled "Apply" button.
Then I thought about hiding the apply button and just having the kebab in its own row, but that would also be ugly.
This is the only non-ugly solution I could think of.

#### What are the testing steps for this pull request?

Make sure the ErrataTab continues to work properly in all situations (no errata, some errata, no search results)
