### PR TITLE
Fixes #36850 - Add indexes to speed up applicability calculation when there are lots of module streams installed

### DIFF
--- a/db/migrate/20231020153017_create_indexes_for_nvra_and_epoch.rb
+++ b/db/migrate/20231020153017_create_indexes_for_nvra_and_epoch.rb
@@ -1,0 +1,6 @@
+class CreateIndexesForNvraAndEpoch < ActiveRecord::Migration[6.1]
+  def change
+    add_index :katello_installed_packages, :nvra
+    add_index :katello_installed_packages, [:nvra, :epoch]
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add indexes to the `katello_installed_packages` table. This should hopefully speed up applicability calculations when there are a lot of module streams installed.

#### Considerations taken when implementing this change?

This is really tricky to test when you don't have a lot of hosts. The best testing steps I found are those @hao-yu gave us, I'll adapt them below

#### What are the testing steps for this pull request?

Steps to Reproduce:
1. Prepare a RHEL 8 client and register it to the Satellite.
2. Enable the appstream repository.
3. Enable and install as many module streams as possible.
4. After that force upload the package profile to the Satellite to trigger the  "Katello::Applicability::Hosts::BulkGenerate" task.

Now, in Rails console, do this both before and after running the migration:

```
cf = Host.find(XXXX).content_facet
bound_repos = cf.bound_repositories.collect {|repo| repo.library_instance_id.nil? ? repo.id : repo.library_instance_id}
helper = Katello::Applicability::ApplicableContentHelper.new(cf, ::Katello::Rpm, bound_repos)
helper.fetch_enabled_module_stream_ids.size
Benchmark.measure {p helper.locked_modular_installed_packages(helper.fetch_enabled_module_stream_ids).size}
```

Do the benchmark 5-6 times in a row and take the average.

For my dev setup with a single rhel8 host - Typical benchmarks after the migration:

```
#<Benchmark::Tms:0x0000562b392fe9b8
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=0.2544070029980503,
 @stime=0.0011980000000000046,
 @total=0.18494600000000003,
 @utime=0.18374800000000002>
```

Before the migration, the `@real` was closer to .50 or .41. So not a _huge_ improvement at this scale, but still measurable.
