### PR TITLE
Fixes #37518 - Clear KS repo upon unregistration and show inherited hostgroup vals

### DIFF
--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -12,6 +12,22 @@ module Katello
       edit_action? && !using_discovered_hosts_page?
     end
 
+    def content_source_inherited?
+      !using_hostgroups_page? && @host.content_source.blank? && @host&.hostgroup&.content_source.present? && cv_lce_disabled?
+    end
+
+    def lifecycle_environment_inherited?
+      !using_hostgroups_page? && @host.lifecycle_environments.empty? && @host&.hostgroup&.lifecycle_environment.present? && cv_lce_disabled?
+    end
+
+    def content_view_inherited?
+      !using_hostgroups_page? && @host.content_views.empty? && @host&.hostgroup&.content_view.present? && cv_lce_disabled?
+    end
+
+    def kickstart_repo_inherited?
+      !using_hostgroups_page? && @host.kickstart_repository_id.blank? && @host&.hostgroup&.kickstart_repository.present? && cv_lce_disabled?
+    end
+
     def using_discovered_hosts_page?
       controller.controller_name == "discovered_hosts"
     end

--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -301,6 +301,7 @@ module Katello
           host.content_facet.uuid = nil
           host.content_facet.content_view_environments = []
           host.content_facet.content_source = ::SmartProxy.pulp_primary
+          host.content_facet.kickstart_repository_id = nil
           host.content_facet.save!
           Rails.logger.debug "remove_host_artifacts: marking CVEs unchanged to prevent backend update"
           host.content_facet.mark_cves_unchanged

--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -16,25 +16,30 @@
 <% cs_select_name =  using_hostgroups_page? ? 'hostgroup[content_source_id]' : 'host[content_facet_attributes][content_source_id]' %>
 <% cs_select_attr = using_hostgroups_page? ? 'content_source' : 'content_facet.content_source' %>
 
-<%= field(f, cs_select_attr, {:label => _("Content Source")}) do
-  if using_hostgroups_page?
-    select_tag cs_select_id, content_source_options(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path},
-               :class => 'form-control',  :name => cs_select_name
-  else
-    select_tag cs_select_id, content_source_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cs_select_name, :disabled => cv_lce_disabled?
-  end
-end %>
+<%= field(f, cs_select_attr, {:label => _("Content Source"), :help_inline => content_source_inherited? ? 'Inherited' : nil }) do %>
+  <% if using_hostgroups_page? %>
+    <%= select_tag cs_select_id, content_source_options(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path},
+               :class => 'form-control',  :name => cs_select_name %>
+  <% else %>
+    <%= select_tag cs_select_id, content_source_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cs_select_name, :disabled => cv_lce_disabled? %>
+  <% end %>
+<% end %>
 
 <% env_select_id = using_hostgroups_page? ? :hostgroup_lifecycle_environment_id : :host_lifecycle_environment_id %>
 <% env_select_name =  using_hostgroups_page? ? 'hostgroup[lifecycle_environment_id]' : 'host[content_facet_attributes][lifecycle_environment_id]' %>
 <% env_select_attr = using_hostgroups_page? ? 'lifecycle_environment' : 'content_facet.single_lifecycle_environment' %>
 
-<%= field(f, env_select_attr, {:label => _("Lifecycle Environment")}) do %>
+<%= field(f, env_select_attr, {:label => _("Lifecycle Environment"), :help_inline => lifecycle_environment_inherited? ? 'Inherited' : nil}) do %>
   <% if using_hostgroups_page? %>
     <%= select_tag env_select_id, lifecycle_environment_options(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name %>
   <% elsif cv_lce_disabled? %>
-    <%= hidden_field_tag 'host[content_facet_attributes][lifecycle_environment_id]', fetch_lifecycle_environment(@host).try(:id) %>
-    <%= select_tag env_select_id, lifecycle_environment_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name, :disabled => true %>
+    <% host_or_hostgroup_lce = (@host.lifecycle_environments.empty? && @host.hostgroup.present? && @host.hostgroup.lifecycle_environment.present?) ? fetch_lifecycle_environment(@host.hostgroup) : fetch_lifecycle_environment(@host) %>
+    <%= hidden_field_tag 'host[content_facet_attributes][lifecycle_environment_id]', host_or_hostgroup_lce.try(:id) %>
+    <% if @host&.hostgroup&.lifecycle_environment.present? %>
+      <%= select_tag env_select_id, lifecycle_environment_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name, :disabled => true %>
+    <% else %>
+      <%= select_tag env_select_id, '<option></option>', :class => 'form-control',  :name => env_select_name, :disabled => true %>
+    <% end %>
   <% else %>
     <%= select_tag env_select_id, lifecycle_environment_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name %>
   <% end %>
@@ -43,7 +48,8 @@ end %>
 <% cv_select_id =  using_hostgroups_page? ? :hostgroup_content_view_id : :host_content_view_id %>
 <% cv_select_name =  using_hostgroups_page? ? 'hostgroup[content_view_id]' : 'host[content_facet_attributes][content_view_id]' %>
 <% cv_select_attr = using_hostgroups_page? ? 'content_view' : 'content_facet.single_content_view' %>
-<%= field(f, cv_select_attr, {:label => _("Content View")}) do %>
+
+<%= field(f, cv_select_attr, {:label => _("Content View"), :help_inline => content_view_inherited? ? 'Inherited' : nil}) do %>
   <% if using_hostgroups_page? %>
     <%= select_tag cv_select_id,  content_views_for_host(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cv_select_name %>
   <% elsif cv_lce_disabled? %>

--- a/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
@@ -18,10 +18,10 @@
 
 <% spinner_path = asset_path('spinner.gif') %>
 
-<%= field(f, ks_repo_select_attr, {:label => _("Synced Content")}) do
-  select_tag ks_repo_select_id,  view_to_options(kickstart_options, kickstart_repo_id, blank_or_inherit_with_id(f, :kickstart_repository)), :data => {"spinner_path" => spinner_path, "kickstart-repository-id" => kickstart_repo_id},
-             :class => 'form-control',  :name => ks_repo_select_name, :disabled => kickstart_options.empty?
-end %>
+<%= field(f, ks_repo_select_attr, {:label => _("Synced Content"), :help_inline => kickstart_repo_inherited? ? 'Inherited' : nil}) do %>
+  <%= select_tag ks_repo_select_id,  view_to_options(kickstart_options, kickstart_repo_id, blank_or_inherit_with_id(f, :kickstart_repository)), :data => {"spinner_path" => spinner_path, "kickstart-repository-id" => kickstart_repo_id},
+             :class => 'form-control',  :name => ks_repo_select_name, :disabled => kickstart_options.empty? %>
+<% end %>
 
 <% content_for(:javascripts) do -%>
   <script>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Clears the kickstart repo when unregistering a host. Also make it more obvious when a cleared LCE, CV, content source, or synced content value on the host edit page is actually inheriting something from a host group.

#### Considerations taken when implementing this change?
The "Inherited" text will only pop up for the 4 specific fields mentioned above. With how the UI is, we'd need to specifically add the inherited check to every field that needs it. LCE, CV, and Synced Content (KS Repo) were the ones requested to be highlighted, and I threw content source in there too since it was in the same ERB file.


#### What are the testing steps for this pull request?
1) Create a hostgroup with synced content filled out and the fields needed to get that to work (LCE, CV, CS)
2) Register a host with that host group
3) Unregister the host
4) Edit the host
5) Click "manage host"
6) See that the 4 fields mentioned above are still filled out, but say "inherited".

TODO: ensure that it doesn't say "Inherited" if the value from the hostgroup is actually blank.