### PR TITLE
Fixes #37279 - Re-create remotes when the type needs to change

### DIFF
--- a/app/services/katello/pulp3/alternate_content_source.rb
+++ b/app/services/katello/pulp3/alternate_content_source.rb
@@ -88,18 +88,16 @@ module Katello
       end
 
       def get_remote(href = smart_proxy_acs.remote_href)
-        acs.base_url&.start_with?('uln') ? api.remotes_uln_api.read(href) : api.remotes_api.read(href)
+        api.get_remotes_api(href: href).read(href)
       end
 
-      def update_remote
-        api.remotes_api.partial_update(smart_proxy_acs.remote_href, remote_options)
+      def update_remote(href = smart_proxy_acs.remote_href)
+        api.get_remotes_api(href: href).partial_update(href, remote_options)
       end
 
-      # The old repo URL is needed to determine which remote API to use.
       def delete_remote(options = {})
         options[:href] ||= smart_proxy_acs.remote_href
-        options[:old_url] ||= remote_options[:url]
-        ignore_404_exception { options[:old_url]&.start_with?('uln') ? api.remotes_uln_api.delete(options[:href]) : api.remotes_api.delete(options[:href]) } if options[:href]
+        ignore_404_exception { api.get_remotes_api(href: options[:href]).delete(options[:href]) } if options[:href]
       end
 
       def create

--- a/app/services/katello/pulp3/api/core.rb
+++ b/app/services/katello/pulp3/api/core.rb
@@ -47,6 +47,11 @@ module Katello
           fail NotImplementedError
         end
 
+        # Method is called with either :url or :href parameters for the sake of yum content.
+        def get_remotes_api(*)
+          remotes_api
+        end
+
         def publications_api
           repository_type.publications_api_class.new(api_client) #Optional
         end

--- a/app/services/katello/pulp3/api/yum.rb
+++ b/app/services/katello/pulp3/api/yum.rb
@@ -32,6 +32,17 @@ module Katello
           PulpRpmClient::RemotesUlnApi.new(api_client)
         end
 
+        def get_remotes_api(href: nil, url: nil)
+          fail 'Provide exactly one of href or url for yum remote selection!' if url.blank? && href.blank?
+          fail 'The href must be a pulp_rpm remote href!' if href && !href.start_with?('/pulp/api/v3/remotes/rpm/')
+
+          if href&.start_with?('/pulp/api/v3/remotes/rpm/uln/') || url&.start_with?('uln')
+            remotes_uln_api
+          else
+            remotes_api
+          end
+        end
+
         def copy_api
           PulpRpmClient::RpmCopyApi.new(api_client)
         end

--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -24,11 +24,9 @@ module Katello
       def refresh_entities
         href = remote_href
         if href
-          if remote_options[:url]&.start_with?('uln')
-            [api.remotes_uln_api.partial_update(href, remote_options)]
-          else
-            [api.remotes_api.partial_update(href, remote_options)]
-          end
+          # Do not consider remotes_uln_api, since the Katello server is not a ULN server. Even if the sync
+          # to Katello used ULN, the sync from Katello server to smart proxy will use a normal RPM remote!
+          [api.remotes_api.partial_update(href, remote_options)]
         else
           create_remote
           []
@@ -111,13 +109,10 @@ module Katello
       end
 
       def create_remote
-        if remote_options[:url]&.start_with?('uln')
-          remote_file_data = @repo_service.api.class.remote_uln_class.new(remote_options)
-          api.remotes_uln_api.create(remote_file_data)
-        else
-          remote_file_data = @repo_service.api.remote_class.new(remote_options)
-          api.remotes_api.create(remote_file_data)
-        end
+        # Do not consider remotes_uln_api, since the Katello server is not a ULN server. Even if the sync
+        # to Katello used ULN, the sync from Katello server to smart proxy will use a normal RPM remote!
+        remote_file_data = @repo_service.api.remote_class.new(remote_options)
+        api.remotes_api.create(remote_file_data)
       end
 
       def compute_remote_options

--- a/app/services/katello/pulp3/service_common.rb
+++ b/app/services/katello/pulp3/service_common.rb
@@ -9,11 +9,7 @@ module Katello
           remote_file_data = api.remote_class.new(remote_options)
         end
         reformat_api_exception do
-          if remote_options[:url]&.start_with?('uln')
-            response = api.remotes_uln_api.create(remote_file_data)
-          else
-            response = api.remotes_api.create(remote_file_data)
-          end
+          response = api.get_remotes_api(url: remote_options[:url]).create(remote_file_data)
         end
         response
       end
@@ -37,11 +33,7 @@ module Katello
         end
 
         reformat_api_exception do
-          if remote_options[:url]&.start_with?('uln')
-            response = api.remotes_uln_api.create(remote_file_data)
-          else
-            response = api.remotes_api.create(remote_file_data)
-          end
+          response = api.get_remotes_api(url: remote_options[:url]).create(remote_file_data)
           #delete is async, but if its not properly deleted, orphan cleanup will take care of it later
           delete_remote(href: response.pulp_href)
         end

--- a/test/services/katello/pulp3/repository/file/update_remote_test.rb
+++ b/test/services/katello/pulp3/repository/file/update_remote_test.rb
@@ -20,7 +20,7 @@ module Katello
           @file_repo_service = @file_repo.backend_service(@mock_smart_proxy)
           @file_repo.root.update(url: 'my-files.org')
           @file_repo_service.stubs(:api).returns(@mock_api_wrapper)
-          @mock_api_wrapper.stubs(:remotes_api).returns(@mock_pulp3_api)
+          @mock_api_wrapper.stubs(:get_remotes_api).returns(@mock_pulp3_api)
 
           @file_repo.remote_href = '193874298udsfsdf'
           refute_empty @file_repo.remote_href


### PR DESCRIPTION
When updating a remote, we may need to re-create it instead if the type has changed from uln to rpm or vice versa.

For operations on a remote href, the type is now determined from the href, rather than indirectly from the url. This is more robust since it is the actually relevant source of truth.

All other changes are for readability, deduplication, or consistency