### PR TITLE
Fixes #37267 - Link upgradable packages for Debian Ubuntu to debs package page

### DIFF
--- a/app/views/katello/hosts/_errata_counts.html.erb
+++ b/app/views/katello/hosts/_errata_counts.html.erb
@@ -43,7 +43,7 @@
 <% end %>
 <% if host.operatingsystem_name&.match(/Debian|Ubuntu/) %>
 <% if Setting["host_details_ui"] %>
-<a href="/new/hosts/<%= host.name %>#/Content/packages?status=Upgradable">
+<a href="/new/hosts/<%= host.name %>#/Content/debs?status=Upgradable">
 <% else %>
 <a href="/content_hosts/<%= host.id %>/debs/applicable">
 <% end %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This PR fixes the link for the Upgradable Packages count on the Hosts page, to link to the correct Packages page,
as this is now a separate page for Debian and Ubuntu now.

#### Considerations taken when implementing this change?

- N/A

#### What are the testing steps for this pull request?

Add a Debian or Ubuntu machine to the dev system, then the link for Upgradable Packages should still link to /Content/packages for everything beside these 2 distros to /Content/debs.

Please consider backporting this to 2.12, thanks!