### PR TITLE
Fixes #35215 - Handle cloned hostgroups in hosts_and_hostgroups_helper

### DIFF
--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -72,6 +72,10 @@ module Katello
     def fetch_lifecycle_environment(host_or_hostgroup, options = {})
       return host_or_hostgroup.single_lifecycle_environment if host_or_hostgroup.try(:single_lifecycle_environment)
       return host_or_hostgroup.lifecycle_environment if host_or_hostgroup.try(:lifecycle_environment)
+      if host_or_hostgroup.is_a?(::Hostgroup) && host_or_hostgroup.content_facet.present?
+        # to handle cloned hostgroups that are new records
+        return host_or_hostgroup.content_facet.lifecycle_environment
+      end
       selected_host_group = options.fetch(:selected_host_group, nil)
       return selected_host_group.lifecycle_environment if selected_host_group.present?
     end
@@ -79,12 +83,20 @@ module Katello
     def fetch_content_view(host_or_hostgroup, options = {})
       return host_or_hostgroup.single_content_view if host_or_hostgroup.try(:single_content_view)
       return host_or_hostgroup.content_view if host_or_hostgroup.try(:content_view)
+      if host_or_hostgroup.is_a?(::Hostgroup) && host_or_hostgroup.content_facet.present?
+        # to handle cloned hostgroups that are new records
+        return host_or_hostgroup.content_facet.content_view
+      end
       selected_host_group = options.fetch(:selected_host_group, nil)
       return selected_host_group.content_view if selected_host_group.present?
     end
 
-    def fetch_content_source(host, options = {})
-      return host.content_source if host.try(:content_source_id)
+    def fetch_content_source(host_or_hostgroup, options = {})
+      return host_or_hostgroup.content_source if host_or_hostgroup.content_source_id&.present? && host_or_hostgroup.persisted?
+      if host_or_hostgroup.is_a?(::Hostgroup) && host_or_hostgroup.content_facet.present?
+        # to handle cloned hostgroups that are new records
+        return host_or_hostgroup.content_facet.content_source
+      end
       selected_host_group = options.fetch(:selected_host_group, nil)
       return selected_host_group.content_source if selected_host_group.present?
     end


### PR DESCRIPTION
Requires https://github.com/theforeman/foreman/pull/10055

#### What are the changes introduced in this pull request?

When cloning a hostgroup, all existing hostgroup attributes should be pre-filled on the new form. However, some fields were not being pre-populated, including

- Content source
- Lifecycle environment
- Content view

There were two reasons for this.

First, I discovered that when a hostgroup is cloned, its content facet was not also being cloned. Because of this, only the "main" attributes were being copied over, and not the content facet attributes above. That should be addressed for all facets, not just content, so that fix is in https://github.com/theforeman/foreman/pull/10055.

Second, `host_and_hostgroups_helper` has a few methods to fetch the existing values:

- fetch_lifecycle_environment
- fetch_content_view
- fetch_content_source

These methods were returning `nil` for the newly-cloned hostgroup. I think this is because they relied on Rails associations which assume all the records are already saved in the database. The problem with cloned hostgroups is that the record is a new record, and is not yet saved in the database. For example, when calling `host_or_hostgroup.lifecycle_environment` (assuming `host_or_hostgroup` is a `::Hostgroup`), Rails normally looks at its associations:

```rb
# app/models/katello/concerns/hostgroup_extensions.rb

has_one :lifecycle_environment, :through => :content_facet
```

Rails is probably trying to look up the content facet via its ID, so that it can then retrieve the lifecycle environment. But since the content facet is a new record and does not have an ID, it would not be able to do this. I got around this by calling `host_or_hostgroup.content_facet.lifecycle_environment` directly, which seems to work. 

I also made similar changes for content view and content source.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Clone a hostgroup and verify that content source, lifecycle environment, and content view values are properly cloned
Save the cloned hostgroup and verify everything works as expected

