### PR TITLE
Fixes #36820 - translate modulemd content counts

### DIFF
--- a/app/services/katello/pulp3/pulp_content_unit.rb
+++ b/app/services/katello/pulp3/pulp_content_unit.rb
@@ -7,6 +7,7 @@ module Katello
       # Any class that extends this class should define:
       # Class#update_model
 
+      # rubocop:disable Metrics/MethodLength
       def self.katello_name_from_pulpcore_name(pulpcore_name, repo)
         # Counts shouldn't be needed for more than the default generic content unit type.
         if repo.generic?
@@ -25,6 +26,8 @@ module Katello
           ::Katello::PackageGroup::CONTENT_TYPE
         when ::Katello::Pulp3::Erratum::PULPCORE_CONTENT_TYPE
           ::Katello::Erratum::CONTENT_TYPE
+        when ::Katello::Pulp3::ModuleStream::PULPCORE_CONTENT_TYPE
+          'module_stream'
         when ::Katello::Pulp3::DockerTag::PULPCORE_CONTENT_TYPE
           ::Katello::DockerTag::CONTENT_TYPE
         when ::Katello::Pulp3::DockerManifest::PULPCORE_CONTENT_TYPE
@@ -41,6 +44,7 @@ module Katello
           pulpcore_name
         end
       end
+      # rubocop:enable Metrics/MethodLength
 
       def self.content_api
         fail NotImplementedError

--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -103,7 +103,7 @@ module Katello
       expected_counts = { "content_view_versions" =>
         { yum_repo.content_view_version.id.to_s =>
           { "repositories" =>
-            { yum_repo.id.to_s => { "erratum" => 4, "srpm" => 1, "rpm" => 31, "rpm.modulemd" => 7, "rpm.modulemd_defaults" => 3, "package_group" => 7, "rpm.packagecategory" => 1 },
+            { yum_repo.id.to_s => { "erratum" => 4, "srpm" => 1, "rpm" => 31, "module_stream" => 7, "rpm.modulemd_defaults" => 3, "package_group" => 7, "rpm.packagecategory" => 1 },
               file_repo.id.to_s => { "file" => 100 },
               ansible_repo.id.to_s => { "ansible.collection" => 802 },
               container_repo.id.to_s => { "container.blob" => 30, "docker_manifest_list" => 1, "docker_manifest" => 9, "docker_tag" => 5 },


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Module streams weren't translated properly to Katello terms for smart proxy counts.

#### Considerations taken when implementing this change?
I considered that rpm.modulemd is completely confusing for Katello users.

#### What are the testing steps for this pull request?
1) Sync a smart proxy with some module streams
2) `curl -X GET https://`hostname`/katello/api/capsules/2/content/counts -H "Content-Type: application/json" -uadmin:changeme | jq`
3) See that instead of rpm.modulemd it says "module_stream" for module streams.