### PR TITLE
Fixes #37044 - Remove LCE option from registration API

### DIFF
--- a/app/controllers/katello/concerns/api/v2/registration_commands_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/registration_commands_controller_extensions.rb
@@ -29,7 +29,6 @@ module Katello
           param :registration_command, Hash do
             param :activation_key, String, desc: N_('Activation key for subscription-manager client, required for CentOS and Red Hat Enterprise Linux. For multiple keys use `activation_keys` param instead.'), deprecated: true
             param :activation_keys, Array, desc: N_('Activation keys for subscription-manager client, required for CentOS and Red Hat Enterprise Linux. Required only if host group has no activation keys.')
-            param :lifecycle_environment_id, :number, required: false, desc: N_('Lifecycle environment for the host.')
             param :force, :bool, required: false, desc: N_('Clear any previous registration and run subscription-manager with --force.')
             param :ignore_subman_errors, :bool, required: false, desc: N_('Ignore subscription-manager errors for `subscription-manager register` command')
           end

--- a/test/controllers/foreman/registration_commands_controller_test.rb
+++ b/test/controllers/foreman/registration_commands_controller_test.rb
@@ -86,13 +86,6 @@ class Api::V2::RegistrationCommandsControllerTest < ActionController::TestCase
     assert_includes(JSON.parse(@response.body)['registration_command'], 'ignore_subman_errors=true')
   end
 
-  def test_with_lifecycle_environment_id
-    post :create, params: { lifecycle_environment_id: 23, activation_keys: ['key1'] }
-
-    assert_response :success
-    assert_includes(JSON.parse(@response.body)['registration_command'], 'lifecycle_environment_id=23')
-  end
-
   def test_hostgroup_with_ack
     hostgroup = FactoryBot.create(:hostgroup)
     FactoryBot.create(:hostgroup_parameter, hostgroup: hostgroup, name: 'kt_activation_keys', value: 'key1')


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Remove the Lifecycle param from the `registration_commands_controller` 
* Jeremy removed it from the UI in https://github.com/Katello/katello/pull/10764

#### Considerations taken when implementing this change?

* N/A

#### What are the testing steps for this pull request?

* Checkout PR
* Fetch the new API doc with hammer by doing `hammer -r`
* Run ` hammer host-registration generate-command --help | grep lifecycle` see if the option is removed