### PR TITLE
Fixes #37481 - Update cached value for manifest expiration date during import

### DIFF
--- a/app/lib/actions/katello/organization/manifest_import.rb
+++ b/app/lib/actions/katello/organization/manifest_import.rb
@@ -27,6 +27,11 @@ module Actions
           end
         end
 
+        def run
+          organization = ::Organization.find_by(name: input[:organization_name])
+          organization&.manifest_expiration_date(cached: false) # update the date
+        end
+
         def failure_notification(plan)
           ::Katello::UINotifications::Subscriptions::ManifestImportError.deliver!(
             :subject => subject_organization,

--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -102,7 +102,7 @@ module Katello
 
         def manifest_expiration_date(cached: true)
           Rails.cache.fetch("#{self.label}_manifest_expiration_date", expires_in: 1.minute, force: !cached) do
-            unless manifest_imported?(cached: true)
+            unless manifest_imported?(cached: cached)
               Rails.logger.error "Manifest not imported for organization #{self.label}"
               return nil
             end
@@ -117,8 +117,8 @@ module Katello
           end
         end
 
-        def manifest_expired?
-          manifest_expiry = manifest_expiration_date
+        def manifest_expired?(cached: true)
+          manifest_expiry = manifest_expiration_date(cached: cached)
 
           if manifest_expiry
             manifest_expiry < DateTime.now

--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
@@ -174,7 +174,7 @@ class ManageManifestModal extends Component {
                           />
                         </Alert>
                       }
-                      {manifestExpired &&
+                      {manifestExpired && isManifestImported &&
                         <Alert
                           ouiaId="manifest-expired-alert"
                           variant="danger"
@@ -198,7 +198,7 @@ class ManageManifestModal extends Component {
                           {getManifestName()}
                         </Col>
                       </Row>
-                      {isManifestImported &&
+                      {isManifestImported && manifestExpirationDate &&
                         <Row>
                           <Col sm={5} />
                           <Col sm={7}>


### PR DESCRIPTION
Our stored manifest expiration date relies on a Rails cached value which is held for 1 minute:

```rb
def manifest_expiration_date(cached: true)
          Rails.cache.fetch("#{self.label}_manifest_expiration_date", expires_in: 1.minute, force: !cached) do
```

This means that after a manifest import / refresh, the manifest expiration date may be inaccurate until the cache expiration time (1 minute). Because of this you must refresh the browser page to see the new manifest expiration date.

#### What are the changes introduced in this pull request?

1. During manifest import (and as a consequence, during manifest refresh), I found that calling `manifest_expiration_date(cached: false)` is enough to prevent stale data from making it to the user's screen.
2. If the manifest expiration date is not populated for some reason, don't display anything.


#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Delete and reimport a manifest. Visit the Manage Manifest modal.

Before:
You'll see a manifest expiration date of the Unix epoch (31 Dec 1969 or 01 Jan 1970)

After:
You'll see the correct manifest expiration date

