### PR TITLE
Fixes #36988 - CV version should display Container manifest list count

### DIFF
--- a/webpack/scenes/ContentViews/ContentViewsConstants.js
+++ b/webpack/scenes/ContentViews/ContentViewsConstants.js
@@ -9,6 +9,7 @@ const MODULE_STREAMS_KEY = 'MODULE_STREAMS';
 const DEB_PACKAGES_KEY = 'DEB_PACKAGES';
 const DOCKER_TAGS_KEY = 'DOCKER_TAGS';
 const FILES_KEY = 'FILES';
+const CONTAINER_MANIFEST_LISTS_KEY = 'CONTAINER_MANIFEST_LISTS';
 export const CREATE_CONTENT_VIEW_KEY = 'CONTENT_VIEW_CREATE';
 export const COPY_CONTENT_VIEW_KEY = 'CONTENT_VIEW_COPY';
 export const CREATE_CONTENT_VIEW_FILTER_KEY = 'CONTENT_VIEW_FILTER_CREATE';
@@ -31,6 +32,7 @@ export const RPM_PACKAGE_GROUPS_CONTENT = 'RPM_PACKAGE_GROUPS_CONTENT';
 export const REPOSITORY_CONTENT = 'REPOSITORY_CONTENT';
 export const ERRATA_CONTENT = 'ERRATA_CONTENT';
 export const DOCKER_TAGS_CONTENT = 'DOCKER_TAGS_CONTENT';
+export const CONTAINER_MANIFEST_LIST_CONTENT = 'CONTAINER_MANIFEST_LIST_CONTENT';
 export const MODULE_STREAMS_CONTENT = 'MODULE_STREAMS_CONTENT';
 export const DEB_PACKAGES_CONTENT = 'DEB_PACKAGES_CONTENT';
 export const RPM_PACKAGES_CONTENT = 'RPM_PACKAGES_CONTENT';
