### PR TITLE
Refs #36924 - Add breadcrumb bar to Add Subscription page, fix add subscription button url

### DIFF
--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
@@ -222,19 +222,20 @@ class UpstreamSubscriptionsPage extends Component {
 
     return (
       <Grid bsClass="container-fluid">
-        <BreadcrumbsBar data={{
-          isSwitchable: false,
-          breadcrumbItems: [
-            {
-              caption: __('Subscriptions'),
-              onClick: () => this.props.history.push('/subscriptions'),
-            },
-            {
-              caption: __('Add Subscriptions'),
-            },
-          ],
-        }}
-        />
+        {!upstreamSubscriptions.loading && <div style={{marginBottom: "10px"}}>
+          <BreadcrumbsBar
+            isLoadingResources={upstreamSubscriptions.loading}
+            breadcrumbItems={[
+              {
+                caption: __('Subscriptions'),
+                url: '/subscriptions/',
+              },
+              {
+                caption: String(__('Add Subscriptions')),
+              },
+            ]}
+          />
+        </div>}
 
         <LoadingState loading={upstreamSubscriptions.loading} loadingText={__('Loading')}>
           <Row>

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/__snapshots__/UpstreamSubscriptionsPage.test.js.snap
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/__snapshots__/UpstreamSubscriptionsPage.test.js.snap
@@ -6,22 +6,28 @@ exports[`upstream subscriptions page should render 1`] = `
   componentClass="div"
   fluid={false}
 >
-  <BreadcrumbsBar
-    data={
+  <div
+    style={
       Object {
-        "breadcrumbItems": Array [
+        "marginBottom": "10px",
+      }
+    }
+  >
+    <BreadcrumbsBar
+      breadcrumbItems={
+        Array [
           Object {
             "caption": "Subscriptions",
-            "onClick": [Function],
+            "url": "/subscriptions/",
           },
           Object {
             "caption": "Add Subscriptions",
           },
-        ],
-        "isSwitchable": false,
+        ]
       }
-    }
-  />
+      isLoadingResources={false}
+    />
+  </div>
   <LoadingState
     loading={false}
     loadingText="Loading"

--- a/webpack/scenes/Subscriptions/components/SubscriptionsToolbar/SubscriptionsToolbar.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsToolbar/SubscriptionsToolbar.js
@@ -49,7 +49,7 @@ const SubscriptionsToolbar = ({
           <FormGroup>
             {canManageSubscriptionAllocations &&
               <LinkContainer
-                to="subscriptions/add"
+                to="/subscriptions/add"
                 disabled={disableManifestActions || disableAddButton}
               >
                 <TooltipButton


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
The add subscription page now has a breadcrumb bar showing the user's path through the subscriptions overview page.

#### Considerations taken when implementing this change?
This is the second pull request for [this redmine issue](https://projects.theforeman.org/issues/36924). The first PR failed QA; this PR should correct missing elements from the first PR. Both PRs are necessary to complete the issue.

#### What are the testing steps for this pull request?
Open Katello to the subscriptions overview page. Click 'Add Subscription'. The add subscription page should display a breadcrumb bar in the header which allows the user to return to the subscriptions overview page.