### PR TITLE
Fixes #37380 - Container push can fail with a different JSON error

### DIFF
--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -87,7 +87,7 @@ module Katello
         logger.debug "Headers: #{headers.to_json}"
         begin
           logger.debug "Body: #{filter_sensitive_data(payload.to_json)}"
-        rescue JSON::GeneratorError
+        rescue JSON::GeneratorError, Encoding::UndefinedConversionError
           logger.debug "Body: Error: could not render payload as json"
         end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds another error to catch that was found to have been raised on another machine when debug logging the push body.

#### Considerations taken when implementing this change?


#### What are the testing steps for this pull request?
Try pushing container content to Katello. To enable this, add 
```
  :container_image_registry:
    :allow_push: true
```
to Katello's config file and ensure that your pulp-container has https://github.com/pulp/pulp_container/pull/1589.

podman push 66640e9653de `hostname`/organization/product/arianna

I cannot reproduce this on another machine, so here's the old stack trace to go off of:

```
2024-04-22T18:02:13 [E|kat|deee32e7] Encoding::UndefinedConversionError: "\x8B" from ASCII-8BIT to UTF-8
...
 deee32e7 | /usr/share/gems/gems/katello-4.13.0.pre.master/app/lib/katello/http_resource.rb:89:in `issue_request'
 deee32e7 | /usr/share/gems/gems/katello-4.13.0.pre.master/app/lib/katello/resources/registry.rb:33:in `patch'
 deee32e7 | /usr/share/gems/gems/katello-4.13.0.pre.master/app/controllers/katello/api/registry/registry_proxies_controller.rb:248:in `upload_blob'
...
2024-04-22T18:02:13 [I|app|deee32e7] Completed 500 Internal Server Error in 116ms (Views: 0.2ms | ActiveRecord: 3.8ms | Allocations: 6849)
```

I did add this same fix to the reproducer machine and pushing worked right after.