### PR TITLE
Fixes #37137 - Use insert_all when creating available module streams

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -342,12 +342,13 @@ module Katello
             context: module_stream["context"]
           }
         end
-        AvailableModuleStream.insert_all(
-          streams,
-          unique_by: %w[name stream context],
-          returning: %w[id name stream context]
-        )
-
+        if streams.any?
+          AvailableModuleStream.insert_all(
+            streams,
+            unique_by: %w[name stream context],
+            returning: %w[id name stream context]
+          )
+        end
         indexed_module_streams = module_streams.index_by do |module_stream|
           available_module_stream_id_from(
                   name: module_stream["name"],
@@ -355,7 +356,6 @@ module Katello
                   context: module_stream["context"]
                 )
         end
-
         sync_available_module_stream_associations(indexed_module_streams)
       end
 

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -325,50 +325,73 @@ module Katello
         content_facet.update_repositories_by_paths(paths.compact)
       end
 
+      def available_module_stream_id_from(name:, stream:, context:)
+        AvailableModuleStream.find_by!(name: name, stream: stream, context: context).id
+      rescue ActiveRecord::RecordNotFound
+        Rails.logger.warn("Module stream not found: name: #{name}, stream: #{stream}, context: #{context}")
+        nil
+      end
+
       def import_module_streams(module_streams)
-        # create_or_find_by avoids race conditions during concurrent registrations but clogs postgres logs with harmless errors.
-        # So we'll use create_or_find_by! during registration and first_or_create! otherwise.
-        registered_time = subscription_facet&.registered_at
-        use_create_or_find_by = registered_time.nil? || registered_time > 1.minute.ago
-        streams = {}
-        module_streams.each do |module_stream|
-          if use_create_or_find_by
-            stream = AvailableModuleStream.create_or_find_by!(name: module_stream["name"],
-                                                context: module_stream["context"],
-                                                stream: module_stream["stream"])
-          else
-            stream = AvailableModuleStream.where(name: module_stream["name"],
-            context: module_stream["context"],
-            stream: module_stream["stream"]).first_or_create!
-          end
-          streams[stream.id] = module_stream
+        Rails.logger.debug "INSERT_ALL-------------------------------------"
+        Rails.logger.debug module_streams.first(3)
+        streams = module_streams.map do |module_stream|
+          {
+            name: module_stream["name"],
+            stream: module_stream["stream"],
+            context: module_stream["context"]
+          }
         end
-        sync_available_module_stream_associations(streams)
+        newly_added_records = AvailableModuleStream.insert_all(
+          streams,
+          unique_by: %w[name stream context],
+          returning: %w[id name stream context]
+        )
+        Rails.logger.debug "newly_added_records-------------------------------------"
+        Rails.logger.debug newly_added_records.to_a
+        # module_streams looks like this
+        # {"name"=>"389-ds", "stream"=>"1.4", "version"=>"8030020201203210520", "context"=>"e114a9e7", "arch"=>"x86_64", "profiles"=>[], "installed_profiles"=>[], "status"=>"default", "active"=>false}
+
+        indexed_module_streams = module_streams.index_by do |module_stream|
+          available_module_stream_id_from(
+                  name: module_stream["name"],
+                  stream: module_stream["stream"],
+                  context: module_stream["context"]
+                )
+        end
+        Rails.logger.debug "INDEXED_MODULE_STREAMS-------------------------------------"
+        Rails.logger.debug indexed_module_streams
+
+        sync_available_module_stream_associations(indexed_module_streams)
       end
 
       def sync_available_module_stream_associations(new_available_module_streams)
         upgradable_streams = self.host_available_module_streams.where(:available_module_stream_id => new_available_module_streams.keys)
+        new_associated_ids = new_available_module_streams.keys.compact
         old_associated_ids = self.available_module_stream_ids
-        delete_ids = old_associated_ids - new_available_module_streams.keys
+        delete_ids = old_associated_ids - new_associated_ids
 
         if delete_ids.any?
           self.host_available_module_streams.where(:available_module_stream_id => delete_ids).delete_all
         end
 
-        new_ids = new_available_module_streams.keys - old_associated_ids
-        new_ids.each do |new_id|
+        new_ids = new_associated_ids - old_associated_ids
+
+        hams_to_create = new_ids.map do |new_id|
           module_stream = new_available_module_streams[new_id]
           status = module_stream["status"]
           # Set status to "unknown" only if the active field is in use and set to false and the module is enabled
           if enabled_module_stream_inactive?(module_stream)
             status = "unknown"
           end
