### PR TITLE
Fixes #36803 - Smart Proxy content repair

### DIFF
--- a/app/controllers/katello/api/v2/capsule_content_controller.rb
+++ b/app/controllers/katello/api/v2/capsule_content_controller.rb
@@ -112,6 +112,14 @@ module Katello
       respond_for_async :resource => task
     end
 
+    api :POST, '/capsules/:id/verify_checksum', N_('Check for missing or corrupted artifacts, and attempt to redownload them.')
+    param :id, :number, :required => true, :desc => N_('Id of the smart proxy')
+    def verify_checksum
+      find_capsule(true)
+      task = async_task(::Actions::Pulp3::CapsuleContent::VerifyChecksum, @capsule)
+      respond_for_async :resource => task
+    end
+
     protected
 
     def respond_for_lifecycle_environments_index(environments)

--- a/app/lib/actions/pulp3/capsule_content/verify_checksum.rb
+++ b/app/lib/actions/pulp3/capsule_content/verify_checksum.rb
@@ -1,0 +1,16 @@
+module Actions
+  module Pulp3
+    module CapsuleContent
+      class VerifyChecksum < Pulp3::AbstractAsyncTask
+        def plan(smart_proxy)
+          action_subject(smart_proxy)
+          plan_self(smart_proxy_id: smart_proxy.id)
+        end
+
+        def invoke_external_task
+          output[:pulp_tasks] = ::Katello::Pulp3::Api::Core.new(SmartProxy.find(input[:smart_proxy_id])).repair
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/api/core.rb
+++ b/app/services/katello/pulp3/api/core.rb
@@ -136,6 +136,10 @@ module Katello
           client
         end
 
+        def repair_api
+          PulpcoreClient::RepairApi.new(core_api_client)
+        end
+
         def uploads_api
           PulpcoreClient::UploadsApi.new(core_api_client)
         end
@@ -228,6 +232,10 @@ module Katello
           self.class.fetch_from_list do |page_opts|
             remotes_api.list(page_opts.merge(options))
           end
+        end
+
+        def repair
+          repair_api.post(PulpcoreClient::Repair.new(verify_checksums: true))
         end
 
         def self.fetch_from_list

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -29,6 +29,7 @@ Katello::Engine.routes.draw do
               get :sync, :action => :sync_status
               delete :sync, :action => :cancel_sync
               post :reclaim_space
+              post :verify_checksum
               post '/lifecycle_environments' => 'capsule_content#add_lifecycle_environment'
               delete '/lifecycle_environments/:environment_id' => 'capsule_content#remove_lifecycle_environment'
             end

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -54,7 +54,7 @@ module Katello
       @plugin.permission :manage_capsule_content,
                          {
                            'katello/api/v2/capsule_content' => [:add_lifecycle_environment, :remove_lifecycle_environment,
-                                                                :update_counts, :sync, :reclaim_space, :cancel_sync],
+                                                                :update_counts, :sync, :reclaim_space, :verify_checksum, :cancel_sync],
                            'katello/api/v2/capsules' => [:index, :show]
                          },
                          :resource_type => 'SmartProxy'


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Implements "Verify checksum" or repair task for capsules
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
On the UI > capsule > click on sync dropdown and select Verify Checksum
You should see a task starting and calling the Pulp -> Repair task on the capsule.