### PR TITLE
Fixes #36979 - Remove cdn_ssl_version setting

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -373,13 +373,6 @@ Foreman::Plugin.register :katello do
         collection: proc { http_proxy_select },
         include_blank: N_("no global default")
 
-      setting 'cdn_ssl_version',
-        type: :string,
-        default: nil,
-        full_name: N_('CDN SSL version'),
-        description: N_("SSL version used to communicate with the CDN"),
-        collection: proc { hashify_parameters(Katello::Resources::CDN::SUPPORTED_SSL_VERSIONS) }
-
       setting 'katello_default_provision',
         type: :string,
         default: 'Kickstart default',

--- a/test/lib/resources/cdn_test.rb
+++ b/test/lib/resources/cdn_test.rb
@@ -1,22 +1,5 @@
 require 'katello_test_helper'
 class CdnResourceTest < ActiveSupport::TestCase
-  def test_http_downloader_v2
-    Setting[:cdn_ssl_version] = 'SSLv23'
-    cdn_resource = Katello::Resources::CDN::CdnResource.new('http://foo.com')
-    assert_equal cdn_resource.http_downloader.ssl_version, 'SSLv23'
-  end
-
-  def test_http_downloader_tls
-    Setting[:cdn_ssl_version] = 'TLSv1'
-    cdn_resource = Katello::Resources::CDN::CdnResource.new('http://foo.com')
-    assert_equal cdn_resource.http_downloader.ssl_version, 'TLSv1'
-  end
-
-  def test_http_downloader_no_version
-    cdn_resource = Katello::Resources::CDN::CdnResource.new('http://foo.com')
-    assert_nil cdn_resource.http_downloader.ssl_version
-  end
-
   def test_http_proxy_no_cacert
     proxy = FactoryBot.create(:http_proxy, :url => 'http://foo.com:1000',
                               :username => 'admin',
@@ -26,13 +9,6 @@ class CdnResourceTest < ActiveSupport::TestCase
     OpenSSL::X509::Store.any_instance.expects(:add_file)
     Foreman::Util.expects(:add_ca_bundle_to_store).never
     Katello::Resources::CDN::CdnResource.new('http://foo.com', ssl_ca_file: "lol")
-  end
-
-  def test_http_downloader_bad_param
-    Setting[:cdn_ssl_version] = 'Foo'
-    assert_raise RuntimeError do
-      Katello::Resources::CDN::CdnResource.new('http://foo.com')
-    end
   end
 
   def test_custom_cdn_auth

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -17,15 +17,6 @@ module Katello
       assert setting.valid?
     end
 
-    def test_cdn_ssl_setting
-      # TODO: assert an error raised by the SettingRegistry
-      # setting = Foreman.settings.set_user_value('cdn_ssl_version', nil)
-      # assert setting.valid?
-
-      setting = Foreman.settings.set_user_value('cdn_ssl_version', 'SSLv23')
-      assert setting.valid?
-    end
-
     def test_recalculate_errata_status
       ForemanTasks.expects(:async_task).with(::Actions::Katello::Host::RecalculateErrataStatus)
       Setting['errata_status_installable'] = !Setting['errata_status_installable']


### PR DESCRIPTION
This was originally added to allow downgrading the CDN connection SSL version for compatibility with much older proxy servers. That should be less of a concern now.

We do still set a value of TLS v1.2 for the min_version, but only because https://github.com/ruby/openssl/issues/709 prevents using the system-wide crypto policy for now. In the future, that can be removed as well, restoring control to the user at the OS level.

This change is a simpler alternative to https://github.com/Katello/katello/pull/10824