### PR TITLE
Fixes #37080 - content counts index goes over max size

### DIFF
--- a/db/migrate/20240122150431_remove_content_counts_index.rb
+++ b/db/migrate/20240122150431_remove_content_counts_index.rb
@@ -1,0 +1,5 @@
+class RemoveContentCountsIndex < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :smart_proxies, :content_counts
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Removes the index on smart proxies and content counts because the size can grow too large.

Since we read back the entire content count and write it in its entirety, an index likely doesn't help much anyway.

#### Considerations taken when implementing this change?
I think you can make indexes on items within the jsonb type, but I'm not sure that would help us here because, again, we always use the entire json blob. We don't have queries looking into the json blob (yet).

#### What are the testing steps for this pull request?

Run through the testing steps in the redmine https://projects.theforeman.org/issues/37080?issue_count=10&issue_position=5&next_issue_id=37077&prev_issue_id=37058