### PR TITLE
Fixes #36557 - ouiaId does not apply to PF3

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@testing-library/user-event": "^13.5.0",
     "@theforeman/builder": ">= 6.0.0",
     "@theforeman/find-foreman": "^4.8.0",
-    "@theforeman/eslint-plugin-rules": "^12.0.1",
+    "@theforeman/eslint-plugin-rules": "^12.2.0",
     "axios-mock-adapter": "^1.10.0",
     "eslint": "^6.2.2",
     "eslint-config-airbnb": "^16.0.0",

--- a/webpack/components/Content/Details/ContentDetails.js
+++ b/webpack/components/Content/Details/ContentDetails.js
@@ -10,7 +10,7 @@ const ContentDetails = (props) => {
 
   const tabHeaders = () => {
     const tabs = schema.map(node => (
-      <NavItem key={node.key} eventKey={node.key} ouiaId={`${node.key}-nav-item`}>
+      <NavItem key={node.key} eventKey={node.key}>
         <div>{node.tabHeader}</div>
       </NavItem>
     ));
@@ -40,12 +40,12 @@ const ContentDetails = (props) => {
           <Grid>
             <Row>
               <Col sm={12}>
-                <Nav id="content-nav-container" bsClass="nav nav-tabs" ouiaId="content-details-nav">
+                <Nav id="content-nav-container" bsClass="nav nav-tabs">
                   {schema && tabHeaders()}
                 </Nav>
               </Col>
             </Row>
-            <TabContent animation={false} ouiaId="content-details-tab-content">
+            <TabContent animation={false}>
               {schema && tabPanes()}
             </TabContent>
           </Grid>

--- a/webpack/components/Content/Details/__tests__/__snapshots__/ContentDetails.test.js.snap
+++ b/webpack/components/Content/Details/__tests__/__snapshots__/ContentDetails.test.js.snap
@@ -35,7 +35,6 @@ exports[`Content Details Info should render and contain appropriate components 1
               bsClass="nav nav-tabs"
               id="content-nav-container"
               justified={false}
-              ouiaId="content-details-nav"
               pullLeft={false}
               pullRight={false}
               stacked={false}
@@ -45,7 +44,6 @@ exports[`Content Details Info should render and contain appropriate components 1
                 disabled={false}
                 eventKey={1}
                 key="1"
-                ouiaId="1-nav-item"
               >
                 <div>
                   Details
@@ -56,7 +54,6 @@ exports[`Content Details Info should render and contain appropriate components 1
                 disabled={false}
                 eventKey={2}
                 key="2"
-                ouiaId="2-nav-item"
               >
                 <div>
                   Repositories
@@ -70,7 +67,6 @@ exports[`Content Details Info should render and contain appropriate components 1
           bsClass="tab"
           componentClass="div"
           mountOnEnter={false}
-          ouiaId="content-details-tab-content"
           unmountOnExit={false}
         >
           <TabPane

--- a/webpack/components/SelectOrg/SetOrganization.js
+++ b/webpack/components/SelectOrg/SetOrganization.js
@@ -74,7 +74,6 @@ class SetOrganization extends Component {
               <div className="col-sm-3">
                 <a href={`/organizations/${id}/select`}>
                   <Button
-                    ouiaId="select-org-button"
                     disabled={this.state.disabled}
                     className="btn btn-primary"
                     onClick={this.onSend}

--- a/webpack/components/TooltipButton/TooltipButton.js
+++ b/webpack/components/TooltipButton/TooltipButton.js
@@ -6,7 +6,7 @@ import './TooltipButton.scss';
 const TooltipButton = ({
   disabled, title, tooltipText, tooltipId, tooltipPlacement, renderedButton, ...props
 }) => {
-  if (!disabled) return renderedButton || (<Button {...props} ouiaId="tooltip-button">{title}</Button>);
+  if (!disabled) return renderedButton || (<Button {...props}>{title}</Button>);
   return (
     <OverlayTrigger
       placement={tooltipPlacement}
@@ -14,7 +14,7 @@ const TooltipButton = ({
       overlay={<Tooltip id={tooltipId}>{tooltipText}</Tooltip>}
     >
       <div className="tooltip-button-helper">
-        {renderedButton || (<Button {...props} disabled ouiaId="tooltip-disabled-button">{title}</Button>)}
+        {renderedButton || (<Button {...props} disabled>{title}</Button>)}
       </div>
     </OverlayTrigger>
   );

--- a/webpack/components/TooltipButton/__snapshots__/TooltipButton.test.js.snap
+++ b/webpack/components/TooltipButton/__snapshots__/TooltipButton.test.js.snap
@@ -30,7 +30,6 @@ exports[`TooltipButton renders disabled TooltipButton 1`] = `
       bsClass="btn"
       bsStyle="default"
       disabled={true}
-      ouiaId="tooltip-disabled-button"
     >
       some-title
     </Button>
@@ -74,7 +73,6 @@ exports[`TooltipButton renders enabled TooltipButton 1`] = `
   bsClass="btn"
   bsStyle="default"
   disabled={false}
-  ouiaId="tooltip-button"
 >
   some-title
 </Button>
@@ -89,6 +87,5 @@ exports[`TooltipButton renders minimal TooltipButton 1`] = `
   bsClass="btn"
   bsStyle="default"
   disabled={false}
-  ouiaId="tooltip-button"
 />
 `;

--- a/webpack/components/pf3Table/components/Table.js
+++ b/webpack/components/pf3Table/components/Table.js
@@ -42,7 +42,6 @@ const Table = ({
         {body}
       </PfTable.PfProvider>
       {shouldRenderPagination && (
-        // eslint-disable-next-line @theforeman/rules/require-ouiaid
         <Pagination
           itemCount={itemCount}
           onChange={onPaginationChange}

--- a/webpack/scenes/RedHatRepositories/__tests__/__snapshots__/RedHatRepositoriesPage.test.js.snap
+++ b/webpack/scenes/RedHatRepositories/__tests__/__snapshots__/RedHatRepositoriesPage.test.js.snap
@@ -119,7 +119,6 @@ exports[`RedHatRepositories page should render 1`] = `
               onChange={[Function]}
               onPerPageSelect={null}
               onSetPage={null}
-              ouiaId="enabled-repos-pagination"
               page={1}
               perPage={null}
               updateParamsByUrl={true}

--- a/webpack/scenes/RedHatRepositories/components/RecommendedRepositorySetsToggler.js
+++ b/webpack/scenes/RedHatRepositories/components/RecommendedRepositorySetsToggler.js
@@ -19,7 +19,6 @@ const RecommendedRepositorySetsToggler = ({
   return (
     <div className={classes} {...props}>
       <Switch
-        ouiaId="enabled-repo-set-switch"
         bsSize="mini"
         value={enabled}
         onChange={() => onChange(!enabled)}

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
@@ -53,7 +53,7 @@ export class RepositorySetRepositories extends Component {
 
     if (data.error) {
       return (
-        <Alert type="danger" ouiaId="repo-set-alert">
+        <Alert type="danger">
           <span>{data.error.displayMessage}</span>
         </Alert>
       );

--- a/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/RecommendedRepositorySetsToggler.test.js.snap
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/RecommendedRepositorySetsToggler.test.js.snap
@@ -19,7 +19,6 @@ exports[`RecommendedRepositorySetsToggler rendering renders recommended-reposito
     onChange={[Function]}
     onColor="primary"
     onText="ON"
-    ouiaId="enabled-repo-set-switch"
     readonly={false}
     tristate={false}
     value={true}

--- a/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/RepositorySetRepositories.test.js.snap
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/RepositorySetRepositories.test.js.snap
@@ -18,7 +18,6 @@ exports[`RepositorySetRepositories Component should render with error 1`] = `
 <Alert
   className=""
   onDismiss={null}
-  ouiaId="repo-set-alert"
   type="danger"
 >
   <span>

--- a/webpack/scenes/RedHatRepositories/helpers.js
+++ b/webpack/scenes/RedHatRepositories/helpers.js
@@ -34,7 +34,6 @@ export const getSetsComponent = (repoSetsState, onPaginationChange) => {
     <ListView>
       <div className="sticky-pagination">
         <Pagination
-          ouiaId="repos-pagination"
           itemCount={itemCount}
           onChange={onPaginationChange}
           isCompact
@@ -65,7 +64,6 @@ export const getEnabledComponent = (enabledReposState, onPaginationChange) => {
     <ListView>
       <div className="sticky-pagination sticky-pagination-grey">
         <Pagination
-          ouiaId="enabled-repos-pagination"
           isCompact
           itemCount={itemCount}
           onChange={onPaginationChange}

--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetails.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetails.js
@@ -81,16 +81,16 @@ class SubscriptionDetails extends Component {
         <TabContainer id="subscription-tabs-container" defaultActiveKey={1}>
           <div>
             <LoadingState loading={subscriptionDetails.loading} loadingText={__('Loading')}>
-              <Nav bsClass="nav nav-tabs" ouiaId="subscription-details-nav">
-                <NavItem eventKey={1} ouiaId="details-nav-item">
+              <Nav bsClass="nav nav-tabs">
+                <NavItem eventKey={1}>
                   <div>{__('Details')}</div>
                 </NavItem>
-                <NavItem eventKey={2} ouiaId="product-content-nav-item">
+                <NavItem eventKey={2}>
                   <div>{__('Product Content')}</div>
                 </NavItem>
               </Nav>
               <Grid bsClass="container-fluid">
-                <TabContent ouiaId="subscription-details-tab-content" animation={false}>
+                <TabContent animation={false}>
                   <TabPane eventKey={1}>
                     <div>
                       <Row>

--- a/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
+++ b/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
@@ -39,7 +39,6 @@ exports[`subscriptions details page should render and contain appropiate compone
         <Nav
           bsClass="nav nav-tabs"
           justified={false}
-          ouiaId="subscription-details-nav"
           pullLeft={false}
           pullRight={false}
           stacked={false}
@@ -48,7 +47,6 @@ exports[`subscriptions details page should render and contain appropiate compone
             active={false}
             disabled={false}
             eventKey={1}
-            ouiaId="details-nav-item"
           >
             <div>
               Details
@@ -58,7 +56,6 @@ exports[`subscriptions details page should render and contain appropiate compone
             active={false}
             disabled={false}
             eventKey={2}
-            ouiaId="product-content-nav-item"
           >
             <div>
               Product Content
@@ -75,7 +72,6 @@ exports[`subscriptions details page should render and contain appropiate compone
             bsClass="tab"
             componentClass="div"
             mountOnEnter={false}
-            ouiaId="subscription-details-tab-content"
             unmountOnExit={false}
           >
             <TabPane

--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
@@ -129,10 +129,9 @@ class ManageManifestModal extends Component {
 
     return (
       <ForemanModal id={MANAGE_MANIFEST_MODAL_ID} title={__('Manage Manifest')}>
-        <Tabs id="manifest-history-tabs" ouiaId="manifest-history-tabs">
+        <Tabs id="manifest-history-tabs">
           {showManifestTab &&
             <Tab
-              ouiaId="subscription-manifest-tab"
               eventKey={1}
               title={__('Manifest')}
             >
@@ -199,10 +198,10 @@ class ManageManifestModal extends Component {
                           <ForemanModal title={__('Confirm delete manifest')} id={DELETE_MANIFEST_MODAL_ID}>
                             <DeleteManifestModalText simpleContentAccess={simpleContentAccess} />
                             <ForemanModal.Footer>
-                              <Button ouiaId="cancel-button" bsStyle="default" onClick={this.hideDeleteManifestModal}>
+                              <Button bsStyle="default" onClick={this.hideDeleteManifestModal}>
                                 {__('Cancel')}
                               </Button>
-                              <Button ouiaId="delete-button" bsStyle="danger" onClick={this.deleteManifest}>
+                              <Button bsStyle="danger" onClick={this.deleteManifest}>
                                 {__('Delete')}
                               </Button>
                             </ForemanModal.Footer>
@@ -216,13 +215,11 @@ class ManageManifestModal extends Component {
             </Tab>
           }
           <Tab
-            ouiaId="manifest-history-tab"
             eventKey={2}
             title={__('Manifest History')}
           >
             <LoadingState loading={manifestHistory.loading} loadingText={__('Loading')}>
               <Table
-                ouiaId="manifest-history-table"
                 rows={manifestHistory.results}
                 columns={columns}
                 emptyState={emptyStateData()}
@@ -231,7 +228,6 @@ class ManageManifestModal extends Component {
           </Tab>
           {showCdnConfigurationTab &&
             <Tab
-              ouiaId="cdn-configuration-tab"
               eventKey={3}
               title={__('CDN Configuration')}
             >
@@ -248,7 +244,7 @@ class ManageManifestModal extends Component {
           }
         </Tabs>
         <ForemanModal.Footer>
-          <Button ouiaId="close-button" bsStyle="primary" onClick={this.hideModal}>
+          <Button bsStyle="primary" onClick={this.hideModal}>
             {__('Close')}
           </Button>
         </ForemanModal.Footer>

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -222,7 +222,7 @@ class SubscriptionsPage extends Component {
       };
 
     const SCAAlert = (
-      <Alert ouiaId="sca-alert" type="warning">
+      <Alert type="warning">
         <FormattedMessage
           id="sca-alert"
           values={{

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
@@ -132,7 +132,6 @@ class UpstreamSubscriptionsPage extends Component {
           <Row>
             <Col sm={12}>
               <Button
-                ouiaId="submit-button"
                 style={{ marginTop: '10px', marginRight: '5px' }}
                 bsStyle="primary"
                 type="submit"
@@ -144,7 +143,7 @@ class UpstreamSubscriptionsPage extends Component {
               </Button>
 
               <LinkContainer to="/subscriptions" style={{ marginTop: '10px' }}>
-                <Button ouiaId="cancel-button">
+                <Button>
                   {__('Cancel')}
                 </Button>
               </LinkContainer>

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/__snapshots__/UpstreamSubscriptionsPage.test.js.snap
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/__snapshots__/UpstreamSubscriptionsPage.test.js.snap
@@ -191,7 +191,6 @@ exports[`upstream subscriptions page should render 1`] = `
           bsStyle="primary"
           disabled={true}
           onClick={[Function]}
-          ouiaId="submit-button"
           style={
             Object {
               "marginRight": "5px",
@@ -216,7 +215,6 @@ exports[`upstream subscriptions page should render 1`] = `
             bsClass="btn"
             bsStyle="default"
             disabled={false}
-            ouiaId="cancel-button"
           >
             Cancel
           </Button>

--- a/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsPage.test.js.snap
+++ b/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsPage.test.js.snap
@@ -78,7 +78,6 @@ exports[`subscriptions page should render 1`] = `
         <Alert
           className=""
           onDismiss={null}
-          ouiaId="sca-alert"
           type="warning"
         >
           <FormattedMessage

--- a/webpack/scenes/Subscriptions/components/SubscriptionsToolbar/SubscriptionsToolbar.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsToolbar/SubscriptionsToolbar.js
@@ -74,14 +74,11 @@ const SubscriptionsToolbar = ({
               </a>
             }
 
-            <Button ouiaId="manage-manifest-button" onClick={onManageManifestButtonClick}>
+            <Button onClick={onManageManifestButtonClick}>
               {__('Manage Manifest')}
             </Button>
 
-            <Button
-              ouiaId="export-csv-button"
-              onClick={onExportCsvButtonClick}
-            >
+            <Button onClick={onExportCsvButtonClick}>
               {__('Export CSV')}
             </Button>
             {canManageSubscriptionAllocations &&

--- a/webpack/scenes/Subscriptions/components/SubscriptionsToolbar/__snapshots__/SubscriptionsToolbar.test.js.snap
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsToolbar/__snapshots__/SubscriptionsToolbar.test.js.snap
@@ -72,7 +72,6 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar 1`] = `
             bsStyle="default"
             disabled={false}
             onClick={[Function]}
-            ouiaId="manage-manifest-button"
           >
             Manage Manifest
           </Button>
@@ -83,7 +82,6 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar 1`] = `
             bsStyle="default"
             disabled={false}
             onClick={[Function]}
-            ouiaId="export-csv-button"
           >
             Export CSV
           </Button>
@@ -166,7 +164,6 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar with disabled add but
             bsStyle="default"
             disabled={false}
             onClick={[Function]}
-            ouiaId="manage-manifest-button"
           >
             Manage Manifest
           </Button>
@@ -177,7 +174,6 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar with disabled add but
             bsStyle="default"
             disabled={false}
             onClick={[Function]}
-            ouiaId="export-csv-button"
           >
             Export CSV
           </Button>
@@ -260,7 +256,6 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar with disabled delete 
             bsStyle="default"
             disabled={false}
             onClick={[Function]}
-            ouiaId="manage-manifest-button"
           >
             Manage Manifest
           </Button>
@@ -271,7 +266,6 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar with disabled delete 
             bsStyle="default"
             disabled={false}
             onClick={[Function]}
-            ouiaId="export-csv-button"
           >
             Export CSV
           </Button>
@@ -354,7 +348,6 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar with disabled manifes
             bsStyle="default"
             disabled={false}
             onClick={[Function]}
-            ouiaId="manage-manifest-button"
           >
             Manage Manifest
           </Button>
@@ -365,7 +358,6 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar with disabled manifes
             bsStyle="default"
             disabled={false}
             onClick={[Function]}
-            ouiaId="export-csv-button"
           >
             Export CSV
           </Button>
@@ -466,7 +458,6 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar with table columns 1`
             bsStyle="default"
             disabled={false}
             onClick={[Function]}
-            ouiaId="manage-manifest-button"
           >
             Manage Manifest
           </Button>
@@ -477,7 +468,6 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar with table columns 1`
             bsStyle="default"
             disabled={false}
             onClick={[Function]}
-            ouiaId="export-csv-button"
           >
             Export CSV
           </Button>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Remove `ouiaId` from PF3 components.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Make sure `@theforeman/eslint-plugin-rules` `12.2.0` is installed.
`npx eslint webpack` passes.
No error in `console` like:
```
react-dom.development.js:88 Warning: React does not recognize the `ouiaId` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `ouiaid` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
``` 