### PR TITLE
Fixes #36946 - cache if tracer/host_tools is installed

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -8,6 +8,9 @@ module Katello
       HOST_TOOLS_PACKAGE_NAME = 'katello-host-tools'.freeze
       HOST_TOOLS_TRACER_PACKAGE_NAME = 'katello-host-tools-tracer'.freeze
       SUBSCRIPTION_MANAGER_PACKAGE_NAME = 'subscription-manager'.freeze
+      ALL_HOST_TOOLS_PACKAGE_NAMES = [ "python-#{HOST_TOOLS_PACKAGE_NAME}",
+                                       "python3-#{HOST_TOOLS_PACKAGE_NAME}",
+                                       HOST_TOOLS_PACKAGE_NAME ].freeze
       ALL_TRACER_PACKAGE_NAMES = [ "python-#{HOST_TOOLS_TRACER_PACKAGE_NAME}",
                                    "python3-#{HOST_TOOLS_TRACER_PACKAGE_NAME}",
                                    HOST_TOOLS_TRACER_PACKAGE_NAME ].freeze
@@ -307,22 +310,22 @@ module Katello
         end
       end
 
-      def tracer_installed?
-        self.host.installed_packages.where("#{Katello::InstalledPackage.table_name}.name" => ALL_TRACER_PACKAGE_NAMES).any? ||
-          self.host.installed_debs.where("#{Katello::InstalledDeb.table_name}.name" => ALL_TRACER_PACKAGE_NAMES).any?
+      def tracer_installed?(force_update_cache: false)
+        Rails.cache.fetch("#{self.host.id}/tracer_installed", expires_in: 7.days, force: force_update_cache) do
+          self.host.installed_packages.where("#{Katello::InstalledPackage.table_name}.name" => ALL_TRACER_PACKAGE_NAMES).any? ||
+            self.host.installed_debs.where("#{Katello::InstalledDeb.table_name}.name" => ALL_TRACER_PACKAGE_NAMES).any?
+        end
       end
 
       def tracer_rpm_available?
         ::Katello::Rpm.yum_installable_for_host(self.host).where(name: ALL_TRACER_PACKAGE_NAMES).any?
       end
 
-      def host_tools_installed?
-        host.installed_packages.where("#{Katello::InstalledPackage.table_name}.name" => [ "python-#{HOST_TOOLS_PACKAGE_NAME}",
-                                                                                          "python3-#{HOST_TOOLS_PACKAGE_NAME}",
-                                                                                          HOST_TOOLS_PACKAGE_NAME ]).any? ||
-          host.installed_debs.where("#{Katello::InstalledDeb.table_name}.name" => [ "python-#{HOST_TOOLS_PACKAGE_NAME}",
-                                                                                    "python3-#{HOST_TOOLS_PACKAGE_NAME}",
-                                                                                    HOST_TOOLS_PACKAGE_NAME ]).any?
+      def host_tools_installed?(force_update_cache: false)
+        Rails.cache.fetch("#{self.host.id}/host_tools_installed", expires_in: 7.days, force: force_update_cache) do
+          self.host.installed_packages.where("#{Katello::InstalledPackage.table_name}.name" => ALL_HOST_TOOLS_PACKAGE_NAMES).any? ||
+            self.host.installed_debs.where("#{Katello::InstalledDeb.table_name}.name" => ALL_HOST_TOOLS_PACKAGE_NAMES).any?
+        end
       end
 
       def update_errata_status

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -32,7 +32,21 @@ module Katello
 
       host.installed_packages << Katello::InstalledPackage.create!(:name => 'katello-host-tools-tracer', 'nvrea' => 'katello-host-tools-tracer-1.0.x86_64', 'nvra' => 'katello-host-tools-tracer-1.0.x86_64')
 
+      # make sure the cache is gets updated
+      host.reload.content_facet.tracer_installed?(force_update_cache: true)
+
       assert host.reload.content_facet.tracer_installed?
+    end
+
+    def test_host_tools_installed?
+      refute host.content_facet.host_tools_installed?
+
+      host.installed_packages << Katello::InstalledPackage.create!(:name => 'katello-host-tools', 'nvrea' => 'katello-host-tools-1.0.x86_64', 'nvra' => 'katello-host-tools-1.0.x86_64')
+
+      # make sure the cache is gets updated
+      host.reload.content_facet.host_tools_installed?(force_update_cache: true)
+
+      assert host.reload.content_facet.host_tools_installed?
     end
 
     def test_in_content_view_version_environments


### PR DESCRIPTION
Access to hosts page "/hosts" with about 72 hosts.

```
Without cached data:
Completed 200 OK in 9369ms (Views: 8113.6ms | ActiveRecord: 640.9ms | Allocations: 5036689)
Completed 200 OK in 8512ms (Views: 7289.0ms | ActiveRecord: 669.4ms | Allocations: 5044464)
SQL Queries just for installed packages: 264

With cached data:
Completed 200 OK in 9833ms (Views: 8730.5ms | ActiveRecord: 628.5ms | Allocations: 4952378)
Completed 200 OK in 9131ms (Views: 8049.9ms | ActiveRecord: 637.1ms | Allocations: 4950737)
No query to installed packages
```