### PR TITLE
Fixes #37197 - Kickstart repository correctly listed on hostgroup

### DIFF
--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -56,6 +56,11 @@ module Katello
         Katello::KTEnvironment.find_by(:id => inherited_lifecycle_environment_id)
       end
 
+      def kickstart_repository
+        return super if ancestry.nil? || self.kickstart_repository_id.present?
+        Katello::Repository.find_by(:id => inherited_kickstart_repository_id)
+      end
+
       # instead of calling nested_attribute_for(:content_source_id) in Foreman, define the methods explictedly
       def content_source
         return super if ancestry.nil? || self.content_source_id.present?

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -250,6 +250,10 @@ module Katello
       self.pulp_id = SecureRandom.uuid if self.pulp_id.length > PULP_ID_MAX_LENGTH
     end
 
+    def self.attribute_name
+      :name
+    end
+
     def set_container_repository_name
       self.container_repository_name = Repository.safe_render_container_name(self)
     end

--- a/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
@@ -3,7 +3,7 @@
      kickstart_repo_id = kickstart_repository_id(@host, :selected_host_group => @host&.hostgroup)
      kickstart_options = kickstart_repository_options(@host, :selected_host_group => @host&.hostgroup)
    elsif using_hostgroups_page?
-     kickstart_repo_id = kickstart_repository_id(@host, :selected_host_group => @host&.hostgroup)
+     kickstart_repo_id = kickstart_repository_id(@hostgroup, :selected_host_group => @host&.hostgroup)
      kickstart_options = kickstart_repository_options(@hostgroup)
    else
      kickstart_repo_id = kickstart_repository_id(@host, :selected_host_group => @hostgroup)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Fixed a bug related to the display of the hostgroup's kickstart 

#### What are the testing steps for this pull request?

Steps to Reproduce:
1. Sync a kickstart repository ks-zoo (I synced => https://partha.fedorapeople.org/test-repos/kickstart-zoo/)
2. Create a hostgroup with Library/Default Org View/x86_64/Redhat-7/ks-zoo in synced content.
3. Save the hostgroup
4. Click on the hostgroup again and go to Operating System tab

Before PR :
Notice that Synced Content is not populated

After PR:
Synced Content should be showing ks-zoo


Also possibly test things like inherited hostgroups, host creation etc