### PR TITLE
Fixes #36989 - Unscope smart proxies when deciding content source

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -276,7 +276,7 @@ module Katello
     end
 
     def get_content_source_id(hostname)
-      proxies = SmartProxy.authorized.filter do |sp|
+      proxies = SmartProxy.unscoped.authorized.filter do |sp|
         hostname == URI.parse(sp.url).hostname
       end
       return nil if proxies.length != 1

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -69,13 +69,13 @@ module Katello
         scope :with_content, -> { with_features(PULP_FEATURE, PULP_NODE_FEATURE, PULP3_FEATURE) }
 
         def self.load_balanced
-          proxies = self.with_content # load balancing is only supported for pulp proxies
+          proxies = unscoped.with_content # load balancing is only supported for pulp proxies
           ids = proxies.select { |proxy| proxy.load_balanced? }.map(&:id)
           proxies.where(id: ids)
         end
 
         def self.behind_load_balancer(load_balancer_hostname)
-          proxies = self.with_content
+          proxies = unscoped.with_content
           ids = proxies.select { |proxy| proxy.load_balanced? && proxy.registration_host == load_balancer_hostname }.map(&:id)
           proxies.where(id: ids)
         end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

A commit was recently introduced to attempt to surmise when a host is being registered thru a load balancer.

To do this, candlepin_proxies_controller needs to look through ::SmartProxy.all to find smart proxies matching the hostname of the server receiving the registration request.

However, if there are smart proxies assigned to locations, and those locations are not the same locations assigned to the registering user (the --username passed to subscription-manager), Rails will act as if those smart proxies don't exist.

The effect is that Katello doesn't have access to its own list of smart proxies, and so doesn't know how to correctly assign a content source.

So the host will get registered, and its "registered_through" smart proxies for REX will be correct, but content source will be incorrectly nil.

With this change, `.unscoped` is added to `::SmartProxy` so that it doesn't care what locations are assigned. This will allow the correct content source to be assigned to the host.

#### Considerations taken when implementing this change?

I think this will affect all registrations to smart proxies (when those smart proxies have locations assigned that aren't the same as the registering user) -- not just those that involve load balancers.

#### What are the testing steps for this pull request?

To reproduce this I think you could

1. Set up an external smart proxy (I know, sorry, but it's not as bad as setting up a LB :)
2. Assign the smart proxy to a non-default location
3. Register the host to the smart proxy (make sure the admin user isn't assigned to the smart proxy's location)

Before the patch:

Host will not have a content source assigned (`host.content source == nil`)
You'll see an error in the log like
```
Host containerhost-hq-1-container10.blue.ddns.perf.redhat.com registered through unknown proxy 
```

After checking out this patch, and reregistering the host:

* Host will have content source correctly assigned

If registering thru a load balancer, you'll see a message in the log like
```
Host containerhost-b-1-container10.blue.ddns.perf.redhat.com registered through load balancer capsule-lb-b.blue.ddns.perf.redhat.com
```

(If not registering thru a load balancer, you won't see that message but it's fine)
