### PR TITLE
Fixes #37346 - Fetching Host's details does not scale wrt Hosts Collections

### DIFF
--- a/app/models/katello/host_collection.rb
+++ b/app/models/katello/host_collection.rb
@@ -29,7 +29,10 @@ module Katello
     scoped_search :relation => :hosts, :on => :name, :rename => :host, :complete_value => true
 
     def max_hosts_check
-      if !unlimited_hosts && (hosts.length > 0 && (hosts.length.to_i > max_hosts.to_i)) && max_hosts_changed?
+      # NOTE: max_hosts_check and max_hosts_no_exceeded use size() instead of count() because
+      # the host list exists as an array rather than a DB query when run as a validation.
+      host_count = hosts.size
+      if !unlimited_hosts && (host_count > 0 && (host_count.to_i > max_hosts.to_i)) && max_hosts_changed?
         errors.add :max_host, N_("may not be less than the number of hosts associated with the host collection.")
       end
     end
@@ -60,8 +63,14 @@ module Katello
       type ? query.of_type(type) : query
     end
 
-    def total_hosts
-      hosts.count
+    def cache_key
+      "#{self.class.name}/#{self.id}"
+    end
+
+    def total_hosts(cached: false)
+      Rails.cache.fetch("#{cache_key}/total_hosts", expires_in: 1.minute, force: !cached) do
+        hosts.count
+      end
     end
 
     # Retrieve the list of accessible host collections in the organization specified, returning

--- a/app/models/katello/host_collection.rb
+++ b/app/models/katello/host_collection.rb
@@ -61,7 +61,7 @@ module Katello
     end
 
     def total_hosts
-      hosts.length
+      hosts.count
     end
 
     # Retrieve the list of accessible host collections in the organization specified, returning

--- a/app/views/katello/api/v2/hosts/host_collections.json.rabl
+++ b/app/views/katello/api/v2/hosts/host_collections.json.rabl
@@ -1,3 +1,7 @@
 child :host_collections => :host_collections do
-  attributes :id, :name, :description, :max_hosts, :unlimited_hosts, :total_hosts
+  attributes :id, :name, :description, :max_hosts, :unlimited_hosts
+
+  node :total_hosts do |host_collection|
+    host_collection.total_hosts(cached: true)
+  end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Changes `length` to `count` in HostCollection#total_hosts since `length` will load all records in hosts where `count` does a `count` query.

This should significantly improve API performance when loading hosts.

#### Considerations taken when implementing this change?
I considered if we should remove total_hosts completely from the host collections view snippet, but the count query change should make it much faster.

#### What are the testing steps for this pull request?
With my patch, when listing a host via the UI you should see postgres queries like:

```
2024-04-11 15:40:06 UTC LOG:  execute a28: SELECT "katello_host_collections".* FROM "katello_host_collections" INNER JOIN "katello_host_collection_hosts" ON "katello_host_collections"."id" = "katello_host_collection_hosts"."host_collection_id" WHERE "katello_host_collection_hosts"."host_id" = $1
2024-04-11 15:40:06 UTC DETAIL:  parameters: $1 = '1'
2024-04-11 15:40:06 UTC LOG:  execute <unnamed>: SELECT COUNT(*) FROM "hosts" INNER JOIN "katello_host_collection_hosts" ON "hosts"."id" = "katello_host_collection_hosts"."host_id" WHERE "hosts"."type" = $1 AND "katello_host_collection_hosts"."host_collection_id" = $2
2024-04-11 15:40:06 UTC DETAIL:  parameters: $1 = 'Host::Managed', $2 = '1'
2024-04-11 15:40:06 UTC LOG:  execute a29: SELECT "katello_content_view_versions".* FROM "katello_content_view_versions" WHERE "katello_content_view_versions"."id" = $1 LIMIT $2
```
Note the `SELECT COUNT(*) FROM "hosts"`.

Without my patch, you'll see logs like:
```
2024-04-11 15:39:38 UTC LOG:  execute a27: SELECT "katello_host_collections".* FROM "katello_host_collections" INNER JOIN "katello_host_collection_hosts" ON "katello_host_collections"."id" = "katello_host_collection_hosts"."host_collection_id" WHERE "katello_host_collection_hosts"."host_id" = $1
2024-04-11 15:39:38 UTC DETAIL:  parameters: $1 = '1'
2024-04-11 15:39:38 UTC LOG:  execute a28: SELECT "hosts".* FROM "hosts" INNER JOIN "katello_host_collection_hosts" ON "hosts"."id" = "katello_host_collection_hosts"."host_id" WHERE "hosts"."type" = $1 AND "katello_host_collection_hosts"."host_collection_id" = $2
2024-04-11 15:39:38 UTC DETAIL:  parameters: $1 = 'Host::Managed', $2 = '1'
```

The `SELECT "hosts".*` is what should be causing the performance issue.

Try doing a timing test or a SQL complexity comparison to help prove that this is indeed an improvement.