### PR TITLE
Fixes #37442 - Sync status page presenter doesn't work

### DIFF
--- a/app/assets/javascripts/katello/sync_management/sync_management.js
+++ b/app/assets/javascripts/katello/sync_management/sync_management.js
@@ -333,6 +333,7 @@ KT.content_actions = (function () {
           updater.stop();
         }
       );
+      updater.restart();
     };
 
   return {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fix sync status page presenter
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Sync some repos from the Sync status page.
2. Ensure you see the presenter and updates on an active sync.