### PR TITLE
Fixes #36962 - UI should display module stream content counts on Smart Proxy

### DIFF
--- a/webpack/scenes/SmartProxy/AdditionalCapsuleContent.js
+++ b/webpack/scenes/SmartProxy/AdditionalCapsuleContent.js
@@ -10,7 +10,7 @@ const AdditionalCapsuleContent = ({ counts }) => {
     file: fileCount = 0,
     erratum: errataCount = 0,
     package_group: packageGroup = 0,
-    'rpm.modulemd': moduleStreamCount = 0,
+    module_stream: moduleStreamCount = 0,
   } = counts;
 
   const contentConfigTypes = ContentConfig.filter(({ names: { capsuleCountLabel } }) =>
@@ -82,7 +82,7 @@ AdditionalCapsuleContent.propTypes = {
     file: PropTypes.number,
     erratum: PropTypes.number,
     package_group: PropTypes.number,
-    'rpm.modulemd': PropTypes.number,
+    module_stream: PropTypes.number,
   }),
 };
 

--- a/webpack/scenes/SmartProxy/__tests__/SmartProxyContentTest.fixtures.json
+++ b/webpack/scenes/SmartProxy/__tests__/SmartProxyContentTest.fixtures.json
@@ -496,7 +496,7 @@
               "package_group": 2,
               "rpm.packagecategory": 1,
               "rpm.distribution_tree": 1,
-              "rpm.modulemd_defaults": 3
+              "module_stream": 3
             },
             "metadata": {
               "env_id": 2,
@@ -529,7 +529,7 @@
             "counts": {
               "rpm": 22,
               "erratum": 7,
-              "rpm.modulemd": 14,
+              "module_stream": 14,
               "package_group": 2,
               "rpm.packagecategory": 1,
               "rpm.distribution_tree": 1,
@@ -586,7 +586,7 @@
             "counts": {
               "rpm": 22,
               "erratum": 7,
-              "rpm.modulemd": 14,
+              "module_stream": 14,
               "package_group": 2,
               "rpm.packagecategory": 1,
               "rpm.distribution_tree": 1,
@@ -638,7 +638,7 @@
             "counts": {
               "rpm": 22,
               "erratum": 7,
-              "rpm.modulemd": 14,
+              "module_stream": 14,
               "package_group": 2,
               "rpm.packagecategory": 1,
               "rpm.distribution_tree": 1,
@@ -704,7 +704,7 @@
             "counts": {
               "rpm": 22,
               "erratum": 7,
-              "rpm.modulemd": 14,
+              "module_stream": 14,
               "package_group": 2,
               "rpm.packagecategory": 1,
               "rpm.distribution_tree": 1,
@@ -756,7 +756,7 @@
             "counts": {
               "rpm": 14,
               "erratum": 6,
-              "rpm.modulemd": 14,
+              "module_stream": 14,
               "rpm.distribution_tree": 1,
               "rpm.modulemd_defaults": 3
             },
@@ -776,7 +776,7 @@
             "counts": {
               "rpm": 14,
               "erratum": 6,
-              "rpm.modulemd": 14,
+              "module_stream": 14,
               "rpm.distribution_tree": 1,
               "rpm.modulemd_defaults": 3
             },


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
The API handles rpm.modulemd -> module_stream naming conversion already.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Sync a repo with module streams and have a capsule sync the repo too via a CV or library default view.
Go to Infra > Smart proxy > Your Proxy > Content tab
Verify that you see Module stream count in the repository expansion.