### PR TITLE
Fixes #37358 - relese_version to be updated when client unsets release

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -67,7 +67,7 @@ module Katello
           self.purpose_addon_ids = consumer_params['addOns'].map { |addon_name| ::Katello::PurposeAddon.find_or_create_by(name: addon_name).id }
         end
 
-        unless consumer_params['releaseVer'].blank?
+        unless consumer_params['releaseVer'].nil?
           release = consumer_params['releaseVer']
           release = release['releaseVer'] if release.is_a?(Hash)
           self.release_version = release


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When unsetting the release from a client server, the variable consumer_params['releaseVer'] is populated with an empty string, which returns true when using ".blank?" to validate it.

If we change that to ".nil?" then it returns false for an empty string and false when releaseVer is not sent at all.  

With this change, when a client unsets its release the information will be reflected. 

#### Considerations taken when implementing this change?

`subscription-manager release --unset`  was updating the information only on Candlepin and leaving old data on foreman DB

#### What are the testing steps for this pull request?

1. On a client:

~~~
subscription-manager release --set <some release> 
~~~

2. On Satellite, verify that the release is properly set:
~~~
hammer host info --name <host name> --fields "Subscription information/release version"
~~~

3. Unset the release on the host:
~~~
subscription-manager release --unset
~~~

4. Check the data again on Satellite and ensure the release is unset:

~~~
hammer host info --name <host name> --fields "Subscription information/release version"
~~~