### PR TITLE
Fixes #36850 - Avoid duplicate database indexes

### DIFF
--- a/db/migrate/20231020153017_create_indexes_for_nvra_and_epoch.rb
+++ b/db/migrate/20231020153017_create_indexes_for_nvra_and_epoch.rb
@@ -1,6 +1,19 @@
 class CreateIndexesForNvraAndEpoch < ActiveRecord::Migration[6.1]
-  def change
+  def up
+    if index_exists?(:katello_installed_packages, :nvra)
+      remove_index :katello_installed_packages, :nvra
+    end
+
+    if index_exists?(:katello_installed_packages, [:nvra, :epoch])
+      remove_index :katello_installed_packages, [:nvra, :epoch]
+    end
+
     add_index :katello_installed_packages, :nvra
     add_index :katello_installed_packages, [:nvra, :epoch]
+  end
+
+  def down
+    remove_index :katello_installed_packages, :nvra
+    remove_index :katello_installed_packages, [:nvra, :epoch]
   end
 end


### PR DESCRIPTION
Some downstream users have already created the indexes manually to relieve the issue. When upgrading Katello, the migration script will create duplicate indexes to the table with different index names or the migration will fail with PG duplicate index error due to index name conflict with the one migration script creates.

Thus, modify this migration script to check for existing indexes in the table and then drop them before creating the new indexes.
