### PR TITLE
Fixes #36862 - Added the slot fill for hosts index

### DIFF
--- a/webpack/components/extensions/Hosts/ActionsBar/index.js
+++ b/webpack/components/extensions/Hosts/ActionsBar/index.js
@@ -1,0 +1,40 @@
+import React, { useContext } from 'react';
+import { DropdownItem } from '@patternfly/react-core';
+import { CubeIcon } from '@patternfly/react-icons';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { foremanUrl } from 'foremanReact/common/helpers';
+import { ForemanHostsIndexActionsBarContext } from 'foremanReact/components/HostsIndex';
+
+const HostActionsBar = () => {
+  const {
+    fetchBulkParams,
+    selectedCount,
+    selectAllMode,
+  } = useContext(ForemanHostsIndexActionsBarContext);
+
+  let href = '';
+  if (selectAllMode) {
+    const query = fetchBulkParams({ selectAllQuery: 'created_at < "1 second ago"' });
+    href = foremanUrl(`/change_host_content_source?search=${query}`);
+  } else if (selectedCount > 0) {
+    href = foremanUrl(`/change_host_content_source?search=${fetchBulkParams({})}`);
+  }
+
+  const title = __('Change content source');
+  return (
+    <>
+      <DropdownItem
+        ouiaId="change-content-s-dropdown-item"
+        key="change-content-source-dropdown-item"
+        title={title}
+        href={href}
+        isDisabled={selectedCount === 0}
+        icon={<CubeIcon />}
+      >
+        {title}
+      </DropdownItem>
+    </>
+  );
+};
+
+export default HostActionsBar;

--- a/webpack/components/extensions/Hosts/constants.js
+++ b/webpack/components/extensions/Hosts/constants.js
@@ -1,0 +1,2 @@
+const HOSTS_INDEX = 'HOSTS';
+export default HOSTS_INDEX;

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -25,7 +25,8 @@ import {
   SystemPropertiesCardVirtualization,
   SystemPropertiesCardTracer,
 } from './components/extensions/HostDetails/DetailsTabCards/SystemPropertiesCardExtensions';
-import HostActionsBar from './components/extensions/HostDetails/ActionsBar';
+import HostDetailsActionsBar from './components/extensions/HostDetails/ActionsBar';
+import HostsIndexActionsBar from './components/extensions/Hosts/ActionsBar';
 import RecentCommunicationCardExtensions from './components/extensions/HostDetails/DetailsTabCards/RecentCommunicationCardExtensions';
 import SystemPurposeCard from './components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeCard';
 
@@ -67,7 +68,15 @@ addGlobalFill('host-details-tab-properties-3', 'Virtualization', <SystemProperti
 addGlobalFill(
   'host-details-kebab',
   'katello-host-details-kebab',
-  <HostActionsBar key="katello-host-details-kebab" />,
+  <HostDetailsActionsBar key="katello-host-details-kebab" />,
   100,
 );
+
+addGlobalFill(
+  'hosts-index-kebab',
+  'katello-hosts-index-kebab',
+  <HostsIndexActionsBar key="katello-hosts-index-kebab" />,
+  100,
+);
+
 addGlobalFill('host-tab-details-cards', 'HW properties', <HwPropertiesCard key="hw-properties" />, 200);

--- a/webpack/scenes/Hosts/ChangeContentSource/index.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/index.js
@@ -8,6 +8,7 @@ import { foremanUrl } from 'foremanReact/common/helpers';
 import { STATUS } from 'foremanReact/constants';
 import BreadcrumbBar from 'foremanReact/components/BreadcrumbBar';
 import Head from 'foremanReact/components/Head';
+import { useForemanHostsPageUrl } from 'foremanReact/Root/Context/ForemanContext';
 
 import { selectApiDataStatus,
   selectApiContentViewStatus,
@@ -96,14 +97,14 @@ const ChangeContentSourcePage = () => {
     setShouldShowTemplate(true);
   };
 
+  const hostIndexUrl = useForemanHostsPageUrl();
   const breadcrumbItems = () => {
-    const linkHosts = { caption: __('Hosts'), url: foremanUrl('/hosts') };
+    const linkHosts = { caption: __('Hosts'), url: hostIndexUrl };
     const linkContent = { caption: __('Change host content source') };
 
     if (urlParams.host_id) {
       const hostName = contentHosts.concat(hostsWithoutContent)
         .find(h => `${h.id}` === urlParams.host_id)?.name;
-
       return ([linkHosts, { caption: hostName, url: foremanUrl(`/new/hosts/${hostName}`) }, linkContent]);
     }
     return ([linkHosts, linkContent]);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This adds the Change Content Source action to the HostsIndex page

Goes with PR => https://github.com/theforeman/foreman/pull/9860

#### What are the testing steps for this pull request?

Check out both https://github.com/theforeman/foreman/pull/9860 and this PR

* Goto `Administer > Settings` and set the `new_hosts_pages` property to true
* Reload the page
* Go to `Hosts > All Hosts`  => you should see the new page
* Click on the kebab
* You should notice the Change Content Source action (disabled if nothing is selected, enable if something is.)
* Select a few hosts and click on the kebab.
* Make sure the change content source actually redirects you to the correct page.