### PR TITLE
Fixes #37302 - push containers through Katello

### DIFF
--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -38,6 +38,7 @@ module Katello
       get: Net::HTTP::Get,
       post: Net::HTTP::Post,
       put: Net::HTTP::Put,
+      patch: Net::HTTP::Patch,
       delete: Net::HTTP::Delete
     }.freeze
 
@@ -84,7 +85,11 @@ module Katello
       def issue_request(method:, path:, headers: {}, payload: nil)
         logger.debug("Resource #{method.upcase} request: #{path}")
         logger.debug "Headers: #{headers.to_json}"
-        logger.debug "Body: #{filter_sensitive_data(payload.to_json)}"
+        begin
+          logger.debug "Body: #{filter_sensitive_data(payload.to_json)}"
+        rescue JSON::GeneratorError
+          logger.debug "Body: Error: could not render payload as json"
+        end
 
         client = rest_client(REQUEST_MAP[method], method, path)
         args = [method, payload, headers].compact

--- a/app/lib/katello/resources/registry.rb
+++ b/app/lib/katello/resources/registry.rb
@@ -18,10 +18,35 @@ module Katello
           client.options.merge!(options)
           client.get(headers)
         end
+
+        def self.put(path, body, headers)
+          logger.debug "Sending PUT request to Registry: #{path}"
+          resource = RegistryResource.load_class
+          joined_path = resource.prefix.chomp("/") + path
+          resource.issue_request(method: :put, path: joined_path, headers: headers, payload: body)
+        end
+
+        def self.patch(path, body, headers)
+          logger.debug "Sending PATCH request to Registry: #{path}"
+          resource = RegistryResource.load_class
+          joined_path = resource.prefix.chomp("/") + path
+          resource.issue_request(method: :patch, path: joined_path, headers: headers, payload: body)
+        end
+
+        def self.post(path, body, headers)
+          logger.debug "Sending PUT request to Registry: #{path}"
+          resource = RegistryResource.load_class
+          joined_path = resource.prefix.chomp("/") + path
+          resource.issue_request(method: :post, path: joined_path, headers: headers, payload: body)
+        end
       end
 
       class RegistryResource < HttpResource
         class << self
+          def logger
+            ::Foreman::Logging.logger('katello/registry_proxy')
+          end
+
           def load_class
             pulp_primary = ::SmartProxy.pulp_primary
             content_app_url = pulp_primary.setting(SmartProxy::PULP3_FEATURE, 'content_app_url')

--- a/config/routes/api/registry.rb
+++ b/config/routes/api/registry.rb
@@ -10,16 +10,12 @@ Katello::Engine.routes.draw do
       match '/v2/token' => 'registry_proxies#token', :via => :get
       match '/v2/token' => 'registry_proxies#token', :via => :post
       match '/v2/*repository/manifests/:tag' => 'registry_proxies#pull_manifest', :via => :get
-      # Push-related routes are disabled until there is support for pushing to Pulp 3.
-      # match '/v2/*repository/manifests/:tag' => 'registry_proxies#push_manifest', :via => :put
+      match '/v2/*repository/manifests/:tag' => 'registry_proxies#push_manifest', :via => :put
       match '/v2/*repository/blobs/:digest' => 'registry_proxies#pull_blob', :via => :get
       match '/v2/*repository/blobs/:digest' => 'registry_proxies#check_blob', :via => :head
-      # match '/v2/*repository/blobs/uploads' => 'registry_proxies#start_upload_blob', :via => :post
-      # match '/v2/*repository/blobs/uploads/:uuid' => 'registry_proxies#chunk_upload_blob', :via => :post
-      # match '/v2/*repository/blobs/uploads/:uuid' => 'registry_proxies#finish_upload_blob', :via => :put
-      # match '/v2/*repository/blobs/uploads/:uuid' => 'registry_proxies#upload_blob', :via => :patch
-      # match '/v2/*repository/blobs/uploads/:uuid' => 'registry_proxies#status_upload_blob', :via => :get
-      # match '/v2/*repository/blobs/uploads/:uuid' => 'registry_proxies#cancel_upload_blob', :via => :delete
+      match '/v2/*repository/blobs/uploads' => 'registry_proxies#start_upload_blob', :via => :post
+      match '/v2/*repository/blobs/uploads/:uuid' => 'registry_proxies#finish_upload_blob', :via => :put
+      match '/v2/*repository/blobs/uploads/:uuid' => 'registry_proxies#upload_blob', :via => :patch
       match '/v2/_catalog' => 'registry_proxies#catalog', :via => :get
       match '/v2/*repository/tags/list' => 'registry_proxies#tags_list', :via => :get
       match '/v2' => 'registry_proxies#ping', :via => :get

