### PR TITLE
Refs #36866 - Removes an unused method since this got ported to foreman

### DIFF
--- a/webpack/utils/helpers.js
+++ b/webpack/utils/helpers.js
@@ -124,4 +124,3 @@ export default {
   apiError,
 };
 
-export const friendlySearchParam = searchParam => decodeURIComponent(searchParam.replace(/\+/g, ' '));


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Removes an unused method. This should ve gotten removed as a part of https://github.com/Katello/katello/pull/10783

#### Considerations taken when implementing this change?

The usedUrlParams method  - which was the only place this method was used in - got moved to Foreman  as a part of => https://github.com/theforeman/foreman/pull/9899 

#### What are the testing steps for this pull request?
Grep for `friendlySearchParam` in katello code and see zero references.