### PR TITLE
Fixes #37268 - add repository_url back

### DIFF
--- a/app/helpers/katello/katello_urls_helper.rb
+++ b/app/helpers/katello/katello_urls_helper.rb
@@ -37,11 +37,36 @@ module Katello
       "#{prefix}/pub/#{config}"
     end
 
-    apipie :method, 'Generates an absolute path to the file' do
+    apipie :method, 'Generates an absolute path to the file for liveimg kickstart templates' do
       required :content_path, String, desc: "Relative path to the file or it's name"
       optional :schema, String, desc: 'Optional URL schema for the content source', default: 'http'
       optional :content_type, String, desc: 'Content type', default: 'repos'
       returns String, desc: 'Absolute path to a file'
+    end
+    def repository_url(content_path, _content_type = nil, schema = 'http')
+      return content_path if content_path =~ %r|^([\w\-\+]+)://|
+      url = if @host.content_source
+              "#{schema}://#{@host.content_source.hostname}"
+            else
+              foreman_settings_url(schema)
+            end
+      content_path = content_path.sub(%r|^/|, '')
+
+      lifecycle_environment = nil
+      if @host.default_environment?
+        # Don't update the content_path if the host is using the default org view / library
+        lifecycle_environment = ::Katello::KTEnvironment.library.find_by(organization_id: @host.organization_id)
+      elsif !@host.single_content_view_environment?
+        fail ::Katello::Errors::MultiEnvironmentNotSupportedError,
+          "Host #{@host.name} must be subscribed to only a single content view & environment or subscribe to the default organization content view for liveimg provisioning."
+      else
+        lifecycle_environment = @host.single_lifecycle_environment
+        content_path = [@host.single_content_view.label, content_path].join('/')
+      end
+
+      path = ::Katello::Repository.repo_path_from_content_path(
+        lifecycle_environment, content_path)
+      "#{url}/pulp/content/#{path}"
     end
   end
 end

--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -10,6 +10,10 @@ module Katello
 
     class RegistrationError < StandardError; end
 
+    class InvalidRepositoryTypeError < StandardError; end
+
+    class MultiEnvironmentNotSupportedError < StandardError; end
+
     # unauthorized access
     class SecurityViolation < StandardError; end
 

--- a/app/models/katello/candlepin/repository_mapper.rb
+++ b/app/models/katello/candlepin/repository_mapper.rb
@@ -74,7 +74,7 @@ module Katello
       end
 
       def relative_path
-        ::Katello::Glue::Pulp::Repos.repo_path_from_content_path(product.organization.library, path)
+        ::Katello::Repository.repo_path_from_content_path(product.organization.library, path)
       end
 
       def prune_substitutions(subs, url)

--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -6,12 +6,6 @@ module Katello
       base.send :include, InstanceMethods
     end
 
-    def self.repo_path_from_content_path(environment, content_path)
-      path = content_path.sub(%r|^/|, '')
-      path_prefix = [environment.organization.label, environment.label].join('/')
-      "#{path_prefix}/#{path}"
-    end
-
     module InstanceMethods
       def distributions(env)
         to_ret = []

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -201,6 +201,12 @@ module Katello
       joins(:root).where("#{Katello::RootRepository.table_name}.product_id" => products)
     end
 
+    def self.repo_path_from_content_path(environment, content_path)
+      path = content_path.sub(%r|^/|, '')
+      path_prefix = [environment.organization.label, environment.label].join('/')
+      "#{path_prefix}/#{path}"
+    end
+
     def to_label
       name
     end

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -173,10 +173,10 @@ module Katello
     def test_bad_promote_out_of_sequence
       version = @library_dev_staging_view.versions.first
       @controller.expects(:async_task).with(::Actions::Katello::ContentView::Promote, version, [@beta], false, nil).
-          raises(::Katello::HttpErrors::BadRequest)
+          raises(::Katello::HttpErrors::BadRequest.new('Cannot promote environment out of sequence. Use force to bypass restriction.'))
       post :promote, params: { :id => version.id, :environment_ids => [@beta.id] }
 
-      assert_response 500
+      assert_response 400
     end
 
     def test_promote_out_of_sequence_force


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Re-adds `repository_url` for liveimg provisioning (https://access.redhat.com/documentation/en-us/red_hat_satellite/6.14/html-single/provisioning_hosts/index#Using_an_Image_Builder_Image_for_Provisioning_provisioning) and makes it work with multiple cv environments.

#### Considerations taken when implementing this change?

Currently, two approaches are both coded in. I'd like feedback on which is better:

1) Force the user to use a single content view environment only when provisioning liveimg files. This is a safer and more simple option.

2) Allow the user to have multiple CVs on their host. If that is the case, search for the correct repository among the multiple CVs. If there are multiple root repositories with this file, throw an error.

#### What are the testing steps for this pull request?
Ideally, run through the steps in the docs above to provision a host using the template that uses this method.
Alternatively, simulate the provisioning by only rendering the script, or perhaps just run `repository_url` with the right inputs to trigger all of the errors.

To go through the host provisioning process, first sync some repo with kickstart content and create a domain. Then, create a host and fill in all the fields. Don't forget the domain and fake mac address on the interface. Lastly, add the parameter `kickstart_liveimg = some/path/to/a/file/that/does/not/need/to/exist.jpg`

Then build the host and look at the rendered kickstart default provisioning template. You can find it on the Details tab by clicking "Kickstart default".

Also test that `relative_path` in `repository_mapper.rb` still works since I moved one method from pulp glue to the repository model.