--- a/lib/katello/permissions/registry_permissions.rb
+++ b/lib/katello/permissions/registry_permissions.rb
@@ -8,13 +8,10 @@ Foreman::AccessControl.permission(:create_personal_access_tokens).actions.concat
   'katello/api/registry/registry_proxies/catalog',
   'katello/api/registry/registry_proxies/tags_list',
   'katello/api/registry/registry_proxies/pull_manifest',
-  #'katello/api/registry/registry_proxies/push_manifest',
+  'katello/api/registry/registry_proxies/push_manifest',
   'katello/api/registry/registry_proxies/pull_blob',
   'katello/api/registry/registry_proxies/check_blob',
-  #'katello/api/registry/registry_proxies/start_upload_blob',
-  #'katello/api/registry/registry_proxies/upload_blob',
-  #'katello/api/registry/registry_proxies/chunk_upload_blob',
-  #'katello/api/registry/registry_proxies/finish_upload_blob',
-  'katello/api/registry/registry_proxies/status_upload_blob',
-  'katello/api/registry/registry_proxies/cancel_upload_blob'
+  'katello/api/registry/registry_proxies/start_upload_blob',
+  'katello/api/registry/registry_proxies/upload_blob',
+  'katello/api/registry/registry_proxies/finish_upload_blob'
 ]


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds support for pushing content through Katello to Pulp. Does not index any information from Pulp. As such, only pushing is possible through Katello.

#### Considerations taken when implementing this change?
The REMOTE_USER header must be set to perform remote auth with the Pulpcore registry. Apache will set this rather than Katello, so it's left out here.

#### What are the testing steps for this pull request?
0) Cherry-pick @sjha4 's changes here before pulling in this PR and upgrade to Pulpcore nightly: https://github.com/theforeman/foreman-packaging/pull/10658
  - Pulpcore Nightly repo: https://stagingyum.theforeman.org/pulpcore/nightly/
1) Due to https://github.com/pulp/pulp_container/issues/1577, hacking is required for auth with Pulp to work. In `/usr/lib/python3.11/site-packages/pulp_container/app/token_verification.py`, add `return RemoteUserRegistryAuthentication().authenticate(request)` to the top of `RegistryAuthentication.authenticate.`
  - Don't forget to restart Pulpcore after making the changes.
2) Apache must also be configured to send the REMOTE_USER header over to Pulp. Edit `/etc/httpd/conf.d/05-foreman-ssl.conf` so that the `/pulpcore_registry/v2/` location loses `RequestHeader set REMOTE_USER "%{SSL_CLIENT_S_DN_CN}s" env=SSL_CLIENT_S_DN_CN` and gains `RequestHeader set REMOTE_USER "admin"`.
  - https://github.com/theforeman/puppet-pulpcore/pull/337
3) Add the following to `foreman/config/settings.plugins.d/katello.yaml`:
```yaml
# The katello section should exist already.
:katello:
  :container_image_registry:
    :allow_push: true
```
4) Pull some image to your system using `podman pull` so there is something to push.
5) Push to Katello:
```
# Example -- 76435261c6d3 must point to an image on your machine. Find it with 'podman image ls' after pulling.
podman push 76435261c6d3 centos8-katello-devel.manicotto.example.com/organization/product/quarkus-micro-image
```
6) Check that a container push repo was created in Pulp:
```
pulp container repository -t push list
```
  - Make sure that actual content was uploaded.
7) Try a few images. Try some big ones!