### PR TITLE
Fixes #37145 - Ruby 3 support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,3 +25,4 @@ jobs:
       plugin: katello
       postgresql_container: ghcr.io/theforeman/postgresql-evr
       test_existing_database: false
+      foreman_version: 'test-dyn'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,7 +31,7 @@ AllCops:
     - '**/*.rb'
     - app/views/**/*.rabl
     - '**/*.rake'
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
 
 Metrics/MethodLength:
   Description: 'Avoid methods longer than 30 lines of code.'

--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -36,7 +36,7 @@ module Actions
             if smart_proxy.has_feature?(SmartProxy::PULP3_FEATURE)
               plan_action(Actions::Pulp3::ContentGuard::Refresh, smart_proxy)
             end
-            plan_action(SyncCapsule, smart_proxy, refresh_options)
+            plan_action(SyncCapsule, smart_proxy, **refresh_options)
           end
           plan_self(smart_proxy_id: smart_proxy.id)
         end

--- a/app/lib/actions/katello/capsule_content/sync_capsule.rb
+++ b/app/lib/actions/katello/capsule_content/sync_capsule.rb
@@ -19,7 +19,7 @@ module Actions
               options[:repository_ids_list] = repos.pluck(:id)
             end
             if smart_proxy.has_feature?(SmartProxy::PULP3_FEATURE)
-              plan_action(Actions::Pulp3::Orchestration::Repository::RefreshRepos, smart_proxy, options)
+              plan_action(Actions::Pulp3::Orchestration::Repository::RefreshRepos, smart_proxy, **options)
             end
 
             repos.in_groups_of(Setting[:foreman_proxy_content_batch_size], false) do |repo_batch|

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -13,7 +13,7 @@ module Actions
         def plan(content_view, description = "", options = {importing: false, syncable: false}) # rubocop:disable Metrics/PerceivedComplexity
           action_subject(content_view)
 
-          content_view.check_ready_to_publish!(options.slice(:importing, :syncable))
+          content_view.check_ready_to_publish!(**options.slice(:importing, :syncable))
           unless options[:importing] || options[:syncable]
             ::Katello::Util::CandlepinRepositoryChecker.check_repositories_for_publish!(content_view)
           end
@@ -57,7 +57,7 @@ module Actions
             separated_repo_map = separated_repo_mapping(repository_mapping, content_view.solve_dependencies)
 
             if options[:importing]
-              handle_import(version, options.slice(:path, :metadata))
+              handle_import(version, **options.slice(:path, :metadata))
             elsif separated_repo_map[:pulp3_yum_multicopy].keys.flatten.present?
               plan_action(Repository::MultiCloneToVersion, separated_repo_map[:pulp3_yum_multicopy], version)
             end

--- a/app/lib/actions/katello/content_view/remove.rb
+++ b/app/lib/actions/katello/content_view/remove.rb
@@ -31,7 +31,7 @@ module Actions
               concurrence do
                 all_cv_envs.each do |cv_env|
                   if cv_env.hosts.any? || cv_env.activation_keys.any?
-                    plan_action(ContentViewEnvironment::ReassignObjects, cv_env, options)
+                    plan_action(ContentViewEnvironment::ReassignObjects, cv_env, **options)
                   end
                 end
               end

--- a/app/lib/actions/katello/content_view_version/destroy.rb
+++ b/app/lib/actions/katello/content_view_version/destroy.rb
@@ -14,7 +14,7 @@ module Actions
               repos.each do |repo|
                 repo_options = options.clone
                 repo_options[:docker_cleanup] = false
-                plan_action(Repository::Destroy, repo, repo_options)
+                plan_action(Repository::Destroy, repo, **repo_options)
                 docker_cleanup ||= repo.docker?
               end
             end

--- a/app/lib/actions/katello/content_view_version/export.rb
+++ b/app/lib/actions/katello/content_view_version/export.rb
@@ -11,7 +11,7 @@ module Actions
           action_subject(options.fetch(:content_view_version))
 
           sequence do
-            export_output = plan_action(::Actions::Pulp3::Orchestration::ContentViewVersion::Export, options).output
+            export_output = plan_action(::Actions::Pulp3::Orchestration::ContentViewVersion::Export, **options).output
 
             plan_self(export_history_id: export_output[:export_history_id],
                       exported_file_checksum: export_output[:exported_file_checksum],

--- a/app/lib/actions/katello/product/destroy.rb
+++ b/app/lib/actions/katello/product/destroy.rb
@@ -73,7 +73,7 @@ module Actions
         def plan_repo_destruction(product, options)
           product.repositories.in_default_view.each do |repo|
             repo_options = options.clone
-            plan_action(Katello::Repository::Destroy, repo, repo_options.merge(destroy_content: false))
+            plan_action(Katello::Repository::Destroy, repo, **repo_options.merge(destroy_content: false))
           end
         end
 

--- a/app/lib/actions/katello/repository/bulk_metadata_generate.rb
+++ b/app/lib/actions/katello/repository/bulk_metadata_generate.rb
@@ -4,9 +4,9 @@ module Actions
       class BulkMetadataGenerate < Actions::Base
         def plan(repos, options = {})
           sequence do
-            plan_action(::Actions::BulkAction, ::Actions::Katello::Repository::MetadataGenerate, repos.in_default_view, options) if repos.in_default_view.any?
-            plan_action(::Actions::BulkAction, ::Actions::Katello::Repository::MetadataGenerate, repos.archived, options) if repos.archived.any?
-            plan_action(::Actions::BulkAction, ::Actions::Katello::Repository::MetadataGenerate, repos.in_published_environments, options) if repos.in_published_environments.any?
+            plan_action(::Actions::BulkAction, ::Actions::Katello::Repository::MetadataGenerate, repos.in_default_view, **options) if repos.in_default_view.any?
+            plan_action(::Actions::BulkAction, ::Actions::Katello::Repository::MetadataGenerate, repos.archived, **options) if repos.archived.any?
+            plan_action(::Actions::BulkAction, ::Actions::Katello::Repository::MetadataGenerate, repos.in_published_environments, **options) if repos.in_published_environments.any?
           end
         end
       end

--- a/app/lib/actions/katello/repository/clone_contents.rb
+++ b/app/lib/actions/katello/repository/clone_contents.rb
@@ -25,7 +25,7 @@ module Actions
 
             index_options = {id: new_repository.id, force_index: true}
             index_options[:source_repository_id] = source_repositories.first.id if source_repositories.count == 1 && filters.empty? && rpm_filenames.nil?
-            plan_action(Katello::Repository::IndexContent, index_options)
+            plan_action(Katello::Repository::IndexContent, **index_options)
           end
         end
 
@@ -38,7 +38,7 @@ module Actions
             metadata_options[:source_repository] = source_repositories.first
           end
 
-          plan_action(Katello::Repository::MetadataGenerate, new_repository, metadata_options)
+          plan_action(Katello::Repository::MetadataGenerate, new_repository, **metadata_options)
           unless source_repositories.first.saved_checksum_type == new_repository.saved_checksum_type
             plan_self(:source_checksum_type => source_repositories.first.saved_checksum_type,
                       :target_repo_id => new_repository.id)

--- a/app/lib/actions/katello/repository/import_upload.rb
+++ b/app/lib/actions/katello/repository/import_upload.rb
@@ -43,7 +43,7 @@ module Actions
                   action_class = ::Actions::Pulp3::Orchestration::Repository::ImportUpload
                 end
 
-                import_upload = plan_action(action_class, repository, SmartProxy.pulp_primary, import_upload_args)
+                import_upload = plan_action(action_class, repository, SmartProxy.pulp_primary, **import_upload_args)
                 plan_action(FinishUpload, repository, :import_upload_task => import_upload.output,
                             generate_metadata: false, content_type: options[:content_type])
                 import_upload.output

--- a/app/lib/actions/katello/repository/multi_clone_contents.rb
+++ b/app/lib/actions/katello/repository/multi_clone_contents.rb
@@ -42,7 +42,7 @@ module Actions
             metadata_options[:source_repository] = source_repositories.first
           end
 
-          plan_action(Katello::Repository::MetadataGenerate, new_repository, metadata_options)
+          plan_action(Katello::Repository::MetadataGenerate, new_repository, **metadata_options)
           unless source_repositories.first.saved_checksum_type == new_repository.saved_checksum_type
             plan_self(:source_checksum_type => source_repositories.first.saved_checksum_type,
                       :target_repo_id => new_repository.id)

--- a/app/lib/actions/katello/repository/remove_content.rb
+++ b/app/lib/actions/katello/repository/remove_content.rb
@@ -32,7 +32,7 @@ module Actions
             repository.clear_smart_proxy_sync_histories
             pulp_action = plan_action(
               Pulp3::Orchestration::Repository::RemoveUnits,
-              repository, SmartProxy.pulp_primary, remove_content_args)
+              repository, SmartProxy.pulp_primary, **remove_content_args)
             return if pulp_action.error
             plan_self(:content_unit_class => content_units.first.class.name, :content_unit_ids => content_unit_ids)
             plan_action(CapsuleSync, repository) if sync_capsule

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -42,7 +42,7 @@ module Actions
               sync_action = plan_action(Actions::Pulp3::Orchestration::Repository::Sync,
                                         repo,
                                         SmartProxy.pulp_primary,
-                                        pulp_sync_options)
+                                        **pulp_sync_options)
               output = sync_action.output
 
               plan_action(Katello::Repository::IndexContent, :id => repo.id, :force_index => skip_metadata_check)

