### PR TITLE
Fixes #31257 - support incremental update for debs

### DIFF
--- a/app/helpers/katello/content_view_helper.rb
+++ b/app/helpers/katello/content_view_helper.rb
@@ -1,10 +1,12 @@
 module Katello
   module ContentViewHelper
     def separated_repo_mapping(repo_mapping, use_multicopy_actions)
-      separated_mapping = { :pulp3_yum_multicopy => {}, :other => {} }
+      separated_mapping = { :pulp3_deb_multicopy => {}, :pulp3_yum_multicopy => {}, :other => {} }
       repo_mapping.each do |source_repos, dest_repo|
         if dest_repo.content_type == "yum" && SmartProxy.pulp_primary.pulp3_support?(dest_repo) && use_multicopy_actions
           separated_mapping[:pulp3_yum_multicopy][source_repos] = dest_repo
+        elsif dest_repo.content_type == "deb" && SmartProxy.pulp_primary.pulp3_support?(dest_repo) && use_multicopy_actions
+          separated_mapping[:pulp3_deb_multicopy][source_repos] = dest_repo
         else
           separated_mapping[:other][source_repos] = dest_repo
         end

--- a/app/lib/actions/katello/content_view/presenters/incremental_updates_presenter.rb
+++ b/app/lib/actions/katello/content_view/presenters/incremental_updates_presenter.rb
@@ -6,7 +6,8 @@ module Actions
           HUMANIZED_TYPES = {
             ::Katello::Erratum::CONTENT_TYPE => "Errata",
             ::Katello::ModuleStream::CONTENT_TYPE => "Module Streams",
-            ::Katello::Rpm::CONTENT_TYPE => "Packages",
+            ::Katello::Rpm::CONTENT_TYPE => "RPM Packages",
+            ::Katello::Deb::CONTENT_TYPE => "Deb Packages",
           }.freeze
 
           def humanized_output
@@ -25,7 +26,7 @@ module Actions
               if cvv
                 humanized_lines << "Content View: #{cvv.content_view.name} version #{cvv.version}"
                 humanized_lines << _("Added Content:")
-                [::Katello::Erratum, ::Katello::ModuleStream, ::Katello::Rpm].each do |content_type|
+                [::Katello::Erratum, ::Katello::ModuleStream, ::Katello::Rpm, ::Katello::Deb].each do |content_type|
                   unless output[:added_units][content_type::CONTENT_TYPE].blank?
                     humanized_lines << "  #{HUMANIZED_TYPES[content_type::CONTENT_TYPE]}:"
                     humanized_lines += output[:added_units][content_type::CONTENT_TYPE].sort.map { |unit| "        #{unit}" }

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -59,8 +59,13 @@ module Actions
 
             if options[:importing]
               handle_import(version, **options.slice(:path, :metadata))
-            elsif separated_repo_map[:pulp3_yum_multicopy].keys.flatten.present?
-              plan_action(Repository::MultiCloneToVersion, separated_repo_map[:pulp3_yum_multicopy], version)
+            else
+              if separated_repo_map[:pulp3_deb_multicopy].keys.flatten.present?
+                plan_action(Repository::MultiCloneToVersion, separated_repo_map[:pulp3_deb_multicopy], version)
+              end
+              if separated_repo_map[:pulp3_yum_multicopy].keys.flatten.present?
+                plan_action(Repository::MultiCloneToVersion, separated_repo_map[:pulp3_yum_multicopy], version)
+              end
             end
 
             concurrence do

