### PR TITLE
Fixes #37283 - add sort_by param & reduce per_page

### DIFF
--- a/app/lib/katello/resources/candlepin/consumer.rb
+++ b/app/lib/katello/resources/candlepin/consumer.rb
@@ -7,7 +7,7 @@ module Katello
         class << self
           def all_uuids
             cp_consumers = Organization.all.map do |org|
-              ::Katello::Resources::Candlepin::Consumer.get('owner' => org.label, :include_only => [:uuid])
+              ::Katello::Resources::Candlepin::Consumer.get('owner' => org.label, :include_only => [:uuid], :sort_by => "uuid")
             end
             cp_consumers.flatten!
             cp_consumers.map { |consumer| consumer["uuid"] }

--- a/lib/katello/tasks/clean_backend_objects.rake
+++ b/lib/katello/tasks/clean_backend_objects.rake
@@ -75,7 +75,7 @@ namespace :katello do
       print "The following changes will not actually be performed.  Rerun with COMMIT=true to apply the changes\n"
     end
 
-    SETTINGS[:katello][:candlepin][:bulk_load_size] = 1_500
+    SETTINGS[:katello][:candlepin][:bulk_load_size] = 125
     User.current = User.anonymous_admin
     cleaner = BackendCleaner.new
     cleaner.populate!


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Added  ":sort_by => uuid"  to the "::Katllo::Resource::Candlepin::Consumer.get"  call.   This way uuids get returned in order.  Otherwise there is a chance duplicate uuids get returned, but the real count will be the same, which means we aren't grabbing all of the correct uuids.  Then when we compare with the list from katello, we see a discrepancy and hosts will get removed erroneously.


Also, changed a per_page of 1_500 to 125, which drastically reduces the time necessary for the candlepin consumer request (by a factor of 8).  Doing curl requests directly to the candlepin endpoint, we see the uuids returned per second drastically goes up as the per_page value is increased:

~~~
Per page is 125   
  real	0m1.536s    <== 81 per second

Per page is 250
  real	0m4.007s    <== 62 per second

Per page is 500
  real	0m14.050s   <== 36 per second

Per page is 1000   
  real	0m56.440s   <== 18 per second
 
Per page is 1500
  real	2m15.842s   <== 11 per second

Per page is 2000
  real	4m11.618s   <== 8 per second

Per page is 4000   
  real	19m38.112s  <== 3 per second
~~~


#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Tested the  katello:clean_backend_objects rake script, and no hosts were removed.  
Prior to patch, custom environment was removing roughly 1000 consumers from an organization with 6000+ consumers.