@@ -72,6 +74,7 @@ export const cvErrataCompareKey = (versionOne, versionTwo, viewBy) => `${ERRATA_
 export const cvModuleStreamsCompareKey = (versionOne, versionTwo, viewBy) => `${MODULE_STREAMS_KEY}_COMPARE_${versionOne}_${versionTwo}_VIEW_BY_${toUpper(viewBy)}`;
 export const cvDebPackagesCompareKey = (versionOne, versionTwo, viewBy) => `${DEB_PACKAGES_KEY}_COMPARE_${versionOne}_${versionTwo}_VIEW_BY_${toUpper(viewBy)}`;
 export const cvDockerTagsCompareKey = (versionOne, versionTwo, viewBy) => `${DOCKER_TAGS_KEY}_COMPARE_${versionOne}_${versionTwo}_VIEW_BY_${toUpper(viewBy)}`;
+export const cvContainerManifestListsCompareKey = (versionOne, versionTwo, viewBy) => `${CONTAINER_MANIFEST_LISTS_KEY}_COMPARE_${versionOne}_${versionTwo}_VIEW_BY_${toUpper(viewBy)}`;
 export const filesCompareKey = (versionOne, versionTwo, viewBy) => `${FILES_KEY}_COMPARE_${versionOne}_${versionTwo}_VIEW_BY_${toUpper(viewBy)}`;
 // Repo added to content view status display and key
 export const ADDED = __('Added');

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailActions.js
@@ -47,6 +47,7 @@ import {
   MODULE_STREAMS_CONTENT,
   DEB_PACKAGES_CONTENT,
   DOCKER_TAGS_CONTENT,
+  CONTAINER_MANIFEST_LIST_CONTENT,
   generatedContentKey,
   STATUS_TRANSLATIONS_ENUM,
   bulkRemoveVersionKey,
@@ -58,7 +59,7 @@ import {
   cvDebPackagesCompareKey,
   filesCompareKey,
   genericContentCompareKey,
-  cvRepositoriesCompareKey,
+  cvRepositoriesCompareKey, cvContainerManifestListsCompareKey,
 } from '../ContentViewsConstants';
 import api, { foremanApi, orgId } from '../../../services/api';
 import { getResponseErrorMsgs } from '../../../utils/helpers';
@@ -179,6 +180,19 @@ export const getDockerTagsComparison = (versionOne, versionTwo, viewBy, params) 
   });
 };
 
+export const getContainerManifestListsComparison = (versionOne, versionTwo, viewBy, params) => {
+  const versions = { content_view_version_ids: [versionOne, versionTwo] };
+  const restrictComparison = { restrict_comparison: viewBy };
+  const apiParams = { ...versions, ...restrictComparison, ...params };
+  const apiUrl = '/docker_manifest_lists/compare';
+  return get({
+    key: cvContainerManifestListsCompareKey(versionOne, versionTwo, viewBy),
+    params: apiParams,
+    errorToast: error => __(`Something went wrong while retrieving the container tags! ${getResponseErrorMsgs(error.response)}`),
+    url: api.getApiUrl(apiUrl),
+  });
+};
+
 export const getFilesComparison = (versionOne, versionTwo, viewBy, params) => {
   const versions = { content_view_version_ids: [versionOne, versionTwo] };
   const restrictComparison = { restrict_comparison: viewBy };
@@ -266,6 +280,14 @@ export const getDockerTags = params => get({
   url: api.getApiUrl('/docker_tags'),
   params,
   errorToast: error => __(`Something went wrong while getting container tags! ${getResponseErrorMsgs(error.response)}`),
+});
+
+export const getContainerManifestLists = params => get({
+  type: API_OPERATIONS.GET,
+  key: CONTAINER_MANIFEST_LIST_CONTENT,
+  url: api.getApiUrl('/docker_manifest_lists'),
+  params,
+  errorToast: error => __(`Something went wrong while getting container manifest lists! ${getResponseErrorMsgs(error.response)}`),
 });
 
 export const getErrata = params => get({

--- a/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetailSelectors.js
@@ -44,7 +44,10 @@ import {
   cvDockerTagsCompareKey,
   cvDebPackagesCompareKey,
   filesCompareKey,
-  genericContentCompareKey, cvRepositoriesCompareKey,
+  genericContentCompareKey,
+  cvRepositoriesCompareKey,
+  CONTAINER_MANIFEST_LIST_CONTENT,
+  cvContainerManifestListsCompareKey,
 } from '../ContentViewsConstants';
 
 export const selectCVDetails = (state, cvId) =>
@@ -191,6 +194,15 @@ export const selectDockerTagsComparisonStatus = (state, versionOne, versionTwo, 
 export const selectDockerTagsComparisonError = (state, versionOne, versionTwo, viewBy) =>
   selectAPIError(state, cvDockerTagsCompareKey(versionOne, versionTwo, viewBy));
 
+export const selectContainerManifestListsComparison = (state, versionOne, versionTwo, viewBy) =>
+  selectAPIResponse(state, cvContainerManifestListsCompareKey(versionOne, versionTwo, viewBy))
+    || {};
+
+export const selectContainerManifestListsComparisonStatus =
+    (state, versionOne, versionTwo, viewBy) =>
+      selectAPIStatus(state, cvContainerManifestListsCompareKey(versionOne, versionTwo, viewBy))
+    || STATUS.PENDING;
+
 export const selectDebPackagesComparison = (state, versionOne, versionTwo, viewBy) =>
   selectAPIResponse(state, cvDebPackagesCompareKey(versionOne, versionTwo, viewBy)) || {};
 
@@ -242,6 +254,12 @@ export const selectDockerTags = state =>
 
 export const selectDockerTagsStatus = state =>
   selectAPIStatus(state, DOCKER_TAGS_CONTENT) || STATUS.PENDING;
+
+export const selectContainerManifestLists = state =>
+  selectAPIResponse(state, CONTAINER_MANIFEST_LIST_CONTENT);
+
+export const selectContainerManifestListsStatus = state =>
+  selectAPIStatus(state, CONTAINER_MANIFEST_LIST_CONTENT) || STATUS.PENDING;
 
 export const selectRepositories = state =>
   selectAPIResponse(state, REPOSITORY_CONTENT);

--- a/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareConfig.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareConfig.js
@@ -21,6 +21,8 @@ import {
   selectDebPackagesComparisonStatus,
   selectDockerTagsComparison,
   selectDockerTagsComparisonStatus,
+  selectContainerManifestListsComparison,
+  selectContainerManifestListsComparisonStatus,
   selectGenericContentComparison,
   selectGenericContentComparisonStatus,
   selectRepositoriesComparison,
@@ -34,6 +36,7 @@ import {
   getModuleStreamsComparison,
   getDebPackagesComparison,
   getDockerTagsComparison,
+  getContainerManifestListsComparison,
   getGenericContentComparison,
   getRepositoriesComparison,
 } from '../../ContentViewDetailActions';
@@ -361,10 +364,10 @@ export default ({
             </a>),
         },
         {
-          title: __('Available Schema Versions'),
+          title: __('Available schema versions'),
           getProperty: (item) => {
-            if (item?.manifest_schema1) return __('Schema Version 1');
-            return __('Schema Version 2');
+            if (item?.manifest_schema1) return __('Schema version 1');
+            return __('Schema version 2');
           },
         },
         {
@@ -380,6 +383,37 @@ export default ({
       ],
       sortConfig: {
         [__('Name')]: 'name',
+      },
+    },
+    {
+      name: __('Container manifest lists'),
+      getCountKey: (itemVersionOne, itemVersionTwo) =>
+          itemVersionOne?.docker_manifest_list_count || itemVersionTwo?.docker_manifest_list_count,
+      responseSelector: state =>
+        selectContainerManifestListsComparison(state, versionOneId, versionTwoId, viewBy),
+      statusSelector: state =>
+        selectContainerManifestListsComparisonStatus(state, versionOneId, versionTwoId, viewBy),
+      autocompleteEndpoint: '/katello/api/v2/docker_manifest_lists',
+      bookmarkController: 'katello_content_view_components',
+      fetchItems: params =>
+        getContainerManifestListsComparison(versionOneId, versionTwoId, viewBy, params),
+      columnHeaders: [
+        {
+          title: __('Digest'),
+          getProperty: item => item?.digest,
+        },
+        {
+          title: __('Available schema versions'),
+          getProperty: (item) => {
+            if (item?.manifest_schema1) return __('Schema version 1');
+            return __('Schema version 2');
+          },
+        },
+        { title: __(`Version ${versionOne}`), getProperty: item => compareContent(item, versionOneId) },
+        { title: __(`Version ${versionTwo}`), getProperty: item => compareContent(item, versionTwoId) },
+      ],
+      sortConfig: {
+        [__('Digest')]: 'digest',
       },
     },
     ...ContentConfig.filter(config => !(config.names.pluralLabel === 'ostree_refs')).map(({

--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionContent.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionContent.js
@@ -11,12 +11,12 @@ const ContentViewVersionContent = ({ cvId, versionId, cvVersion }) => {
   const {
     deb_count: debCount = 0,
     docker_manifest_count: dockerManifestCount = 0,
+    docker_manifest_list_count: dockerManifestListCount = 0,
     docker_tag_count: dockerTagCount = 0,
     file_count: fileCount = 0,
     module_stream_count: moduleStreamCount = 0,
     ansible_collection_count: ansibleCollectionCount = 0,
   } = cvVersion;
-
 
   const contentConfigTypes = ContentConfig.filter(({ names: { singularLabel } }) =>
     !!cvVersion[`${singularLabel}_count`])
@@ -37,7 +37,7 @@ const ContentViewVersionContent = ({ cvId, versionId, cvVersion }) => {
   const noCounts =
     !Number(debCount) && !Number(dockerManifestCount) && !Number(dockerTagCount) &&
     !Number(fileCount) && !Number(moduleStreamCount) && !Number(ansibleCollectionCount) &&
-    !contentConfigTypes?.length;
+    !Number(dockerManifestListCount) && !contentConfigTypes?.length;
 
   if (noCounts) {
     return <InactiveText text={__('No content')} />;
@@ -67,6 +67,13 @@ const ContentViewVersionContent = ({ cvId, versionId, cvVersion }) => {
           <a href={urlBuilder(`content_views/${cvId}#/versions/${versionId}/dockerTags`, '')}>{`${dockerManifestCount} Container manifests`}</a><br />
         </>
       }
