### PR TITLE
Fixes #36908 - Creating an override with hammer for one repository should not override all repositories

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -176,7 +176,6 @@ module Katello
       content_override_values = @content_overrides.map do |override_params|
         validate_content_overrides_enabled(override_params)
       end
-
       sync_task(::Actions::Katello::Host::UpdateContentOverrides, @host, content_override_values, false)
       fetch_product_content
     end
@@ -232,7 +231,7 @@ module Katello
     end
 
     def find_content_overrides
-      if params[:content_overrides_search]
+      if !params.dig(:content_overrides_search, :search).nil?
         content_labels = ::Katello::Content.joins(:product_contents)
                             .where("#{Katello::ProductContent.table_name}.product_id": @host.organization.products.subscribable.enabled)
                             .search_for(params[:content_overrides_search][:search])

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -230,6 +230,17 @@ module Katello
       assert_template 'katello/api/v2/repository_sets/index'
     end
 
+    def test_find_content_overrides_with_empty_string_search
+      controller = ::Katello::Api::V2::HostSubscriptionsController.new
+      controller.params = { :host_id => @host.id, :content_overrides => "wrong", :content_overrides_search => { :search => '' } }
+      controller.instance_variable_set(:@host, @host)
+      controller.send(:find_content_overrides)
+
+      # content_overrides should be set from search param, not content_overrides param
+      result = controller.instance_variable_get(:@content_overrides)
+      refute_equal result, "wrong"
+    end
+
     def test_content_override_bulk
       content_overrides = [{:content_label => 'some-content', :value => 1}]
       expected_content_labels = content_overrides.map { |co| co[:content_label] }


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Issue happens only with Katello 4.7.

#### Considerations taken when implementing this change?
Backport fix https://github.com/Katello/katello/pull/10387 to Katello 4.7.

#### What are the testing steps for this pull request?
1. List enabled repositories for the client
    `hammer host subscription product-content --content-access-mode-all=true --content-access-mode-env=true  --host myhost.example.com`
2. Change one repo to be enabled
    `hammer host subscription content-override --host myhost.example.com --content-label satellite-client-6-for-rhel-9-x86_64-rpms --enabled=true --value=true`
3. List enabled repositories for the client again
     `hammer host subscription product-content --content-access-mode-all=true --content-access-mode-env=true  --host myhost.example.com`