### PR TITLE
Fixes #37108 - Preload content_view_components

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -59,7 +59,7 @@ module Katello
     param_group :search, Api::V2::ApiController
     add_scoped_search_description_for(ContentView)
     def index
-      content_view_includes = [:activation_keys, :content_view_versions,
+      content_view_includes = [:activation_keys, :content_view_versions, :content_view_components,
                                :environments, :organization, :repositories]
       respond(:collection => scoped_search(index_relation.distinct, :name, :asc, :includes => content_view_includes))
     end


### PR DESCRIPTION
[root@or content_views]# grep SELECT /tmp/cv_sql | grep content_view_comp | wc -l
30
[root@or content_views]# grep SELECT /tmp/cv_sql_opt1 | grep content_view_comp | wc -l
16