### PR TITLE
Fixes #11938 - Drop WebMock.allow_net_connect!

### DIFF
--- a/test/support/vcr.rb
+++ b/test/support/vcr.rb
@@ -1,8 +1,6 @@
 require "vcr"
 require "active_support/concern"
 
-WebMock.allow_net_connect!
-
 module VCR
   def self.live?
     VCR.configuration.default_cassette_options[:record] != :none


### PR DESCRIPTION
Reportedly this was only done to allow ElasticSearch tests to pass, but that's been gone for a long time.