### PR TITLE
Fixes #37099 - Update repo fixture URL to Pulp hosted for tests

### DIFF
--- a/test/actions/pulp3/orchestration/alternate_content_source_refresh_test.rb
+++ b/test/actions/pulp3/orchestration/alternate_content_source_refresh_test.rb
@@ -70,7 +70,7 @@ module ::Actions::Pulp3
       ::Katello::Pulp3::Repository.any_instance.stubs(:generate_backend_object_name).returns(@yum_simplified_acs.name)
       ::Katello::Pulp3::AlternateContentSource.any_instance.stubs(:generate_backend_object_name).returns(@yum_simplified_acs.name)
       repo = katello_repositories(:fedora_17_x86_64_duplicate)
-      repo.root.update!(url: 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/')
+      repo.root.update!(url: 'https://fixtures.pulpproject.org/rpm-no-comps/')
       smart_proxy_acs = ::Katello::SmartProxyAlternateContentSource.create(alternate_content_source_id: @yum_simplified_acs.id, smart_proxy_id: @primary.id, repository_id: repo.id)
       ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::AlternateContentSource::Create, smart_proxy_acs)
       ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::AlternateContentSource::Refresh, smart_proxy_acs)

--- a/test/actions/pulp3/orchestration/copy_all_units_test.rb
+++ b/test/actions/pulp3/orchestration/copy_all_units_test.rb
@@ -101,10 +101,10 @@ module ::Actions::Pulp3
       @primary = SmartProxy.pulp_primary
       @repo = katello_repositories(:fedora_17_x86_64_duplicate)
       @repo.update!(:environment_id => nil)
