### PR TITLE
Refs #17748 - Filter out who to send the emails to

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -53,7 +53,7 @@ module Actions
           notification = MailNotification[:proxy_sync_failure]
           proxy = SmartProxy.find(input.fetch(:smart_proxy, {})[:id])
           subjects = subjects(input[:options]).merge(smart_proxy: proxy)
-          notification.users.each do |user|
+          notification.users.where(disabled: [nil, false], mail_enabled: true).each do |user|
             notification.deliver(subjects.merge(user: user, task: task))
           end
         end

--- a/app/lib/actions/katello/content_view/promote.rb
+++ b/app/lib/actions/katello/content_view/promote.rb
@@ -27,7 +27,7 @@ module Actions
         def notify_on_failure(_plan)
           notification = MailNotification[:content_view_promote_failure]
           view = ::Katello::ContentView.find(input.fetch(:content_view, {})[:id])
-          notification.users.each do |user|
+          notification.users.where(disabled: [nil, false], mail_enabled: true).each do |user|
             notification.deliver(user: user, content_view: view, task: task)
           end
         end

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -136,7 +136,7 @@ module Actions
         def notify_on_failure(_plan)
           notification = MailNotification[:content_view_publish_failure]
           view = ::Katello::ContentView.find(input.fetch(:content_view, {})[:id])
-          notification.users.each do |user|
+          notification.users.where(disabled: [nil, false], mail_enabled: true).each do |user|
             notification.deliver(user: user, content_view: view, task: task)
           end
         end

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -102,7 +102,7 @@ module Actions
         def notify_on_failure(_plan)
           notification = MailNotification[:repository_sync_failure]
           repo = ::Katello::Repository.find(input.fetch(:repository, {})[:id])
-          notification.users.each do |user|
+          notification.users.where(disabled: [nil, false], mail_enabled: true).each do |user|
             notification.deliver(user: user, repo: repo, task: task)
           end
         end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Previously the emails were sent out to all the users which opt-in for it, even if those users were disabled or didn't have mail notification checkbox enabled.

#### What are the testing steps for this pull request?
1) Set up a user, opt in for repo sync failure email notifications, disable the user
2) Run a repo sync that will fail
3) The user from 1 shouldn't get an email