--- a/app/lib/actions/middleware/remote_action.rb
+++ b/app/lib/actions/middleware/remote_action.rb
@@ -4,9 +4,9 @@ module Actions
     # wraps the plan/run/finalize methods to include the info about the user
     # that triggered the action.
     class RemoteAction < Dynflow::Middleware
-      def plan(*args)
+      def plan(*args, **kwargs)
         fail "No current user is set. Please set User.current to perform a remote action" if User.current.nil?
-        pass(*args).tap do
+        pass(*args, **kwargs).tap do
           action.input[:remote_user] = User.remote_user
           action.input[:remote_cp_user] = User.remote_user
         end

--- a/app/lib/actions/pulp3/capsule_content/sync.rb
+++ b/app/lib/actions/pulp3/capsule_content/sync.rb
@@ -7,7 +7,7 @@ module Actions
           sequence do
             sync_task = plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id, :options => options)
             options[:sync_task_output] = sync_task.output[:pulp_tasks]
-            plan_action(GenerateMetadata, repository, smart_proxy, options)
+            plan_action(GenerateMetadata, repository, smart_proxy, **options)
           end
         end
 

--- a/app/lib/actions/pulp3/orchestration/alternate_content_source/delete.rb
+++ b/app/lib/actions/pulp3/orchestration/alternate_content_source/delete.rb
@@ -6,7 +6,7 @@ module Actions
           def plan(smart_proxy_acs, options = {})
             sequence do
               plan_action(Actions::Pulp3::AlternateContentSource::Delete, smart_proxy_acs)
-              plan_action(Actions::Pulp3::AlternateContentSource::DeleteRemote, smart_proxy_acs, options)
+              plan_action(Actions::Pulp3::AlternateContentSource::DeleteRemote, smart_proxy_acs, **options)
               plan_self(smart_proxy_id: smart_proxy_acs.smart_proxy_id, smart_proxy_acs_id: smart_proxy_acs.id)
             end
           end

--- a/app/lib/actions/pulp3/orchestration/repository/generate_metadata.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/generate_metadata.rb
@@ -13,7 +13,7 @@ module Actions
               if options[:source_repository] && publication_content_type
                 plan_self(source_repository_id: options[:source_repository].id, target_repository_id: repository.id, smart_proxy_id: smart_proxy.id)
               elsif publication_content_type && (force_publication || repository.publication_href.nil? || !repository.using_mirrored_metadata?)
-                plan_action(Actions::Pulp3::Repository::CreatePublication, repository, smart_proxy, options)
+                plan_action(Actions::Pulp3::Repository::CreatePublication, repository, smart_proxy, **options)
               elsif !publication_content_type
                 plan_self(target_repository_id: repository.id, contents_changed: options[:contents_changed], skip_publication: true)
               end

--- a/app/lib/actions/pulp3/orchestration/repository/import_upload.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/import_upload.rb
@@ -16,7 +16,7 @@ module Actions
                                                   smart_proxy,
                                                   args).output
                 plan_self(:commit_output => tag_manifest_output[:pulp_tasks])
-                plan_action(Pulp3::Repository::SaveVersion, repository, {force_fetch_version: true, tasks: tag_manifest_output[:pulp_tasks]})
+                plan_action(Pulp3::Repository::SaveVersion, repository, force_fetch_version: true, tasks: tag_manifest_output[:pulp_tasks])
               else
                 if content_unit_href
                   artifact_output = { :content_unit_href => content_unit_href }
@@ -33,7 +33,7 @@ module Actions
                                                 repository,
                                                 smart_proxy,
                                                 commit_output[:pulp_tasks],
-                                                args.dig(:unit_type_id), args).output
+                                                args.dig(:unit_type_id), **args).output
                 end
 
                 plan_self(:commit_output => commit_output[:pulp_tasks], :artifact_output => artifact_output)

--- a/app/lib/actions/pulp3/orchestration/repository/remove_units.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/remove_units.rb
@@ -7,7 +7,7 @@ module Actions
 
           def plan(repository, smart_proxy, options)
             sequence do
-              action_output = plan_action(Actions::Pulp3::Repository::RemoveUnits, repository, smart_proxy, options).output
+              action_output = plan_action(Actions::Pulp3::Repository::RemoveUnits, repository, smart_proxy, **options).output
               plan_action(Pulp3::Repository::SaveVersion, repository, tasks: action_output[:pulp_tasks])
             end
           end

--- a/app/lib/actions/pulp3/orchestration/repository/sync.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/sync.rb
@@ -4,10 +4,10 @@ module Actions
       module Repository
         class Sync < Pulp3::Abstract
           include Actions::Helpers::OutputPropagator
-          def plan(repository, smart_proxy, options)
+          def plan(repository, smart_proxy, **options)
             sequence do
               plan_action(Actions::Pulp3::Repository::RefreshRemote, repository, smart_proxy)
-              action_output = plan_action(Actions::Pulp3::Repository::Sync, repository, smart_proxy, options).output
+              action_output = plan_action(Actions::Pulp3::Repository::Sync, repository, smart_proxy, **options).output
 
               force_fetch_version = true if options[:optimize] == false
               version_output = plan_action(Pulp3::Repository::SaveVersion, repository, tasks: action_output[:pulp_tasks], :force_fetch_version => force_fetch_version).output

--- a/app/lib/katello/lazy_accessor.rb
+++ b/app/lib/katello/lazy_accessor.rb
@@ -56,21 +56,21 @@ module Katello
         @changed_remote_attributes = val
       end
 
-      def save(*)
-        if (status = super)
+      def save(...)
+        if (status = super(...))
           changed_remote_attributes.clear
         end
         status
       end
 
-      def save!(*)
-        super.tap do
+      def save!(...)
+        super(...).tap do
           changed_remote_attributes.clear
         end
       end
 
-      def reload(*)
-        super.tap do
+      def reload(...)
+        super(...).tap do
           changed_remote_attributes.clear
         end
       end

--- a/app/services/katello/pulp3/content_view_version/export.rb
+++ b/app/services/katello/pulp3/content_view_version/export.rb
@@ -8,11 +8,11 @@ module Katello
         FORMATS = [SYNCABLE, IMPORTABLE].freeze
 
         attr_reader :smart_proxy, :content_view_version, :destination_server, :from_content_view_version, :repository, :base_path
-        def self.create(options)
+        def self.create(**options)
           if options.delete(:format) == SYNCABLE
-            SyncableFormatExport.new(options)
+            SyncableFormatExport.new(**options)
           else
-            self.new(options)
+            self.new(**options)
           end
         end
 

--- a/gemfile.d/test.rb
+++ b/gemfile.d/test.rb
@@ -1,4 +1,6 @@
 group :test do
   gem "vcr", "~> 6.1"
   gem 'theforeman-rubocop', '~> 0.0.6', require: false
