### PR TITLE
Fixes #36943 - reduce the amount of queries to get the errata counts

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -181,12 +181,14 @@ module Katello
         }
         installable_hash[:total] = installable_hash.values.inject(:+)
         # same for applicable, but we need to get the counts from the db
+        applicable_errata_counts = applicable_errata.pluck(:errata_type).tally
         applicable_hash = {
-          :security => applicable_errata.security.count,
-          :bugfix => applicable_errata.bugfix.count,
-          :enhancement => applicable_errata.enhancement.count
+          :bugfix => applicable_errata_counts.values_at(*Katello::Erratum::BUGZILLA).compact.sum,
+          :security => applicable_errata_counts.values_at(*Katello::Erratum::SECURITY).compact.sum,
+          :enhancement => applicable_errata_counts.values_at(*Katello::Erratum::ENHANCEMENT).compact.sum
         }
-        applicable_hash[:total] = applicable_hash.values.inject(:+)
+        applicable_hash[:total] = applicable_errata_counts.values.sum
+
         # keeping installable at the top level for backward compatibility
         installable_hash.merge({
                                  :applicable => applicable_hash


### PR DESCRIPTION
Loading the all hosts page (http://myforeman/hosts) with about 72 hosts.

```
OLD
Completed 200 OK in 9900ms (Views: 8613.5ms | ActiveRecord: 787.6ms | Allocations: 5520271)
Completed 200 OK in 9595ms (Views: 8381.8ms | ActiveRecord: 789.9ms | Allocations: 5524887)
SQL Queries: 195

irb(main):049:0> total=0; 100.times do x=Benchmark.measure { Host.all.each do |h| h.content_facet.nil? || h.content_facet.errata_counts_old end }; total = total + x.total; sleep 0.5; end; puts total;
68.09449500000002

NEW
Completed 200 OK in 10789ms (Views: 9794.5ms | ActiveRecord: 549.5ms | Allocations: 5511210)
Completed 200 OK in 9244ms (Views: 8400.2ms | ActiveRecord: 385.6ms | Allocations: 5511208)
SQL Queries: 65

irb(main):050:0> total=0; 100.times do x=Benchmark.measure { Host.all.each do |h| h.content_facet.nil? || h.content_facet.errata_counts end }; total = total + x.total; sleep 0.5; end; puts total;
37.18352599999951
```



