### PR TITLE
Fixes #35901 - Allow searching for CCVs based on component CVs

### DIFF
--- a/app/controllers/katello/concerns/filtered_auto_complete_search.rb
+++ b/app/controllers/katello/concerns/filtered_auto_complete_search.rb
@@ -7,7 +7,7 @@ module Katello
 
       def auto_complete_search
         begin
-          options = resource_class.respond_to?(:completer_scope_options) ? resource_class.completer_scope_options : {}
+          options = resource_class.respond_to?(:completer_scope_options) ? resource_class.completer_scope_options(params[:search]) : {}
           items = resource_class.where(:id => self.index_relation).complete_for(params[:search], options)
           items = items.map do |item|
             category = ['and', 'or', 'not', 'has'].include?(item.to_s.sub(/^.*\s+/, '')) ? _('Operators') : ''

--- a/app/models/katello/docker_tag.rb
+++ b/app/models/katello/docker_tag.rb
@@ -73,7 +73,7 @@ module Katello
       self.where(:id => ids)
     end
 
-    def self.completer_scope_options
+    def self.completer_scope_options(_search)
       {"#{Katello::Repository.table_name}" => lambda { |repo_class| repo_class.docker_type } }
     end
 

--- a/app/models/katello/yum_metadata_file.rb
+++ b/app/models/katello/yum_metadata_file.rb
@@ -15,7 +15,7 @@ module Katello
       [repository]
     end
 
-    def self.completer_scope_options
+    def self.completer_scope_options(_search)
       {"#{Katello::Repository.table_name}" => lambda { |repo_class| repo_class.yum_type } }
     end
   end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add a new field to Content View scoped_search. This will allow you to search for a composite content view that contains a particular content view.

For example:
```
content_views = My-Content_view
```

will return _composite_ content views that have My-Content_view as one of their components.


#### Considerations taken when implementing this change?

I'm still not sure about any performance implications; suggestions welcome

#### What are the testing steps for this pull request?

Create at least one composite CV but preferably hundreds lol
Search on the Content Views page
Make sure everything works as expected
