### PR TITLE
Fixes #37240 - Fix CCV duplicate repo warning

### DIFF
--- a/webpack/scenes/ContentViews/Publish/CVPublishForm.js
+++ b/webpack/scenes/ContentViews/Publish/CVPublishForm.js
@@ -66,7 +66,7 @@ const CVPublishForm = ({
                 </Alert>)
             }
             {!duplicateReposAlertDismissed && composite &&
-                (duplicateRepos !== null || duplicateRepos.length > 0) &&
+                (duplicateRepos !== null && duplicateRepos.length > 0) &&
                 (
                 <Alert
                   ouiaId="duplicate-repos-alert"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
only show duplicate repo warning on CCV publish, if it is actually true.

#### Considerations taken when implementing this change?
duplicate repo value is usually `[]` if no duplicates are present.

#### What are the testing steps for this pull request?
publish CCV without duplicate repos => message should not be there.