### PR TITLE
Fixes #35974 - Extra index to check for installed package id

### DIFF
--- a/db/migrate/20240111032511_add_index_to_host_installed_packages.rb
+++ b/db/migrate/20240111032511_add_index_to_host_installed_packages.rb
@@ -1,0 +1,16 @@
+class AddIndexToHostInstalledPackages < ActiveRecord::Migration[6.1]
+  def up
+    add_index :katello_host_installed_packages, [:installed_package_id],
+      :name => 'katello_host_installed_packages_ip_id'
+    add_index :katello_host_installed_packages, [:host_id],
+      :name => 'katello_host_installed_packages_host_id'
+  end
+
+  def down
+    remove_index :katello_host_installed_packages,
+      :name => 'katello_host_installed_packages_ip_id'
+
+    remove_index :katello_host_installed_packages,
+      :name => 'katello_host_installed_packages_host_id'
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Its adds an extra index to `katello_host_installed_packages` table to track based on `installed_package_id`

#### Considerations taken when implementing this change?
Explain plan  before this id
```sql
katello=# EXPLAIN SELECT COUNT(DISTINCT "hosts"."id") FROM "hosts" LEFT OUTER JOIN "katello_host_installed_packages" ON "katello_host_installed_packages"."host_id" = "hosts"."id" LEFT OUTER JOIN "katello_installed_packages" ON "katello_installed_packages"."id" = "katello_host_installed_packages"."installed_package_id" WHERE "hosts"."type" = 'Host::Managed' AND ("hosts"."id" IN (SELECT "hosts"."id" FROM "hosts"          INNER JOIN "katello_host_installed_packages" ON "hosts"."id" = "katello_host_installed_packages"."host_id"  INNER JOIN "katello_installed_packages" ON "katello_host_installed_packages"."installed_package_id" = "katello_installed_packages"."id" WHERE "katello_installed_packages"."name" = 'katello-ca-consumer-phoenix-devel.lagrange.example.com' ))
;
                                                                                  QUERY PLAN                                                                                 
 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
 Aggregate  (cost=1007.56..1007.57 rows=1 width=8)
   ->  Nested Loop Left Join  (cost=958.77..1005.80 rows=703 width=4)
         ->  Nested Loop  (cost=958.48..959.70 rows=4 width=4)
               ->  HashAggregate  (cost=958.33..958.37 rows=4 width=8)
                     Group Key: hosts_1.id
                     ->  Nested Loop  (cost=8.46..958.32 rows=4 width=8)
                           ->  Hash Join  (cost=8.31..957.66 rows=4 width=4)
                                 Hash Cond: (katello_host_installed_packages_1.installed_package_id = katello_installed_packages.id)
                                 ->  Seq Scan on katello_host_installed_packages katello_host_installed_packages_1  (cost=0.00..814.09 rows=51509 width=8)
                                 ->  Hash  (cost=8.30..8.30 rows=1 width=4)
                                       ->  Index Scan using index_katello_installed_packages_on_name_and_nvra on katello_installed_packages  (cost=0.29..8.30 rows=1 width=4)
                                             Index Cond: ((name)::text = 'katello-ca-consumer-phoenix-devel.lagrange.example.com'::text)
                           ->  Index Only Scan using hosts_pkey on hosts hosts_1  (cost=0.15..0.17 rows=1 width=4)
                                 Index Cond: (id = katello_host_installed_packages_1.host_id)
               ->  Index Scan using hosts_pkey on hosts  (cost=0.15..0.33 rows=1 width=4)
                     Index Cond: (id = hosts_1.id)
                     Filter: ((type)::text = 'Host::Managed'::text)
         ->  Index Only Scan using katello_host_installed_packages_h_id_ip_id on katello_host_installed_packages  (cost=0.29..9.78 rows=174 width=8)
               Index Cond: (host_id = hosts.id)
(19 rows)

```

