### PR TITLE
Fixes #37051 - Add Katello Ansible default job templates

### DIFF
--- a/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
@@ -1,0 +1,24 @@
+<%#
+kind: job_template
+name: Install errata by search query - Katello Ansible Default
+job_category: Katello
+description_format: 'Install errata %{Errata search query}'
+feature: katello_errata_install_by_search
+provider_type: Ansible
+template_inputs:
+- name: Errata search query
+  description: Filter criteria for errata to be installed.
+  input_type: user
+  required: false
+%>
+
+<% advisory_ids = @host.advisory_ids(search: input("Errata search query")) -%>
+<% render_error(N_("No errata matching given search query")) if !input("Errata search query").blank? && advisory_ids.blank? -%>
+# RESOLVED_ERRATA_IDS=<%= advisory_ids.join(',') %>
+
+<% if @host.operatingsystem.family == 'Suse' -%>
+<%= render_template('Run Command - Ansible Default', :command => "zypper -n install -t patch #{advisory_ids.join(' ')}") %>
+<% else -%>
+<% advisories = advisory_ids.map { |e| "--advisory=#{e}" }.join(' ') -%>
+<%= render_template('Run Command - Ansible Default', :command => "yum -y update-minimal #{advisories}") %>
+<% end -%>

--- a/app/views/foreman/job_templates/install_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_packages_by_search_query_-_katello_ansible_default.erb
@@ -1,0 +1,28 @@
+<%#
+kind: job_template
+name: Install packages by search query - Katello Ansible Default
+job_category: Katello
+description_format: 'Install package(s) %{Package search query}'
+feature: katello_package_install_by_search
+provider_type: Ansible
+template_inputs:
+- name: Package search query
+  description: Filter criteria for packages to be installed. IMPORTANT- If left blank, the job will attempt to install all possible packages.
+  input_type: user
+  required: false
+%>
+<% package_names = @host.package_names_for_job_template(
+  action: 'install',
+  search: input('Package search query')
+) -%>
+---
+- hosts: all
+  tasks:
+    - package:
+<% if package_names.empty? -%>
+        name: []
+<% else -%>
+        name: <%= indent(10) { to_yaml(package_names).gsub(/---/, "") } -%>
+        state: present
+<% end -%>
+

--- a/app/views/foreman/job_templates/remove_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/remove_packages_by_search_query_-_katello_ansible_default.erb
@@ -1,0 +1,26 @@
+<%#
+kind: job_template
+name: Remove packages by search query - Katello Ansible Default
+job_category: Katello
+description_format: 'Remove package(s) %{Packages search query}'
+feature: katello_package_remove_by_search
+provider_type: Ansible
+template_inputs:
+- name: Packages search query
+  description: Filter criteria for packages to be removed.
+  input_type: user
+  required: false
+%>
+<% package_names = @host.package_names_for_job_template(
+  action: 'remove',
+  search: input('Packages search query')
+) -%>
+---
+- hosts: all
+  tasks:
+    - package:
+        name: 
+<% package_names.each do |package_name| -%>
+          - <%= package_name %>
+<% end -%>
+        state: absent

--- a/app/views/foreman/job_templates/update_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/update_packages_by_search_query_-_katello_ansible_default.erb
@@ -1,0 +1,33 @@
+<%#
+kind: job_template
+name: Update packages by search query - Katello Ansible Default
+job_category: Katello
+description_format: 'Update package(s) %{Packages search query}'
+feature: katello_package_remove_by_search
+provider_type: Ansible
+template_inputs:
+- name: Packages search query
+  description: Filter criteria for packages to be updated.
+  input_type: user
+  required: false
+- name: Selected update versions
+  description: JSON string of selected package versions to be updated, in the format [ nvra ]. Leave blank to upgrade to latest available version.
+  input_type: user
+  required: false
+  value_type: plain
+%>
+<% package_names = @host.package_names_for_job_template(
+  action: 'update',
+  search: input('Packages search query'),
+  versions: input('Selected update versions')
+) -%>
+<% if package_names.empty? -%>
+<%= render_template('Run Command - Ansible Default', :command => "yum -y update") %>
+<% else -%>
+---
+- hosts: all
+  tasks:
+    - package:
+        name: <%= indent(10) { to_yaml(package_names).gsub(/---/, "") } -%>
+        state: latest
+<% end -%>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

In the new host details UI, remote execution jobs use, by default, the 'xxx by search - Katello Script Default' job templates for package install / remove / upgrade, and errata apply. For those that use remote execution via Ansible, previously there was no way to use the web UI because there were no corresponding 'by search' Ansible job templates. This PR adds those.

#### Considerations taken when implementing this change?

For the package actions, I was originally looking at inheriting from "Package Action - Ansible Default." But that template only takes a single package name, and I needed multiple. So I'm just rendering the Ansible directly in Katello's template, instead of raising a PR to foreman_ansible. You can yell at me if you must.

#### What are the testing steps for this pull request?
1. Set up REX with Ansible (enable foreman_ansible and make sure your smart proxy shows the "Ansible" feature)
2. Check out the PR
3. `bundle exec rails runner "ForemanInternal.all.first.destroy"` to trigger seeds, then restart your Foreman server
4. Go to the Remote Execution Features page and click on each feature
5. Select the '`<feature name>` by search - Katello Ansible Default' as the default template for each feature. Example:
![image](https://github.com/Katello/katello/assets/22042343/88e7d586-f424-43d9-bade-24198916468e)


From the new host details Packages and Errata tabs, try

- package remove
- package install
- errata apply
- package upgrade
- package upgrade but the one where you have the little dropdown and you select which version to upgrade to (I didn't test this yet)

Make sure that templates render the Ansible correctly (check the 'Preview templates' tab on the REX job details). There's no need to actually communicate with the host, though this is nice to have.
