### PR TITLE
Fixes #37040 - Fix outdated registration wording for AKs

### DIFF
--- a/app/views/overrides/activation_keys/_host_tab_pane.html.erb
+++ b/app/views/overrides/activation_keys/_host_tab_pane.html.erb
@@ -21,9 +21,11 @@
     </div>
 
     <p><%= _('Activation keys and subscriptions can be managed') %>
-      <b><a href="/activation_keys" target="_blank"> <%= _('here') %></a></b>
+      <b><a href="/activation_keys" target="_blank"> <%= _('here.') %></a></b>
     </p>
-    <p><%= subscription_manager_configuration_url %></p>
+    <p translate>
+    Activation keys may be used during <a href="/hosts/register">system registration.</a>
+  </p>
     <p><a href="" id="ak_refresh_subscriptions"><%= _('Reload data') %></a></p>
   </div>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-info.html
@@ -2,11 +2,8 @@
 
 <div bst-alert="info">
   <span translate>
-    This activation key may be used during system registration. For example:
+    This activation key may be used during <a href="/hosts/register?initialAKSelection={{ activationKey.name }}">system registration.</a>
   </span>
-  <p translate>
-    subscription-manager register --org="{{ activationKey.organization.label }}" --activationkey="{{ activationKey.name }}"
-  </p>
 </div>
 
 <div data-extend-template="layouts/two-column-details.html">

--- a/webpack/components/extensions/RegistrationCommands/fields/ActivationKeys.js
+++ b/webpack/components/extensions/RegistrationCommands/fields/ActivationKeys.js
@@ -147,7 +147,9 @@ ActivationKeys.propTypes = {
     PropTypes.array,
   ]),
   hostGroupId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  pluginValues: PropTypes.objectOf(PropTypes.shape({})),
+  pluginValues: PropTypes.shape({
+    activationKeys: PropTypes.array,
+  }),
   onChange: PropTypes.func.isRequired,
   handleInvalidField: PropTypes.func.isRequired,
   isLoading: PropTypes.bool,

--- a/webpack/components/extensions/RegistrationCommands/index.js
+++ b/webpack/components/extensions/RegistrationCommands/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'foremanReact/common/helpers';
+import { useUrlParams } from 'foremanReact/components/PF4/TableIndexPage/Table/TableHooks';
 
 import ActivationKeys from './fields/ActivationKeys';
 import IgnoreSubmanErrors from './fields/IgnoreSubmanErrors';
@@ -48,9 +49,17 @@ export const RegistrationActivationKeys = ({
   handleInvalidField,
   isLoading,
 }) => {
+  const { initialAKSelection } = useUrlParams();
   useEffect(() => {
     onChange({ activationKeys: [] });
   }, [onChange, organizationId, hostGroupId]);
+
+  useEffect(() => {
+    if (initialAKSelection &&
+       (pluginData?.activationKeys ?? []).some(ak => ak.name === initialAKSelection)) {
+      onChange({ activationKeys: initialAKSelection.split(',') });
+    }
+  }, [initialAKSelection, onChange, pluginData?.activationKeys]);
 
   return (
     <ActivationKeys


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

1. Fix outdated wording on the Activation Key details page which recommends a deprecated host registration method.
2. Fix outdated wording on the Activation Key tab of the Host Group details page which recommends a deprecated host registration method.
3. In those places, add links to the new Global Registration page.
4. :partying_face: Bonus! :partying_face: Improve the Global Registration form so that we can have a certain activation key selected immediately on page load.

Activation Key details page:
![image](https://github.com/Katello/katello/assets/22042343/28dcf1cf-571e-4c33-895d-0043ebc1a314)

Host Group details page:
![image](https://github.com/Katello/katello/assets/22042343/dfee1e0c-7818-4b93-b36c-bdd6c82f7e10)

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Create at least one activation key
Create a host group
Verify the new wording on both pages

Verify the new features of the Host Registration form:

1. Link from Activation Key details page works and pre-selects the activation key
2. Link from Host Group details page works and does not pre-select any key (unless there's only one in the system, see no. 5 below)
3. Loading the page with `?initialAKSelection=` and a valid activation key pre-selects that key
4. Loading the page with `?initialAKSelection=` and an _invalid_ activation key does not error and does not pre-select a key
5. Loading the page when only one activation key exists still pre-selects that activation key, with or without  `?initialAKSelection=` 