### PR TITLE
Fixes #37350 - Set content_access_mode_all to true and deprecate param

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -235,7 +235,7 @@ module Katello
 
     api :GET, "/activation_keys/:id/product_content", N_("Show content available for an activation key")
     param :id, String, :desc => N_("ID of the activation key"), :required => true
-    param :content_access_mode_all, :bool, :desc => N_("Get all content available, not just that provided by subscriptions")
+    param :content_access_mode_all, :bool, :desc => N_("Get all content available, not just that provided by subscriptions"), deprecated: true, default: true
     param :content_access_mode_env, :bool, :desc => N_("Limit content to just that available in the activation key's content view version")
     param_group :search, Api::V2::ApiController
     def product_content

--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -29,7 +29,7 @@ module Katello
     param :with_custom, :bool, :required => false, :desc => N_("If true, return custom repository sets along with redhat repos. Will be ignored if repository_type is supplied.")
     param :activation_key_id, :number, :desc => N_("activation key identifier"), :required => false
     param :host_id, :number, :desc => N_("Id of the host"), :required => false
-    param :content_access_mode_all, :bool, :desc => N_("Get all content available, not just that provided by subscriptions.")
+    param :content_access_mode_all, :bool, :desc => N_("Get all content available, not just that provided by subscriptions."), deprecated: true, default: true
     param :content_access_mode_env, :bool, :desc => N_("Limit content to just that available in the host's or activation key's content view version and lifecycle environment.")
     param :status, [:enabled, :disabled, :overridden],
                                   :desc => N_("Limit content to enabled / disabled / overridden"),
@@ -225,6 +225,7 @@ module Katello
 
     def setup_params
       return unless params[:id]
+      params[:content_access_mode_all] = true
       if params[:entity] == :activation_key
         params[:activation_key_id] ||= params[:id]
       else

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-repository-sets.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-repository-sets.controller.js
@@ -23,7 +23,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyRepositorySet
 
         params = {
             'activation_key_id': $scope.$stateParams.activationKeyId,
-            'content_access_mode_all': $scope.simpleContentAccessEnabled,
+            'content_access_mode_all': true,
             'content_access_mode_env': true,
             'sort_order': 'ASC',
             'paged': true
@@ -39,7 +39,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyRepositorySet
         $scope.repositoryType = {};
 
         $scope.contentAccessModes = {
-            contentAccessModeAll: $scope.simpleContentAccessEnabled,
+            contentAccessModeAll: true,
             contentAccessModeEnv: true
         };
 
@@ -53,7 +53,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyRepositorySet
 
         $scope.toggleFilters = function () {
             $scope.nutupane.table.params['content_access_mode_env'] = $scope.contentAccessModes.contentAccessModeEnv;
-            $scope.nutupane.table.params['content_access_mode_all'] = $scope.contentAccessModes.contentAccessModeAll || $scope.simpleContentAccessEnabled;
+            $scope.nutupane.table.params['content_access_mode_all'] = true;
             $scope.nutupane.refresh();
         };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-repository-sets.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-repository-sets.controller.js
@@ -20,7 +20,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostRepositorySetsCon
 
         params = {
             'host_id': $scope.$stateParams.hostId,
-            'content_access_mode_all': $scope.simpleContentAccessEnabled,
+            'content_access_mode_all': true,
             'sort_order': 'ASC',
             'paged': true
         };
@@ -33,11 +33,11 @@ angular.module('Bastion.content-hosts').controller('ContentHostRepositorySetsCon
         $scope.nutupane.primaryOnly = true;
 
         $scope.contentAccessModes = {
-            contentAccessModeAll: $scope.simpleContentAccessEnabled,
+            contentAccessModeAll: true,
             contentAccessModeEnv: false
         };
         $scope.toggleFilters = function () {
-            $scope.nutupane.table.params['content_access_mode_all'] = $scope.contentAccessModes.contentAccessModeAll || $scope.simpleContentAccessEnabled;
+            $scope.nutupane.table.params['content_access_mode_all'] = true;
             $scope.nutupane.table.params['content_access_mode_env'] = $scope.contentAccessModes.contentAccessModeEnv;
             $scope.nutupane.refresh();
         };

--- a/engines/bastion_katello/test/activation-keys/details/activation-key-repository-sets.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/details/activation-key-repository-sets.controller.test.js
@@ -178,17 +178,6 @@ describe('Controller: ActivationKeyRepositorySetsController', function () {
         });
     });
 
-    describe("can toggle repository set filters", function () {
-        it("all and env toggles correctly with no SCA", function () {
-            $scope.contentAccessModes.contentAccessModeAll = false;
-            $scope.contentAccessModes.contentAccessModeEnv = false;
-            $scope.simpleContentAccessEnabled = false;
-            $scope.toggleFilters();
-            expect($scope.nutupane.table.params['content_access_mode_env']).toEqual($scope.contentAccessModes.contentAccessModeEnv);
-            expect($scope.nutupane.table.params['content_access_mode_all']).toEqual($scope.contentAccessModes.contentAccessModeAll);
-        });
-    });
-
     describe("can select repository type", function () {
         it("correctly sets the repo params for redhat", function () {
             $scope.repositoryType["value"] = "redhat";

--- a/engines/bastion_katello/test/content-hosts/details/content-host-repository-sets.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-repository-sets.controller.test.js
@@ -177,17 +177,6 @@ describe('Controller: ContentHostRepositorySetsController', function () {
             expect(Notification.setErrorMessage).toHaveBeenCalled();
         });
     });
-
-    describe("can toggle repository set filters", function () {
-        it("all and env toggles correctly with no SCA", function () {
-            $scope.contentAccessModes.contentAccessModeAll = false;
-            $scope.contentAccessModes.contentAccessModeEnv = false;
-            $scope.simpleContentAccessEnabled = false;
-            $scope.toggleFilters();
-            expect($scope.nutupane.table.params['content_access_mode_env']).toEqual($scope.contentAccessModes.contentAccessModeEnv);
-            expect($scope.nutupane.table.params['content_access_mode_all']).toEqual($scope.contentAccessModes.contentAccessModeAll);
-        });
-    });
 });
 
 describe('Controller: ContentHostRepositorySetsControllerWithSCA', function () {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Set the param to always be true in the legacy UI
* Set the param to always be true in the controller for users using hammer/api
* Deprecated the param in the AK controller and repo_sets controller

#### Considerations taken when implementing this change?
* Made sure the page still works correctly and I didn't break anything

#### What are the testing steps for this pull request?

* Create Organization
* Sync RedHat Repository
* Enable RedHat Repository on Activation key
* Hit GET /katello/api/activation_keys/:id/product_content endpoint or run 

`hammer activation-key product-content --id --organization-id`

with and without the `--content-access-mode-all` param 

Actual results:

Without adding the `--content-access-mode-all` param, an empty list is returned 

With adding the `--content-access-mode-all` param, the added repository is shown

Expected results:

We should see the enabled repositories on the activation key without needed to pass this param in since sca is now the default

With PR:
```bash
[vagrant@hammer ~]$ hammer activation-key product-content --id 1 --organization-id 1
----|-----------------------------------------------------|-------------------------------------------|------------------|---------
ID  | NAME                                                | LABEL                                     | DEFAULT ENABLED? | OVERRIDE
----|-----------------------------------------------------|-------------------------------------------|------------------|---------
324 | Red Hat Satellite Client 6 for RHEL 8 x86_64 (RPMs) | satellite-client-6-for-rhel-8-x86_64-rpms | no
 |
----|-----------------------------------------------------|-------------------------------------------|------------------|---------
```