### PR TITLE
Fixes #37313 - Change Content Source form improvements

### DIFF
--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -8,7 +8,7 @@
 
 <% if edit_action? && !using_hostgroups_page? && !using_discovered_hosts_page? %>
   <div style="margin-left: 270px">
-    <%= link_to _("Change content source"), "/change_host_content_source?host_id=#{@host.id}" %>
+    <%= link_to _("Change content source"), "/change_host_content_source?fromPage=hostEdit&host_id=#{@host.id}&initialContentSourceId=#{@host.content_source_id}" %>
   </div>
 <% end %>
 

--- a/webpack/components/extensions/HostDetails/ActionsBar/index.js
+++ b/webpack/components/extensions/HostDetails/ActionsBar/index.js
@@ -65,7 +65,7 @@ const HostActionsBar = () => {
       <DropdownItem
         ouiaId="katello-change-host-content-source"
         key="katello-change-host-content-source"
-        href={foremanUrl(`/change_host_content_source?host_id=${hostDetails?.id}`)}
+        href={foremanUrl(`/change_host_content_source?host_id=${hostDetails?.id}&initialContentSourceId=${hostDetails?.content_facet_attributes?.content_source_id}`)}
         icon={<CubeIcon />}
       >
         {__('Change content source')}

--- a/webpack/scenes/Hosts/ChangeContentSource/actions.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/actions.js
@@ -18,7 +18,7 @@ export const getFormData = (hostIds, search) => (post({
 }));
 
 export const changeContentSource =
-  (environmentId, contentViewId, contentSourceId, hostIds, handleSuccess) =>
+  (environmentId, contentViewId, contentSourceId, hostIds, handleSuccess, successToast) =>
     put({
       key: CHANGE_CONTENT_SOURCE,
       url: foremanUrl('/api/v2/hosts/bulk/change_content_source'),
@@ -29,6 +29,7 @@ export const changeContentSource =
         host_ids: hostIds,
       },
       errorToast: () => __('Something went wrong while updating the content source. See the logs for more information'),
+      successToast,
       handleSuccess,
     });
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Several improvements to the Change Content Source page:

1. Add a url parameter, `initialContentSourceId`. When this is specified, the dropdown's initial value is set. In addition, if there is only one host to update, _and_ `initialContentSourceId` is passed, the form assumes that you are not really changing the host's content source, and instead only the host content view environment is changing.  In such a case, the UI is improved accordingly (see the following items).
2. Add a banner for the situation above, letting you know that the content source is not changing.
3. In the situation above - Instead of "Run job invocation" / "Update manually" buttons, there is only a single "Save" button.
4. The 'Change content source' link from the new host details page now specifies `initialContentSourceId`.
5. The 'Change content source' link from the Edit Hosts page now specifies `initialContentSourceId`.

#### Considerations taken when implementing this change?

Currently the form can't check the host's _real_ content source ID against the selected one because the API response it's using for the host list is quite "thin," and only contains host ID and name. So I came up with the logic above as a sort of compromise. I think that most users will not manually compose the URL with URL params, and so a situation where `initialContentSourceId` doesn't match the single host's real content source ID is unlikely.



#### What are the testing steps for this pull request?

test all flows and make sure everything still works

- link from Edit Host
- link from host details
- Bulk select from new All Hosts
- bulk select from old All Hosts
- single host
- multi-host

