### PR TITLE
Fixes #37509 - Display multi-CV in web UI

### DIFF
--- a/app/views/katello/api/v2/content_facet/base.json.rabl
+++ b/app/views/katello/api/v2/content_facet/base.json.rabl
@@ -10,13 +10,29 @@ attributes :applicable_module_stream_count, :upgradable_module_stream_count
 
 child :content_view_environments => :content_view_environments do
   node :content_view do |cve|
-    { id: cve.content_view.id, name: cve.content_view.name, composite: cve.content_view.composite }
+    {
+      id: cve.content_view&.id,
+      name: cve.content_view&.name,
+      composite: cve.content_view&.composite,
+      content_view_version: cve.content_view_version&.version,
+      content_view_version_id: cve.content_view_version&.id,
+      content_view_version_latest: cve.content_view_version&.latest?,
+      content_view_default: cve.content_view&.default?
+    }
   end
   node :lifecycle_environment do |cve|
-    { id: cve.lifecycle_environment.id, name: cve.lifecycle_environment.name }
+    {
+      id: cve.lifecycle_environment&.id,
+      name: cve.lifecycle_environment&.name,
+      lifecycle_environment_library: cve.lifecycle_environment&.library?
+    }
+  end
+  node :candlepin_name do |cve|
+    cve.candlepin_name
   end
 end
 
+# single cv/lce for backward compatibility
 node :content_view do |content_facet|
   content_view = content_facet.single_content_view
   if content_view.present?

--- a/webpack/ForemanColumnExtensions/index.js
+++ b/webpack/ForemanColumnExtensions/index.js
@@ -7,9 +7,11 @@ import {
   PackageIcon,
 } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