--- a/app/lib/actions/pulp3/repository/multi_copy_units.rb
+++ b/app/lib/actions/pulp3/repository/multi_copy_units.rb
@@ -35,6 +35,10 @@ module Actions
                     katello_errata.id in (#{input[:unit_map][:errata].join(",")})").map(&:erratum_pulp3_href)
           end
 
+          if input[:unit_map][:debs].any?
+            unit_hrefs << ::Katello::Deb.where(:id => input[:unit_map][:debs]).map(&:pulp_id)
+          end
+
           if input[:unit_map][:rpms].any?
             unit_hrefs << ::Katello::Rpm.where(:id => input[:unit_map][:rpms]).map(&:pulp_id)
           end

--- a/test/actions/katello/content_view_version_test.rb
+++ b/test/actions/katello/content_view_version_test.rb
@@ -87,7 +87,7 @@ module ::Actions::Katello::ContentViewVersion
         pulp3_repo_map[[library_repo.id]] = { :dest_repo => new_repo.id, :base_version => nil }
         assert_action_planned_with(action, ::Actions::Pulp3::Repository::MultiCopyUnits,
                                   pulp3_repo_map,
-                                  { :errata => [], :rpms => [old_rpm.id] },
+                                  { :debs => [], :errata => [], :rpms => [old_rpm.id] },
                                   :dependency_solving => false)
         assert_action_planned_with(action, ::Actions::Pulp3::Repository::CopyContent, library_repo, SmartProxy.pulp_primary, new_repo, copy_all: true, remove_all: true)
         assert_action_planned_with(action, ::Actions::Katello::Repository::MetadataGenerate, new_repo)
@@ -103,7 +103,7 @@ module ::Actions::Katello::ContentViewVersion
         pulp3_repo_map[[library_repo.id]] = { :dest_repo => new_repo.id, :base_version => 1 }
         assert_action_planned_with(action, ::Actions::Pulp3::Repository::MultiCopyUnits,
                                   pulp3_repo_map,
-                                  { :errata => [], :rpms => [old_rpm.id] },
+                                  { :debs => [], :errata => [], :rpms => [old_rpm.id] },
                                   :dependency_solving => true)
         refute_action_planned(action, ::Actions::Pulp3::Repository::CopyContent)
       end

--- a/test/helpers/content_view_helper_test.rb
+++ b/test/helpers/content_view_helper_test.rb
@@ -7,6 +7,8 @@ class ContentViewHelperTest < ActionView::TestCase
 
   def setup
     @primary = SmartProxy.pulp_primary
+    @deb_repo1 = katello_repositories(:debian_10_amd64)
+    @deb_repo2 = katello_repositories(:debian_9_amd64)
     @docker_repo1 = katello_repositories(:busybox)
     @docker_repo2 = katello_repositories(:busybox2)
     @yum_repo1 = katello_repositories(:fedora_17_x86_64)
@@ -19,20 +21,20 @@ class ContentViewHelperTest < ActionView::TestCase
     SETTINGS[:katello][:use_pulp_2_for_content_type] = nil
   end
 
-  test 'separated_repo_mapping must separate Pulp 3 yum repos from others if using multi-copy actions' do
-    repo_map = { [@docker_repo1] => @docker_repo2, [@yum_repo1] => @yum_repo2, [@file_repo1] => @file_repo2 }
+  test 'separated_repo_mapping must separate Pulp 3 deb/yum repos from others if using multi-copy actions' do
+    repo_map = { [@docker_repo1] => @docker_repo2, [@deb_repo1] => @deb_repo2, [@yum_repo1] => @yum_repo2, [@file_repo1] => @file_repo2 }
     separated_repo_map = separated_repo_mapping(repo_map, true)
 
-    assert_equal separated_repo_map, { :pulp3_yum_multicopy => { [@yum_repo1] => @yum_repo2 },
+    assert_equal separated_repo_map, { :pulp3_deb_multicopy => { [@deb_repo1] => @deb_repo2 }, :pulp3_yum_multicopy => { [@yum_repo1] => @yum_repo2 },
                                        :other => { [@docker_repo1] => @docker_repo2, [@file_repo1] => @file_repo2 } }
   end
 
-  test 'separated_repo_mapping must not separate Pulp 3 yum repos from others if not using multi-copy actions' do
-    repo_map = { [@docker_repo1] => @docker_repo2, [@yum_repo1] => @yum_repo2, [@file_repo1] => @file_repo2 }
+  test 'separated_repo_mapping must not separate Pulp 3 deb/yum repos from others if not using multi-copy actions' do
+    repo_map = { [@docker_repo1] => @docker_repo2, [@deb_repo1] => @deb_repo2, [@yum_repo1] => @yum_repo2, [@file_repo1] => @file_repo2 }
     separated_repo_map = separated_repo_mapping(repo_map, false)
 
-    assert_equal separated_repo_map, { :pulp3_yum_multicopy => { },
+    assert_equal separated_repo_map, { :pulp3_deb_multicopy => { }, :pulp3_yum_multicopy => { },
                                        :other => { [@yum_repo1] => @yum_repo2, [@docker_repo1] => @docker_repo2,
-                                                   [@file_repo1] => @file_repo2 } }
+                                                   [@deb_repo1] => @deb_repo2, [@file_repo1] => @file_repo2 } }
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Support copying of deb-packages in incremental Update of ContentViews .

#### Considerations taken when implementing this change?
Adding deb-packages does not support dependency-solving. Trying to do that will fail the incremental update.
#10734 ensures the dependency-solving option is ignored for deb-packages/-repositories.

#### What are the testing steps for this pull request?
No UI support; use the Content_view_versions / incremental_update REST-API endpoint for testing:
```
POST /katello/api/content_view_versions/incremental_update
...
{
  "add_content": {
    "deb_ids": [ <pkg_ids> ]
  }
}
