### PR TITLE
Fixes #36926 - RefreshRepos called for relevant repos only

### DIFF
--- a/app/lib/actions/katello/capsule_content/refresh_repos.rb
+++ b/app/lib/actions/katello/capsule_content/refresh_repos.rb
@@ -18,7 +18,8 @@ module Actions
           plan_self(:smart_proxy_id => smart_proxy.id,
                     :environment_id => options[:environment]&.id,
                     :content_view_id => options[:content_view]&.id,
-                    :repository_id => options[:repository]&.id)
+                    :repository_id => options[:repository]&.id,
+                    :repository_ids_list => options[:repository_ids_list])
         end
 
         def invoke_external_task
@@ -33,7 +34,12 @@ module Actions
           current_repos_on_capsule = smart_proxy_service.current_repositories(environment, content_view)
           current_repos_on_capsule_ids = current_repos_on_capsule.pluck(:id)
 
-          list_of_repos_to_sync = smart_proxy_helper.combined_repos_available_to_capsule(environment, content_view, repository)
+          if input[:repository_ids_list].nil?
+            list_of_repos_to_sync = smart_proxy_helper.combined_repos_available_to_capsule(environment, content_view, repository)
+          else
+            list_of_repos_to_sync = ::Katello::Repository.where(:id => input[:repository_ids_list])
+          end
+
           list_of_repos_to_sync.each do |repo|
             next unless act_on_repo?(repo, smart_proxy)
 

--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -35,7 +35,6 @@ module Actions
           sequence do
             if smart_proxy.has_feature?(SmartProxy::PULP3_FEATURE)
               plan_action(Actions::Pulp3::ContentGuard::Refresh, smart_proxy)
-              plan_action(Actions::Pulp3::Orchestration::Repository::RefreshRepos, smart_proxy, refresh_options)
             end
             plan_action(SyncCapsule, smart_proxy, refresh_options)
           end

--- a/app/lib/actions/katello/capsule_content/sync_capsule.rb
+++ b/app/lib/actions/katello/capsule_content/sync_capsule.rb
@@ -15,6 +15,13 @@ module Actions
             repos = repos_to_sync(smart_proxy, environment, content_view, repository, skip_metadata_check)
             return nil if repos.empty?
 
+            if environment.nil? && content_view.nil? && repository.nil?
+              options[:repository_ids_list] = repos.pluck(:id)
+            end
+            if smart_proxy.has_feature?(SmartProxy::PULP3_FEATURE)
+              plan_action(Actions::Pulp3::Orchestration::Repository::RefreshRepos, smart_proxy, options)
+            end
+
             repos.in_groups_of(Setting[:foreman_proxy_content_batch_size], false) do |repo_batch|
               concurrence do
                 repo_batch.each do |repo|

--- a/test/actions/katello/capsule_content_test.rb
+++ b/test/actions/katello/capsule_content_test.rb
@@ -48,6 +48,7 @@ module ::Actions::Katello::CapsuleContent
       options = { smart_proxy_id: capsule_content.smart_proxy.id,
                   content_view_id: nil,
                   repository_id: repo.id,
+                  repository_ids_list: nil,
                   environment_id: nil
                 }
       assert_tree_planned_with(tree, ::Actions::Pulp3::Orchestration::Repository::RefreshRepos, options)
@@ -87,6 +88,7 @@ module ::Actions::Katello::CapsuleContent
       options = { smart_proxy_id: capsule_content.smart_proxy.id,
                   content_view_id: nil,
                   repository_id: repo.id,
+                  repository_ids_list: nil,
                   environment_id: nil
       }
       assert_tree_planned_with(tree, ::Actions::Pulp3::Orchestration::Repository::RefreshRepos, options)
@@ -145,6 +147,7 @@ module ::Actions::Katello::CapsuleContent
       options = { smart_proxy_id: capsule_content.smart_proxy.id,
                   content_view_id: nil,
                   repository_id: repo.id,
+                  repository_ids_list: nil,
                   environment_id: nil
                 }
 
@@ -174,6 +177,7 @@ module ::Actions::Katello::CapsuleContent
       options = { smart_proxy_id: capsule_content.smart_proxy.id,
                   content_view_id: nil,
                   repository_id: repo.id,
+                  repository_ids_list: nil,
                   environment_id: nil
                 }
 
@@ -188,6 +192,7 @@ module ::Actions::Katello::CapsuleContent
       options = { smart_proxy_id: capsule_content.smart_proxy.id,
                   content_view_id: nil,
                   repository_id: repo.id,
+                  repository_ids_list: nil,
                   environment_id: nil
                 }
 
@@ -202,6 +207,7 @@ module ::Actions::Katello::CapsuleContent
       options = { smart_proxy_id: capsule_content.smart_proxy.id,
                   content_view_id: nil,
                   repository_id: repo.id,
+                  repository_ids_list: nil,
                   environment_id: nil
                 }
 
@@ -218,6 +224,7 @@ module ::Actions::Katello::CapsuleContent
       options = { smart_proxy_id: capsule_content.smart_proxy.id,
                   content_view_id: nil,
                   repository_id: nil,
+                  repository_ids_list: nil,
                   environment_id: dev_environment.id
                 }
       assert_tree_planned_with(tree, ::Actions::Pulp3::Orchestration::Repository::RefreshRepos, options)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

For unscoped Capsule Sync, call RefreshRepos only for repos to be synced, not for all that exist on the Capsule. That makes the RefreshRepos step significantly faster (from minutes to seconds). E.g. when I had 500 repos on a Capsule and was about to sync just one or a few repos in unsoped Capsule sync, RefreshRepos execution time dropped from 155s to 3s.

#### Considerations taken when implementing this change?

`:repository_ids_list` option can be merged with `:repository`. I left the later one as it is already used, to propose a minimalistic change. But I am open to update `:repository` to :repositories` as one common option and amend existing code.

#### What are the testing steps for this pull request?

Testing steps described in #36926 . Another test scenarios worth to check: syncing a LE or CV or repository to Capsule - the behaviour should be unchanged there.