### PR TITLE
Fixes #37303 - Fix PropType errors in ContentSourceForm

### DIFF
--- a/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
@@ -114,7 +114,7 @@ const ContentSourceForm = ({
   const hostCount = contentHosts.length;
 
   const handleCSSelect = (_event, selection) => {
-    handleContentSource(selection);
+    handleContentSource(typeof selection === 'number' ? selection.toString() : selection);
     setCSSelectOpen(false);
   };
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When selecting a content source in the web UI, we get a couple console errors including:

```
ContentSourceForm.js:184 Warning: Failed prop type: Invalid prop `selections` of type `number` supplied to `ContentSourceSelect`, expected `string`.
```

This fixes it by making sure we call the event handler with a string and not a number.

#### Considerations taken when implementing this change?

Alternative is to change the PropType to expect a number instead, but this seemed a bit safer? Idk, I could go either way.

Also, not sure what caused this. Guessing it was a Patternfly update or something.

#### What are the testing steps for this pull request?

1. Select a few hosts > Change Content Source
2. Select a content source from the dropdown. You should see the console errors.
3. Now check out the PR and the errors should be gone.

