### PR TITLE
Fixes #36998 - declare development dependency on theforeman-rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,9 @@ inherit_from:
 Rails:
   Enabled: true
 
+Rails/ContentTag:
+  Enabled: false
+
 AllCops:
   Exclude:
     - db/migrate/20131014135042_katello_tables.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,7 @@ AllCops:
     - Gemfile
     - locale/action_names.rb
     - lib/monkeys/remove_hidden_distribution.rb
+    - vendor/**/*
   Include:
     - '**/*.rb'
     - app/views/**/*.rabl

--- a/app/mailers/katello/errata_mailer.rb
+++ b/app/mailers/katello/errata_mailer.rb
@@ -50,9 +50,9 @@ module Katello
 
     def errata_counts(errata)
       counts = {:total => errata.count}
-      counts.merge(Hash[[:security, :bugfix, :enhancement].collect do |errata_type|
-        [errata_type, errata.send(errata_type).count]
-      end])
+      counts.merge([:security, :bugfix, :enhancement].index_with do |errata_type|
+        errata.send(errata_type).count
+      end)
     end
   end
 end

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -123,7 +123,7 @@ module Katello
           facet_model = Facets.registered_facets[facet].hostgroup_configuration.model
           value = facet_model.where.not(attribute => nil).joins(:hostgroup).merge(
             ::Hostgroup.where(id: self.ancestor_ids).reorder(ancestry: :desc)
-          ).limit(1).pluck(attribute).first
+          ).pick(attribute)
         end
         value
       end

--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -79,7 +79,7 @@ module Katello
         end
 
         def redhat_account_number
-          pools.upstream.pluck(:account_number).first
+          pools.upstream.pick(:account_number)
         end
 
         def active_pools_count

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -75,4 +75,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "simplecov"
   gem.add_development_dependency "simplecov-rcov"
   gem.add_development_dependency "robottelo_reporter"
+
+  # Rubocop
+  gem.add_development_dependency 'theforeman-rubocop', '~> 0.0.6'
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

1. adds development dependency on `theforeman-rubocop ~> 0.0.6` (version picked to match todays Foreman develop branch)
2. fixes config and cops to pass `bundle exec rubocop` in a plain Katello checkout

#### Considerations taken when implementing this change?

Only confusion why the fixed cops weren't flagged before.

#### What are the testing steps for this pull request?

1. CI still passes
2. clean checkout of `katello.git` passes `bundle install && bundle exec rubocop`