### PR TITLE
Fixes #37058 - Optimize query to identify orphaned content units

### DIFF
--- a/app/models/katello/concerns/pulp_database_unit.rb
+++ b/app/models/katello/concerns/pulp_database_unit.rb
@@ -169,7 +169,7 @@ module Katello
 
       def orphaned
         if many_repository_associations
-          where.not(:id => repository_association_class.select(unit_id_field))
+          left_joins(repository_association.to_sym).where("#{repository_association_class.table_name}.#{unit_id_field}" => nil)
         else
           where.not(:repository_id => ::Katello::Repository.select(:id))
         end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Optimizes query used to identify orphaned content units

#### Considerations taken when implementing this change?

Query generated by the method was slow and inefficient. This attempts to offer an alternative with better performance.

#### What are the testing steps for this pull request?

Execution time of Remove Orphans task should improve drastically.