### PR TITLE
Fixes #31318 - Never synced products show synced date

### DIFF
--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -50,7 +50,7 @@ module Katello
       end
 
       def last_sync_audit
-        Audited::Audit.where(:auditable_id => self.repositories, :auditable_type => Katello::Repository.name).order(:created_at).last
+        Audited::Audit.where(:auditable_id => self.repositories, :auditable_type => Katello::Repository.name, :action => "sync").order(:created_at).last
       end
 
       def last_sync
@@ -58,13 +58,14 @@ module Katello
       end
 
       def last_repo_sync_task
-        @last_sync_task ||= last_repo_sync_tasks.first
+        @last_sync_task ||= last_repo_sync_tasks&.first
       end
 
       def last_repo_sync_tasks
         ids = repos(self.library, nil, false).pluck(:id).join(',')
         label = ::Actions::Katello::Repository::Sync.name
         type = ::Katello::Repository.name
+        return nil if ids.empty?
         ForemanTasks::Task.search_for("label = #{label} and resource_type = #{type} and resource_id ^ (#{ids})")
           .order("started_at desc")
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Never synced products show synced date in product list page.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a product.
2. Create a repository.
3. Go to Content > Products.
4. The table will show a date/time for last synced column.

With this PR:

The table will show "Never synced" for products with repos that have never been synced.