### PR TITLE
Fixes #36968 - Add container manifest list to UI and aria-label for repo icon

### DIFF
--- a/webpack/scenes/ContentViews/Details/Repositories/RepoIcon.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/RepoIcon.js
@@ -14,7 +14,7 @@ const RepoIcon = ({ type }) => {
   };
   const Icon = iconMap[type] || BoxIcon;
 
-  return <Tooltip content={<div>{type}</div>}><Icon /></Tooltip>;
+  return <Tooltip content={<div>{type}</div>}><Icon aria-label={`${type}_type_icon`} /></Tooltip>;
 };
 
 RepoIcon.propTypes = {

--- a/webpack/scenes/SmartProxy/AdditionalCapsuleContent.js
+++ b/webpack/scenes/SmartProxy/AdditionalCapsuleContent.js
@@ -6,6 +6,7 @@ const AdditionalCapsuleContent = ({ counts }) => {
   const {
     deb: debPackageCount = 0,
     docker_manifest: dockerManifestCount = 0,
+    docker_manifest_list: dockerManifestListCount = 0,
     docker_tag: dockerTagCount = 0,
     file: fileCount = 0,
     erratum: errataCount = 0,
@@ -55,6 +56,11 @@ const AdditionalCapsuleContent = ({ counts }) => {
         {`${dockerManifestCount} Container manifests`}<br />
       </>
             }
+      {dockerManifestListCount > 0 &&
+      <>
+        {`${dockerManifestListCount} Container manifest lists`}<br />
+      </>
+      }
       {fileCount > 0 &&
       <>
         {`${fileCount} Files`}<br />
@@ -78,6 +84,7 @@ AdditionalCapsuleContent.propTypes = {
   counts: PropTypes.shape({
     deb: PropTypes.number,
     docker_manifest: PropTypes.number,
+    docker_manifest_list: PropTypes.number,
     docker_tag: PropTypes.number,
     file: PropTypes.number,
     erratum: PropTypes.number,

--- a/webpack/scenes/SmartProxy/AdditionalCapsuleContent.js
+++ b/webpack/scenes/SmartProxy/AdditionalCapsuleContent.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
 import ContentConfig from '../Content/ContentConfig';
 
 const AdditionalCapsuleContent = ({ counts }) => {
@@ -33,42 +34,42 @@ const AdditionalCapsuleContent = ({ counts }) => {
     <>
       {errataCount > 0 &&
       <>
-        {`${errataCount} Errata`}<br />
+        {`${errataCount} ${__('Errata')}`}<br />
       </>
             }
       {moduleStreamCount > 0 &&
       <>
-        {`${moduleStreamCount} Module streams`}<br />
+        {`${moduleStreamCount} ${__('Module streams')}`}<br />
       </>
             }
       {packageGroup > 0 &&
       <>
-        {`${packageGroup} Package groups`}<br />
+        {`${packageGroup} ${__('Package groups')}`}<br />
       </>
             }
       {dockerTagCount > 0 &&
       <>
-        {`${dockerTagCount} Container tags`}<br />
+        {`${dockerTagCount} ${__('Container tags')}`}<br />
       </>
             }
       {dockerManifestCount > 0 &&
       <>
-        {`${dockerManifestCount} Container manifests`}<br />
+        {`${dockerManifestCount} ${__('Container manifests')}`}<br />
       </>
             }
       {dockerManifestListCount > 0 &&
       <>
-        {`${dockerManifestListCount} Container manifest lists`}<br />
+        {`${dockerManifestListCount} ${__('Container manifest lists')}`}<br />
       </>
       }
       {fileCount > 0 &&
       <>
-        {`${fileCount} Files`}<br />
+        {`${fileCount} ${__('Files')}`}<br />
       </>
             }
       {debPackageCount > 0 &&
       <>
-        {`${debPackageCount} Debian packages`}<br />
+        {`${debPackageCount} ${__('Debian packages')}`}<br />
       </>}
       {contentConfigTypes?.length > 0 &&
                 contentConfigTypes.map(({ count, pluralLowercase }) => (

--- a/webpack/scenes/SmartProxy/ExpandedSmartProxyRepositories.js
+++ b/webpack/scenes/SmartProxy/ExpandedSmartProxyRepositories.js
@@ -31,7 +31,7 @@ const ExpandedSmartProxyRepositories = ({
     const cellList = [];
     /* eslint-disable max-len */
     cellList.push(<DataListCell key={`${repo.id}-name`}><span><a href={`/products/${envContentCounts[repo].metadata.product_id}/repositories/${envContentCounts[repo].metadata.library_instance_id}/`}>{getRepositoryNameById(envContentCounts[repo].metadata.library_instance_id)}</a></span></DataListCell>);
-    cellList.push(<DataListCell key={`${repo.id}-type`}><RepoIcon type={envContentCounts[repo].metadata.content_type} /></DataListCell>);
+    cellList.push(<DataListCell key={`${repo.id}-type`}><RepoIcon type={envContentCounts[repo].metadata.content_type} identifier={repo.id} /></DataListCell>);
     cellList.push(<DataListCell key={`${repo.id}-rpm`}><span>{envContentCounts[repo].counts.rpm ? `${envContentCounts[repo].counts.rpm} Packages` : 'N/A'}</span></DataListCell>);
     cellList.push(<DataListCell key={`${repo.id}-count`}><AdditionalCapsuleContent counts={envContentCounts[repo].counts} /></DataListCell>);
     /* eslint-enable max-len */
@@ -42,7 +42,7 @@ const ExpandedSmartProxyRepositories = ({
     const cellList = [];
     /* eslint-disable max-len */
     cellList.push(<DataListCell key={`${repo.id}-name`}><span><a href={`/products/${repo.product_id}/repositories/${repo.library_id}/`}>{repo.name}</a></span></DataListCell>);
-    cellList.push(<DataListCell key={`${repo.id}-type`}><RepoIcon type={repo.content_type} /></DataListCell>);
+    cellList.push(<DataListCell key={`${repo.id}-type`}><RepoIcon type={repo.content_type} identifier={repo.id} /></DataListCell>);
     cellList.push(<DataListCell key={`${repo.id}-rpm`}><span><InactiveText text="N/A" /></span></DataListCell>);
     cellList.push(<DataListCell key={`${repo.id}-count`}><InactiveText text="N/A" /></DataListCell>);
     /* eslint-enable max-len */

--- a/webpack/scenes/SmartProxy/ExpandedSmartProxyRepositories.js
+++ b/webpack/scenes/SmartProxy/ExpandedSmartProxyRepositories.js
@@ -32,7 +32,7 @@ const ExpandedSmartProxyRepositories = ({
     /* eslint-disable max-len */
     cellList.push(<DataListCell key={`${repo.id}-name`}><span><a href={`/products/${envContentCounts[repo].metadata.product_id}/repositories/${envContentCounts[repo].metadata.library_instance_id}/`}>{getRepositoryNameById(envContentCounts[repo].metadata.library_instance_id)}</a></span></DataListCell>);
     cellList.push(<DataListCell key={`${repo.id}-type`}><RepoIcon type={envContentCounts[repo].metadata.content_type} identifier={repo.id} /></DataListCell>);
-    cellList.push(<DataListCell key={`${repo.id}-rpm`}><span>{envContentCounts[repo].counts.rpm ? `${envContentCounts[repo].counts.rpm} Packages` : 'N/A'}</span></DataListCell>);
+    cellList.push(<DataListCell key={`${repo.id}-rpm`}><span>{envContentCounts[repo].counts.rpm ? `${envContentCounts[repo].counts.rpm} ${__('Packages')}` : 'N/A'}</span></DataListCell>);
     cellList.push(<DataListCell key={`${repo.id}-count`}><AdditionalCapsuleContent counts={envContentCounts[repo].counts} /></DataListCell>);
     /* eslint-enable max-len */
     return cellList;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Create a docker repo with manifest lists. ex: libpod/testimage from quay.io
Sync repo and have the repo sync to a capsule
Check the capsule content page to make sure you see manifest lists in content counts.
Also do an inspect element on repo type icon. It should have aria-lebel = Repo type