### PR TITLE
Fixes #36883 - Wrong date when using an errata by date filter

### DIFF
--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
@@ -21,7 +21,9 @@ export const dateFormat = date => `${(date.getMonth() + 1).toString().padStart(2
 
 export const convertAPIDateToUIFormat = (dateString) => {
   if (!dateString || dateString === '') return '';
-  return dateFormat(new Date(dateString));
+  const dateTZ = new Date(dateString);
+  dateTZ.setMinutes(dateTZ.getMinutes() + dateTZ.getTimezoneOffset());
+  return dateFormat(dateTZ);
 };
 
 export const dateParse = (date) => {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Updates CV -> Filters -> Errata by date range filter to ignore timezone by adding timezone offset to time to show times in UTC instead of local timezone
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Create an errata by date filter.
In the console, update the date to something like this : cvf.start_date = "2023-10-01"
On the UI, the date will show up as 9/30 instead of 10/01
With this change, you should see 9/30