### PR TITLE
Refs #36846 - change descriptionFormat to snake case

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
@@ -15,7 +15,7 @@ const baseParams = ({
   job_invocation: {
     feature,
     inputs,
-    descriptionFormat,
+    description_format: descriptionFormat,
     search_query: `name ^ (${hostname})`,
   },
 });
@@ -41,7 +41,7 @@ const katelloPackageInstallBySearchParams = ({ hostname, search, descriptionForm
     hostname,
     inputs: { [PACKAGE_SEARCH_QUERY]: search },
     feature: REX_FEATURES.KATELLO_PACKAGE_INSTALL_BY_SEARCH,
-    description_format: descriptionFormat,
+    descriptionFormat,
   });
 
 const katelloPackageRemoveParams = ({ hostname, packageName }) =>
@@ -56,7 +56,7 @@ const katelloPackagesRemoveParams = ({ hostname, search, descriptionFormat }) =>
     hostname,
     inputs: { [PACKAGES_SEARCH_QUERY]: search },
     feature: REX_FEATURES.KATELLO_PACKAGES_REMOVE_BY_SEARCH,
-    description_format: descriptionFormat,
+    descriptionFormat,
   });
 
 const katelloPackageUpdateParams = ({ hostname, packageName }) =>
@@ -73,7 +73,7 @@ const katelloPackagesUpdateParams = ({
     feature: REX_FEATURES.KATELLO_PACKAGES_UPDATE_BY_SEARCH,
     inputs: { [PACKAGES_SEARCH_QUERY]: search, [SELECTED_UPDATE_VERSIONS]: versions },
     search_query: `name ^ (${hostname})`,
-    description_format: descriptionFormat,
+    descriptionFormat,
   },
 });
 

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/packagesTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/packagesTab.test.js
@@ -271,7 +271,7 @@ test('Can bulk upgrade via remote execution', async (done) => {
         },
         search_query: `name ^ (${hostname})`,
         feature: REX_FEATURES.KATELLO_PACKAGES_UPDATE_BY_SEARCH,
-        description_format: 'Upgrade package(s) chrony, coreutils',
+        descriptionFormat: 'Upgrade package(s) chrony, coreutils',
       },
     })
     .reply(201);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

In https://github.com/Katello/katello/pull/10772 a new feature was introduced, but the `descriptionFormat` request parameter was never translated to snake case, so it wasn't getting sent in the API request. 

This appears to be the result of a commit made after the PR was acked, adding a test (and breaking the real-life behavior in the process:)

![image](https://github.com/Katello/katello/assets/22042343/ef8d1d57-c01e-4287-8374-abc741be3541)


#### Considerations taken when implementing this change?

uggghhhghh

#### What are the testing steps for this pull request?

Install or remove a package and verify that the toast contains the package name(s) as in https://github.com/Katello/katello/pull/10772 (you may have to also cherry-pick https://github.com/Katello/katello/pull/10845)

