### PR TITLE
Fixes #37206 - Allow hosts to not have an os

### DIFF
--- a/app/views/katello/api/v2/hosts/base.json.rabl
+++ b/app/views/katello/api/v2/hosts/base.json.rabl
@@ -6,11 +6,11 @@ object @resource
 attributes :id, :name, :description
 
 node :operatingsystem_family do |resource|
-  resource.operatingsystem.family
+  resource.operatingsystem&.family
 end
 
 node :operatingsystem_major do |resource|
-  resource.operatingsystem.major
+  resource.operatingsystem&.major
 end
 
 if @facet


### PR DESCRIPTION
Fixes f14f58e

#### What are the changes introduced in this pull request?
Hosts are no longer required to have an OS assigned in order for host details to show for them.

#### Considerations taken when implementing this change?
While having an OS assigned makes sense from katello point of view, we didn't require it prior to https://github.com/Katello/katello/commit/f14f58e3d7dc2a3c5a14b7b64592d5c9a9900868#

#### What are the testing steps for this pull request?
1) Have a host without an OS, see the hammer command below
2) Go to /hosts/myhost.example.com

```shell
    hammer host create\
        --name "myhost.example.com" \
        --managed false \
        --build false \
        --organization "Default Organization" \
        --location "Default Location"
```

Without this page the backend returns 500 and frontend redirects to the not found page.