-      @repo.root.update!(:url => 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/')
+      @repo.root.update!(:url => 'https://fixtures.pulpproject.org/rpm-no-comps/')
       @repo_clone = katello_repositories(:fedora_17_x86_64_dev)
       @repo_clone.update!(:environment_id => nil)
-      @repo_clone.root.update!(:url => 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/')
+      @repo_clone.root.update!(:url => 'https://fixtures.pulpproject.org/rpm-no-comps/')
 
       ensure_creatable(@repo, @primary)
       create_repo(@repo, @primary)
@@ -601,7 +601,7 @@ module ::Actions::Pulp3
       FactoryBot.create(:katello_content_view_module_stream_filter_rule,
                                    :filter => filter,
                                    :module_stream => duck)
-      @repo.root.update!(:url => 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/')
+      @repo.root.update!(:url => 'https://fixtures.pulpproject.org/rpm-no-comps/')
 
       sync_args = {:smart_proxy_id => @primary.id, :repo_id => @repo.id}
       ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @primary, sync_args)

--- a/test/actions/pulp3/orchestration/export_test.rb
+++ b/test/actions/pulp3/orchestration/export_test.rb
@@ -9,7 +9,7 @@ module ::Actions::Katello::ContentViewVersion
       Setting[:ssl_priv_key] = '/etc/foreman/client_key.pem'
       @primary = SmartProxy.pulp_primary
       @repo = katello_repositories(:fedora_17_x86_64_duplicate)
-      @repo.root.update!(url: 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/')
+      @repo.root.update!(url: 'https://fixtures.pulpproject.org/rpm-no-comps/')
       @repo = create_and_sync(@repo, @primary)
       @content_view = @repo.content_view
       @content_view_version = @repo.content_view_version

--- a/test/actions/pulp3/orchestration/multi_copy_all_units_test.rb
+++ b/test/actions/pulp3/orchestration/multi_copy_all_units_test.rb
@@ -66,7 +66,6 @@ module ::Actions::Pulp3
       @repo_clone.reload
 
       refute_includes @repo_clone.rpms.pluck(:name), "crow"
-      refute_includes @repo_clone.rpms.pluck(:name), "duck"
       refute_includes @repo_clone.rpms.pluck(:name), "stork"
       refute_includes @repo_clone.errata.pluck(:pulp_id), "RHEA-2012:0056"
     end
@@ -103,7 +102,9 @@ module ::Actions::Pulp3
       @repo_clone.reload
 
       refute_empty @repo.rpms
-      assert_equal ["trout-0.12-1.noarch.rpm"], @repo_clone.rpms.pluck(:filename)
+      assert_equal ["trout-0.12-1.noarch.rpm", "frog-0.1-1.noarch.rpm", "duck-0.8-1.noarch.rpm",
+                    "walrus-5.21-1.noarch.rpm", "walrus-0.71-1.noarch.rpm", "kangaroo-0.3-1.noarch.rpm",
+                    "kangaroo-0.2-1.noarch.rpm", "duck-0.7-1.noarch.rpm", "duck-0.6-1.noarch.rpm"], @repo_clone.rpms.pluck(:filename)
     end
 
     def test_yum_copy_nonmatching_package_includion_filter_copies_no_content
@@ -139,7 +140,7 @@ module ::Actions::Pulp3
       @repo_clone.reload
 
       refute_empty @repo.rpms
-      assert_equal 32, @repo_clone.rpms.pluck(:name).sort.count
+      assert_equal 35, @repo_clone.rpms.pluck(:name).sort.count
     end
 
     def test_yum_copy_all_no_filter_rules_with_dependency_solving
@@ -158,9 +159,10 @@ module ::Actions::Pulp3
       @repo_clone.reload
 
       refute_empty @repo.rpms
-      assert_equal ["bear", "cat", "crow", "dolphin", "elephant", "gorilla", "horse",
-                    "kangaroo", "lion", "mouse", "penguin", "pike", "tiger", "trout",
-                    "wolf", "zebra"], @repo_clone.rpms.pluck(:name).sort
+      assert_equal ["bear", "cat", "cockateel", "crow", "dolphin", "duck", "duck", "duck",
+                    "elephant", "frog", "gorilla", "horse", "kangaroo", "kangaroo", "lion",
+                    "mouse", "penguin", "pike", "tiger", "trout", "walrus",
+                    "walrus", "wolf", "zebra"], @repo_clone.rpms.pluck(:name).sort
     end
 
     def test_yum_copy_with_whitelist_name_filter
@@ -177,7 +179,7 @@ module ::Actions::Pulp3
       @repo_clone.reload
 
       refute_empty @repo.rpms
-      assert_equal ['kangaroo'], @repo_clone.rpms.pluck(:name)
+      assert_equal ["frog", "duck", "walrus", "walrus", "kangaroo", "kangaroo", "duck", "duck"], @repo_clone.rpms.pluck(:name)
     end
 
     def test_yum_copy_with_whitelist_min_version_filter
@@ -194,7 +196,9 @@ module ::Actions::Pulp3
       @repo_clone.reload
 
       refute_empty @repo.rpms
-      assert_equal ['walrus-5.21-1.noarch.rpm'], @repo_clone.rpms.pluck(:filename)
+      assert_equal ["frog-0.1-1.noarch.rpm", "duck-0.8-1.noarch.rpm", "walrus-5.21-1.noarch.rpm",
+                    "walrus-0.71-1.noarch.rpm", "kangaroo-0.3-1.noarch.rpm", "kangaroo-0.2-1.noarch.rpm",
+                    "duck-0.7-1.noarch.rpm", "duck-0.6-1.noarch.rpm"], @repo_clone.rpms.pluck(:filename)
     end
 
     def test_yum_copy_with_whitelist_max_version_filter
@@ -211,13 +215,15 @@ module ::Actions::Pulp3
       @repo_clone.reload
 
       refute_empty @repo.rpms
-      assert_equal ['walrus-0.71-1.noarch.rpm'], @repo_clone.rpms.pluck(:filename)
+      assert_equal ["frog-0.1-1.noarch.rpm", "duck-0.8-1.noarch.rpm", "walrus-5.21-1.noarch.rpm", "walrus-0.71-1.noarch.rpm",
+                    "kangaroo-0.3-1.noarch.rpm", "kangaroo-0.2-1.noarch.rpm", "duck-0.7-1.noarch.rpm",
+                    "duck-0.6-1.noarch.rpm"], @repo_clone.rpms.pluck(:filename)
     end
 
     def test_yum_copy_with_duplicate_content
       filter = FactoryBot.build(:katello_content_view_package_filter, :inclusion => true)
 
-      assert_equal 32, @repo.rpms.count
+      assert_equal 35, @repo.rpms.count
       assert_includes @repo.rpms.pluck(:filename), 'walrus-0.71-1.noarch.rpm'
 
       @repo_clone_original_version_href = @repo_clone.version_href
@@ -274,7 +280,9 @@ module ::Actions::Pulp3
       ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
       @repo_clone.reload
 
-      assert_equal ["whale-0.2-1.noarch.rpm", "walrus-0.71-1.noarch.rpm", "stork-0.12-2.noarch.rpm", "shark-0.1-1.noarch.rpm"].sort,
+      assert_equal ["cockateel-3.1-1.noarch.rpm", "duck-0.6-1.noarch.rpm", "duck-0.7-1.noarch.rpm", "duck-0.8-1.noarch.rpm",
+                    "frog-0.1-1.noarch.rpm", "kangaroo-0.2-1.noarch.rpm", "kangaroo-0.3-1.noarch.rpm", "lion-0.4-1.noarch.rpm",
+                    "walrus-0.71-1.noarch.rpm", "walrus-5.21-1.noarch.rpm", "wolf-9.4-2.noarch.rpm"].sort,
         @repo_clone.rpms.pluck(:filename).sort
     end
   end

--- a/test/actions/pulp3/orchestration/multi_copy_all_units_test.rb
+++ b/test/actions/pulp3/orchestration/multi_copy_all_units_test.rb
@@ -7,10 +7,10 @@ module ::Actions::Pulp3
       @primary = SmartProxy.pulp_primary
       @repo = katello_repositories(:fedora_17_x86_64_duplicate)
       @repo.update!(:environment_id => nil)
-      @repo.root.update!(:url => 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/')
+      @repo.root.update!(:url => 'https://fixtures.pulpproject.org/rpm-no-comps/')
       @repo_clone = katello_repositories(:fedora_17_x86_64_dev)
       @repo_clone.update!(:environment_id => nil)
-      @repo_clone.root.update!(:url => 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/')
+      @repo_clone.root.update!(:url => 'https://fixtures.pulpproject.org/rpm-no-comps/')
 
       ::Katello::Repository.any_instance.stubs(:soft_copy_of_library?).returns(false)
 

--- a/test/actions/pulp3/orchestration/yum_sync_test.rb
+++ b/test/actions/pulp3/orchestration/yum_sync_test.rb
@@ -8,7 +8,7 @@ module ::Actions::Pulp3
       User.current = users(:admin)
       @primary = SmartProxy.pulp_primary
       @repo = katello_repositories(:fedora_17_x86_64_duplicate)
-      @repo.root.update!(url: 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/')
+      @repo.root.update!(url: 'https://fixtures.pulpproject.org/rpm-no-comps/')
       create_repo(@repo, @primary)
       ForemanTasks.sync_task(
           ::Actions::Katello::Repository::MetadataGenerate, @repo)

--- a/test/actions/pulp3/repository/repair_test.rb
+++ b/test/actions/pulp3/repository/repair_test.rb
@@ -8,7 +8,7 @@ module ::Actions::Pulp3::Repository
       User.current = users(:admin)
       @primary = SmartProxy.pulp_primary
       @repo = katello_repositories(:fedora_17_x86_64_duplicate)
-      @repo.root.update!(url: 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/')
+      @repo.root.update!(url: 'https://fixtures.pulpproject.org/rpm-no-comps/')
       create_repo(@repo, @primary)
       ForemanTasks.sync_task(
         ::Actions::Katello::Repository::MetadataGenerate, @repo)

--- a/test/lib/tasks/pulpcore/repository_vcr_test.rb
+++ b/test/lib/tasks/pulpcore/repository_vcr_test.rb
@@ -21,7 +21,7 @@ module Katello
 
         @primary = SmartProxy.pulp_primary
         @library_repo = katello_repositories(:fedora_17_x86_64_duplicate)
-        @library_repo.root.update(:url => 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/')
+        @library_repo.root.update(:url => 'https://fixtures.pulpproject.org/rpm-no-comps/')
         @backend_service = ::Katello::Pulp3::Repository::Yum.new(@library_repo, @primary)
 
         ENV['COMMIT'] = nil

--- a/test/services/katello/pulp3/rpm_test.rb
+++ b/test/services/katello/pulp3/rpm_test.rb
@@ -10,7 +10,7 @@ module Katello
         def setup
           @primary = SmartProxy.pulp_primary
           @repo = katello_repositories(:fedora_17_x86_64_duplicate)
-          @repo.root.update(:url => 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/')
+          @repo.root.update(:url => 'https://fixtures.pulpproject.org/rpm-no-comps/')
           ensure_creatable(@repo, @primary)
           create_repo(@repo, @primary)
 

--- a/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewDetailRepos.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/Repositories/__tests__/contentViewDetailRepos.fixtures.json
@@ -46,7 +46,7 @@
         "name": "Library"
       },
       "content_type": "yum",
-      "url": "https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/",
+      "url": "https://fixtures.pulpproject.org/rpm-no-comps/",
       "arch": "noarch",
       "content_id": "1597685535659",
       "auto_enabled": true,

--- a/webpack/scenes/ContentViews/Details/Versions/Compare/__tests__/cvCompareRepositories.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/__tests__/cvCompareRepositories.fixtures.json
@@ -149,7 +149,7 @@
         "name": "Library"
       },
       "content_type": "yum",
-      "url": "https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/",
+      "url": "https://fixtures.pulpproject.org/rpm-no-comps/",
       "arch": "noarch",
       "os_versions": [],
       "content_id": "1664981648561",


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Change URL from https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/ to https://fixtures.pulpproject.org/
* Used https://fixtures.pulpproject.org/rpm-no-comps/

#### Considerations taken when implementing this change?

* N/A

#### What are the testing steps for this pull request?

* Make sure tests pass