### PR TITLE
Fixes #36835 - host applicable errata filter too slow

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -71,7 +71,7 @@ module Katello
       # It is not the errata "belonging" to the host. Its rather the errata that is "applicable"
       # which is calculated elsewhere.
 
-      self.joins(:content_facets).
+      self.group(:id).distinct.joins(:content_facets).
         where("#{Katello::Host::ContentFacet.table_name}.host_id" => hosts.select(:id))
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Makes the errata returned by `self.applicable_to_hosts` distinct so that fewer records are returned. In one case, where a user had 10,000 hosts but only 7000 applicable errata, `self.applicable_to_hosts` returned over a million errata records with many duplicates.

This caused the following command to timeout due to too much processing on the web server:
```
hammer erratum list --errata-restrict-applicable 1 ...
```

#### Considerations taken when implementing this change?
There may have been other approaches for taking care of the timeouts, but this seemed to be the most impactful

#### What are the testing steps for this pull request?
1) Register some hosts and ensure they have applicable errata.
2) Run `hammer erratum list --errata-restrict-applicable 1 ...` and ensure that the returned list makes sense.
 -> I don't think it's feasible to test with a massive installation, so checking for correctness on the output should be good enough.
 -> Bonus points if you want to do a quick check of the performance of the query with and without the distinctness.
