### PR TITLE
Fixes #37402 - add jquery-ui dependency

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -64,6 +64,7 @@ Gem::Specification.new do |gem|
   # UI
   gem.add_dependency "deface", '>= 1.0.2', '< 2.0.0'
   gem.add_dependency "angular-rails-templates", "~> 1.1"
+  gem.add_dependency "jquery-ui-rails", "~> 6.0"
 
   gem.add_development_dependency "theforeman-rubocop", '~> 0.1.0'
 end


### PR DESCRIPTION
we want to remove it in core since its no longer used https://github.com/theforeman/foreman/pull/10142
so adding it here as only Katello seem to use it, and hopefully it will be removed here as well