### PR TITLE
Fixes #36840 - Clear content source when unregistering host

### DIFF
--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -306,6 +306,7 @@ module Katello
           host.content_facet.applicable_errata = []
           host.content_facet.uuid = nil
           host.content_facet.content_view_environments = []
+          host.content_facet.content_source = ::SmartProxy.pulp_primary
           host.content_facet.save!
           Rails.logger.debug "remove_host_artifacts: marking CVEs unchanged to prevent backend update"
           host.content_facet.mark_cves_unchanged

--- a/webpack/components/extensions/HostDetails/DetailsTabCards/RegistrationCard.js
+++ b/webpack/components/extensions/HostDetails/DetailsTabCards/RegistrationCard.js
@@ -55,9 +55,12 @@ const RegistrationCard = ({ isExpandedGlobal, hostDetails }) => {
   const subscriptionFacetAttributes
     = propsToCamelCase(hostDetails?.subscription_facet_attributes || {});
   const {
-    registeredAt, registeredThrough, activationKeys, user,
+    registeredAt, activationKeys, user,
   }
     = subscriptionFacetAttributes;
+  const contentFacetAttributes
+    = propsToCamelCase(hostDetails?.content_facet_attributes || {});
+  const { contentSourceName } = contentFacetAttributes;
   const login = user?.login;
   if (!registeredAt) return null;
   return (
@@ -78,7 +81,7 @@ const RegistrationCard = ({ isExpandedGlobal, hostDetails }) => {
         </DescriptionListGroup>
         <DescriptionListGroup>
           <DescriptionListTerm>{__('Content source')}</DescriptionListTerm>
-          <DescriptionListDescription>{registeredThrough}</DescriptionListDescription>
+          <DescriptionListDescription>{contentSourceName}</DescriptionListDescription>
         </DescriptionListGroup>
       </DescriptionList>
     </CardTemplate>
@@ -98,6 +101,9 @@ RegistrationCard.propTypes = {
         id: PropTypes.number,
         name: PropTypes.string,
       })),
+    }),
+    content_facet_attributes: PropTypes.shape({
+      content_source_name: PropTypes.string,
     }),
   }),
 };


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* When unregistering (but not destroying the host), reset the host's content source to the Pulp Primary smart proxy.
 * Also correctly display the content source on the host details page (previously it was showing the
  Registered Through smart proxy mislabeled as content source.)

#### Considerations taken when implementing this change?

This can happen when you re-register a host using `--force`.

#### What are the testing steps for this pull request?

1. Set up an external smart proxy (I know, sorry)
2. Set up a new lifecycle environment, and a content view promoted to that environment
3. Sync this LCE to the smart proxy (but don't sync Library)
4. Register the host
 - to this smart proxy
 - using global registration
 - and an AK that assigns your newly created LCE/CV
6. Register the host again
 - to the Pulp Primary smart proxy (your Foreman server)
 - using global registration
 - and the __Force__ checkbox checked
 - and an AK that assigns the Library / Default Organization View

Before checking out this patch: you'll get an error like

```
Validation failed: Host rhel9b.fedora.example.com: Cannot add content view environment to content facet. The host's content source 'rhel8b.fedora.example.com' does not sync lifecycle environment 'Library'. (HTTP error code 422: Unprocessable Entity)
```

If you re-register again after checking out the patch, you should be able to register without errors, and the host's content facet should show the Foreman server as its content source.
