### PR TITLE
Fixes #37379 - Index labels and other fields for manifests

### DIFF
--- a/app/services/katello/pulp3/docker_manifest.rb
+++ b/app/services/katello/pulp3/docker_manifest.rb
@@ -26,7 +26,11 @@ module Katello
         {
           schema_version: unit['schema_version'],
           digest: unit['digest'],
-          pulp_id: unit[unit_identifier]
+          pulp_id: unit[unit_identifier],
+          annotations: unit['annotations'],
+          labels: unit['labels'],
+          is_bootable: unit['is_bootable'],
+          is_flatpak: unit['is_flatpak']
         }
       end
     end

--- a/app/views/katello/api/v2/docker_manifests/show.json.rabl
+++ b/app/views/katello/api/v2/docker_manifests/show.json.rabl
@@ -1,6 +1,7 @@
 object @resource
 
 attributes :id, :schema_version, :digest, :manifest_type
+attributes :annotations, :labels, :is_bootable, :is_flatpak
 
 child :docker_tags => :tags do
   attributes :associated_meta_tag_identifier => :id

--- a/db/migrate/20240423112842_add_fields_to_katello_docker_manifest.rb
+++ b/db/migrate/20240423112842_add_fields_to_katello_docker_manifest.rb
@@ -1,0 +1,8 @@
+class AddFieldsToKatelloDockerManifest < ActiveRecord::Migration[6.1]
+  def change
+    add_column :katello_docker_manifests, :annotations, :jsonb, default: {}
+    add_column :katello_docker_manifests, :labels, :jsonb, default: {}
+    add_column :katello_docker_manifests, :is_bootable, :boolean, default: false
+    add_column :katello_docker_manifests, :is_flatpak, :boolean, default: false
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Index new fields on container manifests and add them to the API
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Sync a container repo with labels/anotations.
ex: https://quay.io/repository/centos-bootc/fedora-bootc 
tag: sha256-4b336aaec054e57549075517ae025a8c3b8b23703d928437dce6a1db068eae5a

Check the API , replace :ID :
```
https://centos8-katello-devel-stable.example.com/katello/api/v2/docker_manifests?organization_id=1&page=1&paged=true&per_page=20&repository_id=:ID&search=
```
![Screenshot from 2024-04-23 08-09-20](https://github.com/Katello/katello/assets/21146741/d77f5b0a-e10b-4423-b1bf-f0b08972ac41)

