### PR TITLE
Fixes #37123 - Correct virtual_host subscription facet name in Legacy UI

### DIFF
--- a/app/views/katello/api/v2/subscription_facet/show.json.rabl
+++ b/app/views/katello/api/v2/subscription_facet/show.json.rabl
@@ -7,6 +7,9 @@ child :subscription_facet => :subscription_facet_attributes do |_facet|
 
   child :hypervisor_host => :virtual_host do
     attributes :id, :name
+    node :display_name do |host|
+      host.to_label
+    end
   end
 
   child :virtual_guests => :virtual_guests do


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* We must have changed the name of the `subscription_facet_attributes.virtual_host` from `display_name` to `name` when we were doing stuff in the new UI, because it works fine there but we didn't check the old UI. This fixes that up, so it shows correctly the displays the guest/host mapping.

#### Considerations taken when implementing this change?
* N/A

#### What are the testing steps for this pull request?

* Spin up a 6.15/stream in beaker, need to be on the RH network so you can register a host to your box
* Check out PR
* Create a virt-who config for VMware (Ping me for creds if you don't have a login)
* Run the deploy script so it sends the guest/host mapping back
* Register a client to your 6.15/stream box and see if the host/guest mapping works correctly in the legacy UI(if you don't want to spin up a client on vmware, ping me and I can give you a test client to register.)
* Verify that the guest/host mapping looks correct in the legacy UI

Screenshot before:
![hostmapbefore](https://github.com/Katello/katello/assets/1518655/4772dff2-bb69-4bde-a8ea-0f6d921f21a9)

Screenshot after:
![hostmapafter](https://github.com/Katello/katello/assets/1518655/a8a0c868-8faf-4953-ab5a-485c5b6d2b51)
