### PR TITLE
Fixes #36976 - Too many audit records slow down CV loading

### DIFF
--- a/app/views/katello/api/v2/content_views/base.json.rabl
+++ b/app/views/katello/api/v2/content_views/base.json.rabl
@@ -12,7 +12,6 @@ attributes :import_only
 attributes :generated_for
 attributes :related_cv_count
 attributes :related_composite_cvs
-attributes :needs_publish? => :needs_publish
 attributes :filtered? => :filtered
 
 node :next_version do |content_view|

--- a/app/views/katello/api/v2/content_views/show.json.rabl
+++ b/app/views/katello/api/v2/content_views/show.json.rabl
@@ -3,6 +3,7 @@ object @resource
 extends "katello/api/v2/content_views/base"
 
 attributes :content_host_count
+attributes :needs_publish? => :needs_publish
 
 node :errors do
   unless @resource.valid?


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Query based on version.created_at instead of filtering through records after fetching.
#### Considerations taken when implementing this change?
Too many audit records in a system can make the filtering in-memory really slow.
#### What are the testing steps for this pull request?
Have a box with a very large number of audit records. 
Try loading CV index page. 
It shouldn't take forever to load. 😸 