### PR TITLE
Refs #37201 - display short host name in activation keys menu

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
@@ -29,8 +29,8 @@
             ng-controller="ContentHostStatusController">
           <td bst-table-cell>
             <span ng-switch="newHostDetailsUI">
-              <a ng-switch-when="true" ng-href="/new/hosts/{{host.name}}">{{ host.name }}</a>
-              <a ng-switch-when="false" ui-sref="content-host.info({hostId: host.id})">{{ host.name }}</a>
+              <a ng-switch-when="true" ng-href="/new/hosts/{{host.name}}">{{ host.display_name }}</a>
+              <a ng-switch-when="false" ui-sref="content-host.info({hostId: host.id})">{{ host.display_name }}</a>
             </span>
           </td>
           <td bst-table-cell>{{ host.content_facet_attributes.lifecycle_environment.name }}</td>


### PR DESCRIPTION
Followup of [10538](https://github.com/Katello/katello/pull/10538).
