### PR TITLE
Fixes #37073 - only rename Katello settings if category column exists

### DIFF
--- a/db/migrate/20160505181337_rename_katello_settings.rb
+++ b/db/migrate/20160505181337_rename_katello_settings.rb
@@ -1,9 +1,9 @@
 class RenameKatelloSettings < ActiveRecord::Migration[4.2]
   def up
-    Setting.where(category: 'Setting::Katello').update_all(:category => 'Setting::Content')
+    Setting.where(category: 'Setting::Katello').update_all(:category => 'Setting::Content') if column_exists?(:settings, :category)
   end
 
   def down
-    Setting.where(category: 'Setting::Content').update_all(:category => 'Setting::Katello')
+    Setting.where(category: 'Setting::Content').update_all(:category => 'Setting::Katello') if column_exists?(:settings, :category)
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

make the migration work even when the `category` column was removed from Foreman core

#### Considerations taken when implementing this change?

none

#### What are the testing steps for this pull request?

in theory: install foreman, db:migrate, install katello, db:migrate, but there are other things that prevent this from working :(