+  # TODO: Remove it, just to test the changes.
+  gem 'foreman-tasks', git: 'https://github.com/ofedoren/foreman-tasks.git', branch: 'feat-37103-kwargs-compat'
 end

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.homepage    = "http://www.katello.org"
   gem.summary     = "Content and Subscription Management plugin for Foreman"
   gem.description = "Katello adds Content and Subscription Management to Foreman. For this it relies on Candlepin and Pulp."
-  gem.required_ruby_version = '~> 2.5'
+  gem.required_ruby_version = '>= 2.7', '< 3.1'
 
   gem.files = Dir["{app,webpack,vendor,lib,db,ca,config,locale}/**/*"] +
     Dir['LICENSE.txt', 'README.md', 'package.json']
@@ -49,6 +49,9 @@ Gem::Specification.new do |gem|
 
   # Pulp
   gem.add_dependency "anemone"
+  # required by anemone: https://github.com/chriskite/anemone/blob/next/lib/anemone/page.rb#L3
+  # webrick is no longer a part of Ruby's stdlib: https://bugs.ruby-lang.org/issues/17303
+  gem.add_dependency "webrick"
 
   #pulp3
   gem.add_dependency "pulpcore_client", ">= 3.39.0", "< 3.40.0"

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -33,9 +33,9 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rest-client"
 
   gem.add_dependency "rabl"
-  gem.add_dependency "foreman-tasks", ">= 5.0"
+  gem.add_dependency "foreman-tasks"
   gem.add_dependency "foreman_remote_execution", ">= 7.1.0"
-  gem.add_dependency "dynflow", ">= 1.6.1"
+  gem.add_dependency "dynflow"
   gem.add_dependency "activerecord-import"
   gem.add_dependency "stomp"
   gem.add_dependency "scoped_search", ">= 4.1.9"

--- a/test/actions/katello/activation_key_test.rb
+++ b/test/actions/katello/activation_key_test.rb
@@ -29,7 +29,7 @@ module ::Actions::Katello::ActivationKey
 
       plan_action action, activation_key, service_level: 'Self-support'
 
-      assert_action_planned_with(action, ::Actions::Candlepin::ActivationKey::Create, candlepin_input)
+      assert_action_planned_with(action, ::Actions::Candlepin::ActivationKey::Create, **candlepin_input)
     end
 
     it 'raises error when validation fails' do

--- a/test/actions/katello/content_view_version/destroy_test.rb
+++ b/test/actions/katello/content_view_version/destroy_test.rb
@@ -20,7 +20,7 @@ module Katello::Host
         plan_action(action, @version, options)
 
         @version.repositories.each do |repo|
-          assert_action_planned_with(action, Actions::Katello::Repository::Destroy, repo, options)
+          assert_action_planned_with(action, Actions::Katello::Repository::Destroy, repo, **options)
         end
       end
     end

--- a/test/actions/katello/organization_test.rb
+++ b/test/actions/katello/organization_test.rb
@@ -218,7 +218,7 @@ module ::Actions::Katello::Organization
                                  ::Actions::Candlepin::Owner::ImportProducts,
                                  organization_id: organization.id
                                 )
-      assert_action_planned_with(action, ::Actions::Katello::Repository::RefreshRepository) do |args|
+      assert_action_planned_with(action, ::Actions::Katello::Repository::RefreshRepository) do |*args|
         assert args.first.library_instance?
       end
     end
@@ -298,7 +298,7 @@ module ::Actions::Katello::Organization
                                  ::Actions::Candlepin::Owner::DestroyImports,
                                  label: organization.label
                                 )
-      assert_action_planned_with(action, ::Actions::Katello::Repository::RefreshRepository) do |args|
+      assert_action_planned_with(action, ::Actions::Katello::Repository::RefreshRepository) do |*args|
         assert args.first.library_instance?
       end
     end

--- a/test/actions/katello/product_test.rb
+++ b/test/actions/katello/product_test.rb
@@ -203,11 +203,11 @@ module ::Actions::Katello::Product
 
       assert_action_planned_with(action, candlepin_destroy_class, cp_id: product.cp_id, owner: product.organization.label)
       assert_action_planned_with(action, ::Actions::Katello::Product::ContentDestroy) do |root|
-        root.first.repositories.where.not(id: root.first.repositories.first.id).empty?
-        !root.first.repositories.first.redhat?
+        root.repositories.where.not(id: root.repositories.first.id).empty?
+        !root.repositories.first.redhat?
       end
       assert_action_planned_with(action, ::Actions::Katello::Repository::Destroy) do |repo|
-        default_view_repos.include?(repo.first.id)
+        default_view_repos.include?(repo.id)
       end
 
       assert_action_planned_with(action,

--- a/test/actions/katello/repository/import_upload_test.rb
+++ b/test/actions/katello/repository/import_upload_test.rb
@@ -26,7 +26,7 @@ module Actions
 
       assert_action_planned_with(action, pulp3_import_class,
                                 repo, SmartProxy.pulp_primary,
-                                import_upload_args)
+                                **import_upload_args)
     end
   end
 end

--- a/test/actions/katello/repository/metadata_generate_test.rb
+++ b/test/actions/katello/repository/metadata_generate_test.rb
@@ -23,7 +23,7 @@ module Actions
       plan_action(action, yum_repo)
 
       assert_action_planned_with(action, pulp_metadata_generate_class, yum_repo, SmartProxy.pulp_primary,
-            action_options)
+            **action_options)
     end
 
     it 'plans a yum refresh in other location' do
@@ -34,7 +34,7 @@ module Actions
       plan_action(action, yum_repo)
 
       assert_action_planned_with(action, pulp_metadata_generate_class, yum_repo, SmartProxy.pulp_primary,
-                                action_options)
+                                **action_options)
     ensure
       Location.current = old_location
     end
@@ -47,7 +47,7 @@ module Actions
       yum_action_options[:source_repository] = yum_repo2
 
       assert_action_planned_with(action, pulp_metadata_generate_class, yum_repo, SmartProxy.pulp_primary,
-            yum_action_options)
+            **yum_action_options)
     end
 
     it 'plans a yum refresh with matching content true' do
@@ -57,7 +57,7 @@ module Actions
       yum_action_options = action_options.clone
       yum_action_options[:matching_content] = true
       assert_action_planned_with(action, pulp_metadata_generate_class, yum_repo, SmartProxy.pulp_primary,
-                                yum_action_options)
+                                **yum_action_options)
     end
 
     it 'plans a yum refresh with matching content set to some deferred object' do
@@ -68,7 +68,7 @@ module Actions
       yum_action_options = action_options.clone
       yum_action_options[:matching_content] = not_falsey
       assert_action_planned_with(action, pulp_metadata_generate_class, yum_repo, SmartProxy.pulp_primary,
-                                yum_action_options)
+                                **yum_action_options)
     end
   end
 end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -590,7 +590,7 @@ module ::Actions::Katello::Repository
       }
       assert_action_planned_with(action, ::Actions::Pulp3::Orchestration::Repository::ImportUpload,
                                  docker_repository, SmartProxy.pulp_primary,
-                                 import_upload_args
+                                 **import_upload_args
                                 )
     end
 
@@ -616,7 +616,7 @@ module ::Actions::Katello::Repository
       }
       assert_action_planned_with(action, ::Actions::Pulp3::Orchestration::Repository::ImportUpload,
                                  docker_repository, SmartProxy.pulp_primary,
-                                 import_upload_args
+                                 **import_upload_args
                                 )
     end
   end
@@ -662,8 +662,8 @@ module ::Actions::Katello::Repository
     it 'plans pulp3 orchestration actions with file repo' do
       action = create_action pulp3_action_class
       action.stubs(:action_subject).with(repository_pulp3)
-      plan_action action, repository_pulp3, proxy, {}
-      assert_action_planned_with(action, ::Actions::Pulp3::Repository::Sync, repository_pulp3, proxy, {})
+      plan_action action, repository_pulp3, proxy
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::Sync, repository_pulp3, proxy)
       assert_action_planed action, ::Actions::Pulp3::Repository::SaveVersion
       assert_action_planed action, ::Actions::Pulp3::Orchestration::Repository::GenerateMetadata
     end
@@ -679,8 +679,8 @@ module ::Actions::Katello::Repository
     it 'plans pulp3 orchestration actions with apt repo' do
       action = create_action pulp3_action_class
       action.stubs(:action_subject).with(repository_apt_pulp3)
