### PR TITLE
Refs #37378 - fix TableWrapper PropTypes

### DIFF
--- a/webpack/components/Table/TableWrapper.js
+++ b/webpack/components/Table/TableWrapper.js
@@ -322,8 +322,8 @@ TableWrapper.propTypes = {
   bookmarkController: PropTypes.string,
   readOnlyBookmarks: PropTypes.bool,
   resetFilters: PropTypes.func,
-  inclusionSet: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
-  exclusionSet: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
+  inclusionSet: PropTypes.oneOfType([PropTypes.array, PropTypes.element, PropTypes.object]),
+  exclusionSet: PropTypes.oneOfType([PropTypes.array, PropTypes.element, PropTypes.object]),
 };
 
 TableWrapper.defaultProps = {
@@ -358,8 +358,8 @@ TableWrapper.defaultProps = {
   readOnlyBookmarks: false,
   resetFilters: undefined,
   autocompleteQueryParams: undefined,
-  inclusionSet: [],
-  exclusionSet: [],
+  inclusionSet: new Set([]),
+  exclusionSet: new Set([]),
 };
 
 export default TableWrapper;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

https://github.com/Katello/katello/pull/10976 added `selectionSet` and `exclusionSet` to TableWrapper PropTypes, but these are `ReactConnectedSet`s and not arrays.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

make sure CI is green

