### PR TITLE
Fixes #37111 - use preloaded count

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -188,7 +188,7 @@ module Katello
     end
 
     def content_host_count
-      hosts.count
+      hosts.size
     end
 
     def component_ids
@@ -735,7 +735,7 @@ module Katello
     end
 
     def version_count
-      content_view_versions.count
+      content_view_versions.size
     end
 
     def on_demand_repositories


### PR DESCRIPTION
Use size instead of count which just reuse the preloaded data if already available. See https://www.speedshop.co/2019/01/10/three-activerecord-mistakes.html

Before
[root@or v2]# grep SELECT /tmp/cv_opt2.log | grep COUNT | wc -l
47

Afterwards:
[root@or v2]# grep SELECT /tmp/cv_opt2.log | grep COUNT | wc -l
27

(20 CVs)