### PR TITLE
Fixes #36794 - Preselect upgradable packages with link on hosts page

### DIFF
--- a/app/views/katello/hosts/_errata_counts.html.erb
+++ b/app/views/katello/hosts/_errata_counts.html.erb
@@ -27,7 +27,7 @@
 
 <% if !host.operatingsystem_name&.match(/Debian|Ubuntu/) %>
 <% if Setting["host_details_ui"] %>
-<a href="/new/hosts/<%= host.name %>#/Content/packages">
+<a href="/new/hosts/<%= host.name %>#/Content/packages?status=Upgradable">
 <% else %>
 <a href="/content_hosts/<%= host.id %>/packages/applicable">
 <% end %>
@@ -43,7 +43,7 @@
 <% end %>
 <% if host.operatingsystem_name&.match(/Debian|Ubuntu/) %>
 <% if Setting["host_details_ui"] %>
-<a href="/new/hosts/<%= host.name %>#/Content/packages">
+<a href="/new/hosts/<%= host.name %>#/Content/packages?status=Upgradable">
 <% else %>
 <a href="/content_hosts/<%= host.id %>/debs/applicable">
 <% end %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Before this change the following button:
![image](https://github.com/Katello/katello/assets/42647570/e8305eed-70ab-48e0-834e-1ccab8856536)

- leads to this page:
![image](https://github.com/Katello/katello/assets/42647570/11c7cda0-2b00-4245-ad07-f8686d256ac7)

- and after the change to this page:
![image](https://github.com/Katello/katello/assets/42647570/b343ccec-c82c-45a2-9f31-4e9bd8b2bdc5)



#### Considerations taken when implementing this change?

The capital letter in "Upgradable" is on purpose or the text in the status dropdown will suddenly show up as all lower letters.

#### What are the testing steps for this pull request?

- Make sure the above mentioned click on the "RPM package updates" directly selects the Upgradable packages status
- The hosts ui's packages page should still work without issues (removing the status, searching, ...)