-      plan_action action, repository_apt_pulp3, proxy, {}
-      assert_action_planned_with(action, ::Actions::Pulp3::Repository::Sync, repository_apt_pulp3, proxy, {})
+      plan_action action, repository_apt_pulp3, proxy
+      assert_action_planned_with(action, ::Actions::Pulp3::Repository::Sync, repository_apt_pulp3, proxy)
       assert_action_planed action, ::Actions::Pulp3::Repository::SaveVersion
       assert_action_planed action, ::Actions::Pulp3::Orchestration::Repository::GenerateMetadata
     end

--- a/test/actions/pulp3/content_view_version/export_repository_test.rb
+++ b/test/actions/pulp3/content_view_version/export_repository_test.rb
@@ -28,13 +28,14 @@ module ::Actions::Pulp3::ContentView
       action_class.any_instance.expects(:action_subject).with(repository)
 
       plan_action(action, repository)
-      assert_action_planned_with(action, ::Actions::Katello::ContentView::Publish) do |content_view, _|
+      assert_action_planned_with(action, ::Actions::Katello::ContentView::Publish) do |*args|
+        content_view = args.first
         assert_equal content_view.name, "Export-#{repository.label}-#{repository.id}"
         assert_equal content_view.repository_ids.sort, [repository.id]
         assert content_view.generated_for_repository?
       end
 
-      assert_action_planned_with(action, Actions::Katello::ContentViewVersion::Export) do |**options|
+      assert_action_planned_with(action, Actions::Katello::ContentViewVersion::Export) do |_, **options|
         assert_equal version, options[:content_view_version]
       end
     end

--- a/test/actions/pulp3/orchestration/ansible_collection_sync_test.rb
+++ b/test/actions/pulp3/orchestration/ansible_collection_sync_test.rb
@@ -30,7 +30,7 @@ module ::Actions::Pulp3
 
     def test_sync
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
       refute_equal @repo.version_href, @repo_version_href
       repository_reference = Katello::Pulp3::RepositoryReference.find_by(
@@ -42,7 +42,7 @@ module ::Actions::Pulp3
 
     def test_sync_mirror_false
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
       repository_reference = Katello::Pulp3::RepositoryReference.find_by(
           :root_repository_id => @repo.root.id,
@@ -60,7 +60,7 @@ module ::Actions::Pulp3
           @repo,
           @primary)
 
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
       @repo.index_content
       post_content = ::Katello::RepositoryAnsibleCollection.where(:repository_id => @repo.id)
@@ -75,7 +75,7 @@ module ::Actions::Pulp3
 
     def test_sync_mirror_true
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
       @repo.index_content
       pre_content = ::Katello::RepositoryAnsibleCollection.where(:repository_id => @repo.id)
@@ -88,7 +88,7 @@ module ::Actions::Pulp3
           @repo,
           @primary)
 
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
       @repo.index_content
 

--- a/test/actions/pulp3/orchestration/copy_all_units_test.rb
+++ b/test/actions/pulp3/orchestration/copy_all_units_test.rb
@@ -36,7 +36,7 @@ module ::Actions::Pulp3
 
     def test_inclusion_docker_filters
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @docker_repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @docker_repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @docker_repo, @primary, **sync_args)
       index_args = {:id => @docker_repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
       @docker_repo.reload
@@ -67,7 +67,7 @@ module ::Actions::Pulp3
 
     def test_exclusion_docker_filters
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @docker_repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @docker_repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @docker_repo, @primary, **sync_args)
       index_args = {:id => @docker_repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
       @docker_repo.reload
@@ -107,7 +107,7 @@ module ::Actions::Pulp3
       create_repo(@repo_clone, @primary)
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
@@ -191,13 +191,13 @@ module ::Actions::Pulp3
 
       ::Katello::Pulp3::Repository::Yum.any_instance.stubs(:generate_backend_object_name).returns(@repo.pulp_id)
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       ::Katello::Pulp3::Repository::Yum.any_instance.stubs(:generate_backend_object_name).returns(repo2.pulp_id)
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => repo2.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, repo2, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, repo2, @primary, **sync_args)
       ::Katello::Pulp3::Repository::Yum.any_instance.stubs(:generate_backend_object_name).returns(repo3.pulp_id)
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => repo3.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, repo3, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, repo3, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
@@ -405,7 +405,7 @@ module ::Actions::Pulp3
       create_repo(@repo_clone, @primary)
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
@@ -446,7 +446,7 @@ module ::Actions::Pulp3
       create_repo(@repo_clone, @primary)
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
@@ -536,7 +536,7 @@ module ::Actions::Pulp3
       create_repo(@repo_clone, @primary)
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
@@ -578,7 +578,7 @@ module ::Actions::Pulp3
       @repo.root.update!(:url => 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/')
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
@@ -644,7 +644,7 @@ module ::Actions::Pulp3
       create_repo(@repo_clone, @primary)
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
@@ -702,7 +702,7 @@ module ::Actions::Pulp3
       create_repo(@repo_clone, @primary)
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
@@ -766,7 +766,7 @@ module ::Actions::Pulp3
       create_repo(@repo_clone, @primary)
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
@@ -810,7 +810,7 @@ module ::Actions::Pulp3
       create_repo(@repo_clone, @primary)
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)

--- a/test/actions/pulp3/orchestration/docker_sync_test.rb
+++ b/test/actions/pulp3/orchestration/docker_sync_test.rb
@@ -29,7 +29,7 @@ module ::Actions::Pulp3
 
     def test_sync
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
       refute_equal @repo.version_href, @repo_version_href
       repository_reference = Katello::Pulp3::RepositoryReference.find_by(

--- a/test/actions/pulp3/orchestration/file_remove_units_test.rb
+++ b/test/actions/pulp3/orchestration/file_remove_units_test.rb
@@ -17,7 +17,7 @@ module ::Actions::Pulp3
         ::Actions::Katello::Repository::MetadataGenerate, repo)
       sync_args = {:smart_proxy_id => proxy.id, :repo_id => repo.id}
       sync_action = ForemanTasks.sync_task(
-        ::Actions::Pulp3::Orchestration::Repository::Sync, repo, proxy, sync_args)
+        ::Actions::Pulp3::Orchestration::Repository::Sync, repo, proxy, **sync_args)
       contents_changed = sync_action.output[:contents_changed]
       ForemanTasks.sync_task(
         ::Actions::Katello::Repository::IndexContent,

--- a/test/actions/pulp3/orchestration/file_sync_test.rb
+++ b/test/actions/pulp3/orchestration/file_sync_test.rb
@@ -29,7 +29,7 @@ module ::Actions::Pulp3
 
     def test_sync
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
       refute_equal @repo.version_href, @repo_version_href
       repository_reference = Katello::Pulp3::RepositoryReference.find_by(
@@ -50,7 +50,7 @@ module ::Actions::Pulp3
       ::Setting[:bulk_load_size] = 10
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       begin
         @repo.reload
@@ -65,7 +65,7 @@ module ::Actions::Pulp3
 
     def test_sync_with_mirror_false
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
       @repo.index_content
       pre_count_content = ::Katello::RepositoryFileUnit.where(:repository_id => @repo.id).count
@@ -76,7 +76,7 @@ module ::Actions::Pulp3
           @repo,
           @primary)
 
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
       @repo.index_content
       post_count_content = ::Katello::RepositoryFileUnit.where(:repository_id => @repo.id).count
@@ -85,7 +85,7 @@ module ::Actions::Pulp3
 
     def test_sync_with_mirror_true
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
       @repo.index_content
       pre_count_content = ::Katello::RepositoryFileUnit.where(:repository_id => @repo.id).count
@@ -96,7 +96,7 @@ module ::Actions::Pulp3
           @repo,
           @primary)
 
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
       @repo.index_content
       post_count_content = ::Katello::RepositoryFileUnit.where(:repository_id => @repo.id).count

