### PR TITLE
Fixes #37144 - Use OS family for host details page packages tab

### DIFF
--- a/app/views/katello/api/v2/hosts/base.json.rabl
+++ b/app/views/katello/api/v2/hosts/base.json.rabl
@@ -4,6 +4,15 @@ object @resource
 @facet = @resource.content_facet
 
 attributes :id, :name, :description
+
+node :operatingsystem_family do |resource|
+  resource.operatingsystem.family
+end
+
+node :operatingsystem_major do |resource|
+  resource.operatingsystem.major
+end
+
 if @facet
   node :content_view do
     content_view = @facet&.single_content_view

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -303,6 +303,7 @@ Foreman::Plugin.register :katello do
 
   extend_rabl_template 'api/v2/smart_proxies/main', 'katello/api/v2/smart_proxies/pulp_info'
   extend_rabl_template 'api/v2/hosts/show', 'katello/api/v2/hosts/host_collections'
+  extend_rabl_template 'api/v2/hosts/show', 'katello/api/v2/hosts/show'
 
   # Katello variables for Host Registration
   extend_allowed_registration_vars :activation_keys

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -8,7 +8,7 @@ module Katello
     tests Katello::Api::V2::HostSubscriptionsController
 
     def models
-      @host = FactoryBot.create(:host, :with_subscription)
+      @host = FactoryBot.create(:host, :with_subscription, :with_operatingsystem)
       users(:restricted).update_attribute(:organizations, [@host.organization])
       users(:restricted).update_attribute(:locations, [@host.location])
       @pool = katello_pools(:pool_one)

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -12,7 +12,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     @environment = katello_environments(:library)
     @dev = katello_environments(:dev)
     @cv2 = katello_content_views(:library_view_no_version)
-    @host = FactoryBot.create(:host)
+    @host = FactoryBot.create(:host, :with_operatingsystem)
   end
 
   def host_index_and_show(host)
@@ -32,26 +32,26 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
   end
 
   def test_content_and_subscriptions
-    host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @content_view,
+    host = FactoryBot.create(:host, :with_content, :with_subscription, :with_operatingsystem, :content_view => @content_view,
                               :lifecycle_environment => @environment)
     host_index_and_show(host)
   end
 
   def test_with_content
