### PR TITLE
Fixes #37005 - Allow to set the the default name of template change…

### DIFF
--- a/app/controllers/katello/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/hosts_controller_extensions.rb
@@ -95,7 +95,7 @@ module Katello
                                       .distinct
 
           if Katello.with_remote_execution?
-            template_id = JobTemplate.find_by(name: 'Configure host for new content source')&.id
+            template_id = RemoteExecutionFeature.feature!(:katello_change_content_source).job_template_id
             job_invocation_path = new_job_invocation_path(template_id: template_id, host_ids: content_hosts.map { |h| h[:id] }) if template_id
           end
 

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -685,6 +685,7 @@ Foreman::Plugin.register :katello do
     RemoteExecutionFeature.register(:katello_errata_install_by_search, N_("Katello: Install errata by search query"), :description => N_("Install errata using scoped search query"), :provided_inputs => ['Errata search query'])
     RemoteExecutionFeature.register(:katello_service_restart, N_("Katello: Service Restart"), :description => N_("Restart Services via Katello interface"), :provided_inputs => ['helpers'])
     RemoteExecutionFeature.register(:katello_host_tracer_resolve, N_("Katello: Resolve Traces"), :description => N_("Resolve traces via Katello interface"), :provided_inputs => ['ids'])
+    RemoteExecutionFeature.register(:katello_change_content_source, N_("Katello: Configure host for new content source"), :description => N_("Replace content source on the target machine"), :provided_inputs => [])
     RemoteExecutionFeature.register(:katello_module_stream_action, N_("Katello: Module Stream Actions"),
                                     :description => N_("Perform a module stream action via Katello interface"),
                                     :provided_inputs => ['action', 'module_spec', 'options'])


### PR DESCRIPTION
… content source

#### What are the changes introduced in this pull request?

Add a setting
use that setting

#### Considerations taken when implementing this change?

I have added js part (because I grepped and identified the same constant their) but it might not be needed.

I haven't considered how migration should add this setting (If I read correctly it is pure runtime so no migration and the feature will be upserted)

#### What are the testing steps for this pull request?

I did test in foreman-rake console (by copying the lines)
What is remaining:
- On fresh instance with remote execution feature enabled:
Their is a new setting `Katello: Configure host for new content source` that allow to change the default template used when changing content source
- On old instance updated: the option should appear
