### PR TITLE
Fixes #37074 - drop users.disabled field

### DIFF
--- a/db/migrate/20131014225132_add_users_fields.rb
+++ b/db/migrate/20131014225132_add_users_fields.rb
@@ -3,7 +3,6 @@ class AddUsersFields < ActiveRecord::Migration[4.2]
     add_column :users, :helptips_enabled, :boolean, :default => true
     add_column :users, :hidden, :boolean, :default => false, :null => false
     add_column :users, :page_size, :integer, :default => 25, :null => false
-    add_column :users, :disabled, :boolean, :default => false
     add_column :users, :preferences, :text
     add_column :users, :remote_id, :string, :limit => 255
   end

--- a/db/migrate/20150603045418_remove_user_fields.rb
+++ b/db/migrate/20150603045418_remove_user_fields.rb
@@ -2,7 +2,6 @@ class RemoveUserFields < ActiveRecord::Migration[4.2]
   def up
     remove_column :users, :helptips_enabled
     remove_column :users, :page_size
-    remove_column :users, :disabled
     remove_column :users, :preferences
     remove_column :users, :remote_id
   end
@@ -11,7 +10,6 @@ class RemoveUserFields < ActiveRecord::Migration[4.2]
     add_column :users, :helptips_enabled, :boolean, :default => true
     add_column :users, :hidden, :boolean, :default => false, :null => false
     add_column :users, :page_size, :integer, :default => 25, :null => false
-    add_column :users, :disabled, :boolean, :default => false
     add_column :users, :preferences, :text
     add_column :users, :remote_id, :string, :limit => 255
   end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

droping the users.disabled field as it exists in Foreman since 2.2 and makes DB migrations fail when installing Katello ontop of Foreman

Fixes: c4b6d2cb1c7e8c9bbfc90018d31ff4cd52c6d67a or 40ebede2648138b8fbba39eeab7a7cb8e8a0410c

#### Considerations taken when implementing this change?

none

#### What are the testing steps for this pull request?

in theory: install foreman, db:migrate, install katello, db:migrate, but there are other things that prevent this from working :(