### PR TITLE
Fixes #36857 - Run content count update on smart proxy after orphan cleanup

### DIFF
--- a/app/lib/actions/katello/orphan_cleanup/remove_orphans.rb
+++ b/app/lib/actions/katello/orphan_cleanup/remove_orphans.rb
@@ -15,7 +15,15 @@ module Actions
               plan_action(
                 Actions::Pulp3::Orchestration::OrphanCleanup::RemoveOrphans,
                 proxy)
+              plan_self(:smart_proxy_id => proxy.id)
             end
+          end
+        end
+
+        def finalize
+          smart_proxy = ::SmartProxy.unscoped.find(input[:smart_proxy_id])
+          if smart_proxy.pulp_mirror?
+            ::ForemanTasks.async_task(::Actions::Katello::CapsuleContent::UpdateContentCounts, smart_proxy)
           end
         end
       end

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -126,9 +126,8 @@ module Katello
         new_content_counts = { content_view_versions: {} }
         smart_proxy_helper = ::Katello::SmartProxyHelper.new(self)
         repos = smart_proxy_helper.repositories_available_to_capsule
-        return new_content_counts if repos.empty?
 
-        repos.each do |repo|
+        repos&.each do |repo|
           repo_mirror_service = repo.backend_service(self).with_mirror_adapter
           repo_content_counts = repo_mirror_service.latest_content_counts
           translated_counts = {metadata: {}, counts: {}}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Trigger a content count update task after running orphan cleanup
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Have a proxy and some content views/envs tied to it and sync the capsule.
2. Check the result from endpoint `/katello/api/capsules/:id/content/counts`
3. Remove an env from capsule and don't sync.
4. Run `bundle exec rails katello:delete_orphaned_content`
5. Check the result from endpoint `/katello/api/capsules/:id/content/counts`
6. The content_counts will remain the same.
7. Checkout this PR.
8. Run `bundle exec rails katello:delete_orphaned_content`
9. The content_counts should get updated to reflect only envs still tied to smart_proxy.