### PR TITLE
Fixes #37075 - make RemoveKatelloFromNotificationName a noop

### DIFF
--- a/db/migrate/20160404132250_remove_katello_from_notification_name.rb
+++ b/db/migrate/20160404132250_remove_katello_from_notification_name.rb
@@ -1,26 +1,8 @@
 class RemoveKatelloFromNotificationName < ActiveRecord::Migration[4.2]
-  class FakeMailNotification < ApplicationRecord
-    self.table_name = 'mail_notifications'
-  end
-
   def up
-    FakeMailNotification.all.each do |notification|
-      if notification_names.keys.include?(notification.name)
-        new_name = notification_names[notification.name]
-        FakeMailNotification.where(:name => new_name).destroy_all
-        notification.name = new_name
-        notification.save!
-      end
-    end
-  end
-
-  private
-
-  def notification_names
-    {
-      :katello_promote_errata => 'promote_errata',
-      :katello_sync_errata => 'sync_errata',
-      :katello_host_advisory => 'host_errata_advisory'
-    }.with_indifferent_access
+    # historical placeholder
+    # only required on setups before https://projects.theforeman.org/issues/14459
+    # we can safely assume that fresh installs have the above change already
+    # and existing install had this migration applied back in 2016
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

making an own migration a noop, so that Rails remains happy (the migration still "exists"), but the code does not error out

#### Considerations taken when implementing this change?

The change from this migration is irrelevant by now as
* We do not support upgrades from a 2016 Katello straight to master
* Any installation that needed this migration was updated by now and thus has the "real" migration applied

#### What are the testing steps for this pull request?

in theory: install foreman, db:migrate, install katello, db:migrate, but there are other things that prevent this from working :(