-import { Flex, FlexItem } from '@patternfly/react-core';
+import { Flex, FlexItem, Popover, Badge } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import RelativeDateTime from 'foremanReact/components/common/dates/RelativeDateTime';
+import { ContentViewEnvironmentDisplay } from '../components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard';
+import { truncate } from '../utils/helpers';
 
 const hostsIndexColumnExtensions = [
   {
@@ -96,6 +98,47 @@ const hostsIndexColumnExtensions = [
     },
     weight: 2400,
     isSorted: true,
+  },
+  {
+    columnName: 'content_view_environments',
+    title: __('Content view environments'),
+    wrapper: (hostDetails) => {
+      const contentViewEnvironments =
+        hostDetails?.content_facet_attributes?.content_view_environments ?? [];
+      if (contentViewEnvironments.length === 0) return '—'; // don't show popover
+      return (
+        <Flex>
+          {contentViewEnvironments.length > 1 &&
+            <FlexItem>
+              <Badge isRead>{contentViewEnvironments.length}</Badge>
+            </FlexItem>
+          }
+          <Popover
+            id="content-view-environments-tooltip"
+            className="content-view-environments-tooltip"
+            maxWidth="34rem"
+            headerContent={hostDetails.display_name}
+            bodyContent={
+              <Flex direction={{ default: 'column' }}>
+                {contentViewEnvironments.map(env => (
+                  <ContentViewEnvironmentDisplay
+                    key={`${env.lifecycle_environment.name}-${env.content_view.name}`}
+                    contentView={env.content_view}
+                    lifecycleEnvironment={env.lifecycle_environment}
+                  />
+                ))}
+              </Flex>
+            }
+          >
+            <FlexItem>
+              {truncate(contentViewEnvironments.map(cve => cve.candlepin_name).join(', '), 35)}
+            </FlexItem>
+          </Popover>
+        </Flex>
+      );
+    },
+    weight: 2290,
+    isSorted: false,
   },
   {
     columnName: 'content_source',

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -32,6 +32,7 @@ const ChangeHostCVModal = ({
   hostId,
   contentSourceId,
   hostName,
+  multiEnv,
 }) => {
   const [selectedEnvForHost, setSelectedEnvForHost]
     = useState([]);
@@ -174,13 +175,22 @@ const ChangeHostCVModal = ({
           <a href={`/change_host_content_source?host_id=${hostId}`}>{__('change the host\'s content source.')}</a>
         </Alert>
       }
+      {multiEnv &&
+        <Alert
+          variant="warning"
+          ouiaId="multi-env-alert"
+          isInline
+          title={__('This host is associated with multiple content view environments. If you assign a lifecycle environment and content view here, the host will be removed from the other environments.')}
+          style={{ marginBottom: '1rem' }}
+        />
+      }
       <EnvironmentPaths
         userCheckedItems={selectedEnvForHost}
         setUserCheckedItems={handleEnvSelect}
         publishing={false}
         multiSelect={false}
         hostId={hostId}
-        headerText={__('Select environment')}
+        headerText={__('Select lifecycle environment')}
         isDisabled={hostUpdateStatus === STATUS.PENDING}
       />
       <ContentViewSelect
@@ -229,6 +239,7 @@ ChangeHostCVModal.propTypes = {
   hostId: PropTypes.number.isRequired,
   contentSourceId: PropTypes.number,
   hostName: PropTypes.string.isRequired,
+  multiEnv: PropTypes.bool,
 };
 
 ChangeHostCVModal.defaultProps = {
@@ -236,6 +247,7 @@ ChangeHostCVModal.defaultProps = {
   closeModal: () => {},
   hostEnvId: null,
   contentSourceId: null,
+  multiEnv: false,
 };
 
 

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/__tests__/contentViewDetailsCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/__tests__/contentViewDetailsCard.test.js
@@ -18,6 +18,23 @@ const baseHostDetails = {
     content_view_version_id: 1000,
     content_view_version: '1.0',
     content_view_version_latest: true,
+    content_view_environments: [
+      {
+        content_view: {
+          name: 'CV',
+          id: 100,
+          composite: false,
+          content_view_default: false,
+          content_view_version_id: 1000,
+          content_view_version: '1.0',
+          content_view_version_latest: true,
+        },
+        lifecycle_environment: {
+          name: 'ENV',
+          id: 300,
+        },
+      },
+    ],
   },
   subscription_facet_attributes: {
     uuid: '123',
@@ -26,7 +43,7 @@ const baseHostDetails = {
 
 test('shows content view details when host is registered', () => {
   const { getByText } = render(<ContentViewDetailsCard hostDetails={baseHostDetails} />);
-  expect(getByText('Version 1.0 (latest)')).toBeInTheDocument();
+  expect(getByText('Version {version} (latest)')).toBeInTheDocument();
 });
 
 
@@ -36,7 +53,7 @@ test('does not show content view details when host is not registered', () => {
     subscription_facet_attributes: undefined,
   };
   const { queryByText } = render(<ContentViewDetailsCard hostDetails={hostDetails} />);
-  expect(queryByText('Version 1.0')).toBeNull();
+  expect(queryByText('Version {version}')).toBeNull();
 });
 
 
@@ -45,12 +62,20 @@ test('shows when the CV in use is not the latest version', () => {
     ...baseHostDetails,
     content_facet_attributes: {
       ...baseHostDetails.content_facet_attributes,
-      content_view_version_latest: false,
+      content_view_environments: [
+        {
+          content_view: {
+            ...baseHostDetails.content_facet_attributes.content_view_environments[0].content_view,
+            content_view_version_latest: false,
+          },
+          lifecycle_environment: baseHostDetails.content_facet_attributes.lifecycle_environment,
+        },
+      ],
     },
   };
   const { getByText, queryByText } = render(<ContentViewDetailsCard hostDetails={hostDetails} />);
-  expect(getByText('Version 1.0')).toBeInTheDocument();
-  expect(queryByText('Version 1.0 (latest)')).toBeNull();
+  expect(getByText('Version {version}')).toBeInTheDocument();
+  expect(queryByText('Version {version} (latest)')).toBeNull();
 });
 
 test('does not show version info when using Default Organization View', () => {
@@ -58,17 +83,21 @@ test('does not show version info when using Default Organization View', () => {
     ...baseHostDetails,
     content_facet_attributes: {
       ...baseHostDetails.content_facet_attributes,
-      content_view:
+      content_view_environments: [
         {
-          ...baseHostDetails.content_facet_attributes.content_view,
-          content_view_default: true,
-          name: 'Default Organization View',
+          content_view: {
+            ...baseHostDetails.content_facet_attributes.content_view_environments[0].content_view,
+            content_view_default: true,
+            name: 'Default Organization View',
+          },
+          lifecycle_environment: baseHostDetails.content_facet_attributes.lifecycle_environment,
         },
+      ],
     },
   };
 
   const { queryByText } = render(<ContentViewDetailsCard hostDetails={hostDetails} />);
   expect(queryByText('Default Organization View')).toBeInTheDocument();
-  expect(queryByText('Version 1.0')).toBeNull();
+  expect(queryByText('Version {version}')).toBeNull();
 });
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

1. Add multi-CV display to host details
![image](https://github.com/Katello/katello/assets/22042343/c024f099-0877-453d-9df6-903c988d33d7)

2. Add a column for multi-CV display to new All Hosts 
![image](https://github.com/Katello/katello/assets/22042343/6434ae11-6b8e-4685-9334-ed010fbbec37)

We haven't yet built the web UI for changing or rearranging a host's multiple environments. Until then, using the web UI to change CV/LCE will transform a multi-environment host back into a single-environment one. So,

3. Add an alert banner (for now) on the change CV modal:
![image](https://github.com/Katello/katello/assets/22042343/a5d0b3e3-8a29-46f3-8d89-4c82af0f3fef)

#### Considerations taken when implementing this change?

I had added a badge on the card as well, but it took up too much space and caused the kebab to wrap to the next line. I decided the badge wasn't useful enough to include.

#### What are the testing steps for this pull request?

Register a host to multiple environments:
```
subscription-manager register --environments dev/cv1,prod/cv2
```

Check and verify correct display on
* All Hosts experimental page (turn on the 'Content view environments' column)
* Host details - Content view card
* Host details - Edit content view environments modal
