### PR TITLE
Fixes #36873 - Store all env_ids for smart_proxy complete sync in task

### DIFF
--- a/app/controllers/katello/api/v2/capsule_content_controller.rb
+++ b/app/controllers/katello/api/v2/capsule_content_controller.rb
@@ -73,12 +73,16 @@ module Katello
       find_content_view if params[:content_view_id]
       find_repository if params[:repository_id]
       skip_metadata_check = ::Foreman::Cast.to_bool(params[:skip_metadata_check])
+      sync_options = {
+        :environment_id => @environment.try(:id),
+        :content_view_id => @content_view.try(:id),
+        :repository_id => @repository.try(:id),
+        :skip_metadata_check => skip_metadata_check
+      }
+      sync_options[:environment_ids] = @capsule.lifecycle_environments&.pluck(:id) unless (@environment || @content_view || @repository)
       task = async_task(::Actions::Katello::CapsuleContent::Sync,
                         @capsule,
-                        :environment_id => @environment.try(:id),
-                        :content_view_id => @content_view.try(:id),
-                        :repository_id => @repository.try(:id),
-                        :skip_metadata_check => skip_metadata_check)
+                        sync_options)
       respond_for_async :resource => task
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Added a new environment_ids value in capsule sync task input which stores all env_ids o proxy when a full sync task is started
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1. Sync a smart proxy and add some env/cvs and run a full sync.
2. Go to smart proxy > content tab and check sync time against envs.
3. Wait a minute and then run an env specific capsule sync task from hammer : ex: `hammer capsule content synchronize --id 2 --lifecycle-environment qa --organization-id 1`
4. Go to smart proxy > content tab and check sync time against env you ran sync on. it should show latest task and others should show older complete task.
5. Add a new env to smart proxy from edit smart proxy action.
6. Go back to content tab for proxy and confirm that you see N/A for sync time against the env.