### PR TITLE
Fixes #36979 - Change cdn_ssl_version setting to cdn_min_tls_version

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -377,12 +377,12 @@ Foreman::Plugin.register :katello do
         collection: proc { http_proxy_select },
         include_blank: N_("no global default")
 
-      setting 'cdn_ssl_version',
+      setting 'cdn_min_tls_version',
         type: :string,
-        default: nil,
-        full_name: N_('CDN SSL version'),
-        description: N_("SSL version used to communicate with the CDN"),
-        collection: proc { hashify_parameters(Katello::Resources::CDN::SUPPORTED_SSL_VERSIONS) }
+        default: Katello::Resources::CDN::SUPPORTED_TLS_VERSIONS.include?('TLSv1.3') ? 'TLSv1.3' : 'TLSv1.2',
+        full_name: N_('CDN minimum allowed TLS version'),
+        description: N_("Minimum allowed TLS version used to communicate with the CDN. WARNING: Older versions of the TLS standard than TLSv1.2 are deprecated and should only be enabled when required for backwards compatibility with HTTP proxy servers."),
+        collection: proc { hashify_parameters(Katello::Resources::CDN::SUPPORTED_TLS_VERSIONS) }
 
       setting 'katello_default_provision',
         type: :string,

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -17,15 +17,6 @@ module Katello
       assert setting.valid?
     end
 
-    def test_cdn_ssl_setting
-      # TODO: assert an error raised by the SettingRegistry
-      # setting = Foreman.settings.set_user_value('cdn_ssl_version', nil)
-      # assert setting.valid?
-
-      setting = Foreman.settings.set_user_value('cdn_ssl_version', 'SSLv23')
-      assert setting.valid?
-    end
-
     def test_recalculate_errata_status
       ForemanTasks.expects(:async_task).with(::Actions::Katello::Host::RecalculateErrataStatus)
       Setting['errata_status_installable'] = !Setting['errata_status_installable']


### PR DESCRIPTION
This uses the min_version attribute from Net::HTTP instead of ssl_version, which in turn uses OpenSSL::SSL::SSLContext#min_version and not the older OpenSSL::SSL::SSLContent#ssl_version. As a result the there is no longer a blanket SSLv23 setting and the data format for specifying TLS versions has changed.

It also sets a default value of the new setting for TLSv1.2, which is reasonable because older versions of the standard are deprecated. Users requiring a deprecated protocol version due to their network infrastructure can lower this value as needed.

#### Considerations taken when implementing this change?

1. What is a reasonable default value? I went with TLSv1.2 since TLSv1.1 and older standards are officially deprecated
2. How to best handle the difference in allowed values for `min_version` and `ssl_version` in OpenSSL, since `ssl_version` is deprecated? I opted to introduce a new setting entirely since the functionality has changed and we can't directly map the old allowed values onto the new allowed values.
3. I removed the related tests from `test/models/setting_test.rb` as it seems that `test/lib/resources/cdn_test.rb` provides adequate coverage.

#### What are the testing steps for this pull request?

1. Test uploading a manifest, syncing from CDN, etc
4. Test inter-server sync from a server that has newer TLS disabled... this should fail because older TLS is now blocked by default
5. Lower the `CDN min TLS version` value and re-try inter-server sync. Now it should succeed once older TLS has been permitted.

#### Open Questions

1. Is there any need for continued support for insecure protocols such as SSLv3 ?
2. Is a DB migration needed to clean up the removed setting? I tested giving a non-nil value to the older setting before applying the change, it doesn't seem to cause any issue, and it looks like there is precedent for skipping this, as in https://github.com/Katello/katello/commit/283c63dc301b52f08ff6e09d45f0e817e811f9a0