--- a/test/actions/pulp3/orchestration/multi_copy_all_units_test.rb
+++ b/test/actions/pulp3/orchestration/multi_copy_all_units_test.rb
@@ -20,7 +20,7 @@ module ::Actions::Pulp3
       create_repo(@repo_clone, @primary)
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
@@ -293,7 +293,7 @@ module ::Actions::Pulp3
       create_repo(@repo_clone, @primary)
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
@@ -336,7 +336,7 @@ module ::Actions::Pulp3
       create_repo(@repo_clone, @primary)
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
@@ -429,7 +429,7 @@ module ::Actions::Pulp3
       create_repo(@repo_clone, @primary)
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
@@ -517,7 +517,7 @@ module ::Actions::Pulp3
       create_repo(@repo_clone, @primary)
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
@@ -605,7 +605,7 @@ module ::Actions::Pulp3
       create_repo(@repo_clone, @primary)
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
@@ -671,7 +671,7 @@ module ::Actions::Pulp3
       create_repo(@repo_clone, @primary)
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
@@ -717,7 +717,7 @@ module ::Actions::Pulp3
       create_repo(@repo_clone, @primary)
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
 
       index_args = {:id => @repo.id}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)

--- a/test/actions/pulp3/orchestration/remove_orphans_test.rb
+++ b/test/actions/pulp3/orchestration/remove_orphans_test.rb
@@ -14,7 +14,7 @@ module ::Actions::Pulp3
       sync_args = {:smart_proxy_id => smart_proxy.id, :repo_id => repo.id}
       ForemanTasks.sync_task(
         ::Actions::Pulp3::Orchestration::Repository::Sync,
-        repo, smart_proxy, sync_args)
+        repo, smart_proxy, **sync_args)
     end
 
     def repo_reference(repo)

--- a/test/actions/pulp3/orchestration/rpm_remove_units_test.rb
+++ b/test/actions/pulp3/orchestration/rpm_remove_units_test.rb
@@ -23,7 +23,7 @@ module ::Actions::Pulp3
 
       sync_args = { :smart_proxy_id => proxy.id, :repo_id => repo.id, :full_index => true }
       sync_action = ForemanTasks.sync_task(
-        ::Actions::Pulp3::Orchestration::Repository::Sync, repo, proxy, sync_args)
+        ::Actions::Pulp3::Orchestration::Repository::Sync, repo, proxy, **sync_args)
 
       contents_changed = sync_action.output[:contents_changed]
       ForemanTasks.sync_task(

--- a/test/actions/pulp3/orchestration/yum_sync_test.rb
+++ b/test/actions/pulp3/orchestration/yum_sync_test.rb
@@ -33,7 +33,7 @@ module ::Actions::Pulp3
     def test_sync
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
       @repo.update(publication_href: nil, version_href: nil) #validate that sync populates these
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
       refute_equal @repo.version_href, @repo_version_href
       repository_reference = Katello::Pulp3::RepositoryReference.find_by(
@@ -49,7 +49,7 @@ module ::Actions::Pulp3
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
       @repo.root.update(mirroring_policy: ::Katello::RootRepository::MIRRORING_POLICY_ADDITIVE)
       @repo.update(publication_href: nil, version_href: nil) #validate that sync populates these
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
       refute_equal @repo.version_href, @repo_version_href
       repository_reference = Katello::Pulp3::RepositoryReference.find_by(
@@ -64,7 +64,7 @@ module ::Actions::Pulp3
     def test_optimize_false
       SETTINGS[:katello][:katello_applicability] = true
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
 
       old_url = @repo.version_href
@@ -88,7 +88,7 @@ module ::Actions::Pulp3
 
     def test_index_erratum_href
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
       @repo.index_content
       @repo.reload
@@ -100,7 +100,7 @@ module ::Actions::Pulp3
 
     def test_reindex_outdated_erratum
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
       @repo.index_content
       @repo.reload
@@ -118,7 +118,7 @@ module ::Actions::Pulp3
       @repo.reload
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
       assert_raises ForemanTasks::TaskError do
-        ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+        ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       end
     end
 
@@ -140,7 +140,7 @@ module ::Actions::Pulp3
       ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::AlternateContentSource::Refresh, smart_proxy_acs)
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
       repository_reference = Katello::Pulp3::RepositoryReference.find_by(
           :root_repository_id => @repo.root.id,

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -188,7 +188,7 @@ module Katello
 
       it "should update facts" do
         facts = {'rhsm_fact' => 'rhsm_value'}
-        ::Host.any_instance.expects(:update_candlepin_associations).with("facts" => facts)
+        ::Host.any_instance.expects(:update_candlepin_associations).with({ "facts" => facts })
         put :facts, params: { :id => @host.subscription_facet.uuid, :facts => facts }
         assert_equal 200, response.status
       end
@@ -207,7 +207,7 @@ module Katello
         uuid = @host.subscription_facet.uuid
         stub_cp_consumer_with_uuid(uuid)
         facts = {'rhsm_fact' => 'rhsm_value'}
-        ::Host.any_instance.expects(:update_candlepin_associations).with("facts" => facts)
+        ::Host.any_instance.expects(:update_candlepin_associations).with({ "facts" => facts })
         put :facts, params: { :id => @host.subscription_facet.uuid, :facts => facts}
         assert_response 200
       end

--- a/test/controllers/api/v2/api_controller_test.rb
+++ b/test/controllers/api/v2/api_controller_test.rb
@@ -73,8 +73,8 @@ module Katello
 
       User.current = users(:restricted)
       key = katello_activation_keys(:simple_key)
-      setup_current_user_with_permissions(:name => "view_activation_keys",
-                                          :search => "environment = #{key.environment}")
+      setup_current_user_with_permissions({ :name => "view_activation_keys",
+                                            :search => "environment = #{key.environment}" })
 
       @options = { :resource_class => Katello::ActivationKey }
       keys = @controller.scoped_search(ActivationKey.readable, @default_sort[0], @default_sort[1], @options)

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -940,7 +940,7 @@ module Katello
       # this is yum repo. So unit keys should accept name
       @controller.expects(:sync_task)
         .with(::Actions::Katello::Repository::ImportUpload, @repository, uploads,
-              generate_metadata: true, content_type: nil, sync_capsule: true)
+              { generate_metadata: true, content_type: nil, sync_capsule: true })
         .returns(build_task_stub)
 
       put :import_uploads, params: { id: @repository.id, uploads: uploads }
@@ -979,7 +979,7 @@ module Katello
       uploads = [{'id' => '1', 'size' => '12333', 'checksum' => 'asf23421324', 'name' => 'test'}]
       @controller.expects(:sync_task)
         .with(::Actions::Katello::Repository::ImportUpload, file_repo, uploads,
-              generate_metadata: true, content_type: 'file', sync_capsule: true)
+              { generate_metadata: true, content_type: 'file', sync_capsule: true })
         .returns(build_task_stub)
 
       put :import_uploads, params: { id: file_repo, uploads: uploads, content_type: 'file' }
@@ -993,7 +993,7 @@ module Katello
       uploads = [{'id' => '1', 'size' => '12333', 'checksum' => 'asf23421324', 'name' => 'test'}]
       @controller.expects(:sync_task)
         .with(::Actions::Katello::Repository::ImportUpload, @docker_repo, uploads,
-              generate_metadata: true, content_type: 'docker_manifest', sync_capsule: true)
+              { generate_metadata: true, content_type: 'docker_manifest', sync_capsule: true })
         .returns(build_task_stub)
 
       put :import_uploads, params: { id: @docker_repo.id, uploads: uploads, content_type: 'docker_manifest' }
@@ -1007,7 +1007,7 @@ module Katello
       # this is docker repo so unit keys should acccept name
       @controller.expects(:sync_task)
         .with(::Actions::Katello::Repository::ImportUpload, @docker_repo, uploads,
-              generate_metadata: true, content_type: nil, sync_capsule: true)
+              { generate_metadata: true, content_type: nil, sync_capsule: true })
         .returns(build_task_stub)
 
       put :import_uploads, params: { id: @docker_repo.id, uploads: uploads }
@@ -1021,7 +1021,7 @@ module Katello
       # this is yum repo. So unit keys should accept name
       @controller.expects(:sync_task)
         .with(::Actions::Katello::Repository::ImportUpload, @srpm_repo, uploads,
-              generate_metadata: true, content_type: 'srpm', sync_capsule: true)
+              { generate_metadata: true, content_type: 'srpm', sync_capsule: true })
         .returns(build_task_stub)
 
       put :import_uploads, params: { id: @srpm_repo.id, uploads: uploads, content_type: 'srpm' }

