### PR TITLE
Fixes #37109 - allow to use eager loading on latest_version_object

### DIFF
--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -66,6 +66,8 @@ module Katello
       joins(:repositories).includes(:content_view).merge(repositories).distinct
     end
 
+    scope :latest, -> { order('major DESC', 'minor DESC').limit(1) }
+
     scoped_search :on => :content_view_id, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
     scoped_search :on => :major, :rename => :version, :complete_value => true, :ext_method => :find_by_version
     serialize :content_counts

--- a/test/models/content_view_component_test.rb
+++ b/test/models/content_view_component_test.rb
@@ -229,6 +229,7 @@ module Katello
                                                       :action => "publish")
       assert_equal @composite.needs_publish?, true
       @composite.create_new_version
+      @composite.reload
       cv_history.update!(katello_content_view_version_id: @composite.latest_version_object.id)
       assert_equal @composite.reload.needs_publish?, false
       version1 = create(:katello_content_view_version, :content_view => view1)
@@ -236,6 +237,7 @@ module Katello
                                          :content_view_version => version1, :latest => false)
       assert_equal @composite.reload.needs_publish?, true
       @composite.create_new_version
+      @composite.reload
       cv_history.update!(katello_content_view_version_id: @composite.latest_version_object.id)
       assert_equal @composite.reload.needs_publish?, false
       create(:katello_content_view_version, :content_view => view2)
@@ -243,11 +245,13 @@ module Katello
                                          :content_view => view2, :latest => true)
       assert_equal @composite.reload.needs_publish?, true
       @composite.create_new_version
+      @composite.reload
       cv_history.update!(katello_content_view_version_id: @composite.latest_version_object.id)
       assert_equal @composite.reload.needs_publish?, false
       create(:katello_content_view_version, :content_view => view2, :major => "1000")
       assert_equal @composite.reload.needs_publish?, true
       @composite.create_new_version
+      @composite.reload
       cv_history.update!(katello_content_view_version_id: @composite.latest_version_object.id)
       assert_equal @composite.reload.needs_publish?, false
     end

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -664,6 +664,7 @@ module Katello
       content_view = FactoryBot.build(:katello_content_view, :name => "New CV cleaned audits")
       content_view.save!
       content_view.create_new_version
+      content_view.reload
       task = ForemanTasks::Task.create!(:label => 'Actions::Katello::ContentView::Publish', :state => 'stopped',
                                         :type => 'ForemanTasks::Task::DynflowTask', :result => 'success')
       ::Katello::ContentViewHistory.create!(:katello_content_view_version_id => content_view.latest_version_object.id,
@@ -678,6 +679,7 @@ module Katello
       content_view = FactoryBot.build(:katello_content_view, :name => "New CV applied filters nil")
       content_view.save!
       content_view.create_new_version
+      content_view.reload
       task = ForemanTasks::Task.create!(:label => 'Actions::Katello::ContentView::Publish', :state => 'stopped',
                                         :type => 'ForemanTasks::Task::DynflowTask', :result => 'success')
       ::Katello::ContentViewHistory.create!(:katello_content_view_version_id => content_view.latest_version_object.id,
@@ -695,6 +697,7 @@ module Katello
       content_view.save!
       assert content_view.needs_publish? #New CV needs publish
       content_view.create_new_version
+      content_view.reload
       content_view.latest_version_object.update!(applied_filters: {"dependency_solving": false})
       task = ForemanTasks::Task.create!(:label => 'Actions::Katello::ContentView::Publish', :state => 'stopped',
                                         :type => 'ForemanTasks::Task::DynflowTask', :result => 'success')
@@ -721,6 +724,7 @@ module Katello
       content_view.save!
       assert content_view.needs_publish? #New CV needs publish
       content_view.create_new_version
+      content_view.reload
       task = ForemanTasks::Task.create!(:label => 'Actions::Katello::ContentView::Publish', :state => 'stopped',
                                         :type => 'ForemanTasks::Task::DynflowTask', :result => 'success')
       ::Katello::ContentViewHistory.create!(:katello_content_view_version_id => content_view.latest_version_object.id,
@@ -745,6 +749,7 @@ module Katello
       content_view.save!
       assert content_view.needs_publish? #New CV needs publish
       content_view.create_new_version
+      content_view.reload
       task = ForemanTasks::Task.create!(:label => 'Actions::Katello::ContentView::Publish', :state => 'stopped',
                                         :type => 'ForemanTasks::Task::DynflowTask', :result => 'success')
       ::Katello::ContentViewHistory.create!(:katello_content_view_version_id => content_view.latest_version_object.id,
@@ -761,6 +766,7 @@ module Katello
       content_view.save!
       assert content_view.needs_publish? #no version needs publish
       content_view.create_new_version
+      content_view.reload
       task = ForemanTasks::Task.create!(:label => 'Actions::Katello::ContentView::Publish', :state => 'stopped',
                                         :type => 'ForemanTasks::Task::DynflowTask', :result => 'failed')
       ::Katello::ContentViewHistory.create!(:katello_content_view_version_id => content_view.latest_version_object.id,


### PR DESCRIPTION
Strips away 480 sql queries because of needs_publish? and especially the implementation of latest_version_object

Display 20 Content Views on UI (index page)

Total amount of queries:
[root@or v2]# grep SELECT /tmp/cv_without_opt1.log | wc -l
1234
[root@or v2]# grep SELECT /tmp/cv_opt1.log | wc -l
755

[root@or v2]# grep SELECT /tmp/cv_without_opt1.log | grep content_view_version    | wc -l
641
[root@or v2]# grep SELECT /tmp/cv_opt1.log | grep content_view_version    | wc -l
181

Details: https://pawelurbanek.com/rails-eager-ordered (and thank you so much for this page)