### PR TITLE
use foreman-devel module for packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -32,7 +32,7 @@ jobs:
     trigger: pull_request
     targets:
       centos-stream-8:
-        additional_modules: "katello:el8,nodejs:12"
+        additional_modules: "katello:el8,foreman-devel:el8"
         additional_repos:
           - http://koji.katello.org/releases/yum/foreman-nightly/el8/x86_64/
           - http://yum.theforeman.org/plugins/nightly/el8/x86_64/


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

don't directly depend on nodejs module, so that foreman is in charge of deciding which nodejs we use

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
