### PR TITLE
Fixes #37483 - Fix CV/LCE display in a couple angular places

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
@@ -62,14 +62,14 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
                 previousEnv;
 
             if (host.hasContent()) {
-                currentEnv = translate("Current Lifecycle Environment (%e/%cv)").replace("%e", host.content_facet_attributes.lifecycle_environment.name).replace("%cv", host.content_facet_attributes.content_view_name);
+                currentEnv = translate("Current Lifecycle Environment (%e/%cv)").replace("%e", host.content_facet_attributes.lifecycle_environment.name).replace("%cv", host.content_facet_attributes.content_view.name);
                 $scope.errataOptions = [{name: currentEnv, label: 'current', order: 3}];
 
                 if (!host['content_facet_attributes']['lifecycle_environment_library?']) {
                     Environment.get({id: host['content_facet_attributes'].lifecycle_environment.id}).$promise.then(function (env) {
-                        previousEnv = translate("Previous Lifecycle Environment (%e/%cv)").replace('%e', env.prior.name).replace("%cv", host.content_facet_attributes.content_view_name);
+                        previousEnv = translate("Previous Lifecycle Environment (%e/%cv)").replace('%e', env.prior.name).replace("%cv", host.content_facet_attributes.content_view.name);
                         $scope.errataOptions.push({name: previousEnv,
-                                                   label: 'prior', order: 2, 'content_view_id': host.content_facet_attributes.content_view_id, 'environment_id': env.prior.id});
+                                                   label: 'prior', order: 2, 'content_view_id': host.content_facet_attributes.content_view.id, 'environment_id': env.prior.id});
 
                     });
                 }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-content-hosts.html
@@ -68,8 +68,8 @@
             </span>
           </td>
           <td bst-table-cell>{{ contentHost.operatingsystem_name }}</td>
-          <td bst-table-cell>{{ contentHost.content_facet_attributes.lifecycle_environment_name }}</td>
-          <td bst-table-cell>{{ contentHost.content_facet_attributes.content_view_name || "" }}</td>
+          <td bst-table-cell>{{ contentHost.content_facet_attributes.lifecycle_environment.name }}</td>
+          <td bst-table-cell>{{ contentHost.content_facet_attributes.content_view.name || "" }}</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Replace an underscore with a dot in a few places. This will allow the return of proper display of content view and lifecycle environment names on Angular pages:

* Legacy Content host Errata tab - dropdown
* Errata Incremental Update page - Select Content Hosts table

#### Considerations taken when implementing this change?

Almost didn't bother since Legacy CH is going away soon. But it was an easy fix.

#### What are the testing steps for this pull request?

ensure that CV and LCE names are properly displayed on screen in those two places
