### PR TITLE
Missing related changes on install package page when display_fqdn_for_hosts is disabled

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-content-hosts.html
@@ -63,8 +63,8 @@
             ng-controller="ContentHostStatusController">
           <td bst-table-cell>
             <span ng-switch="newHostDetailsUI">
-              <a ng-switch-when="true" ng-href="/new/hosts/{{contentHost.name}}/content">{{ contentHost.name }}</a>
-              <a ng-switch-when="false" ui-sref="content-host.info({hostId: contentHost.id})">{{ contentHost.name }}</a>
+              <a ng-switch-when="true" ng-href="/new/hosts/{{contentHost.name}}/content">{{ contentHost.display_name }}</a>
+              <a ng-switch-when="false" ui-sref="content-host.info({hostId: contentHost.id})">{{ contentHost.display_name }}</a>
             </span>
           </td>
           <td bst-table-cell>{{ contentHost.operatingsystem_name }}</td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-content-hosts.html
@@ -63,8 +63,8 @@
             ng-controller="ContentHostStatusController">
           <td bst-table-cell>
             <span ng-switch="newHostDetailsUI">
-              <a ng-switch-when="true" ng-href="/new/hosts/{{contentHost.name}}/content">{{ contentHost.display_name }}</a>
-              <a ng-switch-when="false" ui-sref="content-host.info({hostId: contentHost.id})">{{ contentHost.display_name }}</a>
+              <a ng-switch-when="true" ng-href="/new/hosts/{{contentHost.name}}/content">{{ contentHost.name }}</a>
+              <a ng-switch-when="false" ui-sref="content-host.info({hostId: contentHost.id})">{{ contentHost.name }}</a>
             </span>
           </td>
           <td bst-table-cell>{{ contentHost.operatingsystem_name }}</td>

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -121,6 +121,7 @@ export const PackagesTab = () => {
   const {
     id: hostId,
     name: hostname,
+    display_name: display_name,
   } = hostDetails;
 
   const { searchParam, status: statusParam } = useUrlParams();
@@ -617,7 +618,7 @@ export const PackagesTab = () => {
           closeModal={closeModal}
           hostId={hostId}
           key={hostId}
-          hostName={hostname}
+          hostName={display_name}
           triggerPackageInstall={triggerPackageInstall}
         />
       }


### PR DESCRIPTION
Followup of [10538](https://github.com/Katello/katello/pull/10538).