### PR TITLE
Fixes #37118 - Remove Virtual Guests in legacy UI for non hypervisors

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -51,8 +51,8 @@
           </button>
         </dd>
 
-        <dt ng-show="host.subscription_facet_attributes.virtual_guests" translate>Virtual Guests</dt>
-        <dd ng-show="host.subscription_facet_attributes.virtual_guests">
+        <dt ng-show="host.subscription_facet_attributes.virtual_guests.length" translate>Virtual Guests</dt>
+        <dd ng-show="host.subscription_facet_attributes.virtual_guests.length">
           <a ng-href="/content_hosts?search={{virtualGuestIds(host)}}"
              translate translate-n="host.subscription_facet_attributes.virtual_guests.length"
              translate-plural="{{ host.subscription_facet_attributes.virtual_guests.length }} Content Hosts">


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Virtual guests is returning an empty array when the host does not have any virtual guests. This is not present in the new UI, and I don't want to disrupt anything in the consumer.rb which could break something. Since the old UI will be going away soon and the issue is only present there, I just changed that section to hide that field/value if the array is empty.
* This does work correctly when `virt-who` reports in because then we do have values in the `virtual_guest` array, I did check this on my box and confirms the field shows up correctly.

#### Considerations taken when implementing this change?

* See above

#### What are the testing steps for this pull request?

* Register your devel box or a client to your Katello devel box
* Check out the old UI and see that is has a section called Virtual Guests (0)
* Check out PR
* Verify that section is gone

Screenshot before:
![guestbefore](https://github.com/Katello/katello/assets/1518655/488bcd63-7155-4c0f-8c4e-1478e96867dc)

Screenshot after:
![guestafter](https://github.com/Katello/katello/assets/1518655/857b021d-a034-48e1-8fc9-0b5b0829d006)
