### PR TITLE
Fixes #37430 - Added create_content_views permission in Content Expor…

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -721,7 +721,7 @@ Foreman::Plugin.register :katello do
   ], 'Role granting permission to import content views in an organization'
 
   role 'Content Exporter', [
-    :export_content, :view_products, :view_content_views, :view_organizations
+    :export_content, :view_products, :view_content_views, :create_content_views, :view_organizations
   ], 'Role granting permission to export content views in an organization'
 
   def find_katello_assets(args = {})


### PR DESCRIPTION

#### What are the changes introduced in this pull request?

Please refer to the description of https://projects.theforeman.org/issues/37430 for more details. Without the create_content_view permission, It's impossible to export a Repository\CV version\Library itself when the API\hammer user is a non-admin user with `Content Exporter` role assigned.

This PR adds the `create_content_views` permission in the `Content Exporter` role to fix this issue.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

* Create a product name TestP
* Have a repo created in it called TestR with any one rpm uploaded in it and the download policy set to `Immediate` 
* Setup a non-admin user called `TestU` with password set to `password` and associate the `Content Exporter` role with the user 
* Try to export the repository ( in whichever format you want ), using hammer or API and the non-admin user:

Results:

```
# hammer -u TestU -p password content-export complete repository --name TestR --product TestP --organization-id 1
Could not export the repository:
  Validation failed: Label has already been taken, Name has already been taken
```

Reason:

Due to the lack of permissions to create a CV in the Content Exporter role, The failure occurs

```
# hammer -u admin -p redhat role filters --name "Content Exporter"
----|----------------------|--------|------------|-----------|------------------|-----------------------------------
ID  | RESOURCE TYPE        | SEARCH | UNLIMITED? | OVERRIDE? | ROLE             | PERMISSIONS                       
----|----------------------|--------|------------|-----------|------------------|-----------------------------------
249 | Katello::ContentView | none   | yes        | no        | Content Exporter | view_content_views                
250 | Organization         | none   | yes        | no        | Content Exporter | export_content, view_organizations
251 | Katello::Product     | none   | yes        | no        | Content Exporter | view_products                     
----|----------------------|--------|------------|-----------|------------------|-----------------------------------
```

Fix:
* Checkout the PR and apply it on your instance
* Restart services 
* Check that the `Content Exporter` role now have the `create_content_views` permission

```
# hammer -u admin -p redhat role filters --name "Content Exporter"
----|----------------------|--------|------------|-----------|------------------|-----------------------------------------
ID  | RESOURCE TYPE        | SEARCH | UNLIMITED? | OVERRIDE? | ROLE             | PERMISSIONS                             
----|----------------------|--------|------------|-----------|------------------|-----------------------------------------
249 | Katello::ContentView | none   | yes        | no        | Content Exporter | view_content_views, create_content_views
250 | Organization         | none   | yes        | no        | Content Exporter | export_content, view_organizations      
251 | Katello::Product     | none   | yes        | no        | Content Exporter | view_products                           
----|----------------------|--------|------------|-----------|------------------|-----------------------------------------
```

* Try exporting the TestR repo using the TestU user again.

```
# hammer -u TestU -p password content-export complete repository --name TestR --product TestP --organization-id 1
[..............................................................................................................................................................................................................................] [100%]
Generated /var/lib/pulp/exports/RedHat/Export-TestR-532/1.0/2024-05-09T16-02-53-05-30/metadata.json
```