### PR TITLE
Fixes #37194 - Uses ENV option for RHSM and UPSTREAM_RHSM api url

### DIFF
--- a/app/lib/katello/resources/candlepin/upstream_job.rb
+++ b/app/lib/katello/resources/candlepin/upstream_job.rb
@@ -11,7 +11,7 @@ module Katello
           end
 
           def get(id, upstream)
-            url = API_URL
+            url = ENV['REDHAT_RHSM_API_URL'] || API_URL
             response = Resources::Candlepin::UpstreamConsumer.start_upstream_export("#{url}#{path(id)}", upstream['idCert']['cert'],
               upstream['idCert']['key'], nil)
             job = JSON.parse(response)

--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -34,7 +34,7 @@ module Katello
       API_URL = 'https://subscription.rhsm.redhat.com/subscription/consumers/'.freeze
       def api_url(upstream = {})
         # Default to Red Hat
-        upstream['apiUrl'] || API_URL
+        ENV['REDHAT_RHSM_API_URL'] || upstream['apiUrl'] || API_URL
       end
 
       def sync
@@ -65,7 +65,6 @@ module Katello
           Rails.logger.error "Upstream identity certificate not available"
           fail _("Upstream identity certificate not available")
         end
-
         params = {}
         params[:capabilities] = Resources::Candlepin::CandlepinPing.ping['managerCapabilities'].inject([]) do |result, element|
           result << {'name' => element}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Provides a way for setting an alternate rhsm url to test against staging environments.

#### What are the testing steps for this pull request?
`REDHAT_RHSM_API_URL=http://alternate-rhsm-fqdn  bundle exec foreman start`

You should see upstream request subscriptions go to the  alternate server.