### PR TITLE
Refs #36328 - display short host name in Content Hosts page

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -53,8 +53,8 @@
 
     <span data-block="list-actions" ng-hide="contentHost.readonly">
       <div bst-modal="applySelected()" model="host">
-        <div data-block="modal-header" translate>Apply Errata to Content Host "{{host.displayname}}"?</div>
-        <div data-block="modal-body" translate>Are you sure you want to apply Errata to content host "{{ host.displayname }}"?</div>
+        <div data-block="modal-header" translate>Apply Errata to Content Host "{{host.display_name}}"?</div>
+        <div data-block="modal-body" translate>Are you sure you want to apply Errata to content host "{{ host.display_name }}"?</div>
         <span data-block="modal-confirm-button">
           <button class="btn btn-primary" ng-click="ok()">
             <span translate>Apply</span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-traces.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-traces.html
@@ -39,9 +39,9 @@
   <div data-extend-template="layouts/partials/table.html">
     <span data-block="list-actions" ng-hide="contentHost.readonly">
       <div bst-modal="performViaRemoteExecution(false)" model="host">
-        <div data-block="modal-header" translate>Restart Services on Content Host "{{host.displayname}}"?</div>
+        <div data-block="modal-header" translate>Restart Services on Content Host "{{host.display_name}}"?</div>
         <div data-block="modal-body">
-          <span translate>Are you sure you want to restart services on content host "{{ host.displayname }}"?</span>
+          <span translate>Are you sure you want to restart services on content host "{{ host.display_name }}"?</span>
           <span ng-show="host.rebootRequired()">
             <strong translate>Resolving the selected Traces will reboot this host.</strong>
           </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -345,7 +345,7 @@
 
       <dl class="dl-horizontal dl-horizontal-left">
         <dt translate>Hostname</dt>
-        <dd>{{ host.displayname }}</dd>
+        <dd>{{ host.display_name }}</dd>
 
         <dt translate>IPv4 Address</dt>
         <dd>{{ host.facts["network::ipv4_address"] }}</dd>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Followup of https://github.com/Katello/katello/pull/10538.
Missed a few places to replace `host.displayname` with `host.display_name`.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Verify the host name displayed in `Content Hosts` page is based on setting `display_fqdn_for_hosts`.