### PR TITLE
Fixes #37139 - Block content view publish during repository publication tasks

### DIFF
--- a/app/lib/actions/katello/repository/metadata_generate.rb
+++ b/app/lib/actions/katello/repository/metadata_generate.rb
@@ -1,8 +1,10 @@
 module Actions
   module Katello
     module Repository
-      class MetadataGenerate < Actions::Base
+      class MetadataGenerate < Actions::EntryAction
         def plan(repository, options = {})
+          action_subject(repository)
+          repository.check_ready_to_act!
           source_repository = options.fetch(:source_repository, nil)
           source_repository ||= repository.target_repository if repository.link?
           smart_proxy = options.fetch(:smart_proxy, SmartProxy.pulp_primary)
@@ -14,6 +16,10 @@ module Actions
                         :force_publication => force_publication,
                         :source_repository => source_repository,
                         :matching_content => matching_content)
+        end
+
+        def resource_locks
+          :link
         end
       end
     end

--- a/app/lib/actions/katello/repository/remove_content.rb
+++ b/app/lib/actions/katello/repository/remove_content.rb
@@ -5,6 +5,7 @@ module Actions
         include Dynflow::Action::WithSubPlans
 
         def plan(repository, content_units, options = {})
+          repository.check_ready_to_act!
           sync_capsule = options.fetch(:sync_capsule, true)
           if repository.redhat?
             fail _("Cannot remove content from a non-custom repository")

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -20,6 +20,7 @@ module Actions
         #   of Katello and we just need to finish the rest of the orchestration
         def plan(repo, options = {})
           action_subject(repo)
+          repo.check_ready_to_act!
 
           validate_contents = options.fetch(:validate_contents, false)
           skip_metadata_check = options.fetch(:skip_metadata_check, false) || (validate_contents && (repo.yum? || repo.deb?))

--- a/app/lib/actions/katello/repository/upload_files.rb
+++ b/app/lib/actions/katello/repository/upload_files.rb
@@ -8,6 +8,7 @@ module Actions
       class UploadFiles < Actions::EntryAction
         def plan(repository, files, content_type = nil, options = {})
           action_subject(repository)
+          repository.check_ready_to_act!
           repository.clear_smart_proxy_sync_histories
           tmp_files = prepare_tmp_files(files)
 

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -629,12 +629,21 @@ module Katello
         check_ready_to_import!
       else
         fail _("Import-only content views can not be published directly") if import_only? && !syncable
+        check_repositories_blocking_publish!
         check_composite_action_allowed!(organization.library)
         check_docker_repository_names!([organization.library])
         check_orphaned_content_facets!(environments: self.environments)
       end
 
       true
+    end
+
+    def check_repositories_blocking_publish!
+      repositories_with_blocking_tasks = repositories.select { |repo| repo.blocking_tasks }
+
+      if repositories_with_blocking_tasks.any?
+        fail _("Pending tasks detected in repositories of this content view. Please wait before publishing.")
+      end
     end
 
     def check_docker_repository_names!(environments)

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -641,6 +641,18 @@ module Katello
                                 for_resource(self).order(:started_at).last
     end
 
+    def blocking_tasks
+      blocking_task_labels = [
+        ::Actions::Katello::Repository::Sync.name,
+        ::Actions::Katello::Repository::UploadFiles.name
+      ]
+      ForemanTasks::Task::DynflowTask.where(:label => blocking_task_labels)
+                                     .where.not(state: 'stopped')
+                                     .for_resource(self)
+                                     .order(:started_at)
+                                     .last
+    end
+
     # returns other instances of this repo with the same library
     # equivalent of repo
     def environmental_instances(view)

--- a/test/actions/katello/repository/metadata_generate_test.rb
+++ b/test/actions/katello/repository/metadata_generate_test.rb
@@ -8,6 +8,7 @@ module Actions
 
     let(:action_class) { ::Actions::Katello::Repository::MetadataGenerate }
     let(:pulp_metadata_generate_class) { ::Actions::Pulp3::Orchestration::Repository::GenerateMetadata }
+    let(:success_task) { ForemanTasks::Task::DynflowTask.create!(state: :success, result: "good") }
     let(:yum_repo) { katello_repositories(:fedora_17_x86_64) }
     let(:yum_repo2) { katello_repositories(:fedora_17_x86_64_dev) }
     let(:action_options) do
@@ -20,6 +21,8 @@ module Actions
 
     it 'plans a yum metadata generate' do
       action = create_action(action_class)
+      action.stubs(:task).returns(success_task)
+      action.expects(:action_subject).with(yum_repo)
       plan_action(action, yum_repo)
 
       assert_action_planned_with(action, pulp_metadata_generate_class, yum_repo, SmartProxy.pulp_primary,
@@ -31,6 +34,7 @@ module Actions
       Location.current = taxonomies(:location1)
 
       action = create_action(action_class)
+      action.stubs(:task).returns(success_task)
       plan_action(action, yum_repo)
 
       assert_action_planned_with(action, pulp_metadata_generate_class, yum_repo, SmartProxy.pulp_primary,
@@ -41,6 +45,7 @@ module Actions
 
     it 'plans a yum refresh with source repo' do
       action = create_action(action_class)
+      action.stubs(:task).returns(success_task)
       plan_action(action, yum_repo, :source_repository => yum_repo2)
 
       yum_action_options = action_options.clone
@@ -52,6 +57,7 @@ module Actions
 
     it 'plans a yum refresh with matching content true' do
       action = create_action(action_class)
+      action.stubs(:task).returns(success_task)
       plan_action(action, yum_repo, :matching_content => true)
 
       yum_action_options = action_options.clone
@@ -62,6 +68,7 @@ module Actions
 
     it 'plans a yum refresh with matching content set to some deferred object' do
       action = create_action(action_class)
+      action.stubs(:task).returns(success_task)
       not_falsey = Object.new
       plan_action(action, yum_repo, :matching_content => not_falsey)
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Blocks content view publish task while certain repo actions (Sync/upload/remove content) are in progress. Similarly block these repo actions when corresponding CV publish is in progress.
#### Considerations taken when implementing this change?
There are multiple places in CV publish orchestration where we fetch repository contents. If repository contents are changed during a publication, different steps in the publish workflow will receive different versions of the repository with possibly different contents. This would lead to improper cv publications. 
#### What are the testing steps for this pull request?
Have a few repos and cvs with those repos. 
Try a combination of actions like sync/upload/remove content/generate metadata and associated CV publish to make sure the 2-way blocking works as expected.