--- a/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
@@ -23,7 +23,7 @@ module Katello
 
     def test_index
       params = { page: '3', per_page: '7', organization_id: @organization.id }
-      UpstreamPool.expects(:fetch_pools).with('page' => '3', 'per_page' => '7').returns(pools: [{}], total: nil)
+      UpstreamPool.expects(:fetch_pools).with({ 'page' => '3', 'per_page' => '7' }).returns(pools: [{}], total: nil)
       get :index, params: params
 
       assert_response :success
@@ -42,7 +42,7 @@ module Katello
     def test_index_pool_ids
       params = {pool_ids: %w(1 2 3), page: '3', per_page: '7', organization_id: @organization.id}
       # omit page and per_page params for candlepin
-      UpstreamPool.expects(:fetch_pools).with('pool_ids' => %w(1 2 3)).returns({})
+      UpstreamPool.expects(:fetch_pools).with({ 'pool_ids' => %w(1 2 3) }).returns({})
 
       get :index, params: params
 
@@ -51,7 +51,7 @@ module Katello
 
     def test_index_no_per_page
       params = {page: '3', organization_id: @organization.id }
-      UpstreamPool.expects(:fetch_pools).with('page' => '3', 'per_page' => Setting[:entries_per_page]).returns({})
+      UpstreamPool.expects(:fetch_pools).with({ 'page' => '3', 'per_page' => Setting[:entries_per_page] }).returns({})
 
       get :index, params: params
 

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -172,8 +172,8 @@ end
 module DynflowFullTreePlanning
   IGNORED_INPUT = [:remote_user, :remote_cp_user].freeze
 
-  def plan_action_tree(action_class, *args)
-    Rails.application.dynflow.world.plan(action_class, *args)
+  def plan_action_tree(action_class, *args, **kwargs)
+    Rails.application.dynflow.world.plan(action_class, *args, **kwargs)
   end
 
   def assert_tree_planned_steps(execution_plan, action_class)

--- a/test/lib/repo_discovery_test.rb
+++ b/test/lib/repo_discovery_test.rb
@@ -61,7 +61,7 @@ module Katello
       search = 'busybox'
 
       RestClient::Request.expects(:execute)
-        .with(method: :get, url: base_url.to_s + "v1/search?q=#{search}", headers: {:accept => :json})
+        .with({ method: :get, url: base_url.to_s + "v1/search?q=#{search}", headers: {:accept => :json} })
         .returns({results: ['busybox']}.to_json)
 
       rd = RepoDiscovery.new(base_url, 'docker', nil, nil, search, crawled, found, to_follow)
@@ -78,7 +78,7 @@ module Katello
       search = 'busybox'
 
       RestClient::Request.expects(:execute)
-        .with(method: :get, url: base_url.to_s + "v1/search?q=#{search}", proxy: @proxy_url, headers: {:accept => :json})
+        .with({ method: :get, url: base_url.to_s + "v1/search?q=#{search}", proxy: @proxy_url, headers: {:accept => :json} })
         .returns({results: ['busybox']}.to_json)
 
       rd = RepoDiscovery.new(base_url, 'docker', nil, nil, search, crawled, found, to_follow)
@@ -101,11 +101,11 @@ module Katello
       search = 'busybox'
 
       RestClient::Request.expects(:execute)
-        .with(method: :get, url: base_url.to_s + "v1/search?q=#{search}", proxy: @proxy_url, headers: {:accept => :json})
+        .with({ method: :get, url: base_url.to_s + "v1/search?q=#{search}", proxy: @proxy_url, headers: {:accept => :json} })
         .returns({code: Net::HTTPNotFound}.to_json)
 
       RestClient::Request.expects(:execute)
-        .with(method: :get, url: base_url.to_s + "v2/_catalog", proxy: @proxy_url, headers: {:accept => :json})
+        .with({ method: :get, url: base_url.to_s + "v2/_catalog", proxy: @proxy_url, headers: {:accept => :json} })
         .returns({'repositories' => ['busybox']}.to_json.extend(MockHeaders))
 
       rd = RepoDiscovery.new(base_url, 'docker', nil, nil, search, crawled, found, to_follow)

--- a/test/lib/tasks/clean_backend_objects_test.rb
+++ b/test/lib/tasks/clean_backend_objects_test.rb
@@ -42,7 +42,7 @@ module Katello
       @host.subscription_facet.update!(:uuid => nil)
       mock_cp
 
-      Katello::RegistrationManager.expects(:unregister_host).with(@host, :unregistering => true).once
+      Katello::RegistrationManager.expects(:unregister_host).with(@host, { :unregistering => true }).once
 
       Rake.application.invoke_task('katello:clean_backend_objects')
     end
@@ -55,7 +55,7 @@ module Katello
       @host.subscription_facet.update!(:uuid => nil)
       mock_cp
 
-      Katello::RegistrationManager.expects(:unregister_host).with(@host, :unregistering => true).once
+      Katello::RegistrationManager.expects(:unregister_host).with(@host, { :unregistering => true }).once
 
       Rake.application.invoke_task('katello:clean_backend_objects')
     end

--- a/test/lib/tasks/repository_test.rb
+++ b/test/lib/tasks/repository_test.rb
@@ -140,7 +140,7 @@ module Katello
       Katello::Repository.stubs(:in_environment).returns(Katello::Repository.where(:id => @library_repo))
       PulpRpmClient::RepositoriesRpmApi.any_instance.expects(:read).once.with("test_repo_1/").raises(PulpRpmClient::ApiError)
 
-      ForemanTasks.expects(:sync_task).with(::Actions::Katello::Repository::Create, @library_repo, { force_repo_create: true })
+      ForemanTasks.expects(:sync_task).with(::Actions::Katello::Repository::Create, @library_repo, force_repo_create: true)
 
       Rake.application.invoke_task('katello:correct_repositories')
     end

--- a/test/lib/tasks/update_subscription_facet_backend_data_test.rb
+++ b/test/lib/tasks/update_subscription_facet_backend_data_test.rb
@@ -19,7 +19,7 @@ module Katello
       Katello::Resources::Candlepin::Consumer.stubs(:virtual_guests).returns([])
       Katello::Resources::Candlepin::Consumer.stubs(:virtual_host).returns(nil)
 
-      Katello::Host::SubscriptionFacet.expects(:update_facts).with(@host, :foo => :bar).once
+      Katello::Host::SubscriptionFacet.expects(:update_facts).with(@host, { :foo => :bar }).once
 
       Rake.application.invoke_task('katello:update_subscription_facet_backend_data')
     end

--- a/test/models/authorization/activation_key_authorization_test.rb
+++ b/test/models/authorization/activation_key_authorization_test.rb
@@ -83,8 +83,8 @@ module Katello
 
       clause = keys.map { |key| "name=\"#{key.name}\"" }.join(" or ")
 
-      setup_current_user_with_permissions(:name => "edit_activation_keys",
-                                          :search => clause)
+      setup_current_user_with_permissions({ :name => "edit_activation_keys",
+                                            :search => clause })
       assert ActivationKey.all_editable?(ak.content_view, ak.environment)
     end
   end

--- a/test/models/authorization/lifecycle_environment_authorization_test.rb
+++ b/test/models/authorization/lifecycle_environment_authorization_test.rb
@@ -75,8 +75,8 @@ module Katello
 
     def test_readables
       environment = katello_environments(:staging_path1)
-      setup_current_user_with_permissions(:name => "view_lifecycle_environments",
-                                          :search => "name=\"#{environment.name}\"")
+      setup_current_user_with_permissions({ :name => "view_lifecycle_environments",
+                                            :search => "name=\"#{environment.name}\"" })
       assert_equal([environment.id], KTEnvironment.readable.pluck(:id))
       assert environment.readable?
       refute environment.prior.readable?
@@ -84,8 +84,8 @@ module Katello
 
     def test_promotables
       environment = katello_environments(:staging_path1)
-      setup_current_user_with_permissions(:name => "promote_or_remove_content_views_to_environments",
-                                          :search => "name=\"#{environment.name}\"")
+      setup_current_user_with_permissions({ :name => "promote_or_remove_content_views_to_environments",
+                                            :search => "name=\"#{environment.name}\"" })
       assert_equal([environment.id], KTEnvironment.promotable.pluck(:id))
       assert environment.promotable_or_removable?
       refute environment.prior.promotable_or_removable?

