### PR TITLE
Fixes #37024 - Set 'Requires virt_who' regardless of product presence or Red-Hatness

### DIFF
--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -129,7 +129,6 @@ module Katello
         providers.any?
       end
 
-      # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
       # rubocop:disable Metrics/CyclomaticComplexity
       def import_data(index_hosts_and_activation_keys = false)
         pool_attributes = {}.with_indifferent_access
@@ -161,11 +160,7 @@ module Katello
           pool_attributes[:unmapped_guest] = true
         end
 
-        if subscription.try(:redhat?)
-          pool_attributes[:virt_who] = pool_attributes['virt_limit'] != "0" && pool_attributes['virt_limit'].present?
-        else
-          pool_attributes[:virt_who] = false
-        end
+        pool_attributes[:virt_who] = (pool_attributes['virt_limit'].present? && pool_attributes['virt_limit'] != "0")
 
         pool_attributes['stack_id'] = pool_json['stackId']
         exceptions = pool_attributes.keys.map(&:to_sym) - self.attribute_names.map(&:to_sym)
@@ -175,7 +170,7 @@ module Katello
         self.create_product_associations
         self.import_hosts if index_hosts_and_activation_keys
       end
-      # rubocop:enable Metrics/MethodLength,Metrics/AbcSize
+      # rubocop:enable
 
       def create_product_associations
         products = self.backend_data["providedProducts"] + self.backend_data["derivedProvidedProducts"]


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Check to see if a pool's attributes have a `virt_limit` value regardless of whether its subscription has products associated.

- Certain subscriptions require virt-who
- These pools are noted in Candlepin with a `virt_limit` value of either "unlimited" or an integer
- The presence of the `virt_limit` value is taken by Katello and translated into a `virt_who` boolean attribute on the `Katello::Pool` (a number or "unlimited" means true). This is what causes it to show 'Requires Virt-who' in the UI.
- This is what a manifest import action plan looks like:
![image](https://github.com/Katello/katello/assets/22042343/1bf7ee2d-e4bc-4d1c-8ad9-93a08c525a49)
- `Owner::ImportProducts` is the part where `virt_who` is supposed to get set on the newly-created `Katello::Pool`s.
- It wasn't getting set properly here because `subscription.try(:redhat?)` was returning false:
```rb
if subscription.try(:redhat?)
  pool_attributes[:virt_who] = pool_attributes['virt_limit'] != "0" && pool_attributes['virt_limit'].present?
else
  pool_attributes[:virt_who] = false
end
```

This is not because the subscription isn't Red Hat; rather it's because the subscription doesn't have any products at this point.

```rb
# subscription.rb
    def redhat?
      products.redhat.any?
    end
```

So this change checks the `virt_limit` value regardless of that.

#### Considerations taken when implementing this change?

Previously I was reindexing all pools and subscriptions, but I realized I could just do this instead and save a ton of time.

#### What are the testing steps for this pull request?

* Ping me for the manifest (or look in the BZ)
* Make a _new_ organization and import the manifest
* On the Subscriptions page, look at the 'Requires Virt-who' column for "Red Hat Enterprise Linux for Virtual Datacenters with Satellite, Premium." It should have a check mark, but instead will have a "--". Likewise, when you click into its details, it will show 'Requires Virt-who' = false.
* Now delete the manifest and make another _new_ organization. (For some reason I couldn't reproduce again in the same org, so this part is important)
* Check out my PR and reimport the manifest again.
* You should now see the subscription as correctly showing Requires Virt-who.

![image](https://github.com/Katello/katello/assets/22042343/9fdac19a-6200-459c-94dc-5957498fe60e)
