### PR TITLE
Fixes #37032 - Drop minitest-tags development dependency

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -68,7 +68,6 @@ Gem::Specification.new do |gem|
 
   # Testing
   gem.add_development_dependency "factory_bot_rails", "~> 4.5"
-  gem.add_development_dependency "minitest-tags"
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "vcr", "< 4.0.0"
   gem.add_development_dependency "webmock"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

minitest-tags allows developers to run a single test, but it hasn't been updated since 2012.

#### Considerations taken when implementing this change?

Some developers may be using this functionality. Perhaps there are alternatives. Foreman also uses minitest so it would be better to discuss it in a wider group.

#### What are the testing steps for this pull request?

Nothing. It drops some developer functionality, so more of a question: does anyone use that?