### PR TITLE
Fixes #37014 - set correct Host owner during registration

### DIFF
--- a/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
@@ -11,6 +11,7 @@ module Katello
             fail ActiveRecord::RecordNotFound, msg
           end
           @host.assign_attributes(host_params('host'))
+          @host.owner = User.current
           @host.save!
         else
           super


### PR DESCRIPTION
This commit modifies the prepare_host method to include the host owner. 
This change ensures that the host owner is set to the current user, providing consistency with the prepare_host method in the Foreman [repository](https://github.com/theforeman/foreman/blob/develop/app/controllers/api/v2/registration_controller.rb#L120).