### PR TITLE
Fixes #37018 - Use correct function signature for fetchBulkParams

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -377,7 +377,7 @@ const RepositorySetsTab = () => {
       singular: singular || selectedCount === 1,
     }));
   };
-  const bulkParams = () => fetchBulkParams('cp_content_id');
+  const bulkParams = () => fetchBulkParams({ idColumnName: 'cp_content_id' });
   const enableRepoSets = () => updateOverrides({ enabled: true, search: bulkParams() });
   const disableRepoSets = () => updateOverrides({ enabled: false, search: bulkParams() });
   const resetToDefaultRepoSets = () => updateOverrides({ remove: true, search: bulkParams() });


### PR DESCRIPTION
In https://github.com/Katello/katello/pull/10783, the `fetchBulkParams` method was removed from Katello.

In https://github.com/theforeman/foreman/pull/9860, it was moved to Foreman.

In the course of doing so, the function signature was changed from

```js
const fetchBulkParams = (idColumnName = idColumn) => {
```

to

```js
const fetchBulkParams = ({
    idColumnName = idColumn,
    selectAllQuery = '',
  }) => {
```

This means that you now have to pass an object instead of a string. This breaks bulk repository set overrides in the web UI.

#### What are the changes introduced in this pull request?

* Correctly pass an object to `fetchBulkParams`

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?