### PR TITLE
Refs #37148 - Remove removed_widgets override

### DIFF
--- a/app/helpers/katello/concerns/dashboard_helper_extensions.rb
+++ b/app/helpers/katello/concerns/dashboard_helper_extensions.rb
@@ -8,16 +8,6 @@ module Katello
       def total_host_count
         host_query.size
       end
-
-      def removed_widgets
-        widgets = super
-
-        if Organization.current&.simple_content_access?
-          widgets.reject! { |widget| ::Widget.singleton_class::SUBSCRIPTION_TEMPLATES.include? widget[:template] }
-        end
-
-        widgets
-      end
     end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

https://github.com/Katello/katello/pull/10882 removed subscription-related widgets, but we still had some code that refers to them. This code was an override of Foreman's `removed_widgets` method and is no longer needed.

This is causing the Dashboard page to break with

```
uninitialized constant SUBSCRIPTION_TEMPLATES
Extracted source (around line #16):

        if Organization.current&.simple_content_access?
          widgets.reject! { |widget| ::Widget.singleton_class::SUBSCRIPTION_TEMPLATES.include? widget[:template] }
        end

        widgets

Rails.root: /home/vagrant/foreman

Application Trace | Framework Trace | Full Trace
/home/vagrant/katello/app/helpers/katello/concerns/dashboard_helper_extensions.rb:16:in `block in removed_widgets'

```

#### Considerations taken when implementing this change?

Both of the referenced widgets are removed, so removing this is correct

#### What are the testing steps for this pull request?

On master: Load the dashboard page. You will get that error.

On this branch: Load the dashboard page. You should get no error.

