### PR TITLE
Fixes #37169 - Managing a Hosts Repository Sets does not behave as expected

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsActions.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsActions.js
@@ -24,6 +24,7 @@ export const setContentOverrides = ({
   hostId,
   search,
   enabled,
+  limit_to_env: limitToEnv,
   remove = false,
   updateResults,
   singular,
@@ -35,6 +36,7 @@ export const setContentOverrides = ({
     content_overrides_search: {
       search,
       enabled,
+      limit_to_env: limitToEnv,
       remove,
     },
   },

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -369,6 +369,7 @@ const RepositorySetsTab = () => {
       hostId,
       search,
       enabled,
+      limit_to_env: toggleGroupState === LIMIT_TO_ENVIRONMENT,
       remove,
       updateResults: resp => updateResults(resp),
       singular: singular || selectedCount === 1,

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySetsTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySetsTab.test.js
@@ -371,6 +371,39 @@ test('Can override in bulk', async (done) => {
   assertNockRequest(scope);
   assertNockRequest(contentOverrideScope, done); // Pass jest callback to confirm test is done});
 });
+test('Can override in bulk when limited to environment', async (done) => {
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
+  const scope = nockInstance
+    .get(hostRepositorySets)
+    .query(limitToEnvQuery)
+    .reply(200, mockRepoSetData);
+  const contentOverrideScope = nockInstance
+    .put(contentOverride, {
+      content_overrides_search:
+        {
+          search: '',
+          limit_to_env: true,
+          remove: true,
+        },
+    })
+    .reply(200, mockContentOverride);
+
+  const {
+    getByText, getByLabelText, queryByText,
+  } = renderWithRedux(<RepositorySetsTab />, renderOptions());
+
+  await patientlyWaitFor(() => expect(getByText(firstRepoSet.contentUrl)).toBeInTheDocument());
+  getByLabelText('Select all').click();
+  const actionMenu = getByLabelText('bulk_actions');
+  actionMenu.click();
+  const resetToDefault = queryByText('Reset to default');
+  expect(resetToDefault).toBeInTheDocument();
+  resetToDefault.click();
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(scope);
+  assertNockRequest(contentOverrideScope, done);
+});
 
 test('Can filter by status', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);


### PR DESCRIPTION
Ticket with information on how to reproduce and pictures: [Bug #37169](https://projects.theforeman.org/issues/37169)

This pull request fixes #37169 by adding a new "limit_to_env" parameter to `/api/v2/hosts/<id>/subscriptions/content_override`.

**Detailed problem description**

When entering the Repository sets page, a request is made to the _RepositorySetsController_, which returns the according repository sets.
When the user selects "**Limit to environment"**, a new request is made. This time however, the parameter `content_access_mode_env` is set to true and included in the request. _RepositorySetsController_ now returns the subset of repositories which all belong to the environment.

When the user selects "Override to enabled/disabled" from the kebab-menu in the toolbar, a function called `fetchBulkParams`, which is part of `tableHooks` is called. This function queries the table and constructs a valid search query, which is then passed to the _HostSubscriptionsController_, where repositories described by the query are enabled/disabled.

When the user selects every table-entry by using the "select all" checkbox in the toolbar, a flag `selectAllMode` is set and `fetchBulkParams` evaluates to `''`. The _HostSubscriptionsController_ evaluates this query and enables/disables every repository.
While this works fine for "**Show all**", if "**Limit to environment**" is selected in the UI, the information that the `''`-query should only be applied to a subset is not passed to _HostSubscriptionsController_ and instead of only repositories belonging to the environment, all repositories are enabled/disabled.

**This subset problem may very well be still an issue elsewhere**


I found that the easiest way to address this issue without breaking existing usages, was to partially replicate the functionality of _RepositorySetsController_ and add a parameter to indicate that a query should only be applied to items belonging to the environment.