### PR TITLE
Fixes #36995 - bump recommended Sat repos to 6.15

### DIFF
--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -34,9 +34,9 @@ const recommendedRepositoriesSatTools = [
 ];
 
 const recommendedRepositoriesMisc = [
-  'satellite-capsule-6.14-for-rhel-8-x86_64-rpms',
-  'satellite-maintenance-6.14-for-rhel-8-x86_64-rpms',
-  'satellite-utils-6.14-for-rhel-8-x86_64-rpms',
+  'satellite-capsule-6.15-for-rhel-8-x86_64-rpms',
+  'satellite-maintenance-6.15-for-rhel-8-x86_64-rpms',
+  'satellite-utils-6.15-for-rhel-8-x86_64-rpms',
 ];
 
 const recommendedRepositorySetLables = recommendedRepositoriesRHEL


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Bumps recommended Satellite repositories to 6.15

#### Considerations taken when implementing this change?
I'm assuming that the repository label scheme is still the same.

#### What are the testing steps for this pull request?
Nothing for now, the repositories won't show up until they're published on the RH CDN.