### PR TITLE
Fixes #36987 - Remove param :source_url since it's no longer supported

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -343,7 +343,6 @@ Alternatively, use the 'force' parameter to regenerate metadata locally. On the 
 
     api :POST, "/repositories/:id/sync", N_("Sync a repository")
     param :id, :number, :required => true, :desc => N_("repository ID")
-    param :source_url, String, :desc => N_("temporarily override feed URL for sync"), :required => false
     param :incremental, :bool, :desc => N_("perform an incremental import"), :required => false
     param :skip_metadata_check, :bool, :desc => N_("Force sync even if no upstream changes are detected. Only used with yum or deb repositories."), :required => false
     param :validate_contents, :bool, :desc => N_("Force a sync and validate the checksums of all content. Only used with yum repositories."), :required => false
@@ -352,15 +351,10 @@ Alternatively, use the 'force' parameter to regenerate metadata locally. On the 
       sync_options = {
         :skip_metadata_check => ::Foreman::Cast.to_bool(params[:skip_metadata_check]),
         :validate_contents => ::Foreman::Cast.to_bool(params[:validate_contents]),
-        :incremental => ::Foreman::Cast.to_bool(params[:incremental]),
-        :source_url => params[:source_url]
+        :incremental => ::Foreman::Cast.to_bool(params[:incremental])
       }
 
-      if params[:source_url].present? && params[:source_url] !~ /\A#{URI::DEFAULT_PARSER.make_regexp}\z/
-        fail HttpErrors::BadRequest, _("source URL is malformed")
-      end
-
-      if params[:source_url].blank? && @repository.url.blank?
+      if @repository.url.blank?
         fail HttpErrors::BadRequest, _("attempted to sync without a feed URL")
       end
 

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -21,13 +21,11 @@ module Actions
         def plan(repo, options = {})
           action_subject(repo)
 
-          source_url = options.fetch(:source_url, nil)
           validate_contents = options.fetch(:validate_contents, false)
           skip_metadata_check = options.fetch(:skip_metadata_check, false) || (validate_contents && (repo.yum? || repo.deb?))
           generate_applicability =  options.fetch(:generate_applicability, repo.yum? || repo.deb?)
 
           validate_repo!(repo: repo,
-                        source_url: source_url,
                         skip_metadata_check: skip_metadata_check,
                         skip_candlepin_check: options.fetch(:skip_candlepin_check, false))
 
@@ -82,8 +80,8 @@ module Actions
           end
         end
 
-        def validate_repo!(repo:, source_url:, skip_metadata_check:, skip_candlepin_check:)
-          fail ::Katello::Errors::InvalidActionOptionError, _("Unable to sync repo. This repository does not have a feed url.") if repo.url.blank? && source_url.blank?
+        def validate_repo!(repo:, skip_metadata_check:, skip_candlepin_check:)
+          fail ::Katello::Errors::InvalidActionOptionError, _("Unable to sync repo. This repository does not have a feed url.") if repo.url.blank?
           fail ::Katello::Errors::InvalidActionOptionError, _("Cannot skip metadata check on non-yum/deb repositories.") if skip_metadata_check && !repo.yum? && !repo.deb?
           fail ::Katello::Errors::InvalidActionOptionError, _("Unable to sync repo. This repository is not a library instance repository.") unless repo.library_instance?
           ::Katello::Util::CandlepinRepositoryChecker.check_repository_for_sync!(repo) if repo.yum? && !skip_candlepin_check

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -819,28 +819,13 @@ module Katello
       assert_response :success
     end
 
-    def test_sync_with_url_override
-      assert_async_task ::Actions::Katello::Repository::Sync do |repo, options|
-        assert_equal @repository.id, repo.id
-        assert_equal options[:source_url], 'file:///tmp/'
-      end
-      post :sync, params: { :id => @repository.id, :source_url => 'file:///tmp/' }
-      assert_response :success
-    end
-
     def test_sync_with_incremental_flag
       assert_async_task ::Actions::Katello::Repository::Sync do |repo, options|
         assert_equal @repository.id, repo.id
-        assert_equal options[:source_url], 'file:///tmp/'
         assert_equal options[:incremental], true
       end
-      post :sync, params: { :id => @repository.id, :source_url => 'file:///tmp/', :incremental => true }
+      post :sync, params: { :id => @repository.id, :incremental => true }
       assert_response :success
-    end
-
-    def test_sync_with_bad_url_override
-      post :sync, params: { :id => @repository.id, :source_url => 'file:|||tmp/' }
-      assert_response 400
     end
 
     def test_sync_no_feed_urls
@@ -856,13 +841,6 @@ module Katello
       task_attrs[:output] = {}
 
       stub('task', task_attrs).mimic!(::ForemanTasks::Task)
-    end
-
-    def test_sync_no_feed_urls_with_override
-      repo = katello_repositories(:feedless_fedora_17_x86_64)
-      @controller.stubs(:async_task).returns(build_task_stub)
-      post :sync, params: { :id => repo.id, :source_url => 'http://www.wikipedia.org' }
-      assert_response :success
     end
 
     def test_sync_protected


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
We have not supported :source_url param to override repository URL during sync which was supported in pulp2 world since upgrading to pulp3.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Make sure all references to :source_url are removed.