### PR TITLE
Fixes #37400 - Add setting to control validation of host/lifecycle environment/content source coherence

### DIFF
--- a/app/models/katello/content_view_environment_content_facet.rb
+++ b/app/models/katello/content_view_environment_content_facet.rb
@@ -14,7 +14,9 @@ module Katello
       hostname = self.content_facet&.host&.name
       return unless [source, env].all? { |x| x.present? }
       unless source.lifecycle_environments.include?(env)
-        errors.add(:base, _("Host %{hostname}: Cannot add content view environment to content facet. The host's content source '%{content_source}' does not sync lifecycle environment '%{lce}'.") % { hostname: hostname, content_source: source.name, lce: env.name })
+        error_msg = _("Host %{hostname}: Cannot add content view environment to content facet. The host's content source '%{content_source}' does not sync lifecycle environment '%{lce}'.") % { hostname: hostname, content_source: source.name, lce: env.name }
+        Rails.logger.warn error_msg
+        errors.add(:base, error_msg)
       end
     end
   end

--- a/app/models/katello/content_view_environment_content_facet.rb
+++ b/app/models/katello/content_view_environment_content_facet.rb
@@ -5,7 +5,7 @@ module Katello
 
     validates :content_view_environment_id, presence: true
     validates :content_facet_id, presence: true, unless: :new_record?
-    validate :ensure_valid_content_source
+    validate :ensure_valid_content_source, if: proc { Setting['validate_host_lce_content_source_coherence'] }
 
     def ensure_valid_content_source
       source = self.content_facet&.content_source

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -44,7 +44,7 @@ module Katello
 
       validates_with ::AssociationExistsValidator, attributes: [:content_source]
       validates_with Katello::Validators::GeneratedContentViewValidator
-      validates_associated :content_view_environment_content_facets
+      validates_associated :content_view_environment_content_facets, :message => _("invalid: The content source must sync the lifecycle environment assigned to the host. See the logs for more information.")
       validates :host, :presence => true, :allow_blank => false
 
       attr_accessor :cves_changed

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -512,6 +512,12 @@ Foreman::Plugin.register :katello do
         description: N_("Default download policy for Smart Proxy syncs (either 'inherit', immediate', or 'on_demand')"),
         collection: proxy_download_policies
 
+      setting 'validate_host_lce_content_source_coherence',
+        type: :boolean,
+        default: true,
+        full_name: N_('Validate host/lifecycle environment/content source coherence'),
+        description: N_("Validate that a host's assigned lifecycle environment is synced by the smart proxy from which the host will get its content. Applies only to API requests; does not affect web UI checks")
+
       setting 'pulpcore_export_destination',
         type: :string,
         default: "/var/lib/pulp/exports",


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Adds a Setting to allow you to skip running the validation `ensure_valid_content_source`. In certain edge-case situations, this validation can cause problems with host registrations.

#### Considerations taken when implementing this change?

Turning this setting off will erase the guardrails introduced in https://github.com/Katello/katello/pull/10524. Therefore, it defaults to on and the vast majority of users should never need to touch it.

Regardless of the value of the setting, the web UI will still look at coherence of the assigned content source/LCE, and you'll still get UI niceties like those pictured in https://github.com/Katello/katello/pull/10524.

#### What are the testing steps for this pull request?

set up an external smart proxy
Don't sync any environments to it (not even Library)
Register the host to the external smart proxy.

With the setting on, you'll get an error. With the setting off, registration will succeed with no errors.

