### PR TITLE
Pin foreman_remote_execution to < 13

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "rabl"
   gem.add_dependency "foreman-tasks", ">= 5.0"
-  gem.add_dependency "foreman_remote_execution", ">= 7.1.0"
+  gem.add_dependency "foreman_remote_execution", ">= 7.1.0", "< 13"
   gem.add_dependency "dynflow", ">= 1.6.1"
   gem.add_dependency "activerecord-import"
   gem.add_dependency "stomp"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This pins to < 13 because version 13 is incompatible with Foreman 3.9. It allows https://github.com/theforeman/foreman/pull/10134 to pass again.

#### Considerations taken when implementing this change?

https://github.com/theforeman/foreman-packaging/tree/rpm/3.9/packages/plugins/rubygem-foreman_remote_execution contains version 12.0.5, so this matches packaging.

#### What are the testing steps for this pull request?

CI passes.