### PR TITLE
Fixes #37178 - use safe navigation for operatingsystem

### DIFF
--- a/app/views/katello/api/v2/hosts/base.json.rabl
+++ b/app/views/katello/api/v2/hosts/base.json.rabl
@@ -6,11 +6,11 @@ object @resource
 attributes :id, :name, :description
 
 node :operatingsystem_family do |resource|
-  resource.operatingsystem.family
+  resource.operatingsystem&.family
 end
 
 node :operatingsystem_major do |resource|
-  resource.operatingsystem.major
+  resource.operatingsystem&.major
 end
 
 if @facet


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Use Ruby safe navigation operator for `operatingsystem`. This fixes a bug introduced in https://github.com/Katello/katello/pull/10881

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Clone a registered rhel8 host
Make sure you can display the host details page without getting a 500
