### PR TITLE
Fixes #36924 - Added breadcrumb bar to the header of subscription details pages

### DIFF
--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetails.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetails.js
@@ -59,24 +59,21 @@ class SubscriptionDetails extends Component {
 
     return (
       <div id="subscription-details">
-        {!subscriptionDetails.loading &&
-          <BreadcrumbsBar
-            onSwitcherItemClick={(e, url) => this.handleBreadcrumbSwitcherItem(e, url)}
-            data={{
-              isSwitchable: true,
-              breadcrumbItems: [
-                {
-                  caption: __('Subscriptions'),
-                  onClick: () =>
-                    this.props.history.push('/subscriptions'),
-                },
-                {
-                  caption: String(subscriptionDetails.name || __('Subscription Details')),
-                },
-              ],
-              resource,
-            }}
-          />}
+        {!subscriptionDetails.loading && <BreadcrumbsBar
+          isLoadingResources={subscriptionDetails.loading}
+          onSwitcherItemClick={(e, url) => this.handleBreadcrumbSwitcherItem(e, url)}
+          isSwitchable
+          breadcrumbItems={[
+            {
+              caption: __('Subscriptions'),
+              url: '/subscriptions/',
+            },
+            {
+              caption: String(subscriptionDetails.name || __('Subscription Details')),
+            },
+          ]}
+          resource={resource}
+        />}
 
         <TabContainer id="subscription-tabs-container" defaultActiveKey={1}>
           <div>

--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetails.scss
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetails.scss
@@ -1,4 +1,6 @@
 #subscription-details {
+  margin: 24px;
+
   .scrolld-list {
     max-height: 400px;
     overflow-y: auto;

--- a/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
+++ b/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
@@ -5,26 +5,27 @@ exports[`subscriptions details page should render and contain appropiate compone
   id="subscription-details"
 >
   <BreadcrumbsBar
-    data={
-      Object {
-        "breadcrumbItems": Array [
-          Object {
-            "caption": "Subscriptions",
-            "onClick": [Function],
-          },
-          Object {
-            "caption": "OpenShift Employee Subscription",
-          },
-        ],
-        "isSwitchable": true,
-        "resource": Object {
-          "nameField": "name",
-          "resourceUrl": "/katello/api/v2/organizations/1/subscriptions",
-          "switcherItemUrl": "/subscriptions/:id",
+    breadcrumbItems={
+      Array [
+        Object {
+          "caption": "Subscriptions",
+          "url": "/subscriptions/",
         },
+        Object {
+          "caption": "OpenShift Employee Subscription",
+        },
+      ]
+    }
+    isLoadingResources={false}
+    isSwitchable={true}
+    onSwitcherItemClick={[Function]}
+    resource={
+      Object {
+        "nameField": "name",
+        "resourceUrl": "/katello/api/v2/organizations/1/subscriptions",
+        "switcherItemUrl": "/subscriptions/:id",
       }
     }
-    onSwitcherItemClick={[Function]}
   />
   <ForwardRef
     defaultActiveKey={1}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
The subscription details page now features a functional breadcrumb bar allowing the user to change the subscription they are investigating or navigate back to the subscription overview page.

#### Considerations taken when implementing this change?
n/a

#### What are the testing steps for this pull request?
1. Launch Katello with a few subscriptions.
2. Go to the subscriptions page and click on a subscription to view its details. The header should contain a breadcrumb bar allowing you to both navigate back to the subscription overview page and to switch between possible subscriptions.
3. Ensure similarity between this breadcrumb bar and others in Katello (module stream details page, content view details page, etc).