### PR TITLE
Fixes #36861 - fix username and password definition into request_params

### DIFF
--- a/app/lib/katello/repo_discovery.rb
+++ b/app/lib/katello/repo_discovery.rb
@@ -117,8 +117,8 @@ module Katello
         url: "#{@uri}v1/search?q=#{@search}"
       }
 
-      request_params[:headers][:user] = @upstream_username unless @upstream_username.empty?
-      request_params[:headers][:password] = @upstream_password unless @upstream_password.empty?
+      request_params[:user] = @upstream_username unless @upstream_username.empty?
+      request_params[:password] = @upstream_password unless @upstream_password.empty?
       request_params[:proxy] = proxy_uri if proxy
 
       begin


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

username and password should not be inside headers

#### What are the testing steps for this pull request?

- To properly test this a private container registry, using API v2 is necessary. 
- Having the registry url and credentials, try discovering the repositories available on such registry
- no authentication errors are to be expected
