### PR TITLE
Fixes #36853 - Fix the tests that caused SIGKILL

### DIFF
--- a/test/services/katello/ui_notifications/hosts/lifecycle_expire_soon_test.rb
+++ b/test/services/katello/ui_notifications/hosts/lifecycle_expire_soon_test.rb
@@ -32,54 +32,17 @@ module Katello
         end
 
         def test_with_year_2024_1_1
-          Time.stubs(:now).returns(Time.utc(2024, 1, 1))
+          expire_soon = {"RHEL7" => {"maintenance_support" => Time.parse("2024-06-30")}, "RHEL6" => {"extended_support" => Time.parse("2024-06-30")}}
+          ::Katello::RhelLifecycleStatus.expects(:lifecycles_expire_soon).returns(expire_soon)
           @subject.expects(:hosts_with_index).with("RHEL6").returns([mock('rhel6')])
           @subject.expects(:hosts_with_index).with("RHEL7").returns([mock('rhel7')])
           @subject.deliver!
           assert_equal 2, NotificationBlueprint.find_by(name: 'host_lifecycle_expire_soon').notifications.count
         end
 
-        def test_with_year_2025_1_1
-          Time.stubs(:now).returns(Time.utc(2025, 1, 1))
-          @subject.deliver!
-          assert_equal 0, NotificationBlueprint.find_by(name: 'host_lifecycle_expire_soon').notifications.count
-        end
-
-        def test_with_year_2026_6_1
-          Time.stubs(:now).returns(Time.utc(2026, 6, 1))
-          @subject.deliver!
-          assert_equal 0, NotificationBlueprint.find_by(name: 'host_lifecycle_expire_soon').notifications.count
-        end
-
-        def test_with_year_2027_7_1
-          Time.stubs(:now).returns(Time.utc(2027, 7, 1))
-          @subject.expects(:hosts_with_index).with("RHEL7").returns([mock('rhel7')])
-          @subject.deliver!
-          assert_equal 1, NotificationBlueprint.find_by(name: 'host_lifecycle_expire_soon').notifications.count
-        end
-
-        def test_with_year_2028_6_1
-          Time.stubs(:now).returns(Time.utc(2028, 6, 1))
-          @subject.expects(:hosts_with_index).with("RHEL7").returns([mock('rhel7')])
-          @subject.expects(:hosts_with_index).with("RHEL8").returns([mock('rhel8')])
-          @subject.deliver!
-          assert_equal 2, NotificationBlueprint.find_by(name: 'host_lifecycle_expire_soon').notifications.count
-        end
-
-        def test_with_year_2029_6_1
-          Time.stubs(:now).returns(Time.utc(2029, 6, 1))
-          @subject.deliver!
-          assert_equal 0, NotificationBlueprint.find_by(name: 'host_lifecycle_expire_soon').notifications.count
-        end
-
-        def test_with_year_2030_6_1
-          Time.stubs(:now).returns(Time.utc(2030, 6, 1))
-          @subject.deliver!
-          assert_equal 0, NotificationBlueprint.find_by(name: 'host_lifecycle_expire_soon').notifications.count
-        end
-
         def test_with_year_2031_6_1
-          Time.stubs(:now).returns(Time.utc(2031, 6, 1))
+          expire_soon = {"RHEL9" => {"maintenance_support" => Time.parse("2032-05-31")}, "RHEL8" => {"extended_support" => Time.parse("2032-05-31")}}
+          ::Katello::RhelLifecycleStatus.expects(:lifecycles_expire_soon).returns(expire_soon)
           @subject.expects(:hosts_with_index).with("RHEL8").returns([mock('rhel8')])
           @subject.expects(:hosts_with_index).with("RHEL9").returns([mock('rhel9')])
           @subject.deliver!


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Seems line like `Time.stubs(:now).returns(Time.utc(2024, 1, 1))` alone without other code would cause SIGKIL.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
`bundle exec rake jenkins:katello TESTOPTS="-v" --trace` could pass without SIGKIL.