### PR TITLE
Fixes #37381 - Change export tasks to Ruby3 kwargs

### DIFF
--- a/app/lib/actions/pulp3/orchestration/content_view_version/syncable_export.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/syncable_export.rb
@@ -16,10 +16,11 @@ module Actions
             param :export_history_id, Integer
           end
 
-          def plan(content_view_version:,
-                   smart_proxy:,
-                   destination_server:,
-                   from_content_view_version:)
+          def plan(opts = {})
+            content_view_version = opts[:content_view_version]
+            smart_proxy = opts[:smart_proxy]
+            destination_server = opts[:destination_server]
+            from_content_view_version = opts[:from_content_view_version]
             format = ::Katello::Pulp3::ContentViewVersion::Export::SYNCABLE
             sequence do
               export_service = ::Katello::Pulp3::ContentViewVersion::Export.create(


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Change a few missed tasks to Ruby 3 kwargs

#### Considerations taken when implementing this change?

* Didn't break anything

#### What are the testing steps for this pull request?

* Spin up an EL 9 box
### Steps to Reproduce:
------------------

1. Ensure that you set the download policy to Immediate for the repository within the Library lifecycle environment you export. .

2. Synchronize the repository.

3. Execute this command

~~~
# hammer content-export complete repository --name="Red Hat Enterprise Linux 7 Server RPMs x86_64 7Server" --organization-id=1 --product="Red Hat Enterprise Linux Server" --format=syncable
~~~

Actual results:
--------------
```
Could not export the repository:
  500 Internal Server Error
```
Expected results:
----------------
```
Generated /var/lib/pulp/exports/<ORG>/Export-SYNCABLE-Red_Hat_Enterprise_Linux_7_Server_RPMs_x86_64_7Server-176/1.0/2024-04-09T17-07-52-02-00/metadata.json
```

Output of my patch with hammer on my box:
```
[root@ip-10-0-167-124 content_view_version]# hammer content-export complete repository --id 1 --organization-id=1 --product-id 1 --format=syncable
[........................................................................................................................................................................................................] [100%]
Generated /var/lib/pulp/exports/Default_Organization/Export-SYNCABLE-Test-Repo-1/1.0/2024-05-20T12-59-45-04-00/metadata.json
```