### PR TITLE
Fixes #37117 - Add link to SCA warning banner

### DIFF
--- a/app/views/overrides/organizations/_edit_override.html.erb
+++ b/app/views/overrides/organizations/_edit_override.html.erb
@@ -19,7 +19,8 @@
   end %>
 
   <div class="alert alert-warning" role="alert">
-    <%= _('Simple Content Access will be required for all organizations in Katello 4.12.') %>
+    <%= link_to _('Simple Content Access'), 'https://access.redhat.com/articles/transition_of_subscription_services_to_the_hybrid_cloud_console', :rel => "external" %>
+    <%= _(' will be required for all organizations in Katello 4.12.') %>
   </div>
 
 <% end %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add a hyperlink to the SCA warning banner on the Organization Edit page.

![image](https://github.com/Katello/katello/assets/22042343/74541cf0-88a9-4ab9-91ce-e684ee88bf1d)


#### Considerations taken when implementing this change?

This PR will be irrelevant once Katello 4.12 is branched, so it can't go on the `master` branch. Therefore, I am raising it against the `KATELLO-4.11` branch.

The original suggestion was to change the wording from 
```
Simple Content Access will be required for all organizations in Katello 4.12.
```

to
```
Simple Content Access is mandatory from Katello 4.12.
```

but I think "mandatory" sounds too harsh and punishing. So I left it as-is.


#### What are the testing steps for this pull request?

verify that the link works and opens in a new tab
