### PR TITLE
Fixes #36921 - Host queue not added to sidekiq

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -68,9 +68,7 @@ module Katello
 
     initializer "katello.register_actions", :before => :finisher_hook do |_app|
       ForemanTasks.dynflow.require!
-      if (Setting.table_exists? rescue(false)) && Setting['host_tasks_workers_pool_size'].to_i > 0
-        ForemanTasks.dynflow.config.queues.add(HOST_TASKS_QUEUE, :pool_size => Setting['host_tasks_workers_pool_size'])
-      end
+      ForemanTasks.dynflow.config.queues.add(HOST_TASKS_QUEUE)
 
       action_paths = %W(#{Katello::Engine.root}/app/lib/actions
                         #{Katello::Engine.root}/app/lib/headpin/actions


### PR DESCRIPTION
The host queue is added too early during the initialization which is before the settings for Foreman plugins are loaded.

Fix it by removing the setting check because pool size is no longer define here. Since Dynflow migrated to Sidekiq, the
concurrency is defined externally in the Sidekiq workers configuration.
