### PR TITLE
Fixes #37340 - do not use shell to update packages

### DIFF
--- a/app/views/foreman/job_templates/update_package_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/update_package_-_katello_ansible_default.erb
@@ -13,4 +13,8 @@ provider_type: Ansible
 kind: job_template
 %>
 
-<%= render_template('Run Command - Ansible Default', :command => "yum -y update #{input('package')}") %>
+<%
+pkgs = input('package')
+pkgs = '"*"' if pkgs.empty?
+-%>
+<%= render_template('Package Action - Ansible Default', :state => 'latest', :name => pkgs) %>

--- a/app/views/foreman/job_templates/update_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/update_packages_by_search_query_-_katello_ansible_default.erb
@@ -3,7 +3,7 @@ kind: job_template
 name: Update packages by search query - Katello Ansible Default
 job_category: Katello
 description_format: 'Update package(s) %{Packages search query}'
-feature: katello_package_remove_by_search
+feature: katello_package_update_by_search
 provider_type: Ansible
 template_inputs:
 - name: Packages search query
@@ -22,7 +22,7 @@ template_inputs:
   versions: input('Selected update versions')
 ) -%>
 <% if package_names.empty? -%>
-<%= render_template('Run Command - Ansible Default', :command => "yum -y update") %>
+<%= render_template('Package Action - Ansible Default', :state => 'latest', :name => '"*"') %>
 <% else -%>
 ---
 - hosts: all


### PR DESCRIPTION
In favor of just running a shell command, you can use the Ansible module "ansible.builtin.package" to perform package actions such as installing, updating, and removing packages.

* docs: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/package_module.html
* see also "install_package_-_katello_ansible_default.erb"

#### What are the changes introduced in this pull request?

Make better use of Ansible to run package manager-indenpendent package actions.

#### Considerations taken when implementing this change?

copied code shamelessly from https://github.com/Katello/katello/blob/master/app/views/foreman/job_templates/install_package_-_katello_ansible_default.erb#L16

I noticed that there is also the option to further nest the templates, i.e. call another template from within this template. However, I consider this a worse solution because the `state` in `install_package_-_katello_ansible_default.erb` should be "present", not "latest". (IMHO a bug). Therefore, we should differentiate between "installing" as in "ensuring it's present" and actually updating a package.

#### What are the testing steps for this pull request?

Apply the patch manually to the job templates on your Foreman+Katello nightly and then execute a job on multiple hosts, for example on RHEL 8 and Debian 12.