### PR TITLE
Fixes #11760 - Update repo deletion message to include --remove-from-content-view-versions help text

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -752,7 +752,8 @@ module Katello
           return true
         else
           errors.add(:base, _("Repository cannot be deleted since it has already been included in a published Content View. " \
-                              "Please delete all Content View versions containing this repository before attempting to delete it."))
+                              "Please delete all Content View versions containing this repository before attempting to delete it "\
+                              "or use --remove-from-content-view-versions flag to automatically remove the repository from all published versions."))
 
           return false
         end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Update the repo deletion error message to include --remove-from-content-view-versions flag suggestion.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Create a CV and add a repo and publish.
From hammer, try hammer repository delete --id=$REPO_ID
The error should now include mention of the flag to delete the repo from all cv versions.
Use the --remove-from-content-view-versions true option in the hammer repo delete command and the deletion should succeed.