### PR TITLE
Fixes #37403 - make repository rpm ID sequence bigint

### DIFF
--- a/db/migrate/20240502192021_change_katello_repository_rpms_id_seq_to_big_int.rb
+++ b/db/migrate/20240502192021_change_katello_repository_rpms_id_seq_to_big_int.rb
@@ -1,0 +1,9 @@
+class ChangeKatelloRepositoryRpmsIdSeqToBigInt < ActiveRecord::Migration[6.1]
+  def up
+    execute 'ALTER SEQUENCE katello_repository_rpms_id_seq AS bigint;'
+  end
+
+  def down
+    execute 'ALTER SEQUENCE katello_repository_rpms_id_seq AS integer;'
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Makes katello_repository_rpms_id_seq a bigint since users are hitting the ID limit.

#### Considerations taken when implementing this change?
I was thinking if we need to make other fields larger, however no user has complained so I think it should be safe to only increase this one.

#### What are the testing steps for this pull request?
1) In `psql`, look at `select * from pg_sequences where sequencename='katello_repository_rpms_id_seq';`
2) See that the sequence has the type of `integer`
3) Run the migration
4) Run the query above again
5) See that the data type is now `bigint`
6) Rollback the query
7) Run `ALTER SEQUENCE katello_repository_rpms_id_seq AS bigint;` in `psql`
8) Run the migration again. Ensure there are no errors
9) Check that the ID sequence data type is still `bigint`.