-          self.host_available_module_streams.create!(host_id: self.id,
-                                                     available_module_stream_id: new_id,
-                                                     installed_profiles: module_stream["installed_profiles"],
-                                                     status: status)
+          {
+            host_id: self.id,
+            available_module_stream_id: new_id,
+            installed_profiles: module_stream["installed_profiles"],
+            status: status
+          }
         end
-
+        HostAvailableModuleStream.insert_all(hams_to_create) if hams_to_create.any?
         upgradable_streams.each do |hams|
           module_stream = new_available_module_streams[hams.available_module_stream_id]
           shared_keys = hams.attributes.keys & module_stream.keys

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -367,6 +367,10 @@ module Katello
       assert_equal 2, @foreman_host.host_available_module_streams.unknown.count
     end
 
+    def clear_cached_available_module_streams
+      @foreman_host.instance_variable_set(:@indexed_available_module_streams, nil)
+    end
+
     def test_import_modules_with_update
       modules_json = [make_module_json("enabled21111", "enabled")]
       prior_count = HostAvailableModuleStream.count
@@ -384,6 +388,7 @@ module Katello
       assert_empty @foreman_host.reload.host_available_module_streams
       assert_equal prior_count, HostAvailableModuleStream.count
 
+      clear_cached_available_module_streams
       @foreman_host.import_module_streams([make_module_json("xxxx", "enabled", 'blah', ["default"])])
       assert_equal "enabled", @foreman_host.reload.host_available_module_streams.first.status
       assert_equal ["default"], @foreman_host.reload.host_available_module_streams.first.installed_profiles


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

During a profile upload, a host's module streams are updated in Katello's database.

In https://github.com/Katello/katello/pull/10412 we changed to using `create_or_find_by!` to create those records. This solved an issue where concurrent host registrations would sometimes fail due to a PostgreSQL error:

```
ERROR:  duplicate key value violates unique constraint "katello_available_module_streams_name_stream_context"
```

However, these errors are still inserted into postgres logs. They are harmless, but log files can fill up quickly. This is because there will be one log for _every_ module stream creation attempt, for every host with module streams, _not just at registration_ but also during every profile upload. This results in log files that can quickly build to 200000 lines with just those error logs.

With this change, we're now using `insert_all` to insert all of the records in a single SQL query, which should avoid the race condition.


#### Considerations taken when implementing this change?

This required some major refactoring, because

1. `import_module_streams` takes module stream data in a list of Hashes, but those don't include Katello's ID. (There's no way they could, as this info is coming from sub-man/dnf.)
2. In our previous implementation, we relied on the `id`s returned from `create_or_find_by` etc. to pass on to the next method, `sync_available_module_stream_associations`. `sync_available_module_stream_associations` requires a Hash indexed by database ID. 
3. Previously, the data passed to `sync_available_module_stream_associations` was _all_ of the host's available module streams, indexed by ID, _including_ the ones we just newly added. Thus, `new_available_module_streams` was a bit of a misnomer. I did some refactoring to recreate this format of the indexed hash.

#### What are the testing steps for this pull request?

1. `tail -f /var/lib/pgsql/data/log/postgresql-Thu.log` (replace Thu with whatever day it is today)
6. Register a host (without this patch) - Notice that the file fills up with error logs

```
2024-02-01 21:57:16 UTC STATEMENT:  INSERT INTO "katello_available_module_streams" ("name", "stream", "context") VALUES ($1, $2, $3) RETURNING "id"
2024-02-01 21:57:16 UTC ERROR:  duplicate key value violates unique constraint "katello_available_module_streams_name_stream_context"
2024-02-01 21:57:16 UTC DETAIL:  Key (name, stream, context)=(virt, rhel, 30b713e6) already exists.
```

You can also check how many logs there are:

```
grep 'duplicate key value violates unique constraint "katello_available_module_streams_name_stream_context"' /var/lib/pgsql/data/log/postgresql-Thu.log | wc -l
---
227950
---
```

7. Enable or disable a module stream - Notice that more error logs are created.
8. Check out this PR
9. Enable or disable a module stream - No new logs should be created.
10. Register a host - No new logs should be created.
