### PR TITLE
Multi-CV: Add ordering to content view environments

### DIFF
--- a/app/models/katello/concerns/subscription_facet_host_extensions.rb
+++ b/app/models/katello/concerns/subscription_facet_host_extensions.rb
@@ -42,6 +42,7 @@ module Katello
       end
 
       def update_candlepin_associations(consumer_params = nil)
+        Rails.logger.debug "Updating Candlepin associations for host #{name}"
         content_facet.cves_changed = false if content_facet
         content_facet&.save!
 

--- a/app/models/katello/content_view_environment.rb
+++ b/app/models/katello/content_view_environment.rb
@@ -47,10 +47,9 @@ module Katello
       content_view.default? && environment.library?
     end
 
-    # TODO: uncomment when we need to start showing multiple CVE names in UI
-    # def candlepin_name
-    #   "#{environment.label}/#{content_view.label}"
-    # end
+    def candlepin_name
+      "#{environment.label}/#{content_view.label}"
+    end
 
     private
 

--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -162,8 +162,20 @@ module Katello
         end
       end
 
+      def candlepin_environments_cp_ids
+        candlepin_environments.map { |e| e[:id] }
+      end
+
       def content_view_environments
         self.host.content_facet.try(:content_view_environments)
+      end
+
+      def consumer_cve_order_from_candlepin
+        Katello::Resources::Candlepin::Consumer.get(uuid)['environments'].map { |e| e['id'] }
+      end
+
+      def cves_ordered_correctly?
+        consumer_cve_order_from_candlepin == candlepin_environments_cp_ids
       end
 
       def organization

--- a/db/migrate/20240522165308_add_priority_to_content_view_environment_content_facet.rb
+++ b/db/migrate/20240522165308_add_priority_to_content_view_environment_content_facet.rb
@@ -1,0 +1,5 @@
+class AddPriorityToContentViewEnvironmentContentFacet < ActiveRecord::Migration[6.1]
+  def change
+    add_column :katello_content_view_environment_content_facets, :priority, :integer, default: 0, null: false
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Since Katello 4.8, you've been able to register hosts to multiple content view environments:
```
subscription-manager register --environments dev/cv1, prod/cv2
```

For the situation where the same repository is contained in multiple content view versions, we may end up with "repo conflicts" where Candlepin must make a decision about which content view environment to serve the repo from. The way that Candlepin handles it is via the _order_ of the content view environments, with first being highest priority. Therefore, in the example above, if the same repo were in both of the host's content views, `dev/cv1` would win, since it was specified first.

Until now, it was not possible to change this order without reregistering a host. This PR adds a (backend) way to change the order:

- Add a zero-indexed `priority` field to `ContentViewEnvironmentContentFacet`
- When changing a host's content view environments, update this `priority` to reflect the order that the user specified
- Always sort by priority when sending params to Candlepin.

Thus, it's now possible to change the order of a host's content view environments like this:

```
[13] pry(main)> rhel8b.content_view_environments.map(&:candlepin_name)
=> ["dev/cv1", "prod/cv2"]
[14] pry(main)> rhel8b.content_facet.content_view_environments = [prodCv2, devCv1]
[16] pry(main)> rhel8b.content_view_environments.reload.map(&:candlepin_name)
=> ["prod/cv2", "dev/cv1"]
```

#### Considerations taken when implementing this change?

Web UI will come in a future PR. For now, you will have to use Rails console.

#### What are the testing steps for this pull request?

1. Have at least 2 published content views
2. Register a host to multiple environments (remember, no activation keys or global registration allowed)

```
subscription-manager register --environments dev/cv1, prod/cv2
```

3. Verify that the host's environments are listed in the same order, by running on the host

```
subscription-manager environments --list-enabled
```

4. Change the order of environments like the example above
5. Run `subscription-manager environments --list-enabled` again. You should see the environments in the new order.

You can also use these methods on `host.subscription_facet` to verify:
```rb
subscription_facet.candlepin_environments_cp_ids # returns ordered array of environment ids, as stored in Katello
subscription_facet.consumer_cve_order_from_candlepin # makes Candlepin API call and returns ordered array of environment ids
subscription_facet.cves_ordered_correctly? # compares the 2 things above and returns true if they're the same
```