### PR TITLE
Refs #36797 - Allow message rebranding in preparation for API SCA-only

### DIFF
--- a/app/controllers/katello/api/v2/simple_content_access_controller.rb
+++ b/app/controllers/katello/api/v2/simple_content_access_controller.rb
@@ -10,7 +10,7 @@ module Katello
     api :GET, "/organizations/:organization_id/simple_content_access/eligible",
       N_("Check if the specified organization is eligible for Simple Content Access. %s") % sca_only_deprecation_text, deprecated: true
     def eligible
-      ::Foreman::Deprecation.api_deprecation_warning("This endpoint is deprecated and will be removed in Katello 4.12. All organizations are now eligible for Simple Content Access.")
+      ::Foreman::Deprecation.api_deprecation_warning(N_("This endpoint is deprecated and will be removed in Katello 4.12. All organizations are now eligible for Simple Content Access."))
       eligible = @organization.simple_content_access_eligible?
       render json: { simple_content_access_eligible: eligible }
     end

--- a/app/controllers/katello/concerns/organizations_controller_extensions.rb
+++ b/app/controllers/katello/concerns/organizations_controller_extensions.rb
@@ -25,7 +25,7 @@ module Katello
             begin
               @taxonomy = Organization.new(resource_params)
               sca = ::Foreman::Cast.to_bool(params[:simple_content_access])
-              ::Foreman::Deprecation.api_deprecation_warning("Simple Content Access will be required for all organizations in Katello 4.12.")
+              ::Foreman::Deprecation.api_deprecation_warning(N_("Simple Content Access will be required for all organizations in Katello 4.12."))
               ::Katello::OrganizationCreator.new(@taxonomy, sca: sca).create!
               @taxonomy.reload
               switch_taxonomy


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Followup of https://github.com/Katello/katello/pull/10760.
So the messages could be rebranded by https://github.com/RedHatSatellite/foreman_theme_satellite.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

- Organization /Create/Edit throws a log message in satellite server.

2023-10-03T20:04:59 [W|app|19e3e9b9] DEPRECATION WARNING: Simple Content Access will be required for all organizations in Satellite 6.16.