### PR TITLE
Refs #37217 Install package tab & FQDN setting

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -617,7 +617,7 @@ export const PackagesTab = () => {
           closeModal={closeModal}
           hostId={hostId}
           key={hostId}
-          hostName={hostname}
+          hostName={hostDetails.display_name}
           triggerPackageInstall={triggerPackageInstall}
         />
       }

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/packageInstallModal.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/packageInstallModal.test.js
@@ -31,6 +31,7 @@ const renderOptions = (facetAttributes = contentFacetAttributes) => ({
           id: 1,
           name: 'test-host',
           content_facet_attributes: { ...facetAttributes },
+          display_name: 'test-host',
         },
         status: 'RESOLVED',
       },

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/packagesTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/packagesTab.test.js
@@ -33,6 +33,7 @@ const renderOptions = (facetAttributes = contentFacetAttributes) => ({
           id: 1,
           name: hostname,
           content_facet_attributes: { ...facetAttributes },
+          display_name: hostname,
         },
         status: 'RESOLVED',
       },


### PR DESCRIPTION
Use `host.display_name` instead of `host.hostname`

#### What are the changes introduced in this pull request?
 Follow up to https://github.com/Katello/katello/pull/10913

#### Considerations taken when implementing this change?
@Dyrkon is out of the office, so I'm taking his PR.

#### What are the testing steps for this pull request?
* Change the `Display FQDN for hosts` setting to `No`
* Go to the host detail
* On the packages tab click Install packages
* Verify that host is displayed without domain