### PR TITLE
Fixes #36941 - get rid of n+1 db queries for trace status

### DIFF
--- a/app/controllers/katello/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/hosts_controller_extensions.rb
@@ -20,6 +20,10 @@ module Katello
       included do
         prepend Overrides
 
+        def included_associations(include = [])
+          [:host_traces] + super
+        end
+
         def update_multiple_taxonomies(type)
           if type == :organization
             new_org_id = params.dig(type, 'id')

--- a/app/models/katello/host_tracer.rb
+++ b/app/models/katello/host_tracer.rb
@@ -2,10 +2,14 @@ module Katello
   class HostTracer < Katello::Model
     include Katello::Authorization::HostTracer
 
+    TRACE_APP_TYPE_STATIC = 'static'.freeze
+    TRACE_APP_TYPE_SESSION = 'session'.freeze
+    TRACE_APP_TYPE_DAEMON = 'daemon'.freeze
+
     belongs_to :host, :inverse_of => :host_traces, :class_name => '::Host::Managed'
 
-    scope :reboot_required, -> { where(app_type: 'static') }
-    scope :selectable, -> { where.not(app_type: 'session') }
+    scope :reboot_required, -> { where(app_type: TRACE_APP_TYPE_STATIC) }
+    scope :selectable, -> { where.not(app_type: TRACE_APP_TYPE_SESSION) }
 
     validates :application, :length => {:maximum => 255}, :presence => true
     validates :app_type, :length => {:maximum => 255}, :presence => true
@@ -16,14 +20,14 @@ module Katello
     scoped_search :on => :helper, :complete_value => true
 
     def reboot_required?
-      self.app_type == 'static'
+      self.app_type == TRACE_APP_TYPE_STATIC
     end
 
     def restart_command
       case self.app_type
-      when 'static'
+      when TRACE_APP_TYPE_STATIC
         'reboot'
-      when 'session'
+      when TRACE_APP_TYPE_SESSION
         nil
       else
         self.helper

--- a/app/models/katello/trace_status.rb
+++ b/app/models/katello/trace_status.rb
@@ -4,6 +4,7 @@ module Katello
     REQUIRE_PROCESS_RESTART = 1
     UP_TO_DATE = 0
     UNKNOWN = -1
+
     def self.status_name
       N_("Traces")
     end
@@ -35,9 +36,12 @@ module Katello
     end
 
     def to_status(_options = {})
-      if host.host_traces.reboot_required.any?
+      traces = host.host_traces.pluck(:app_type)
+      traces.delete(Katello::HostTracer::TRACE_APP_TYPE_SESSION)
+
+      if traces.include?(Katello::HostTracer::TRACE_APP_TYPE_STATIC)
         REQUIRE_REBOOT
-      elsif host.host_traces.where.not(:app_type => "session").any?
+      elsif !traces.empty?
         REQUIRE_PROCESS_RESTART
       else
         UP_TO_DATE


### PR DESCRIPTION
Loading All Hosts page (https://myforeman/hosts) with about 72 hosts.

```
# old Completed 200 OK in 11991ms (Views: 9501.2ms | ActiveRecord: 814.3ms | Allocations: 5770440)
# old ompleted 200 OK in 10883ms (Views: 8610.8ms | ActiveRecord: 731.7ms | Allocations: 5754905)
# old Completed 200 OK in 11429ms (Views: 9214.5ms | ActiveRecord: 747.4ms | Allocations: 5763296)
# old 14sek page loading
# old 337 select katello_host_tracers
# sql queries (incl. cached): 2503
# sql queries without cached: 1350

# new Completed 200 OK in 10791ms (Views: 8602.9ms | ActiveRecord: 727.8ms | Allocations: 5673860)
# new Completed 200 OK in 7878ms (Views: 6362.9ms | ActiveRecord: 462.1ms | Allocations: 5686666)
# new Completed 200 OK in 7878ms (Views: 6362.9ms | ActiveRecord: 462.1ms | Allocations: 5686666)
# new 13 sek page loading
# new 1 select katello_host_tracers
# sql queries (incl. cached): 2168
# sql queries without cached: 1267
```

general issue is explained here: https://medium.com/@deepakmahakale/eager-loading-scoped-associations-in-rails-3c125a52e209