### PR TITLE
Fixes #37192 - Use with_enabled_email scope

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -52,7 +52,7 @@ module Actions
           notification = MailNotification[:proxy_sync_failure]
           proxy = SmartProxy.find(input.fetch(:smart_proxy, {})[:id])
           subjects = subjects(input[:options]).merge(smart_proxy: proxy)
-          notification.users.where(disabled: [nil, false], mail_enabled: true).each do |user|
+          notification.users.with_enabled_email.each do |user|
             notification.deliver(subjects.merge(user: user, task: task))
           end
         end

--- a/app/lib/actions/katello/content_view/promote.rb
+++ b/app/lib/actions/katello/content_view/promote.rb
@@ -27,7 +27,7 @@ module Actions
         def notify_on_failure(_plan)
           notification = MailNotification[:content_view_promote_failure]
           view = ::Katello::ContentView.find(input.fetch(:content_view, {})[:id])
-          notification.users.where(disabled: [nil, false], mail_enabled: true).each do |user|
+          notification.users.with_enabled_email.each do |user|
             notification.deliver(user: user, content_view: view, task: task)
           end
         end

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -136,7 +136,7 @@ module Actions
         def notify_on_failure(_plan)
           notification = MailNotification[:content_view_publish_failure]
           view = ::Katello::ContentView.find(input.fetch(:content_view, {})[:id])
-          notification.users.where(disabled: [nil, false], mail_enabled: true).each do |user|
+          notification.users.with_enabled_email.each do |user|
             notification.deliver(user: user, content_view: view, task: task)
           end
         end

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -100,7 +100,7 @@ module Actions
         def notify_on_failure(_plan)
           notification = MailNotification[:repository_sync_failure]
           repo = ::Katello::Repository.find(input.fetch(:repository, {})[:id])
-          notification.users.where(disabled: [nil, false], mail_enabled: true).each do |user|
+          notification.users.with_enabled_email.each do |user|
             notification.deliver(user: user, repo: repo, task: task)
           end
         end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -4,7 +4,7 @@ require 'katello/host_status_manager'
 # rubocop:disable Metrics/BlockLength
 
 Foreman::Plugin.register :katello do
-  requires_foreman '>= 3.7'
+  requires_foreman '>= 3.11'
   register_gettext
 
   sub_menu :top_menu, :content_menu, :caption => N_('Content'),


### PR DESCRIPTION
Instead of typing out the same query explicitly.

#### What are the changes introduced in this pull request?

Reusing a scope introduced in https://github.com/theforeman/foreman/pull/9892 from foreman instead of doing the same thing explicitly.

#### What are the testing steps for this pull request?

Email notifications on capsule sync, cv promote, cv publish and repo sync should still work exactly as they did, but now with less code.