### PR TITLE
Fixes #36975 - Pass cp_products as array to ProductContentImporter instead of hash

### DIFF
--- a/app/models/katello/content.rb
+++ b/app/models/katello/content.rb
@@ -50,7 +50,7 @@ module Katello
         cp_products = ::Katello::Resources::Candlepin::Product.all(org.label, [:id, :productContent])
         product_hash = cp_products.group_by { |prod| prod['id'] }
 
-        prod_content_importer = Katello::ProductContentImporter.new(product_hash)
+        prod_content_importer = Katello::ProductContentImporter.new(cp_products)
         org.products.each do |product|
           product_json = product_hash[product.cp_id]&.first
 

--- a/app/services/katello/product_content_importer.rb
+++ b/app/services/katello/product_content_importer.rb
@@ -21,46 +21,6 @@ module Katello
     #    "enabled":false
     # }
     #
-    #Example cp_products json structure (key:values where values are arrays and productContent is an array of contents inside value array)
-    # {
-    #    "230"=>
-    #   [{"id"=>"230",
-    #     "productContent"=>
-    #      [{"content"=>
-    #         {"created"=>"2023-11-01T18:02:54+0000",
-    #          "updated"=>"2023-11-01T18:02:54+0000",
-    #          "uuid"=>"ff8080818b715841018b8c0d76d90190",
-    #          "id"=>"3996",
-    #          "type"=>"yum",
-    #          "label"=>"rhel-7-server-rt-htb-rpms",
-    #          "name"=>"Red Hat Enterprise Linux for Real Time HTB (RHEL 7 Server) (RPMs)",
-    #          "vendor"=>"Red Hat",
-    #          "contentUrl"=>"/content/htb/rhel/server/7/$basearch/rt/os",
-    #          "requiredTags"=>"rhel-7-server",
-    #          "releaseVer"=>nil,
-    #          "gpgUrl"=>"file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
-    #          "modifiedProductIds"=>[],
-    #          "arches"=>nil,
-    #          "metadataExpire"=>1},
-    #        "enabled"=>false},
-    #       {"content"=>
-    #         {"created"=>"2023-11-01T18:02:54+0000",
-    #          "updated"=>"2023-11-01T18:02:54+0000",
-    #          "uuid"=>"ff8080818b715841018b8c0d76d90181",
-    #          "id"=>"2165",
-    #          "type"=>"yum",
-    #          "label"=>"rhel-7-server-optional-htb-debug-rpms",
-    #          "name"=>"Red Hat Enterprise Linux 7 Server - Optional HTB (Debug RPMs)",
-    #          "vendor"=>"Red Hat",
-    #          "contentUrl"=>"/content/htb/rhel/server/7/$basearch/optional/debug",
-    #          "requiredTags"=>"rhel-7-server",
-    #          "releaseVer"=>nil,
-    #          "gpgUrl"=>"file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release",
-    #          "modifiedProductIds"=>[],
-    #          "arches"=>nil,
-    #          "metadataExpire"=>1},
-    #        "enabled"=>false}]}]
-    # }
     attr_reader :content_url_updated
 
     def initialize(cp_products = [])
@@ -76,13 +36,13 @@ module Katello
     end
 
     def find_product_for_content(content_id)
-      #Hash.find converts hash into enumerable iterating over each key,value pair which we can capture based on find result
-      cp_product_id, __cp_product_value = @cp_products.find do |prod_json|
-        prod_json&.last&.first&.[]('productContent')&.any? do |product_content_json|
-          product_content_json["content"]["id"] == content_id
+      prod = @cp_products.find do |prod_json|
+        next if prod_json&.[]('productContent').blank?
+        prod_json['productContent'].any? do |product_content_json|
+          product_content_json&.dig("content", "id") == content_id
         end
       end
-      ::Katello::Product.find_by(cp_id: cp_product_id)
+      ::Katello::Product.find_by(cp_id: prod["id"]) if prod
     end
 
     def fetch_product_contents_to_move(product, prod_contents_json)

--- a/test/services/katello/product_content_importer_test.rb
+++ b/test/services/katello/product_content_importer_test.rb
@@ -95,5 +95,39 @@ module Katello
 
       assert_empty(@service.content_url_updated)
     end
+
+    def test_find_product_for_content
+      cp_products = [{"id" => "590",
+                      "productContent" =>
+                        [{"content" =>
+                            {
+                              "id" => "11210",
+                              "type" => "yum",
+                              "label" => "codeready-builder-for-rhel-9-s390x-eus-rpms",
+                              "name" => "Red Hat CodeReady Linux Builder for RHEL 9 IBM z Systems - Extended Update Support (RPMs)"
+                            },
+                          "enabled" => false},
+                         {"content" =>
+                            {"id" => "9268",
+                             "type" => "yum",
+                             "label" => "codeready-builder-for-rhel-8-s390x-eus-debug-rpms",
+                             "name" => "Red Hat CodeReady Linux Builder for RHEL 8 IBM z Systems - Extended Update Support (Debug RPMs)"
+                             },
+                          "enabled" => false}]},
+                     {"id" => "350", "productContent" => []},
+                     {"id" => "380"}]
+      prod_content_importer = Katello::ProductContentImporter.new(cp_products)
+      test_product = ::Katello::Product.create(
+        name: 'empty',
+        organization_id: ::Organization.first.id,
+        provider: ::Organization.first.anonymous_provider,
+        cp_id: '590'
+      )
+      assert_equal test_product, prod_content_importer.find_product_for_content("11210")
+      assert_nil prod_content_importer.find_product_for_content(nil)
+      assert_nil prod_content_importer.find_product_for_content("")
+      assert_nil prod_content_importer.find_product_for_content('350')
+      assert_nil prod_content_importer.find_product_for_content('380')
+    end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
~~We have a second code path that initializes ProductContentImporter. This second code path was passing an array to the initializer vs the first path of import_all which passes a hash.~~

UPDATE: So instead of converting the 2nd code path to pass a hash, we are revrting to using array as input for ProductContentImporter and correcting the import_all flow to array instead of Hash.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Import an expired manifest into an org.
2. Delete the manifest
3. Import a newer, valid manifest.

Refer to steps in https://bugzilla.redhat.com/show_bug.cgi?id=2253621 for more details.