### PR TITLE
Fixes #37482 - asterisk symbol is missing for required field

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/new/views/new-content-credential.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/new/views/new-content-credential.html
@@ -35,7 +35,8 @@
                   class="form-control"
                   style="font-family: monospace"
                   rows="15"
-                  placeholder="{{ 'Paste contents of Content Credential' | translate }}">
+                  placeholder="{{ 'Paste contents of Content Credential' | translate }}"
+                  required>
         </textarea>
       </div>
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Makes content credential content required when submitting one.



#### Considerations taken when implementing this change?
There is no asterisk like requested in the bug, however the "Save" button is disabled. Our Angular UI doesn't seem to do asterisks anywhere, anyway.

#### What are the testing steps for this pull request?
Try to make a content credential in the UI with no content.