### PR TITLE
Refs #35713 - correctly call methods with kwargs

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -542,9 +542,9 @@ module Katello
 
       def package_names_for_job_template(action:, search:, versions: nil)
         if self.operatingsystem.family == 'Debian'
-          deb_names_for_job_template(action, search)
+          deb_names_for_job_template(action: action, search: search)
         else
-          yum_names_for_job_template(action, search, versions)
+          yum_names_for_job_template(action: action, search: search, versions: versions)
         end
       end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

In https://github.com/Katello/katello/pull/10744 package_names_for_job_template was extracted into two new methods, `yum_names_for_job_template` and `deb_names_for_job_template`.

These new methods accept only keyword arguments, but are called only with regular non-kwargs.

This change fixes that and properly calls the methods with kwargs.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Install or remove a package via the new host details UI and make sure that the job template renders without errors.
