### PR TITLE
Fixes #36797 - Update API in preparation for SCA-only

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -56,7 +56,7 @@ module Katello
     api :PUT, '/organizations/:id', N_('Update organization')
     param :id, :number, :desc => N_("organization ID"), :required => true
     param :redhat_repository_url, String, :desc => N_("Red Hat CDN URL"), deprecated: true
-    param :simple_content_access, :bool, :desc => N_('Whether Simple Content Access should be enabled for the organization.'), :required => false, :default => true
+    param :simple_content_access, :bool, :desc => N_('Whether Simple Content Access should be enabled for the organization.'), :required => false, :default => true, deprecated: true
     param_group :resource
     def update
       if params[:redhat_repository_url]
@@ -80,7 +80,7 @@ module Katello
     param :organization, Hash do
       param :label, String, :required => false
     end
-    param :simple_content_access, :bool, :desc => N_('Whether to turn on Simple Content Access for the organization.'), :required => false, :default => true
+    param :simple_content_access, :bool, :desc => N_('Whether to turn on Simple Content Access for the organization.'), :required => false, :default => true, deprecated: true
     def create
       @organization = Organization.new(resource_params)
       sca = params.key?(:simple_content_access) ? ::Foreman::Cast.to_bool(params[:simple_content_access]) : true

--- a/app/controllers/katello/api/v2/simple_content_access_controller.rb
+++ b/app/controllers/katello/api/v2/simple_content_access_controller.rb
@@ -8,15 +8,15 @@ module Katello
     end
 
     api :GET, "/organizations/:organization_id/simple_content_access/eligible",
-      N_("Check if the specified organization is eligible for Simple Content Access")
+      N_("Check if the specified organization is eligible for Simple Content Access. %s") % sca_only_deprecation_text, deprecated: true
     def eligible
-      ::Foreman::Deprecation.api_deprecation_warning("This endpoint is deprecated and will be removed in a future release. All organizations are now eligible for Simple Content Access.")
+      ::Foreman::Deprecation.api_deprecation_warning("This endpoint is deprecated and will be removed in Katello 4.12. All organizations are now eligible for Simple Content Access.")
       eligible = @organization.simple_content_access_eligible?
       render json: { simple_content_access_eligible: eligible }
     end
 
     api :GET, "/organizations/:organization_id/simple_content_access/status",
-      N_("Check if the specified organization has Simple Content Access enabled")
+      N_("Check if the specified organization has Simple Content Access enabled. %s") % sca_only_deprecation_text, deprecated: true
     param :organization_id, :number, :desc => N_("Organization ID"), :required => true
     def status
       status = @organization.simple_content_access?
@@ -24,7 +24,7 @@ module Katello
     end
 
     api :PUT, "/organizations/:organization_id/simple_content_access/enable",
-      N_("Enable simple content access for a manifest")
+      N_("Enable simple content access for a manifest"), deprecated: true
     param :organization_id, :number, :desc => N_("Organization ID"), :required => true
     def enable
       task = async_task(::Actions::Katello::Organization::SimpleContentAccess::Enable, params[:organization_id])
@@ -32,7 +32,7 @@ module Katello
     end
 
     api :PUT, "/organizations/:organization_id/simple_content_access/disable",
-      N_("Disable simple content access for a manifest")
+      N_("Disable simple content access for a manifest. %s") % sca_only_deprecation_text, deprecated: true
     param :organization_id, :number, :desc => N_("Organization ID"), :required => true
     def disable
       task = async_task(::Actions::Katello::Organization::SimpleContentAccess::Disable, params[:organization_id])

--- a/app/controllers/katello/concerns/api/api_controller.rb
+++ b/app/controllers/katello/concerns/api/api_controller.rb
@@ -17,6 +17,12 @@ module Katello
         User.current
       end
 
+      class_methods do
+        def sca_only_deprecation_text
+          N_("WARNING: Simple Content Access will be required for all organizations in Katello 4.12.")
+        end
+      end
+
       protected
 
       def request_from_katello_cli?

--- a/app/controllers/katello/concerns/organizations_controller_extensions.rb
+++ b/app/controllers/katello/concerns/organizations_controller_extensions.rb
@@ -25,6 +25,7 @@ module Katello
             begin
               @taxonomy = Organization.new(resource_params)
               sca = ::Foreman::Cast.to_bool(params[:simple_content_access])
+              ::Foreman::Deprecation.api_deprecation_warning("Simple Content Access will be required for all organizations in Katello 4.12.")
               ::Katello::OrganizationCreator.new(@taxonomy, sca: sca).create!
               @taxonomy.reload
               switch_taxonomy
@@ -47,6 +48,7 @@ module Katello
       def update
         return if params[:simple_content_access].nil?
         sca_param = ::Foreman::Cast.to_bool(params[:simple_content_access])
+        ::Foreman::Deprecation.api_deprecation_warning("Simple Content Access will be required for all organizations in Katello 4.12.")
         if sca_param && !@taxonomy.simple_content_access?(cached: false)
           # user has requested SCA enable
           sync_task(::Actions::Katello::Organization::SimpleContentAccess::Enable, params[:id])


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Prepare API endpoints and params for the retirement of entitlement mode in Katello 4.12.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
- Organization /Create/Edit throws a log message.

`2023-10-03T20:04:59 [W|app|19e3e9b9] DEPRECATION WARNING: Simple Content Access will be required for all organizations in Katello 4.12.`
