### PR TITLE
Fixes #37271 - Warn users before their manifests expire

### DIFF
--- a/app/jobs/create_manifest_expire_soon_warning_notifications.rb
+++ b/app/jobs/create_manifest_expire_soon_warning_notifications.rb
@@ -1,0 +1,11 @@
+class CreateManifestExpireSoonWarningNotifications < ApplicationJob
+  def perform
+    Katello::UINotifications::Subscriptions::ManifestExpireSoonWarning.deliver!
+  ensure
+    self.class.set(:wait => 24.hours).perform_later
+  end
+
+  def humanized_name
+    _('Subscription Manifest expiration date check')
+  end
+end

--- a/app/services/katello/ui_notifications/subscriptions/manifest_expire_soon_warning.rb
+++ b/app/services/katello/ui_notifications/subscriptions/manifest_expire_soon_warning.rb
@@ -1,0 +1,75 @@
+module Katello
+  module UINotifications
+    module Subscriptions
+      class ManifestExpireSoonWarning
+        class << self
+          def deliver!
+            ::Organization.unscoped.all.each do |organization|
+              if (notification = existing_notification(organization))
+                days_remaining = organization.manifest_expire_days_remaining
+                if days_remaining == 0 || days_remaining > Setting[:expire_soon_days].to_i
+                  # if the manifest has already expired, delete the notification;
+                  # user will have a ManifestExpiredWarning instead.
+                  # If user changes the expire_soon_days setting, remove notifications
+                  # that are no longer relevant.
+                  Rails.logger.debug("ManifestExpireSoonWarning: deleting notification for #{organization.name}")
+                  notification.destroy
+                  next
+                end
+                # don't update if the message hasn't changed
+                next unless message(organization).to_s !=
+                  notification.message.to_s
+                notification.update(
+                  :message => message(organization),
+                  :actions => actions
+                )
+              else
+                next unless organization.manifest_expiring_soon?
+                ::Notification.create!(
+                  :subject => organization,
+                  :initiator => User.anonymous_admin,
+                  :audience => Notification::AUDIENCE_SUBJECT,
+                  :message => message(organization),
+                  :actions => actions,
+                  :notification_blueprint => blueprint
+                )
+              end
+            end
+          end
+
+          def existing_notification(subject)
+            matching_notification = Notification.unscoped.find_by(:subject => subject, :notification_blueprint => blueprint)
+            return false if matching_notification.blank?
+            matching_notification
+          end
+
+          def message(organization)
+            ::UINotifications::StringParser.new(
+              blueprint.message,
+              :manifest_expire_date => organization.manifest_expiration_date&.to_date,
+              :subject => organization,
+              :days_remaining => organization.manifest_expire_days_remaining
+            )
+          end
+
+          def actions
+            {
+              :links => [
+                {
+                  :href => "/subscriptions",
+                  :title => _('Subscriptions'),
+                  :external => false
+                }
+              ]
+            }
+          end
+
+          def blueprint
+            @blueprint ||= NotificationBlueprint.unscoped.find_by(
+              :name => 'manifest_expire_soon_warning')
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/views/katello/api/v2/organizations/show.json.rabl
+++ b/app/views/katello/api/v2/organizations/show.json.rabl
@@ -3,9 +3,17 @@ object @organization
 extends "api/v2/taxonomies/show"
 
 attributes :task_id, :label, :redhat_repository_url
-
+attributes :manifest_expiration_date, :manifest_expire_days_remaining
 attributes :system_purposes, :system_purposes
 attributes :service_levels, :service_level
+
+node :manifest_expiring_soon do |org|
+  org.manifest_expiring_soon?
+end
+
+node :manifest_expired do |org|
+  org.manifest_expired?
+end
 
 node :simple_content_access do |org|
   org.simple_content_access?

--- a/db/seeds.d/109-katello-notification-blueprints.rb
+++ b/db/seeds.d/109-katello-notification-blueprints.rb
@@ -27,6 +27,12 @@ blueprints = [
   },
   {
     group: N_('Subscriptions'),
+    name: 'manifest_expire_soon_warning',
+    message: N_('Manifest in organization %{subject} has an identity certificate that will expire in %{days_remaining} days, on %{manifest_expire_date}. To extend the expiration date, please refresh your manifest.'),
+    level: 'info'
+  },
+  {
+    group: N_('Subscriptions'),
     name: 'manifest_expired_warning',
     message: N_('The manifest imported within Organization %{subject} is no longer valid. Please import a new manifest.'),
     level: 'warning'

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -578,7 +578,7 @@ Foreman::Plugin.register :katello do
         type: :integer,
         default: 120,
         full_name: N_('Expire soon days'),
-        description: N_('The number of days remaining in a subscription before you will be reminded about renewing it.')
+        description: N_('The number of days remaining in a subscription before you will be reminded about renewing it. Also used for manifest expiration warnings.')
 
       setting 'host_dmi_uuid_duplicates',
         type: :array,

--- a/lib/katello/scheduled_jobs.rb
+++ b/lib/katello/scheduled_jobs.rb
@@ -1,6 +1,12 @@
 # First, we check if there's a job already enqueued for any notifications
 ::Foreman::Application.dynflow.config.on_init do |world|
-  [CreateExpiredManifestNotifications, CreateHostLifecycleExpireSoonNotifications, CreatePulpDiskSpaceNotifications, SendExpireSoonNotifications].each do |job_class|
+  [
+    CreateExpiredManifestNotifications,
+    CreateHostLifecycleExpireSoonNotifications,
+    CreatePulpDiskSpaceNotifications,
+    SendExpireSoonNotifications,
+    CreateManifestExpireSoonWarningNotifications
+  ].each do |job_class|
     job_class.spawn_if_missing(world)
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

We're now warning users _before_ their manifest('s upstream consumer identity certificate) expires, in various ways:

* Add a notification blueprint (the bell thingy on the upper right) for manifest expiring soon warnings
* Add manifest expiration date to the Manage Manifest modal
* Add Alerts to the Manage Manifest modal for manifest expiring soon and manifest expired

As part of this, the "Expire soon days" Setting description is updated. We're using this Setting for manifest expiring soon warnings now, too.

![expiring-manifest-notification](https://github.com/Katello/katello/assets/22042343/44a4877b-f0de-4841-aee0-105c73bd47c5)
![expiring-soon-manifest](https://github.com/Katello/katello/assets/22042343/b95b4707-9f97-48a9-b4bf-432e62caed29)
![expired-manifest](https://github.com/Katello/katello/assets/22042343/f2769003-f058-42e4-bfae-f994caee72a2)


#### Considerations taken when implementing this change?

I want this to be as backportable as possible, so I am keeping the Ruby and React commits separate. 

#### What are the testing steps for this pull request?

Set your Setting `expire_soon_days` to something large, like 365.

In Rails console, run
```
Katello::UINotifications::Subscriptions::ManifestExpireSoonWarning.deliver!
```

- You should see the notification in your notification drawer.
- You should see the warning alert in the Manage Manifest modal.
(You can also see this by running `Katello::UINotifications::Subscriptions::ManifestExpireSoonWarning.existing_notification(Organization.find(1))`)

Optional: Import an expired manifest and view the Manage Manifest modal for that.

- Note that you can run `Katello::UINotifications::Subscriptions::ManifestExpireSoonWarning.deliver!` multiple times, and it should be idempotent -- you should not receive multiple notifications for a single organization.
- If you change your Setting back to a low number, and then run `Katello::UINotifications::Subscriptions::ManifestExpireSoonWarning.deliver!` again, existing notifications will be deleted.
- 
