### PR TITLE
Fixes #37030 - Wrong link to Files in CV Repositories tab

### DIFF
--- a/webpack/scenes/ContentViews/Details/Repositories/ContentCounts.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/ContentCounts.js
@@ -15,7 +15,7 @@ const repoLabels = {
   docker_manifest: ['container manifests', 'container manifest', 'docker_manifests'],
   docker_manifest_list: ['container manifest lists', 'container manifest list', 'docker_manifest_lists'],
   docker_tag: ['container tags', 'container tag', 'docker_tags'],
-  file: ['files', 'file', 'content/files'],
+  file: ['files', 'file', 'files'],
   package_group: ['package groups', 'package group', 'package_groups'],
   srpm: ['source RPMs', 'source RPM', 'source_rpms'], // no link?
 };


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Link to files on Content View Repositories page contains one extra 'content' in