--- a/test/models/authorization/organization_authorization_test.rb
+++ b/test/models/authorization/organization_authorization_test.rb
@@ -42,8 +42,8 @@ module Katello
 
     def test_read_promotion_paths_one
       environment = katello_environments(:staging_path1)
-      setup_current_user_with_permissions(:name => "view_lifecycle_environments",
-                                          :search => "name=\"#{environment.name}\"")
+      setup_current_user_with_permissions({ :name => "view_lifecycle_environments",
+                                            :search => "name=\"#{environment.name}\"" })
 
       refute_equal(@org.promotion_paths, @org.readable_promotion_paths)
       assert_equal(1, @org.readable_promotion_paths.size)
@@ -51,8 +51,8 @@ module Katello
 
     def test_promotable_promotion_paths_one
       environment = katello_environments(:staging_path1)
-      setup_current_user_with_permissions(:name => "promote_or_remove_content_views_to_environments",
-                                          :search => "name=\"#{environment.name}\"")
+      setup_current_user_with_permissions({ :name => "promote_or_remove_content_views_to_environments",
+                                            :search => "name=\"#{environment.name}\"" })
 
       refute_equal(@org.promotion_paths, @org.promotable_promotion_paths)
       assert_equal(1, @org.promotable_promotion_paths.size)

--- a/test/models/authorization/product_authorization_test.rb
+++ b/test/models/authorization/product_authorization_test.rb
@@ -101,8 +101,8 @@ module Katello
 
     def test_readable_repositories_with_search
       repo = @fedora_17_x86_64
-      setup_current_user_with_permissions(:name => "view_products",
-                                          :search => "name=\"#{repo.product.name}\"")
+      setup_current_user_with_permissions({ :name => "view_products",
+                                            :search => "name=\"#{repo.product.name}\"" })
 
       assert_equal([repo], Product.readable_repositories([repo.id]))
       assert_empty(Product.readable_repositories(

--- a/test/models/authorization/repository_authorization_test.rb
+++ b/test/models/authorization/repository_authorization_test.rb
@@ -100,25 +100,25 @@ module Katello
 
     def test_readable_with_product
       refute_includes Repository.readable, @fedora_17_x86_64
-      setup_current_user_with_permissions(:name => "view_products", :search => nil)
+      setup_current_user_with_permissions({ :name => "view_products", :search => nil })
       assert_includes Repository.readable, @fedora_17_x86_64
     end
 
     def test_readable_with_content_view
       refute_includes Repository.readable, @fedora_17_x86_64
-      setup_current_user_with_permissions(:name => "view_content_views", :search => nil)
+      setup_current_user_with_permissions({ :name => "view_content_views", :search => nil })
       assert_includes Repository.readable, @fedora_17_x86_64
     end
 
     def test_readable_with_versions
       refute_includes Repository.readable, @fedora_17_x86_64_dev
-      setup_current_user_with_permissions(:name => "view_content_views", :search => "name = \"#{@fedora_17_x86_64_dev.content_view_version.content_view.name}\"")
+      setup_current_user_with_permissions({ :name => "view_content_views", :search => "name = \"#{@fedora_17_x86_64_dev.content_view_version.content_view.name}\"" })
       assert_includes Repository.readable, @fedora_17_x86_64_dev
     end
 
     def test_readable_with_environment
       refute_includes Repository.readable, @fedora_17_x86_64
-      setup_current_user_with_permissions(:name => "view_lifecycle_environments", :search => "name = \"#{@fedora_17_x86_64.environment.name}\"")
+      setup_current_user_with_permissions({ :name => "view_lifecycle_environments", :search => "name = \"#{@fedora_17_x86_64.environment.name}\"" })
       repos = Repository.readable
       refute_empty repos
       assert repos.all? { |repo| repo.environment_id == @fedora_17_x86_64.environment_id }

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -218,7 +218,7 @@ module Katello
       host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @library_view, :lifecycle_environment => @library)
       host.content_facet.expects(:save!)
       host.subscription_facet.stubs(:consumer_attributes).returns('autoheal' => true)
-      host.subscription_facet.expects(:update_from_consumer_attributes).with('autoheal' => true)
+      host.subscription_facet.expects(:update_from_consumer_attributes).with({ 'autoheal' => true })
       ::Katello::Resources::Candlepin::Consumer.expects(:update).with(host.subscription_facet.uuid, host.subscription_facet.consumer_attributes)
       ::Katello::Resources::Candlepin::Consumer.expects(:refresh_entitlements).never
       ::Katello::Host::SubscriptionFacet.expects(:update_facts).never

--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -249,7 +249,7 @@ module Katello
       capsule_content.smart_proxy.add_lifecycle_environment(environment)
 
       repo_list_update_expectation = ProxyAPI::ContainerGateway.any_instance.expects(:repository_list).with(
-        :repositories => [{:repository => "empty_organization-puppet_product-busybox", :auth_required => true}, {:repository => "busybox", :auth_required => true}]
+        { :repositories => [{:repository => "empty_organization-puppet_product-busybox", :auth_required => true}, {:repository => "busybox", :auth_required => true}] }
       )
       repo_list_update_expectation.once.returns(true)
 

--- a/test/models/content_view_package_group_filter_test.rb
+++ b/test/models/content_view_package_group_filter_test.rb
@@ -26,7 +26,7 @@ module Katello
           repository_creation: true)
       @repo.reload
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       @repo.reload
       @repo.index_content
       Katello::PackageGroup.import_for_repository(@repo)

--- a/test/models/katello/ostree_test.rb
+++ b/test/models/katello/ostree_test.rb
@@ -28,7 +28,7 @@ module Katello
       skip "TODO: Until the ostree support is present in pulp packaging"
       Katello::GenericContentUnit.destroy_all
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
       index_args = {:id => @repo.id, :contents_changed => true}
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
       @repo.reload

--- a/test/services/katello/pulp3/deb_test.rb
+++ b/test/services/katello/pulp3/deb_test.rb
@@ -18,7 +18,7 @@ module Katello
         def test_index_model
           Katello::Deb.destroy_all
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
           @repo.reload
           @repo.index_content
           post_unit_count = Katello::Deb.all.count
@@ -31,7 +31,7 @@ module Katello
         def test_index_on_sync
           Katello::Deb.destroy_all
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
           index_args = {:id => @repo.id, :contents_changed => true}
           ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
           @repo.reload

--- a/test/services/katello/pulp3/docker_tag_test.rb
+++ b/test/services/katello/pulp3/docker_tag_test.rb
@@ -18,7 +18,7 @@ module Katello
         def test_index_model
           Katello::DockerTag.destroy_all
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
           @repo.reload
           @repo.index_content
           assert_equal @repo, ::Katello::Repository.find_by(:id => ::Katello::RepositoryDockerTag.first.repository_id)
@@ -35,7 +35,7 @@ module Katello
         def test_index_on_sync
           Katello::DockerTag.destroy_all
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
           index_args = {:id => @repo.id, :contents_changed => true}
           ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
           @repo.reload
@@ -50,7 +50,7 @@ module Katello
           @repo.root.update(url: 'https://quay.io', docker_upstream_name: 'ansible/ansible-runner')
           Katello::DockerTag.destroy_all
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
           index_args = {:id => @repo.id, :contents_changed => true}
 
           # Test that indexing works
@@ -61,7 +61,7 @@ module Katello
           # https://projects.theforeman.org/issues/34257
           Katello::DockerTag.destroy_all
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
           index_args = {:id => @repo.id, :contents_changed => true}
           ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
           @repo.reload
@@ -75,7 +75,7 @@ module Katello
           @repo.root.update(:include_tags => ['doesntexist'])
           @repo.backend_service(SmartProxy.pulp_primary).refresh_if_needed
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
           index_args = {:id => @repo.id, :contents_changed => true}
           ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
           @repo.reload

--- a/test/services/katello/pulp3/erratum_test.rb
+++ b/test/services/katello/pulp3/erratum_test.rb
@@ -27,7 +27,7 @@ module Katello
         def test_index_model
           Katello::Erratum.destroy_all
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
           @repo.reload
           @repo.index_content
           post_unit_count = Katello::Erratum.all.count
