### PR TITLE
Fixes #36960 - Assign default content view environment during migration when no existing CVE found

### DIFF
--- a/app/lib/katello/util/cvecf_migrator.rb
+++ b/app/lib/katello/util/cvecf_migrator.rb
@@ -1,0 +1,34 @@
+module Katello
+  module Util
+    class CVECFMigrator # used in db/migrate/20220929204746_add_content_view_environment_content_facet.rb
+      def execute!
+        hosts_with_no_cve = []
+        hosts_with_missing_cve = []
+
+        ::Host::Managed.all.each do |host|
+          next if host.content_facet.blank?
+          if ::Katello::ContentView.exists?(id: host.content_facet.content_view_id) && ::Katello::KTEnvironment.exists?(host.content_facet.lifecycle_environment_id)
+            cve = ::Katello::ContentViewEnvironment.find_by(content_view_id: host.content_facet.content_view_id, environment_id: host.content_facet.lifecycle_environment_id)
+            if cve.blank?
+              hosts_with_no_cve << host
+            end
+          else
+            hosts_with_missing_cve << host
+          end
+        end
+
+        if hosts_with_missing_cve.present? || hosts_with_no_cve.present?
+          Rails.logger.warn "Found #{hosts_with_no_cve.count} hosts whose lifecycle environment does not have a corresponding ContentViewEnvironment"
+          Rails.logger.warn "Found #{hosts_with_missing_cve.count} hosts whose content facet is missing either content_view_id or lifecycle_environment_id"
+          Rails.logger.info "You may want to change the content view / lifecycle environment for these hosts manually."
+        end
+        (hosts_with_no_cve + hosts_with_missing_cve).each do |host|
+          default_content_view = host.organization.default_content_view
+          library = host.organization.library
+          Rails.logger.info "Updating host #{host.name} with default content_view_id and lifecycle_environment_id"
+          host.content_facet&.update_columns(content_view_id: default_content_view&.id, lifecycle_environment_id: library&.id)
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20220929204746_add_content_view_environment_content_facet.rb
+++ b/db/migrate/20220929204746_add_content_view_environment_content_facet.rb
@@ -8,12 +8,13 @@ class AddContentViewEnvironmentContentFacet < ActiveRecord::Migration[6.1]
       t.references :content_view_environment, :null => false, :index => false, :foreign_key => { :to_table => 'katello_content_view_environments' }
       t.references :content_facet, :null => false, :index => false, :foreign_key => { :to_table => 'katello_content_facets' }
     end
+    ::Katello::Util::CVECFMigrator.new.execute!
     FakeContentFacet.all.each do |content_facet|
       cve_id = ::Katello::KTEnvironment.find(content_facet.lifecycle_environment_id)
           .content_view_environments
           .find_by(content_view_id: content_facet.content_view_id)
