### PR TITLE
Fixes #37259 - Only repair library instance repos for products

### DIFF
--- a/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
@@ -55,7 +55,7 @@ module Katello
       repairable_products = @products.syncable
       repairable_roots = RootRepository.where(:product_id => repairable_products).has_url.select { |r| r.library_instance }.uniq
 
-      repairable_repositories = Katello::Repository.where(:root_id => repairable_roots)
+      repairable_repositories = Katello::Repository.library.where(:root_id => repairable_roots)
       task = async_task(::Actions::BulkAction,
                         ::Actions::Katello::Repository::VerifyChecksum,
                         repairable_repositories)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Only repair library instances of repositories when product verify checksum is run.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Steps to Reproduce:
1. Sync a repository
2. Add this repo to a content view
3. Create 1 or more content view versions with different filters to exclude any package to cause pulp to create a clone of the repository
4. WebUI > Content > Product > [select a checkbox for a product] > Select Action > Verify Content Checksum, execute a verify checksum action on the product
5. Watch the tasks that spawn in foreman-tasks and make sure you see only repair tasks for library instance repos and not all clones and version repos.