### PR TITLE
Fixes #37266 - Regenerate upstream identity certificate on manifest refresh

### DIFF
--- a/app/lib/actions/candlepin/owner/regenerate_upstream_identity_cert.rb
+++ b/app/lib/actions/candlepin/owner/regenerate_upstream_identity_cert.rb
@@ -1,0 +1,21 @@
+module Actions
+  module Candlepin
+    module Owner
+      class RegenerateUpstreamIdentityCert < Candlepin::Abstract
+        input_format do
+          param :organization_id
+          param :upstream
+        end
+
+        def run
+          organization = ::Organization.find(input[:organization_id])
+          output[:response] = organization.redhat_provider.owner_upstream_regenerate_identity_cert(input[:upstream])
+        end
+
+        def rescue_strategy
+          Dynflow::Action::Rescue::Skip
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/organization/manifest_refresh.rb
+++ b/app/lib/actions/katello/organization/manifest_refresh.rb
@@ -21,6 +21,9 @@ module Actions
             upstream_update = plan_action(Candlepin::Owner::UpstreamUpdate,
                         { :organization_id => organization.id,
                           :upstream => upstream })
+            plan_action(Candlepin::Owner::RegenerateUpstreamIdentityCert,
+                        { :organization_id => organization.id,
+                          :upstream => upstream })
             export_action = plan_action(Candlepin::Owner::StartUpstreamExport,
                         { :organization_id => organization.id,
                           :upstream => upstream,

--- a/app/lib/katello/resources/candlepin/upstream_consumer.rb
+++ b/app/lib/katello/resources/candlepin/upstream_consumer.rb
@@ -40,19 +40,31 @@ module Katello
             raise ::Katello::Errors::UpstreamEntitlementGone
           end
 
-          def get_export(url, client_cert, client_key, ca_file)
+          def start_upstream_export(url, client_cert, client_key, ca_file)
             logger.debug "Sending GET request to upstream Candlepin: #{url}"
-            return resource(url: url, client_cert: client_cert, client_key: client_key, ca_file: ca_file).get
+            resource(url: url, client_cert: client_cert, client_key: client_key, ca_file: ca_file).get
           rescue RestClient::Exception => e
             raise e
           end
 
+          alias_method :retrieve_upstream_export, :start_upstream_export
+
           def update(url, client_cert, client_key, ca_file, attributes)
             logger.debug "Sending PUT request to upstream Candlepin: #{url} #{attributes.to_json}"
-            return resource(url: url, client_cert: client_cert, client_key: client_key, ca_file: ca_file).put(attributes.to_json,
-                                                                       'accept' => 'application/json',
-                                                                       'accept-language' => I18n.locale,
-                                                                       'content-type' => 'application/json')
+            resource(
+              url: url,
+              client_cert: client_cert,
+              client_key: client_key,
+              ca_file: ca_file).put(
+                attributes.to_json,
+                'accept' => 'application/json',
+                'accept-language' => I18n.locale,
+                'content-type' => 'application/json')
+          end
+
+          def regenerate_upstream_identity(url, client_cert, client_key, ca_file)
+            logger.debug "Sending POST request to upstream Candlepin: #{url}"
+            resource(url: url, client_cert: client_cert, client_key: client_key, ca_file: ca_file).post(nil)
           end
 
           def bind_entitlement(**pool)

--- a/app/lib/katello/resources/candlepin/upstream_job.rb
+++ b/app/lib/katello/resources/candlepin/upstream_job.rb
@@ -12,7 +12,7 @@ module Katello
 
           def get(id, upstream)
             url = API_URL
-            response = Resources::Candlepin::UpstreamConsumer.get_export("#{url}#{path(id)}", upstream['idCert']['cert'],
+            response = Resources::Candlepin::UpstreamConsumer.start_upstream_export("#{url}#{path(id)}", upstream['idCert']['cert'],
               upstream['idCert']['key'], nil)
             job = JSON.parse(response)
             job.with_indifferent_access


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When a manifest is imported into Katello, a consumer is created in hosted Candlepin. We call this the "upstream consumer." This upstream consumer has an identity certificate which is stored in Katello's database and sent along with any requests to upstream Candlepin (adding subscriptions to the manifest, refreshing, etc.) The normal expiration for this certificate is 1 year from the time it was exported from hosted Candlepin.

When the upstream consumer's identity certificate expires, Katello calls this an "expired manifest." With an expired manifest, your hosts can no longer access content. You must import a new manifest with a nonexpired identity certificate, which can be quite inconvenient for users.

With this change, Katello will request hosted Candlepin to regenerate the upstream consumer identity certificate as the first step of a manifest refresh action. Thus, if you refresh your manifest at least once a year, you'll never be caught with an expired manifest. We do this by calling the upstream Candlepin endpoint `POST consumers/{consumer_uuid}`.

This PR also adds a `manifest_expiration_date` method to Organizations.

#### Considerations taken when implementing this change?

This step isn't essential for a manifest refresh itself, so I set the `rescue_strategy` to Skip. This way it won't halt the entire manifest refresh task if something fails with regenerating the identity certificate.

#### What are the testing steps for this pull request?

In Rails console, check your manifest expiration date:

```
org = Organization.find 1
org.manifest_expiration_date

...

=> Fri, 01 Nov 2024 16:31:23
```

Now, refresh your manifest and check again:
```
org = Organization.find 1
org.manifest_expiration_date

...

=> Fri, 14 Mar 2025 16:33:29
```
