### PR TITLE
Fixes #36808 - Add sudo to Resolve Traces template

### DIFF
--- a/app/views/foreman/job_templates/resolve_traces.erb
+++ b/app/views/foreman/job_templates/resolve_traces.erb
@@ -20,5 +20,5 @@ reboot = commands.delete('reboot')
 shutdown -r +1
 <% else -%>
 <%= commands.join("\n") %>
-katello-tracer-upload
+sudo katello-tracer-upload
 <% end %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

In the Resolve Traces - Katello Script Default template, use `sudo` when running `katello-tracer-upload`. This will allow REX to use a non-root user when executing the job.

#### Considerations taken when implementing this change?

We also have a "Resolve Traces - Katello Ansible Default" but I didn't change that one because I think Ansible defaults to `become: true` anyway, is that right?

#### What are the testing steps for this pull request?

Check out the PR.
Refresh your job templates:
```
# bundle exec rails console
ForemanInternal.all.last.destroy
```

Then go look at the locked job template and verify that it's updated. Bonus: actually run it via REX as a non-root user