@@ -40,7 +40,7 @@ module Katello
         def test_index_on_sync
           Katello::Erratum.destroy_all
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
           index_args = {:id => @repo.id, :contents_changed => true}
           ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
           @repo.reload

--- a/test/services/katello/pulp3/file_unit_test.rb
+++ b/test/services/katello/pulp3/file_unit_test.rb
@@ -19,7 +19,7 @@ module Katello
         def test_index_model
           Katello::FileUnit.destroy_all
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
           @repo.reload
           @repo.index_content
           post_unit_count = Katello::FileUnit.all.count
@@ -32,7 +32,7 @@ module Katello
         def test_index_on_sync
           Katello::FileUnit.destroy_all
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
           index_args = {:id => @repo.id, :contents_changed => true}
           ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
           @repo.reload

--- a/test/services/katello/pulp3/orphan_test.rb
+++ b/test/services/katello/pulp3/orphan_test.rb
@@ -17,7 +17,7 @@ module Katello
           sync_args = {:smart_proxy_id => smart_proxy.id, :repo_id => repo.id}
           ForemanTasks.sync_task(
             ::Actions::Pulp3::Orchestration::Repository::Sync,
-            repo, smart_proxy, sync_args)
+            repo, smart_proxy, **sync_args)
         end
 
         def assert_version(repo, version)

--- a/test/services/katello/pulp3/package_group_test.rb
+++ b/test/services/katello/pulp3/package_group_test.rb
@@ -21,7 +21,7 @@ module Katello
               repository_creation: true)
           @repo.reload
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
           @repo.reload
           Katello::PackageGroup.import_for_repository(@repo)
           @repo.reload

--- a/test/services/katello/pulp3/repository/ansible_collection/ansible_collection_repository_mirror_test.rb
+++ b/test/services/katello/pulp3/repository/ansible_collection/ansible_collection_repository_mirror_test.rb
@@ -18,7 +18,7 @@ module Katello
           @repo_mirror.stubs(:remote_href).returns("remote_href")
           @repo_mirror.stubs(:repository_href).returns("repository_href")
           sync_url = @repo_service.api.repository_sync_url_class.new(remote: "remote_href", mirror: true)
-          PulpAnsibleClient::AnsibleRepositorySyncURL.expects(:new).with(remote: "remote_href", mirror: true).once.returns(sync_url)
+          PulpAnsibleClient::AnsibleRepositorySyncURL.expects(:new).with({ remote: "remote_href", mirror: true }).once.returns(sync_url)
           PulpAnsibleClient::RepositoriesAnsibleApi.any_instance.expects(:sync).once.with("repository_href", sync_url)
           @repo_mirror.sync(optimize: "test", skip_types: "another test")
         end

--- a/test/services/katello/pulp3/repository/apt/apt_test.rb
+++ b/test/services/katello/pulp3/repository/apt/apt_test.rb
@@ -52,7 +52,7 @@ module Katello
             PulpcoreClient::SigningServicesApi
               .any_instance
               .expects(:list)
-              .with({name: 'katello_deb_sign'})
+              .with(name: 'katello_deb_sign')
               .returns(signing_service_response_list)
             service = Katello::Pulp3::Repository::Apt.new(@repo, @proxy)
 
@@ -71,7 +71,7 @@ module Katello
             PulpcoreClient::SigningServicesApi
               .any_instance
               .expects(:list)
-              .with({name: 'katello_deb_sign'})
+              .with(name: 'katello_deb_sign')
               .returns(signing_service_response_list)
             service = Katello::Pulp3::Repository::Apt.new(@repo, @proxy)
 

--- a/test/services/katello/pulp3/repository/docker/docker_repository_mirror_test.rb
+++ b/test/services/katello/pulp3/repository/docker/docker_repository_mirror_test.rb
@@ -22,7 +22,7 @@ module Katello
           @repo_mirror.stubs(:remote_href).returns("remote_href")
           @repo_mirror.stubs(:repository_href).returns("repository_href")
           sync_url = @repo_service.api.repository_sync_url_class.new(remote: "remote_href", mirror: true)
-          PulpContainerClient::ContainerRepositorySyncURL.expects(:new).with(remote: "remote_href", mirror: true).once.returns(sync_url)
+          PulpContainerClient::ContainerRepositorySyncURL.expects(:new).with({ remote: "remote_href", mirror: true }).once.returns(sync_url)
           PulpContainerClient::RepositoriesContainerApi.any_instance.expects(:sync).once.with("repository_href", sync_url)
           @repo_mirror.sync(optimize: "test", skip_types: "another test")
         end

--- a/test/services/katello/pulp3/repository/python/python_test.rb
+++ b/test/services/katello/pulp3/repository/python/python_test.rb
@@ -43,7 +43,7 @@ module Katello
           def test_index_on_sync
             Katello::GenericContentUnit.destroy_all
             sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-            ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+            ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
             index_args = {:id => @repo.id, :contents_changed => true}
             ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
             @repo.reload

--- a/test/services/katello/pulp3/repository_list_test.rb
+++ b/test/services/katello/pulp3/repository_list_test.rb
@@ -16,7 +16,7 @@ module Katello
           sync_args = {:smart_proxy_id => smart_proxy.id, :repo_id => repo.id}
           ForemanTasks.sync_task(
             ::Actions::Pulp3::Orchestration::Repository::Sync,
-            repo, smart_proxy, sync_args)
+            repo, smart_proxy, **sync_args)
         end
 
         def test_list_with_pagination

--- a/test/services/katello/pulp3/rpm_test.rb
+++ b/test/services/katello/pulp3/rpm_test.rb
@@ -20,7 +20,7 @@ module Katello
         def test_index_model
           Katello::Rpm.destroy_all
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
           @repo.reload
           @repo.index_content
           post_unit_count = Katello::Rpm.all.count
@@ -35,7 +35,7 @@ module Katello
         def test_index_on_sync
           Katello::Rpm.destroy_all
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
           index_args = {:id => @repo.id, :contents_changed => true}
           ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
           @repo.reload

--- a/test/services/katello/pulp3/srpm_test.rb
+++ b/test/services/katello/pulp3/srpm_test.rb
@@ -31,7 +31,7 @@ module Katello
         def setup
           super
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
-          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
           @repo.reload
           Katello::Srpm.import_for_repository(@repo)
           @repo.reload
@@ -55,7 +55,7 @@ module Katello
         def test_sync_skipped_srpm
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
           @repo.root.update!(ignorable_content: ["srpm"])
-          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
           @repo.reload
           Katello::Srpm.import_for_repository(@repo)
           @repo.reload
@@ -66,7 +66,7 @@ module Katello
         def test_sync_skipped_treeinfo
           sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
           @repo.root.update!(ignorable_content: ["treeinfo"])
-          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)
+          ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, **sync_args)
         end
       end
 

--- a/test/support/controller_support.rb
+++ b/test/support/controller_support.rb
@@ -67,11 +67,11 @@ module ControllerSupport
 
   def assert_authorized(params)
     check_params = params.merge(authorized: true)
-    check_permission(check_params)
+    check_permission(**check_params)
   end
 
   def refute_authorized(params)
     check_params = params.merge(authorized: false)
-    check_permission(check_params)
+    check_permission(**check_params)
   end
 end

--- a/test/support/pulp3_support.rb
+++ b/test/support/pulp3_support.rb
@@ -90,7 +90,7 @@ module Katello
       refute_empty repository_reference.repository_href
       refute_empty Katello::Pulp3::DistributionReference.where(repository_id: repo.id)
       sync_args = {:smart_proxy_id => smart_proxy.id, :repo_id => repo.id}
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, repo, smart_proxy, sync_args)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, repo, smart_proxy, **sync_args)
       repo
     end
   end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Updates for kwargs usage across the code base to comply with Ruby 3.0.

Please, review carefully, since there might be a lot of unnecessary changes as well as some breaking changes (such as changing signatures for action planning methods).

#### Considerations taken when implementing this change?

Depends on
 - https://github.com/Katello/katello/pull/10780
 - https://github.com/theforeman/foreman/pull/9989
 - https://github.com/theforeman/foreman-tasks/pull/739 (including Dynflow changes)

#### What are the testing steps for this pull request?

Run CI and hope for the best.