+      {dockerManifestListCount > 0 &&
+      <>
+        <Link to={`/versions/${versionId}/dockerManifestList`}>
+          {`${dockerManifestListCount} Container manifest lists`}
+        </Link><br />
+      </>
+      }
       {fileCount > 0 &&
         <>
           <a href={urlBuilder(`content_views/${cvId}#/versions/${versionId}/files`, '')}>{`${fileCount} Files`}</a><br />
@@ -90,6 +97,7 @@ ContentViewVersionContent.propTypes = {
   cvVersion: PropTypes.shape({
     deb_count: PropTypes.number,
     docker_manifest_count: PropTypes.number,
+    docker_manifest_list_count: PropTypes.number,
     docker_tag_count: PropTypes.number,
     file_count: PropTypes.number,
     module_stream_count: PropTypes.number,

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
@@ -20,7 +20,7 @@ import {
   getPackageGroups,
   getRepositories,
   getRPMPackages,
-  getContent,
+  getContent, getContainerManifestLists,
 } from '../../ContentViewDetailActions';
 import {
   selectCVVersions,
@@ -42,7 +42,7 @@ import {
   selectRPMPackages,
   selectRPMPackagesStatus,
   selectContent,
-  selectContentStatus,
+  selectContentStatus, selectContainerManifestLists, selectContainerManifestListsStatus,
 } from '../../ContentViewDetailSelectors';
 import ContentViewVersionRepositoryCell from './ContentViewVersionRepositoryCell';
 import ContentConfig from '../../../../Content/ContentConfig';
@@ -324,10 +324,10 @@ export default ({ cvId, versionId }) => [
           </a>),
       },
       {
-        title: __('Available Schema Versions'),
+        title: __('Available schema versions'),
         getProperty: (item) => {
-          if (item?.manifest_schema1) return __('Schema Version 1');
-          return __('Schema Version 2');
+          if (item?.manifest_schema1) return __('Schema version 1');
+          return __('Schema version 2');
         },
       },
       {
@@ -338,6 +338,32 @@ export default ({ cvId, versionId }) => [
           </a>),
       },
       { title: __('Image'), getProperty: item => item?.upstream_name },
+    ],
+  },
+  {
+    name: __('Container manifest lists'),
+    route: 'dockerManifestList',
+    repoType: 'docker',
+    getCountKey: item => item?.docker_manifest_list_count,
+    responseSelector: state => selectContainerManifestLists(state),
+    statusSelector: state => selectContainerManifestListsStatus(state),
+    autocompleteEndpoint: '/katello/api/v2/docker_manifest_lists',
+    autocompleteQueryParams: { content_view_version_id: versionId },
+    bookmarkController: 'katello_content_view_components',
+    fetchItems: params =>
+      getContainerManifestLists({ content_view_version_id: versionId, ...params }),
+    columnHeaders: [
+      {
+        title: __('Digest'),
+        getProperty: item => item?.digest,
+      },
+      {
+        title: __('Available schema versions'),
+        getProperty: (item) => {
+          if (item?.manifest_schema1) return __('Schema version 1');
+          return __('Schema version 2');
+        },
+      },
     ],
   },
   ...ContentConfig.map(({


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add container mainfest list views to CV versions and details and CV version comparison
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a couple container repos
2. Create a CV with the repo and publish a couple versions.
3. Make sure you can see container manifest list count in the versions list table under Additional Content
4. Make sure you see a vertical tab for it in the Version details view
5. Make sure you a container manifest list tab in CV version comparison screen when selecting and comparing 2 versions.