### PR TITLE
Fixes #37237 - Allow repairing content view versions

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -3,8 +3,8 @@ module Katello
     include ::Api::V2::BulkHostsExtension
     include Katello::Concerns::FilteredAutoCompleteSearch
 
-    before_action :find_authorized_katello_resource, :only => [:show, :update, :promote, :destroy, :republish_repositories]
-    before_action :find_content_view_from_version, :only => [:show, :update, :promote, :destroy, :republish_repositories]
+    before_action :find_authorized_katello_resource, :only => [:show, :update, :promote, :destroy, :republish_repositories, :verify_checksum]
+    before_action :find_content_view_from_version, :only => [:show, :update, :promote, :destroy, :republish_repositories, :verify_checksum]
     before_action :find_optional_readable_content_view, :only => [:index]
 
     before_action :find_environment, :only => [:index]
@@ -138,6 +138,13 @@ Alternatively, use the 'force' parameter to regenerate metadata locally. New ver
       resolve_dependencies = params.fetch(:resolve_dependencies, true)
       task = async_task(::Actions::Katello::ContentView::IncrementalUpdates, @content_view_version_environments, @composite_version_environments,
                         params[:add_content], resolve_dependencies, hosts, params[:description])
+      respond_for_async :resource => task
+    end
+
+    api :POST, "/content_view_versions/:id/verify_checksum", N_("Verify checksum of repository contents in the content view version")
+    param :id, :number, :required => true, :desc => N_("Content view version identifier")
+    def verify_checksum
+      task = async_task(::Actions::Katello::ContentViewVersion::VerifyChecksum, @content_view_version)
       respond_for_async :resource => task
     end
 

--- a/app/controllers/katello/concerns/api/v2/authorization.rb
+++ b/app/controllers/katello/concerns/api/v2/authorization.rb
@@ -49,7 +49,7 @@ module Katello
 
         # promote_or_remove_content_views_to_environments has a special relationship to promote_or_remove_content_views
         if path_to_authenticate["controller"] == "katello/api/v2/content_view_versions" &&
-            path_to_authenticate["action"].in?(["promote", "remove_from_environment", "remove", "republish_repositories"])
+            path_to_authenticate["action"].in?(["promote", "remove_from_environment", "remove", "republish_repositories", "verify_checksum"])
           missing_perms << ::Permission.find_by(name: "promote_or_remove_content_views_to_environments")
         end
         missing_perms

--- a/app/lib/actions/katello/content_view_version/verify_checksum.rb
+++ b/app/lib/actions/katello/content_view_version/verify_checksum.rb
@@ -1,0 +1,29 @@
+module Actions
+  module Katello
+    module ContentViewVersion
+      class VerifyChecksum < Actions::EntryAction
+        def plan(content_view_version)
+          action_subject(content_view_version.content_view)
+          plan_self(:version_id => content_view_version.id)
+          plan_action(::Actions::BulkAction, ::Actions::Katello::Repository::VerifyChecksum, content_view_version.repositories) if content_view_version.repositories.any?
+        end
+
+        def run
+          #dummy run phase to save input and support humanized_name
+        end
+
+        def humanized_name
+          if input && input[:version_id]
+            version = ::Katello::ContentViewVersion.find_by(:id => input[:version_id])
+          end
+
+          if version
+            _("Verify checksum of repositories in %{name} %{version}") % {:name => version.content_view.name, :version => version.version}
+          else
+            _("Verify checksum of version repositories")
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -149,6 +149,7 @@ Katello::Engine.routes.draw do
             post :promote
             post :export
             put :republish_repositories
+            post :verify_checksum
           end
           collection do
             get :auto_complete_search

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -134,7 +134,7 @@ module Katello
       @plugin.permission :publish_content_views,
                          {
                            'katello/api/v2/content_views' => [:publish],
-                           'katello/api/v2/content_view_versions' => [:incremental_update, :republish_repositories],
+                           'katello/api/v2/content_view_versions' => [:incremental_update, :republish_repositories, :verify_checksum],
                            'katello/api/v2/content_imports' => [:version, :index]
                          },
                          :resource_type => 'Katello::ContentView',
@@ -142,7 +142,7 @@ module Katello
       @plugin.permission :promote_or_remove_content_views,
                          {
                            'katello/api/v2/content_view_versions' => [:promote],
-                           'katello/api/v2/content_views' => [:remove_from_environment, :remove, :republish_repositories]
+                           'katello/api/v2/content_views' => [:remove_from_environment, :remove, :republish_repositories, :verify_checksum]
                          },
                          :resource_type => 'Katello::ContentView',
                          :finder_scope => :promotable_or_removable


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
1. Add an API endpoint for verify_checksum on CV versions
2. Add actions to support CV version repository repairs
#### Considerations taken when implementing this change?
This action will only be allowed via API/Hammer.
No UI implementation becuase this is not a regular workflow action users should be running. Only for fixing corrupted content on FS.
#### What are the testing steps for this pull request?
In foreman console: (Note :id to be replaced with a CV version id)
```
cvv = Katello::ContentViewVersion.find(:id)
ForemanTasks.sync_task(::Actions::Katello::ContentViewVersion::VerifyChecksum, cvv)
```

If https://github.com/Katello/hammer-cli-katello/pull/932 is merged, or you check it out on hammer,
Follow steps there to verify hammer calls to the API.