Explain plan after
```sql
katello=# EXPLAIN SELECT COUNT(DISTINCT "hosts"."id") FROM "hosts" LEFT OUTER JOIN "katello_host_installed_packages" ON "katello_host_installed_packages"."host_id" = "hosts"."id" LEFT OUTER JOIN "katello_installed_packages" ON "katello_installed_packages"."id" = "katello_host_installed_packages"."installed_package_id" WHERE "hosts"."type" = 'Host::Managed' AND ("hosts"."id" IN (SELECT "hosts"."id" FROM "hosts"          INNER JOIN "katello_host_installed_packages" ON "hosts"."id" = "katello_host_installed_packages"."host_id"  INNER JOIN "katello_installed_packages" ON "katello_host_installed_packages"."installed_package_id" = "katello_installed_packages"."id" WHERE "katello_installed_packages"."name" = 'katello-ca-consumer-phoenix-devel.lagrange.example.com' ))
;
                                                                               QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=306.39..306.40 rows=1 width=8)
   ->  Nested Loop Left Join  (cost=257.60..304.63 rows=703 width=4)
         ->  Nested Loop  (cost=257.31..258.53 rows=4 width=4)
               ->  HashAggregate  (cost=257.16..257.20 rows=4 width=8)
                     Group Key: hosts_1.id
                     ->  Nested Loop  (cost=5.76..257.15 rows=4 width=8)
                           ->  Nested Loop  (cost=5.61..256.49 rows=4 width=4)
                                 ->  Index Scan using index_katello_installed_packages_on_name_and_nvra on katello_installed_packages  (cost=0.29..8.30 rows=1 width=4)
                                       Index Cond: ((name)::text = 'katello-ca-consumer-phoenix-devel.lagrange.example.com'::text)
                                 ->  Bitmap Heap Scan on katello_host_installed_packages katello_host_installed_packages_1  (cost=5.33..246.84 rows=134 width=8)
                                       Recheck Cond: (installed_package_id = katello_installed_packages.id)
                                       ->  Bitmap Index Scan on katello_host_installed_packages_ip_id  (cost=0.00..5.29 rows=134 width=0)
                                             Index Cond: (installed_package_id = katello_installed_packages.id)
                           ->  Index Only Scan using hosts_pkey on hosts hosts_1  (cost=0.15..0.17 rows=1 width=4)
                                 Index Cond: (id = katello_host_installed_packages_1.host_id)
               ->  Index Scan using hosts_pkey on hosts  (cost=0.15..0.33 rows=1 width=4)
                     Index Cond: (id = hosts_1.id)
                     Filter: ((type)::text = 'Host::Managed'::text)
         ->  Index Only Scan using katello_host_installed_packages_h_id_ip_id on katello_host_installed_packages  (cost=0.29..9.78 rows=174 width=8)
               Index Cond: (host_id = hosts.id)
(20 rows)
```

Note that the later query avoids the 
` ->  Seq Scan on katello_host_installed_packages katello_host_installed_packages_1  (cost=0.00..814.09 rows=51509 width=8)`

Over all cost is reduced by a third.

While i was not able to reproduce the OOM Search issue with 300+ hosts and 15K installed packages the explain plan clearly indicate the benefits.

#### What are the testing steps for this pull request?

Run the explain plan query both before and after this pr
```sql
katello=# EXPLAIN SELECT COUNT(DISTINCT "hosts"."id") FROM "hosts" LEFT OUTER JOIN "katello_host_installed_packages" ON "katello_host_installed_packages"."host_id" = "hosts"."id" LEFT OUTER JOIN "katello_installed_packages" ON "katello_installed_packages"."id" = "katello_host_installed_packages"."installed_package_id" WHERE "hosts"."type" = 'Host::Managed' AND ("hosts"."id" IN (SELECT "hosts"."id" FROM "hosts"          INNER JOIN "katello_host_installed_packages" ON "hosts"."id" = "katello_host_installed_packages"."host_id"  INNER JOIN "katello_installed_packages" ON "katello_host_installed_packages"."installed_package_id" = "katello_installed_packages"."id" WHERE "katello_installed_packages"."name" = 'katello-ca-consumer-phoenix-devel.lagrange.example.com' ))
;
```

Before should have a Seq Scan in it
After should have the index version

May be try this on a system of 1000s of hosts