### PR TITLE
Fixes #37084 - Drop simplecov dependency

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -72,7 +72,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "vcr", "< 4.0.0"
   gem.add_development_dependency "webmock"
-  gem.add_development_dependency "simplecov"
-  gem.add_development_dependency "simplecov-rcov"
   gem.add_development_dependency "robottelo_reporter"
 end

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -1,24 +1,9 @@
-require 'simplecov'
-require 'simplecov-rcov'
-
 require 'test_helper'
 require 'factory_bot_rails'
 require "webmock/minitest"
 require 'mocha/minitest'
 require 'set'
 require 'robottelo/reporter/attributes'
-
-SimpleCov.formatters = [
-  SimpleCov::Formatter::RcovFormatter,
-  SimpleCov::Formatter::HTMLFormatter
-]
-
-SimpleCov.start do
-  filters.clear
-  add_filter do |src|
-    !src.filename.include?('/plugin/app/') && !src.filename.include?('/plugin/lib/')
-  end
-end
 
 require "#{Katello::Engine.root}/test/support/minitest/spec/shared_examples"
 require "#{Katello::Engine.root}/spec/models/model_spec_helper"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This is a test dependency, but marked as a development dependency. We currently install all development dependencies while testing katello, but don't do that for any other plugin. This is an effort to reduce the development dependencies to pure development dependencies.

#### Considerations taken when implementing this change?

We may want this, but then we need to figure that out. Currently this is marked as a draft because it's only up for discussion now.

One option is to rescue `LoadError` if it's unavailable and gracefully deal with it.

Big question is: does anyone use these coverage reports?