-          .id
-      unless ::Katello::ContentViewEnvironmentContentFacet.create(
+          &.id
+      unless cve_id.present? && ::Katello::ContentViewEnvironmentContentFacet.create(
         content_facet_id: content_facet.id,
         content_view_environment_id: cve_id
       )
@@ -39,14 +40,46 @@ class AddContentViewEnvironmentContentFacet < ActiveRecord::Migration[6.1]
 
     ::Katello::ContentViewEnvironmentContentFacet.all.each do |cvecf|
       content_facet = cvecf.content_facet
-      content_facet.content_view_id = cvecf.content_view_environment.content_view_id
-      content_facet.lifecycle_environment_id = cvecf.content_view_environment.environment_id
+      cve = cvecf.content_view_environment
+      default_org = cve.environment&.organization
+      default_cv_id = default_org&.default_content_view&.id
+      default_lce_id = default_org&.library&.id
+      cv_id = cvecf.content_view_environment.content_view_id || default_cv_id
+      lce_id = cvecf.content_view_environment.environment_id || default_lce_id
+      say "Updating content_facet #{content_facet.id} with cv_id #{cv_id} and lce_id #{lce_id}"
+      content_facet.content_view_id = cv_id
+      content_facet.lifecycle_environment_id = lce_id
       content_facet.save(validate: false)
     end
 
+    ensure_no_null_cv_lce
     change_column :katello_content_facets, :content_view_id, :integer, :null => false
     change_column :katello_content_facets, :lifecycle_environment_id, :integer, :null => false
 
     drop_table :katello_content_view_environment_content_facets
+  end
+
+  def ensure_no_null_cv_lce
+    # The following is to try to prevent PG::NotNullViolation: ERROR:  column "content_view_id" contains null values
+    # since we add null constraints to the columns in the next step
+    content_facets_without_cv = ::Katello::Host::ContentFacet.where(content_view_id: nil)
+    if content_facets_without_cv.any?
+      say "Found #{content_facets_without_cv.count} content_facets with nil content_view_id"
+      content_facets_without_cv.each do |content_facet|
+        say "reassigning bad content_facet #{content_facet.id} to default content view"
+        content_facet.content_view_id = content_facet.host&.organization&.default_content_view&.id
+        content_facet.save(validate: false)
+      end
+    end
+
+    content_facets_without_lce = ::Katello::Host::ContentFacet.where(lifecycle_environment_id: nil)
+    if content_facets_without_lce.any?
+      say "Found #{content_facets_without_lce.count} content_facets with nil lifecycle_environment_id"
+      content_facets_without_lce.each do |content_facet|
+        say "reassigning bad content_facet #{content_facet.id} to default lifecycle environment"
+        content_facet.lifecycle_environment_id = content_facet.host&.organization&.library&.id
+        content_facet.save(validate: false)
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

If a content facet has an assigned lifecycle environment which does not have any content views promoted to it, there will be no associated ContentViewEnvironment objects in the database. This breaks a migration and thus breaks upgrades.

With this change, such hosts are assigned to the default content view environment during migration.

#### Considerations taken when implementing this change?

This condition may appear if you've assigned a host/content facet to a lifecycle environment, but haven't promoted any content views to that environment.

It seems it may also be triggered if at some point in the past you've deleted a content view or lifecycle environment, and the deletion task failed.

#### What are the testing steps for this pull request?

1. If you don't already have a host assigned to a content view, create a content view and assign a host to it
2. Create a lifecycle environment, but do NOT promote the content view to it. This will ensure that the LCE does not have an associated ContentViewEnvironment.
3. Reverse the migration:

```
bundle exec rails db:migrate:down VERSION=20220929204746
```

4. Find your host and change its lifecycle environment to the one you created. We need to skip validations because of the reverted migration, so you'll have to do it in rails console:

```
rhel8 = Host::Managed.find_by(name: 'rhel8.fedora.example.com')
[2] pry(main)> cf = rhel8.content_facet
=> #<Katello::Host::ContentFacet:0x00005599477823b0
 id: 1,
 host_id: 2,
...
 content_view_id: 1,
 lifecycle_environment_id: 1>
[3] pry(main)> cf.update_columns(lifecycle_environment_id: <your new LCE id>)
```

5. Checkout master, if you like, and run the up migration:

```
bundle exec rails db:migrate:up VERSION=20220929204746
```

You'll get an error

```
StandardError: An error has occurred, this and all later migrations canceled:

undefined method `id' for nil:NilClass
```

Now, check out the PR and run the migration again. You should see something like this, with no errors:

```
== 20220929204746 AddContentViewEnvironmentContentFacet: migrating ============
-- create_table(:katello_content_view_environment_content_facets)
   -> 0.0070s
2023-12-06T22:11:24 [I|app|] Found 1 hosts whose lifecycle environment does not have a corresponding ContentViewEnvironment
2023-12-06T22:11:24 [I|app|] Creating CVE for host 2 with content_view_id 2 and lifecycle_environment_id 3
2023-12-06T22:11:24 [I|app|] Found 0 hosts whose content facet is missing either content_view_id or lifecycle_environment_id
-- remove_column(:katello_content_facets, :content_view_id)
   -> 0.0006s
-- remove_column(:katello_content_facets, :lifecycle_environment_id)
   -> 0.0004s
== 20220929204746 AddContentViewEnvironmentContentFacet: migrated (0.1426s) ===
```

