### PR TITLE
Fixes #36986 - Warn users on traces that require reboot

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/traces.fixtures.json
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/traces.fixtures.json
@@ -39,6 +39,16 @@
         "host_id": 1,
         "host": "centos7.katello.lan",
         "reboot_required": false
-     }
+     },
+     {
+        "id": 4,
+        "application": "dbus",
+        "helper": "You will have to reboot your computer",
+        "restart_command": "reboot",
+        "app_type": "static",
+        "host_id": 1,
+        "host": "centos7.katello.lan",
+        "reboot_required": true
+    }
   ]
 }


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add a warning on the Traces tab when one of the selected traces is "static" type, and thus requires a reboot of the host.

Also
* added a warning icon next to the helper, and
* changed the button text to "Reboot Host" just in case you didn't see _any_ of those other things


![image](https://github.com/Katello/katello/assets/22042343/562f59a7-b7ee-4a4e-a725-e1ce24ac080a)

#### Considerations taken when implementing this change?

With select all mode, we haven't downloaded the data for all selected traces, so we don't know for sure if one of the undownloaded traces requires a reboot. The best we can do in that case is see if any of the results we _have_ downloaded require a reboot. If so, it'll show the warning in select all mode as well. However, there are two edge cases where the warning will be a lie:

 - If you select all, and then deselect all of the static-type traces, the warning will still show.
 - If you select all, and the current page of results happens not to have any static traces, the warning will _not_ show.

I consider these cases to be rare enough not to need special treatment.

#### What are the testing steps for this pull request?

Set up a box with traces (easiest way for me is to spin up a new rhel8, then apply all errata)
Go to the host details / Traces tab and verify the warning shows

