### PR TITLE
Fixes #37238 - show upstream auth token only for yum repos

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -189,12 +189,14 @@
                  type="{{ repository.upstream_password.length < 1 ? 'text': 'password' }}"
                  autocomplete="{{ (repository.upstream_username==null || repository.upstream_username=='') ? 'new-password' : '' }}"
                  ng-model="repository.upstream_password"/>
-          <div translate>Upstream Authentication Token</div>
-          <input id="upstream_authentication_token"
-                  name="upstream_authentication_token"
-                  type="{{ repository.upstream_authentication_token.length < 1 ? 'text': 'password' }}"
-                  autocomplete="off"
-                  ng-model="repository.upstream_authentication_token"/>
+          <span ng-show="repository.content_type === 'yum'">
+            <div translate>Upstream Authentication Token</div>
+            <input id="upstream_authentication_token"
+                   name="upstream_authentication_token"
+                   type="{{ repository.upstream_authentication_token.length < 1 ? 'text': 'password' }}"
+                   autocomplete="off"
+                   ng-model="repository.upstream_authentication_token"/>
+          </span>
         </dd>
       </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -250,16 +250,18 @@
         </p>
       </div>
 
-      <div bst-form-group label="{{ 'Upstream Authentication Token' | translate }}" >
-        <input id="upstream_authentication_token"
-              name="upstream_authentication_token"
-              type="text"
-              autocomplete="off"
-              ng-model="repository.upstream_authentication_token"/>
-        <p class="help-block" translate>
-          Token of the upstream repository user for authentication. Leave empty if repository does not require authentication.
-        </p>
-      </div>
+      <span ng-show="repository.content_type === 'yum'">
+        <div bst-form-group label="{{ 'Upstream Authentication Token' | translate }}" >
+          <input id="upstream_authentication_token"
+                name="upstream_authentication_token"
+                type="text"
+                autocomplete="off"
+                ng-model="repository.upstream_authentication_token"/>
+          <p class="help-block" translate>
+            Token of the upstream repository user for authentication. Leave empty if repository does not require authentication.
+          </p>
+        </div>
+      </span>
 
       <div ng-repeat="option in genericRemoteOptions" ng-if="repository.generic_remote_options !== []">
         <div ng-if='option.input_type=="text"' bst-form-group label="{{ option.title | translate }}">


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Hides the upstream authentication token for non-yum repositories. This field is only helpful for SLES repositories for now, but could potentially be used for other purposes in the future. By hiding it for other repositories, it's less likely that users will get confused.

#### Considerations taken when implementing this change?
I considered renaming the field to "SLES token" or something like that, but SLES users by now are likely used to that naming convention. Plus, the field could be expanded in the future to be useful for other repositories.

#### What are the testing steps for this pull request?
1. Make sure that the upstream auth token field is only settable for yum repos
2. Make sure that the upstream auth token field is still settable for yum repos (check the Pulp remote)

---

There might be some tests I need to add / updates.