### PR TITLE
Fixes #36994 - remove spaces from Ansible template

### DIFF
--- a/app/views/foreman/job_templates/install_errata_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_errata_-_katello_ansible_default.erb
@@ -15,9 +15,9 @@ kind: job_template
 %>
 
 <% if @host.operatingsystem.family == 'Suse' -%>
-  <% advisories = input(:errata).split(',').join(' ') -%>
-  <%= render_template('Run Command - Ansible Default', :command => "zypper -n install -t patch #{advisories}") %>
+<% advisories = input(:errata).split(',').join(' ') -%>
+<%= render_template('Run Command - Ansible Default', :command => "zypper -n install -t patch #{advisories}") %>
 <% else -%>
-  <% advisories = input(:errata).split(',').map { |e| "--advisory=#{e}" }.join(' ') -%>
-  <%= render_template('Run Command - Ansible Default', :command => "yum -y update-minimal #{advisories}") %>
+<% advisories = input(:errata).split(',').map { |e| "--advisory=#{e}" }.join(' ') -%>
+<%= render_template('Run Command - Ansible Default', :command => "yum -y update-minimal #{advisories}") %>
 <% end -%>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Remove indentations from the Install Errata - Katello Ansible Default job template. These indentations were causing invalid YAML and thus Ansible would freak out and not understand.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Enable foreman-ansible:
```
foreman-installer --enable-foreman-proxy-plugin-ansible
```
On the Job Templates page, ensure you can see the "Katello Ansible Default" templates
Run the 'Install Errata - Katello Ansible Default' REX job with one of them
Check the rendered template output on the job details / 'Preview templates' tab

Example of BAD template rendering (note the spaces before `---`):
![image](https://github.com/Katello/katello/assets/22042343/8a0349ec-f1cd-454b-9fdc-cc6d109ff5f8)

Now, check out this PR
In rails console, run `ForemanInternal.all.first.destroy`
Then restart the Foreman server, seeds will run
Now run a job again, and you should see the GOOD template rendering:
![image](https://github.com/Katello/katello/assets/22042343/bdfa59b3-d4e7-4bc8-a6b7-04dd72ee1686)

