### PR TITLE
Fixes #37107 - Refresh RHEL lifecycle status on facts update

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -260,6 +260,7 @@ module Katello
       User.current = User.anonymous_admin
       @host.update_candlepin_associations(rhsm_params)
       update_host_registered_through(@host, request.headers)
+      @host.refresh_statuses([::Katello::RhelLifecycleStatus])
       render :json => {:content => _("Facts successfully updated.")}, :status => :ok
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
RHEL Lifecycle Status of a host will get refreshed when subman facts get updated.

#### Considerations taken when implementing this change?
Basic issue was that during global registration of a host - the host gets set to build (to track registration.) This clears up all the facts of the host. When the registration is complete the new facts are updated. However the update facts does not refresh rhel lifecycle status. 
This PR addresses that part


#### What are the testing steps for this pull request?
Multiple ways to test
On master

1. Register a rhel host via global registration (make sure the host did not previously exist in an org)
2. Hosts -> All Hosts 
3. Select the host for details
4. Manage All Statuses
5. Note the RHEL lifecycle is listed as Unknown
6. Delete  the host
7. Check out this PR and try 1-4 again
8. Note the RHEL lifecycle is listed as Full support
