### PR TITLE
Fixes #37504 - send 404 to v2 client requesting v1/search

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -278,10 +278,10 @@ module Katello
     end
 
     def v1_search
-      # Checks for podman client and issues a 404 in that case. Podman
+      # Checks for v2 client and issues a 404 in that case. Podman
       # examines the response from a /v1_search request. If the result
       # is a 4XX, it will then proceed with a request to /_catalog
-      if request.headers['HTTP_USER_AGENT'].downcase.include?('libpod')
+      if request.headers['HTTP_DOCKER_DISTRIBUTION_API_VERSION'] == 'registry/2.0'
         render json: {}, status: :not_found
         return
       end

--- a/test/controllers/api/registry/registry_proxies_controller_test.rb
+++ b/test/controllers/api/registry/registry_proxies_controller_test.rb
@@ -324,7 +324,7 @@ module Katello
       it "blocks search for podman" do
         @docker_repo.set_container_repository_name
         @docker_env_repo.set_container_repository_name
-        @request.env['HTTP_USER_AGENT'] = "libpod/1.8.0"
+        @request.env['HTTP_DOCKER_DISTRIBUTION_API_VERSION'] = "registry/2.0"
         get :v1_search, params: { q: "abc", n: 2 }
         assert_response 404
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Podman no longer has libpod in the HTTP_USER_AGENT header. Now, we should check for v2 clients instead. This should apply to docker as well.

#### Considerations taken when implementing this change?
/_catalog and /v1/search are both removed from the OCI spec, but we should keep supporting them for now since the clients allow it.

#### What are the testing steps for this pull request?
1) Test podman search with unauthenticated pull off (default) and some search text:
```
$ podman search `hostname`/ubuntu

NAME                                                                                                                     DESCRIPTION
centos9-katello-devel.manicotto.example.com/default_organization-buttermilk_biscuits-docker_ubuntu                       
centos9-katello-devel.manicotto.example.com/default_organization-library-export_view-buttermilk_biscuits-docker_ubuntu   
centos9-katello-devel.manicotto.example.com/default_organization-buttermilk_biscuits-ubuntu                              
centos9-katello-devel.manicotto.example.com/default_organization-library-container_push_view-buttermilk_biscuits-ubuntu 
```

2) Try the code as well with a Docker client, just to be safe. Installed Docker-CE via their online instructions.
