### PR TITLE
Fixes #36882 - errata's issued and updated times shouldn't be changed to local timezone

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-info.html
@@ -24,10 +24,10 @@
       <dd>{{ errata.severity | errataSeverity }}</dd>
 
       <dt translate>Issued</dt>
-      <dd><long-date-time date="errata.issued" /></dd>
+      <dd>{{ errata.issued }}</dd>
 
       <dt translate>Last Updated On</dt>
-      <dd><long-date-time date="errata.updated" /></dd>
+      <dd>{{ errata.updated }}</dd>
 
       <dt translate>Reboot Suggested?</dt>
       <dd>{{ errata.reboot_suggested | booleanToYesNo }}</dd>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
@@ -101,7 +101,7 @@
             <span translate>{{ errata.hosts_applicable_count || 0 }} Applicable, </span>
             <span translate>{{ errata.hosts_available_count || 0 }} Installable</span>
           </td>
-          <td bst-table-cell><long-date-time date="errata.updated" /></td>
+          <td bst-table-cell>{{ errata.updated }}</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Show errata issued and updated as Date strings instead of dates with timezones to match the errata details page. ex: https://access.redhat.com/errata/RHSA-2023:5244
![2023-10-11 16 27 09 access redhat com 60681be49574](https://github.com/Katello/katello/assets/21146741/69f77028-988f-4475-91b8-6bdca31fe56b)

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1. Go to any errata details page.
2. If you are in EST (UTC -4) timezone, you'll see your redhat errata have a day - 1 as the issued/updated date.
3. With this PR, you'll see the same issued/updated as on the https://access.redhat.com/errata/ details page
