### PR TITLE
Fixes #37033 - Drop unused katello:rubocop:jenkins rake task

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -72,7 +72,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "vcr", "< 4.0.0"
   gem.add_development_dependency "webmock"
-  gem.add_development_dependency "rubocop-checkstyle_formatter"
   gem.add_development_dependency "simplecov"
   gem.add_development_dependency "simplecov-rcov"
   gem.add_development_dependency "robottelo_reporter"

--- a/lib/katello/tasks/rubocop.rake
+++ b/lib/katello/tasks/rubocop.rake
@@ -6,13 +6,4 @@ namespace :katello do
     system("bundle exec rubocop -D #{Katello::Engine.root}")
     exit($CHILD_STATUS.exitstatus)
   end
-
-  desc "Runs Rubocop style checker with xml output for Jenkins"
-  task 'rubocop:jenkins' do
-    system("bundle exec rubocop #{Katello::Engine.root} \
-            --require rubocop/formatter/checkstyle_formatter \
-            --format RuboCop::Formatter::CheckstyleFormatter \
-            --no-color --out rubocop.xml")
-    exit($CHILD_STATUS.exitstatus)
-  end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The task is dropped and the unused `rubocop-checkstyle_formatter` dependency is removed.

#### Considerations taken when implementing this change?

Jenkins uses katello:rubocop and doesn't parse the results right now, so the dependency can be dropped safely.

https://github.com/theforeman/jenkins-jobs/pull/400 enables parsing of the results again, but these days the default formatter (progress) output can be parsed by Jenkins.

#### What are the testing steps for this pull request?

Verify CI still passes.