### PR TITLE
Refs #37181 - Add module stream info to cv filter rules rabl

### DIFF
--- a/app/views/katello/api/v2/content_view_filter_rules/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_filter_rules/show.json.rabl
@@ -15,4 +15,13 @@ attributes :architecture, :if => lambda { |rule| rule.respond_to?(:architecture)
 attributes :types, :if => lambda { |rule| rule.respond_to?(:types) && !rule.types.blank? }
 attributes :date_type, :if => lambda { |rule| rule.respond_to?(:date_type) }
 attributes :module_stream_id, :if => lambda { |rule| rule.respond_to?(:module_stream_id) && !rule.module_stream_id.blank? }
+if @resource&.try(:module_stream)
+  node :module_stream do |rule|
+    {
+      :module_stream_id => rule.module_stream.id,
+      :module_stream_name => rule.module_stream.name,
+      :module_stream_stream => rule.module_stream.stream
+    }
+  end
+end
 extends 'katello/api/v2/common/timestamps'


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Added ID, Name, Stream to rabl for better filter info when we use hammer.

#### Considerations taken when implementing this change?
* N/A

#### What are the testing steps for this pull request?
* Create a CV with a module stream exclude or include filter 
* Check out PR
* With hammer run `hammer -d content-view filter rule info --content-view-filter-id X --id X` and see if you see the new attributes coming down, will make a hammer PR for this once this gets merged.