### PR TITLE
Fixes #36852 - Allow fetching capsule sync task per env

### DIFF
--- a/app/views/katello/api/v2/capsule_content/sync_status.json.rabl
+++ b/app/views/katello/api/v2/capsule_content/sync_status.json.rabl
@@ -35,6 +35,17 @@ child @lifecycle_environments => :lifecycle_environments do
     @capsule.environment_syncable?(env)
   end
 
+  node :last_sync do |env|
+    last_env_sync_task = @capsule.last_env_sync_task(env)
+    attributes = {
+      :id => last_env_sync_task&.id,
+      :started_at => last_env_sync_task&.started_at,
+      :result => last_env_sync_task&.result,
+      :last_sync_words => last_env_sync_task.try(:started_at) ? time_ago_in_words(Time.parse(last_env_sync_task.started_at.to_s)) : nil
+    }
+    attributes
+  end
+
   if @capsule.has_feature?(SmartProxy::PULP_NODE_FEATURE) || @capsule.has_feature?(SmartProxy::PULP3_FEATURE)
     node :counts do |env|
       {

--- a/webpack/scenes/SmartProxy/SmartProxyExpandableTable.js
+++ b/webpack/scenes/SmartProxy/SmartProxyExpandableTable.js
@@ -25,8 +25,7 @@ const SmartProxyExpandableTable = ({ smartProxyId, organizationId }) => {
   const dispatch = useDispatch();
   let metadata = {};
   const {
-    lifecycle_environments: results, last_sync_task: lastTask, last_sync_words: lastSyncWords,
-    content_counts: contentCounts,
+    lifecycle_environments: results, content_counts: contentCounts,
   } = response;
   if (results) {
     metadata = { total: results.length, subtotal: results.length };
@@ -89,7 +88,7 @@ const SmartProxyExpandableTable = ({ smartProxyId, organizationId }) => {
       {
           results?.map((env, rowIndex) => {
             const {
-              id, content_views: contentViews,
+              id, content_views: contentViews, last_sync: lastSync,
             } = env;
             const isExpanded = tableRowIsExpanded(id);
             return (
@@ -106,7 +105,7 @@ const SmartProxyExpandableTable = ({ smartProxyId, organizationId }) => {
                     }}
                   />
                   <Td><ComponentEnvironments environments={[env]} /></Td>
-                  <Td><LastSync lastSync={lastTask} lastSyncWords={lastSyncWords} emptyMessage="N/A" /></Td>
+                  <Td><LastSync lastSync={lastSync} lastSyncWords={lastSync?.last_sync_words} emptyMessage="N/A" /></Td>
                   <Td
                     key={`rowActions-${id}`}
                     actions={{


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Update Smart Proxy content UI to show env level sync tasks if those exist. 
#### Considerations taken when implementing this change?
We are showing env level records on new smart proxy page. We have a column to show the last sync task for the environments individually. The only way to start an env sync is via hammer/API which starts a capsule sync task with environment_id set in input[:options]

**PS:** There's a known issue here where if you run a complete sync and then later add a new env to the smart proxy, the complete sync task will appear to have run on the env on the page. Right now we have no way of telling if envs were added before or after a sync was run. Open to ideas. In these cases, even if the env suggests capsule is synced, the expansion aka CV will show not synced cause that information comes from smart_proxy_sync_history record. 

#### What are the testing steps for this pull request?
1. Add a few env to a capsule and run a complete sync.
2. In hammer, run a targeted sync for a particular environment: `hammer capsule content synchronize --lifecycle-environment-id=4 --id=2`
3. Go to smart proxy UI and confirm if the Sync time for the env changes to the latest task.
