### PR TITLE
Fixes #37254 - Unpublishable content views should always return false for needs_publish?

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -800,6 +800,10 @@ module Katello
       repositories.any? { |repo| repo.last_indexed && repo.last_indexed > latest_version_object.created_at }
     end
 
+    def unpublishable?
+      default? || import_only? || generated?
+    end
+
     def needs_publish?
       #Returns
       # True:
@@ -819,7 +823,9 @@ module Katello
       #     a) No changes were detected via audits *and*
       #        Audit for CV publish exists (Audits haven't been cleaned up)
       #        *and* applied_filters field is set(Published after upgrade)
+      #     b) Default, import only and generated CVs can not be published, hence these will always return false.
       #
+      return false if unpublishable?
       return true unless latest_version_object
       return nil unless last_publish_task_success?
       return composite_cv_components_changed? if composite?

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -654,6 +654,18 @@ module Katello
       end
     end
 
+    def test_unpublishable?
+      default_content_view = ContentView.default.first
+      import_only_content_view = FactoryBot.create(:katello_content_view, :import_only)
+      generated_content_view = FactoryBot.create(:katello_content_view, generated_for: "repository_export")
+      normal_content_view = FactoryBot.create(:katello_content_view, generated_for: "none")
+
+      assert default_content_view.unpublishable?
+      assert import_only_content_view.unpublishable?
+      assert generated_content_view.unpublishable?
+      refute normal_content_view.unpublishable?
+    end
+
     def test_new_cv_needs_publish
       content_view = FactoryBot.build(:katello_content_view, :name => "New CV")
       content_view.save!


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Always return false as needs_publish for default, import_only and generated content views.
#### Considerations taken when implementing this change?
Default, import only and other generated CVs can not be published by user. We should return false for such CVs immediately and not look for change etc.
#### What are the testing steps for this pull request?
In console:
```
cv = Katello::ContentView.default.first
cv.needs_publish?
```
should be false
Export/import a cv
In console:
```
cv = Katello::ContentView.find(:id)
cv.needs_publish?
```
Should also be false.