### PR TITLE
pin victory-core to ~36.8.6

### DIFF
--- a/.github/workflows/react_tests.yml
+++ b/.github/workflows/react_tests.yml
@@ -39,6 +39,13 @@ jobs:
       run:  npm i --package-lock-only --no-audit
     - name: Install Katello dependencies
       run:  npm ci --no-audit
+    - name: Archive package-lock.json
+      uses: actions/upload-artifact@v4
+      with:
+        name: package-lock.json
+        path: |
+          foreman/package-lock.json
+          katello/package-lock.json
     - name: Run Katello linting
       run: npm run lint
     - name: Run Katello tests

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "jest": "^24.9.0",
     "nock": "^12.0.3",
-    "react-test-renderer": "^16.0.0"
+    "react-test-renderer": "^16.0.0",
+    "victory-core": "~36.8.6"
   },
   "_comment": "We don't include @theforeman/vendor because it's assumed to be present in Foreman",
   "dependencies": {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

pinning victory-core to the same version as foreman, so that CI passes

#### Considerations taken when implementing this change?

removing victory-core from our dep-chain was not an option

#### What are the testing steps for this pull request?

"React Tests (non-blocking) (Required)" apss