-    host = FactoryBot.create(:host, :with_content, :content_view => @content_view,
+    host = FactoryBot.create(:host, :with_content, :with_operatingsystem, :content_view => @content_view,
                               :lifecycle_environment => @environment)
     host_index_and_show(host)
   end
 
   def test_no_content_view_environments
-    host = FactoryBot.create(:host, :with_content, :with_subscription)
+    host = FactoryBot.create(:host, :with_content, :with_subscription, :with_operatingsystem)
     assert_empty host.content_facet.content_view_environments
 
     host_index_and_show(host)
   end
 
   def test_content_facet_attributes_assigned_as_cve
-    host = FactoryBot.create(:host, :with_content, :with_subscription,
+    host = FactoryBot.create(:host, :with_content, :with_subscription, :with_operatingsystem,
                               :content_view => @content_view, :lifecycle_environment => @environment)
     Katello::Host::SubscriptionFacet.any_instance.expects(:backend_update_needed?).returns(false)
     orig_cves = host.content_facet.content_view_environment_ids.to_a
@@ -110,7 +110,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
   end
 
   def test_with_subscriptions
-    host = FactoryBot.create(:host, :with_subscription)
+    host = FactoryBot.create(:host, :with_subscription, :with_operatingsystem)
     host_index_and_show(host)
   end
 
@@ -122,7 +122,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     Katello::Candlepin::Consumer.any_instance.stubs(:virtual_guests).returns([])
     Katello::Candlepin::Consumer.any_instance.stubs(:installed_products).returns([])
 
-    host = FactoryBot.create(:host, :with_subscription)
+    host = FactoryBot.create(:host, :with_subscription, :with_operatingsystem)
     host.subscription_facet.update!(:autoheal => true,
                                                :installed_products_attributes => [{:product_name => 'foo', :version => '6', :product_id => '69'}])
 
@@ -136,7 +136,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
 
   def test_with_smartproxy
     smart_proxy = FactoryBot.create(:smart_proxy, :features => [FactoryBot.create(:feature, name: 'Pulp')])
-    host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @content_view,
+    host = FactoryBot.create(:host, :with_content, :with_subscription, :with_operatingsystem, :content_view => @content_view,
                               :lifecycle_environment => @environment, :content_source => smart_proxy)
     host_show(host, smart_proxy)
   end

--- a/test/factories/host_factory.rb
+++ b/test/factories/host_factory.rb
@@ -6,6 +6,10 @@ FactoryBot.modify do
       content_source { nil }
     end
 
+    trait :with_operatingsystem do
+      operatingsystem
+    end
+
     trait :with_content do
       association :content_facet, :factory => :content_facet, :strategy => :build
 

--- a/webpack/components/extensions/HostDetails/Tabs/DebsTab/DebsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/DebsTab/DebsTab.js
@@ -45,12 +45,7 @@ import { hasRequiredPermissions as can,
 import SortableColumnHeaders from '../../../../Table/components/SortableColumnHeaders';
 import { useRexJobPolling } from '../RemoteExecutionHooks';
 
-export const hideDebsTab = ({ hostDetails }) => {
-  const osMatch = hostDetails?.operatingsystem_name?.match(/(\D+) (\d+|\D+)/);
-  if (!osMatch) return false;
-  const [, os] = osMatch;
-  return !(osMatch && os.match(/Debian|Ubuntu/i));
-};
+export const hideDebsTab = ({ hostDetails }) => !(hostDetails?.operatingsystem_family === 'Debian');
 
 const invokeRexJobs = ['create_job_invocations'];
 const createBookmarks = ['create_bookmarks'];

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -47,14 +47,7 @@ import {
   userPermissionsFromHostDetails,
 } from '../../hostDetailsHelpers';
 
-const moduleStreamSupported = ({ os, version }) =>
-  os.match(/RedHat|RHEL|CentOS|Rocky|AlmaLinux|Oracle Linux/i) && Number(version) > 7;
-export const hideModuleStreamsTab = ({ hostDetails }) => {
-  const osMatch = hostDetails?.operatingsystem_name?.match(/(\D+) (\d+)/);
-  if (!osMatch) return false;
-  const [, os, version] = osMatch;
-  return !(osMatch && moduleStreamSupported({ os, version }));
-};
+export const hideModuleStreamsTab = ({ hostDetails }) => !(hostDetails?.operatingsystem_family === 'Redhat' && Number(hostDetails?.operatingsystem_major > 7));
 
 const EnabledIcon = ({ streamText, streamInstallStatus, upgradable }) => {
   switch (true) {

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -50,12 +50,7 @@ import { runSubmanRepos } from '../../Cards/ContentViewDetailsCard/HostContentVi
 const invokeRexJobs = ['create_job_invocations'];
 const createBookmarks = ['create_bookmarks'];
 
-export const hidePackagesTab = ({ hostDetails }) => {
-  const osMatch = hostDetails?.operatingsystem_name?.match(/(\D+) (\d+|\D+)/);
-  if (!osMatch) return false;
-  const [, os] = osMatch;
-  return !(osMatch && os.match(/RedHat|RHEL|CentOS|Rocky|AlmaLinux|Alma|Oracle Linux|Oracle|Suse Linux Enterprise Server|SLES/i));
-};
+export const hidePackagesTab = ({ hostDetails }) => !(hostDetails?.operatingsystem_family?.match(/RedHat|SUSE/i));
 
 const UpdateVersionsSelect = ({
   packageName,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
At the moment, the packages sub tab on the new host details page is shown based on the description of the operating system (e.g. checking whether it should load rpm or debs). The condition checks for various strings, but the description itself can be randomly assigned by the user. Hence, this is not a safe method to determine which OS was used.

#### Considerations taken when implementing this change?
We need to find an unchangeable attribute to test against for the content packages tabs which is the operatingsystem family. 

#### What are the testing steps for this pull request?
Have a host with packages and some OS. Change OS name to something like "Test OS" --> Host packages should still be available. 