### PR TITLE
Fixes #37394 - content_view_filter_id only works for ID-type filters

### DIFF
--- a/app/controllers/katello/api/v2/debs_controller.rb
+++ b/app/controllers/katello/api/v2/debs_controller.rb
@@ -37,7 +37,7 @@ module Katello
     api :GET, "/repositories/:repository_id/debs", N_("List deb packages")
     param :organization_id, :number, :desc => N_("Organization identifier")
     param :content_view_version_id, :number, :desc => N_("Content View Version identifier")
-    param :content_view_filter_id, :number, :desc => N_("Content View Filter identifier")
+    param :content_view_filter_id, :number, :desc => N_("Content View Filter identifier. Use to filter by ID")
     param :repository_id, :number, :desc => N_("Repository identifier")
     param :environment_id, :number, :desc => N_("Environment identifier")
     param :ids, Array, :desc => N_("Deb package identifiers to filter content by")

--- a/app/controllers/katello/api/v2/errata_controller.rb
+++ b/app/controllers/katello/api/v2/errata_controller.rb
@@ -9,7 +9,7 @@ module Katello
     api :GET, "/errata", N_("List errata")
     param :organization_id, :number, :desc => N_("Organization identifier")
     param :content_view_version_id, :number, :desc => N_("Content View Version identifier")
-    param :content_view_filter_id, :number, :desc => N_("Content View Filter identifier")
+    param :content_view_filter_id, :number, :desc => N_("Content View Filter identifier. Use to filter by ID")
     param :repository_id, :number, :desc => N_("Repository identifier")
     param :environment_id, :number, :desc => N_("Environment identifier")
     param :cve, String, :desc => N_("CVE identifier")

--- a/app/controllers/katello/api/v2/packages_controller.rb
+++ b/app/controllers/katello/api/v2/packages_controller.rb
@@ -32,7 +32,7 @@ module Katello
     api :GET, "/repositories/:repository_id/:resource_id", N_("List :resource_id")
     param :organization_id, :number, :desc => N_("Organization identifier")
     param :content_view_version_id, :number, :desc => N_("Content View Version identifier")
-    param :content_view_filter_id, :number, :desc => N_("Content View Filter identifier")
+    param :content_view_filter_id, :number, :desc => N_("Content View Filter identifier. Use to filter by ID")
     param :repository_id, :number, :desc => N_("Repository identifier")
     param :environment_id, :number, :desc => N_("Environment identifier")
     param :ids, Array, :desc => N_("Package identifiers to filter content by")


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

https://bugzilla.redhat.com/show_bug.cgi?id=1785146, and by extension https://projects.theforeman.org/issues/37394, requests documenting that the --content-view-filter-id flag only works for ID-type filters.

#### Considerations taken when implementing this change?



#### What are the testing steps for this pull request?

CI checks are successful.