### PR TITLE
Fixes #36844 - Fail early when syncing non-library repos

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -348,6 +348,7 @@ Alternatively, use the 'force' parameter to regenerate metadata locally. On the 
     param :skip_metadata_check, :bool, :desc => N_("Force sync even if no upstream changes are detected. Only used with yum or deb repositories."), :required => false
     param :validate_contents, :bool, :desc => N_("Force a sync and validate the checksums of all content. Only used with yum repositories."), :required => false
     def sync
+      fail HttpErrors::BadRequest, _("attempted to sync a non-library repository.") unless @repository.library_instance?
       sync_options = {
         :skip_metadata_check => ::Foreman::Cast.to_bool(params[:skip_metadata_check]),
         :validate_contents => ::Foreman::Cast.to_bool(params[:validate_contents]),

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -85,6 +85,7 @@ module Actions
         def validate_repo!(repo:, source_url:, skip_metadata_check:, skip_candlepin_check:)
           fail ::Katello::Errors::InvalidActionOptionError, _("Unable to sync repo. This repository does not have a feed url.") if repo.url.blank? && source_url.blank?
           fail ::Katello::Errors::InvalidActionOptionError, _("Cannot skip metadata check on non-yum/deb repositories.") if skip_metadata_check && !repo.yum? && !repo.deb?
+          fail ::Katello::Errors::InvalidActionOptionError, _("Unable to sync repo. This repository is not a library instance repository.") unless repo.library_instance?
           ::Katello::Util::CandlepinRepositoryChecker.check_repository_for_sync!(repo) if repo.yum? && !skip_candlepin_check
         end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fail properly when trying to sync non-library repos
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a repository. (Note repo_id)
2. Add it to some CV and publish.
3. Fetch either the archived or the cv-env version repo from console. `Katello::Repository.where(library_instance_id: repo_id).first`
4. Try to sync the repo from step 3 using hammer: `hammer repository sync --id=env_repo_id`