### PR TITLE
Fixes #34044 - stop caring about array order in test_sync_container_gateway

### DIFF
--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -248,9 +248,12 @@ module Katello
       with_pulp3_features(capsule_content.smart_proxy)
       capsule_content.smart_proxy.add_lifecycle_environment(environment)
 
-      repo_list_update_expectation = ProxyAPI::ContainerGateway.any_instance.expects(:repository_list).with({
-                                                                                                              :repositories => [{:repository => "empty_organization-puppet_product-busybox", :auth_required => true}, {:repository => "busybox", :auth_required => true}]
-                                                                                                            })
+      expected_repo_list_args = {
+        :repositories => [{:repository => "empty_organization-puppet_product-busybox", :auth_required => true}, {:repository => "busybox", :auth_required => true}]
+      }
+      repo_list_update_expectation = ProxyAPI::ContainerGateway.any_instance.expects(:repository_list).with do |value|
+        Set.new(value[:repositories]) == Set.new(expected_repo_list_args[:repositories])
+      end
       repo_list_update_expectation.once.returns(true)
 
       repo_mapping_update_expectation = ProxyAPI::ContainerGateway.any_instance.expects(:user_repository_mapping).with do |arg|


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

I'm hoping this will fix an intermittent test failure in Katello CI:

```
[2024-02-13T21:28:49.603Z] Failure:

[2024-02-13T21:28:49.603Z] Katello::SmartProxyExtensionsTest#test_sync_container_gateway [/home/jenkins/workspace/foreman-pr-katello-test/app/models/katello/concerns/smart_proxy_extensions.rb:199]

[2024-02-13T21:28:49.603Z] Minitest::Assertion: unexpected invocation: #<AnyInstance:ProxyAPI::ContainerGateway>.repository_list({:repositories => [{:repository => "busybox", :auth_required => true}, {:repository => "empty_organization-puppet_product-busybox", :auth_required => true}]})

[2024-02-13T21:28:49.603Z] unsatisfied expectations:

[2024-02-13T21:28:49.603Z] - expected exactly once, invoked never: #<AnyInstance:ProxyAPI::ContainerGateway>.user_repository_mapping()

[2024-02-13T21:28:49.603Z] - expected exactly once, invoked never: #<AnyInstance:ProxyAPI::ContainerGateway>.repository_list({:repositories => [{:repository => "empty_organization-puppet_product-busybox", :auth_required => true}, {:repository => "busybox", :auth_required => true}]})

[2024-02-13T21:28:49.603Z] - expected exactly once, invoked never: #<SmartProxy:0x88f1d0>.container_gateway_users(any_parameters)
```

Example failure: https://ci.theforeman.org/blue/organizations/jenkins/foreman-pr-katello-test/detail/foreman-pr-katello-test/2326/pipeline/


#### Considerations taken when implementing this change?

I can't reproduce the failure locally; it's very intermittent and seems to only happen on CI

#### What are the testing steps for this pull request?

I guess just run the tests a bunch of times
