### PR TITLE
Fixes #37455 - Create Katello push repositories as needed at container push time, handle non-auth validation.

### DIFF
--- a/app/lib/actions/katello/repository/create_root.rb
+++ b/app/lib/actions/katello/repository/create_root.rb
@@ -2,13 +2,15 @@ module Actions
   module Katello
     module Repository
       class CreateRoot < Actions::EntryAction
-        def plan(root)
+        def plan(root, relative_path = nil)
           root.save!
           repository = ::Katello::Repository.new(:environment => root.organization.library,
                                       :content_view_version => root.organization.library.default_content_view_version,
                                       :root => root)
-          repository.relative_path = repository.custom_repo_path
+          repository.container_repository_name = relative_path
+          repository.relative_path = relative_path || repository.custom_repo_path
           repository.save!
+
           action_subject(repository)
           plan_action(::Actions::Katello::Repository::Create, repository)
         end

--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -133,7 +133,14 @@ module Katello
 
         repo_param[:mirroring_policy] = Katello::RootRepository::MIRRORING_POLICY_ADDITIVE if repo_param[:mirroring_policy].blank?
 
-        RootRepository.new(repo_param.merge(:product_id => self.id))
+        repo_param = repo_param.merge(:product_id => self.id)
+
+        # Container push may concurrently call root add several times before the db can update.
+        if repo_param[:is_container_push]
+          RootRepository.create_or_find_by!(repo_param)
+        else
+          RootRepository.new(repo_param)
+        end
       end
     end
   end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -118,7 +118,7 @@ module Katello
     end}
 
     before_validation :set_pulp_id
-    before_validation :set_container_repository_name, :if => :docker?
+    before_validation :set_container_repository_name, :unless => :skip_container_name?
 
     scope :has_url, -> { joins(:root).where.not("#{RootRepository.table_name}.url" => nil) }
     scope :on_demand, -> { joins(:root).where("#{RootRepository.table_name}.download_policy" => ::Katello::RootRepository::DOWNLOAD_ON_DEMAND) }
@@ -266,6 +266,10 @@ module Katello
 
     def content_view
       self.content_view_version.content_view
+    end
+
+    def skip_container_name?
+      self.library_instance? && self.root.docker? && self.root.is_container_push
     end
 
     def library_instance?

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -112,6 +112,8 @@ module Katello
         only_integer: true
       }
 
+    validates :container_push_name_format, inclusion: { in: ['label', 'id'].freeze, allow_nil: true}
+
     scope :subscribable, -> { where(content_type: RootRepository::SUBSCRIBABLE_TYPES) }
     scope :skipable_metadata_check, -> { where(content_type: RootRepository::SKIPABLE_METADATA_TYPES) }
     scope :has_url, -> { where.not(:url => nil) }
@@ -195,7 +197,7 @@ module Katello
     def ensure_docker_repo_unprotected
       unless unprotected
         errors.add(:base, _("Container Image Repositories are not protected at this time. " \
-                             "They need to be published via http to be available to containers."))
+                            "They need to be published via http to be available to containers."))
       end
     end
 

--- a/app/services/katello/pulp3/api/docker.rb
+++ b/app/services/katello/pulp3/api/docker.rb
@@ -15,6 +15,10 @@ module Katello
         def recursive_add_api
           PulpContainerClient::ContainerRecursiveAddApi.new(api_client)
         end
+
+        def container_push_api
+          PulpContainerClient::RepositoriesContainerPushApi.new(api_client)
+        end
       end
     end
   end

--- a/db/migrate/20240520142245_add_container_push_props_to_repo.rb
+++ b/db/migrate/20240520142245_add_container_push_props_to_repo.rb
@@ -1,0 +1,7 @@
+class AddContainerPushPropsToRepo < ActiveRecord::Migration[6.1]
+  def change
+    add_column :katello_root_repositories, :is_container_push, :boolean, default: false
+    add_column :katello_root_repositories, :container_push_name, :string, default: nil
+    add_column :katello_root_repositories, :container_push_name_format, :string, default: nil
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

- When using podman to push containers to Katello, ensure that the container name is of a valid format:
  - <org_label>/<product_label>/<container_name>[:tag] (down-case all letters)
  -  id/<org_id>/<product_id>/<container_name>[:tag]
- Limits to container names:
  - Org and product fields must always correspond to a valid, existing org and product, respectively. No fields can be blank or omitted.
  - Org and product labels must be downcased. Container names must be lowercase and contain only letters and underscores (podman rejects these automatically).
  - Org and product labels cannot be ambiguous (for example 'foo_bar' and 'Foo_Bar' both map to 'foo_bar'). For ambiguous orgs or products, the user is directed to use the id format.
  - Org and product IDs must be integers with no leading zeros.
  - A user must stick to a specific format for each org, product, name combination. Pushes are not permitted to alternate between label and id or vice versa.
  - If a label format push becomes ambiguous due to external changes, the user will be directed to destroy either the offending org/product or will be directed to destroy the existing push container and re-push using the id format.
- Create a new push repository matching the container name under the appropriate product where required.
- Update existing push repos where required.
- Run content indexing after completion of the container upload.
- Ensure the root repository fields are correct after upload:
  - name: matches container_name
  - label: matches container_name
  - content_type: docker
  - is_container_push (new field): true
  - container_push_name (new field): name used in podman command e.g. "id/0/0/foo"
  - container_push_name_format (new field): name format used, `label` or `id` 
- Ensure that the instance repository fields are correct after upload:
  - relative_path: matches the container_push_name above
  - container_repository_name: matches the container_push_name above
  - environment_id: correct for product
  - content_view_version_id: correct for product
  - latest_version_href: pulp latest version href
  - pulp_href: pulp href

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1. Pull a few different podman images:
 ```
podman pull quay.io/aptible/hello-world
 ```
 2. Launch katello and create an empty product. Log in with podman:
 ```
 podman login <url>
 ```
 3. Get the image ID for one of the test podman images. Push that image to katello using the correct organization label and product label. Make sure to down-case the labels or podman will reject the container name:
 ```
 podman image list
 podman push <img_id> <url>/<organization_label>/<product_label>/<container_name>
 ```
4. Use the rake console to ensure the root repository and repository were created properly:
```
bundle exec rake console
::Katello::Products.find(<id>).root_repositories.where(label: "<container_name>").first
::Katello::Products.find(<id>).root_repositories.where(label: "<container_name>").first.library_instance
```
5. Repeat steps 3 and 4 using the id push format. You will need to change the container name.
```
podman push <img_id> <url>/id/<organization_id>/<product_id>/<container_name>
```
6. Repeat steps 3 and 4 with a [:tag] field. This should work as usual.
7. Repeat steps 3 and 4 while trying every error in the above 'Limits to container names' list. This is an extensive but not exhaustive list of all the error handling included. List duplicated below:
  - Org and product fields must always correspond to a valid, existing org and product, respectively. No fields can be blank or omitted.
  - Org and product labels must be downcased. Container names must be lowercase and contain only letters and underscores (podman rejects these automatically).
  - Org and product labels cannot be ambiguous (for example 'foo_bar' and 'Foo_Bar' both map to 'foo_bar'). For ambiguous orgs or products, the user is directed to use the id format.
  - Org and product IDs must be integers with no leading zeros.
  - A user must stick to a specific format for each org, product, name combination. Pushes are not permitted to alternate between label and id or vice versa for a given container.
  - If a label format push becomes ambiguous due to external changes, the user will be directed to destroy either the offending org/product or will be directed to destroy the existing push container and re-push using the id format.
8. Validate the test cases for coverage and accuracy.