### PR TITLE
Fixes #37028 - Set up sp-reference for content source

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -168,6 +168,8 @@ module Katello
 
         scoped_search relation: :pools, on: :pools_expiring_in_days, ext_method: :find_with_expiring_pools, only_explicit: true
 
+        smart_proxy_reference :content_facet => [:content_source_id]
+
         def add_back_cve_errors
           if @pending_cve_attrs&.[](:content_view_id).present? || @pending_cve_attrs&.[](:lifecycle_environment_id).present?
             check_cve_attributes({ content_facet_attributes: @pending_cve_attrs })


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
These changes establish a link between a host and its content source using the smart proxy reference framework.

#### Considerations taken when implementing this change?
The drive is to resolve a bug with proxy taxonomy setting. We can rely on this reference to determine in which taxonomies (locations more specifically) a proxy *has to be* so that there are no between a proxy and hosts that are linked to it.

This will probably not work 100% reliably with proxies behind a load balancer, but it's still better than nothing I guess.

#### What are the testing steps for this pull request?
1) Have a host
2) Have a content proxy
3) Change the host's content source to be the content proxy
4) Make sure the host is not linked to the content proxy in any other way
5) Run something like `Host::Managed.smart_proxy_ids(Host.where(id: $id))`, it should give you the id of the smart proxy