### PR TITLE
Fixes #37162 - Make sure ESXi check in is reflected in sub facet

### DIFF
--- a/app/lib/actions/katello/host/hypervisors_update.rb
+++ b/app/lib/actions/katello/host/hypervisors_update.rb
@@ -169,6 +169,7 @@ module Actions
           if @candlepin_attributes.key?(uuid)
             host.subscription_facet.candlepin_consumer.consumer_attributes = @candlepin_attributes[uuid]
             host.subscription_facet.import_database_attributes
+            host.subscription_facet.last_checkin = Time.now
             host.subscription_facet.save!
             host.subscription_facet.update_subscription_status(@candlepin_attributes[uuid].try(:[], :entitlementStatus))
           end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* When the hypervisors checkin from a `virt-who` report we call the method `update_hosts` which calls `update_subscripiton_facet`
* In `update_subscripiton_facet` we were not declaring the checkin time. We only created a fake subscription_facet for an ESXi host on initial check-in and creation
* Since ESXi does not have `rhsmcertd` running, it cannot check in like a RHEL host can and update its own `subscription_facet`
* This makes sure each time we get a report from virt-who we make sure the checkin time in the UI reflects when the report was recieved

#### Considerations taken when implementing this change?
* There is another bug I am filing with virt-who were after 6 days it just stops sending the report until the service is restarted.
* https://issues.redhat.com/browse/RHEL-25413

#### What are the testing steps for this pull request?
* Either install virt-who configure plugin either by adding it to forklift in extra plugins, or cloning the repo, adding to bundler.d in the foreman directory and then doing a db:migrate db:seed or spin up a stream box with Beaker
* Check out PR
* Create a config for VMware (Ping me for creds) set it for an hour or lower
* Run the deploy scripts for each one, verify that each report updates in the UI
* Check the UI to make sure the check in time reflects correctly
* Check on it for a few hours with virt-who running on your box and see if you notice it keeping up with the check in