### PR TITLE
Fixes #37521 - Purge complete pulp tasks

### DIFF
--- a/app/lib/actions/pulp3/orchestration/orphan_cleanup/remove_orphans.rb
+++ b/app/lib/actions/pulp3/orchestration/orphan_cleanup/remove_orphans.rb
@@ -14,6 +14,7 @@ module Actions
                   plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanRemotes, proxy)
                 end
                 plan_action(Actions::Pulp3::OrphanCleanup::RemoveOrphans, proxy)
+                plan_action(Actions::Pulp3::OrphanCleanup::PurgeCompletedTasks, proxy)
               end
             end
           end

--- a/app/lib/actions/pulp3/orphan_cleanup/purge_completed_tasks.rb
+++ b/app/lib/actions/pulp3/orphan_cleanup/purge_completed_tasks.rb
@@ -1,0 +1,15 @@
+module Actions
+  module Pulp3
+    module OrphanCleanup
+      class PurgeCompletedTasks < Pulp3::AbstractAsyncTask
+        def plan(smart_proxy)
+          plan_self(:smart_proxy_id => smart_proxy.id)
+        end
+
+        def run
+          output[:pulp_tasks] = ::Katello::Pulp3::Api::Core.new(smart_proxy).purge_completed_tasks
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/api/core.rb
+++ b/app/services/katello/pulp3/api/core.rb
@@ -176,6 +176,14 @@ module Katello
           nil
         end
 
+        def purge_class
+          PulpcoreClient::Purge
+        end
+
+        def purge_completed_tasks
+          tasks_api.purge(purge_class.new(finished_before: DateTime.now - Setting[:completed_pulp_task_protection_days]))
+        end
+
         def delete_orphans
           [orphans_api.cleanup(PulpcoreClient::OrphansCleanup.new(orphan_protection_time: (smart_proxy.pulp_mirror? ? 0 : Setting[:orphan_protection_time])))]
         end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -634,6 +634,12 @@ Foreman::Plugin.register :katello do
         full_name: N_('Orphaned Content Protection Time'),
         description: N_('Time in minutes before content that is not contained within a repository and has not been accessed is considered orphaned.')
 
+      setting 'completed_pulp_task_protection_days',
+        type: :integer,
+        default: 30,
+        full_name: N_('Completed pulp task protection days'),
+        description: N_('How many days before a completed Pulp task is purged by Orphan Cleanup.')
+
       setting 'remote_execution_prefer_registered_through_proxy',
         type: :boolean,
         default: false,

--- a/test/actions/pulp3/orchestration/file_upload_test.rb
+++ b/test/actions/pulp3/orchestration/file_upload_test.rb
@@ -19,6 +19,9 @@ module ::Actions::Pulp3
       @repo.backend_service(@primary).delete_publication
       ForemanTasks.sync_task(
           ::Actions::Pulp3::Orchestration::Repository::Delete, @repo, @primary)
+
+      Setting[:completed_pulp_task_protection_days] = 0
+      DateTime.expects(:now).returns(DateTime.new(3000, 1, 1))
       ForemanTasks.sync_task(
           ::Actions::Pulp3::Orchestration::OrphanCleanup::RemoveOrphans, @primary)
     end

--- a/test/actions/pulp3/orchestration/yum_update_test.rb
+++ b/test/actions/pulp3/orchestration/yum_update_test.rb
@@ -28,6 +28,9 @@ module ::Actions::Pulp3
       @repo.backend_service(@primary).delete_publication
       ForemanTasks.sync_task(
           ::Actions::Pulp3::Orchestration::Repository::Delete, @repo, @primary)
+
+      Setting[:completed_pulp_task_protection_days] = 0
+      DateTime.expects(:now).returns(DateTime.new(3000, 1, 1))
       ForemanTasks.sync_task(
           ::Actions::Pulp3::Orchestration::OrphanCleanup::RemoveOrphans, @primary)
     end
@@ -134,6 +137,8 @@ module ::Actions::Pulp3
       @repo.backend_service(@primary).delete_publication
       ForemanTasks.sync_task(
         ::Actions::Pulp3::Orchestration::Repository::Delete, @repo, @primary)
+      Setting[:completed_pulp_task_protection_days] = 0
+      DateTime.expects(:now).returns(DateTime.new(3000, 1, 1))
       ForemanTasks.sync_task(
         ::Actions::Pulp3::Orchestration::OrphanCleanup::RemoveOrphans, @primary)
     end

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:00 GMT
+      - Wed, 05 Jun 2024 14:33:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5a2f7d94b317471389c808468becd67f
+      - 436c3e41642d4d9daed191fa6d97509e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:00 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:52 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:00 GMT
+      - Wed, 05 Jun 2024 14:33:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bbdb9d602e86471692c02e3778405868
+      - ca2866ac4bd24dd58b0f61e9a624cc16
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:00 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:52 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
@@ -118,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:00 GMT
+      - Wed, 05 Jun 2024 14:33:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 154eecef51d54d1db6205e92fda4c58a
+      - 48acb1d7a7444bd99faace6db6488fcc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:00 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:53 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
@@ -172,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:00 GMT
+      - Wed, 05 Jun 2024 14:33:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0aac1240e5ce4ad49a4bdbd89d3db153
+      - 8d72751bc18e42b893c4bbb5f75afb25
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:00 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:53 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
@@ -235,7 +235,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -248,13 +248,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:01 GMT
+      - Wed, 05 Jun 2024 14:33:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/018f54e3-69fb-7d6a-b8b2-2d69abbf61a0/"
+      - "/pulp/api/v3/remotes/file/file/018fe8d2-1581-7d7f-ac14-f1ef2ddbfa6d/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -270,7 +270,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ed72371dd97f490c863a304229add23b
+      - b405735eae264af59d6565c476e5f1a6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -279,9 +279,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE4ZjU0ZTMtNjlmYi03ZDZhLWI4YjItMmQ2OWFiYmY2MWEwLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDk6MDEuMDUxOTA0WiIsInB1bHBf
-        bGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowOTowMS4wNTE5MjBaIiwi
+        MDE4ZmU4ZDItMTU4MS03ZDdmLWFjMTQtZjFlZjJkZGJmYTZkLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTMuMjgyMTUzWiIsInB1bHBf
+        bGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozMzo1My4yODIxNjZaIiwi
         bmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMi
         LCJ1cmwiOiJodHRwOi8vdGVzdC90ZXN0Ly9QVUxQX01BTklGRVNUIiwiY2Ff
         Y2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9u
@@ -295,7 +295,7 @@ http_interactions:
         bWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwcm94eV9wYXNzd29yZCIs
         ImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InVzZXJuYW1lIiwiaXNfc2V0Ijpm
         YWxzZX0seyJuYW1lIjoicGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfV19
-  recorded_at: Tue, 07 May 2024 21:09:01 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:53 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/
@@ -308,7 +308,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -321,13 +321,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:01 GMT
+      - Wed, 05 Jun 2024 14:33:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/018f54e3-6ac8-71f8-b462-733acb8756e9/"
+      - "/pulp/api/v3/repositories/file/file/018fe8d2-1625-7155-a51c-137f3c91b8c1/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -343,7 +343,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 27513c73477e47188eeef09e07eb16c5
+      - 9c51d0790938437cb6fd1e2ec5884908
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -352,22 +352,22 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMThmNTRlMy02YWM4LTcxZjgtYjQ2Mi03MzNhY2I4NzU2ZTkvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyNC0wNS0wN1QyMTowOTowMS4yNTc1MDhaIiwi
-        cHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA5OjAxLjI2NTkw
-        M1oiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvMDE4ZjU0ZTMtNmFjOC03MWY4LWI0NjItNzMzYWNiODc1
-        NmU5L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
+        ZmlsZS8wMThmZThkMi0xNjI1LTcxNTUtYTUxYy0xMzdmM2M5MWI4YzEvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wNVQxNDozMzo1My40NDY5NzdaIiwi
+        cHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTA1VDE0OjMzOjUzLjQ1Mzc0
+        OVoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvMDE4ZmU4ZDItMTYyNS03MTU1LWE1MWMtMTM3ZjNjOTFi
+        OGMxL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
         b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzAxOGY1NGUzLTZhYzgtNzFmOC1iNDYyLTczM2FjYjg3NTZlOS92ZXJzaW9u
+        LzAxOGZlOGQyLTE2MjUtNzE1NS1hNTFjLTEzN2YzYzkxYjhjMS92ZXJzaW9u
         cy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15
         X0ZpbGVzIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNp
         b25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwi
         bWFuaWZlc3QiOiJQVUxQX01BTklGRVNUIn0=
-  recorded_at: Tue, 07 May 2024 21:09:01 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:53 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018f54e3-6ac8-71f8-b462-733acb8756e9/versions/2/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018fe8d2-1625-7155-a51c-137f3c91b8c1/versions/2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -375,7 +375,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -388,7 +388,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:04 GMT
+      - Wed, 05 Jun 2024 14:33:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -408,7 +408,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4b4368d83509486090fa9dbf5486c70e
+      - 685da5e1d971415aa1670dea99b2f0bc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -417,25 +417,25 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMThmNTRlMy02YWM4LTcxZjgtYjQ2Mi03MzNhY2I4NzU2ZTkvdmVy
-        c2lvbnMvMi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA5OjA0
-        LjIwMTUzOVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6
-        MDk6MDQuMjU4NDkxWiIsIm51bWJlciI6MiwicmVwb3NpdG9yeSI6Ii9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOGY1NGUzLTZhYzgt
-        NzFmOC1iNDYyLTczM2FjYjg3NTZlOS8iLCJiYXNlX3ZlcnNpb24iOm51bGws
+        ZmlsZS8wMThmZThkMi0xNjI1LTcxNTUtYTUxYy0xMzdmM2M5MWI4YzEvdmVy
+        c2lvbnMvMi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjMzOjU1
+        LjkyMzI2MVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6
+        MzM6NTUuOTcxOTc3WiIsIm51bWJlciI6MiwicmVwb3NpdG9yeSI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOGZlOGQyLTE2MjUt
+        NzE1NS1hNTFjLTEzN2YzYzkxYjhjMS8iLCJiYXNlX3ZlcnNpb24iOm51bGws
         ImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291
         bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVz
         Lz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvMDE4ZjU0ZTMtNmFjOC03MWY4LWI0NjItNzMz
-        YWNiODc1NmU5L3ZlcnNpb25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2Vu
+        aXRvcmllcy9maWxlL2ZpbGUvMDE4ZmU4ZDItMTYyNS03MTU1LWE1MWMtMTM3
+        ZjNjOTFiOGMxL3ZlcnNpb25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2Vu
         dCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjIsImhyZWYiOiIvcHVscC9hcGkv
         djMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE4ZjU0ZTMtNmFj
-        OC03MWY4LWI0NjItNzMzYWNiODc1NmU5L3ZlcnNpb25zLzIvIn19fX0=
-  recorded_at: Tue, 07 May 2024 21:09:04 GMT
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE4ZmU4ZDItMTYy
+        NS03MTU1LWE1MWMtMTM3ZjNjOTFiOGMxL3ZlcnNpb25zLzIvIn19fX0=
+  recorded_at: Wed, 05 Jun 2024 14:33:56 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018f54e3-69fb-7d6a-b8b2-2d69abbf61a0/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018fe8d2-1581-7d7f-ac14-f1ef2ddbfa6d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -443,7 +443,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -456,7 +456,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:04 GMT
+      - Wed, 05 Jun 2024 14:33:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -476,7 +476,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - be4f58a288c74d43a459c5fc49a40c11
+      - '0157255207094535b7c03b1f042c5ac3'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -484,12 +484,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUzLTc4OWUtN2U1
-        NS1iNWE0LTg3NzRjNDg5MzhiZS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:09:04 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLTIxZGYtN2Jj
+        ZS04YTA4LWE4NWFlNjE3NDY2Zi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:56 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e3-789e-7e55-b5a4-8774c48938be/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-21df-7bce-8a08-a85ae617466f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -497,7 +497,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -510,7 +510,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:05 GMT
+      - Wed, 05 Jun 2024 14:33:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -530,7 +530,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d6e282c9b60945739eaa44b3f2805c7c
+      - eaf5deadd38441fd8c1b2a62474e48b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -538,28 +538,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTMtNzg5
-        ZS03ZTU1LWI1YTQtODc3NGM0ODkzOGJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDk6MDQuNzk5MTA5WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowOTowNC43OTkxMjNaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItMjFk
+        Zi03YmNlLThhMDgtYTg1YWU2MTc0NjZmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzM6NTYuNDQ4MDE0WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozMzo1Ni40NDgwMjhaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImJlNGY1OGEyODhjNzRkNDNhNDU5
-        YzVmYzQ5YTQwYzExIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDk6MDQuODEx
-        MjA2WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA5OjA0Ljg1NzY5
-        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDk6MDQuOTIwMzY4
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjAxNTcyNTUyMDcwOTQ1MzViN2Mw
+        M2IxZjA0MmM1YWMzIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTYuNDYx
+        Njg1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjMzOjU2LjQ5Mzk2
+        MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTYuNTMzMTE2
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGU4LTc0ODctOWFhMC0zYzNlYzFhMTk5ZDcvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE4ZjU0ZTMtNjlmYi03ZDZhLWI4YjIt
-        MmQ2OWFiYmY2MWEwLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8w
-        MThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:09:05 GMT
+        djMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE4ZmU4ZDItMTU4MS03ZDdmLWFjMTQt
+        ZjFlZjJkZGJmYTZkLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8w
+        MThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:33:56 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018f54e3-6ac8-71f8-b462-733acb8756e9/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018fe8d2-1625-7155-a51c-137f3c91b8c1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -567,7 +567,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -580,7 +580,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:05 GMT
+      - Wed, 05 Jun 2024 14:33:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -600,7 +600,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b76490fe3fe74dd5a06305a7486c0ff8
+      - 44fb087231054e39bae02169285f27a2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -608,12 +608,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUzLTc5ZDItN2M3
-        YS04MTE1LTM2ZDAzYjYyMTc2Ny8ifQ==
-  recorded_at: Tue, 07 May 2024 21:09:05 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLTIyY2UtN2Ez
+        YS05ZDVjLTZkNGMwYTkzN2M0ZS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:56 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e3-79d2-7c7a-8115-36d03b621767/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-22ce-7a3a-9d5c-6d4c0a937c4e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -621,7 +621,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -634,7 +634,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:05 GMT
+      - Wed, 05 Jun 2024 14:33:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -654,7 +654,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a5dcf9ccde2d43cbb11bd7eecb618850
+      - 17c1cd0b4861493fb8c04cf681173a94
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -662,25 +662,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTMtNzlk
-        Mi03YzdhLTgxMTUtMzZkMDNiNjIxNzY3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDk6MDUuMTA3NDY3WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowOTowNS4xMDc0ODFaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItMjJj
+        ZS03YTNhLTlkNWMtNmQ0YzBhOTM3YzRlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzM6NTYuNjg2OTc3WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozMzo1Ni42ODY5ODlaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImI3NjQ5MGZlM2ZlNzRkZDVhMDYz
-        MDVhNzQ4NmMwZmY4IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDk6MDUuMTIw
-        ODAxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA5OjA1LjE3MjE2
-        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDk6MDUuMjY2MDQ4
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjQ0ZmIwODcyMzEwNTRlMzliYWUw
+        MjE2OTI4NWYyN2EyIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTYuNjk3
+        MTA4WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjMzOjU2LjcyOTg2
+        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTYuNzk0Nzkx
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGU4LTc0ODctOWFhMC0zYzNlYzFhMTk5ZDcvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmNTRlMy02YWM4LTcxZjgt
-        YjQ2Mi03MzNhY2I4NzU2ZTkvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21h
-        aW5zLzAxOGY1NGRmLTdmZDItNzVmYS05YjM1LWMyNzUxM2ZmOThmNC8iXX0=
-  recorded_at: Tue, 07 May 2024 21:09:05 GMT
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmZThkMi0xNjI1LTcxNTUt
+        YTUxYy0xMzdmM2M5MWI4YzEvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21h
+        aW5zLzAxOGZlM2M5LTcwYWEtNzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:33:56 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
@@ -691,7 +691,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.21.3/ruby
+      - OpenAPI-Generator/0.21.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -704,7 +704,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:05 GMT
+      - Wed, 05 Jun 2024 14:33:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -724,7 +724,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3b1cb1a43b814fc59eef853556978ab5
+      - 1c2effe3855c4e7fb4ed5e331fa6bf44
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -734,7 +734,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:05 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:57 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -758,7 +758,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:05 GMT
+      - Wed, 05 Jun 2024 14:33:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -778,7 +778,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 046732143c744bf78d9187fb8676bf24
+      - 58fbdcd4141d4f1cb12b514748f95760
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -788,7 +788,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:05 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:57 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -812,7 +812,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:05 GMT
+      - Wed, 05 Jun 2024 14:33:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -832,7 +832,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e2b8fe2b351a4d218d7c7f7978539e75
+      - a3c869e8370e4c00bd1d0a9be2102543
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -842,7 +842,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:05 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:57 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -853,7 +853,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -866,7 +866,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:05 GMT
+      - Wed, 05 Jun 2024 14:33:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -886,7 +886,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 33e7d4bb879940988d02224980c9438e
+      - ae5cd091c0304b0eaef594342f2708a9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -896,7 +896,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:05 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:57 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -920,7 +920,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:05 GMT
+      - Wed, 05 Jun 2024 14:33:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -940,7 +940,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 10b4ba8b72c7459eafc12aed2868bfab
+      - fafe1ff85d834a07a6f5710d3f2ac162
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -950,7 +950,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:05 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:57 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -974,7 +974,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:05 GMT
+      - Wed, 05 Jun 2024 14:33:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -994,7 +994,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f3247c6660694a0a8f303957abb994a4
+      - d2fd08a00d294ec5b427fe71c28c9afd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1004,7 +1004,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:05 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:57 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -1015,7 +1015,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1028,7 +1028,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:05 GMT
+      - Wed, 05 Jun 2024 14:33:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1048,7 +1048,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bbbaf54d19ed49ec8aff7494dfb29459
+      - 916d129c455641b9b8e33b802016aaae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1058,7 +1058,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:05 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:57 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
@@ -1071,7 +1071,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1084,7 +1084,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:05 GMT
+      - Wed, 05 Jun 2024 14:33:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1104,7 +1104,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b6fc9d195fd246ec919ca960164ea5ef
+      - e616c1d1bd734f34acd20c53bc2849dd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1112,12 +1112,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUzLTdkMGQtNzBh
-        OC1iYzZjLTU5OWFjMjAwZmY5Mi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:09:05 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLTI1NzEtNzBj
+        My1iYmVmLWQ2YWM5Njg0MDZjZi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:57 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e3-7d0d-70a8-bc6c-599ac200ff92/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-2571-70c3-bbef-d6ac968406cf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1125,7 +1125,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1138,7 +1138,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:06 GMT
+      - Wed, 05 Jun 2024 14:33:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1158,7 +1158,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d72b8f409f72437db330aadc822f706c
+      - 702a15684d494ddfb1fab00787ec5daa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1166,18 +1166,18 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTMtN2Qw
-        ZC03MGE4LWJjNmMtNTk5YWMyMDBmZjkyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDk6MDUuOTMzODA4WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowOTowNS45MzM4MjNaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItMjU3
+        MS03MGMzLWJiZWYtZDZhYzk2ODQwNmNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzM6NTcuMzYyNDA2WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozMzo1Ny4zNjI0MjBaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLm9ycGhhbi5vcnBo
-        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiYjZmYzlkMTk1ZmQyNDZlYzkx
-        OWNhOTYwMTY0ZWE1ZWYiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
-        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMTowOTowNS45
-        NTYwMTFaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDk6MDYuMDA5
-        NzIyWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMTowOTowNi4yMjA1
-        NzVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzAxOGY1NGUwLWE0YzEtNzE3NS1hMzdiLWI2MzMyMjU1YTIwYS8iLCJw
+        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiZTYxNmMxZDFiZDczNGYzNGFj
+        ZDIwYzUzYmMyODQ5ZGQiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
+        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozMzo1Ny4z
+        NzkzODhaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTcuNDE4
+        NzAyWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozMzo1Ny41Njgw
+        NTNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzAxOGZlM2NiLTBkNDMtNzczMS05ODUyLTg3MjlkMDA4MTk2My8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xlYW4g
         dXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIs
@@ -1187,7 +1187,63 @@ http_interactions:
         ZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
         IjpbIi9hcGkvdjMvb3JwaGFucy9jbGVhbnVwLyIsInNoYXJlZDovcHVscC9h
-        cGkvdjMvZG9tYWlucy8wMThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNm
-        Zjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:09:06 GMT
+        cGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2Fk
+        MzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:33:57 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/purge/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJmaW5pc2hlZF9iZWZvcmUiOiIzMDAwLTAxLTAxVDAwOjAwOjAwLjAwMCsw
+        MDowMCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 79b7a333bed5435586b0765454ae8ea8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLTI2YTQtNzA1
+        Yy04YzE1LTA4MjNmZjU3YmE2MC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:57 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary.yml
@@ -9348,174 +9348,6 @@ http_interactions:
         fQ==
   recorded_at: Tue, 07 May 2024 20:31:40 GMT
 - request:
-    method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 07 May 2024 21:09:01 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - eb9038ee4a4e4d889479e9cf103a8834
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:01 GMT
-- request:
-    method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 07 May 2024 21:09:01 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 9ab4f5f51eba43a58180de95dfbcf1c1
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:01 GMT
-- request:
-    method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjo3NDB9
-
-        '
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Tue, 07 May 2024 21:09:01 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/uploads/018f54e3-6c78-7c2d-a253-6744a8dfac57/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '180'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - a757639dc59c4eac8660fedc161279b0
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmNTRlMy02
-        Yzc4LTdjMmQtYTI1My02NzQ0YThkZmFjNTcvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyNC0wNS0wN1QyMTowOTowMS42ODkzNjhaIiwicHVscF9sYXN0X3VwZGF0
-        ZWQiOiIyMDI0LTA1LTA3VDIxOjA5OjAxLjY4OTM4NFoiLCJzaXplIjo3NDB9
-  recorded_at: Tue, 07 May 2024 21:09:01 GMT
-- request:
     method: put
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/018f54e3-6c78-7c2d-a253-6744a8dfac57/
     body:
@@ -9598,60 +9430,6 @@ http_interactions:
         Yzc4LTdjMmQtYTI1My02NzQ0YThkZmFjNTcvIiwicHVscF9jcmVhdGVkIjoi
         MjAyNC0wNS0wN1QyMTowOTowMS42ODkzNjhaIiwicHVscF9sYXN0X3VwZGF0
         ZWQiOiIyMDI0LTA1LTA3VDIxOjA5OjAxLjY4OTM4NFoiLCJzaXplIjo3NDB9
-  recorded_at: Tue, 07 May 2024 21:09:01 GMT
-- request:
-    method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 07 May 2024 21:09:01 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 7fd7a5ebad084555b4aeecf6740db108
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
   recorded_at: Tue, 07 May 2024 21:09:01 GMT
 - request:
     method: post
@@ -9779,195 +9557,6 @@ http_interactions:
         Ii9wdWxwL2FwaS92My91cGxvYWRzLzAxOGY1NGUzLTZjNzgtN2MyZC1hMjUz
         LTY3NDRhOGRmYWM1Ny8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMv
         MDE4ZjU0ZGYtN2ZkMi03NWZhLTliMzUtYzI3NTEzZmY5OGY0LyJdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:02 GMT
-- request:
-    method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 07 May 2024 21:09:02 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '771'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 3b09f2033c4642c1858768e40e17c664
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE4
-        ZjU0ZTMtNmQ4Zi03M2IzLTg4N2EtYmQ5ZTJjOTliY2EzLyIsInB1bHBfY3Jl
-        YXRlZCI6IjIwMjQtMDUtMDdUMjE6MDk6MDEuOTY4NTMwWiIsInB1bHBfbGFz
-        dF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowOTowMS45Njg1NDlaIiwiZmls
-        ZSI6ImFydGlmYWN0L2VmLzBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3
-        ZjE4YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwic2l6ZSI6NzQw
-        LCJtZDUiOm51bGwsInNoYTEiOiI2MDk4ODU3MTVmZDhkNmE3MDdmMThmYzU1
-        OWQ2MWI4YmRlZTcxODBlIiwic2hhMjI0IjoiZTI5MzFmMDM2NjU2YmE2ZDAx
-        N2I1MDZiOGZlYzU3Yjg3ZTU3ZWVjMjdhZWFkMGRmN2FkOGVkM2MiLCJzaGEy
-        NTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4YWQzODFh
-        Y2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwic2hhMzg0IjoiZDNjNTI4ZDIx
-        MTBkODA2Njc1OWJlZDBjZGRjMDk5MTM5MWQ0NzcyN2Q3YmIwMDM4NjRlYTkz
-        NjIxM2E4ZWM0NGEzZGY1MmRkMWIyN2M3ODVjN2U2N2IxMDMyMmU5OWZkIiwi
-        c2hhNTEyIjoiY2ZiODUyM2U4N2M3YmY5MWU4MjMwZjVjZTE2OGJlMWQ4NTI3
-        YWI3NjdmNTU3MTRlZTQ1ZGJjZDUwNWY3N2U4NDFhNTQxNzgyMjQ4N2ZkZTIy
-        NWU2MjJmZDRmOWNkZjMzMzg0NWQ5MDE0MDA3ODYzYTk5YTE5YTdmNDkwMmVl
-        MjgifV19
-  recorded_at: Tue, 07 May 2024 21:09:02 GMT
-- request:
-    method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 07 May 2024 21:09:02 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - d7432ed3c38544328e53ee04c078f5e0
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:02 GMT
-- request:
-    method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWU3OTdlOTI5YmNlOTE5
-        NjU4ODQzMzg1ZTQ4NmJkY2VmDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bS5q
-        c29uDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtZTc5N2U5Mjli
-        Y2U5MTk2NTg4NDMzODVlNDg2YmRjZWYNCkNvbnRlbnQtRGlzcG9zaXRpb246
-        IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2FwaS92My9h
-        cnRpZmFjdHMvMDE4ZjU0ZTMtNmQ4Zi03M2IzLTg4N2EtYmQ5ZTJjOTliY2Ez
-        Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWU3OTdlOTI5YmNl
-        OTE5NjU4ODQzMzg1ZTQ4NmJkY2VmLS0NCg==
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-e797e929bce919658843385e486bdcef
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '385'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 07 May 2024 21:09:02 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 3a8915d73a70471da0360f12f7ce4650
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUzLTZlZTMtNzQy
-        MS04MTZiLTNkOGJiNDMyZjM1Mi8ifQ==
   recorded_at: Tue, 07 May 2024 21:09:02 GMT
 - request:
     method: get
@@ -10169,4 +9758,826 @@ http_interactions:
         bWFpbnMvMDE4ZjU0ZGYtN2ZkMi03NWZhLTliMzUtYzI3NTEzZmY5OGY0LyJd
         fQ==
   recorded_at: Tue, 07 May 2024 21:09:03 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - f1e0c4d6fd8040639980576a0a48f84e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:53 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 218c2297b2cd43c7b6500fa865450152
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:53 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjo3NDB9
+
+        '
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/018fe8d2-179f-7b27-b847-24548e4dbcce/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '180'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 640405e7834349f19fe9bbed2a558fa1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmZThkMi0x
+        NzlmLTdiMjctYjg0Ny0yNDU0OGU0ZGJjY2UvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyNC0wNi0wNVQxNDozMzo1My44MjMzMDdaIiwicHVscF9sYXN0X3VwZGF0
+        ZWQiOiIyMDI0LTA2LTA1VDE0OjMzOjUzLjgyMzMyMFoiLCJzaXplIjo3NDB9
+  recorded_at: Wed, 05 Jun 2024 14:33:53 GMT
+- request:
+    method: put
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/018fe8d2-179f-7b27-b847-24548e4dbcce/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTBiNDM4MzJiZGZjMjhm
+        ZDA3MzBmM2Y5MDEzYWFjM2JhDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyNDA2
+        MDUtNDQyODItYmVrYnNjIg0KQ29udGVudC1MZW5ndGg6IDc0MA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQp7InVuaXRfa2V5IjogeyJpZCI6
+        ICJ0ZXN0In0sICJ1bml0X21ldGFkYXRhIjogeyJzdGF0dXMiOiAiZmluYWwi
+        LCAidXBkYXRlZCI6ICIyMDEyLTctMjUgMDA6MDA6MDAiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiaXNzdWVkIjogIjIwMTAtMTEtNyAwMDowMDowMCIsICJw
+        dXNoY291bnQiOiAiIiwgInJlZmVyZW5jZXMiOiBbXSwgImZyb20iOiAicHVs
+        cC1saXN0QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjog
+        IlRlc3QgRXJyYXRhIHJlZmVycmluZyB0byB0ZXN0LXBhY2thZ2UtMC4yIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InZlcnNpb24iOiAiMSIsICJyZWxlYXNlIjogIiIsICJyZWJvb3Rfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50cyIsICJwa2dsaXN0
+        IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAidGVzdC1wYWNrYWdlLTAuMi0x
+        LmVsNi5zcmMucnBtIiwgIm5hbWUiOiAidGVzdC1wYWNrYWdlIiwgInN1bSI6
+        IFsibWQ1IiwgIjViNTkwY2M5NWZkZmYxNDU2MDAzNGExZjMzNGE0NzUzIl0s
+        ICJmaWxlbmFtZSI6ICJ0ZXN0LXBhY2thZ2UtMC4yLTEuZWw2Lm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNl
+        IjogIjEuZWw2IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJQdWxw
+        IFRlc3QgUGFja2FnZXMiLCAic2hvcnQiOiAiVGVzdENvbGxlY3Rpb24ifV19
+        fQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTBiNDM4MzJiZGZj
+        MjhmZDA3MzBmM2Y5MDEzYWFjM2JhLS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-0b43832bdfc28fd0730f3f9013aac3ba
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1060'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '180'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - d4a6097204c342349c9bb442b9a6c9dd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmZThkMi0x
+        NzlmLTdiMjctYjg0Ny0yNDU0OGU0ZGJjY2UvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyNC0wNi0wNVQxNDozMzo1My44MjMzMDdaIiwicHVscF9sYXN0X3VwZGF0
+        ZWQiOiIyMDI0LTA2LTA1VDE0OjMzOjUzLjgyMzMyMFoiLCJzaXplIjo3NDB9
+  recorded_at: Wed, 05 Jun 2024 14:33:53 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - a9a27899e01045768105d4a56d113678
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:53 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/018fe8d2-179f-7b27-b847-24548e4dbcce/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0ee496914121449fb8b329d7db0273b2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLTE4MmMtN2Fj
+        OS04ZjNmLWRhYTZhMjE5NjA5ZS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:53 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-182c-7ac9-8f3f-daa6a219609e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '850'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - '098c1dd24f1b4fbd8d369b2c21e40b68'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItMTgy
+        Yy03YWM5LThmM2YtZGFhNmEyMTk2MDllLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzM6NTMuOTY0OTQzWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozMzo1My45NjQ5NjhaIiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLnVwbG9hZC5jb21t
+        aXQiLCJsb2dnaW5nX2NpZCI6IjBlZTQ5NjkxNDEyMTQ0OWZiOGIzMjlkN2Ri
+        MDI3M2IyIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vycy8xLyIs
+        InVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTMuOTgwODI5WiIs
+        InN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjMzOjU0LjAxNzkzNFoiLCJm
+        aW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTQuMDcwODE5WiIsImVy
+        cm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMThm
+        ZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFyZW50X3Rh
+        c2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVsbCwi
+        cHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9w
+        dWxwL2FwaS92My9hcnRpZmFjdHMvMDE4ZmU4ZDItMTg3Ni03NmRlLWIxZmYt
+        N2FiZmJjZmE3NjU4LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpb
+        Ii9wdWxwL2FwaS92My91cGxvYWRzLzAxOGZlOGQyLTE3OWYtN2IyNy1iODQ3
+        LTI0NTQ4ZTRkYmNjZS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMv
+        MDE4ZmUzYzktNzBhYS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '771'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - f66563d14a474319a3c9193c08913320
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE4
+        ZmU4ZDItMTg3Ni03NmRlLWIxZmYtN2FiZmJjZmE3NjU4LyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTQuMDM5ODg3WiIsInB1bHBfbGFz
+        dF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozMzo1NC4wMzk5MDRaIiwiZmls
+        ZSI6ImFydGlmYWN0L2VmLzBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3
+        ZjE4YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwic2l6ZSI6NzQw
+        LCJtZDUiOm51bGwsInNoYTEiOiI2MDk4ODU3MTVmZDhkNmE3MDdmMThmYzU1
+        OWQ2MWI4YmRlZTcxODBlIiwic2hhMjI0IjoiZTI5MzFmMDM2NjU2YmE2ZDAx
+        N2I1MDZiOGZlYzU3Yjg3ZTU3ZWVjMjdhZWFkMGRmN2FkOGVkM2MiLCJzaGEy
+        NTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4YWQzODFh
+        Y2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwic2hhMzg0IjoiZDNjNTI4ZDIx
+        MTBkODA2Njc1OWJlZDBjZGRjMDk5MTM5MWQ0NzcyN2Q3YmIwMDM4NjRlYTkz
+        NjIxM2E4ZWM0NGEzZGY1MmRkMWIyN2M3ODVjN2U2N2IxMDMyMmU5OWZkIiwi
+        c2hhNTEyIjoiY2ZiODUyM2U4N2M3YmY5MWU4MjMwZjVjZTE2OGJlMWQ4NTI3
+        YWI3NjdmNTU3MTRlZTQ1ZGJjZDUwNWY3N2U4NDFhNTQxNzgyMjQ4N2ZkZTIy
+        NWU2MjJmZDRmOWNkZjMzMzg0NWQ5MDE0MDA3ODYzYTk5YTE5YTdmNDkwMmVl
+        MjgifV19
+  recorded_at: Wed, 05 Jun 2024 14:33:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3a16430d6eeb42be8ba003c82199d8c8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:54 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTNkYzQxYzdmMzExNWEx
+        OTc3YTBhMzI0MjhkZTA1NzlkDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bS5q
+        c29uDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtM2RjNDFjN2Yz
+        MTE1YTE5NzdhMGEzMjQyOGRlMDU3OWQNCkNvbnRlbnQtRGlzcG9zaXRpb246
+        IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2FwaS92My9h
+        cnRpZmFjdHMvMDE4ZmU4ZDItMTg3Ni03NmRlLWIxZmYtN2FiZmJjZmE3NjU4
+        Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTNkYzQxYzdmMzEx
+        NWExOTc3YTBhMzI0MjhkZTA1NzlkLS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-3dc41c7f3115a1977a0a32428de0579d
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '385'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6fe9b3975a464ed7bf2f5151fd3c4807
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLTFhMTItN2Ex
+        OC04MTRhLTZlZDI2YWZmMTVhNy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-1a12-7a18-814a-6ed26aff15a7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '804'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1c1410f8c80e49138420da786fe3aeca
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItMWEx
+        Mi03YTE4LTgxNGEtNmVkMjZhZmYxNWE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzM6NTQuNDUwNzc3WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozMzo1NC40NTA3ODlaIiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
+        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6IjZmZTliMzk3NWE0NjRlZDdiZjJm
+        NTE1MWZkM2M0ODA3IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTQuNDY0
+        ODYzWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjMzOjU0LjQ5Nzk4
+        NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTQuNjQ4ODcy
+        WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
+        ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
+        bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
+        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvMDE4ZmU4ZDIt
+        MWFjYi03ZTRkLTljODAtMDliYjZmYzk5OTQyLyJdLCJyZXNlcnZlZF9yZXNv
+        dXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8w
+        MThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:33:54 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018fe8d2-1625-7155-a51c-137f3c91b8c1/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzAxOGZlOGQyLTFhY2ItN2U0ZC05YzgwLTA5YmI2ZmM5OTk0
+        Mi8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8745bb1df1bc41218a7e202268585977
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLTFiNTMtN2Nk
+        Yy1iZDA4LTQ0Yzc2NGQ0ZTlkYy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-1b53-7cdc-bd08-44c764d4e9dc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '901'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - e1299738a20d4718be50bf27c44f756a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItMWI1
+        My03Y2RjLWJkMDgtNDRjNzY0ZDRlOWRjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzM6NTQuNzcyMzY3WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozMzo1NC43NzIzNzlaIiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnku
+        YWRkX2FuZF9yZW1vdmUiLCJsb2dnaW5nX2NpZCI6Ijg3NDViYjFkZjFiYzQx
+        MjE4YTdlMjAyMjY4NTg1OTc3IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92
+        My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6
+        NTQuNzg0NDAzWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjMzOjU0
+        LjgxMzYyMloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTQu
+        ODk3Mzc0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMv
+        IiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19n
+        cm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
+        b3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
+        LzAxOGZlOGQyLTE2MjUtNzE1NS1hNTFjLTEzN2YzYzkxYjhjMS92ZXJzaW9u
+        cy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOGZlOGQyLTE2MjUtNzE1
+        NS1hNTFjLTEzN2YzYzkxYjhjMS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2Rv
+        bWFpbnMvMDE4ZmUzYzktNzBhYS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJd
+        fQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:54 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary_duplicate.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary_duplicate.yml
@@ -6516,249 +6516,6 @@ http_interactions:
   recorded_at: Tue, 07 May 2024 20:31:41 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum1.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 07 May 2024 21:09:03 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - a5086cf999d448cebc45d878a4e1072c
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:03 GMT
-- request:
-    method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 07 May 2024 21:09:03 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '771'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 26d2e9f08e1648f6a1a402888b2b6272
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE4
-        ZjU0ZTMtNmQ4Zi03M2IzLTg4N2EtYmQ5ZTJjOTliY2EzLyIsInB1bHBfY3Jl
-        YXRlZCI6IjIwMjQtMDUtMDdUMjE6MDk6MDEuOTY4NTMwWiIsInB1bHBfbGFz
-        dF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowOTowMS45Njg1NDlaIiwiZmls
-        ZSI6ImFydGlmYWN0L2VmLzBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3
-        ZjE4YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwic2l6ZSI6NzQw
-        LCJtZDUiOm51bGwsInNoYTEiOiI2MDk4ODU3MTVmZDhkNmE3MDdmMThmYzU1
-        OWQ2MWI4YmRlZTcxODBlIiwic2hhMjI0IjoiZTI5MzFmMDM2NjU2YmE2ZDAx
-        N2I1MDZiOGZlYzU3Yjg3ZTU3ZWVjMjdhZWFkMGRmN2FkOGVkM2MiLCJzaGEy
-        NTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4YWQzODFh
-        Y2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwic2hhMzg0IjoiZDNjNTI4ZDIx
-        MTBkODA2Njc1OWJlZDBjZGRjMDk5MTM5MWQ0NzcyN2Q3YmIwMDM4NjRlYTkz
-        NjIxM2E4ZWM0NGEzZGY1MmRkMWIyN2M3ODVjN2U2N2IxMDMyMmU5OWZkIiwi
-        c2hhNTEyIjoiY2ZiODUyM2U4N2M3YmY5MWU4MjMwZjVjZTE2OGJlMWQ4NTI3
-        YWI3NjdmNTU3MTRlZTQ1ZGJjZDUwNWY3N2U4NDFhNTQxNzgyMjQ4N2ZkZTIy
-        NWU2MjJmZDRmOWNkZjMzMzg0NWQ5MDE0MDA3ODYzYTk5YTE5YTdmNDkwMmVl
-        MjgifV19
-  recorded_at: Tue, 07 May 2024 21:09:03 GMT
-- request:
-    method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum1.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 07 May 2024 21:09:03 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 821a7194b73042059e987e4a42fb9b1a
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:03 GMT
-- request:
-    method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTY1ZGY3YjY5MzI4YmEw
-        NTJiODAwZDk4NDZhN2JmOGM4DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bTEu
-        anNvbg0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTY1ZGY3YjY5
-        MzI4YmEwNTJiODAwZDk4NDZhN2JmOGM4DQpDb250ZW50LURpc3Bvc2l0aW9u
-        OiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0KDQovcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzAxOGY1NGUzLTZkOGYtNzNiMy04ODdhLWJkOWUyYzk5YmNh
-        My8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC02NWRmN2I2OTMy
-        OGJhMDUyYjgwMGQ5ODQ2YTdiZjhjOC0tDQo=
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-65df7b69328ba052b800d9846a7bf8c8
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '386'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 07 May 2024 21:09:03 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 6621feb14f0645c5a5ce8c97839f77c9
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUzLTc0NmEtNzkw
-        MC05YmUxLWQzNTMxZTgzMzcxMS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:09:03 GMT
-- request:
-    method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e3-746a-7900-9be1-d3531e833711/
     body:
       encoding: US-ASCII
@@ -6957,4 +6714,447 @@ http_interactions:
         bWFpbnMvMDE4ZjU0ZGYtN2ZkMi03NWZhLTliMzUtYzI3NTEzZmY5OGY0LyJd
         fQ==
   recorded_at: Tue, 07 May 2024 21:09:04 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum1.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 54470198f5f341bfba1e93f065aac508
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:55 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '771'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8f4fc6bcda9247748ff6aabcd0ac4861
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE4
+        ZmU4ZDItMTg3Ni03NmRlLWIxZmYtN2FiZmJjZmE3NjU4LyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTQuMDM5ODg3WiIsInB1bHBfbGFz
+        dF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozMzo1NC4wMzk5MDRaIiwiZmls
+        ZSI6ImFydGlmYWN0L2VmLzBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3
+        ZjE4YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwic2l6ZSI6NzQw
+        LCJtZDUiOm51bGwsInNoYTEiOiI2MDk4ODU3MTVmZDhkNmE3MDdmMThmYzU1
+        OWQ2MWI4YmRlZTcxODBlIiwic2hhMjI0IjoiZTI5MzFmMDM2NjU2YmE2ZDAx
+        N2I1MDZiOGZlYzU3Yjg3ZTU3ZWVjMjdhZWFkMGRmN2FkOGVkM2MiLCJzaGEy
+        NTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4YWQzODFh
+        Y2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwic2hhMzg0IjoiZDNjNTI4ZDIx
+        MTBkODA2Njc1OWJlZDBjZGRjMDk5MTM5MWQ0NzcyN2Q3YmIwMDM4NjRlYTkz
+        NjIxM2E4ZWM0NGEzZGY1MmRkMWIyN2M3ODVjN2U2N2IxMDMyMmU5OWZkIiwi
+        c2hhNTEyIjoiY2ZiODUyM2U4N2M3YmY5MWU4MjMwZjVjZTE2OGJlMWQ4NTI3
+        YWI3NjdmNTU3MTRlZTQ1ZGJjZDUwNWY3N2U4NDFhNTQxNzgyMjQ4N2ZkZTIy
+        NWU2MjJmZDRmOWNkZjMzMzg0NWQ5MDE0MDA3ODYzYTk5YTE5YTdmNDkwMmVl
+        MjgifV19
+  recorded_at: Wed, 05 Jun 2024 14:33:55 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum1.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7578c7cfd4d9475ab85c0946f192a206
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:55 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTRmMDI2YzE2MDZiOGYw
+        ODExMzk1NDA1NmM1M2RhNjMyDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bTEu
+        anNvbg0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTRmMDI2YzE2
+        MDZiOGYwODExMzk1NDA1NmM1M2RhNjMyDQpDb250ZW50LURpc3Bvc2l0aW9u
+        OiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0KDQovcHVscC9hcGkvdjMv
+        YXJ0aWZhY3RzLzAxOGZlOGQyLTE4NzYtNzZkZS1iMWZmLTdhYmZiY2ZhNzY1
+        OC8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC00ZjAyNmMxNjA2
+        YjhmMDgxMTM5NTQwNTZjNTNkYTYzMi0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-4f026c1606b8f08113954056c53da632
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '386'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 527dd6fbec8c4de19efdedf14a6d3ead
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLTFlNjAtNzY0
+        OS05MTRlLTM3MzExZWVjMTI3MS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:55 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-1e60-7649-914e-37311eec1271/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '804'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0e843e9dba3f4d65b0987ace897e0a5d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItMWU2
+        MC03NjQ5LTkxNGUtMzczMTFlZWMxMjcxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzM6NTUuNTUyNzQ0WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozMzo1NS41NTI3NTRaIiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
+        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6IjUyN2RkNmZiZWM4YzRkZTE5ZWZk
+        ZWRmMTRhNmQzZWFkIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTUuNTYz
+        Nzc2WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjMzOjU1LjU5NjUw
+        M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTUuNzMxMzI5
+        WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
+        ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
+        bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
+        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvMDE4ZmU4ZDIt
+        MWYwNS03MjliLTgwMTMtZTRkNTU4OTBiMGRhLyJdLCJyZXNlcnZlZF9yZXNv
+        dXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8w
+        MThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:33:55 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018fe8d2-1625-7155-a51c-137f3c91b8c1/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzAxOGZlOGQyLTFmMDUtNzI5Yi04MDEzLWU0ZDU1ODkwYjBk
+        YS8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 986c8bf7f509407b965c67b28699442d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLTFmOGYtN2Y3
+        Ni1hNGQzLWU5NDE0MzBiZmY3OC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:55 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-1f8f-7f76-a4d3-e941430bff78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '901'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 01dfd676e8b948589b9e66ecc5de1218
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItMWY4
+        Zi03Zjc2LWE0ZDMtZTk0MTQzMGJmZjc4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzM6NTUuODU2MDY2WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozMzo1NS44NTYwNzdaIiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnku
+        YWRkX2FuZF9yZW1vdmUiLCJsb2dnaW5nX2NpZCI6Ijk4NmM4YmY3ZjUwOTQw
+        N2I5NjVjNjdiMjg2OTk0NDJkIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92
+        My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6
+        NTUuODY3ODQxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjMzOjU1
+        LjkwODY5NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTUu
+        OTg2ODA0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3Zjkv
+        IiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19n
+        cm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
+        b3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
+        LzAxOGZlOGQyLTE2MjUtNzE1NS1hNTFjLTEzN2YzYzkxYjhjMS92ZXJzaW9u
+        cy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOGZlOGQyLTE2MjUtNzE1
+        NS1hNTFjLTEzN2YzYzkxYjhjMS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2Rv
+        bWFpbnMvMDE4ZmUzYzktNzBhYS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJd
+        fQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:56 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:07 GMT
+      - Wed, 05 Jun 2024 14:33:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bc27b59013f9424daf0d6037564f688c
+      - 3cea4b0856ac45cb9ecf48a95fd55a1a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:07 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:58 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:07 GMT
+      - Wed, 05 Jun 2024 14:33:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5743310dc3c6439ba6c4635049a48402
+      - b652f83229124e1888bfbdc1a216cdbb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:07 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:58 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
@@ -118,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:07 GMT
+      - Wed, 05 Jun 2024 14:33:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 81d5de45fc6041099f430ea6f85a99bf
+      - cc6315d90b804293a544621383df5f1b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:07 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:58 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
@@ -172,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:07 GMT
+      - Wed, 05 Jun 2024 14:33:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7a3d3ef19dda4239b65c985a80747bcd
+      - 93694a7a444e46a78117f21ec66af8ad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:07 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:58 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
@@ -235,7 +235,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -248,13 +248,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:07 GMT
+      - Wed, 05 Jun 2024 14:33:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/018f54e3-8292-71c8-bc1c-a3eef0e1be38/"
+      - "/pulp/api/v3/remotes/file/file/018fe8d2-29ff-7cee-bc11-b39090ef8f4f/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -270,7 +270,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fc872268aefa462ab2d37aa241241ecb
+      - e033dd378a4c4fc28e68588740d9974c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -279,9 +279,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE4ZjU0ZTMtODI5Mi03MWM4LWJjMWMtYTNlZWYwZTFiZTM4LyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDk6MDcuMzQ2NTQwWiIsInB1bHBf
-        bGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowOTowNy4zNDY1NTZaIiwi
+        MDE4ZmU4ZDItMjlmZi03Y2VlLWJjMTEtYjM5MDkwZWY4ZjRmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTguNTI3MzA3WiIsInB1bHBf
+        bGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozMzo1OC41MjczMjBaIiwi
         bmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMi
         LCJ1cmwiOiJodHRwOi8vdGVzdC90ZXN0Ly9QVUxQX01BTklGRVNUIiwiY2Ff
         Y2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9u
@@ -295,7 +295,7 @@ http_interactions:
         bWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwcm94eV9wYXNzd29yZCIs
         ImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InVzZXJuYW1lIiwiaXNfc2V0Ijpm
         YWxzZX0seyJuYW1lIjoicGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfV19
-  recorded_at: Tue, 07 May 2024 21:09:07 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:58 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/
@@ -308,7 +308,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -321,13 +321,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:07 GMT
+      - Wed, 05 Jun 2024 14:33:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/018f54e3-832c-77ad-9682-b8bb912723f3/"
+      - "/pulp/api/v3/repositories/file/file/018fe8d2-2a89-79e1-9b58-32283e220208/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -343,7 +343,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 077db8c6ab70426a9041b9a0c3e16deb
+      - 2a4d1cea34054c6689532c42ac8a7946
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -352,22 +352,22 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMThmNTRlMy04MzJjLTc3YWQtOTY4Mi1iOGJiOTEyNzIzZjMvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyNC0wNS0wN1QyMTowOTowNy41MDEyNjVaIiwi
-        cHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA5OjA3LjUwOTEx
-        MloiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvMDE4ZjU0ZTMtODMyYy03N2FkLTk2ODItYjhiYjkxMjcy
-        M2YzL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
+        ZmlsZS8wMThmZThkMi0yYTg5LTc5ZTEtOWI1OC0zMjI4M2UyMjAyMDgvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wNVQxNDozMzo1OC42NjU2ODVaIiwi
+        cHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTA1VDE0OjMzOjU4LjY3MTU4
+        N1oiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvMDE4ZmU4ZDItMmE4OS03OWUxLTliNTgtMzIyODNlMjIw
+        MjA4L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
         b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzAxOGY1NGUzLTgzMmMtNzdhZC05NjgyLWI4YmI5MTI3MjNmMy92ZXJzaW9u
+        LzAxOGZlOGQyLTJhODktNzllMS05YjU4LTMyMjgzZTIyMDIwOC92ZXJzaW9u
         cy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15
         X0ZpbGVzIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNp
         b25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwi
         bWFuaWZlc3QiOiJQVUxQX01BTklGRVNUIn0=
-  recorded_at: Tue, 07 May 2024 21:09:07 GMT
+  recorded_at: Wed, 05 Jun 2024 14:33:58 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018f54e3-8292-71c8-bc1c-a3eef0e1be38/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018fe8d2-29ff-7cee-bc11-b39090ef8f4f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -375,7 +375,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -388,7 +388,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:08 GMT
+      - Wed, 05 Jun 2024 14:33:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -408,7 +408,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 16f9695f171245948f6072a4d5be7a37
+      - 787815ff5dfa4538adab5104b69fcdd4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -416,12 +416,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUzLTg2ZTUtN2Jh
-        ZS05YWI2LTAyZGQ1Mzg1ZDBhNS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:09:08 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLTJkYzQtN2Y1
+        Yi1hNWUzLTA5MWMwYTNlMzU2NS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:59 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e3-86e5-7bae-9ab6-02dd5385d0a5/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-2dc4-7f5b-a5e3-091c0a3e3565/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -429,7 +429,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -442,7 +442,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:08 GMT
+      - Wed, 05 Jun 2024 14:33:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -462,7 +462,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 052047fde00d4e6dab9bee3ef042ff24
+      - a69c3d8e9d184e998ca017874794540b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -470,28 +470,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTMtODZl
-        NS03YmFlLTlhYjYtMDJkZDUzODVkMGE1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDk6MDguNDUzNTc2WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowOTowOC40NTM1OTJaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItMmRj
+        NC03ZjViLWE1ZTMtMDkxYzBhM2UzNTY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzM6NTkuNDkzMTMwWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozMzo1OS40OTMxNDNaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjE2Zjk2OTVmMTcxMjQ1OTQ4ZjYw
-        NzJhNGQ1YmU3YTM3IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDk6MDguNDY5
-        MTExWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA5OjA4LjUyNTI4
-        N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDk6MDguNTgxODM3
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6Ijc4NzgxNWZmNWRmYTQ1MzhhZGFi
+        NTEwNGI2OWZjZGQ0IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTkuNTA1
+        MzMwWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjMzOjU5LjU0MTQ5
+        M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTkuNTg1NDQx
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGMxLTcxNzUtYTM3Yi1iNjMzMjI1NWEyMGEvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE4ZjU0ZTMtODI5Mi03MWM4LWJjMWMt
-        YTNlZWYwZTFiZTM4LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8w
-        MThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:09:08 GMT
+        djMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE4ZmU4ZDItMjlmZi03Y2VlLWJjMTEt
+        YjM5MDkwZWY4ZjRmLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8w
+        MThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:33:59 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018f54e3-832c-77ad-9682-b8bb912723f3/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018fe8d2-2a89-79e1-9b58-32283e220208/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -499,7 +499,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -512,7 +512,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:08 GMT
+      - Wed, 05 Jun 2024 14:33:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -532,7 +532,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4b18e0b157624e08ad0e44e1b476d291
+      - 6ab0f2428d8941d587afa732220619e5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -540,12 +540,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUzLTg4MDUtN2Vk
-        OC04N2MwLTU1ZTU3ZTczZjc0Ni8ifQ==
-  recorded_at: Tue, 07 May 2024 21:09:08 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLTJlYzMtNzFh
+        Mi05YmY1LWRlNjhjMWFkNDIzOS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:59 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e3-8805-7ed8-87c0-55e57e73f746/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-2ec3-71a2-9bf5-de68c1ad4239/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -553,7 +553,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -566,7 +566,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:08 GMT
+      - Wed, 05 Jun 2024 14:33:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -586,7 +586,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a85a74856a514216934d305822c9c1e4
+      - d53c644d007f4171912f65fe00ab8cb7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -594,25 +594,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTMtODgw
-        NS03ZWQ4LTg3YzAtNTVlNTdlNzNmNzQ2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDk6MDguNzQxNzMyWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowOTowOC43NDE3NDhaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItMmVj
+        My03MWEyLTliZjUtZGU2OGMxYWQ0MjM5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzM6NTkuNzQ4MTk0WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozMzo1OS43NDgyMDlaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjRiMThlMGIxNTc2MjRlMDhhZDBl
-        NDRlMWI0NzZkMjkxIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDk6MDguNzU2
-        OTAwWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA5OjA4LjgwMzcw
-        MloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDk6MDguODg5Nzgy
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjZhYjBmMjQyOGQ4OTQxZDU4N2Fm
+        YTczMjIyMDYxOWU1IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTkuNzU4
+        Njg0WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjMzOjU5Ljc4ODc0
+        OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTkuODYyNDE2
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGMxLTcxNzUtYTM3Yi1iNjMzMjI1NWEyMGEvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmNTRlMy04MzJjLTc3YWQt
-        OTY4Mi1iOGJiOTEyNzIzZjMvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21h
-        aW5zLzAxOGY1NGRmLTdmZDItNzVmYS05YjM1LWMyNzUxM2ZmOThmNC8iXX0=
-  recorded_at: Tue, 07 May 2024 21:09:08 GMT
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmZThkMi0yYTg5LTc5ZTEt
+        OWI1OC0zMjI4M2UyMjAyMDgvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21h
+        aW5zLzAxOGZlM2M5LTcwYWEtNzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:33:59 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
@@ -623,7 +623,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.21.3/ruby
+      - OpenAPI-Generator/0.21.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -636,7 +636,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:09 GMT
+      - Wed, 05 Jun 2024 14:34:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -656,7 +656,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e2d898c2eb7f46df8d5acf848342e971
+      - d4a67d07c5054552893b448ded101248
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -666,7 +666,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:09 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:00 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -690,7 +690,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:09 GMT
+      - Wed, 05 Jun 2024 14:34:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -710,7 +710,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d2fee632b05d4e31831b57d1ffb7825d
+      - 0a8f9738c3394eab9aca0713718514f6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -720,7 +720,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:09 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:00 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -744,7 +744,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:09 GMT
+      - Wed, 05 Jun 2024 14:34:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -764,7 +764,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 97d759e16f9d4ae0b52df9c9eb755f87
+      - 158f24abf5e940129cb95aa62327324b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -774,7 +774,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:09 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:00 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -785,7 +785,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -798,7 +798,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:09 GMT
+      - Wed, 05 Jun 2024 14:34:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -818,7 +818,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8492f94c679c48ec83be403b46d23d5f
+      - 359199a4f2294817b62186d4f4624cdf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -828,7 +828,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:09 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:00 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -852,7 +852,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:09 GMT
+      - Wed, 05 Jun 2024 14:34:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -872,7 +872,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 422a884d813f4d018850d5eabf60e845
+      - 00d528e18d1b4237a379da62805bf4a7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -882,7 +882,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:09 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:00 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -906,7 +906,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:09 GMT
+      - Wed, 05 Jun 2024 14:34:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -926,7 +926,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0d880e07a0ba4fc290da7ca01313f351
+      - 12da73f5447149fab54fcc72d050bd41
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -936,7 +936,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:09 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:00 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -947,7 +947,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -960,7 +960,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:09 GMT
+      - Wed, 05 Jun 2024 14:34:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -980,7 +980,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d2519a15761f4ab3927a9a45b514a811
+      - 34ec3f6625ac4d73bf2117f611e4d8e9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -990,7 +990,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:09:09 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:00 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
@@ -1003,7 +1003,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1016,7 +1016,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:09 GMT
+      - Wed, 05 Jun 2024 14:34:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1036,7 +1036,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 64e2df7bd9aa46ebbdac734c7189e706
+      - f4517ba12ef64f5b910f4b606c5f7b34
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1044,12 +1044,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUzLThiMjgtNzQz
-        OS05ZGU3LTExZDcyZGViY2Q3Ny8ifQ==
-  recorded_at: Tue, 07 May 2024 21:09:09 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLTMxN2EtNzVj
+        My05ZGY1LTgwMDBkMTI1NTQ0Mi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:00 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e3-8b28-7439-9de7-11d72debcd77/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-317a-75c3-9df5-8000d1255442/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1057,7 +1057,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1070,7 +1070,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:09:09 GMT
+      - Wed, 05 Jun 2024 14:34:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1090,7 +1090,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 29d83272f4f5492299dc0fd30fe793dc
+      - 51feae2854a1438aa8110f8c5527d4b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1098,18 +1098,18 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTMtOGIy
-        OC03NDM5LTlkZTctMTFkNzJkZWJjZDc3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDk6MDkuNTQ1Mjc4WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowOTowOS41NDUyOTJaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItMzE3
+        YS03NWMzLTlkZjUtODAwMGQxMjU1NDQyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzQ6MDAuNDQyNzU1WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNDowMC40NDI3NjlaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLm9ycGhhbi5vcnBo
-        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiNjRlMmRmN2JkOWFhNDZlYmJk
-        YWM3MzRjNzE4OWU3MDYiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
-        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMTowOTowOS41
-        NTgzODVaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDk6MDkuNjI2
-        ODg3WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMTowOTowOS44NjMx
-        NDdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzAxOGY1NGUwLWE0YzEtNzE3NS1hMzdiLWI2MzMyMjU1YTIwYS8iLCJw
+        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiZjQ1MTdiYTEyZWY2NGY1Yjkx
+        MGY0YjYwNmM1ZjdiMzQiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
+        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozNDowMC40
+        NTYzNTZaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6MDAuNDky
+        MDE3WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozNDowMC42NTY3
+        MjZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzAxOGZlM2NiLTBkNDMtNzczMS05ODUyLTg3MjlkMDA4MTk2My8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xlYW4g
         dXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIs
@@ -1119,7 +1119,63 @@ http_interactions:
         ZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
         IjpbIi9hcGkvdjMvb3JwaGFucy9jbGVhbnVwLyIsInNoYXJlZDovcHVscC9h
-        cGkvdjMvZG9tYWlucy8wMThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNm
-        Zjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:09:09 GMT
+        cGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2Fk
+        MzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:34:00 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/purge/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJmaW5pc2hlZF9iZWZvcmUiOiIzMDAwLTAxLTAxVDAwOjAwOjAwLjAwMCsw
+        MDowMCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:34:00 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - b7707130bbb3438e8d74dca10bf49f16
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLTMyY2EtNzg3
+        OC04ZTk4LWVhZjQ1MWU4MWE4My8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:00 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload_binary.yml
@@ -7392,76 +7392,6 @@ http_interactions:
         fQ==
   recorded_at: Tue, 07 May 2024 20:17:03 GMT
 - request:
-    method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 07 May 2024 20:31:44 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '795'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 44d1e92e26c545a5a8e38904ade5a13e
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
-        ZmlsZXMvMDE4ZjU0YzEtMzcxZC03OTJmLWI2NjUtMjMxMDE5N2UxOGQ5LyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjA6MzE6MzkuODA3NzAwWiIs
-        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMDozMTozOS44MDc3
-        MjdaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzAxOGY1
-        NGMxLTM0YmYtNzJhYy05ZjYwLTNiNDUyYmNlNDA4YS8iLCJyZWxhdGl2ZV9w
-        YXRoIjoidGVzdF9lcnJhdHVtLmpzb24iLCJtZDUiOm51bGwsInNoYTEiOiI2
-        MDk4ODU3MTVmZDhkNmE3MDdmMThmYzU1OWQ2MWI4YmRlZTcxODBlIiwic2hh
-        MjI0IjoiZTI5MzFmMDM2NjU2YmE2ZDAxN2I1MDZiOGZlYzU3Yjg3ZTU3ZWVj
-        MjdhZWFkMGRmN2FkOGVkM2MiLCJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRm
-        OTQzODUwZGY5NDQyMGU3ZjE4YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3
-        NzkxIiwic2hhMzg0IjoiZDNjNTI4ZDIxMTBkODA2Njc1OWJlZDBjZGRjMDk5
-        MTM5MWQ0NzcyN2Q3YmIwMDM4NjRlYTkzNjIxM2E4ZWM0NGEzZGY1MmRkMWIy
-        N2M3ODVjN2U2N2IxMDMyMmU5OWZkIiwic2hhNTEyIjoiY2ZiODUyM2U4N2M3
-        YmY5MWU4MjMwZjVjZTE2OGJlMWQ4NTI3YWI3NjdmNTU3MTRlZTQ1ZGJjZDUw
-        NWY3N2U4NDFhNTQxNzgyMjQ4N2ZkZTIyNWU2MjJmZDRmOWNkZjMzMzg0NWQ5
-        MDE0MDA3ODYzYTk5YTE5YTdmNDkwMmVlMjgifV19
-  recorded_at: Tue, 07 May 2024 20:31:44 GMT
-- request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018f54c1-4a59-776e-a722-ccf1f3a6ae30/modify/
     body:
@@ -7791,4 +7721,204 @@ http_interactions:
         bWFpbnMvMDE4ZjU0ZGYtN2ZkMi03NWZhLTliMzUtYzI3NTEzZmY5OGY0LyJd
         fQ==
   recorded_at: Tue, 07 May 2024 21:09:08 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:58 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '795'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - ab56bc70de194c2688ab97fca650d3ea
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
+        ZmlsZXMvMDE4ZmU4ZDItMWFjYi03ZTRkLTljODAtMDliYjZmYzk5OTQyLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTQuNjM3MTgxWiIs
+        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozMzo1NC42Mzcx
+        OTZaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzAxOGZl
+        OGQyLTE4NzYtNzZkZS1iMWZmLTdhYmZiY2ZhNzY1OC8iLCJyZWxhdGl2ZV9w
+        YXRoIjoidGVzdF9lcnJhdHVtLmpzb24iLCJtZDUiOm51bGwsInNoYTEiOiI2
+        MDk4ODU3MTVmZDhkNmE3MDdmMThmYzU1OWQ2MWI4YmRlZTcxODBlIiwic2hh
+        MjI0IjoiZTI5MzFmMDM2NjU2YmE2ZDAxN2I1MDZiOGZlYzU3Yjg3ZTU3ZWVj
+        MjdhZWFkMGRmN2FkOGVkM2MiLCJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRm
+        OTQzODUwZGY5NDQyMGU3ZjE4YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3
+        NzkxIiwic2hhMzg0IjoiZDNjNTI4ZDIxMTBkODA2Njc1OWJlZDBjZGRjMDk5
+        MTM5MWQ0NzcyN2Q3YmIwMDM4NjRlYTkzNjIxM2E4ZWM0NGEzZGY1MmRkMWIy
+        N2M3ODVjN2U2N2IxMDMyMmU5OWZkIiwic2hhNTEyIjoiY2ZiODUyM2U4N2M3
+        YmY5MWU4MjMwZjVjZTE2OGJlMWQ4NTI3YWI3NjdmNTU3MTRlZTQ1ZGJjZDUw
+        NWY3N2U4NDFhNTQxNzgyMjQ4N2ZkZTIyNWU2MjJmZDRmOWNkZjMzMzg0NWQ5
+        MDE0MDA3ODYzYTk5YTE5YTdmNDkwMmVlMjgifV19
+  recorded_at: Wed, 05 Jun 2024 14:33:58 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018fe8d2-2a89-79e1-9b58-32283e220208/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzAxOGZlOGQyLTFhY2ItN2U0ZC05YzgwLTA5YmI2ZmM5OTk0
+        Mi8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:58 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - fe0dc182862344d9b13df099f9b40a07
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLTJiYzItN2My
+        YS05YzM4LTE3NDFkNTJjOWMyOS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:58 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-2bc2-7c2a-9c38-1741d52c9c29/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:33:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '901'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - e7e39e5e2a5b4120a840ae06cae6a669
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItMmJj
+        Mi03YzJhLTljMzgtMTc0MWQ1MmM5YzI5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzM6NTguOTc4ODA3WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozMzo1OC45Nzg4MThaIiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnku
+        YWRkX2FuZF9yZW1vdmUiLCJsb2dnaW5nX2NpZCI6ImZlMGRjMTgyODYyMzQ0
+        ZDliMTNkZjA5OWY5YjQwYTA3IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92
+        My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6
+        NTguOTk2NTYxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjMzOjU5
+        LjAzMDI2MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzM6NTku
+        MTAzNzg2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3Zjkv
+        IiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19n
+        cm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
+        b3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
+        LzAxOGZlOGQyLTJhODktNzllMS05YjU4LTMyMjgzZTIyMDIwOC92ZXJzaW9u
+        cy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOGZlOGQyLTJhODktNzll
+        MS05YjU4LTMyMjgzZTIyMDIwOC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2Rv
+        bWFpbnMvMDE4ZmUzYzktNzBhYS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJd
+        fQ==
+  recorded_at: Wed, 05 Jun 2024 14:33:59 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/actions/pulp3/remove_orphans/orphans_are_removed.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/remove_orphans/orphans_are_removed.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:15 GMT
+      - Mon, 03 Jun 2024 22:14:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 35b65a24d1944c8c8420f151f3d25dfd
+      - 34f04366b55948959f5ddef11ddcd3dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:15 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:22 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:15 GMT
+      - Mon, 03 Jun 2024 22:14:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fd16bf4442684a7391b86c6325a177a8
+      - d36c682b3d2347888564fae26811c05d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:15 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:22 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
@@ -118,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:15 GMT
+      - Mon, 03 Jun 2024 22:14:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 83845796182949fb8fae43b33423011e
+      - 24729bdfaf124223ba611baef74cb252
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:15 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:22 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
@@ -172,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:15 GMT
+      - Mon, 03 Jun 2024 22:14:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 12447249e6e745b79c3b243c206672c8
+      - 1ce67f1d6c2b4537bb4f5d6ef38c38ad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:15 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:22 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
@@ -226,7 +226,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -239,7 +239,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:15 GMT
+      - Mon, 03 Jun 2024 22:14:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -259,7 +259,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d69f3abd0651471f8f982a3c8106f6d8
+      - 63cc5cd121c348709a4f10a8b000fb5a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -269,7 +269,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:15 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:22 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
@@ -280,7 +280,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -293,7 +293,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:15 GMT
+      - Mon, 03 Jun 2024 22:14:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -313,7 +313,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4babce3b40f5481e9b6ab932daca38f2
+      - 182fdd3acd2e44e8a07879704085c34f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -323,7 +323,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:15 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:22 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
@@ -334,7 +334,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -347,7 +347,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:15 GMT
+      - Mon, 03 Jun 2024 22:14:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -367,7 +367,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ac957dd031f541b8b0837b841bf7c822
+      - 43752a8813e047c295b3ce076cec73a4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -377,7 +377,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:15 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:22 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
@@ -388,7 +388,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -401,7 +401,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:15 GMT
+      - Mon, 03 Jun 2024 22:14:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -421,7 +421,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5642ca5dbcef44b8b1629df6cabfbd9d
+      - d05ab072d62a469fb834ad628abea2eb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -431,7 +431,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:15 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:22 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
@@ -451,7 +451,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -464,13 +464,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:16 GMT
+      - Mon, 03 Jun 2024 22:14:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/018f54bd-328a-7ec1-b668-d46512c9ca95/"
+      - "/pulp/api/v3/remotes/file/file/018fe02a-f5ee-7c60-a0e4-143449a7a2b8/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -486,7 +486,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b8280dcf02b649f4a8feebf2a126e6d7
+      - bb02355fb06d44e4b858a79bb547fa16
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -495,9 +495,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE4ZjU0YmQtMzI4YS03ZWMxLWI2NjgtZDQ2NTEyYzljYTk1LyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjQtMDUtMDdUMjA6Mjc6MTYuNDkxNjQ1WiIsInB1bHBf
-        bGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMDoyNzoxNi40OTE2NjNaIiwi
+        MDE4ZmUwMmEtZjVlZS03YzYwLWEwZTQtMTQzNDQ5YTdhMmI4LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjIuOTU4ODQxWiIsInB1bHBf
+        bGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wM1QyMjoxNDoyMi45NTg4NTRaIiwi
         bmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmls
         ZV8xIiwidXJsIjoiaHR0cHM6Ly9maXh0dXJlcy5wdWxwcHJvamVjdC5vcmcv
         ZmlsZTIvL1BVTFBfTUFOSUZFU1QiLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRf
@@ -512,7 +512,7 @@ http_interactions:
         LHsibmFtZSI6InByb3h5X3Bhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX0seyJu
         YW1lIjoidXNlcm5hbWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwYXNz
         d29yZCIsImlzX3NldCI6ZmFsc2V9XX0=
-  recorded_at: Tue, 07 May 2024 20:27:16 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:22 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/
@@ -525,7 +525,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -538,13 +538,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:16 GMT
+      - Mon, 03 Jun 2024 22:14:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/018f54bd-340a-708d-8104-060b733271b1/"
+      - "/pulp/api/v3/repositories/file/file/018fe02a-f6a0-7b24-941f-31ac26dcde55/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -560,7 +560,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5243407302e044979bd15c410f0bc2c3
+      - f22f2ae625004d9aa5421c5e0f22c7b8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -569,19 +569,19 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMThmNTRiZC0zNDBhLTcwOGQtODEwNC0wNjBiNzMzMjcxYjEvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyNC0wNS0wN1QyMDoyNzoxNi44NzU3ODZaIiwi
-        cHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTA3VDIwOjI3OjE2Ljg5MDA2
-        NloiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvMDE4ZjU0YmQtMzQwYS03MDhkLTgxMDQtMDYwYjczMzI3
-        MWIxL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
+        ZmlsZS8wMThmZTAyYS1mNmEwLTdiMjQtOTQxZi0zMWFjMjZkY2RlNTUvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wM1QyMjoxNDoyMy4xMzcxNDZaIiwi
+        cHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTAzVDIyOjE0OjIzLjE0Mjk4
+        OFoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvMDE4ZmUwMmEtZjZhMC03YjI0LTk0MWYtMzFhYzI2ZGNk
+        ZTU1L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
         b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzAxOGY1NGJkLTM0MGEtNzA4ZC04MTA0LTA2MGI3MzMyNzFiMS92ZXJzaW9u
+        LzAxOGZlMDJhLWY2YTAtN2IyNC05NDFmLTMxYWMyNmRjZGU1NS92ZXJzaW9u
         cy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1
         bHAzX0ZpbGVfMSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192
         ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFs
         c2UsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
-  recorded_at: Tue, 07 May 2024 20:27:16 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:23 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
@@ -601,7 +601,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -614,13 +614,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:17 GMT
+      - Mon, 03 Jun 2024 22:14:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/018f54bd-34f4-7caf-81cc-b76331932568/"
+      - "/pulp/api/v3/remotes/file/file/018fe02a-f761-74c2-bfaa-6392d77c0dab/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -636,7 +636,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9e32542d57874aff849419ef9db357fc
+      - 303418fe51054ae2aa3a9cde44b42147
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -645,9 +645,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE4ZjU0YmQtMzRmNC03Y2FmLTgxY2MtYjc2MzMxOTMyNTY4LyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjQtMDUtMDdUMjA6Mjc6MTcuMTA5MzUyWiIsInB1bHBf
-        bGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMDoyNzoxNy4xMDkzNjlaIiwi
+        MDE4ZmUwMmEtZjc2MS03NGMyLWJmYWEtNjM5MmQ3N2MwZGFiLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjMuMzI5Njg3WiIsInB1bHBf
+        bGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wM1QyMjoxNDoyMy4zMjk3MDZaIiwi
         bmFtZSI6InRlc3RfcmVtb3RlX25hbWUiLCJ1cmwiOiJodHRwczovL2ZpeHR1
         cmVzLnB1bHBwcm9qZWN0Lm9yZy9maWxlMi8vUFVMUF9NQU5JRkVTVCIsImNh
         X2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlv
@@ -661,10 +661,10 @@ http_interactions:
         YW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicHJveHlfcGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJ1c2VybmFtZSIsImlzX3NldCI6
         ZmFsc2V9LHsibmFtZSI6InBhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX1dfQ==
-  recorded_at: Tue, 07 May 2024 20:27:17 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:23 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018f54bd-34f4-7caf-81cc-b76331932568/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018fe02a-f761-74c2-bfaa-6392d77c0dab/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -672,7 +672,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -685,7 +685,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:17 GMT
+      - Mon, 03 Jun 2024 22:14:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -705,7 +705,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8ac1e74812024882b08e2a4a59c72a05
+      - 7ca028e9d62640a7b3e2504690a9bcd1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -713,12 +713,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTM1NDMtNzdk
-        Mi04Mjg3LTVhZDU4YWI0NjVlOS8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:17 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJhLWY3OTgtNzcy
+        My05ODJlLWQzYmIzNTM0NDcyMC8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:23 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018f54bd-340a-708d-8104-060b733271b1/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018fe02a-f6a0-7b24-941f-31ac26dcde55/
     body:
       encoding: UTF-8
       base64_string: |
@@ -728,7 +728,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -741,7 +741,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:17 GMT
+      - Mon, 03 Jun 2024 22:14:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -761,7 +761,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0f26b11a4e52404eae9c3520c9acf946
+      - 5c4f9bedee0c4cfc8268bd291478bec8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -769,12 +769,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTM2MjgtN2Zh
-        OS05Mzc3LThlM2JkZDYwNjJkZi8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:17 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJhLWY4M2YtNzkw
+        ZC1hOGI2LTU2NmViNWE5NWMxMy8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:23 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018f54bd-328a-7ec1-b668-d46512c9ca95/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018fe02a-f5ee-7c60-a0e4-143449a7a2b8/
     body:
       encoding: UTF-8
       base64_string: |
@@ -791,7 +791,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -804,7 +804,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:17 GMT
+      - Mon, 03 Jun 2024 22:14:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -824,7 +824,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 74860e9ac88a4f4fb5557e39fcb805ae
+      - 3244702940bf411599a7d1afce073d1f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -832,12 +832,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTM2YjktNzEw
-        Ny1hOTM1LTJiOTYwODlmOWIyNS8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:17 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJhLWY4YTctN2Vi
+        Ny1iM2M1LTQwZmIzZGM2NDM1ZC8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:23 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54bd-36b9-7107-a935-2b96089f9b25/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe02a-f8a7-7eb7-b3c5-40fb3dc6435d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -845,7 +845,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -858,7 +858,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:17 GMT
+      - Mon, 03 Jun 2024 22:14:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -878,7 +878,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 972cf4d486ea433bb69ad08762fa2257
+      - 343a7c26f5344eb3a863d4e203e68483
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -886,24 +886,24 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0YmQtMzZi
-        OS03MTA3LWE5MzUtMmI5NjA4OWY5YjI1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6Mjc6MTcuNTYxODM1WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDoyNzoxNy41NjE4NTVaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmUwMmEtZjhh
+        Ny03ZWI3LWIzYzUtNDBmYjNkYzY0MzVkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDNUMjI6MTQ6MjMuNjU1NzcyWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wM1QyMjoxNDoyMy42NTU3ODRaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6Ijc0ODYwZTlhYzg4YTRmNGZiNTU1
-        N2UzOWZjYjgwNWFlIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MTcuNTc3
-        OTUzWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjI3OjE3LjU4MDYz
-        MloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MTcuNTk2NzU0
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjMyNDQ3MDI5NDBiZjQxMTU5OWE3
+        ZDFhZmNlMDczZDFmIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjMuNjY2
+        MzMxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTAzVDIyOjE0OjIzLjY2OTg2
+        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjMuNjc4NzMy
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMv
-        ZmlsZS9maWxlLzAxOGY1NGJkLTMyOGEtN2VjMS1iNjY4LWQ0NjUxMmM5Y2E5
-        NS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZjU0YjktM2Nj
-        NS03Zjc1LTlmYTktZWZkZDIwYTFmYzgzLyJdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:17 GMT
+        ZmlsZS9maWxlLzAxOGZlMDJhLWY1ZWUtN2M2MC1hMGU0LTE0MzQ0OWE3YTJi
+        OC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZmRmZmItMzI2
+        My03ZWRiLWEyYWEtOWNlOTIwOWY4ZjAzLyJdfQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:23 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
@@ -914,7 +914,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -927,7 +927,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:17 GMT
+      - Mon, 03 Jun 2024 22:14:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -947,7 +947,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 01de9668906442a0b25ebd969bb27f1c
+      - 7b8427116cef4158a1631bda57aa1dee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -957,7 +957,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:17 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:23 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/
@@ -972,7 +972,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -985,7 +985,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:18 GMT
+      - Mon, 03 Jun 2024 22:14:23 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1005,7 +1005,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e862e3893593471db3aaa04084e87a19
+      - 881feeb83721452fb1ec8adec9bc6c7a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1013,12 +1013,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTM4YTUtNzhh
-        Yi05NjhkLTMyMjUxNGY2NTNhNS8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:18 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJhLWY5NzUtNzlm
+        Mi05ZTNiLTcwZDkwZDg2MDRlYS8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:23 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54bd-38a5-78ab-968d-322514f653a5/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe02a-f975-79f2-9e3b-70d90d8604ea/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1026,7 +1026,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1039,7 +1039,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:18 GMT
+      - Mon, 03 Jun 2024 22:14:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1059,7 +1059,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0f0d33be581d40629019bcc5fd162eaa
+      - ec6dd6b00a2942f6997b7879588ea4bd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1067,29 +1067,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0YmQtMzhh
-        NS03OGFiLTk2OGQtMzIyNTE0ZjY1M2E1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6Mjc6MTguMDU0NDg0WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDoyNzoxOC4wNTQ1MDBaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmUwMmEtZjk3
+        NS03OWYyLTllM2ItNzBkOTBkODYwNGVhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDNUMjI6MTQ6MjMuODYyMzk2WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wM1QyMjoxNDoyMy44NjI0MDlaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6ImU4NjJlMzg5MzU5MzQ3MWRiM2Fh
-        YTA0MDg0ZTg3YTE5IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MTguMDcw
-        MTE2WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjI3OjE4LjEzNTk3
-        N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MTguMjM0OTYy
+        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6Ijg4MWZlZWI4MzcyMTQ1MmZiMWVj
+        OGFkZWM5YmM2YzdhIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjMuODc1
+        NTkzWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTAzVDIyOjE0OjIzLjkxNjcx
+        OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjMuOTkxMDA3
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRiYS04MDE3LTdlMWMtOTUxMS04NmM0YTI0Nzc2ZmEvIiwicGFy
+        cy8wMThmZGZmYy00MWJmLTcxNzAtOGEwNS00YWQ3ODA1MGJlZjIvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2ZpbGUvZmlsZS8wMThm
-        NTRiZC0zOTNlLTc4ZGEtYjkxYy0xYzgwNzA3ZDQ2M2IvIl0sInJlc2VydmVk
+        ZTAyYS1mOWU1LTcxNzYtYTg3MC0wNzZmNjU4NjQ4OTEvIl0sInJlc2VydmVk
         X3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyIs
-        InNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNTRiOS0zY2M1LTdm
-        NzUtOWZhOS1lZmRkMjBhMWZjODMvIl19
-  recorded_at: Tue, 07 May 2024 20:27:18 GMT
+        InNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZGZmYi0zMjYzLTdl
+        ZGItYTJhYS05Y2U5MjA5ZjhmMDMvIl19
+  recorded_at: Mon, 03 Jun 2024 22:14:24 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018f54bd-393e-78da-b91c-1c80707d463b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018fe02a-f9e5-7176-a870-076f65864891/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1097,7 +1097,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1110,7 +1110,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:18 GMT
+      - Mon, 03 Jun 2024 22:14:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1130,7 +1130,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a40a5abdd4b246469c57deb614df49ec
+      - b405cff4938b4a82a6e26c2e4239c859
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1139,10 +1139,10 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
-        L2ZpbGUvMDE4ZjU0YmQtMzkzZS03OGRhLWI5MWMtMWM4MDcwN2Q0NjNiLyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjA6Mjc6MTguMjA4NTA2WiIs
-        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMDoyNzoxOC4yMDg1
-        MjRaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
+        L2ZpbGUvMDE4ZmUwMmEtZjllNS03MTc2LWE4NzAtMDc2ZjY1ODY0ODkxLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjMuOTc0Nzk3WiIs
+        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wM1QyMjoxNDoyMy45NzQ4
+        MTNaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
         eS9wdWxwM19GaWxlXzEiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9zOS1r
         YXRlbGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9wdWxwL2NvbnRl
         bnQvRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19GaWxlXzEv
@@ -1150,10 +1150,10 @@ http_interactions:
         YWJlbHMiOnt9LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5l
         dC1wdWxwM19GaWxlXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlv
         biI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 20:27:18 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:24 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018f54bd-328a-7ec1-b668-d46512c9ca95/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018fe02a-f5ee-7c60-a0e4-143449a7a2b8/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1170,7 +1170,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1183,7 +1183,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:18 GMT
+      - Mon, 03 Jun 2024 22:14:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1203,7 +1203,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7e311340e8e74721b0842118d5ebe47b
+      - e88c13caac534640aa4923189124f84a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1211,12 +1211,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTNiNTgtN2I2
-        Ni04ODA4LTA1MzVjMmYxY2Q4MS8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:18 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJhLWZiNzMtN2Rm
+        NS1iYTMxLTlkODY5YzU2YTNhOC8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:24 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54bd-3b58-7b66-8808-0535c2f1cd81/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe02a-fb73-7df5-ba31-9d869c56a3a8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1224,7 +1224,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1237,7 +1237,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:18 GMT
+      - Mon, 03 Jun 2024 22:14:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1257,7 +1257,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d642a1a5b6f64077b9a00a611f7c88ff
+      - 34ff50ab642b4b3b917e4b1ca0897d9f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1265,38 +1265,38 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0YmQtM2I1
-        OC03YjY2LTg4MDgtMDUzNWMyZjFjZDgxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6Mjc6MTguNzQ1MDQzWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDoyNzoxOC43NDUwNTlaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmUwMmEtZmI3
+        My03ZGY1LWJhMzEtOWQ4NjljNTZhM2E4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDNUMjI6MTQ6MjQuMzcxNjk5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wM1QyMjoxNDoyNC4zNzE3MTNaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjdlMzExMzQwZThlNzQ3MjFiMDg0
-        MjExOGQ1ZWJlNDdiIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MTguNzU5
-        MjcwWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjI3OjE4Ljc2Mjk0
-        N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MTguNzc1NTA3
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6ImU4OGMxM2NhYWM1MzQ2NDBhYTQ5
+        MjMxODkxMjRmODRhIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjQuMzgz
+        NDA3WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTAzVDIyOjE0OjI0LjM4NjE3
+        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjQuMzk5MjA4
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMv
-        ZmlsZS9maWxlLzAxOGY1NGJkLTMyOGEtN2VjMS1iNjY4LWQ0NjUxMmM5Y2E5
-        NS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZjU0YjktM2Nj
-        NS03Zjc1LTlmYTktZWZkZDIwYTFmYzgzLyJdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:18 GMT
+        ZmlsZS9maWxlLzAxOGZlMDJhLWY1ZWUtN2M2MC1hMGU0LTE0MzQ0OWE3YTJi
+        OC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZmRmZmItMzI2
+        My03ZWRiLWEyYWEtOWNlOTIwOWY4ZjAzLyJdfQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:24 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018f54bd-340a-708d-8104-060b733271b1/sync/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018fe02a-f6a0-7b24-941f-31ac26dcde55/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE4
-        ZjU0YmQtMzI4YS03ZWMxLWI2NjgtZDQ2NTEyYzljYTk1LyIsIm1pcnJvciI6
+        ZmUwMmEtZjVlZS03YzYwLWEwZTQtMTQzNDQ5YTdhMmI4LyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1309,7 +1309,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:18 GMT
+      - Mon, 03 Jun 2024 22:14:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1329,7 +1329,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b0e6468ea7b2443daadd6557f14c38ea
+      - 2363d57669af44ff90e2a6e4ccce68ae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1337,12 +1337,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTNjMjktNzdi
-        Ni1hYTZiLWRiYTA2MWVlNzJlOS8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:18 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJhLWZjMjAtNzE5
+        NS1hZjM0LTA5YjJlOGE5NmU2MC8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:24 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54bd-3c29-77b6-aa6b-dba061ee72e9/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe02a-fc20-7195-af34-09b2e8a96e60/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1350,7 +1350,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1363,7 +1363,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:19 GMT
+      - Mon, 03 Jun 2024 22:14:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1383,7 +1383,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8ce3d8b9579344408f3c4532ae3d7037
+      - 5ca856b0ef024a8e899c682bfe764cd9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1391,45 +1391,45 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0YmQtM2My
-        OS03N2I2LWFhNmItZGJhMDYxZWU3MmU5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6Mjc6MTguOTUzODg0WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDoyNzoxOC45NTM4OTlaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmUwMmEtZmMy
+        MC03MTk1LWFmMzQtMDliMmU4YTk2ZTYwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDNUMjI6MTQ6MjQuNTQ1MzA4WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wM1QyMjoxNDoyNC41NDUzMjBaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6
-        aW5nLnN5bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJiMGU2NDY4ZWE3YjI0
-        NDNkYWFkZDY1NTdmMTRjMzhlYSIsImNyZWF0ZWRfYnkiOiIvcHVscC9hcGkv
-        djMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjI3
-        OjE4Ljk2NjEwNVoiLCJzdGFydGVkX2F0IjoiMjAyNC0wNS0wN1QyMDoyNzox
-        OS4wMTUwMjRaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjI3OjE5
-        LjkyMTI5MFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3Yz
-        L3dvcmtlcnMvMDE4ZjU0YmEtODAxNy03ZTFjLTk1MTEtODZjNGEyNDc3NmZh
+        aW5nLnN5bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiIyMzYzZDU3NjY5YWY0
+        NGZmOTBlMmE2ZTRjY2NlNjhhZSIsImNyZWF0ZWRfYnkiOiIvcHVscC9hcGkv
+        djMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTA2LTAzVDIyOjE0
+        OjI0LjU1NzUzMloiLCJzdGFydGVkX2F0IjoiMjAyNC0wNi0wM1QyMjoxNDoy
+        NC41OTA3MzNaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTA2LTAzVDIyOjE0OjI1
+        LjEyNTI0MVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3Yz
+        L3dvcmtlcnMvMDE4ZmRmZmMtNDFiZi03MTcwLThhMDUtNGFkNzgwNTBiZWYy
         LyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tf
         Z3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJE
         b3dubG9hZGluZyBNZXRhZGF0YSIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
         Lm1ldGFkYXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwi
-        ZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGlu
-        ZyBBcnRpZmFjdHMiLCJjb2RlIjoic3luYy5kb3dubG9hZGluZy5hcnRpZmFj
-        dHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoz
-        LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRl
-        bnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29t
-        cGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjMsInN1ZmZpeCI6bnVsbH0s
-        eyJtZXNzYWdlIjoiUGFyc2luZyBNZXRhZGF0YSBMaW5lcyIsImNvZGUiOiJz
-        eW5jLnBhcnNpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
-        dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVu
-        LUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5j
+        ZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1l
+        dGFkYXRhIExpbmVzIiwiY29kZSI6InN5bmMucGFyc2luZy5tZXRhZGF0YSIs
+        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRvbmUiOjMsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwi
+        Y29kZSI6InN5bmMuZG93bmxvYWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6
+        InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdl
+        IjoiQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5j
         b250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9u
-        ZSI6MCwic3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOGY1NGJkLTM0
-        MGEtNzA4ZC04MTA0LTA2MGI3MzMyNzFiMS92ZXJzaW9ucy8xLyIsIi9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOGY1NGJkLTNmYzIt
-        NzdkZS04NjhmLTU1NzhhZjFlYzVmNy8iXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
+        ZSI6Mywic3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOGZlMDJhLWY2
+        YTAtN2IyNC05NDFmLTMxYWMyNmRjZGU1NS92ZXJzaW9ucy8xLyIsIi9wdWxw
+        L2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOGZlMDJhLWZlMzgt
+        N2NmMy04ZmRhLWE5MDJlN2QwNGU5MC8iXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
         X3JlY29yZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmls
-        ZS8wMThmNTRiZC0zNDBhLTcwOGQtODEwNC0wNjBiNzMzMjcxYjEvIiwic2hh
-        cmVkOi9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS8wMThmNTRiZC0z
-        MjhhLTdlYzEtYjY2OC1kNDY1MTJjOWNhOTUvIiwic2hhcmVkOi9wdWxwL2Fw
-        aS92My9kb21haW5zLzAxOGY1NGI5LTNjYzUtN2Y3NS05ZmE5LWVmZGQyMGEx
-        ZmM4My8iXX0=
-  recorded_at: Tue, 07 May 2024 20:27:19 GMT
+        ZS8wMThmZTAyYS1mNmEwLTdiMjQtOTQxZi0zMWFjMjZkY2RlNTUvIiwic2hh
+        cmVkOi9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS8wMThmZTAyYS1m
+        NWVlLTdjNjAtYTBlNC0xNDM0NDlhN2EyYjgvIiwic2hhcmVkOi9wdWxwL2Fw
+        aS92My9kb21haW5zLzAxOGZkZmZiLTMyNjMtN2VkYi1hMmFhLTljZTkyMDlm
+        OGYwMy8iXX0=
+  recorded_at: Mon, 03 Jun 2024 22:14:25 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
@@ -1440,7 +1440,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1453,7 +1453,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:20 GMT
+      - Mon, 03 Jun 2024 22:14:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1473,7 +1473,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8666b80ffe124846904354c7105f7207
+      - caab6b5825e9434bad5b2a97e6d80208
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1483,10 +1483,10 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMThmNTRiZC0zOTNlLTc4ZGEtYjkxYy0xYzgwNzA3ZDQ2
-        M2IvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNS0wN1QyMDoyNzoxOC4yMDg1
-        MDZaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTA3VDIwOjI3OjE4
-        LjIwODUyNFoiLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        L2ZpbGUvZmlsZS8wMThmZTAyYS1mOWU1LTcxNzYtYTg3MC0wNzZmNjU4NjQ4
+        OTEvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wM1QyMjoxNDoyMy45NzQ3
+        OTdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTAzVDIyOjE0OjIz
+        Ljk3NDgxM1oiLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9s
         aWJyYXJ5L3B1bHAzX0ZpbGVfMSIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50
         b3M5LWthdGVsbG8tZGV2ZWwubWFuaWNvdHRvLmV4YW1wbGUuY29tL3B1bHAv
         Y29udGVudC9EZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0Zp
@@ -1494,22 +1494,22 @@ http_interactions:
         dWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1D
         YWJpbmV0LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnkiOm51bGwsInB1Ymxp
         Y2F0aW9uIjpudWxsfV19
-  recorded_at: Tue, 07 May 2024 20:27:20 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:25 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018f54bd-393e-78da-b91c-1c80707d463b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018fe02a-f9e5-7176-a870-076f65864891/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE4ZjU0
-        YmQtM2ZjMi03N2RlLTg2OGYtNTU3OGFmMWVjNWY3LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE4ZmUw
+        MmEtZmUzOC03Y2YzLThmZGEtYTkwMmU3ZDA0ZTkwLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1522,7 +1522,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:20 GMT
+      - Mon, 03 Jun 2024 22:14:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1542,7 +1542,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f895def304f84f8da9dce5c4db89292e
+      - 6583d1bdf9f9465d954893440c2719da
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1550,12 +1550,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTQxNGQtNzVl
-        NC1hZTMzLTcxMDk5NmRlNjFhZC8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:20 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJhLWZmNzctNzBi
+        OC04MjI5LTljNmRmYWNlM2QzZi8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:25 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54bd-414d-75e4-ae33-710996de61ad/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe02a-ff77-70b8-8229-9c6dface3d3f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1563,7 +1563,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1576,7 +1576,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:20 GMT
+      - Mon, 03 Jun 2024 22:14:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1596,7 +1596,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 204b5d7dc92847818bad4ebffe23d49a
+      - 6979471f6d3046679ec55f810b7e8a55
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1604,38 +1604,38 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0YmQtNDE0
-        ZC03NWU0LWFlMzMtNzEwOTk2ZGU2MWFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6Mjc6MjAuMjY5NzkzWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDoyNzoyMC4yNjk4MDlaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmUwMmEtZmY3
+        Ny03MGI4LTgyMjktOWM2ZGZhY2UzZDNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDNUMjI6MTQ6MjUuMzk5ODI3WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wM1QyMjoxNDoyNS4zOTk4MzlaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6ImY4OTVkZWYzMDRmODRmOGRhOWRj
-        ZTVjNGRiODkyOTJlIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MjAuMjg0
-        NTY1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjI3OjIwLjI4NzI2
-        NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MjAuMzA2ODY0
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjY1ODNkMWJkZjlmOTQ2NWQ5NTQ4
+        OTM0NDBjMjcxOWRhIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjUuNDA5
+        NDk1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTAzVDIyOjE0OjI1LjQxMTk3
+        OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjUuNDI0ODc3
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25z
-        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNTRiOS0zY2M1
-        LTdmNzUtOWZhOS1lZmRkMjBhMWZjODMvIl19
-  recorded_at: Tue, 07 May 2024 20:27:20 GMT
+        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZGZmYi0zMjYz
+        LTdlZGItYTJhYS05Y2U5MjA5ZjhmMDMvIl19
+  recorded_at: Mon, 03 Jun 2024 22:14:25 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018f54bd-393e-78da-b91c-1c80707d463b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018fe02a-f9e5-7176-a870-076f65864891/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE4ZjU0
-        YmQtM2ZjMi03N2RlLTg2OGYtNTU3OGFmMWVjNWY3LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE4ZmUw
+        MmEtZmUzOC03Y2YzLThmZGEtYTkwMmU3ZDA0ZTkwLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1648,7 +1648,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:20 GMT
+      - Mon, 03 Jun 2024 22:14:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1668,7 +1668,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a74c517f15994e868582fd03031ab348
+      - b0a8dadd844b41cb809162aa8356f361
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1676,9 +1676,9 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTQyNTUtN2Jl
-        MC05MzBmLTFiMDkyZDJkOWMxMy8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:20 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJiLTAwMjItN2Zk
+        OC05ODk4LTEzYTg3ZmJkYjY1My8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:25 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
@@ -1698,7 +1698,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1711,13 +1711,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:20 GMT
+      - Mon, 03 Jun 2024 22:14:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/018f54bd-4364-7d96-b89a-5bffab905b09/"
+      - "/pulp/api/v3/remotes/file/file/018fe02b-00f0-76c3-91e3-81d3a5a086a5/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1733,7 +1733,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b0757a41b4b9420da42f514192d1e90b
+      - c1c904aa9d824ec8a0fa84f5d63cb4c8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1742,9 +1742,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE4ZjU0YmQtNDM2NC03ZDk2LWI4OWEtNWJmZmFiOTA1YjA5LyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjQtMDUtMDdUMjA6Mjc6MjAuODA1MzkwWiIsInB1bHBf
-        bGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMDoyNzoyMC44MDU0MjdaIiwi
+        MDE4ZmUwMmItMDBmMC03NmMzLTkxZTMtODFkM2E1YTA4NmE1LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjUuNzc2OTg4WiIsInB1bHBf
+        bGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wM1QyMjoxNDoyNS43NzcwMDBaIiwi
         bmFtZSI6InRlc3RfcmVtb3RlX25hbWUiLCJ1cmwiOiJodHRwczovL2ZpeHR1
         cmVzLnB1bHBwcm9qZWN0Lm9yZy9maWxlLy9QVUxQX01BTklGRVNUIiwiY2Ff
         Y2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9u
@@ -1758,10 +1758,10 @@ http_interactions:
         bWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwcm94eV9wYXNzd29yZCIs
         ImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InVzZXJuYW1lIiwiaXNfc2V0Ijpm
         YWxzZX0seyJuYW1lIjoicGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfV19
-  recorded_at: Tue, 07 May 2024 20:27:20 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:25 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018f54bd-4364-7d96-b89a-5bffab905b09/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018fe02b-00f0-76c3-91e3-81d3a5a086a5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1769,7 +1769,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1782,7 +1782,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:20 GMT
+      - Mon, 03 Jun 2024 22:14:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1802,7 +1802,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 95a00a507cff4b3b9a2ab9fe74c74f79
+      - '048c83937fa4487eb7b39eb3d68bac12'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1810,12 +1810,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTQzYjItNzZj
-        ZS05MDIzLWMxZTkxZWVlYjg3MC8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:20 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJiLTAxMjctN2Yy
+        ZS05ZDNjLTY5NmFiYjJmMzJmMy8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:25 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018f54bd-340a-708d-8104-060b733271b1/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018fe02a-f6a0-7b24-941f-31ac26dcde55/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1825,7 +1825,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1838,7 +1838,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:21 GMT
+      - Mon, 03 Jun 2024 22:14:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1858,7 +1858,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1ab4c2a1d87b42459f702474efc0b4d6
+      - c09865c5bd2b4708ad32cd1ca64320f2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1866,12 +1866,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTQ0ODQtN2I3
-        OC1iZmEzLWM5YjMyNmI0NzIzYS8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:21 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJiLTAxZDAtNzNl
+        ZC04Yjg2LWI1MTAyODQzZTI2Zi8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:26 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018f54bd-328a-7ec1-b668-d46512c9ca95/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018fe02a-f5ee-7c60-a0e4-143449a7a2b8/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1888,7 +1888,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1901,7 +1901,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:21 GMT
+      - Mon, 03 Jun 2024 22:14:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1921,7 +1921,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 773258d9931347749924bb60ed617372
+      - b161ab38a33e4aaebab207944b7e29bb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1929,12 +1929,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTQ1MGEtNzUz
-        Yy04NWM1LTg4ZTg1MTMyZTRlNS8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:21 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJiLTAyMzUtN2Zk
+        MC04NWUxLTFjY2E3MmRiODkzZS8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:26 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54bd-450a-753c-85c5-88e85132e4e5/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe02b-0235-7fd0-85e1-1cca72db893e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1942,7 +1942,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1955,7 +1955,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:21 GMT
+      - Mon, 03 Jun 2024 22:14:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1975,7 +1975,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a204adf853bc4d8d821e1c30efbed29c
+      - 3a31ad26ed67462e96c81fed79c5efd3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1983,24 +1983,24 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0YmQtNDUw
-        YS03NTNjLTg1YzUtODhlODUxMzJlNGU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6Mjc6MjEuMjI2ODI5WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDoyNzoyMS4yMjY4NDZaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmUwMmItMDIz
+        NS03ZmQwLTg1ZTEtMWNjYTcyZGI4OTNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDNUMjI6MTQ6MjYuMTAxODc3WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wM1QyMjoxNDoyNi4xMDE4OTBaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6Ijc3MzI1OGQ5OTMxMzQ3NzQ5OTI0
-        YmI2MGVkNjE3MzcyIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MjEuMjQz
-        Mzc0WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjI3OjIxLjI0NjE5
-        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MjEuMjU5ODEy
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6ImIxNjFhYjM4YTMzZTRhYWViYWIy
+        MDc5NDRiN2UyOWJiIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjYuMTEy
+        ODU0WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTAzVDIyOjE0OjI2LjExNTI2
+        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjYuMTI2MDkw
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMv
-        ZmlsZS9maWxlLzAxOGY1NGJkLTMyOGEtN2VjMS1iNjY4LWQ0NjUxMmM5Y2E5
-        NS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZjU0YjktM2Nj
-        NS03Zjc1LTlmYTktZWZkZDIwYTFmYzgzLyJdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:21 GMT
+        ZmlsZS9maWxlLzAxOGZlMDJhLWY1ZWUtN2M2MC1hMGU0LTE0MzQ0OWE3YTJi
+        OC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZmRmZmItMzI2
+        My03ZWRiLWEyYWEtOWNlOTIwOWY4ZjAzLyJdfQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:26 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
@@ -2011,7 +2011,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2024,7 +2024,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:21 GMT
+      - Mon, 03 Jun 2024 22:14:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2044,7 +2044,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 74a7215865344c39884a189ca3054215
+      - ae62e1f570e1461aaf8225b905f12222
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2054,10 +2054,10 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMThmNTRiZC0zOTNlLTc4ZGEtYjkxYy0xYzgwNzA3ZDQ2
-        M2IvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNS0wN1QyMDoyNzoxOC4yMDg1
-        MDZaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTA3VDIwOjI3OjIw
-        LjU2NDQzNloiLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        L2ZpbGUvZmlsZS8wMThmZTAyYS1mOWU1LTcxNzYtYTg3MC0wNzZmNjU4NjQ4
+        OTEvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wM1QyMjoxNDoyMy45NzQ3
+        OTdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTAzVDIyOjE0OjI1
+        LjU5NTY4OFoiLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9s
         aWJyYXJ5L3B1bHAzX0ZpbGVfMSIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50
         b3M5LWthdGVsbG8tZGV2ZWwubWFuaWNvdHRvLmV4YW1wbGUuY29tL3B1bHAv
         Y29udGVudC9EZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0Zp
@@ -2065,23 +2065,23 @@ http_interactions:
         dWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1D
         YWJpbmV0LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnkiOm51bGwsInB1Ymxp
         Y2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUv
-        MDE4ZjU0YmQtM2ZjMi03N2RlLTg2OGYtNTU3OGFmMWVjNWY3LyJ9XX0=
-  recorded_at: Tue, 07 May 2024 20:27:21 GMT
+        MDE4ZmUwMmEtZmUzOC03Y2YzLThmZGEtYTkwMmU3ZDA0ZTkwLyJ9XX0=
+  recorded_at: Mon, 03 Jun 2024 22:14:26 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018f54bd-393e-78da-b91c-1c80707d463b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018fe02a-f9e5-7176-a870-076f65864891/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE4ZjU0
-        YmQtM2ZjMi03N2RlLTg2OGYtNTU3OGFmMWVjNWY3LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE4ZmUw
+        MmEtZmUzOC03Y2YzLThmZGEtYTkwMmU3ZDA0ZTkwLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2094,7 +2094,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:21 GMT
+      - Mon, 03 Jun 2024 22:14:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2114,7 +2114,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0f4308ba2d6944c1876fc3811ff9fd4c
+      - 7763960c78554b7f89c81ccf3610adb4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2122,12 +2122,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTQ2MzMtN2E3
-        NC04OWMwLWM1OWYwZTc4ZDdjMC8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:21 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJiLTAzMTUtNzQ4
+        Ny1iODMwLTc4YTI5ZTY0ZTM4Zi8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:26 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54bd-4633-7a74-89c0-c59f0e78d7c0/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe02b-0315-7487-b830-78a29e64e38f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2135,7 +2135,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2148,7 +2148,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:21 GMT
+      - Mon, 03 Jun 2024 22:14:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2168,7 +2168,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 998eea7b26c94639a9eedd6c14bd6844
+      - 349c707b76b3421eb9817ece64c891f9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2176,38 +2176,38 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0YmQtNDYz
-        My03YTc0LTg5YzAtYzU5ZjBlNzhkN2MwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6Mjc6MjEuNTIzNzgxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDoyNzoyMS41MjM3OThaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmUwMmItMDMx
+        NS03NDg3LWI4MzAtNzhhMjllNjRlMzhmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDNUMjI6MTQ6MjYuMzI2MDIxWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wM1QyMjoxNDoyNi4zMjYwMzNaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjBmNDMwOGJhMmQ2OTQ0YzE4NzZm
-        YzM4MTFmZjlmZDRjIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MjEuNTM3
-        NjQ4WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjI3OjIxLjU0MDY4
-        OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MjEuNTU4NDg2
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6Ijc3NjM5NjBjNzg1NTRiN2Y4OWM4
+        MWNjZjM2MTBhZGI0IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjYuMzM1
+        ODY0WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTAzVDIyOjE0OjI2LjMzODQy
+        M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjYuMzUxNjYy
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25z
-        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNTRiOS0zY2M1
-        LTdmNzUtOWZhOS1lZmRkMjBhMWZjODMvIl19
-  recorded_at: Tue, 07 May 2024 20:27:21 GMT
+        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZGZmYi0zMjYz
+        LTdlZGItYTJhYS05Y2U5MjA5ZjhmMDMvIl19
+  recorded_at: Mon, 03 Jun 2024 22:14:26 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018f54bd-393e-78da-b91c-1c80707d463b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018fe02a-f9e5-7176-a870-076f65864891/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE4ZjU0
-        YmQtM2ZjMi03N2RlLTg2OGYtNTU3OGFmMWVjNWY3LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE4ZmUw
+        MmEtZmUzOC03Y2YzLThmZGEtYTkwMmU3ZDA0ZTkwLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2220,7 +2220,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:21 GMT
+      - Mon, 03 Jun 2024 22:14:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2240,7 +2240,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 18534d495d3f4e88aa2105501367928d
+      - 7f13dd692d694dd9959392703dc8cbf2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2248,12 +2248,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTQ3MTQtN2Q4
-        Ni1hY2UyLTgyMTdiNmViZGE2Yy8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:21 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJiLTAzZDEtNzU3
+        Yi1iNzVhLWIyMjNmYzFmNzUwOS8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:26 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018f54bd-328a-7ec1-b668-d46512c9ca95/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018fe02a-f5ee-7c60-a0e4-143449a7a2b8/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2270,7 +2270,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2283,7 +2283,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:22 GMT
+      - Mon, 03 Jun 2024 22:14:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2303,7 +2303,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a29215149f4040cc9349892b720bf4bd
+      - 07c4fb6f39e34c0590b60e631bb2b2a6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2311,12 +2311,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTQ4OWUtN2Rh
-        OC05ZTU3LTExMDQxOTE5MWExMy8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:22 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJiLTA1MmYtN2Mz
+        Zi1hOWQ4LWE0YzdiOGJlMDE0ZC8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:26 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54bd-489e-7da8-9e57-110419191a13/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe02b-052f-7c3f-a9d8-a4c7b8be014d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2324,7 +2324,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2337,7 +2337,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:22 GMT
+      - Mon, 03 Jun 2024 22:14:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2357,7 +2357,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 78291c684f164afdbdf80ead1e479a9f
+      - 38461147d0fc4ee4832292a50e583671
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2365,38 +2365,38 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0YmQtNDg5
-        ZS03ZGE4LTllNTctMTEwNDE5MTkxYTEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6Mjc6MjIuMTQzMjM0WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDoyNzoyMi4xNDMyNTNaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmUwMmItMDUy
+        Zi03YzNmLWE5ZDgtYTRjN2I4YmUwMTRkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDNUMjI6MTQ6MjYuODYzOTQ1WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wM1QyMjoxNDoyNi44NjM5ODJaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6ImEyOTIxNTE0OWY0MDQwY2M5MzQ5
-        ODkyYjcyMGJmNGJkIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MjIuMTYx
-        MjY1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjI3OjIyLjE2Mzg5
-        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MjIuMTc4OTg0
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjA3YzRmYjZmMzllMzRjMDU5MGI2
+        MGU2MzFiYjJiMmE2IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjYuODc5
+        MDgzWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTAzVDIyOjE0OjI2Ljg4MjA0
+        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjYuODkzNjA0
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMv
-        ZmlsZS9maWxlLzAxOGY1NGJkLTMyOGEtN2VjMS1iNjY4LWQ0NjUxMmM5Y2E5
-        NS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZjU0YjktM2Nj
-        NS03Zjc1LTlmYTktZWZkZDIwYTFmYzgzLyJdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:22 GMT
+        ZmlsZS9maWxlLzAxOGZlMDJhLWY1ZWUtN2M2MC1hMGU0LTE0MzQ0OWE3YTJi
+        OC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZmRmZmItMzI2
+        My03ZWRiLWEyYWEtOWNlOTIwOWY4ZjAzLyJdfQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:26 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018f54bd-340a-708d-8104-060b733271b1/sync/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018fe02a-f6a0-7b24-941f-31ac26dcde55/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE4
-        ZjU0YmQtMzI4YS03ZWMxLWI2NjgtZDQ2NTEyYzljYTk1LyIsIm1pcnJvciI6
+        ZmUwMmEtZjVlZS03YzYwLWEwZTQtMTQzNDQ5YTdhMmI4LyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2409,7 +2409,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:22 GMT
+      - Mon, 03 Jun 2024 22:14:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2429,7 +2429,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f5b873aef9cb4c77876cb9d91d3b3a19
+      - f99c344178da4ba296e0e36f2a070b00
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2437,12 +2437,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTQ5ODgtNzYw
-        MS1iYTQ1LTAyM2VlOGJmZmI4YS8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:22 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJiLTA1ZGUtN2I5
+        ZS04NWU1LWEzZTBlOGVlM2MwMC8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:27 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54bd-4988-7601-ba45-023ee8bffb8a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe02b-05de-7b9e-85e5-a3e0e8ee3c00/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2450,7 +2450,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2463,7 +2463,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:23 GMT
+      - Mon, 03 Jun 2024 22:14:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2483,7 +2483,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ba8f322d68584f6c886e9356ae170473
+      - 9adc89365f964463a931831fea7b78d8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2491,45 +2491,45 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0YmQtNDk4
-        OC03NjAxLWJhNDUtMDIzZWU4YmZmYjhhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6Mjc6MjIuMzc3NTE0WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDoyNzoyMi4zNzc1MjlaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmUwMmItMDVk
+        ZS03YjllLTg1ZTUtYTNlMGU4ZWUzYzAwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDNUMjI6MTQ6MjcuMDM5NDM5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wM1QyMjoxNDoyNy4wMzk0NTRaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5zeW5jaHJvbml6
-        aW5nLnN5bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJmNWI4NzNhZWY5Y2I0
-        Yzc3ODc2Y2I5ZDkxZDNiM2ExOSIsImNyZWF0ZWRfYnkiOiIvcHVscC9hcGkv
-        djMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjI3
-        OjIyLjM5MTMwMVoiLCJzdGFydGVkX2F0IjoiMjAyNC0wNS0wN1QyMDoyNzoy
-        Mi40NDc1MjdaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjI3OjIz
-        LjM1MjQzOVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3Yz
-        L3dvcmtlcnMvMDE4ZjU0YmEtODAxNy03ZTFjLTk1MTEtODZjNGEyNDc3NmZh
+        aW5nLnN5bmNocm9uaXplIiwibG9nZ2luZ19jaWQiOiJmOTljMzQ0MTc4ZGE0
+        YmEyOTZlMGUzNmYyYTA3MGIwMCIsImNyZWF0ZWRfYnkiOiIvcHVscC9hcGkv
+        djMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTA2LTAzVDIyOjE0
+        OjI3LjA1MDI4MFoiLCJzdGFydGVkX2F0IjoiMjAyNC0wNi0wM1QyMjoxNDoy
+        Ny4wODQ3MzFaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTA2LTAzVDIyOjE0OjI3
+        LjU4NjgxOFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3Yz
+        L3dvcmtlcnMvMDE4ZmRmZmMtNDFiZi03MTcwLThhMDUtNGFkNzgwNTBiZWYy
         LyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tf
         Z3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJE
         b3dubG9hZGluZyBNZXRhZGF0YSIsImNvZGUiOiJzeW5jLmRvd25sb2FkaW5n
         Lm1ldGFkYXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwi
-        ZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGlu
-        ZyBBcnRpZmFjdHMiLCJjb2RlIjoic3luYy5kb3dubG9hZGluZy5hcnRpZmFj
-        dHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoz
-        LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRl
-        bnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29t
-        cGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjMsInN1ZmZpeCI6bnVsbH0s
-        eyJtZXNzYWdlIjoiUGFyc2luZyBNZXRhZGF0YSBMaW5lcyIsImNvZGUiOiJz
-        eW5jLnBhcnNpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
-        dGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVu
-        LUFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5j
+        ZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1l
+        dGFkYXRhIExpbmVzIiwiY29kZSI6InN5bmMucGFyc2luZy5tZXRhZGF0YSIs
+        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRvbmUiOjMsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwi
+        Y29kZSI6InN5bmMuZG93bmxvYWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6
+        InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdl
+        IjoiQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5j
         b250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9u
         ZSI6Mywic3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOGY1NGJkLTM0
-        MGEtNzA4ZC04MTA0LTA2MGI3MzMyNzFiMS92ZXJzaW9ucy8yLyIsIi9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOGY1NGJkLTRkMjUt
-        NzgzZS1hMzk0LTJkMDE5MDFiNGE0MC8iXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOGZlMDJhLWY2
+        YTAtN2IyNC05NDFmLTMxYWMyNmRjZGU1NS92ZXJzaW9ucy8yLyIsIi9wdWxw
+        L2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOGZlMDJiLTA3ZDct
+        N2VjYS05NGM4LWE0Y2RmZDNkNmUyZS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
         X3JlY29yZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmls
-        ZS8wMThmNTRiZC0zNDBhLTcwOGQtODEwNC0wNjBiNzMzMjcxYjEvIiwic2hh
-        cmVkOi9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS8wMThmNTRiZC0z
-        MjhhLTdlYzEtYjY2OC1kNDY1MTJjOWNhOTUvIiwic2hhcmVkOi9wdWxwL2Fw
-        aS92My9kb21haW5zLzAxOGY1NGI5LTNjYzUtN2Y3NS05ZmE5LWVmZGQyMGEx
-        ZmM4My8iXX0=
-  recorded_at: Tue, 07 May 2024 20:27:23 GMT
+        ZS8wMThmZTAyYS1mNmEwLTdiMjQtOTQxZi0zMWFjMjZkY2RlNTUvIiwic2hh
+        cmVkOi9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS8wMThmZTAyYS1m
+        NWVlLTdjNjAtYTBlNC0xNDM0NDlhN2EyYjgvIiwic2hhcmVkOi9wdWxwL2Fw
+        aS92My9kb21haW5zLzAxOGZkZmZiLTMyNjMtN2VkYi1hMmFhLTljZTkyMDlm
+        OGYwMy8iXX0=
+  recorded_at: Mon, 03 Jun 2024 22:14:27 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
@@ -2540,7 +2540,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2553,7 +2553,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:23 GMT
+      - Mon, 03 Jun 2024 22:14:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2573,7 +2573,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 37d04b0607354cee8ee131aaeda88bf1
+      - 50fa1f654ec743b38d4d6b0011085726
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2583,10 +2583,10 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMThmNTRiZC0zOTNlLTc4ZGEtYjkxYy0xYzgwNzA3ZDQ2
-        M2IvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNS0wN1QyMDoyNzoxOC4yMDg1
-        MDZaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTA3VDIwOjI3OjIx
-        Ljc3NzAzNFoiLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        L2ZpbGUvZmlsZS8wMThmZTAyYS1mOWU1LTcxNzYtYTg3MC0wNzZmNjU4NjQ4
+        OTEvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wM1QyMjoxNDoyMy45NzQ3
+        OTdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTAzVDIyOjE0OjI2
+        LjUzNjc3N1oiLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9s
         aWJyYXJ5L3B1bHAzX0ZpbGVfMSIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50
         b3M5LWthdGVsbG8tZGV2ZWwubWFuaWNvdHRvLmV4YW1wbGUuY29tL3B1bHAv
         Y29udGVudC9EZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0Zp
@@ -2594,23 +2594,23 @@ http_interactions:
         dWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1D
         YWJpbmV0LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnkiOm51bGwsInB1Ymxp
         Y2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUv
-        MDE4ZjU0YmQtM2ZjMi03N2RlLTg2OGYtNTU3OGFmMWVjNWY3LyJ9XX0=
-  recorded_at: Tue, 07 May 2024 20:27:23 GMT
+        MDE4ZmUwMmEtZmUzOC03Y2YzLThmZGEtYTkwMmU3ZDA0ZTkwLyJ9XX0=
+  recorded_at: Mon, 03 Jun 2024 22:14:27 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018f54bd-393e-78da-b91c-1c80707d463b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018fe02a-f9e5-7176-a870-076f65864891/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE4ZjU0
-        YmQtNGQyNS03ODNlLWEzOTQtMmQwMTkwMWI0YTQwLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE4ZmUw
+        MmItMDdkNy03ZWNhLTk0YzgtYTRjZGZkM2Q2ZTJlLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2623,7 +2623,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:23 GMT
+      - Mon, 03 Jun 2024 22:14:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2643,7 +2643,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b2af8f5cc2e04ff1811709011957e941
+      - 01fb010c1a72484bbfed2a4f45b7d513
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2651,12 +2651,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTRlYzAtNzA1
-        Yi1iZGUwLTkxZmMyNGY2ZjY3ZS8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:23 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJiLTA5MTAtNzcx
+        MC1iODVlLTQ0ZjljMmFjYzVhZC8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:27 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54bd-4ec0-705b-bde0-91fc24f6f67e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe02b-0910-7710-b85e-44f9c2acc5ad/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2664,7 +2664,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2677,7 +2677,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:23 GMT
+      - Mon, 03 Jun 2024 22:14:27 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2697,7 +2697,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b9793d2b5b9a4959af3dfc1a439e9d44
+      - 3a81878beaf04079b9eeac9fbab44f14
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2705,38 +2705,38 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0YmQtNGVj
-        MC03MDViLWJkZTAtOTFmYzI0ZjZmNjdlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6Mjc6MjMuNzEyNTcxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDoyNzoyMy43MTI1ODZaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmUwMmItMDkx
+        MC03NzEwLWI4NWUtNDRmOWMyYWNjNWFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDNUMjI6MTQ6MjcuODU2Nzg0WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wM1QyMjoxNDoyNy44NTY3OTdaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6ImIyYWY4ZjVjYzJlMDRmZjE4MTE3
-        MDkwMTE5NTdlOTQxIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MjMuNzIz
-        NzE3WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjI3OjIzLjcyODA3
-        OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MjMuNzU1MDg5
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjAxZmIwMTBjMWE3MjQ4NGJiZmVk
+        MmE0ZjQ1YjdkNTEzIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjcuODY3
+        OTM5WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTAzVDIyOjE0OjI3Ljg3MDQ4
+        MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjcuODg0MzEx
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25z
-        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNTRiOS0zY2M1
-        LTdmNzUtOWZhOS1lZmRkMjBhMWZjODMvIl19
-  recorded_at: Tue, 07 May 2024 20:27:23 GMT
+        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZGZmYi0zMjYz
+        LTdlZGItYTJhYS05Y2U5MjA5ZjhmMDMvIl19
+  recorded_at: Mon, 03 Jun 2024 22:14:27 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018f54bd-393e-78da-b91c-1c80707d463b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018fe02a-f9e5-7176-a870-076f65864891/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE4ZjU0
-        YmQtNGQyNS03ODNlLWEzOTQtMmQwMTkwMWI0YTQwLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE4ZmUw
+        MmItMDdkNy03ZWNhLTk0YzgtYTRjZGZkM2Q2ZTJlLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2749,7 +2749,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:24 GMT
+      - Mon, 03 Jun 2024 22:14:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2769,7 +2769,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b9550d1c3f6048b4aa354c56280f0883
+      - 72a33b4fbb65424d815cbcaaac763ea0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2777,9 +2777,9 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTRmYzMtNzVj
-        Ni04MzU3LWQ5NTRmZDJlMjc3Yy8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:24 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJiLTA5ZDItNzA5
+        NC05YzkwLTdhMDBkMTE3MTA4Ni8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:28 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
@@ -2790,7 +2790,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.21.3/ruby
+      - OpenAPI-Generator/0.21.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -2803,7 +2803,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:24 GMT
+      - Mon, 03 Jun 2024 22:14:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2823,7 +2823,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d6f048801a0b4b9f972cd078b9a3e7e9
+      - 6a54d9cb9eff4038b587ddc5eb37c5cc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2833,7 +2833,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:24 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:28 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -2857,7 +2857,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:24 GMT
+      - Mon, 03 Jun 2024 22:14:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2877,7 +2877,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ec976615664445ccb2377006a975aac5
+      - 2dd5ff8d120441ce870e408f1cccf2a7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2887,7 +2887,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:24 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:28 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -2911,7 +2911,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:24 GMT
+      - Mon, 03 Jun 2024 22:14:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2931,7 +2931,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 332255fa417745d4a980522d95b7db7c
+      - 74f0bfa68b104756989b5d68472c10fe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2941,7 +2941,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:24 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:28 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -2952,7 +2952,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2965,7 +2965,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:24 GMT
+      - Mon, 03 Jun 2024 22:14:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2985,7 +2985,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5274789719704cd18e8e0e1868658f6c
+      - 259aa4f7bb274d7ebee2a058c613c882
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2995,22 +2995,22 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOGY1NGJkLTM0MGEtNzA4ZC04MTA0LTA2MGI3MzMyNzFi
-        MS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTA3VDIwOjI3OjE2Ljg3NTc4
-        NloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjA6Mjc6MjMu
-        MjgyMzAxWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2ZpbGUvZmlsZS8wMThmNTRiZC0zNDBhLTcwOGQtODEwNC0wNjBi
-        NzMzMjcxYjEvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3Rf
+        ZmlsZS9maWxlLzAxOGZlMDJhLWY2YTAtN2IyNC05NDFmLTMxYWMyNmRjZGU1
+        NS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTAzVDIyOjE0OjIzLjEzNzE0
+        NloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDNUMjI6MTQ6Mjcu
+        NTI3NDEyWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2ZpbGUvZmlsZS8wMThmZTAyYS1mNmEwLTdiMjQtOTQxZi0zMWFj
+        MjZkY2RlNTUvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3Rf
         dmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxl
-        L2ZpbGUvMDE4ZjU0YmQtMzQwYS03MDhkLTgxMDQtMDYwYjczMzI3MWIxL3Zl
+        L2ZpbGUvMDE4ZmUwMmEtZjZhMC03YjI0LTk0MWYtMzFhYzI2ZGNkZTU1L3Zl
         cnNpb25zLzIvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
         ZXQtcHVscDNfRmlsZV8xIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9y
         ZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNo
         IjpmYWxzZSwibWFuaWZlc3QiOiJQVUxQX01BTklGRVNUIn1dfQ==
-  recorded_at: Tue, 07 May 2024 20:27:24 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:28 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018f54bd-340a-708d-8104-060b733271b1/versions/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018fe02a-f6a0-7b24-941f-31ac26dcde55/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3018,7 +3018,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -3031,7 +3031,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:24 GMT
+      - Mon, 03 Jun 2024 22:14:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3051,7 +3051,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 05ac271b379c47efa95ed4c6ed71a9c8
+      - 61fdf520ac7f41bdbc866a5c73a89a46
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3061,51 +3061,51 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOGY1NGJkLTM0MGEtNzA4ZC04MTA0LTA2MGI3MzMyNzFi
-        MS92ZXJzaW9ucy8yLyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjA6
-        Mjc6MjIuNDc0MzAzWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0w
-        N1QyMDoyNzoyMy4yODQ4ODFaIiwibnVtYmVyIjoyLCJyZXBvc2l0b3J5Ijoi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE4ZjU0YmQt
-        MzQwYS03MDhkLTgxMDQtMDYwYjczMzI3MWIxLyIsImJhc2VfdmVyc2lvbiI6
+        ZmlsZS9maWxlLzAxOGZlMDJhLWY2YTAtN2IyNC05NDFmLTMxYWMyNmRjZGU1
+        NS92ZXJzaW9ucy8yLyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDNUMjI6
+        MTQ6MjcuMTA0MDgxWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0w
+        M1QyMjoxNDoyNy41MzAwNjhaIiwibnVtYmVyIjoyLCJyZXBvc2l0b3J5Ijoi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE4ZmUwMmEt
+        ZjZhMC03YjI0LTk0MWYtMzFhYzI2ZGNkZTU1LyIsImJhc2VfdmVyc2lvbiI6
         bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmlsZSI6
         eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
         ZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmNTRiZC0zNDBhLTcwOGQtODEw
-        NC0wNjBiNzMzMjcxYjEvdmVyc2lvbnMvMi8ifX0sInJlbW92ZWQiOnsiZmls
+        cmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmZTAyYS1mNmEwLTdiMjQtOTQx
+        Zi0zMWFjMjZkY2RlNTUvdmVyc2lvbnMvMi8ifX0sInJlbW92ZWQiOnsiZmls
         ZS5maWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
         bnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9uX3JlbW92ZWQ9L3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE4ZjU0YmQtMzQw
-        YS03MDhkLTgxMDQtMDYwYjczMzI3MWIxL3ZlcnNpb25zLzIvIn19LCJwcmVz
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE4ZmUwMmEtZjZh
+        MC03YjI0LTk0MWYtMzFhYzI2ZGNkZTU1L3ZlcnNpb25zLzIvIn19LCJwcmVz
         ZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2Fw
         aS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0v
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmNTRiZC0z
-        NDBhLTcwOGQtODEwNC0wNjBiNzMzMjcxYjEvdmVyc2lvbnMvMi8ifX19fSx7
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmZTAyYS1m
+        NmEwLTdiMjQtOTQxZi0zMWFjMjZkY2RlNTUvdmVyc2lvbnMvMi8ifX19fSx7
         InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9m
-        aWxlLzAxOGY1NGJkLTM0MGEtNzA4ZC04MTA0LTA2MGI3MzMyNzFiMS92ZXJz
-        aW9ucy8xLyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjA6Mjc6MTku
-        MDQ5MjQ2WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMDoy
-        NzoxOS44NTQxODFaIiwibnVtYmVyIjoxLCJyZXBvc2l0b3J5IjoiL3B1bHAv
-        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE4ZjU0YmQtMzQwYS03
-        MDhkLTgxMDQtMDYwYjczMzI3MWIxLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwi
+        aWxlLzAxOGZlMDJhLWY2YTAtN2IyNC05NDFmLTMxYWMyNmRjZGU1NS92ZXJz
+        aW9ucy8xLyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjQu
+        NjA5MzUyWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wM1QyMjox
+        NDoyNS4wNjIwOTVaIiwibnVtYmVyIjoxLCJyZXBvc2l0b3J5IjoiL3B1bHAv
+        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE4ZmUwMmEtZjZhMC03
+        YjI0LTk0MWYtMzFhYzI2ZGNkZTU1LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwi
         Y29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3Vu
         dCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMv
         P3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2ZpbGUvZmlsZS8wMThmNTRiZC0zNDBhLTcwOGQtODEwNC0wNjBi
-        NzMzMjcxYjEvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9LCJwcmVzZW50
+        dG9yaWVzL2ZpbGUvZmlsZS8wMThmZTAyYS1mNmEwLTdiMjQtOTQxZi0zMWFj
+        MjZkY2RlNTUvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9LCJwcmVzZW50
         Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92
         My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmNTRiZC0zNDBh
-        LTcwOGQtODEwNC0wNjBiNzMzMjcxYjEvdmVyc2lvbnMvMS8ifX19fSx7InB1
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmZTAyYS1mNmEw
+        LTdiMjQtOTQxZi0zMWFjMjZkY2RlNTUvdmVyc2lvbnMvMS8ifX19fSx7InB1
         bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzAxOGY1NGJkLTM0MGEtNzA4ZC04MTA0LTA2MGI3MzMyNzFiMS92ZXJzaW9u
-        cy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjA6Mjc6MTYuODkz
-        MDA1WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMDoyNzox
-        Ni44OTMwMTZaIiwibnVtYmVyIjowLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBp
-        L3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE4ZjU0YmQtMzQwYS03MDhk
-        LTgxMDQtMDYwYjczMzI3MWIxLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        LzAxOGZlMDJhLWY2YTAtN2IyNC05NDFmLTMxYWMyNmRjZGU1NS92ZXJzaW9u
+        cy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjMuMTQ1
+        MDMyWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wM1QyMjoxNDoy
+        My4xNDUwNDBaIiwibnVtYmVyIjowLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBp
+        L3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE4ZmUwMmEtZjZhMC03YjI0
+        LTk0MWYtMzFhYzI2ZGNkZTU1LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
         dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
         bnQiOnt9fX1dfQ==
-  recorded_at: Tue, 07 May 2024 20:27:24 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:28 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -3129,7 +3129,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:24 GMT
+      - Mon, 03 Jun 2024 22:14:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3149,7 +3149,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 17c9b335308d4197ab098143583125f9
+      - 84620d8de2c1416a95ed1906139a7537
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3159,7 +3159,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:24 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:28 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -3183,7 +3183,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:24 GMT
+      - Mon, 03 Jun 2024 22:14:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3203,7 +3203,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6d9d473785364a119d2dc883fb32d544
+      - 1e35eb8d65684f37bbfec0a18cfe94d9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3213,7 +3213,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:24 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:28 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -3224,7 +3224,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -3237,7 +3237,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:24 GMT
+      - Mon, 03 Jun 2024 22:14:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3257,7 +3257,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - df55de8432fc4c59bf01406d23c387ca
+      - 3d89707f9f8b4823bed30547012669bc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3267,10 +3267,10 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:27:24 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:28 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018f54bd-340a-708d-8104-060b733271b1/versions/1/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018fe02a-f6a0-7b24-941f-31ac26dcde55/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3278,7 +3278,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -3291,7 +3291,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:24 GMT
+      - Mon, 03 Jun 2024 22:14:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3311,7 +3311,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e034a5b97bca4a0890722f8dd09c90b2
+      - f83b351c406448ee8da08b24746c1bcc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3319,9 +3319,9 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTUzNDgtN2Nk
-        Ny05OTJmLTE4YTY0ZmU0YjE1Ni8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:24 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJiLTBjNzAtNzVi
+        Ni1iNjU4LTMzZTMxYTA4ZTQ4ZS8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:28 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
@@ -3334,7 +3334,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -3347,7 +3347,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:25 GMT
+      - Mon, 03 Jun 2024 22:14:28 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3367,7 +3367,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 47a01fba718040c8929f228ed3536075
+      - 5ba2135cb0434268b88ca15c3e24b827
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3375,12 +3375,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTUzYzItNzg1
-        My04YjY4LWUxNDY3ZTIwYTQ1Ni8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:25 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJiLTBjYzMtNzc4
+        Ny04M2JmLTRhMmM4MWQ1Zjc0NC8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:28 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54bd-53c2-7853-8b68-e1467e20a456/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe02b-0cc3-7787-83bf-4a2c81d5f744/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3388,7 +3388,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -3401,7 +3401,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:25 GMT
+      - Mon, 03 Jun 2024 22:14:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3421,7 +3421,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0ca777dd6ca046b4917e1b343666b526
+      - '0090b131279243ca87fd6724a423f01b'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3429,18 +3429,18 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0YmQtNTNj
-        Mi03ODUzLThiNjgtZTE0NjdlMjBhNDU2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6Mjc6MjUuMDAwMzIyWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDoyNzoyNS4wMDAzNjhaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmUwMmItMGNj
+        My03Nzg3LTgzYmYtNGEyYzgxZDVmNzQ0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDNUMjI6MTQ6MjguODA0MDg2WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wM1QyMjoxNDoyOC44MDQxMDZaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLm9ycGhhbi5vcnBo
-        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiNDdhMDFmYmE3MTgwNDBjODky
-        OWYyMjhlZDM1MzYwNzUiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
-        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMDoyNzoyNS4w
-        NDMxNzFaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MjUuMTcx
-        MzI3WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMDoyNzoyNS40NDUy
-        MzFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzAxOGY1NGJhLTgwMTctN2UxYy05NTExLTg2YzRhMjQ3NzZmYS8iLCJw
+        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiNWJhMjEzNWNiMDQzNDI2OGI4
+        OGNhMTVjM2UyNGI4MjciLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
+        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wM1QyMjoxNDoyOC44
+        MTg0MjVaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjguODcy
+        MjQyWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wM1QyMjoxNDoyOS4wNDgw
+        MjFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzAxOGZkZmZjLTQxNjgtNzBhYy04ZWQzLTRkYzcwNzk1MGM2Mi8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xlYW4g
         dXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIs
@@ -3450,12 +3450,68 @@ http_interactions:
         ZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
         IjpbIi9hcGkvdjMvb3JwaGFucy9jbGVhbnVwLyIsInNoYXJlZDovcHVscC9h
-        cGkvdjMvZG9tYWlucy8wMThmNTRiOS0zY2M1LTdmNzUtOWZhOS1lZmRkMjBh
-        MWZjODMvIl19
-  recorded_at: Tue, 07 May 2024 20:27:25 GMT
+        cGkvdjMvZG9tYWlucy8wMThmZGZmYi0zMjYzLTdlZGItYTJhYS05Y2U5MjA5
+        ZjhmMDMvIl19
+  recorded_at: Mon, 03 Jun 2024 22:14:29 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/purge/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJmaW5pc2hlZF9iZWZvcmUiOiIzMDAwLTAxLTAxVDAwOjAwOjAwLjAwMCsw
+        MDowMCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Jun 2024 22:14:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - a3036a3112a24cb8832c76f44736bc8f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJiLTBlMGUtN2M3
+        ZS05Zjg3LWVkY2RjMTJlN2E5My8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:29 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018f54bd-340a-708d-8104-060b733271b1/versions/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018fe02a-f6a0-7b24-941f-31ac26dcde55/versions/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3463,7 +3519,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -3476,7 +3532,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:25 GMT
+      - Mon, 03 Jun 2024 22:14:29 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3496,7 +3552,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e3e9de20461e46f1af2854b105cd65f6
+      - e70c076fa4fa4b1caf0f19ac808bdaed
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3506,34 +3562,34 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOGY1NGJkLTM0MGEtNzA4ZC04MTA0LTA2MGI3MzMyNzFi
-        MS92ZXJzaW9ucy8yLyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjA6
-        Mjc6MjIuNDc0MzAzWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0w
-        N1QyMDoyNzoyMy4yODQ4ODFaIiwibnVtYmVyIjoyLCJyZXBvc2l0b3J5Ijoi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE4ZjU0YmQt
-        MzQwYS03MDhkLTgxMDQtMDYwYjczMzI3MWIxLyIsImJhc2VfdmVyc2lvbiI6
+        ZmlsZS9maWxlLzAxOGZlMDJhLWY2YTAtN2IyNC05NDFmLTMxYWMyNmRjZGU1
+        NS92ZXJzaW9ucy8yLyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDNUMjI6
+        MTQ6MjcuMTA0MDgxWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0w
+        M1QyMjoxNDoyNy41MzAwNjhaIiwibnVtYmVyIjoyLCJyZXBvc2l0b3J5Ijoi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE4ZmUwMmEt
+        ZjZhMC03YjI0LTk0MWYtMzFhYzI2ZGNkZTU1LyIsImJhc2VfdmVyc2lvbiI6
         bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmlsZSI6
         eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
         ZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmNTRiZC0zNDBhLTcwOGQtODEw
-        NC0wNjBiNzMzMjcxYjEvdmVyc2lvbnMvMi8ifX0sInJlbW92ZWQiOnt9LCJw
+        cmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmZTAyYS1mNmEwLTdiMjQtOTQx
+        Zi0zMWFjMjZkY2RlNTUvdmVyc2lvbnMvMi8ifX0sInJlbW92ZWQiOnt9LCJw
         cmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
         L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
-        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmNTRi
-        ZC0zNDBhLTcwOGQtODEwNC0wNjBiNzMzMjcxYjEvdmVyc2lvbnMvMi8ifX19
+        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmZTAy
+        YS1mNmEwLTdiMjQtOTQxZi0zMWFjMjZkY2RlNTUvdmVyc2lvbnMvMi8ifX19
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmls
-        ZS9maWxlLzAxOGY1NGJkLTM0MGEtNzA4ZC04MTA0LTA2MGI3MzMyNzFiMS92
-        ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjA6Mjc6
-        MTYuODkzMDA1WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1Qy
-        MDoyNzoxNi44OTMwMTZaIiwibnVtYmVyIjowLCJyZXBvc2l0b3J5IjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE4ZjU0YmQtMzQw
-        YS03MDhkLTgxMDQtMDYwYjczMzI3MWIxLyIsImJhc2VfdmVyc2lvbiI6bnVs
+        ZS9maWxlLzAxOGZlMDJhLWY2YTAtN2IyNC05NDFmLTMxYWMyNmRjZGU1NS92
+        ZXJzaW9ucy8wLyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDNUMjI6MTQ6
+        MjMuMTQ1MDMyWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wM1Qy
+        MjoxNDoyMy4xNDUwNDBaIiwibnVtYmVyIjowLCJyZXBvc2l0b3J5IjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE4ZmUwMmEtZjZh
+        MC03YjI0LTk0MWYtMzFhYzI2ZGNkZTU1LyIsImJhc2VfdmVyc2lvbiI6bnVs
         bCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30s
         InByZXNlbnQiOnt9fX1dfQ==
-  recorded_at: Tue, 07 May 2024 20:27:25 GMT
+  recorded_at: Mon, 03 Jun 2024 22:14:29 GMT
 - request:
-    method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018f54bd-328a-7ec1-b668-d46512c9ca95/
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/?state__in=completed
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3541,7 +3597,239 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Jun 2024 22:14:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9a7b90edef2440eca32fd0d7b893c651
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:29 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/?state__in=completed
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Jun 2024 22:14:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '1642'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - c2867259b2494a95b3490ec332ae242b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wMThmZTAy
+        Yi0wZTBlLTdjN2UtOWY4Ny1lZGNkYzEyZTdhOTMvIiwicHVscF9jcmVhdGVk
+        IjoiMjAyNC0wNi0wM1QyMjoxNDoyOS4xMzU0MjVaIiwicHVscF9sYXN0X3Vw
+        ZGF0ZWQiOiIyMDI0LTA2LTAzVDIyOjE0OjI5LjEzNTQzNVoiLCJzdGF0ZSI6
+        ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFza3MucHVyZ2Uu
+        cHVyZ2UiLCJsb2dnaW5nX2NpZCI6ImEzMDM2YTMxMTJhMjRjYjg4MzJjNzZm
+        NDQ3MzZiYzhmIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vycy8x
+        LyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjkuMTQ4MjMz
+        WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTAzVDIyOjE0OjI5LjE4ODAyM1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjkuMzI2NzM4WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8w
+        MThmZGZmYy00MTY4LTcwYWMtOGVkMy00ZGM3MDc5NTBjNjIvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IlB1cmdlZCB0YXNr
+        LW9iamVjdHMgb2YgdHlwZSBjb3JlLlRhc2siLCJjb2RlIjoicHVyZ2UudGFz
+        a3Mua2V5LmNvcmUuVGFzayIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
+        OjQ1LCJkb25lIjo0NSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQdXJn
+        ZWQgdGFzay1vYmplY3RzIG9mIHR5cGUgY29yZS5DcmVhdGVkUmVzb3VyY2Ui
+        LCJjb2RlIjoicHVyZ2UudGFza3Mua2V5LmNvcmUuQ3JlYXRlZFJlc291cmNl
+        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MTAsImRvbmUiOjEwLCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlB1cmdlZCB0YXNrLW9iamVjdHMg
+        b2YgdHlwZSBjb3JlLlByb2dyZXNzUmVwb3J0IiwiY29kZSI6InB1cmdlLnRh
+        c2tzLmtleS5jb3JlLlByb2dyZXNzUmVwb3J0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MjksImRvbmUiOjI5LCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IlB1cmdlZCB0YXNrLW9iamVjdHMgb2YgdHlwZSBjb3JlLlVzZXJS
+        b2xlIiwiY29kZSI6InB1cmdlLnRhc2tzLmtleS5jb3JlLlVzZXJSb2xlIiwi
+        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NDUsImRvbmUiOjQ1LCJzdWZm
+        aXgiOm51bGx9LHsibWVzc2FnZSI6IlB1cmdlZCB0YXNrLXJlbGF0ZWQtb2Jq
+        ZWN0cyB0b3RhbCIsImNvZGUiOiJwdXJnZS50YXNrcy50b3RhbCIsInN0YXRl
+        IjoiY29tcGxldGVkIiwidG90YWwiOjEyOSwiZG9uZSI6MTI5LCJzdWZmaXgi
+        Om51bGx9LHsibWVzc2FnZSI6IlRhc2tzIGZhaWxlZCB0byBwdXJnZSIsImNv
+        ZGUiOiJwdXJnZS50YXNrcy5lcnJvciIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOjAsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jl
+        c291cmNlcyI6W10sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsic2hh
+        cmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGZkZmZiLTMyNjMtN2VkYi1h
+        MmFhLTljZTkyMDlmOGYwMy8iXX1dfQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:42 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/?state__in=completed
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Jun 2024 22:14:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '1642'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - a8fd5358431346bcb1afd84d3fffb708
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wMThmZTAy
+        Yi0wZTBlLTdjN2UtOWY4Ny1lZGNkYzEyZTdhOTMvIiwicHVscF9jcmVhdGVk
+        IjoiMjAyNC0wNi0wM1QyMjoxNDoyOS4xMzU0MjVaIiwicHVscF9sYXN0X3Vw
+        ZGF0ZWQiOiIyMDI0LTA2LTAzVDIyOjE0OjI5LjEzNTQzNVoiLCJzdGF0ZSI6
+        ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFza3MucHVyZ2Uu
+        cHVyZ2UiLCJsb2dnaW5nX2NpZCI6ImEzMDM2YTMxMTJhMjRjYjg4MzJjNzZm
+        NDQ3MzZiYzhmIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vycy8x
+        LyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjkuMTQ4MjMz
+        WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTAzVDIyOjE0OjI5LjE4ODAyM1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6MjkuMzI2NzM4WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8w
+        MThmZGZmYy00MTY4LTcwYWMtOGVkMy00ZGM3MDc5NTBjNjIvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IlB1cmdlZCB0YXNr
+        LW9iamVjdHMgb2YgdHlwZSBjb3JlLlRhc2siLCJjb2RlIjoicHVyZ2UudGFz
+        a3Mua2V5LmNvcmUuVGFzayIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
+        OjQ1LCJkb25lIjo0NSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQdXJn
+        ZWQgdGFzay1vYmplY3RzIG9mIHR5cGUgY29yZS5DcmVhdGVkUmVzb3VyY2Ui
+        LCJjb2RlIjoicHVyZ2UudGFza3Mua2V5LmNvcmUuQ3JlYXRlZFJlc291cmNl
+        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MTAsImRvbmUiOjEwLCJz
+        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlB1cmdlZCB0YXNrLW9iamVjdHMg
+        b2YgdHlwZSBjb3JlLlByb2dyZXNzUmVwb3J0IiwiY29kZSI6InB1cmdlLnRh
+        c2tzLmtleS5jb3JlLlByb2dyZXNzUmVwb3J0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MjksImRvbmUiOjI5LCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IlB1cmdlZCB0YXNrLW9iamVjdHMgb2YgdHlwZSBjb3JlLlVzZXJS
+        b2xlIiwiY29kZSI6InB1cmdlLnRhc2tzLmtleS5jb3JlLlVzZXJSb2xlIiwi
+        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NDUsImRvbmUiOjQ1LCJzdWZm
+        aXgiOm51bGx9LHsibWVzc2FnZSI6IlB1cmdlZCB0YXNrLXJlbGF0ZWQtb2Jq
+        ZWN0cyB0b3RhbCIsImNvZGUiOiJwdXJnZS50YXNrcy50b3RhbCIsInN0YXRl
+        IjoiY29tcGxldGVkIiwidG90YWwiOjEyOSwiZG9uZSI6MTI5LCJzdWZmaXgi
+        Om51bGx9LHsibWVzc2FnZSI6IlRhc2tzIGZhaWxlZCB0byBwdXJnZSIsImNv
+        ZGUiOiJwdXJnZS50YXNrcy5lcnJvciIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOjAsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jl
+        c291cmNlcyI6W10sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsic2hh
+        cmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGZkZmZiLTMyNjMtN2VkYi1h
+        MmFhLTljZTkyMDlmOGYwMy8iXX1dfQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:48 GMT
+- request:
+    method: delete
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018fe02a-f5ee-7c60-a0e4-143449a7a2b8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -3554,7 +3842,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:25 GMT
+      - Mon, 03 Jun 2024 22:14:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3574,7 +3862,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f0b7950e2bb0413197e239ab013a66e9
+      - 41248065bdb94ea69e25caab44b68444
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3582,12 +3870,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTU3MzctNzk5
-        NS05MjlmLThhNTdkM2EyOWZmOC8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:25 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJiLTcwODgtNzBk
+        MC1iMTdjLWM5Y2I3NGY4ODY4OC8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:54 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54bd-5737-7995-929f-8a57d3a29ff8/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe02b-7088-70d0-b17c-c9cb74f88688/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3595,7 +3883,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -3608,7 +3896,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:26 GMT
+      - Mon, 03 Jun 2024 22:14:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3628,7 +3916,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 80f9c82c412e4686b06c3ff0b6069209
+      - 8fb0b42f833a4f178a8a9d99391e8635
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3636,28 +3924,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0YmQtNTcz
-        Ny03OTk1LTkyOWYtOGE1N2QzYTI5ZmY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6Mjc6MjUuODgwMzcxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDoyNzoyNS44ODA0MTRaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmUwMmItNzA4
+        OC03MGQwLWIxN2MtYzljYjc0Zjg4Njg4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDNUMjI6MTQ6NTQuMzQ1MTE3WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wM1QyMjoxNDo1NC4zNDUxMjlaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImYwYjc5NTBlMmJiMDQxMzE5N2Uy
-        MzlhYjAxM2E2NmU5IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MjUuODkz
-        OTM2WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjI3OjI1Ljk0NzI1
-        M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MjYuMDA1OTY5
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjQxMjQ4MDY1YmRiOTRlYTY5ZTI1
+        Y2FhYjQ0YjY4NDQ0IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6NTQuMzU1
+        NzU2WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTAzVDIyOjE0OjU0LjM4NzE0
+        NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6NTQuNDMzNDIw
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRiYS04MDE3LTdlMWMtOTUxMS04NmM0YTI0Nzc2ZmEvIiwicGFy
+        cy8wMThmZGZmYy00MWJmLTcxNzAtOGEwNS00YWQ3ODA1MGJlZjIvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE4ZjU0YmQtMzI4YS03ZWMxLWI2Njgt
-        ZDQ2NTEyYzljYTk1LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8w
-        MThmNTRiOS0zY2M1LTdmNzUtOWZhOS1lZmRkMjBhMWZjODMvIl19
-  recorded_at: Tue, 07 May 2024 20:27:26 GMT
+        djMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE4ZmUwMmEtZjVlZS03YzYwLWEwZTQt
+        MTQzNDQ5YTdhMmI4LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8w
+        MThmZGZmYi0zMjYzLTdlZGItYTJhYS05Y2U5MjA5ZjhmMDMvIl19
+  recorded_at: Mon, 03 Jun 2024 22:14:54 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018f54bd-393e-78da-b91c-1c80707d463b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018fe02a-f9e5-7176-a870-076f65864891/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3665,7 +3953,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -3678,7 +3966,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:26 GMT
+      - Mon, 03 Jun 2024 22:14:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3698,7 +3986,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ac67f315f00546c496fc89c840a655c9
+      - 9e0d6ce4710b45dcb6b07be458db5a40
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3706,12 +3994,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTU4NjAtN2Rh
-        YS05OTc1LTdhMjk1YmZiYTIyYS8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:26 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJiLTcxNzQtNzBk
+        Yy1hZTY5LWRjZjMwOTgzMjMwMi8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:54 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018f54bd-340a-708d-8104-060b733271b1/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018fe02a-f6a0-7b24-941f-31ac26dcde55/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3719,7 +4007,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -3732,7 +4020,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:26 GMT
+      - Mon, 03 Jun 2024 22:14:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3752,7 +4040,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0cbecd27ebc54290b0885af86e08aff8
+      - 196453abca2045888ac801e258ec7b20
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3760,12 +4048,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGJkLTU4ZmYtNzZl
-        MS1hZDA5LWY2OWJiZDlkMzQ4ZC8ifQ==
-  recorded_at: Tue, 07 May 2024 20:27:26 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlMDJiLTcxZGYtN2Qw
+        NS05YTVjLTJhM2FiOGViZDJhYy8ifQ==
+  recorded_at: Mon, 03 Jun 2024 22:14:54 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54bd-58ff-76e1-ad09-f69bbd9d348d/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe02b-71df-7d05-9a5c-2a3ab8ebd2ac/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3773,7 +4061,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -3786,7 +4074,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:27:26 GMT
+      - Mon, 03 Jun 2024 22:14:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3806,7 +4094,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a3186765db1f413e9dbdbcd3f3d132ff
+      - 262311d4d7e94f3fbbe05daa9e839b7b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3814,23 +4102,23 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0YmQtNThm
-        Zi03NmUxLWFkMDktZjY5YmJkOWQzNDhkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6Mjc6MjYuMzM2MTM2WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDoyNzoyNi4zMzYxNTNaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmUwMmItNzFk
+        Zi03ZDA1LTlhNWMtMmEzYWI4ZWJkMmFjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDNUMjI6MTQ6NTQuNjg4MTYyWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wM1QyMjoxNDo1NC42ODgxNzRaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjBjYmVjZDI3ZWJjNTQyOTBiMDg4
-        NWFmODZlMDhhZmY4IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MjYuMzQ5
-        NTI0WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjI3OjI2LjM5OTk4
-        OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjA6Mjc6MjYuNTkxMTk3
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjE5NjQ1M2FiY2EyMDQ1ODg4YWM4
+        MDFlMjU4ZWM3YjIwIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6NTQuNjk5
+        MjE5WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTAzVDIyOjE0OjU0LjczNzY1
+        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDNUMjI6MTQ6NTQuODY1NDY0
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRiYS04MDE3LTdlMWMtOTUxMS04NmM0YTI0Nzc2ZmEvIiwicGFy
+        cy8wMThmZGZmYy00MTY4LTcwYWMtOGVkMy00ZGM3MDc5NTBjNjIvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmNTRiZC0zNDBhLTcwOGQt
-        ODEwNC0wNjBiNzMzMjcxYjEvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21h
-        aW5zLzAxOGY1NGI5LTNjYzUtN2Y3NS05ZmE5LWVmZGQyMGExZmM4My8iXX0=
-  recorded_at: Tue, 07 May 2024 20:27:26 GMT
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmZTAyYS1mNmEwLTdiMjQt
+        OTQxZi0zMWFjMjZkY2RlNTUvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21h
+        aW5zLzAxOGZkZmZiLTMyNjMtN2VkYi1hMmFhLTljZTkyMDlmOGYwMy8iXX0=
+  recorded_at: Mon, 03 Jun 2024 22:14:54 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_http_proxy_with_no_url.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_http_proxy_with_no_url.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:10 GMT
+      - Wed, 05 Jun 2024 14:35:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e31b115d09f648d9ace47b2d408d526a
+      - 4c35342a5cee47a3ae985c00833f445a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:10 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:09 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:10 GMT
+      - Wed, 05 Jun 2024 14:35:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 61f216dca59947b4ba8c4f0616c90632
+      - 9060a994c1b1461a8eebb2b15d24cfdf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:10 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:09 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -118,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:10 GMT
+      - Wed, 05 Jun 2024 14:35:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c07fdc35ed40400d83ebe10615c7d50b
+      - 6e272aad4b59486782411716eb696c0e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:10 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:09 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -172,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:10 GMT
+      - Wed, 05 Jun 2024 14:35:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0adbfab6fa3d4cfb8bb84983cfde76fd
+      - b09b97ccc89e4e9abb25c1bfd2c5ceb5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:10 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:09 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -234,7 +234,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -247,13 +247,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:11 GMT
+      - Wed, 05 Jun 2024 14:35:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/018f54e2-a687-7cb5-a151-b06053ead1c8/"
+      - "/pulp/api/v3/remotes/rpm/rpm/018fe8d3-4108-7909-917e-9555e6429e47/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -269,7 +269,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fe85db0e3b154731a95072efed6b3311
+      - '0084dd342816407884f27ba1505eaf25'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -278,9 +278,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OGY1NGUyLWE2ODctN2NiNS1hMTUxLWIwNjA1M2VhZDFjOC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjExLjAxNjI0NloiLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MTEuMDE2MjYyWiIsIm5h
+        OGZlOGQzLTQxMDgtNzkwOS05MTdlLTk1NTVlNjQyOWU0Ny8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM1OjA5Ljk2MDc3M1oiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDkuOTYwNzg3WiIsIm5h
         bWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0dHA6Ly9teXJlcG8uY29tIiwi
         Y2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0
         aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwi
@@ -294,7 +294,7 @@ http_interactions:
         ZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InVzZXJuYW1lIiwiaXNfc2V0
         IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfV0s
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:11 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:09 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -307,7 +307,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -320,13 +320,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:11 GMT
+      - Wed, 05 Jun 2024 14:35:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/018f54e2-a719-7cae-8434-a9e762a3bc9a/"
+      - "/pulp/api/v3/repositories/rpm/rpm/018fe8d3-4189-7db1-85d3-9310d5be2b82/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -342,7 +342,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 213b2f47ab684be493c859862b803402
+      - de0f5257f77f40bbae77f7906440b5d7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -351,14 +351,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMDE4ZjU0ZTItYTcxOS03Y2FlLTg0MzQtYTllNzYyYTNiYzlhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MTEuMTYyMzcwWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoxMS4xNjkzMDZa
+        cG0vMDE4ZmU4ZDMtNDE4OS03ZGIxLTg1ZDMtOTMxMGQ1YmUyYjgyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTAuMDkwMDA2WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNToxMC4wOTU3MTZa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wMThmNTRlMi1hNzE5LTdjYWUtODQzNC1hOWU3NjJhM2JjOWEv
+        cnBtL3JwbS8wMThmZThkMy00MTg5LTdkYjEtODVkMy05MzEwZDViZTJiODIv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzAxOGY1
-        NGUyLWE3MTktN2NhZS04NDM0LWE5ZTc2MmEzYmM5YS92ZXJzaW9ucy8wLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzAxOGZl
+        OGQzLTQxODktN2RiMS04NWQzLTkzMTBkNWJlMmI4Mi92ZXJzaW9ucy8wLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -367,7 +367,7 @@ http_interactions:
         Y2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:11 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:10 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -375,13 +375,13 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE4ZjU0ZTItYTcxOS03Y2FlLTg0MzQtYTllNzYyYTNi
-        YzlhL3ZlcnNpb25zLzAvIn0=
+        aWVzL3JwbS9ycG0vMDE4ZmU4ZDMtNDE4OS03ZGIxLTg1ZDMtOTMxMGQ1YmUy
+        YjgyL3ZlcnNpb25zLzAvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -394,7 +394,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:11 GMT
+      - Wed, 05 Jun 2024 14:35:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -414,7 +414,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c1f80bd04a724817bc81df1765d71a08
+      - 3a572d0c2e794381b2fde9d44f09f0f6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -422,12 +422,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWE4NzctNzAx
-        Zi05ZWE4LWMyNjUyNGExOGIwZC8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:11 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTQyYzYtNzFk
+        Yy05NDEzLTZkZmM5NWQ5MTA1ZS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:10 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-a877-701f-9ea8-c26524a18b0d/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-42c6-71dc-9413-6dfc95d9105e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -435,7 +435,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -448,7 +448,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:11 GMT
+      - Wed, 05 Jun 2024 14:35:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -468,7 +468,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 38aaa266e2ad44558e41e3e25cccf250
+      - cc58158f375e461bb7b4f5e89554d8e2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -476,30 +476,30 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItYTg3
-        Ny03MDFmLTllYTgtYzI2NTI0YTE4YjBkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MTEuNTExNDc2WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoxMS41MTE0OTFaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtNDJj
+        Ni03MWRjLTk0MTMtNmRmYzk1ZDkxMDVlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MTAuNDA3MDUwWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNToxMC40MDcwNjNaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnB1Ymxpc2hpbmcu
-        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiYzFmODBiZDA0YTcyNDgxN2JjODFk
-        ZjE3NjVkNzFhMDgiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
-        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMTowODoxMS41MzE2
-        NTVaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MTEuNTg0NjEw
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMTowODoxMS44MTM4NTha
+        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiM2E1NzJkMGMyZTc5NDM4MWIyZmRl
+        OWQ0NGYwOWYwZjYiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
+        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozNToxMC40MTgw
+        NzZaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTAuNDQ5ODIx
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozNToxMC42MDkzNTha
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzAxOGY1NGUwLWE0ZTgtNzQ4Ny05YWEwLTNjM2VjMWExOTlkNy8iLCJwYXJl
+        LzAxOGZlM2NiLTBkZjItN2M4My1hN2VhLWUyNmExYTI4ZDdmOS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJhdGlu
         ZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2VuZXJh
         dGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEs
         ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTIt
-        YThkMi03ZGUwLThlNDgtMGI5MTcyODA5NWVhLyJdLCJyZXNlcnZlZF9yZXNv
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDMt
+        NDMwMS03ZDdkLWI5Y2QtZmU4NWM4NTdmNTZlLyJdLCJyZXNlcnZlZF9yZXNv
         dXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE4ZjU0ZTItYTcxOS03Y2FlLTg0MzQtYTllNzYyYTNi
-        YzlhLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNTRkZi03
-        ZmQyLTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:11 GMT
+        aWVzL3JwbS9ycG0vMDE4ZmU4ZDMtNDE4OS03ZGIxLTg1ZDMtOTMxMGQ1YmUy
+        YjgyLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03
+        MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:35:10 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -510,7 +510,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -523,7 +523,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:12 GMT
+      - Wed, 05 Jun 2024 14:35:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -543,7 +543,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c0f81c640a334ebabefde4aa2205c03f
+      - 578901f10c2a49479b8de33ace6857b3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -553,10 +553,10 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:12 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:10 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-a8d2-7de0-8e48-0b91728095ea/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d3-4301-7d7d-b9cd-fe85c857f56e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -564,7 +564,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -577,7 +577,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:12 GMT
+      - Wed, 05 Jun 2024 14:35:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -597,7 +597,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 852001df43ce4a7f997a1eec9c2b02c0
+      - '07945d2dd9e94ce2b6f00fd447c98d20'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -606,19 +606,19 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItYThkMi03ZGUwLThlNDgtMGI5MTcyODA5NWVhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MTEuNjA0NjU0WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoxMS44MDMxMzFa
+        cG0vMDE4ZmU4ZDMtNDMwMS03ZDdkLWI5Y2QtZmU4NWM4NTdmNTZlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTAuNDY3NTAzWiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNToxMC42MDI1NzRa
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLWE3MTktN2NhZS04NDM0LWE5ZTc2MmEz
-        YmM5YS92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItYTcxOS03Y2FlLTg0MzQt
-        YTllNzYyYTNiYzlhLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQzLTQxODktN2RiMS04NWQzLTkzMTBkNWJl
+        MmI4Mi92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtNDE4OS03ZGIxLTg1ZDMt
+        OTMxMGQ1YmUyYjgyLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:12 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:10 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/
@@ -628,13 +628,13 @@ http_interactions:
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTItYThkMi03ZGUwLThlNDgtMGI5
-        MTcyODA5NWVhLyJ9
+        bGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDMtNDMwMS03ZDdkLWI5Y2QtZmU4
+        NWM4NTdmNTZlLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -647,7 +647,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:12 GMT
+      - Wed, 05 Jun 2024 14:35:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -667,7 +667,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 75b5d058e2e146a0a4e1ef84437999cf
+      - 81fa558f00e14d1a9d2d89723f9cbd43
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -675,12 +675,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWFhZGMtNzU5
-        My04YmEzLThmYjY5NWQwMmM4OC8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:12 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTQ0ODktNzRj
+        Ni05ZjAzLWM1YzY2ZDdjNGQ4YS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:10 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-aadc-7593-8ba3-8fb695d02c88/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-4489-74c6-9f03-c5c66d7c4d8a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -688,7 +688,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -701,7 +701,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:12 GMT
+      - Wed, 05 Jun 2024 14:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -721,7 +721,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f08dd97ca23c4bce91603d7e12252f90
+      - d80a9ad28bce4efaba297caf3971eebf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -729,29 +729,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItYWFk
-        Yy03NTkzLThiYTMtOGZiNjk1ZDAyYzg4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MTIuMTI0NzY5WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoxMi4xMjQ3ODRaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtNDQ4
+        OS03NGM2LTlmMDMtYzVjNjZkN2M0ZDhhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MTAuODU4MjgzWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNToxMC44NTgyOThaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6Ijc1YjVkMDU4ZTJlMTQ2YTBhNGUx
-        ZWY4NDQzNzk5OWNmIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MTIuMTQx
-        NTA3WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjEyLjIwODE0
-        MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MTIuNDk4ODU3
+        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6IjgxZmE1NThmMDBlMTRkMWE5ZDJk
+        ODk3MjNmOWNiZDQzIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTAuODcx
+        NjA0WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjEwLjkxMDUx
+        MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTEuMTY1MzU3
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGU4LTc0ODctOWFhMC0zYzNlYzFhMTk5ZDcvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
-        IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDE4ZjU0
-        ZTItYWMzZS03Njk3LWI3MWQtNzE1ZjAyMDE0NGFiLyJdLCJyZXNlcnZlZF9y
+        IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDE4ZmU4
+        ZDMtNDViMC03NzU3LTlmODMtNDUxOGUxNzY2NDBmLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iLCJz
-        aGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZjU0ZGYtN2ZkMi03NWZh
-        LTliMzUtYzI3NTEzZmY5OGY0LyJdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:12 GMT
+        aGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZmUzYzktNzBhYS03ODgz
+        LWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:11 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-ac3e-7697-b71d-715f020144ab/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-45b0-7757-9f83-4518e176640f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -759,7 +759,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -772,7 +772,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:12 GMT
+      - Wed, 05 Jun 2024 14:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -792,7 +792,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8aac7eb3289640879b793963129624d3
+      - 7239207af41b470b85dca703a8782f17
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -801,9 +801,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzAxOGY1NGUyLWFjM2UtNzY5Ny1iNzFkLTcxNWYwMjAxNDRhYi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjEyLjQ4MDE3OVoiLCJw
-        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MTIuNDgwMTk4
+        cnBtLzAxOGZlOGQzLTQ1YjAtNzc1Ny05ZjgzLTQ1MThlMTc2NjQwZi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM1OjExLjE1MzQ1OVoiLCJw
+        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTEuMTUzNDgw
         WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
         N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
         OS1rYXRlbGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9wdWxwL2Nv
@@ -811,12 +811,12 @@ http_interactions:
         ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJoaWRkZW4iOmZhbHNl
         LCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInJlcG9z
         aXRvcnkiOm51bGwsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1Ymxp
-        Y2F0aW9ucy9ycG0vcnBtLzAxOGY1NGUyLWE4ZDItN2RlMC04ZTQ4LTBiOTE3
-        MjgwOTVlYS8iLCJnZW5lcmF0ZV9yZXBvX2NvbmZpZyI6ZmFsc2V9
-  recorded_at: Tue, 07 May 2024 21:08:12 GMT
+        Y2F0aW9ucy9ycG0vcnBtLzAxOGZlOGQzLTQzMDEtN2Q3ZC1iOWNkLWZlODVj
+        ODU3ZjU2ZS8iLCJnZW5lcmF0ZV9yZXBvX2NvbmZpZyI6ZmFsc2V9
+  recorded_at: Wed, 05 Jun 2024 14:35:11 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018f54e2-a719-7cae-8434-a9e762a3bc9a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018fe8d3-4189-7db1-85d3-9310d5be2b82/
     body:
       encoding: UTF-8
       base64_string: |
@@ -826,7 +826,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -839,7 +839,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:12 GMT
+      - Wed, 05 Jun 2024 14:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -859,7 +859,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8b48a17598094976afe3ff41197806fe
+      - e6769eca23dd4ed0a056894380f0a446
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -867,9 +867,9 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWFlMGQtN2U3
-        YS04ZTIwLWQzMzEyZmVjNzE3ZS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:12 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTQ3MzktN2Ri
+        Ny04MDZmLWM2YzhlZWU4MDRiNC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:11 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -880,7 +880,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -893,7 +893,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:13 GMT
+      - Wed, 05 Jun 2024 14:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -913,7 +913,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f15938a43bde44d1a8e0fd4ee3bc596a
+      - 8a1e1189986d4e24873c1be20a437d5a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -923,23 +923,23 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMDE4ZjU0ZTItYWMzZS03Njk3LWI3MWQtNzE1ZjAyMDE0NGFi
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MTIuNDgwMTc5
-        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoxMi40
-        ODAxOThaIiwiYmFzZV9wYXRoIjoiQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVk
+        L3JwbS9ycG0vMDE4ZmU4ZDMtNDViMC03NzU3LTlmODMtNDUxOGUxNzY2NDBm
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTEuMTUzNDU5
+        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNToxMS4x
+        NTM0ODBaIiwiYmFzZV9wYXRoIjoiQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVk
         b3JhXzE3X2R1cGxpY2F0ZV9sYWJlbCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9j
         ZW50b3M5LWthdGVsbG8tZGV2ZWwubWFuaWNvdHRvLmV4YW1wbGUuY29tL3B1
         bHAvY29udGVudC9BQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
         bGljYXRlX2xhYmVsLyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsImhpZGRlbiI6
         ZmFsc2UsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGljYXRlIiwi
         cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
-        cHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTItYThkMi03ZGUwLThlNDgt
-        MGI5MTcyODA5NWVhLyIsImdlbmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX1d
+        cHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDMtNDMwMS03ZDdkLWI5Y2Qt
+        ZmU4NWM4NTdmNTZlLyIsImdlbmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX1d
         fQ==
-  recorded_at: Tue, 07 May 2024 21:08:13 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:11 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-a8d2-7de0-8e48-0b91728095ea/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d3-4301-7d7d-b9cd-fe85c857f56e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -947,7 +947,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -960,7 +960,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:13 GMT
+      - Wed, 05 Jun 2024 14:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -980,7 +980,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 22d738f9dff849d095de0653404aae9b
+      - bf6ae6b1e8f848d49fb7a567b1510a8e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -989,34 +989,34 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItYThkMi03ZGUwLThlNDgtMGI5MTcyODA5NWVhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MTEuNjA0NjU0WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoxMS44MDMxMzFa
+        cG0vMDE4ZmU4ZDMtNDMwMS03ZDdkLWI5Y2QtZmU4NWM4NTdmNTZlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTAuNDY3NTAzWiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNToxMC42MDI1NzRa
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLWE3MTktN2NhZS04NDM0LWE5ZTc2MmEz
-        YmM5YS92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItYTcxOS03Y2FlLTg0MzQt
-        YTllNzYyYTNiYzlhLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQzLTQxODktN2RiMS04NWQzLTkzMTBkNWJl
+        MmI4Mi92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtNDE4OS03ZGIxLTg1ZDMt
+        OTMxMGQ1YmUyYjgyLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:13 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:11 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-ac3e-7697-b71d-715f020144ab/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-45b0-7757-9f83-4518e176640f/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4
-        ZjU0ZTItYThkMi03ZGUwLThlNDgtMGI5MTcyODA5NWVhLyJ9
+        ZmU4ZDMtNDMwMS03ZDdkLWI5Y2QtZmU4NWM4NTdmNTZlLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1029,7 +1029,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:13 GMT
+      - Wed, 05 Jun 2024 14:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1049,7 +1049,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8f9818edab564334878f20376c560bac
+      - 5d25c9c0542442dc995e4253923947a2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1057,12 +1057,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWFlZjktNzZj
-        MC1hNjRiLWE3ZWQ3NGQxY2U5YS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:13 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTQ4MDMtN2Nm
+        ZS1hMjEyLTdmZjg2YjFhODBlZS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:11 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-aef9-76c0-a64b-a7ed74d1ce9a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-4803-7cfe-a212-7ff86b1a80ee/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1070,7 +1070,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1083,7 +1083,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:13 GMT
+      - Wed, 05 Jun 2024 14:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1103,7 +1103,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 633bf41474d1452f9aec26d51991ac22
+      - bbf4db0f773a44edbc594143da97bc01
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1111,26 +1111,26 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItYWVm
-        OS03NmMwLWE2NGItYTdlZDc0ZDFjZTlhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MTMuMTc4MDI1WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoxMy4xNzgwNDBaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtNDgw
+        My03Y2ZlLWEyMTItN2ZmODZiMWE4MGVlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MTEuNzQ3ODIzWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNToxMS43NDc4MzVaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjhmOTgxOGVkYWI1NjQzMzQ4Nzhm
-        MjAzNzZjNTYwYmFjIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MTMuMTkw
-        MTc5WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjEzLjE5Mjc5
-        MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MTMuMjA4MDUw
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjVkMjVjOWMwNTQyNDQyZGM5OTVl
+        NDI1MzkyMzk0N2EyIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTEuNzU3
+        MjY2WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjExLjc2MDc5
+        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTEuNzc0NTI3
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25z
-        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNTRkZi03ZmQy
-        LTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:13 GMT
+        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFh
+        LTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:35:11 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-a8d2-7de0-8e48-0b91728095ea/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d3-4301-7d7d-b9cd-fe85c857f56e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1138,7 +1138,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1151,7 +1151,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:13 GMT
+      - Wed, 05 Jun 2024 14:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1171,7 +1171,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 27ad110991df44c1afcc123331f602f5
+      - 43ef2882e2fa460e8304a66ac9f47655
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1180,34 +1180,34 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItYThkMi03ZGUwLThlNDgtMGI5MTcyODA5NWVhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MTEuNjA0NjU0WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoxMS44MDMxMzFa
+        cG0vMDE4ZmU4ZDMtNDMwMS03ZDdkLWI5Y2QtZmU4NWM4NTdmNTZlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTAuNDY3NTAzWiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNToxMC42MDI1NzRa
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLWE3MTktN2NhZS04NDM0LWE5ZTc2MmEz
-        YmM5YS92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItYTcxOS03Y2FlLTg0MzQt
-        YTllNzYyYTNiYzlhLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQzLTQxODktN2RiMS04NWQzLTkzMTBkNWJl
+        MmI4Mi92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtNDE4OS03ZGIxLTg1ZDMt
+        OTMxMGQ1YmUyYjgyLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:13 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:11 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-ac3e-7697-b71d-715f020144ab/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-45b0-7757-9f83-4518e176640f/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4
-        ZjU0ZTItYThkMi03ZGUwLThlNDgtMGI5MTcyODA5NWVhLyJ9
+        ZmU4ZDMtNDMwMS03ZDdkLWI5Y2QtZmU4NWM4NTdmNTZlLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1220,7 +1220,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:13 GMT
+      - Wed, 05 Jun 2024 14:35:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1240,7 +1240,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5298314b6b9a4a5e9e0455f32aabe5b4
+      - a82af021e6fd460dba8a1c0543164ed6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1248,12 +1248,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWFmZWMtNzZk
-        OS04OWUwLTBmZWFhYmExZjQ5MS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:13 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTQ4ZGUtNzIz
+        ZC1iNjczLWU4ZGQ0NmYzZDc5YS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:11 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-ac3e-7697-b71d-715f020144ab/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-45b0-7757-9f83-4518e176640f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1261,7 +1261,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1274,7 +1274,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:13 GMT
+      - Wed, 05 Jun 2024 14:35:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1294,7 +1294,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 126121af3d774425bc3c6923e9cd1080
+      - 0b521753a6aa405f8553968f749c5d8a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1302,12 +1302,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWIwNjctNzk2
-        YS1iMTRiLTJkMmY5NWMxNGI4OS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:13 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTQ5NGQtN2U1
+        YS1iMzI1LWVjZDQ1YTIzOTM5OS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:12 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-a687-7cb5-a151-b06053ead1c8/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d3-4108-7909-917e-9555e6429e47/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1315,7 +1315,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1328,7 +1328,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:13 GMT
+      - Wed, 05 Jun 2024 14:35:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1348,7 +1348,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b76bb7577b404a15abbf14e82ff1f4fa
+      - 6411ee2f43ff46fabdebed66703696e8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1356,12 +1356,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWIxNTQtNzBi
-        OC1hZTZjLTliZmUyZDhmMjBjOS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:13 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTRhMWEtNzNh
+        NC05ZGRjLThlMDNhZjRlMzJlMi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:12 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-b154-70b8-ae6c-9bfe2d8f20c9/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-4a1a-73a4-9ddc-8e03af4e32e2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1369,7 +1369,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1382,7 +1382,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:13 GMT
+      - Wed, 05 Jun 2024 14:35:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1402,7 +1402,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ca107e1c514a4fa59e55141a87627add
+      - 4d07888f428c4d9c841a3a5fdf409415
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1410,28 +1410,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItYjE1
-        NC03MGI4LWFlNmMtOWJmZTJkOGYyMGM5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MTMuNzgwOTg0WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoxMy43ODEwMDBaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtNGEx
+        YS03M2E0LTlkZGMtOGUwM2FmNGUzMmUyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MTIuMjgzMjMyWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNToxMi4yODMyNDRaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImI3NmJiNzU3N2I0MDRhMTVhYmJm
-        MTRlODJmZjFmNGZhIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MTMuNzk1
-        ODUxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjEzLjg1MDgz
-        MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MTMuOTIwOTU0
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjY0MTFlZTJmNDNmZjQ2ZmFiZGVi
+        ZWQ2NjcwMzY5NmU4IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTIuMjkz
+        NjA2WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjEyLjMyOTMw
+        M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTIuMzcxMzAx
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGU4LTc0ODctOWFhMC0zYzNlYzFhMTk5ZDcvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVtb3Rlcy9ycG0vcnBtLzAxOGY1NGUyLWE2ODctN2NiNS1hMTUxLWIw
-        NjA1M2VhZDFjOC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4
-        ZjU0ZGYtN2ZkMi03NWZhLTliMzUtYzI3NTEzZmY5OGY0LyJdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:13 GMT
+        djMvcmVtb3Rlcy9ycG0vcnBtLzAxOGZlOGQzLTQxMDgtNzkwOS05MTdlLTk1
+        NTVlNjQyOWU0Ny8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4
+        ZmUzYzktNzBhYS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:12 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018f54e2-a719-7cae-8434-a9e762a3bc9a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018fe8d3-4189-7db1-85d3-9310d5be2b82/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1439,7 +1439,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1452,7 +1452,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:14 GMT
+      - Wed, 05 Jun 2024 14:35:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1472,7 +1472,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c17e8c09fe604f9abeeb989eb9a62121
+      - 256d41fcb3b74ccabeff9bcef05fdebe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1480,12 +1480,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWIyOGUtNzVm
-        NC04ZGZiLWE0NGNlZmE3OTQ4Ni8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:14 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTRiMGUtNzY5
+        Ny1iZjU1LTVkODQwYWYxZTQ4YS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:12 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-b28e-75f4-8dfb-a44cefa79486/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-4b0e-7697-bf55-5d840af1e48a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1493,7 +1493,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1506,7 +1506,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:14 GMT
+      - Wed, 05 Jun 2024 14:35:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1526,7 +1526,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5e6a9bc20bb041acab6ac390d9f9bdaf
+      - 940753b6e24c40a5b6f43156bea2e8c6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1534,25 +1534,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItYjI4
-        ZS03NWY0LThkZmItYTQ0Y2VmYTc5NDg2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MTQuMDk0OTcyWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoxNC4wOTQ5ODdaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtNGIw
+        ZS03Njk3LWJmNTUtNWQ4NDBhZjFlNDhhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MTIuNTI2ODMyWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNToxMi41MjY4NDRaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImMxN2U4YzA5ZmU2MDRmOWFiZWVi
-        OTg5ZWI5YTYyMTIxIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MTQuMTEz
-        NjEyWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjE0LjE3MzM4
-        MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MTQuMzU1MTA2
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjI1NmQ0MWZjYjNiNzRjY2FiZWZm
+        OWJjZWYwNWZkZWJlIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTIuNTM4
+        OTQ1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjEyLjU3MzA0
+        OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTIuNzE2MjY4
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGMxLTcxNzUtYTM3Yi1iNjMzMjI1NWEyMGEvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItYTcxOS03Y2FlLTg0
-        MzQtYTllNzYyYTNiYzlhLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlu
-        cy8wMThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:14 GMT
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtNDE4OS03ZGIxLTg1
+        ZDMtOTMxMGQ1YmUyYjgyLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlu
+        cy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:35:12 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -1563,7 +1563,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1576,7 +1576,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:14 GMT
+      - Wed, 05 Jun 2024 14:35:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1596,7 +1596,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3d778f4c8f974937990eb63d932b3cf1
+      - 9ab1bd0ff859455aa9d972c9907bc223
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1606,7 +1606,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:14 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:12 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
@@ -1617,7 +1617,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.21.3/ruby
+      - OpenAPI-Generator/0.21.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -1630,7 +1630,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:14 GMT
+      - Wed, 05 Jun 2024 14:35:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1650,7 +1650,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cb5635bb96d1443a8fbcb4eaa865705c
+      - 0cb3c5ce3f6f4c49b795b3f727215861
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1660,7 +1660,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:14 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:13 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -1684,7 +1684,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:14 GMT
+      - Wed, 05 Jun 2024 14:35:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1704,7 +1704,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b3c55a6ac15147e69f1eff8aee1ce4f2
+      - f9d05f33e666498aa05e6b0420c3efac
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1714,7 +1714,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:14 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:13 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -1738,7 +1738,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:14 GMT
+      - Wed, 05 Jun 2024 14:35:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1758,7 +1758,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ab63dd3c173a4fe799ff0603a0f3589b
+      - c2286792287447cf8bebc778825160c5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1768,7 +1768,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:14 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:13 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -1779,7 +1779,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1792,7 +1792,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:14 GMT
+      - Wed, 05 Jun 2024 14:35:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1812,7 +1812,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 927f81b5782f48b5b7d64ea46350146a
+      - 6c22e452a2e34e35b658166a8deb091e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1822,7 +1822,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:14 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:13 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -1846,7 +1846,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:14 GMT
+      - Wed, 05 Jun 2024 14:35:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1866,7 +1866,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ae8b9ccb99d1459e96104227ee65937a
+      - 22f3e4c26b874dabaeef38c09f8db5ce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1876,7 +1876,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:14 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:13 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -1900,7 +1900,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:14 GMT
+      - Wed, 05 Jun 2024 14:35:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1920,7 +1920,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 36350f0b54f547bdbf2718e378656ab5
+      - 5420c5cb8ff34b1ab25aea82a3b4f88a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1930,7 +1930,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:14 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:13 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
@@ -1943,7 +1943,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1956,7 +1956,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:15 GMT
+      - Wed, 05 Jun 2024 14:35:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1976,7 +1976,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e2e78dd0109e4c90b64bf64587408f1b
+      - f4cd916c93a04988a8b2c0edd1b22e6c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1984,12 +1984,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWI2MGYtN2Vi
-        Zi04OWZmLWJiZjg0OGYwOTMxNC8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:15 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTRlMWYtNzc0
+        YS1iNWRmLTA0N2JjMzBjMDcyOC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:13 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-b60f-7ebf-89ff-bbf848f09314/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-4e1f-774a-b5df-047bc30c0728/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1997,7 +1997,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2010,7 +2010,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:15 GMT
+      - Wed, 05 Jun 2024 14:35:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2030,7 +2030,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3d334366e64e4a0cbd8d554d37d25464
+      - 453c580654014b048c0382518f422051
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2038,18 +2038,18 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItYjYw
-        Zi03ZWJmLTg5ZmYtYmJmODQ4ZjA5MzE0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MTQuOTkxODAxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoxNC45OTE4MTVaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtNGUx
+        Zi03NzRhLWI1ZGYtMDQ3YmMzMGMwNzI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MTMuMzEyMDMwWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNToxMy4zMTIwNDRaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLm9ycGhhbi5vcnBo
-        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiZTJlNzhkZDAxMDllNGM5MGI2
-        NGJmNjQ1ODc0MDhmMWIiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
-        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMTowODoxNS4w
-        MDYwNjdaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MTUuMDUw
-        NzIxWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMTowODoxNS4yODEx
-        MTFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzAxOGY1NGUwLWE0YzEtNzE3NS1hMzdiLWI2MzMyMjU1YTIwYS8iLCJw
+        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiZjRjZDkxNmM5M2EwNDk4OGE4
+        YjJjMGVkZDFiMjJlNmMiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
+        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozNToxMy4z
+        MjUwMThaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTMuMzYx
+        ODYyWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozNToxMy41MjYx
+        OTZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzAxOGZlM2NiLTBkNDMtNzczMS05ODUyLTg3MjlkMDA4MTk2My8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xlYW4g
         dXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIs
@@ -2059,7 +2059,63 @@ http_interactions:
         ZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
         IjpbIi9hcGkvdjMvb3JwaGFucy9jbGVhbnVwLyIsInNoYXJlZDovcHVscC9h
-        cGkvdjMvZG9tYWlucy8wMThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNm
-        Zjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:15 GMT
+        cGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2Fk
+        MzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:35:13 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/purge/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJmaW5pc2hlZF9iZWZvcmUiOiIzMDAwLTAxLTAxVDAwOjAwOjAwLjAwMCsw
+        MDowMCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:35:13 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - fc2717253fb34f7a9e17854815ef1953
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTRmNTQtN2Vh
+        OC1iNjBmLWY3OGJjYjVjMjcxMy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:13 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_policy.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_policy.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:59 GMT
+      - Wed, 05 Jun 2024 14:35:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3d0068a97c0149eeaa72d6c1529707cf
+      - 5d20d695fabd4ef5b7353d37c713b3de
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:59 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:14 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:59 GMT
+      - Wed, 05 Jun 2024 14:35:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1a42e53821ea408d96cc4de96c316f26
+      - a813b5e95ae84432be30db5a359aaac0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:59 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:14 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -118,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:59 GMT
+      - Wed, 05 Jun 2024 14:35:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 561567353b784e20ad841755b3807013
+      - 1973f55e025c4ffab469ab71623e3700
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:59 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:14 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -172,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:59 GMT
+      - Wed, 05 Jun 2024 14:35:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1a9dfdef37e2452480d8298bba8c87f5
+      - a28c9ff78b204be0bf71089eb71117c9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:59 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:14 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -234,7 +234,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -247,13 +247,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:00 GMT
+      - Wed, 05 Jun 2024 14:35:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/018f54e2-7b92-765e-8feb-6f739a7eb7c9/"
+      - "/pulp/api/v3/remotes/rpm/rpm/018fe8d3-5268-70ef-b9fa-e4e9dc75054e/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -269,7 +269,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e2c247ac31d94b4e83c6e676ecd0e514
+      - 6abba5e4d2ae4a3bbdae4b8889a07652
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -278,9 +278,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OGY1NGUyLTdiOTItNzY1ZS04ZmViLTZmNzM5YTdlYjdjOS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjAwLjAxOTE4NloiLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MDAuMDE5MjAyWiIsIm5h
+        OGZlOGQzLTUyNjgtNzBlZi1iOWZhLWU0ZTlkYzc1MDU0ZS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM1OjE0LjQwOTA4NloiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTQuNDA5MDk4WiIsIm5h
         bWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0dHA6Ly9teXJlcG8uY29tIiwi
         Y2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0
         aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwi
@@ -294,7 +294,7 @@ http_interactions:
         ZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InVzZXJuYW1lIiwiaXNfc2V0
         IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfV0s
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:00 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:14 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -307,7 +307,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -320,13 +320,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:00 GMT
+      - Wed, 05 Jun 2024 14:35:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/018f54e2-7c30-7ca4-aaa0-86378f48f836/"
+      - "/pulp/api/v3/repositories/rpm/rpm/018fe8d3-52f3-75a6-aed4-82e42fcc800a/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -342,7 +342,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5a1cba22c83f4098ac42d93dca9f4ddd
+      - 1f981d18b7c74a55867e2ff90ddb5dd2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -351,14 +351,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMDE4ZjU0ZTItN2MzMC03Y2E0LWFhYTAtODYzNzhmNDhmODM2LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MDAuMTc2OTQzWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODowMC4xODQ1Mjda
+        cG0vMDE4ZmU4ZDMtNTJmMy03NWE2LWFlZDQtODJlNDJmY2M4MDBhLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTQuNTQ4MzIzWiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNToxNC41NTQwNDBa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wMThmNTRlMi03YzMwLTdjYTQtYWFhMC04NjM3OGY0OGY4MzYv
+        cnBtL3JwbS8wMThmZThkMy01MmYzLTc1YTYtYWVkNC04MmU0MmZjYzgwMGEv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzAxOGY1
-        NGUyLTdjMzAtN2NhNC1hYWEwLTg2Mzc4ZjQ4ZjgzNi92ZXJzaW9ucy8wLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzAxOGZl
+        OGQzLTUyZjMtNzVhNi1hZWQ0LTgyZTQyZmNjODAwYS92ZXJzaW9ucy8wLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -367,7 +367,7 @@ http_interactions:
         Y2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:00 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:14 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -375,13 +375,13 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE4ZjU0ZTItN2MzMC03Y2E0LWFhYTAtODYzNzhmNDhm
-        ODM2L3ZlcnNpb25zLzAvIn0=
+        aWVzL3JwbS9ycG0vMDE4ZmU4ZDMtNTJmMy03NWE2LWFlZDQtODJlNDJmY2M4
+        MDBhL3ZlcnNpb25zLzAvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -394,7 +394,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:00 GMT
+      - Wed, 05 Jun 2024 14:35:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -414,7 +414,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 22ef55ac4375407c835c60d675852ec9
+      - 13b910451dc7448b8353099fbd7329fb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -422,12 +422,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTdkOTQtN2Rm
-        Ni1hY2E4LWY3Zjc4YTI4NjNhOS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:00 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTU0MzEtNzAy
+        NS05YmI3LWUzNWQ5NzE0MjI1Zi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:14 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-7d94-7df6-aca8-f7f78a2863a9/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-5431-7025-9bb7-e35d9714225f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -435,7 +435,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -448,7 +448,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:00 GMT
+      - Wed, 05 Jun 2024 14:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -468,7 +468,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 455671b3796345ff898dde77b99c08d1
+      - a15460afbca74adb939f47a2186b21e6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -476,30 +476,30 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItN2Q5
-        NC03ZGY2LWFjYTgtZjdmNzhhMjg2M2E5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MDAuNTMyNjcxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODowMC41MzI2ODZaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtNTQz
+        MS03MDI1LTliYjctZTM1ZDk3MTQyMjVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MTQuODY1OTQ0WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNToxNC44NjYwNzFaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnB1Ymxpc2hpbmcu
-        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiMjJlZjU1YWM0Mzc1NDA3YzgzNWM2
-        MGQ2NzU4NTJlYzkiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
-        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMTowODowMC41NTM4
-        MTVaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDAuNjEyOTUx
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMTowODowMC44NTIzMDNa
+        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiMTNiOTEwNDUxZGM3NDQ4YjgzNTMw
+        OTlmYmQ3MzI5ZmIiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
+        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozNToxNC44Nzg2
+        MjNaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTQuOTE2NDkw
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozNToxNS4wNzU2Mjda
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzAxOGY1NGUwLWE0YzEtNzE3NS1hMzdiLWI2MzMyMjU1YTIwYS8iLCJwYXJl
+        LzAxOGZlM2NiLTBkZjItN2M4My1hN2VhLWUyNmExYTI4ZDdmOS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJhdGlu
         ZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2VuZXJh
         dGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEs
         ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTIt
-        N2RmZi03MTE0LWEyMTgtNzVhNDJmOWJkMzgzLyJdLCJyZXNlcnZlZF9yZXNv
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDMt
+        NTQ3My03ZDM0LWE3YWItZTE4ZThiMjFlNDc4LyJdLCJyZXNlcnZlZF9yZXNv
         dXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE4ZjU0ZTItN2MzMC03Y2E0LWFhYTAtODYzNzhmNDhm
-        ODM2LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNTRkZi03
-        ZmQyLTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:00 GMT
+        aWVzL3JwbS9ycG0vMDE4ZmU4ZDMtNTJmMy03NWE2LWFlZDQtODJlNDJmY2M4
+        MDBhLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03
+        MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:35:15 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -510,7 +510,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -523,7 +523,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:01 GMT
+      - Wed, 05 Jun 2024 14:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -543,7 +543,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 549d5662de52450c87a006e05c2785c5
+      - 813541d55fe24199a918314d4fd94f5b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -553,10 +553,10 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:01 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:15 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-7dff-7114-a218-75a42f9bd383/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d3-5473-7d34-a7ab-e18e8b21e478/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -564,7 +564,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -577,7 +577,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:01 GMT
+      - Wed, 05 Jun 2024 14:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -597,7 +597,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8e3338ac66214779b00e4229b792104c
+      - 0646661a211a4739bef7784f28926551
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -606,19 +606,19 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItN2RmZi03MTE0LWEyMTgtNzVhNDJmOWJkMzgzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MDAuNjQyMTY5WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODowMC44NDE5MDVa
+        cG0vMDE4ZmU4ZDMtNTQ3My03ZDM0LWE3YWItZTE4ZThiMjFlNDc4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTQuOTMyNzI5WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNToxNS4wNzA1NDJa
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLTdjMzAtN2NhNC1hYWEwLTg2Mzc4ZjQ4
-        ZjgzNi92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItN2MzMC03Y2E0LWFhYTAt
-        ODYzNzhmNDhmODM2LyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQzLTUyZjMtNzVhNi1hZWQ0LTgyZTQyZmNj
+        ODAwYS92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtNTJmMy03NWE2LWFlZDQt
+        ODJlNDJmY2M4MDBhLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:01 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:15 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/
@@ -628,13 +628,13 @@ http_interactions:
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTItN2RmZi03MTE0LWEyMTgtNzVh
-        NDJmOWJkMzgzLyJ9
+        bGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDMtNTQ3My03ZDM0LWE3YWItZTE4
+        ZThiMjFlNDc4LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -647,7 +647,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:01 GMT
+      - Wed, 05 Jun 2024 14:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -667,7 +667,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cf0b9cbb84374fc2bd0d0cc2adb991b5
+      - 6612c4cc57504818be18f54a404df1d9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -675,12 +675,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTgwMWUtN2M2
-        ZC1iNzU3LTNiZWY2Nzg4YTExNy8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:01 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTU1ZjctNzZl
+        Yi1iOGY0LWJmYTdmOTQ0YzQwNC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:15 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-801e-7c6d-b757-3bef6788a117/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-55f7-76eb-b8f4-bfa7f944c404/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -688,7 +688,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -701,7 +701,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:01 GMT
+      - Wed, 05 Jun 2024 14:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -721,7 +721,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9e63b168701042a590e675fe846a486a
+      - 23cfb0927aa043008d297fbddc3baec1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -729,29 +729,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItODAx
-        ZS03YzZkLWI3NTctM2JlZjY3ODhhMTE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MDEuMTgzMzgxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODowMS4xODM0MDhaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtNTVm
+        Ny03NmViLWI4ZjQtYmZhN2Y5NDRjNDA0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MTUuMzIwMTI1WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNToxNS4zMjAxMzhaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6ImNmMGI5Y2JiODQzNzRmYzJiZDBk
-        MGNjMmFkYjk5MWI1IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDEuMjAw
-        ODY5WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjAxLjI2MDEy
-        NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDEuNTg0NDEy
+        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6IjY2MTJjNGNjNTc1MDQ4MThiZTE4
+        ZjU0YTQwNGRmMWQ5IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTUuMzMx
+        MzI0WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjE1LjM2NjE1
+        OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTUuNTg2MzQ2
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGMxLTcxNzUtYTM3Yi1iNjMzMjI1NWEyMGEvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
-        IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDE4ZjU0
-        ZTItODE5Zi03NGVmLTlkNjctMzY4MTRmMGJmYWFjLyJdLCJyZXNlcnZlZF9y
+        IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDE4ZmU4
+        ZDMtNTZmNS03ZDM2LWIzMzItYzE1MzMyYjZkZDQ0LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iLCJz
-        aGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZjU0ZGYtN2ZkMi03NWZh
-        LTliMzUtYzI3NTEzZmY5OGY0LyJdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:01 GMT
+        aGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZmUzYzktNzBhYS03ODgz
+        LWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:15 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-819f-74ef-9d67-36814f0bfaac/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-56f5-7d36-b332-c15332b6dd44/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -759,7 +759,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -772,7 +772,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:01 GMT
+      - Wed, 05 Jun 2024 14:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -792,7 +792,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e16a56edb2ad4494ae93bc0fbc14bc53
+      - 487782f9f1cc476c8078bfde9e3491e6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -801,9 +801,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzAxOGY1NGUyLTgxOWYtNzRlZi05ZDY3LTM2ODE0ZjBiZmFhYy8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjAxLjU2ODY3M1oiLCJw
-        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MDEuNTY4Njkw
+        cnBtLzAxOGZlOGQzLTU2ZjUtN2QzNi1iMzMyLWMxNTMzMmI2ZGQ0NC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM1OjE1LjU3NDM5MVoiLCJw
+        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTUuNTc0NDA4
         WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
         N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
         OS1rYXRlbGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9wdWxwL2Nv
@@ -811,9 +811,9 @@ http_interactions:
         ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJoaWRkZW4iOmZhbHNl
         LCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInJlcG9z
         aXRvcnkiOm51bGwsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1Ymxp
-        Y2F0aW9ucy9ycG0vcnBtLzAxOGY1NGUyLTdkZmYtNzExNC1hMjE4LTc1YTQy
-        ZjliZDM4My8iLCJnZW5lcmF0ZV9yZXBvX2NvbmZpZyI6ZmFsc2V9
-  recorded_at: Tue, 07 May 2024 21:08:01 GMT
+        Y2F0aW9ucy9ycG0vcnBtLzAxOGZlOGQzLTU0NzMtN2QzNC1hN2FiLWUxOGU4
+        YjIxZTQ3OC8iLCJnZW5lcmF0ZV9yZXBvX2NvbmZpZyI6ZmFsc2V9
+  recorded_at: Wed, 05 Jun 2024 14:35:15 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -835,7 +835,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -848,13 +848,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:01 GMT
+      - Wed, 05 Jun 2024 14:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/018f54e2-82d7-75bb-8f4d-23fe0a382cd2/"
+      - "/pulp/api/v3/remotes/rpm/rpm/018fe8d3-5815-7e16-a91a-0745ea262709/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -870,7 +870,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ad4e4f8c4adc48a0b1a58ffefa3d331b
+      - 2f0407f769f741f09da83725e9db8784
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -879,9 +879,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OGY1NGUyLTgyZDctNzViYi04ZjRkLTIzZmUwYTM4MmNkMi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjAxLjg3OTk5MFoiLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MDEuODgwMDAzWiIsIm5h
+        OGZlOGQzLTU4MTUtN2UxNi1hOTFhLTA3NDVlYTI2MjcwOS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM1OjE1Ljg2MjAyNFoiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTUuODYyMDM3WiIsIm5h
         bWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJsIjoiaHR0cDovL215cmVwby5j
         b20iLCJjYV9jZXJ0IjoiS0pMOktERiooREYmKigqJCYoKiMkSkxLSkQoRCgo
         RCIsImNsaWVudF9jZXJ0IjoiS0pMOktERiooREYmKigqJCYoKiMkSkxLSkQo
@@ -896,10 +896,10 @@ http_interactions:
         bWUiOiJwcm94eV9wYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6
         InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfV0sInNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:01 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:15 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-82d7-75bb-8f4d-23fe0a382cd2/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d3-5815-7e16-a91a-0745ea262709/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -907,7 +907,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -920,7 +920,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:01 GMT
+      - Wed, 05 Jun 2024 14:35:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -940,7 +940,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9ecc7690695c4699ae60c880da1f3146
+      - 1e5b95547c77435bb142dad4fa53ebca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -948,12 +948,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTgzMTgtNzZj
-        ZS04NjAwLTA0OTVjNmQxYzBmNi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:01 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTU4NGUtNzUx
+        Ny1iM2QxLTQ0YzEyZTAyYTQ4NC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:15 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018f54e2-7c30-7ca4-aaa0-86378f48f836/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018fe8d3-52f3-75a6-aed4-82e42fcc800a/
     body:
       encoding: UTF-8
       base64_string: |
@@ -963,7 +963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -976,7 +976,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:02 GMT
+      - Wed, 05 Jun 2024 14:35:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -996,7 +996,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '0794ee71ada24c2b893024351aed90cc'
+      - 9c8bd20744ef40c980239705874ac8ca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1004,12 +1004,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTgzZTQtNzZm
-        Ni05ZmU3LWZlMzk4ZTQyZmQ2Mi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:02 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTU4ZmUtNzQw
+        Ni05MjQ3LTliZDA2N2IxMWI1My8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:16 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-7b92-765e-8feb-6f739a7eb7c9/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d3-5268-70ef-b9fa-e4e9dc75054e/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1028,7 +1028,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1041,7 +1041,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:02 GMT
+      - Wed, 05 Jun 2024 14:35:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1061,7 +1061,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a42cd1923a194597aa22cfb47739db1c
+      - c04415bdfc2c4719840fd5b6178fb13a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1069,12 +1069,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTg0NWEtNzFl
-        NC04Njk3LTNhNTc1MTI0ZWYyNi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:02 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTU5NjgtNzdj
+        Yi1hOWIyLWYzYjBhMTY0MWI3ZC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:16 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-845a-71e4-8697-3a575124ef26/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-5968-77cb-a9b2-f3b0a1641b7d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1082,7 +1082,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1095,7 +1095,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:02 GMT
+      - Wed, 05 Jun 2024 14:35:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1115,7 +1115,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6fc5dbdb8d3b4caeaad45d0f83c08e60
+      - 9f4c0c6b4757473d90c027ceced76f8e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1123,24 +1123,24 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItODQ1
-        YS03MWU0LTg2OTctM2E1NzUxMjRlZjI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MDIuMjY2NDkyWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODowMi4yNjY1MDZaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtNTk2
+        OC03N2NiLWE5YjItZjNiMGExNjQxYjdkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MTYuMjAxMjk5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNToxNi4yMDEzMTNaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6ImE0MmNkMTkyM2ExOTQ1OTdhYTIy
-        Y2ZiNDc3MzlkYjFjIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDIuMjc4
-        MTcwWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjAyLjI4MTgz
-        MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDIuMjk0MTQ1
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6ImMwNDQxNWJkZmMyYzQ3MTk4NDBm
+        ZDViNjE3OGZiMTNhIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTYuMjEz
+        MzUxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjE2LjIxNTg3
+        MloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTYuMjI1MzA1
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMv
-        cnBtL3JwbS8wMThmNTRlMi03YjkyLTc2NWUtOGZlYi02ZjczOWE3ZWI3Yzkv
-        Iiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGY1NGRmLTdmZDIt
-        NzVmYS05YjM1LWMyNzUxM2ZmOThmNC8iXX0=
-  recorded_at: Tue, 07 May 2024 21:08:02 GMT
+        cnBtL3JwbS8wMThmZThkMy01MjY4LTcwZWYtYjlmYS1lNGU5ZGM3NTA1NGUv
+        Iiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGZlM2M5LTcwYWEt
+        Nzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:35:16 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -1151,7 +1151,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1164,7 +1164,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:02 GMT
+      - Wed, 05 Jun 2024 14:35:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1184,7 +1184,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8ec938c986024032b11e73e5708883b3
+      - 603f8b39d5c746bb86927366d10990a0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1194,23 +1194,23 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMDE4ZjU0ZTItODE5Zi03NGVmLTlkNjctMzY4MTRmMGJmYWFj
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MDEuNTY4Njcz
-        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODowMS41
-        Njg2OTBaIiwiYmFzZV9wYXRoIjoiQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVk
+        L3JwbS9ycG0vMDE4ZmU4ZDMtNTZmNS03ZDM2LWIzMzItYzE1MzMyYjZkZDQ0
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTUuNTc0Mzkx
+        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNToxNS41
+        NzQ0MDhaIiwiYmFzZV9wYXRoIjoiQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVk
         b3JhXzE3X2R1cGxpY2F0ZV9sYWJlbCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9j
         ZW50b3M5LWthdGVsbG8tZGV2ZWwubWFuaWNvdHRvLmV4YW1wbGUuY29tL3B1
         bHAvY29udGVudC9BQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
         bGljYXRlX2xhYmVsLyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsImhpZGRlbiI6
         ZmFsc2UsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGljYXRlIiwi
         cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
-        cHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTItN2RmZi03MTE0LWEyMTgt
-        NzVhNDJmOWJkMzgzLyIsImdlbmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX1d
+        cHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDMtNTQ3My03ZDM0LWE3YWIt
+        ZTE4ZThiMjFlNDc4LyIsImdlbmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX1d
         fQ==
-  recorded_at: Tue, 07 May 2024 21:08:02 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:16 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-7dff-7114-a218-75a42f9bd383/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d3-5473-7d34-a7ab-e18e8b21e478/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1218,7 +1218,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1231,7 +1231,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:02 GMT
+      - Wed, 05 Jun 2024 14:35:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1251,7 +1251,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 383868d61c914783aca4264b6b88ef88
+      - 57236ec82ea64066a0ecaf2fcc8d7150
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1260,34 +1260,34 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItN2RmZi03MTE0LWEyMTgtNzVhNDJmOWJkMzgzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MDAuNjQyMTY5WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODowMC44NDE5MDVa
+        cG0vMDE4ZmU4ZDMtNTQ3My03ZDM0LWE3YWItZTE4ZThiMjFlNDc4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTQuOTMyNzI5WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNToxNS4wNzA1NDJa
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLTdjMzAtN2NhNC1hYWEwLTg2Mzc4ZjQ4
-        ZjgzNi92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItN2MzMC03Y2E0LWFhYTAt
-        ODYzNzhmNDhmODM2LyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQzLTUyZjMtNzVhNi1hZWQ0LTgyZTQyZmNj
+        ODAwYS92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtNTJmMy03NWE2LWFlZDQt
+        ODJlNDJmY2M4MDBhLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:02 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:16 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-819f-74ef-9d67-36814f0bfaac/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-56f5-7d36-b332-c15332b6dd44/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4
-        ZjU0ZTItN2RmZi03MTE0LWEyMTgtNzVhNDJmOWJkMzgzLyJ9
+        ZmU4ZDMtNTQ3My03ZDM0LWE3YWItZTE4ZThiMjFlNDc4LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1300,7 +1300,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:02 GMT
+      - Wed, 05 Jun 2024 14:35:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1320,7 +1320,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5189022a589349dcae604d59cf0d35ac
+      - 6243eaaabada486ebed98e71f4a4a44e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1328,12 +1328,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTg1OGMtNzM5
-        Ni04YjBmLTJhZjBjZjVjMzA0Ni8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:02 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTVhNzAtNzEx
+        ZS1hYTkzLWM5NTE4OWQxZmY3YS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:16 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-858c-7396-8b0f-2af0cf5c3046/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-5a70-711e-aa93-c95189d1ff7a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1341,7 +1341,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1354,7 +1354,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:02 GMT
+      - Wed, 05 Jun 2024 14:35:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,7 +1374,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 900ddc1ccafd4af9b2c6d35510ee390e
+      - aabcb4ea91484ca086d229444a265dae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1382,26 +1382,26 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItODU4
-        Yy03Mzk2LThiMGYtMmFmMGNmNWMzMDQ2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MDIuNTcyODQ3WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODowMi41NzI4NjJaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtNWE3
+        MC03MTFlLWFhOTMtYzk1MTg5ZDFmZjdhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MTYuNDY0NjE4WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNToxNi40NjQ2MzFaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjUxODkwMjJhNTg5MzQ5ZGNhZTYw
-        NGQ1OWNmMGQzNWFjIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDIuNTgz
-        MDQ2WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjAyLjU4NTU3
-        N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDIuNjAzNzc3
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjYyNDNlYWFhYmFkYTQ4NmViZWQ5
+        OGU3MWY0YTRhNDRlIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTYuNDc0
+        NzA2WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjE2LjQ3NzI0
+        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTYuNDkyMDA3
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25z
-        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNTRkZi03ZmQy
-        LTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:02 GMT
+        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFh
+        LTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:35:16 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-7dff-7114-a218-75a42f9bd383/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d3-5473-7d34-a7ab-e18e8b21e478/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1409,7 +1409,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1422,7 +1422,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:02 GMT
+      - Wed, 05 Jun 2024 14:35:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1442,7 +1442,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4221455857194d7796d891535c4b6214
+      - 4cb7d42b6f734ee3972fe91a1ef47309
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1451,34 +1451,34 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItN2RmZi03MTE0LWEyMTgtNzVhNDJmOWJkMzgzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MDAuNjQyMTY5WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODowMC44NDE5MDVa
+        cG0vMDE4ZmU4ZDMtNTQ3My03ZDM0LWE3YWItZTE4ZThiMjFlNDc4LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTQuOTMyNzI5WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNToxNS4wNzA1NDJa
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLTdjMzAtN2NhNC1hYWEwLTg2Mzc4ZjQ4
-        ZjgzNi92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItN2MzMC03Y2E0LWFhYTAt
-        ODYzNzhmNDhmODM2LyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQzLTUyZjMtNzVhNi1hZWQ0LTgyZTQyZmNj
+        ODAwYS92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtNTJmMy03NWE2LWFlZDQt
+        ODJlNDJmY2M4MDBhLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:02 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:16 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-819f-74ef-9d67-36814f0bfaac/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-56f5-7d36-b332-c15332b6dd44/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4
-        ZjU0ZTItN2RmZi03MTE0LWEyMTgtNzVhNDJmOWJkMzgzLyJ9
+        ZmU4ZDMtNTQ3My03ZDM0LWE3YWItZTE4ZThiMjFlNDc4LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1491,7 +1491,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:02 GMT
+      - Wed, 05 Jun 2024 14:35:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1511,7 +1511,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7d620d1e2635411a99938b9376135059
+      - 0a2382eb6fa04e04bf1ba9bebf2dadce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1519,9 +1519,9 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTg2ODQtNzNk
-        Ny04YWQ3LTIzMDFjYWM5MGU1Ni8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:02 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTViNTItNzY0
+        MC1hMmI0LTA5NDRmMTdjY2RkOC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:16 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -1532,7 +1532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1545,7 +1545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:02 GMT
+      - Wed, 05 Jun 2024 14:35:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1565,7 +1565,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 51f3514c955043468fc4ea9d589f7152
+      - ad6974fbbb2f40809dde504e97fb3f0c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1575,9 +1575,9 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vMDE4ZjU0ZTItN2I5Mi03NjVlLThmZWItNmY3MzlhN2ViN2M5LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MDAuMDE5MTg2WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODowMi4yODg3MDJa
+        cG0vMDE4ZmU4ZDMtNTI2OC03MGVmLWI5ZmEtZTRlOWRjNzUwNTRlLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTQuNDA5MDg2WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNToxNi4yMjE2NzVa
         IiwibmFtZSI6IjJfZHVwbGljYXRlIiwidXJsIjoiaHR0cDovL215cmVwby5j
         b20iLCJjYV9jZXJ0IjoiS0pMOktERiooREYmKigqJCYoKiMkSkxLSkQoRCgo
         RCIsImNsaWVudF9jZXJ0IjoiS0pMOktERiooREYmKigqJCYoKiMkSkxLSkQo
@@ -1592,10 +1592,10 @@ http_interactions:
         bWUiOiJwcm94eV9wYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6
         InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfV0sInNsZXNfYXV0aF90b2tlbiI6bnVsbH1dfQ==
-  recorded_at: Tue, 07 May 2024 21:08:02 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:16 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-819f-74ef-9d67-36814f0bfaac/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-56f5-7d36-b332-c15332b6dd44/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1603,7 +1603,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1616,7 +1616,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:03 GMT
+      - Wed, 05 Jun 2024 14:35:16 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1636,7 +1636,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6fdb5dd141924d7ca6401f70ed915939
+      - edae3891661c48a9a6496e22d7e2e359
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1644,12 +1644,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTg3M2QtN2Zh
-        OS05YmJkLTE3ZTExYmQ0NWY2NS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:03 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTViZjItN2Yy
+        YS1iMjUxLWNiZjU5YTlmYzI2OS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:16 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-7b92-765e-8feb-6f739a7eb7c9/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d3-5268-70ef-b9fa-e4e9dc75054e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1657,7 +1657,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1670,7 +1670,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:03 GMT
+      - Wed, 05 Jun 2024 14:35:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1690,7 +1690,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a8b175b2f4174a2eb1657b61bd5cf269
+      - 6b7b689096084c2095e5315898940bb2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1698,12 +1698,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTg4MzUtNzc1
-        Ny04MzNhLTgxZjM0NDk2OGQ2OC8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:03 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTVjYmMtN2Zh
+        Ny05YWZmLTc4Y2FjM2U4ZWE1MS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:17 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-8835-7757-833a-81f344968d68/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-5cbc-7fa7-9aff-78cac3e8ea51/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1711,7 +1711,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1724,7 +1724,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:03 GMT
+      - Wed, 05 Jun 2024 14:35:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1744,7 +1744,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 83544c8d51a94f5ba0a2c4fe3c82fe3b
+      - 171bb6efc62f4fcabaaf7716ccee99aa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1752,28 +1752,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItODgz
-        NS03NzU3LTgzM2EtODFmMzQ0OTY4ZDY4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MDMuMjU0MjEyWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODowMy4yNTQyMjZaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtNWNi
+        Yy03ZmE3LTlhZmYtNzhjYWMzZThlYTUxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MTcuMDUyOTUzWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNToxNy4wNTI5NzhaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImE4YjE3NWIyZjQxNzRhMmViMTY1
-        N2I2MWJkNWNmMjY5IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDMuMjY2
-        NTI1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjAzLjMzNDI2
-        MloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDMuMzkzNjE3
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjZiN2I2ODkwOTYwODRjMjA5NWU1
+        MzE1ODk4OTQwYmIyIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTcuMDYz
+        MTcxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjE3LjA5NTE0
+        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTcuMTM0Mjk4
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGMxLTcxNzUtYTM3Yi1iNjMzMjI1NWEyMGEvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVtb3Rlcy9ycG0vcnBtLzAxOGY1NGUyLTdiOTItNzY1ZS04ZmViLTZm
-        NzM5YTdlYjdjOS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4
-        ZjU0ZGYtN2ZkMi03NWZhLTliMzUtYzI3NTEzZmY5OGY0LyJdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:03 GMT
+        djMvcmVtb3Rlcy9ycG0vcnBtLzAxOGZlOGQzLTUyNjgtNzBlZi1iOWZhLWU0
+        ZTlkYzc1MDU0ZS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4
+        ZmUzYzktNzBhYS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:17 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018f54e2-7c30-7ca4-aaa0-86378f48f836/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018fe8d3-52f3-75a6-aed4-82e42fcc800a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1781,7 +1781,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1794,7 +1794,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:03 GMT
+      - Wed, 05 Jun 2024 14:35:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1814,7 +1814,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e6b3ced156f94b31880e3d7db0cf4102
+      - 72d15677ab9d49c5847d555c670ff475
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1822,12 +1822,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTg5NWUtNzY3
-        OS04N2IzLWUyNjkwMmUyYWQxNS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:03 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTVkYjctNzFk
+        NS04NjY4LWE3MWQ3NjI0OWMyZS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:17 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-895e-7679-87b3-e26902e2ad15/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-5db7-71d5-8668-a71d76249c2e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1835,7 +1835,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1848,7 +1848,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:03 GMT
+      - Wed, 05 Jun 2024 14:35:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1868,7 +1868,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d5466360c62042df917100d1fe1449a9
+      - 2354678b87a949038217a88280a3f158
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1876,25 +1876,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItODk1
-        ZS03Njc5LTg3YjMtZTI2OTAyZTJhZDE1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MDMuNTUwNDk4WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODowMy41NTA1MTRaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtNWRi
+        Ny03MWQ1LTg2NjgtYTcxZDc2MjQ5YzJlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MTcuMzAzNDI2WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNToxNy4zMDM0MzlaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImU2YjNjZWQxNTZmOTRiMzE4ODBl
-        M2Q3ZGIwY2Y0MTAyIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDMuNTYz
-        Mjc5WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjAzLjYwOTE5
-        MloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDMuNzk5ODc0
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjcyZDE1Njc3YWI5ZDQ5YzU4NDdk
+        NTU1YzY3MGZmNDc1IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTcuMzE0
+        MTUzWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjE3LjM1MTg2
+        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTcuNDg3MzEy
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGU4LTc0ODctOWFhMC0zYzNlYzFhMTk5ZDcvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItN2MzMC03Y2E0LWFh
-        YTAtODYzNzhmNDhmODM2LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlu
-        cy8wMThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:03 GMT
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtNTJmMy03NWE2LWFl
+        ZDQtODJlNDJmY2M4MDBhLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlu
+        cy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:35:17 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -1905,7 +1905,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1918,7 +1918,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:04 GMT
+      - Wed, 05 Jun 2024 14:35:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1938,7 +1938,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 00b6da36ead6429a952356e99797aafc
+      - '097fb0d5f5a546cd80c9fc14d3b60eca'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1948,7 +1948,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:04 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:17 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
@@ -1959,7 +1959,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.21.3/ruby
+      - OpenAPI-Generator/0.21.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -1972,7 +1972,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:04 GMT
+      - Wed, 05 Jun 2024 14:35:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1992,7 +1992,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 423bb6046a934427a813ffb6028e88f0
+      - 30a38017f89d4fbd9b6055bdf4afceb3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2002,7 +2002,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:04 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:17 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -2026,7 +2026,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:04 GMT
+      - Wed, 05 Jun 2024 14:35:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2046,7 +2046,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2aed6865dd664b7a993c56f59a073374
+      - 8041280539114dcbbbae5f1a64b6cd65
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2056,7 +2056,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:04 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:17 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -2080,7 +2080,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:04 GMT
+      - Wed, 05 Jun 2024 14:35:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2100,7 +2100,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b2f4f4ffcbdf402a81544399d4266175
+      - 862126b9505b4ae88a991dd30c9ed225
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2110,7 +2110,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:04 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:17 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -2121,7 +2121,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2134,7 +2134,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:04 GMT
+      - Wed, 05 Jun 2024 14:35:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2154,7 +2154,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 14bfe97dc32c4be9a260dabc329c79fa
+      - 57d35c102a7f4816ad6b4f80a9609189
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2164,7 +2164,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:04 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:17 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -2188,7 +2188,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:04 GMT
+      - Wed, 05 Jun 2024 14:35:17 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2208,7 +2208,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7d0d085e2c094a5e9e16ec59050ee984
+      - b9613a1ee268471088ec444bf38eeb1d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2218,7 +2218,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:04 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:17 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -2242,7 +2242,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:04 GMT
+      - Wed, 05 Jun 2024 14:35:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2262,7 +2262,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a0854d37e1e4480fb2eba71716b3b547
+      - 118198d5d1e04bf5aace20524e6bc80a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2272,7 +2272,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:04 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:18 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
@@ -2285,7 +2285,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2298,7 +2298,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:04 GMT
+      - Wed, 05 Jun 2024 14:35:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2318,7 +2318,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9395f9868ef1471b88dee8b70b300ed8
+      - 67fecc54d2fe407c9e04aa8cf88e8b42
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2326,12 +2326,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLThjY2EtN2Qz
-        OS04NmEwLTFjYWQ0MjgyMmEyYy8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:04 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTYwZGUtN2Nl
+        OC05YzI2LWM5NzA5ZWY4NzdkNy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:18 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-8cca-7d39-86a0-1cad42822a2c/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-60de-7ce8-9c26-c9709ef877d7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2339,7 +2339,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2352,7 +2352,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:04 GMT
+      - Wed, 05 Jun 2024 14:35:18 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2372,7 +2372,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 542d20bf72d74811850a6b8cab895630
+      - d7c197e6a53042d4a5272791acbc0e70
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2380,18 +2380,18 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItOGNj
-        YS03ZDM5LTg2YTAtMWNhZDQyODIyYTJjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MDQuNDI3NDg4WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODowNC40Mjc1MDJaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtNjBk
+        ZS03Y2U4LTljMjYtYzk3MDllZjg3N2Q3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MTguMTExMTI5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNToxOC4xMTExNDNaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLm9ycGhhbi5vcnBo
-        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiOTM5NWY5ODY4ZWYxNDcxYjg4
-        ZGVlOGI3MGIzMDBlZDgiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
-        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMTowODowNC40
-        NDAyNzlaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDQuNDg0
-        ODM4WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMTowODowNC42ODQy
-        MjVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzAxOGY1NGUwLWE0YzEtNzE3NS1hMzdiLWI2MzMyMjU1YTIwYS8iLCJw
+        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiNjdmZWNjNTRkMmZlNDA3Yzll
+        MDRhYThjZjg4ZThiNDIiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
+        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozNToxOC4x
+        MjI2NzhaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MTguMTU2
+        NzQ3WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozNToxOC4zMTY3
+        MDlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzAxOGZlM2NiLTBkNDMtNzczMS05ODUyLTg3MjlkMDA4MTk2My8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xlYW4g
         dXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIs
@@ -2401,7 +2401,63 @@ http_interactions:
         ZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
         IjpbIi9hcGkvdjMvb3JwaGFucy9jbGVhbnVwLyIsInNoYXJlZDovcHVscC9h
-        cGkvdjMvZG9tYWlucy8wMThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNm
-        Zjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:04 GMT
+        cGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2Fk
+        MzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:35:18 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/purge/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJmaW5pc2hlZF9iZWZvcmUiOiIzMDAwLTAxLTAxVDAwOjAwOjAwLjAwMCsw
+        MDowMCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:35:18 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - f6c6b795091e498c9e4ff3fecbf5993c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTYyMTgtNzMz
+        YS1iNThkLWU5YzJjOTdiZWU5MS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:18 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_set_unprotected.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_set_unprotected.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:22 GMT
+      - Wed, 05 Jun 2024 14:34:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - dc530fbb105447d588c1fedc7c2b4608
+      - 3ac06117d2b84b96bb284faa08ea8c95
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:22 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:53 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:23 GMT
+      - Wed, 05 Jun 2024 14:34:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a0dbf8f89c634ddcb05bf3ea0f9fca81
+      - 7ed8b441eb624e1ca63b312685735fce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:23 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:53 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -118,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:23 GMT
+      - Wed, 05 Jun 2024 14:34:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '0609e4cf7bce4b0fb2160d7107299f23'
+      - 1b437e39c29149ca977d469c51e4597e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:23 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:54 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -172,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:23 GMT
+      - Wed, 05 Jun 2024 14:34:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9a87eb629a4e4da2a52c61922caf7f44
+      - fe0f9ed96de94f3c9cd1b4e93f3fd835
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:23 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:54 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -234,7 +234,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -247,13 +247,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:23 GMT
+      - Wed, 05 Jun 2024 14:34:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/018f54e2-d6d9-74ca-bd8f-33483dc31150/"
+      - "/pulp/api/v3/remotes/rpm/rpm/018fe8d3-0359-7c75-936d-fc3ec662f5b2/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -269,7 +269,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - df4fc4c90dae4c01a52caea40c73115e
+      - c995c19775854bb39beb25169e3fddf8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -278,9 +278,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OGY1NGUyLWQ2ZDktNzRjYS1iZDhmLTMzNDgzZGMzMTE1MC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjIzLjM4NjE2NVoiLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MjMuMzg2MTc5WiIsIm5h
+        OGZlOGQzLTAzNTktN2M3NS05MzZkLWZjM2VjNjYyZjViMi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM0OjU0LjE2OTUwMloiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTQuMTY5NTE3WiIsIm5h
         bWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0dHA6Ly9teXJlcG8uY29tIiwi
         Y2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0
         aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwi
@@ -294,7 +294,7 @@ http_interactions:
         ZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InVzZXJuYW1lIiwiaXNfc2V0
         IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfV0s
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:23 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:54 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -307,7 +307,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -320,13 +320,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:23 GMT
+      - Wed, 05 Jun 2024 14:34:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/018f54e2-d814-789a-8bcf-9a0ed83d676a/"
+      - "/pulp/api/v3/repositories/rpm/rpm/018fe8d3-03e4-7707-99a8-5d2fcb2b2212/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -342,7 +342,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1d8a21a13fb448298db2b0321a639c78
+      - 737df868a9b844b39e18f9265ae3dcb4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -351,14 +351,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMDE4ZjU0ZTItZDgxNC03ODlhLThiY2YtOWEwZWQ4M2Q2NzZhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MjMuNzAxNjA0WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoyMy43MDg2ODda
+        cG0vMDE4ZmU4ZDMtMDNlNC03NzA3LTk5YTgtNWQyZmNiMmIyMjEyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTQuMzA4ODQ4WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNDo1NC4zMTQ3OTla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wMThmNTRlMi1kODE0LTc4OWEtOGJjZi05YTBlZDgzZDY3NmEv
+        cnBtL3JwbS8wMThmZThkMy0wM2U0LTc3MDctOTlhOC01ZDJmY2IyYjIyMTIv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzAxOGY1
-        NGUyLWQ4MTQtNzg5YS04YmNmLTlhMGVkODNkNjc2YS92ZXJzaW9ucy8wLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzAxOGZl
+        OGQzLTAzZTQtNzcwNy05OWE4LTVkMmZjYjJiMjIxMi92ZXJzaW9ucy8wLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -367,7 +367,7 @@ http_interactions:
         Y2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:23 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:54 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -375,13 +375,13 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE4ZjU0ZTItZDgxNC03ODlhLThiY2YtOWEwZWQ4M2Q2
-        NzZhL3ZlcnNpb25zLzAvIn0=
+        aWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMDNlNC03NzA3LTk5YTgtNWQyZmNiMmIy
+        MjEyL3ZlcnNpb25zLzAvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -394,7 +394,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:24 GMT
+      - Wed, 05 Jun 2024 14:34:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -414,7 +414,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 88416b07ff344a6baa608cc2ccb22412
+      - f1f393b7bd304663bbfe4c42a61cce6b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -422,12 +422,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWRhNGQtNzIx
-        My1iNmI2LTk4NjYxN2VjYWEyYS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:24 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTA1MTUtNzM3
+        NS1iMDBmLWQ2NjUzMWE5OTM4MC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:54 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-da4d-7213-b6b6-986617ecaa2a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-0515-7375-b00f-d66531a99380/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -435,7 +435,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -448,7 +448,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:24 GMT
+      - Wed, 05 Jun 2024 14:34:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -468,7 +468,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 52893210e2d54003b70ca7bee6e2f589
+      - f4996db536bf445ab12caffeabb6b26d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -476,30 +476,30 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItZGE0
-        ZC03MjEzLWI2YjYtOTg2NjE3ZWNhYTJhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MjQuMjcwMjI0WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoyNC4yNzAyMzlaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMDUx
+        NS03Mzc1LWIwMGYtZDY2NTMxYTk5MzgwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzQ6NTQuNjE0MDIyWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNDo1NC42MTQwMzVaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnB1Ymxpc2hpbmcu
-        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiODg0MTZiMDdmZjM0NGE2YmFhNjA4
-        Y2MyY2NiMjI0MTIiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
-        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMTowODoyNC4zMDQ1
-        MjFaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MjQuMzcyNzg0
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMTowODoyNC42NTE2MTha
+        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiZjFmMzkzYjdiZDMwNDY2M2JiZmU0
+        YzQyYTYxY2NlNmIiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
+        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozNDo1NC42MjQ1
+        MDNaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTQuNjU0NzEw
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozNDo1NC44MzMxNjNa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzAxOGY1NGUwLWE0ZTgtNzQ4Ny05YWEwLTNjM2VjMWExOTlkNy8iLCJwYXJl
+        LzAxOGZlM2NiLTBkNDMtNzczMS05ODUyLTg3MjlkMDA4MTk2My8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJhdGlu
         ZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2VuZXJh
         dGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEs
         ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTIt
-        ZGFjYS03MTBhLTk0YTEtZmY3NmFlZWNlMmRhLyJdLCJyZXNlcnZlZF9yZXNv
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDMt
+        MDU0ZC03ZDMzLThjMmItNzViYTYxNjI3MDljLyJdLCJyZXNlcnZlZF9yZXNv
         dXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE4ZjU0ZTItZDgxNC03ODlhLThiY2YtOWEwZWQ4M2Q2
-        NzZhLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNTRkZi03
-        ZmQyLTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:24 GMT
+        aWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMDNlNC03NzA3LTk5YTgtNWQyZmNiMmIy
+        MjEyLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03
+        MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:34:54 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -510,7 +510,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -523,7 +523,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:24 GMT
+      - Wed, 05 Jun 2024 14:34:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -543,7 +543,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d6ca1f06c1e44050a7e15026a83f3424
+      - ddeb7596525644908f697a4243ef9d65
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -553,10 +553,10 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:24 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:54 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-daca-710a-94a1-ff76aeece2da/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d3-054d-7d33-8c2b-75ba6162709c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -564,7 +564,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -577,7 +577,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:24 GMT
+      - Wed, 05 Jun 2024 14:34:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -597,7 +597,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ed018b75d5c141538809eedf43cf6845
+      - '06943971a0a2448ba91186402b0e4bf1'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -606,19 +606,19 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItZGFjYS03MTBhLTk0YTEtZmY3NmFlZWNlMmRhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MjQuMzk4MTczWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoyNC42NDUyNTla
+        cG0vMDE4ZmU4ZDMtMDU0ZC03ZDMzLThjMmItNzViYTYxNjI3MDljLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTQuNjcwNjk1WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNDo1NC44Mjc5MDZa
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLWQ4MTQtNzg5YS04YmNmLTlhMGVkODNk
-        Njc2YS92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItZDgxNC03ODlhLThiY2Yt
-        OWEwZWQ4M2Q2NzZhLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQzLTAzZTQtNzcwNy05OWE4LTVkMmZjYjJi
+        MjIxMi92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMDNlNC03NzA3LTk5YTgt
+        NWQyZmNiMmIyMjEyLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:24 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:54 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/
@@ -628,13 +628,13 @@ http_interactions:
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTItZGFjYS03MTBhLTk0YTEtZmY3
-        NmFlZWNlMmRhLyJ9
+        bGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDMtMDU0ZC03ZDMzLThjMmItNzVi
+        YTYxNjI3MDljLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -647,7 +647,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:24 GMT
+      - Wed, 05 Jun 2024 14:34:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -667,7 +667,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3acdb6ed08df42229ae246718c07ce06
+      - 9e060a7d7c6b4648a59b3087a7793740
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -675,12 +675,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWRkMDUtNzJh
-        Zi05ZGY0LTA4YjA5ZTNiYTMzMy8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:24 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTA2YmMtN2E0
+        NS04OWY5LWQ0ZDA3ZjZiYWFjMS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:55 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-dd05-72af-9df4-08b09e3ba333/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-06bc-7a45-89f9-d4d07f6baac1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -688,7 +688,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -701,7 +701,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:25 GMT
+      - Wed, 05 Jun 2024 14:34:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -721,7 +721,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4e3759af4e9f4760876411511c8651fc
+      - b2a7aa718e4e47b4803d63169a12ecc3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -729,29 +729,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItZGQw
-        NS03MmFmLTlkZjQtMDhiMDllM2JhMzMzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MjQuOTY1Njc5WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoyNC45NjU2OTVaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMDZi
+        Yy03YTQ1LTg5ZjktZDRkMDdmNmJhYWMxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzQ6NTUuMDM3Mjg3WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNDo1NS4wMzczMDFaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6IjNhY2RiNmVkMDhkZjQyMjI5YWUy
-        NDY3MThjMDdjZTA2IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MjQuOTgx
-        MDA2WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjI1LjA0Mjg2
-        NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MjUuMzU4ODc0
+        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6IjllMDYwYTdkN2M2YjQ2NDhhNTli
+        MzA4N2E3NzkzNzQwIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTUuMDQ4
+        Mjc1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM0OjU1LjA4NTI3
+        OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTUuMjk3Nzgz
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGMxLTcxNzUtYTM3Yi1iNjMzMjI1NWEyMGEvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
-        IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDE4ZjU0
-        ZTItZGU2Zi03M2IzLWEyM2YtY2E2NmM2MjZhNDNmLyJdLCJyZXNlcnZlZF9y
+        IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDE4ZmU4
+        ZDMtMDdiMi03MmIzLWI0ZGUtZjUwMzQ3OGNmMzNhLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iLCJz
-        aGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZjU0ZGYtN2ZkMi03NWZh
-        LTliMzUtYzI3NTEzZmY5OGY0LyJdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:25 GMT
+        aGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZmUzYzktNzBhYS03ODgz
+        LWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:55 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-de6f-73b3-a23f-ca66c626a43f/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-07b2-72b3-b4de-f503478cf33a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -759,7 +759,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -772,7 +772,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:25 GMT
+      - Wed, 05 Jun 2024 14:34:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -792,7 +792,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 24cc80f6d5854b728790439302a97a65
+      - fb2647d9920745a4ba2ed6ee927f8505
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -801,9 +801,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzAxOGY1NGUyLWRlNmYtNzNiMy1hMjNmLWNhNjZjNjI2YTQzZi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjI1LjMyODE5NVoiLCJw
-        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MjUuMzI4MjE0
+        cnBtLzAxOGZlOGQzLTA3YjItNzJiMy1iNGRlLWY1MDM0NzhjZjMzYS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM0OjU1LjI4MzI5MloiLCJw
+        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTUuMjgzMzA3
         WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
         N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
         OS1rYXRlbGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9wdWxwL2Nv
@@ -811,9 +811,9 @@ http_interactions:
         ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJoaWRkZW4iOmZhbHNl
         LCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInJlcG9z
         aXRvcnkiOm51bGwsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1Ymxp
-        Y2F0aW9ucy9ycG0vcnBtLzAxOGY1NGUyLWRhY2EtNzEwYS05NGExLWZmNzZh
-        ZWVjZTJkYS8iLCJnZW5lcmF0ZV9yZXBvX2NvbmZpZyI6ZmFsc2V9
-  recorded_at: Tue, 07 May 2024 21:08:25 GMT
+        Y2F0aW9ucy9ycG0vcnBtLzAxOGZlOGQzLTA1NGQtN2QzMy04YzJiLTc1YmE2
+        MTYyNzA5Yy8iLCJnZW5lcmF0ZV9yZXBvX2NvbmZpZyI6ZmFsc2V9
+  recorded_at: Wed, 05 Jun 2024 14:34:55 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -835,7 +835,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -848,13 +848,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:25 GMT
+      - Wed, 05 Jun 2024 14:34:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/018f54e2-e0e0-7f7e-b36e-d684bb64ce6b/"
+      - "/pulp/api/v3/remotes/rpm/rpm/018fe8d3-08a0-75fa-b294-e1b57189ba1c/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -870,7 +870,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bb1e17de52a24f5db1e7a49ec4c882c6
+      - 25ced63314d7486987d99974bb8609f7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -879,9 +879,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OGY1NGUyLWUwZTAtN2Y3ZS1iMzZlLWQ2ODRiYjY0Y2U2Yi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjI1Ljk1MzE4MFoiLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MjUuOTUzMTk1WiIsIm5h
+        OGZlOGQzLTA4YTAtNzVmYS1iMjk0LWUxYjU3MTg5YmExYy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM0OjU1LjUyMDcxMVoiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTUuNTIwNzIzWiIsIm5h
         bWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJsIjoiaHR0cDovL215cmVwby5j
         b20iLCJjYV9jZXJ0IjoiS0pMOktERiooREYmKigqJCYoKiMkSkxLSkQoRCgo
         RCIsImNsaWVudF9jZXJ0IjoiS0pMOktERiooREYmKigqJCYoKiMkSkxLSkQo
@@ -896,10 +896,10 @@ http_interactions:
         bWUiOiJwcm94eV9wYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6
         InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfV0sInNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:25 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:55 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-e0e0-7f7e-b36e-d684bb64ce6b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d3-08a0-75fa-b294-e1b57189ba1c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -907,7 +907,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -920,7 +920,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:26 GMT
+      - Wed, 05 Jun 2024 14:34:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -940,7 +940,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - abc20edceb9d47fdab1e7cfc88f4c820
+      - faa8abedbece47dbb2ea19c6ecdcb75f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -948,12 +948,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWUxNDUtN2U4
-        OC05MjdjLTBhZGYxOWY1NGNkYS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:26 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTA4ZDUtN2I4
+        Zi1hYmIzLTdhZjdkYTE0ZmMwNS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:55 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018f54e2-d814-789a-8bcf-9a0ed83d676a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018fe8d3-03e4-7707-99a8-5d2fcb2b2212/
     body:
       encoding: UTF-8
       base64_string: |
@@ -963,7 +963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -976,7 +976,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:26 GMT
+      - Wed, 05 Jun 2024 14:34:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -996,7 +996,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d4ca70ca44984aada79103cbf5823f12
+      - 0607d1d478d84690a99a789e371b7e10
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1004,12 +1004,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWUzMzAtN2Qx
-        NC04ZTQwLTI2NjAyNjgwNzRmNC8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:26 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTA5ODktNzVm
+        Zi1hNmQwLTIwNzA4NTdiODgyNC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:55 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-d6d9-74ca-bd8f-33483dc31150/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d3-0359-7c75-936d-fc3ec662f5b2/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1028,7 +1028,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1041,7 +1041,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:26 GMT
+      - Wed, 05 Jun 2024 14:34:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1061,7 +1061,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 133387b494eb41e1adb3ee9644758544
+      - 43af311399814cadb81cb71055d03b16
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1069,12 +1069,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWU0MDQtN2Vk
-        OS1hMzgyLTgxYTU0NjgzZDBhNS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:26 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTA5ZjctNzBh
+        Zi1iZjc3LWM4OGMyZTBmYjBlYS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:55 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-e404-7ed9-a382-81a54683d0a5/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-09f7-70af-bf77-c88c2e0fb0ea/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1082,7 +1082,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1095,7 +1095,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:26 GMT
+      - Wed, 05 Jun 2024 14:34:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1115,7 +1115,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b3ad65fe5e374a5888542d3870cd2985
+      - 269db8db5d444380b49ebeb9c579ef72
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1123,24 +1123,24 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItZTQw
-        NC03ZWQ5LWEzODItODFhNTQ2ODNkMGE1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MjYuNzU3NTM3WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoyNi43NTc1NTNaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMDlm
+        Ny03MGFmLWJmNzctYzg4YzJlMGZiMGVhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzQ6NTUuODYzODkyWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNDo1NS44NjM5MDZaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjEzMzM4N2I0OTRlYjQxZTFhZGIz
-        ZWU5NjQ0NzU4NTQ0IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MjYuNzcy
-        MDM1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjI2Ljc3NTcx
-        OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MjYuNzg4MjQ0
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjQzYWYzMTEzOTk4MTRjYWRiODFj
+        YjcxMDU1ZDAzYjE2IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTUuODc1
+        ODQ1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM0OjU1Ljg3OTQ4
+        M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTUuODg5NzQx
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMv
-        cnBtL3JwbS8wMThmNTRlMi1kNmQ5LTc0Y2EtYmQ4Zi0zMzQ4M2RjMzExNTAv
-        Iiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGY1NGRmLTdmZDIt
-        NzVmYS05YjM1LWMyNzUxM2ZmOThmNC8iXX0=
-  recorded_at: Tue, 07 May 2024 21:08:26 GMT
+        cnBtL3JwbS8wMThmZThkMy0wMzU5LTdjNzUtOTM2ZC1mYzNlYzY2MmY1YjIv
+        Iiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGZlM2M5LTcwYWEt
+        Nzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:34:55 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
@@ -1151,7 +1151,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1164,7 +1164,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:26 GMT
+      - Wed, 05 Jun 2024 14:34:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1176,7 +1176,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '5887'
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1184,7 +1184,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 00c4af0bc5dc47a38aa2856753d32202
+      - 03314e9d94ca489c82e5f1d44022eee6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1192,274 +1192,146 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzAxOGY1NGUyLWM2ZTUtNzgxNy05NjdlLTQ0YTlm
-        MmI0YzE5YS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjE5
-        LjMwMjMzM1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6
-        MDg6MTkuMzAyMzUyWiIsIm5hbWUiOiJSSFNNQ2VydEd1YXJkIiwiZGVzY3Jp
-        cHRpb24iOm51bGwsImNhX2NlcnRpZmljYXRlIjoiQ2VydGlmaWNhdGU6XG4g
-        ICAgRGF0YTpcbiAgICAgICAgVmVyc2lvbjogMyAoMHgyKVxuICAgICAgICBT
-        ZXJpYWwgTnVtYmVyOlxuICAgICAgICAgICAgZmQ6YmE6YmM6NzE6NmU6MjU6
-        YTM6NzhcbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNB
-        RW5jcnlwdGlvblxuICAgICAgICBJc3N1ZXI6IEM9VVMsIFNUPU5vcnRoIENh
-        cm9saW5hLCBMPVJhbGVpZ2gsIE89S2F0ZWxsbywgT1U9U29tZU9yZ1VuaXQs
-        IENOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAg
-        IFZhbGlkaXR5XG4gICAgICAgICAgICBOb3QgQmVmb3JlOiBNYXkgIDcgMTQ6
-        MjE6NTAgMjAyMCBHTVRcbiAgICAgICAgICAgIE5vdCBBZnRlciA6IEphbiAx
-        OCAxNDoyMTo1MCAyMDM4IEdNVFxuICAgICAgICBTdWJqZWN0OiBDPVVTLCBT
-        VD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNv
-        bWVPcmdVbml0LCBDTj1jZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNv
-        bVxuICAgICAgICBTdWJqZWN0IFB1YmxpYyBLZXkgSW5mbzpcbiAgICAgICAg
-        ICAgIFB1YmxpYyBLZXkgQWxnb3JpdGhtOiByc2FFbmNyeXB0aW9uXG4gICAg
-        ICAgICAgICAgICAgUHVibGljLUtleTogKDIwNDggYml0KVxuICAgICAgICAg
-        ICAgICAgIE1vZHVsdXM6XG4gICAgICAgICAgICAgICAgICAgIDAwOjlmOmQy
-        OmMxOjEwOmZmOjAxOjFhOjMzOjE5OjBlOjQzOjlkOjgzOmU1OlxuICAgICAg
-        ICAgICAgICAgICAgICA4YTo3MzpiYToyZDozYzo2NjpiMTo3ODpjZDo4OTo4
-        Yzo2MDplNTo4MTphNjpcbiAgICAgICAgICAgICAgICAgICAgZTg6NGQ6OTY6
-        NWQ6MDc6YzM6YmU6YTI6OWM6YzI6N2M6OTQ6MmQ6NmU6NDM6XG4gICAgICAg
-        ICAgICAgICAgICAgIDQ0OjQ2OmVmOmZkOjM2OjIwOjQ3OjNiOmQ2OjM1OmZk
-        Ojk3OmNkOjk3OjE3OlxuICAgICAgICAgICAgICAgICAgICBkNzozZjplNzo2
-        NzpmZTphOToyYTpmMTpiYzo0Nzo4Nzo2ZTplZDo2ZDpiNjpcbiAgICAgICAg
-        ICAgICAgICAgICAgOWU6ZjE6MGQ6NjM6NTM6YzE6M2Y6ZmQ6MTc6YWI6NWY6
-        MzU6N2E6ODQ6Y2Y6XG4gICAgICAgICAgICAgICAgICAgIDZiOmRkOmE2Ojhl
-        OjA5Ojk5OjU2OjM5OmRlOjI5OjZiOmZiOmMyOmRjOjhjOlxuICAgICAgICAg
-        ICAgICAgICAgICA1NjoyYToxMDpiMzowYTpjYTpiODo2YzpmYjpiODpjODpl
-        YjplNTplMjphZTpcbiAgICAgICAgICAgICAgICAgICAgZDU6NDE6MDU6NGM6
-        YTI6YzA6YmU6N2I6YjA6NmQ6MWQ6N2M6NjY6ODA6ODg6XG4gICAgICAgICAg
-        ICAgICAgICAgIDVhOmI3OjA3OjliOmQzOmI4OmZmOjkzOmYzOjE5OjMzOjYz
-        OjQ4Ojk1OjgzOlxuICAgICAgICAgICAgICAgICAgICAzNDoyNzpjNjphYzpj
-        YzphMDowYjo1NjphYjoyMjozNDo3MTo0Zjo3OTpiZjpcbiAgICAgICAgICAg
-        ICAgICAgICAgNmU6NGI6Yzk6ODk6NTk6ODc6OGI6N2I6MzU6Nzk6Yjg6MWM6
-        NzA6ZWU6NTg6XG4gICAgICAgICAgICAgICAgICAgIGU2OjdiOjIyOjc5OmE3
-        OjFlOmQ5OmIyOjU3OjNhOmUwOjU5OjhlOmIzOjZhOlxuICAgICAgICAgICAg
-        ICAgICAgICA5NzozZDo5YTo4MDpjYzozYjpkNTo3NzpkNDpmYTo3YTo1ODo2
-        OTpiNjpiMzpcbiAgICAgICAgICAgICAgICAgICAgYWE6OTU6NTQ6NTU6OWU6
-        MTM6NjU6N2Y6OTU6YzA6NzM6OTY6YzU6ZmI6Nzc6XG4gICAgICAgICAgICAg
-        ICAgICAgIGEwOjQ4OjIwOmE2OjdkOmY0OmM0OmQzOmU5OmFiOjk0OjkzOjRl
-        OjFhOmUyOlxuICAgICAgICAgICAgICAgICAgICA1ZDo5YjpjNTo4Nzo1MDpj
-        Nzo1NjpmMDo5MzphODpiOTowYTo3MzpjZjpmNzpcbiAgICAgICAgICAgICAg
-        ICAgICAgMDE6MGZcbiAgICAgICAgICAgICAgICBFeHBvbmVudDogNjU1Mzcg
-        KDB4MTAwMDEpXG4gICAgICAgIFg1MDl2MyBleHRlbnNpb25zOlxuICAgICAg
-        ICAgICAgWDUwOXYzIEJhc2ljIENvbnN0cmFpbnRzOlxuICAgICAgICAgICAg
-        ICAgIENBOlRSVUVcbiAgICAgICAgICAgIFg1MDl2MyBLZXkgVXNhZ2U6XG4g
-        ICAgICAgICAgICAgICAgRGlnaXRhbCBTaWduYXR1cmUsIEtleSBFbmNpcGhl
-        cm1lbnQsIENlcnRpZmljYXRlIFNpZ24sIENSTCBTaWduXG4gICAgICAgICAg
-        ICBYNTA5djMgRXh0ZW5kZWQgS2V5IFVzYWdlOlxuICAgICAgICAgICAgICAg
-        IFRMUyBXZWIgU2VydmVyIEF1dGhlbnRpY2F0aW9uLCBUTFMgV2ViIENsaWVu
-        dCBBdXRoZW50aWNhdGlvblxuICAgICAgICAgICAgTmV0c2NhcGUgQ2VydCBU
-        eXBlOlxuICAgICAgICAgICAgICAgIFNTTCBTZXJ2ZXIsIFNTTCBDQVxuICAg
-        ICAgICAgICAgTmV0c2NhcGUgQ29tbWVudDpcbiAgICAgICAgICAgICAgICBL
-        YXRlbGxvIFNTTCBUb29sIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZVxuICAgICAg
-        ICAgICAgWDUwOXYzIFN1YmplY3QgS2V5IElkZW50aWZpZXI6XG4gICAgICAg
-        ICAgICAgICAgOUI6RDI6RDk6Njk6ODg6OTk6MkM6MkU6NzA6MkI6Qjc6Njk6
-        NzY6N0E6N0Q6RDE6ODU6NEQ6NTM6NURcbiAgICAgICAgICAgIFg1MDl2MyBB
-        dXRob3JpdHkgS2V5IElkZW50aWZpZXI6XG4gICAgICAgICAgICAgICAga2V5
-        aWQ6OUI6RDI6RDk6Njk6ODg6OTk6MkM6MkU6NzA6MkI6Qjc6Njk6NzY6N0E6
-        N0Q6RDE6ODU6NEQ6NTM6NURcbiAgICAgICAgICAgICAgICBEaXJOYW1lOi9D
-        PVVTL1NUPU5vcnRoIENhcm9saW5hL0w9UmFsZWlnaC9PPUthdGVsbG8vT1U9
-        U29tZU9yZ1VuaXQvQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5j
-        b21cbiAgICAgICAgICAgICAgICBzZXJpYWw6RkQ6QkE6QkM6NzE6NkU6MjU6
-        QTM6NzhcblxuICAgIFNpZ25hdHVyZSBBbGdvcml0aG06IHNoYTI1NldpdGhS
-        U0FFbmNyeXB0aW9uXG4gICAgICAgICAzMjoxOTo2YzpjNjphZjphZTpjMjpi
-        ZTo2NDoxNjpiMDo3YzphMzo0YjoxMDplODo1YTpiNDpcbiAgICAgICAgIDE3
-        Ojc0OmZkOjc1OmM2OjI2OmQyOjg4OjAxOmZlOjk1OjJlOjNmOjBhOjFlOjg4
-        OmE1OjI1OlxuICAgICAgICAgMTM6NmI6NjA6MzQ6ZDA6MmM6ZGU6ZDg6NDg6
-        MTU6ZjU6Y2M6MWY6MDc6ODA6MmI6MWQ6Mjg6XG4gICAgICAgICA5MDplOTo4
-        Yjo0NzpjMTo3MToxYTpkYTo4NjphMDoyNzplODpjNDo4ODozNjphMzpmZjpk
-        YjpcbiAgICAgICAgIDE3OjJmOjBlOjliOmUxOjM5OmE3OjFmOmRjOjI2Ojk3
-        OjI5OjVlOjRiOjk5OjYwOmZhOjkyOlxuICAgICAgICAgMTI6MjQ6ZmM6YmM6
-        MDQ6OTQ6MjQ6NjU6ZjM6NjA6Y2M6NWU6ZWU6NDI6YmY6OWU6M2M6MzE6XG4g
-        ICAgICAgICBiOTozYzo5OTo4YTo0NDozZDoyOTo1ZDphNjo5OTphYTpkNTow
-        ZToxNTo5NDpjNDpjNToyMzpcbiAgICAgICAgIDhjOmI5OjZlOmU1OjA5OjEz
-        OjhjOjU2OjRiOjA0OjM1Ojk1Ojc5OjUwOjVjOjIyOjJkOjFmOlxuICAgICAg
-        ICAgM2E6Njg6ZDA6ZjM6M2U6ODg6N2Q6Mzg6Mjk6MzI6ZjI6NDc6YjE6MTc6
-        OTk6ZmQ6YTY6NDg6XG4gICAgICAgICAwMjowNDo2Yjo5ZjpiOTpkYTpjMjo2
-        ZTo2NTo5Yjo5OTplNDo2MDo3YTozMjpjZDowMjpmZTpcbiAgICAgICAgIDcx
-        OmRhOjE5OmUzOjkzOmJkOmM1OmE3OmEwOjQ2OjllOjI4OmQyOjkxOmFjOjhl
-        OjkxOmM3OlxuICAgICAgICAgYTc6NTE6NGU6ODE6MDk6ZDE6ZjE6Mzk6NWI6
-        MDc6ODc6NDE6M2I6Yjc6ZTM6MWI6YTg6N2U6XG4gICAgICAgICA1MTo1Mjo0
-        ZTo2NjoyMDpiMTpjZDpjNTphZTpkZToxNzozYTpkNzpjZTowNzozNzpkODo1
-        ZTpcbiAgICAgICAgIDg4OmVmOmUzOjk0OmMwOjk4OjNlOmMzOjBkOjUxOjQ0
-        OjNkOjUzOjUyOmZmOjVlOjBiOjFiOlxuICAgICAgICAgNWI6NmM6OWI6YTZc
-        bi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLVxuTUlJRkJ6Q0NBKytnQXdJ
-        QkFnSUpBUDI2dkhGdUphTjRNQTBHQ1NxR1NJYjNEUUVCQ3dVQU1JR0xNUXN3
-        Q1FZRFxuVlFRR0V3SlZVekVYTUJVR0ExVUVDQXdPVG05eWRHZ2dRMkZ5YjJ4
-        cGJtRXhFREFPQmdOVkJBY01CMUpoYkdWcFxuWjJneEVEQU9CZ05WQkFvTUIw
-        dGhkR1ZzYkc4eEZEQVNCZ05WQkFzTUMxTnZiV1ZQY21kVmJtbDBNU2t3SndZ
-        RFxuVlFRRERDQmpaVzUwYjNNM0xXUmxkbVZzTWk1ellXMXBjaTVsZUdGdGNH
-        eGxMbU52YlRBZUZ3MHlNREExTURjeFxuTkRJeE5UQmFGdzB6T0RBeE1UZ3hO
-        REl4TlRCYU1JR0xNUXN3Q1FZRFZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1xu
-        VG05eWRHZ2dRMkZ5YjJ4cGJtRXhFREFPQmdOVkJBY01CMUpoYkdWcFoyZ3hF
-        REFPQmdOVkJBb01CMHRoZEdWc1xuYkc4eEZEQVNCZ05WQkFzTUMxTnZiV1ZQ
-        Y21kVmJtbDBNU2t3SndZRFZRUUREQ0JqWlc1MGIzTTNMV1JsZG1Wc1xuTWk1
-        ellXMXBjaTVsZUdGdGNHeGxMbU52YlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVC
-        QlFBRGdnRVBBRENDQVFvQ1xuZ2dFQkFKL1N3UkQvQVJvekdRNURuWVBsaW5P
-        NkxUeG1zWGpOaVl4ZzVZR202RTJXWFFmRHZxS2N3bnlVTFc1RFxuUkVidi9U
-        WWdSenZXTmYyWHpaY1gxei9uWi82cEt2RzhSNGR1N1cyMm52RU5ZMVBCUC8w
-        WHExODFlb1RQYTkybVxuamdtWlZqbmVLV3Y3d3R5TVZpb1Fzd3JLdUd6N3VN
-        anI1ZUt1MVVFRlRLTEF2bnV3YlIxOFpvQ0lXcmNIbTlPNFxuLzVQekdUTmpT
-        SldETkNmR3JNeWdDMWFySWpSeFQzbS9ia3ZKaVZtSGkzczFlYmdjY081WTVu
-        c2llYWNlMmJKWFxuT3VCWmpyTnFsejJhZ013NzFYZlUrbnBZYWJhenFwVlVW
-        WjRUWlgrVndIT1d4ZnQzb0VnZ3BuMzB4TlBwcTVTVFxuVGhyaVhadkZoMURI
-        VnZDVHFMa0tjOC8zQVE4Q0F3RUFBYU9DQVdvd2dnRm1NQXdHQTFVZEV3UUZN
-        QU1CQWY4d1xuQ3dZRFZSMFBCQVFEQWdHbU1CMEdBMVVkSlFRV01CUUdDQ3NH
-        QVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakFSQmdsZ1xuaGtnQmh2aENBUUVFQkFN
-        Q0FrUXdOUVlKWUlaSUFZYjRRZ0VOQkNnV0prdGhkR1ZzYkc4Z1UxTk1JRlJ2
-        YjJ3Z1xuUjJWdVpYSmhkR1ZrSUVObGNuUnBabWxqWVhSbE1CMEdBMVVkRGdR
-        V0JCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUlxuaFUxVFhUQ0J3QVlEVlIwakJJ
-        RzRNSUcxZ0JTYjB0bHBpSmtzTG5BcnQybDJlbjNSaFUxVFhhR0JrYVNCampD
-        QlxuaXpFTE1Ba0dBMVVFQmhNQ1ZWTXhGekFWQmdOVkJBZ01EazV2Y25Sb0lF
-        TmhjbTlzYVc1aE1SQXdEZ1lEVlFRSFxuREFkU1lXeGxhV2RvTVJBd0RnWURW
-        UVFLREFkTFlYUmxiR3h2TVJRd0VnWURWUVFMREF0VGIyMWxUM0puVlc1cFxu
-        ZERFcE1DY0dBMVVFQXd3Z1kyVnVkRzl6Tnkxa1pYWmxiREl1YzJGdGFYSXVa
-        WGhoYlhCc1pTNWpiMjJDQ1FEOVxudXJ4eGJpV2plREFOQmdrcWhraUc5dzBC
-        QVFzRkFBT0NBUUVBTWhsc3hxK3V3cjVrRnJCOG8wc1E2RnEwRjNUOVxuZGNZ
-        bTBvZ0IvcFV1UHdvZWlLVWxFMnRnTk5BczN0aElGZlhNSHdlQUt4MG9rT21M
-        UjhGeEd0cUdvQ2ZveElnMlxuby8vYkZ5OE9tK0U1cHgvY0pwY3BYa3VaWVBx
-        U0VpVDh2QVNVSkdYellNeGU3a0svbmp3eHVUeVppa1E5S1YybVxubWFyVkRo
-        V1V4TVVqakxsdTVRa1RqRlpMQkRXVmVWQmNJaTBmT21qUTh6NklmVGdwTXZK
-        SHNSZVovYVpJQWdSclxubjduYXdtNWxtNW5rWUhveXpRTCtjZG9aNDVPOXhh
-        ZWdScDRvMHBHc2pwSEhwMUZPZ1FuUjhUbGJCNGRCTzdmalxuRzZoK1VWSk9a
-        aUN4emNXdTNoYzYxODRITjloZWlPL2psTUNZUHNNTlVVUTlVMUwvWGdzYlcy
-        eWJwZz09XG4tLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tIn1dfQ==
-  recorded_at: Tue, 07 May 2024 21:08:26 GMT
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:56 GMT
 - request:
-    method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/contentguards/certguard/rhsm/018f54e2-c6e5-7817-967e-44a9f2b4c19a/
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4g
-        ICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJl
-        cjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAg
-        U2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25c
-        biAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1S
-        YWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3
-        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxu
-        ICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAg
-        R01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAg
-        MjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fy
-        b2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwg
-        Q049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAg
-        U3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMg
-        S2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAg
-        IFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1
-        bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjow
-        MToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6
-        YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJl
-        OmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAg
-        ICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5Nzox
-        NzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6
-        ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAg
-        IDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNm
-        OlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1Njoz
-        OTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAg
-        NTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6
-        XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdi
-        OmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1
-        YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4Mzpc
-        biAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6
-        YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZl
-        OjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4Olxu
-        ICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1
-        NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6
-        M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4g
-        ICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1
-        OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0
-        ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAg
-        ICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6
-        YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBm
-        XG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxu
-        ICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2
-        MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVF
-        XG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAg
-        ICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0
-        aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4
-        dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNl
-        cnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGlj
-        YXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAg
-        ICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5l
-        dHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wg
-        VG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2
-        MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtl
-        eSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5
-        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
-        OjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0
-        aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0
-        L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAg
-        ICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAg
-        ICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlv
-        blxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6
-        N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpj
-        NjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAg
-        ICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFm
-        OjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6
-        MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAg
-        ICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5
-        OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1
-        OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6
-        M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6
-        YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0Yjow
-        NDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQw
-        OmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4
-        OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6
-        ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5
-        MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAg
-        ICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNi
-        OmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6
-        Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAg
-        ICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1Mjpm
-        Zjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lO
-        IENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZI
-        RnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdF
-        d0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0Jn
-        TlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhG
-        REFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0Jq
-        Wlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVG
-        dzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdM
-        TVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJG
-        eWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9N
-        QjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNr
-        d0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVH
-        RnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURD
-        Q0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZ
-        eGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6
-        WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5
-        Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZU
-        S0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXln
-        QzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhc
-        bk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9X
-        eGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgv
-        M0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3
-        WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdn
-        ckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJ
-        WklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVa
-        WEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlK
-        a3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2Iw
-        dGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtH
-        QTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhN
-        UkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJs
-        Ykd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFV
-        RUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVq
-        YjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFF
-        QU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3
-        b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nm
-        b3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpH
-        WHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1
-        UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFn
-        UnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3Nq
-        cEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2
-        MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0t
-        LS1FTkQgQ0VSVElGSUNBVEUtLS0tLVxuIn0=
+        eyJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImNhX2NlcnRpZmljYXRlIjoiQ2Vy
+        dGlmaWNhdGU6XG4gICAgRGF0YTpcbiAgICAgICAgVmVyc2lvbjogMyAoMHgy
+        KVxuICAgICAgICBTZXJpYWwgTnVtYmVyOlxuICAgICAgICAgICAgZmQ6YmE6
+        YmM6NzE6NmU6MjU6YTM6NzhcbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBz
+        aGEyNTZXaXRoUlNBRW5jcnlwdGlvblxuICAgICAgICBJc3N1ZXI6IEM9VVMs
+        IFNUPU5vcnRoIENhcm9saW5hLCBMPVJhbGVpZ2gsIE89S2F0ZWxsbywgT1U9
+        U29tZU9yZ1VuaXQsIENOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUu
+        Y29tXG4gICAgICAgIFZhbGlkaXR5XG4gICAgICAgICAgICBOb3QgQmVmb3Jl
+        OiBNYXkgIDcgMTQ6MjE6NTAgMjAyMCBHTVRcbiAgICAgICAgICAgIE5vdCBB
+        ZnRlciA6IEphbiAxOCAxNDoyMTo1MCAyMDM4IEdNVFxuICAgICAgICBTdWJq
+        ZWN0OiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdoLCBPPUth
+        dGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWRldmVsMi5zYW1p
+        ci5leGFtcGxlLmNvbVxuICAgICAgICBTdWJqZWN0IFB1YmxpYyBLZXkgSW5m
+        bzpcbiAgICAgICAgICAgIFB1YmxpYyBLZXkgQWxnb3JpdGhtOiByc2FFbmNy
+        eXB0aW9uXG4gICAgICAgICAgICAgICAgUHVibGljLUtleTogKDIwNDggYml0
+        KVxuICAgICAgICAgICAgICAgIE1vZHVsdXM6XG4gICAgICAgICAgICAgICAg
+        ICAgIDAwOjlmOmQyOmMxOjEwOmZmOjAxOjFhOjMzOjE5OjBlOjQzOjlkOjgz
+        OmU1OlxuICAgICAgICAgICAgICAgICAgICA4YTo3MzpiYToyZDozYzo2Njpi
+        MTo3ODpjZDo4OTo4Yzo2MDplNTo4MTphNjpcbiAgICAgICAgICAgICAgICAg
+        ICAgZTg6NGQ6OTY6NWQ6MDc6YzM6YmU6YTI6OWM6YzI6N2M6OTQ6MmQ6NmU6
+        NDM6XG4gICAgICAgICAgICAgICAgICAgIDQ0OjQ2OmVmOmZkOjM2OjIwOjQ3
+        OjNiOmQ2OjM1OmZkOjk3OmNkOjk3OjE3OlxuICAgICAgICAgICAgICAgICAg
+        ICBkNzozZjplNzo2NzpmZTphOToyYTpmMTpiYzo0Nzo4Nzo2ZTplZDo2ZDpi
+        NjpcbiAgICAgICAgICAgICAgICAgICAgOWU6ZjE6MGQ6NjM6NTM6YzE6M2Y6
+        ZmQ6MTc6YWI6NWY6MzU6N2E6ODQ6Y2Y6XG4gICAgICAgICAgICAgICAgICAg
+        IDZiOmRkOmE2OjhlOjA5Ojk5OjU2OjM5OmRlOjI5OjZiOmZiOmMyOmRjOjhj
+        OlxuICAgICAgICAgICAgICAgICAgICA1NjoyYToxMDpiMzowYTpjYTpiODo2
+        YzpmYjpiODpjODplYjplNTplMjphZTpcbiAgICAgICAgICAgICAgICAgICAg
+        ZDU6NDE6MDU6NGM6YTI6YzA6YmU6N2I6YjA6NmQ6MWQ6N2M6NjY6ODA6ODg6
+        XG4gICAgICAgICAgICAgICAgICAgIDVhOmI3OjA3OjliOmQzOmI4OmZmOjkz
+        OmYzOjE5OjMzOjYzOjQ4Ojk1OjgzOlxuICAgICAgICAgICAgICAgICAgICAz
+        NDoyNzpjNjphYzpjYzphMDowYjo1NjphYjoyMjozNDo3MTo0Zjo3OTpiZjpc
+        biAgICAgICAgICAgICAgICAgICAgNmU6NGI6Yzk6ODk6NTk6ODc6OGI6N2I6
+        MzU6Nzk6Yjg6MWM6NzA6ZWU6NTg6XG4gICAgICAgICAgICAgICAgICAgIGU2
+        OjdiOjIyOjc5OmE3OjFlOmQ5OmIyOjU3OjNhOmUwOjU5OjhlOmIzOjZhOlxu
+        ICAgICAgICAgICAgICAgICAgICA5NzozZDo5YTo4MDpjYzozYjpkNTo3Nzpk
+        NDpmYTo3YTo1ODo2OTpiNjpiMzpcbiAgICAgICAgICAgICAgICAgICAgYWE6
+        OTU6NTQ6NTU6OWU6MTM6NjU6N2Y6OTU6YzA6NzM6OTY6YzU6ZmI6Nzc6XG4g
+        ICAgICAgICAgICAgICAgICAgIGEwOjQ4OjIwOmE2OjdkOmY0OmM0OmQzOmU5
+        OmFiOjk0OjkzOjRlOjFhOmUyOlxuICAgICAgICAgICAgICAgICAgICA1ZDo5
+        YjpjNTo4Nzo1MDpjNzo1NjpmMDo5MzphODpiOTowYTo3MzpjZjpmNzpcbiAg
+        ICAgICAgICAgICAgICAgICAgMDE6MGZcbiAgICAgICAgICAgICAgICBFeHBv
+        bmVudDogNjU1MzcgKDB4MTAwMDEpXG4gICAgICAgIFg1MDl2MyBleHRlbnNp
+        b25zOlxuICAgICAgICAgICAgWDUwOXYzIEJhc2ljIENvbnN0cmFpbnRzOlxu
+        ICAgICAgICAgICAgICAgIENBOlRSVUVcbiAgICAgICAgICAgIFg1MDl2MyBL
+        ZXkgVXNhZ2U6XG4gICAgICAgICAgICAgICAgRGlnaXRhbCBTaWduYXR1cmUs
+        IEtleSBFbmNpcGhlcm1lbnQsIENlcnRpZmljYXRlIFNpZ24sIENSTCBTaWdu
+        XG4gICAgICAgICAgICBYNTA5djMgRXh0ZW5kZWQgS2V5IFVzYWdlOlxuICAg
+        ICAgICAgICAgICAgIFRMUyBXZWIgU2VydmVyIEF1dGhlbnRpY2F0aW9uLCBU
+        TFMgV2ViIENsaWVudCBBdXRoZW50aWNhdGlvblxuICAgICAgICAgICAgTmV0
+        c2NhcGUgQ2VydCBUeXBlOlxuICAgICAgICAgICAgICAgIFNTTCBTZXJ2ZXIs
+        IFNTTCBDQVxuICAgICAgICAgICAgTmV0c2NhcGUgQ29tbWVudDpcbiAgICAg
+        ICAgICAgICAgICBLYXRlbGxvIFNTTCBUb29sIEdlbmVyYXRlZCBDZXJ0aWZp
+        Y2F0ZVxuICAgICAgICAgICAgWDUwOXYzIFN1YmplY3QgS2V5IElkZW50aWZp
+        ZXI6XG4gICAgICAgICAgICAgICAgOUI6RDI6RDk6Njk6ODg6OTk6MkM6MkU6
+        NzA6MkI6Qjc6Njk6NzY6N0E6N0Q6RDE6ODU6NEQ6NTM6NURcbiAgICAgICAg
+        ICAgIFg1MDl2MyBBdXRob3JpdHkgS2V5IElkZW50aWZpZXI6XG4gICAgICAg
+        ICAgICAgICAga2V5aWQ6OUI6RDI6RDk6Njk6ODg6OTk6MkM6MkU6NzA6MkI6
+        Qjc6Njk6NzY6N0E6N0Q6RDE6ODU6NEQ6NTM6NURcbiAgICAgICAgICAgICAg
+        ICBEaXJOYW1lOi9DPVVTL1NUPU5vcnRoIENhcm9saW5hL0w9UmFsZWlnaC9P
+        PUthdGVsbG8vT1U9U29tZU9yZ1VuaXQvQ049Y2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb21cbiAgICAgICAgICAgICAgICBzZXJpYWw6RkQ6QkE6
+        QkM6NzE6NkU6MjU6QTM6NzhcblxuICAgIFNpZ25hdHVyZSBBbGdvcml0aG06
+        IHNoYTI1NldpdGhSU0FFbmNyeXB0aW9uXG4gICAgICAgICAzMjoxOTo2Yzpj
+        NjphZjphZTpjMjpiZTo2NDoxNjpiMDo3YzphMzo0YjoxMDplODo1YTpiNDpc
+        biAgICAgICAgIDE3Ojc0OmZkOjc1OmM2OjI2OmQyOjg4OjAxOmZlOjk1OjJl
+        OjNmOjBhOjFlOjg4OmE1OjI1OlxuICAgICAgICAgMTM6NmI6NjA6MzQ6ZDA6
+        MmM6ZGU6ZDg6NDg6MTU6ZjU6Y2M6MWY6MDc6ODA6MmI6MWQ6Mjg6XG4gICAg
+        ICAgICA5MDplOTo4Yjo0NzpjMTo3MToxYTpkYTo4NjphMDoyNzplODpjNDo4
+        ODozNjphMzpmZjpkYjpcbiAgICAgICAgIDE3OjJmOjBlOjliOmUxOjM5OmE3
+        OjFmOmRjOjI2Ojk3OjI5OjVlOjRiOjk5OjYwOmZhOjkyOlxuICAgICAgICAg
+        MTI6MjQ6ZmM6YmM6MDQ6OTQ6MjQ6NjU6ZjM6NjA6Y2M6NWU6ZWU6NDI6YmY6
+        OWU6M2M6MzE6XG4gICAgICAgICBiOTozYzo5OTo4YTo0NDozZDoyOTo1ZDph
+        Njo5OTphYTpkNTowZToxNTo5NDpjNDpjNToyMzpcbiAgICAgICAgIDhjOmI5
+        OjZlOmU1OjA5OjEzOjhjOjU2OjRiOjA0OjM1Ojk1Ojc5OjUwOjVjOjIyOjJk
+        OjFmOlxuICAgICAgICAgM2E6Njg6ZDA6ZjM6M2U6ODg6N2Q6Mzg6Mjk6MzI6
+        ZjI6NDc6YjE6MTc6OTk6ZmQ6YTY6NDg6XG4gICAgICAgICAwMjowNDo2Yjo5
+        ZjpiOTpkYTpjMjo2ZTo2NTo5Yjo5OTplNDo2MDo3YTozMjpjZDowMjpmZTpc
+        biAgICAgICAgIDcxOmRhOjE5OmUzOjkzOmJkOmM1OmE3OmEwOjQ2OjllOjI4
+        OmQyOjkxOmFjOjhlOjkxOmM3OlxuICAgICAgICAgYTc6NTE6NGU6ODE6MDk6
+        ZDE6ZjE6Mzk6NWI6MDc6ODc6NDE6M2I6Yjc6ZTM6MWI6YTg6N2U6XG4gICAg
+        ICAgICA1MTo1Mjo0ZTo2NjoyMDpiMTpjZDpjNTphZTpkZToxNzozYTpkNzpj
+        ZTowNzozNzpkODo1ZTpcbiAgICAgICAgIDg4OmVmOmUzOjk0OmMwOjk4OjNl
+        OmMzOjBkOjUxOjQ0OjNkOjUzOjUyOmZmOjVlOjBiOjFiOlxuICAgICAgICAg
+        NWI6NmM6OWI6YTZcbi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLVxuTUlJ
+        RkJ6Q0NBKytnQXdJQkFnSUpBUDI2dkhGdUphTjRNQTBHQ1NxR1NJYjNEUUVC
+        Q3dVQU1JR0xNUXN3Q1FZRFxuVlFRR0V3SlZVekVYTUJVR0ExVUVDQXdPVG05
+        eWRHZ2dRMkZ5YjJ4cGJtRXhFREFPQmdOVkJBY01CMUpoYkdWcFxuWjJneEVE
+        QU9CZ05WQkFvTUIwdGhkR1ZzYkc4eEZEQVNCZ05WQkFzTUMxTnZiV1ZQY21k
+        VmJtbDBNU2t3SndZRFxuVlFRRERDQmpaVzUwYjNNM0xXUmxkbVZzTWk1ellX
+        MXBjaTVsZUdGdGNHeGxMbU52YlRBZUZ3MHlNREExTURjeFxuTkRJeE5UQmFG
+        dzB6T0RBeE1UZ3hOREl4TlRCYU1JR0xNUXN3Q1FZRFZRUUdFd0pWVXpFWE1C
+        VUdBMVVFQ0F3T1xuVG05eWRHZ2dRMkZ5YjJ4cGJtRXhFREFPQmdOVkJBY01C
+        MUpoYkdWcFoyZ3hFREFPQmdOVkJBb01CMHRoZEdWc1xuYkc4eEZEQVNCZ05W
+        QkFzTUMxTnZiV1ZQY21kVmJtbDBNU2t3SndZRFZRUUREQ0JqWlc1MGIzTTNM
+        V1JsZG1Wc1xuTWk1ellXMXBjaTVsZUdGdGNHeGxMbU52YlRDQ0FTSXdEUVlK
+        S29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ1xuZ2dFQkFKL1N3UkQvQVJv
+        ekdRNURuWVBsaW5PNkxUeG1zWGpOaVl4ZzVZR202RTJXWFFmRHZxS2N3bnlV
+        TFc1RFxuUkVidi9UWWdSenZXTmYyWHpaY1gxei9uWi82cEt2RzhSNGR1N1cy
+        Mm52RU5ZMVBCUC8wWHExODFlb1RQYTkybVxuamdtWlZqbmVLV3Y3d3R5TVZp
+        b1Fzd3JLdUd6N3VNanI1ZUt1MVVFRlRLTEF2bnV3YlIxOFpvQ0lXcmNIbTlP
+        NFxuLzVQekdUTmpTSldETkNmR3JNeWdDMWFySWpSeFQzbS9ia3ZKaVZtSGkz
+        czFlYmdjY081WTVuc2llYWNlMmJKWFxuT3VCWmpyTnFsejJhZ013NzFYZlUr
+        bnBZYWJhenFwVlVWWjRUWlgrVndIT1d4ZnQzb0VnZ3BuMzB4TlBwcTVTVFxu
+        VGhyaVhadkZoMURIVnZDVHFMa0tjOC8zQVE4Q0F3RUFBYU9DQVdvd2dnRm1N
+        QXdHQTFVZEV3UUZNQU1CQWY4d1xuQ3dZRFZSMFBCQVFEQWdHbU1CMEdBMVVk
+        SlFRV01CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakFSQmdsZ1xuaGtn
+        Qmh2aENBUUVFQkFNQ0FrUXdOUVlKWUlaSUFZYjRRZ0VOQkNnV0prdGhkR1Zz
+        Ykc4Z1UxTk1JRlJ2YjJ3Z1xuUjJWdVpYSmhkR1ZrSUVObGNuUnBabWxqWVhS
+        bE1CMEdBMVVkRGdRV0JCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUlxuaFUxVFhU
+        Q0J3QVlEVlIwakJJRzRNSUcxZ0JTYjB0bHBpSmtzTG5BcnQybDJlbjNSaFUx
+        VFhhR0JrYVNCampDQlxuaXpFTE1Ba0dBMVVFQmhNQ1ZWTXhGekFWQmdOVkJB
+        Z01EazV2Y25Sb0lFTmhjbTlzYVc1aE1SQXdEZ1lEVlFRSFxuREFkU1lXeGxh
+        V2RvTVJBd0RnWURWUVFLREFkTFlYUmxiR3h2TVJRd0VnWURWUVFMREF0VGIy
+        MWxUM0puVlc1cFxuZERFcE1DY0dBMVVFQXd3Z1kyVnVkRzl6Tnkxa1pYWmxi
+        REl1YzJGdGFYSXVaWGhoYlhCc1pTNWpiMjJDQ1FEOVxudXJ4eGJpV2plREFO
+        QmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBTWhsc3hxK3V3cjVrRnJCOG8wc1E2
+        RnEwRjNUOVxuZGNZbTBvZ0IvcFV1UHdvZWlLVWxFMnRnTk5BczN0aElGZlhN
+        SHdlQUt4MG9rT21MUjhGeEd0cUdvQ2ZveElnMlxuby8vYkZ5OE9tK0U1cHgv
+        Y0pwY3BYa3VaWVBxU0VpVDh2QVNVSkdYellNeGU3a0svbmp3eHVUeVppa1E5
+        S1YybVxubWFyVkRoV1V4TVVqakxsdTVRa1RqRlpMQkRXVmVWQmNJaTBmT21q
+        UTh6NklmVGdwTXZKSHNSZVovYVpJQWdSclxubjduYXdtNWxtNW5rWUhveXpR
+        TCtjZG9aNDVPOXhhZWdScDRvMHBHc2pwSEhwMUZPZ1FuUjhUbGJCNGRCTzdm
+        alxuRzZoK1VWSk9aaUN4emNXdTNoYzYxODRITjloZWlPL2psTUNZUHNNTlVV
+        UTlVMUwvWGdzYlcyeWJwZz09XG4tLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t
+        XG4ifQ==
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1468,19 +1340,21 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:27 GMT
+      - Wed, 05 Jun 2024 14:34:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
+      Location:
+      - "/pulp/api/v3/contentguards/certguard/rhsm/018fe8d3-0ad5-76c7-91ad-f46384d10b3e/"
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
@@ -1492,7 +1366,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 898987e48bd64631bf4cf5102ecd8e39
+      - a258f62a5cee463f881a45662055c6d6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1501,10 +1375,10 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudGd1YXJkcy9jZXJ0
-        Z3VhcmQvcmhzbS8wMThmNTRlMi1jNmU1LTc4MTctOTY3ZS00NGE5ZjJiNGMx
-        OWEvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoxOS4zMDIz
-        MzNaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjI3
-        LjAzNjYxOVoiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        Z3VhcmQvcmhzbS8wMThmZThkMy0wYWQ1LTc2YzctOTFhZC1mNDYzODRkMTBi
+        M2UvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wNVQxNDozNDo1Ni4wODYy
+        ODJaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM0OjU2
+        LjA4NjI5NloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
         IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
         dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
         IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
@@ -1630,7 +1504,7 @@ http_interactions:
         bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
         V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
         PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9
-  recorded_at: Tue, 07 May 2024 21:08:27 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:56 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -1641,7 +1515,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1654,7 +1528,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:27 GMT
+      - Wed, 05 Jun 2024 14:34:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1674,7 +1548,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 37461640c1034482b733234f80fb7ce7
+      - 41cef35f9a5f4fb2b2d72c7526cb9b22
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1684,23 +1558,23 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMDE4ZjU0ZTItZGU2Zi03M2IzLWEyM2YtY2E2NmM2MjZhNDNm
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MjUuMzI4MTk1
-        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoyNS4z
-        MjgyMTRaIiwiYmFzZV9wYXRoIjoiQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVk
+        L3JwbS9ycG0vMDE4ZmU4ZDMtMDdiMi03MmIzLWI0ZGUtZjUwMzQ3OGNmMzNh
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTUuMjgzMjky
+        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNDo1NS4y
+        ODMzMDdaIiwiYmFzZV9wYXRoIjoiQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVk
         b3JhXzE3X2R1cGxpY2F0ZV9sYWJlbCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9j
         ZW50b3M5LWthdGVsbG8tZGV2ZWwubWFuaWNvdHRvLmV4YW1wbGUuY29tL3B1
         bHAvY29udGVudC9BQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
         bGljYXRlX2xhYmVsLyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsImhpZGRlbiI6
         ZmFsc2UsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGljYXRlIiwi
         cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
-        cHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTItZGFjYS03MTBhLTk0YTEt
-        ZmY3NmFlZWNlMmRhLyIsImdlbmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX1d
+        cHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDMtMDU0ZC03ZDMzLThjMmIt
+        NzViYTYxNjI3MDljLyIsImdlbmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX1d
         fQ==
-  recorded_at: Tue, 07 May 2024 21:08:27 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:56 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-daca-710a-94a1-ff76aeece2da/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d3-054d-7d33-8c2b-75ba6162709c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1708,7 +1582,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1721,7 +1595,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:27 GMT
+      - Wed, 05 Jun 2024 14:34:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1741,7 +1615,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6af818b88cbb4a05a0de0d6e738d60ed
+      - e6a5b7d27a8d4106920717811039ffd2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1750,36 +1624,36 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItZGFjYS03MTBhLTk0YTEtZmY3NmFlZWNlMmRhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MjQuMzk4MTczWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoyNC42NDUyNTla
+        cG0vMDE4ZmU4ZDMtMDU0ZC03ZDMzLThjMmItNzViYTYxNjI3MDljLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTQuNjcwNjk1WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNDo1NC44Mjc5MDZa
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLWQ4MTQtNzg5YS04YmNmLTlhMGVkODNk
-        Njc2YS92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItZDgxNC03ODlhLThiY2Yt
-        OWEwZWQ4M2Q2NzZhLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQzLTAzZTQtNzcwNy05OWE4LTVkMmZjYjJi
+        MjIxMi92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMDNlNC03NzA3LTk5YTgt
+        NWQyZmNiMmIyMjEyLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:27 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:56 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-de6f-73b3-a23f-ca66c626a43f/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-07b2-72b3-b4de-f503478cf33a/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
-        Y2VydGd1YXJkL3Joc20vMDE4ZjU0ZTItYzZlNS03ODE3LTk2N2UtNDRhOWYy
-        YjRjMTlhLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        Y2VydGd1YXJkL3Joc20vMDE4ZmU4ZDMtMGFkNS03NmM3LTkxYWQtZjQ2Mzg0
+        ZDEwYjNlLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMThmNTRlMi1kYWNhLTcx
-        MGEtOTRhMS1mZjc2YWVlY2UyZGEvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMThmZThkMy0wNTRkLTdk
+        MzMtOGMyYi03NWJhNjE2MjcwOWMvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1792,7 +1666,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:27 GMT
+      - Wed, 05 Jun 2024 14:34:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1812,7 +1686,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e59e54c1a68c46af9a8258b46c3432c5
+      - 17233f6d137f47cdbbdd39246373d95c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1820,12 +1694,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWU2M2MtN2Ey
-        YS1hNWI0LTEwODk5MDE5Nzc2My8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:27 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTBiOTEtN2Ez
+        Yi1hMjRiLWQwYjI2Y2M2NDJiMi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:56 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-e63c-7a2a-a5b4-108990197763/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-0b91-7a3b-a24b-d0b26cc642b2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1833,7 +1707,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1846,7 +1720,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:27 GMT
+      - Wed, 05 Jun 2024 14:34:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1866,7 +1740,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - dbadf94038764311ab2bdc8788fb39e5
+      - dd7ea60acb77424794bf7b08bf61d6aa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1874,26 +1748,26 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItZTYz
-        Yy03YTJhLWE1YjQtMTA4OTkwMTk3NzYzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MjcuMzI0NzU5WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoyNy4zMjQ3NzNaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMGI5
+        MS03YTNiLWEyNGItZDBiMjZjYzY0MmIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzQ6NTYuMjc0MzI2WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNDo1Ni4yNzQzMzlaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6ImU1OWU1NGMxYTY4YzQ2YWY5YTgy
-        NThiNDZjMzQzMmM1IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MjcuMzQy
-        MjkxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjI3LjM1OTA0
-        MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MjcuNDEzMzMw
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjE3MjMzZjZkMTM3ZjQ3Y2RiYmRk
+        MzkyNDYzNzNkOTVjIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTYuMjgz
+        NTk0WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM0OjU2LjI4NjIy
+        MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTYuMzAxNzcw
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25z
-        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNTRkZi03ZmQy
-        LTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:27 GMT
+        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFh
+        LTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:34:56 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-daca-710a-94a1-ff76aeece2da/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d3-054d-7d33-8c2b-75ba6162709c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1901,7 +1775,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1914,7 +1788,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:27 GMT
+      - Wed, 05 Jun 2024 14:34:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1934,7 +1808,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 73edacb0556944a78cefc3d06f15c5e8
+      - 8e5d3838ffca45969aa2b6bd709c4081
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1943,36 +1817,36 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItZGFjYS03MTBhLTk0YTEtZmY3NmFlZWNlMmRhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MjQuMzk4MTczWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoyNC42NDUyNTla
+        cG0vMDE4ZmU4ZDMtMDU0ZC03ZDMzLThjMmItNzViYTYxNjI3MDljLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTQuNjcwNjk1WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNDo1NC44Mjc5MDZa
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLWQ4MTQtNzg5YS04YmNmLTlhMGVkODNk
-        Njc2YS92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItZDgxNC03ODlhLThiY2Yt
-        OWEwZWQ4M2Q2NzZhLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQzLTAzZTQtNzcwNy05OWE4LTVkMmZjYjJi
+        MjIxMi92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMDNlNC03NzA3LTk5YTgt
+        NWQyZmNiMmIyMjEyLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:27 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:56 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-de6f-73b3-a23f-ca66c626a43f/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-07b2-72b3-b4de-f503478cf33a/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
-        Y2VydGd1YXJkL3Joc20vMDE4ZjU0ZTItYzZlNS03ODE3LTk2N2UtNDRhOWYy
-        YjRjMTlhLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        Y2VydGd1YXJkL3Joc20vMDE4ZmU4ZDMtMGFkNS03NmM3LTkxYWQtZjQ2Mzg0
+        ZDEwYjNlLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMThmNTRlMi1kYWNhLTcx
-        MGEtOTRhMS1mZjc2YWVlY2UyZGEvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMThmZThkMy0wNTRkLTdk
+        MzMtOGMyYi03NWJhNjE2MjcwOWMvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1985,7 +1859,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:27 GMT
+      - Wed, 05 Jun 2024 14:34:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2005,7 +1879,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2d35c81aa24a4b6786401ed4638de177
+      - 9f8eda57f3924db6afda8465692d7bab
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2013,9 +1887,9 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWU3ZTUtNzU1
-        MC04ZjUxLTNmNDMzNTY5NjRhMi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:27 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTBjNmQtNzQ5
+        MS05NWRlLWE1MTE1M2JlNWZmNi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:56 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -2037,7 +1911,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2050,13 +1924,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:28 GMT
+      - Wed, 05 Jun 2024 14:34:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/018f54e2-e98d-78b0-aaf9-54dbc6d92476/"
+      - "/pulp/api/v3/remotes/rpm/rpm/018fe8d3-0d18-7c6c-b617-5927a5cd5587/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -2072,7 +1946,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 57a3d800e162425b9b45f1b147e45770
+      - 01deac2db79f4b53b1b3a37f5d398a14
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2081,9 +1955,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OGY1NGUyLWU5OGQtNzhiMC1hYWY5LTU0ZGJjNmQ5MjQ3Ni8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjI4LjE3Mzc0MFoiLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MjguMTczNzU3WiIsIm5h
+        OGZlOGQzLTBkMTgtN2M2Yy1iNjE3LTU5MjdhNWNkNTU4Ny8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM0OjU2LjY2NDczNFoiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTYuNjY0NzQ4WiIsIm5h
         bWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJsIjoiaHR0cDovL215cmVwby5j
         b20iLCJjYV9jZXJ0IjoiS0pMOktERiooREYmKigqJCYoKiMkSkxLSkQoRCgo
         RCIsImNsaWVudF9jZXJ0IjoiS0pMOktERiooREYmKigqJCYoKiMkSkxLSkQo
@@ -2098,10 +1972,10 @@ http_interactions:
         bWUiOiJwcm94eV9wYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6
         InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfV0sInNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:28 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:56 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-e98d-78b0-aaf9-54dbc6d92476/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d3-0d18-7c6c-b617-5927a5cd5587/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2109,7 +1983,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2122,7 +1996,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:28 GMT
+      - Wed, 05 Jun 2024 14:34:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2142,7 +2016,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a1475b65d112437099ee981d426e4b54
+      - d10e4655b18245e980c7a4a7da7f5bc1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2150,12 +2024,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWU5ZWYtN2Y4
-        MS05NjUzLWVjNDc0MTkyNDM2ZC8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:28 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTBkNTMtNzRi
+        Ni05MDY0LTk1OWNkYmM0NjMwOC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:56 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018f54e2-d814-789a-8bcf-9a0ed83d676a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018fe8d3-03e4-7707-99a8-5d2fcb2b2212/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2165,7 +2039,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2178,7 +2052,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:28 GMT
+      - Wed, 05 Jun 2024 14:34:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2198,7 +2072,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 847c358c1e324bd98075ec97db72411e
+      - c411cea130eb4ffbb4bfcbe665727512
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2206,12 +2080,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWViNTItNzc5
-        Ni04ODI4LWEzYjNkMWM4ODYwZi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:28 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTBlMDYtNzc0
+        ZC1iZDY3LWNkNjM2YmM0YTk1Yy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:56 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-d6d9-74ca-bd8f-33483dc31150/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d3-0359-7c75-936d-fc3ec662f5b2/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2230,7 +2104,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2243,7 +2117,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:28 GMT
+      - Wed, 05 Jun 2024 14:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2263,7 +2137,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 73dfad2ad88f44d8894dce6b7dc56de7
+      - 8cdea320c4864872806ed6988abc8920
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2271,12 +2145,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWVjMDctN2E5
-        NS04NjU3LWViZDZiNjU1ZjM1OC8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:28 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTBlYjUtN2Q2
+        MC1iNTVlLTAzZGYyNGVjNjA5Yi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:57 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-ec07-7a95-8657-ebd6b655f358/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-0eb5-7d60-b55e-03df24ec609b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2284,7 +2158,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2297,7 +2171,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:28 GMT
+      - Wed, 05 Jun 2024 14:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2317,7 +2191,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - db12807530164d7aad4f390a04fcc977
+      - 7868c5d0bf484df0a04482ff6d79d85f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2325,24 +2199,24 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItZWMw
-        Ny03YTk1LTg2NTctZWJkNmI2NTVmMzU4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MjguODA4MzMyWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoyOC44MDgzNDhaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMGVi
+        NS03ZDYwLWI1NWUtMDNkZjI0ZWM2MDliLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzQ6NTcuMDc4MDA2WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNDo1Ny4wNzgwMjNaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjczZGZhZDJhZDg4ZjQ0ZDg4OTRk
-        Y2U2YjdkYzU2ZGU3IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MjguODI3
-        NDk3WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjI4LjgzMDk5
-        MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MjguODU3MzIy
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjhjZGVhMzIwYzQ4NjQ4NzI4MDZl
+        ZDY5ODhhYmM4OTIwIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTcuMDky
+        MDU1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM0OjU3LjA5NDcz
+        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTcuMTA1NTk1
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMv
-        cnBtL3JwbS8wMThmNTRlMi1kNmQ5LTc0Y2EtYmQ4Zi0zMzQ4M2RjMzExNTAv
-        Iiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGY1NGRmLTdmZDIt
-        NzVmYS05YjM1LWMyNzUxM2ZmOThmNC8iXX0=
-  recorded_at: Tue, 07 May 2024 21:08:29 GMT
+        cnBtL3JwbS8wMThmZThkMy0wMzU5LTdjNzUtOTM2ZC1mYzNlYzY2MmY1YjIv
+        Iiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGZlM2M5LTcwYWEt
+        Nzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:34:57 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -2353,7 +2227,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2366,7 +2240,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:29 GMT
+      - Wed, 05 Jun 2024 14:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2386,7 +2260,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ce7b9139da33450db810c4b26c66ae97
+      - ebdf8945961a4a38b920a637a3369ff3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2396,24 +2270,24 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMDE4ZjU0ZTItZGU2Zi03M2IzLWEyM2YtY2E2NmM2MjZhNDNm
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MjUuMzI4MTk1
-        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoyNy44
-        MzgzODRaIiwiYmFzZV9wYXRoIjoiQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVk
+        L3JwbS9ycG0vMDE4ZmU4ZDMtMDdiMi03MmIzLWI0ZGUtZjUwMzQ3OGNmMzNh
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTUuMjgzMjky
+        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNDo1Ni41
+        MTg3MjZaIiwiYmFzZV9wYXRoIjoiQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVk
         b3JhXzE3X2R1cGxpY2F0ZV9sYWJlbCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9j
         ZW50b3M5LWthdGVsbG8tZGV2ZWwubWFuaWNvdHRvLmV4YW1wbGUuY29tL3B1
         bHAvY29udGVudC9BQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
         bGljYXRlX2xhYmVsLyIsImNvbnRlbnRfZ3VhcmQiOiIvcHVscC9hcGkvdjMv
-        Y29udGVudGd1YXJkcy9jZXJ0Z3VhcmQvcmhzbS8wMThmNTRlMi1jNmU1LTc4
-        MTctOTY3ZS00NGE5ZjJiNGMxOWEvIiwiaGlkZGVuIjpmYWxzZSwicHVscF9s
+        Y29udGVudGd1YXJkcy9jZXJ0Z3VhcmQvcmhzbS8wMThmZThkMy0wYWQ1LTc2
+        YzctOTFhZC1mNDYzODRkMTBiM2UvIiwiaGlkZGVuIjpmYWxzZSwicHVscF9s
         YWJlbHMiOnt9LCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJyZXBvc2l0b3J5Ijpu
         dWxsLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
-        cnBtL3JwbS8wMThmNTRlMi1kYWNhLTcxMGEtOTRhMS1mZjc2YWVlY2UyZGEv
+        cnBtL3JwbS8wMThmZThkMy0wNTRkLTdkMzMtOGMyYi03NWJhNjE2MjcwOWMv
         IiwiZ2VuZXJhdGVfcmVwb19jb25maWciOmZhbHNlfV19
-  recorded_at: Tue, 07 May 2024 21:08:29 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:57 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-daca-710a-94a1-ff76aeece2da/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d3-054d-7d33-8c2b-75ba6162709c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2421,7 +2295,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2434,7 +2308,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:29 GMT
+      - Wed, 05 Jun 2024 14:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2454,7 +2328,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f9f6b45e9abb4011b41ccfece1b1abc1
+      - 4e036b04095e4c9682e21a44b8a31746
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2463,34 +2337,34 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItZGFjYS03MTBhLTk0YTEtZmY3NmFlZWNlMmRhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MjQuMzk4MTczWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoyNC42NDUyNTla
+        cG0vMDE4ZmU4ZDMtMDU0ZC03ZDMzLThjMmItNzViYTYxNjI3MDljLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTQuNjcwNjk1WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNDo1NC44Mjc5MDZa
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLWQ4MTQtNzg5YS04YmNmLTlhMGVkODNk
-        Njc2YS92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItZDgxNC03ODlhLThiY2Yt
-        OWEwZWQ4M2Q2NzZhLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQzLTAzZTQtNzcwNy05OWE4LTVkMmZjYjJi
+        MjIxMi92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMDNlNC03NzA3LTk5YTgt
+        NWQyZmNiMmIyMjEyLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:29 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:57 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-de6f-73b3-a23f-ca66c626a43f/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-07b2-72b3-b4de-f503478cf33a/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4
-        ZjU0ZTItZGFjYS03MTBhLTk0YTEtZmY3NmFlZWNlMmRhLyJ9
+        ZmU4ZDMtMDU0ZC03ZDMzLThjMmItNzViYTYxNjI3MDljLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2503,7 +2377,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:29 GMT
+      - Wed, 05 Jun 2024 14:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2523,7 +2397,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - df8ef21508d34766b52f0692e07cca96
+      - c8637130f46c4754a582138a596cc84c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2531,12 +2405,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWVkZTYtNzc1
-        MS1iMWQ0LWNmMGY3MzA1OTNmZC8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:29 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTEwMDgtNzA3
+        ZC1hNDI5LTgxMmU3ZWY0NzNhNS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:57 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-ede6-7751-b1d4-cf0f730593fd/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-1008-707d-a429-812e7ef473a5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2544,7 +2418,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2557,7 +2431,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:29 GMT
+      - Wed, 05 Jun 2024 14:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2577,7 +2451,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 07fcd09a7bed495097e969f23643f415
+      - d44f9623622245a1aa5be467e875e0bc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2585,26 +2459,26 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItZWRl
-        Ni03NzUxLWIxZDQtY2YwZjczMDU5M2ZkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MjkuMjg2NzA0WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoyOS4yODY3MjFaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMTAw
+        OC03MDdkLWE0MjktODEyZTdlZjQ3M2E1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzQ6NTcuNDE2NjU3WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNDo1Ny40MTY2NzFaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6ImRmOGVmMjE1MDhkMzQ3NjZiNTJm
-        MDY5MmUwN2NjYTk2IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MjkuMzA1
-        ODY0WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjI5LjMxMjMx
-        M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MjkuMzU2OTUy
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6ImM4NjM3MTMwZjQ2YzQ3NTRhNTgy
+        MTM4YTU5NmNjODRjIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTcuNDI2
+        NTMxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM0OjU3LjQyODk2
+        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTcuNDQ0MDk5
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25z
-        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNTRkZi03ZmQy
-        LTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:29 GMT
+        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFh
+        LTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:34:57 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-daca-710a-94a1-ff76aeece2da/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d3-054d-7d33-8c2b-75ba6162709c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2612,7 +2486,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2625,7 +2499,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:29 GMT
+      - Wed, 05 Jun 2024 14:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2645,7 +2519,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7ce0123cc6bb4c78acf968d637bf2395
+      - 3fd0826cb1cd44f3b37f56951be71c83
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2654,34 +2528,34 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItZGFjYS03MTBhLTk0YTEtZmY3NmFlZWNlMmRhLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MjQuMzk4MTczWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoyNC42NDUyNTla
+        cG0vMDE4ZmU4ZDMtMDU0ZC03ZDMzLThjMmItNzViYTYxNjI3MDljLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTQuNjcwNjk1WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNDo1NC44Mjc5MDZa
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLWQ4MTQtNzg5YS04YmNmLTlhMGVkODNk
-        Njc2YS92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItZDgxNC03ODlhLThiY2Yt
-        OWEwZWQ4M2Q2NzZhLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQzLTAzZTQtNzcwNy05OWE4LTVkMmZjYjJi
+        MjIxMi92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMDNlNC03NzA3LTk5YTgt
+        NWQyZmNiMmIyMjEyLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:29 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:57 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-de6f-73b3-a23f-ca66c626a43f/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-07b2-72b3-b4de-f503478cf33a/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4
-        ZjU0ZTItZGFjYS03MTBhLTk0YTEtZmY3NmFlZWNlMmRhLyJ9
+        ZmU4ZDMtMDU0ZC03ZDMzLThjMmItNzViYTYxNjI3MDljLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2694,7 +2568,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:29 GMT
+      - Wed, 05 Jun 2024 14:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2714,7 +2588,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 125bf1ea77f64d2cb0730b2113c20e73
+      - 5a4c77f2e7454fe99b716f103d22f29f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2722,12 +2596,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWVmNDctN2Fl
-        Yy05ZGFlLWQ2MTQ5ZGYwOWFhYS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:29 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTEwZTMtNzdk
+        Ni1iNjUxLTY2OTM2MTA1NmNjNS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:57 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-de6f-73b3-a23f-ca66c626a43f/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-07b2-72b3-b4de-f503478cf33a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2735,7 +2609,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2748,7 +2622,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:29 GMT
+      - Wed, 05 Jun 2024 14:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2768,7 +2642,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0a472d2b02164b66a8673de330b90027
+      - c126aacbcf934be8920fe0a4bfa9a0a6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2776,12 +2650,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWYwMDAtN2E3
-        MC04ZjMxLTA4MDc0ZTQ3ZjVmYy8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:29 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTExNTEtNzUz
+        OC05MzE1LTBmZjljZTAwZDZjMC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:57 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-d6d9-74ca-bd8f-33483dc31150/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d3-0359-7c75-936d-fc3ec662f5b2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2789,7 +2663,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2802,7 +2676,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:30 GMT
+      - Wed, 05 Jun 2024 14:34:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2822,7 +2696,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 055b9e1032634d119e9b34c6ec7b7e2d
+      - 498066d3d48f457c9cfc249192c7ddf3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2830,12 +2704,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWYyOWUtNzE2
-        Yi04ZTM0LTJjOThkOWNjMjgxMy8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:30 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTEyMTktN2Ux
+        MS05MTJjLTUyYzg0OWFiNDA1NC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:57 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-f29e-716b-8e34-2c98d9cc2813/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-1219-7e11-912c-52c849ab4054/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2843,7 +2717,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2856,7 +2730,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:30 GMT
+      - Wed, 05 Jun 2024 14:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2876,7 +2750,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d7a80b66753c4f2286c07f72fc8920d0
+      - 9648d5e3fc1048559207d8c5a04a0579
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2884,28 +2758,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItZjI5
-        ZS03MTZiLThlMzQtMmM5OGQ5Y2MyODEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MzAuNDk0ODA4WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODozMC40OTQ4MjRaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMTIx
+        OS03ZTExLTkxMmMtNTJjODQ5YWI0MDU0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzQ6NTcuOTQ1NTE5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNDo1Ny45NDU1MzFaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjA1NWI5ZTEwMzI2MzRkMTE5ZTli
-        MzRjNmVjN2I3ZTJkIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MzAuNTEz
-        OTgyWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjMwLjU3MTE4
-        MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MzAuNjM5MjA3
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjQ5ODA2NmQzZDQ4ZjQ1N2M5Y2Zj
+        MjQ5MTkyYzdkZGYzIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTcuOTU4
+        MDg3WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM0OjU3Ljk5MDc1
+        MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTguMDMzMTM3
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGMxLTcxNzUtYTM3Yi1iNjMzMjI1NWEyMGEvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVtb3Rlcy9ycG0vcnBtLzAxOGY1NGUyLWQ2ZDktNzRjYS1iZDhmLTMz
-        NDgzZGMzMTE1MC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4
-        ZjU0ZGYtN2ZkMi03NWZhLTliMzUtYzI3NTEzZmY5OGY0LyJdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:30 GMT
+        djMvcmVtb3Rlcy9ycG0vcnBtLzAxOGZlOGQzLTAzNTktN2M3NS05MzZkLWZj
+        M2VjNjYyZjViMi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4
+        ZmUzYzktNzBhYS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:58 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018f54e2-d814-789a-8bcf-9a0ed83d676a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018fe8d3-03e4-7707-99a8-5d2fcb2b2212/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2913,7 +2787,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2926,7 +2800,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:30 GMT
+      - Wed, 05 Jun 2024 14:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2946,7 +2820,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1dbb112f3cca48e2850f07c1ea4d378a
+      - 808df39b3783444aab33bdf4b399c203
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2954,12 +2828,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWYzZTEtN2Q4
-        YS04MGFhLWRkZjBiMmQxYzk4My8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:30 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTEzMGEtN2Vk
+        My04ODRmLTBkNDFlZTlmYTJiMy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:58 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-f3e1-7d8a-80aa-ddf0b2d1c983/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-130a-7ed3-884f-0d41ee9fa2b3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2967,7 +2841,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2980,7 +2854,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:31 GMT
+      - Wed, 05 Jun 2024 14:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3000,7 +2874,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5c40fa7ff7124df08e7cb8841f89bbb9
+      - 9fe03996c0d6463eac904914a842656b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3008,25 +2882,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItZjNl
-        MS03ZDhhLTgwYWEtZGRmMGIyZDFjOTgzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MzAuODE3OTkyWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODozMC44MTgwMDdaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMTMw
+        YS03ZWQzLTg4NGYtMGQ0MWVlOWZhMmIzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzQ6NTguMTg2OTE5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNDo1OC4xODY5MzNaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjFkYmIxMTJmM2NjYTQ4ZTI4NTBm
-        MDdjMWVhNGQzNzhhIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MzAuODMw
-        ODY5WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjMwLjg4NjI2
-        NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MzEuMDc1OTE1
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjgwOGRmMzliMzc4MzQ0NGFhYjMz
+        YmRmNGIzOTljMjAzIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTguMTk3
+        ODY3WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM0OjU4LjIyOTI0
+        MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTguMzY3NzM2
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGU4LTc0ODctOWFhMC0zYzNlYzFhMTk5ZDcvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItZDgxNC03ODlhLThi
-        Y2YtOWEwZWQ4M2Q2NzZhLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlu
-        cy8wMThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:31 GMT
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMDNlNC03NzA3LTk5
+        YTgtNWQyZmNiMmIyMjEyLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlu
+        cy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:34:58 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -3037,7 +2911,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -3050,7 +2924,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:31 GMT
+      - Wed, 05 Jun 2024 14:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3070,7 +2944,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2e17c7861282460da16f1da8b1b2d8c3
+      - f33fe5b8d5ea4bc7887a310efe330f42
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3080,7 +2954,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:31 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:58 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
@@ -3091,7 +2965,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.21.3/ruby
+      - OpenAPI-Generator/0.21.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -3104,7 +2978,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:31 GMT
+      - Wed, 05 Jun 2024 14:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3124,7 +2998,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f10ca6b6c54c4e40be0c1566ee357b1b
+      - edc66de071374de6897cc5b7b0c7dfde
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3134,7 +3008,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:31 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:58 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -3158,7 +3032,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:31 GMT
+      - Wed, 05 Jun 2024 14:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3178,7 +3052,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 78334fb7924043f99012b22005da7a60
+      - 10fdebd6593042d7bf37763f6f1e4e27
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3188,7 +3062,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:31 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:58 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -3212,7 +3086,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:31 GMT
+      - Wed, 05 Jun 2024 14:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3232,7 +3106,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f7308234837645968e546025875cb9fe
+      - 479d4c64e2634e8b8ea32b6ffc75a590
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3242,7 +3116,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:31 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:58 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -3253,7 +3127,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -3266,7 +3140,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:31 GMT
+      - Wed, 05 Jun 2024 14:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3286,7 +3160,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 18036d02b9274a9fa8c215f27db49fb4
+      - 8b5ee0692a5349b287728289f05aa0a6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3296,7 +3170,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:31 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:58 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -3320,7 +3194,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:31 GMT
+      - Wed, 05 Jun 2024 14:34:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3340,7 +3214,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c7dbafc0b404475eaa97edf75a78b297
+      - 1f665a4e816f41259bcee2e320eeb421
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3350,7 +3224,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:31 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:58 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -3374,7 +3248,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:31 GMT
+      - Wed, 05 Jun 2024 14:34:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3394,7 +3268,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e64b7ecb0b37479882d3073ab0d5ed2e
+      - 112cdca67a5a4affb4b9b763bdd68321
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3404,7 +3278,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:31 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:59 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
@@ -3417,7 +3291,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -3430,7 +3304,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:31 GMT
+      - Wed, 05 Jun 2024 14:34:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3450,7 +3324,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7e086a98f1a34f20a938d6f7dc65b04a
+      - ec6e98f4ef8249a391fcd6797f25ad83
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3458,12 +3332,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWY3OGUtN2Ri
-        NC05ZTRhLWI1N2NiZjYwNzRhNS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:31 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTE2YWItN2M4
+        ZC04NTNhLTliODUzYWFhYmMzZi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:59 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-f78e-7db4-9e4a-b57cbf6074a5/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-16ab-7c8d-853a-9b853aaabc3f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3471,7 +3345,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -3484,7 +3358,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:32 GMT
+      - Wed, 05 Jun 2024 14:34:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3504,7 +3378,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ca91f8c4c64945a1bc356e89c4e85dce
+      - e2dc9c0e1e94404dbd77d0bf9aa3c502
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3512,18 +3386,18 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItZjc4
-        ZS03ZGI0LTllNGEtYjU3Y2JmNjA3NGE1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MzEuNzU5MTg5WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODozMS43NTkyMDVaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMTZh
+        Yi03YzhkLTg1M2EtOWI4NTNhYWFiYzNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzQ6NTkuMTE2Mjk4WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNDo1OS4xMTYzMTNaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLm9ycGhhbi5vcnBo
-        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiN2UwODZhOThmMWEzNGYyMGE5
-        MzhkNmY3ZGM2NWIwNGEiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
-        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMTowODozMS43
-        Nzc3NjFaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MzEuODMw
-        MjY1WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMTowODozMi4wMzU5
-        NjhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzAxOGY1NGUwLWE0YzEtNzE3NS1hMzdiLWI2MzMyMjU1YTIwYS8iLCJw
+        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiZWM2ZTk4ZjRlZjgyNDlhMzkx
+        ZmNkNjc5N2YyNWFkODMiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
+        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozNDo1OS4x
+        MzA0ODJaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTkuMTYw
+        NDE5WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozNDo1OS4zMTIx
+        ODZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzAxOGZlM2NiLTBkZjItN2M4My1hN2VhLWUyNmExYTI4ZDdmOS8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xlYW4g
         dXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIs
@@ -3533,7 +3407,63 @@ http_interactions:
         ZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
         IjpbIi9hcGkvdjMvb3JwaGFucy9jbGVhbnVwLyIsInNoYXJlZDovcHVscC9h
-        cGkvdjMvZG9tYWlucy8wMThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNm
-        Zjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:32 GMT
+        cGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2Fk
+        MzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:34:59 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/purge/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJmaW5pc2hlZF9iZWZvcmUiOiIzMDAwLTAxLTAxVDAwOjAwOjAwLjAwMCsw
+        MDowMCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:34:59 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 19bde57c5cbc40b280995c964bc52261
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTE3ZGMtN2Y4
+        MS05NTg2LTgzMzRiMTEyZTA1MS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:59 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_ssl_validation.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_ssl_validation.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:52 GMT
+      - Wed, 05 Jun 2024 14:35:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cd4bea65932c42ba87bd38445c85e7cf
+      - 6641a33bebf34882989ed6fbbdd995c1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:52 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:00 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:53 GMT
+      - Wed, 05 Jun 2024 14:35:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - dfd9ec604ab8444aa6ab93516fd742cb
+      - 8f64bdf253ea40fab30a0d2c12431714
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:53 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:00 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -118,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:53 GMT
+      - Wed, 05 Jun 2024 14:35:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5dee583ca9d5432297aac17610564324
+      - cc1fce10f64643dba41d3f0b43000be8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:53 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:00 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -172,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:53 GMT
+      - Wed, 05 Jun 2024 14:35:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 25b83192782a40dca0091ebfd05bad95
+      - e3b2fca3b2204171bfce03e99365ab92
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:53 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:00 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -234,7 +234,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -247,13 +247,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:53 GMT
+      - Wed, 05 Jun 2024 14:35:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/018f54e2-62a7-7036-9218-bb9b0fc1cb23/"
+      - "/pulp/api/v3/remotes/rpm/rpm/018fe8d3-1b30-7786-bc38-b2153833ddf0/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -269,7 +269,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 84ddf6a66bee4836b0c10613f999e261
+      - 786c59527ebb4a948e6e90fa2e84a494
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -278,9 +278,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OGY1NGUyLTYyYTctNzAzNi05MjE4LWJiOWIwZmMxY2IyMy8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA3OjUzLjY0MDcwOFoiLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDc6NTMuNjQwNzI3WiIsIm5h
+        OGZlOGQzLTFiMzAtNzc4Ni1iYzM4LWIyMTUzODMzZGRmMC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM1OjAwLjI3MzI1N1oiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDAuMjczMjY5WiIsIm5h
         bWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0dHA6Ly9teXJlcG8uY29tIiwi
         Y2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0
         aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwi
@@ -294,7 +294,7 @@ http_interactions:
         ZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InVzZXJuYW1lIiwiaXNfc2V0
         IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfV0s
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:07:53 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:00 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -307,7 +307,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -320,13 +320,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:54 GMT
+      - Wed, 05 Jun 2024 14:35:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/018f54e2-638f-7f56-bf42-8c0cf9bc8a86/"
+      - "/pulp/api/v3/repositories/rpm/rpm/018fe8d3-1bb3-759e-a40a-07d910e5378f/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -342,7 +342,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4198a7d608c54417bc95e3a211dd2c96
+      - 022e060d25f44568be489e2629dc7b0d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -351,14 +351,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMDE4ZjU0ZTItNjM4Zi03ZjU2LWJmNDItOGMwY2Y5YmM4YTg2LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDc6NTMuODcyOTI5WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowNzo1My44ODYwMDJa
+        cG0vMDE4ZmU4ZDMtMWJiMy03NTllLWE0MGEtMDdkOTEwZTUzNzhmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDAuNDAzNjc0WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNTowMC40MTEwMzZa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wMThmNTRlMi02MzhmLTdmNTYtYmY0Mi04YzBjZjliYzhhODYv
+        cnBtL3JwbS8wMThmZThkMy0xYmIzLTc1OWUtYTQwYS0wN2Q5MTBlNTM3OGYv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzAxOGY1
-        NGUyLTYzOGYtN2Y1Ni1iZjQyLThjMGNmOWJjOGE4Ni92ZXJzaW9ucy8wLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzAxOGZl
+        OGQzLTFiYjMtNzU5ZS1hNDBhLTA3ZDkxMGU1Mzc4Zi92ZXJzaW9ucy8wLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -367,7 +367,7 @@ http_interactions:
         Y2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:07:54 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:00 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -375,13 +375,13 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE4ZjU0ZTItNjM4Zi03ZjU2LWJmNDItOGMwY2Y5YmM4
-        YTg2L3ZlcnNpb25zLzAvIn0=
+        aWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMWJiMy03NTllLWE0MGEtMDdkOTEwZTUz
+        NzhmL3ZlcnNpb25zLzAvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -394,7 +394,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:54 GMT
+      - Wed, 05 Jun 2024 14:35:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -414,7 +414,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 52b7d0f027bf46cd9a0dc15c79302d8b
+      - 1fd1185cca164492b2573c2bc0bfec37
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -422,12 +422,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTY3NDYtNzQw
-        Ny1hZWVmLTE2NmYxMDIzNzVjNC8ifQ==
-  recorded_at: Tue, 07 May 2024 21:07:54 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTFjZTctNzBi
+        NS1iYWQxLWMyODE0NzAxOGU5Ni8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:00 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-6746-7407-aeef-166f102375c4/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-1ce7-70b5-bad1-c28147018e96/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -435,7 +435,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -448,7 +448,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:55 GMT
+      - Wed, 05 Jun 2024 14:35:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -468,7 +468,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b04da940460345649a11903b53543da0
+      - 0eedfdabfafa47d894ca206d08037ed1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -476,30 +476,30 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItNjc0
-        Ni03NDA3LWFlZWYtMTY2ZjEwMjM3NWM0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDc6NTQuODIzNzY4WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowNzo1NC44MjM3ODVaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMWNl
+        Ny03MGI1LWJhZDEtYzI4MTQ3MDE4ZTk2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MDAuNzExNDgxWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNTowMC43MTE0OTVaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnB1Ymxpc2hpbmcu
-        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiNTJiN2QwZjAyN2JmNDZjZDlhMGRj
-        MTVjNzkzMDJkOGIiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
-        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMTowNzo1NC44NTE3
-        ODdaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDc6NTQuOTI0MTEz
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMTowNzo1NS4xNTUxMTFa
+        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiMWZkMTE4NWNjYTE2NDQ5MmIyNTcz
+        YzJiYzBiZmVjMzciLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
+        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozNTowMC43MjQx
+        MzFaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDAuNzY1MTYz
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozNTowMC45NDgyNTha
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzAxOGY1NGUwLWE0YzEtNzE3NS1hMzdiLWI2MzMyMjU1YTIwYS8iLCJwYXJl
+        LzAxOGZlM2NiLTBkZjItN2M4My1hN2VhLWUyNmExYTI4ZDdmOS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJhdGlu
         ZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2VuZXJh
         dGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEs
         ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTIt
-        NjdjMy03ZDRiLTllNzItN2ZkZWMyYjVlNWY0LyJdLCJyZXNlcnZlZF9yZXNv
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDMt
+        MWQyYS03Y2RmLTk1MzMtOWRjYTk4MDUxZDBmLyJdLCJyZXNlcnZlZF9yZXNv
         dXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE4ZjU0ZTItNjM4Zi03ZjU2LWJmNDItOGMwY2Y5YmM4
-        YTg2LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNTRkZi03
-        ZmQyLTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:07:55 GMT
+        aWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMWJiMy03NTllLWE0MGEtMDdkOTEwZTUz
+        NzhmLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03
+        MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:35:00 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -510,7 +510,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -523,7 +523,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:55 GMT
+      - Wed, 05 Jun 2024 14:35:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -543,7 +543,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0f6c46c6128f4994957f79afb5ac89a9
+      - 0aea1ef47abd43588b54d7e7ea3f6b87
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -553,10 +553,10 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:55 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:01 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-67c3-7d4b-9e72-7fdec2b5e5f4/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d3-1d2a-7cdf-9533-9dca98051d0f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -564,7 +564,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -577,7 +577,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:55 GMT
+      - Wed, 05 Jun 2024 14:35:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -597,7 +597,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a0c2a6592d54421f933d78026c5c3034
+      - f2b1edf897c54e3195744d232da1d0d3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -606,19 +606,19 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItNjdjMy03ZDRiLTllNzItN2ZkZWMyYjVlNWY0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDc6NTQuOTQ5NTYxWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowNzo1NS4xNDYxMTZa
+        cG0vMDE4ZmU4ZDMtMWQyYS03Y2RmLTk1MzMtOWRjYTk4MDUxZDBmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDAuNzgwMjUzWiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNTowMC45NDA1NDda
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLTYzOGYtN2Y1Ni1iZjQyLThjMGNmOWJj
-        OGE4Ni92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItNjM4Zi03ZjU2LWJmNDIt
-        OGMwY2Y5YmM4YTg2LyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQzLTFiYjMtNzU5ZS1hNDBhLTA3ZDkxMGU1
+        Mzc4Zi92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMWJiMy03NTllLWE0MGEt
+        MDdkOTEwZTUzNzhmLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:07:55 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:01 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/
@@ -628,13 +628,13 @@ http_interactions:
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTItNjdjMy03ZDRiLTllNzItN2Zk
-        ZWMyYjVlNWY0LyJ9
+        bGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDMtMWQyYS03Y2RmLTk1MzMtOWRj
+        YTk4MDUxZDBmLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -647,7 +647,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:55 GMT
+      - Wed, 05 Jun 2024 14:35:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -667,7 +667,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 28977c25f5e047dd86d977dcdb0ebf8e
+      - 42833ac44ba747a183f34ccc98d628d7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -675,12 +675,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTY5YzktNzE2
-        ZC04ZTRkLWQxNDVmOGI5NzZkMi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:07:55 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTFlYTktN2Jl
+        YS05NzcwLTYyYmY3NjM5NGVhMi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:01 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-69c9-716d-8e4d-d145f8b976d2/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-1ea9-7bea-9770-62bf76394ea2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -688,7 +688,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -701,7 +701,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:55 GMT
+      - Wed, 05 Jun 2024 14:35:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -721,7 +721,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 848657dd5f044d3dbf33f325a1f6a45c
+      - bb4438fcf500490cb79fc0e216e602e8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -729,29 +729,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItNjlj
-        OS03MTZkLThlNGQtZDE0NWY4Yjk3NmQyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDc6NTUuNDY2NDgyWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowNzo1NS40NjY0OTdaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMWVh
+        OS03YmVhLTk3NzAtNjJiZjc2Mzk0ZWEyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MDEuMTYxNzk2WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNTowMS4xNjE4MTBaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6IjI4OTc3YzI1ZjVlMDQ3ZGQ4NmQ5
-        NzdkY2RiMGViZjhlIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDc6NTUuNDkw
-        NDE4WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA3OjU1LjU1NTM0
-        M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDc6NTUuODQ0Mjgz
+        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6IjQyODMzYWM0NGJhNzQ3YTE4M2Yz
+        NGNjYzk4ZDYyOGQ3IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDEuMTcy
+        NzMyWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjAxLjIwNTgx
+        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDEuNDM1Njc2
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGU4LTc0ODctOWFhMC0zYzNlYzFhMTk5ZDcvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
-        IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDE4ZjU0
-        ZTItNmIzMS03NTE5LTkxYjMtOTBlZTQ5ZDI1MjI5LyJdLCJyZXNlcnZlZF9y
+        IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDE4ZmU4
+        ZDMtMWZhYi03MzBiLWFkNTEtOGU5OTUwOTBjZjliLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iLCJz
-        aGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZjU0ZGYtN2ZkMi03NWZh
-        LTliMzUtYzI3NTEzZmY5OGY0LyJdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:55 GMT
+        aGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZmUzYzktNzBhYS03ODgz
+        LWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:01 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-6b31-7519-91b3-90ee49d25229/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-1fab-730b-ad51-8e995090cf9b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -759,7 +759,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -772,7 +772,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:56 GMT
+      - Wed, 05 Jun 2024 14:35:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -792,7 +792,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2bd2904d77bb4a448247df218555ca07
+      - 77d7cea031da4d398b138c7450f5e6e9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -801,9 +801,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzAxOGY1NGUyLTZiMzEtNzUxOS05MWIzLTkwZWU0OWQyNTIyOS8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA3OjU1LjgyNjY5NVoiLCJw
-        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDc6NTUuODI2NzE1
+        cnBtLzAxOGZlOGQzLTFmYWItNzMwYi1hZDUxLThlOTk1MDkwY2Y5Yi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM1OjAxLjQyMTQ1M1oiLCJw
+        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDEuNDIxNDc0
         WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
         N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
         OS1rYXRlbGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9wdWxwL2Nv
@@ -811,9 +811,9 @@ http_interactions:
         ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJoaWRkZW4iOmZhbHNl
         LCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInJlcG9z
         aXRvcnkiOm51bGwsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1Ymxp
-        Y2F0aW9ucy9ycG0vcnBtLzAxOGY1NGUyLTY3YzMtN2Q0Yi05ZTcyLTdmZGVj
-        MmI1ZTVmNC8iLCJnZW5lcmF0ZV9yZXBvX2NvbmZpZyI6ZmFsc2V9
-  recorded_at: Tue, 07 May 2024 21:07:56 GMT
+        Y2F0aW9ucy9ycG0vcnBtLzAxOGZlOGQzLTFkMmEtN2NkZi05NTMzLTlkY2E5
+        ODA1MWQwZi8iLCJnZW5lcmF0ZV9yZXBvX2NvbmZpZyI6ZmFsc2V9
+  recorded_at: Wed, 05 Jun 2024 14:35:01 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -835,7 +835,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -848,13 +848,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:56 GMT
+      - Wed, 05 Jun 2024 14:35:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/018f54e2-6ca7-7e70-8877-e3ffc481f17e/"
+      - "/pulp/api/v3/remotes/rpm/rpm/018fe8d3-20b5-7745-aef2-ddf1ebddefc0/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -870,7 +870,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fb7545515e1f41fe8a0aa29473f4f017
+      - 061db37cef824278ba00b6dc0c812029
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -879,9 +879,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OGY1NGUyLTZjYTctN2U3MC04ODc3LWUzZmZjNDgxZjE3ZS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA3OjU2LjIwMDIyMloiLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDc6NTYuMjAwMjM4WiIsIm5h
+        OGZlOGQzLTIwYjUtNzc0NS1hZWYyLWRkZjFlYmRkZWZjMC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM1OjAxLjY4NTYwNVoiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDEuNjg1NjE4WiIsIm5h
         bWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJsIjoiaHR0cDovL215cmVwby5j
         b20iLCJjYV9jZXJ0IjoiS0pMOktERiooREYmKigqJCYoKiMkSkxLSkQoRCgo
         RCIsImNsaWVudF9jZXJ0IjoiS0pMOktERiooREYmKigqJCYoKiMkSkxLSkQo
@@ -896,10 +896,10 @@ http_interactions:
         ZSI6InByb3h5X3Bhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoi
         dXNlcm5hbWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwYXNzd29yZCIs
         ImlzX3NldCI6ZmFsc2V9XSwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
-  recorded_at: Tue, 07 May 2024 21:07:56 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:01 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-6ca7-7e70-8877-e3ffc481f17e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d3-20b5-7745-aef2-ddf1ebddefc0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -907,7 +907,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -920,7 +920,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:56 GMT
+      - Wed, 05 Jun 2024 14:35:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -940,7 +940,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1a25d0cf85164891882892cccfb4dcc4
+      - b1e7981603d54a1fa5e04917ce3f8e4b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -948,12 +948,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTZjZWUtNzI5
-        Ny05ZDU1LWJlNDMwYmFjZTIxMy8ifQ==
-  recorded_at: Tue, 07 May 2024 21:07:56 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTIwZWMtNzk5
+        OS1iOTZiLTQ4ZmYxMjQ1Y2VmNS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:01 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018f54e2-638f-7f56-bf42-8c0cf9bc8a86/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018fe8d3-1bb3-759e-a40a-07d910e5378f/
     body:
       encoding: UTF-8
       base64_string: |
@@ -963,7 +963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -976,7 +976,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:56 GMT
+      - Wed, 05 Jun 2024 14:35:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -996,7 +996,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 68e184b6d8f94875a7b33cd25fb7d80a
+      - fb78de6393d04ec19197564b6b832dc7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1004,12 +1004,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTZkYTktNzM4
-        Zi05NTE2LTc0NTFiNTljZjdjNS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:07:56 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTIxOGQtNzY2
+        Mi04ZDcwLTE1ZjJkZTgyMDM4Yi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:01 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-62a7-7036-9218-bb9b0fc1cb23/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d3-1b30-7786-bc38-b2153833ddf0/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1028,7 +1028,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1041,7 +1041,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:56 GMT
+      - Wed, 05 Jun 2024 14:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1061,7 +1061,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9061d294ff4f43afb99e62dcd41b9464
+      - 8a8f2b5020df45099d2d5c2a51e681f9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1069,12 +1069,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTZlMjgtN2Ni
-        My05OGVhLTBlMDQ3ODFlYWU3Zi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:07:56 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTIxZjEtNzIz
+        OC04MzVlLTEzZGIzMzZjZGU4YS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:02 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-6e28-7cb3-98ea-0e04781eae7f/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-21f1-7238-835e-13db336cde8a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1082,7 +1082,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1095,7 +1095,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:56 GMT
+      - Wed, 05 Jun 2024 14:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1115,7 +1115,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6404570ce79045ca9246abddca470541
+      - b1f4bc3e5a6147adb62919dbe5f7f1d1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1123,24 +1123,24 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItNmUy
-        OC03Y2IzLTk4ZWEtMGUwNDc4MWVhZTdmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDc6NTYuNTg1MzE1WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowNzo1Ni41ODUzMzFaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMjFm
+        MS03MjM4LTgzNWUtMTNkYjMzNmNkZThhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MDIuMDAyMjM4WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNTowMi4wMDIyNTBaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjkwNjFkMjk0ZmY0ZjQzYWZiOTll
-        NjJkY2Q0MWI5NDY0IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDc6NTYuNTk4
-        Nzk0WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA3OjU2LjYwMjgy
-        OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDc6NTYuNjE0Nzgz
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjhhOGYyYjUwMjBkZjQ1MDk5ZDJk
+        NWMyYTUxZTY4MWY5IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDIuMDEy
+        NDczWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjAyLjAxNDcw
+        MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDIuMDIzOTky
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMv
-        cnBtL3JwbS8wMThmNTRlMi02MmE3LTcwMzYtOTIxOC1iYjliMGZjMWNiMjMv
-        Iiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGY1NGRmLTdmZDIt
-        NzVmYS05YjM1LWMyNzUxM2ZmOThmNC8iXX0=
-  recorded_at: Tue, 07 May 2024 21:07:56 GMT
+        cnBtL3JwbS8wMThmZThkMy0xYjMwLTc3ODYtYmMzOC1iMjE1MzgzM2RkZjAv
+        Iiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGZlM2M5LTcwYWEt
+        Nzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:35:02 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -1151,7 +1151,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1164,7 +1164,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:56 GMT
+      - Wed, 05 Jun 2024 14:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1184,7 +1184,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - df4a259293114160928466beed3901dc
+      - 2ae7b3a929654c0190a74dab6dbf3f3d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1194,23 +1194,23 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMDE4ZjU0ZTItNmIzMS03NTE5LTkxYjMtOTBlZTQ5ZDI1MjI5
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDc6NTUuODI2Njk1
-        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowNzo1NS44
-        MjY3MTVaIiwiYmFzZV9wYXRoIjoiQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVk
+        L3JwbS9ycG0vMDE4ZmU4ZDMtMWZhYi03MzBiLWFkNTEtOGU5OTUwOTBjZjli
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDEuNDIxNDUz
+        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNTowMS40
+        MjE0NzRaIiwiYmFzZV9wYXRoIjoiQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVk
         b3JhXzE3X2R1cGxpY2F0ZV9sYWJlbCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9j
         ZW50b3M5LWthdGVsbG8tZGV2ZWwubWFuaWNvdHRvLmV4YW1wbGUuY29tL3B1
         bHAvY29udGVudC9BQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
         bGljYXRlX2xhYmVsLyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsImhpZGRlbiI6
         ZmFsc2UsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGljYXRlIiwi
         cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
-        cHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTItNjdjMy03ZDRiLTllNzIt
-        N2ZkZWMyYjVlNWY0LyIsImdlbmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX1d
+        cHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDMtMWQyYS03Y2RmLTk1MzMt
+        OWRjYTk4MDUxZDBmLyIsImdlbmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX1d
         fQ==
-  recorded_at: Tue, 07 May 2024 21:07:56 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:02 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-67c3-7d4b-9e72-7fdec2b5e5f4/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d3-1d2a-7cdf-9533-9dca98051d0f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1218,7 +1218,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1231,7 +1231,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:56 GMT
+      - Wed, 05 Jun 2024 14:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1251,7 +1251,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3367c87c0d72469882082eac51d3c724
+      - c7bea91dfc9b407082c2dc91ae7dc419
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1260,34 +1260,34 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItNjdjMy03ZDRiLTllNzItN2ZkZWMyYjVlNWY0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDc6NTQuOTQ5NTYxWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowNzo1NS4xNDYxMTZa
+        cG0vMDE4ZmU4ZDMtMWQyYS03Y2RmLTk1MzMtOWRjYTk4MDUxZDBmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDAuNzgwMjUzWiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNTowMC45NDA1NDda
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLTYzOGYtN2Y1Ni1iZjQyLThjMGNmOWJj
-        OGE4Ni92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItNjM4Zi03ZjU2LWJmNDIt
-        OGMwY2Y5YmM4YTg2LyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQzLTFiYjMtNzU5ZS1hNDBhLTA3ZDkxMGU1
+        Mzc4Zi92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMWJiMy03NTllLWE0MGEt
+        MDdkOTEwZTUzNzhmLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:07:56 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:02 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-6b31-7519-91b3-90ee49d25229/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-1fab-730b-ad51-8e995090cf9b/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4
-        ZjU0ZTItNjdjMy03ZDRiLTllNzItN2ZkZWMyYjVlNWY0LyJ9
+        ZmU4ZDMtMWQyYS03Y2RmLTk1MzMtOWRjYTk4MDUxZDBmLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1300,7 +1300,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:56 GMT
+      - Wed, 05 Jun 2024 14:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1320,7 +1320,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8a4064828b47455d9fd29cb01675dd6d
+      - d6249f3026c14df58d3fa7ddd1dfb714
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1328,12 +1328,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTZmOTEtN2Yz
-        My1iMmJlLWJmZDI3NWE3OTkzYS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:07:56 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTIyZjQtNzE5
+        MC1iMTkwLTk0NjUwMTczNmU1Yi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:02 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-6f91-7f33-b2be-bfd275a7993a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-22f4-7190-b190-946501736e5b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1341,7 +1341,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1354,7 +1354,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:57 GMT
+      - Wed, 05 Jun 2024 14:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,7 +1374,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7f99a5ce852e43899725e40d74859020
+      - 4c80f16d141246baa519e81058ca1739
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1382,26 +1382,26 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItNmY5
-        MS03ZjMzLWIyYmUtYmZkMjc1YTc5OTNhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDc6NTYuOTQ2MDYwWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowNzo1Ni45NDYwNzRaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMjJm
+        NC03MTkwLWIxOTAtOTQ2NTAxNzM2ZTViLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MDIuMjYwNzI3WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNTowMi4yNjA3NDFaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjhhNDA2NDgyOGI0NzQ1NWQ5ZmQy
-        OWNiMDE2NzVkZDZkIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDc6NTYuOTU2
-        NTY1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA3OjU2Ljk1OTAx
-        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDc6NTYuOTc0MDEz
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6ImQ2MjQ5ZjMwMjZjMTRkZjU4ZDNm
+        YTdkZGQxZGZiNzE0IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDIuMjcw
+        MTU5WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjAyLjI3MjMx
+        OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDIuMjg1NTMy
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25z
-        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNTRkZi03ZmQy
-        LTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:07:57 GMT
+        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFh
+        LTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:35:02 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-67c3-7d4b-9e72-7fdec2b5e5f4/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d3-1d2a-7cdf-9533-9dca98051d0f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1409,7 +1409,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1422,7 +1422,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:57 GMT
+      - Wed, 05 Jun 2024 14:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1442,7 +1442,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4b3f810138af4b73b21042b25bcba404
+      - 657cf7488e7443c7aa6a7dce932b077c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1451,34 +1451,34 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItNjdjMy03ZDRiLTllNzItN2ZkZWMyYjVlNWY0LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDc6NTQuOTQ5NTYxWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowNzo1NS4xNDYxMTZa
+        cG0vMDE4ZmU4ZDMtMWQyYS03Y2RmLTk1MzMtOWRjYTk4MDUxZDBmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDAuNzgwMjUzWiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNTowMC45NDA1NDda
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLTYzOGYtN2Y1Ni1iZjQyLThjMGNmOWJj
-        OGE4Ni92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItNjM4Zi03ZjU2LWJmNDIt
-        OGMwY2Y5YmM4YTg2LyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQzLTFiYjMtNzU5ZS1hNDBhLTA3ZDkxMGU1
+        Mzc4Zi92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMWJiMy03NTllLWE0MGEt
+        MDdkOTEwZTUzNzhmLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:07:57 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:02 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-6b31-7519-91b3-90ee49d25229/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-1fab-730b-ad51-8e995090cf9b/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4
-        ZjU0ZTItNjdjMy03ZDRiLTllNzItN2ZkZWMyYjVlNWY0LyJ9
+        ZmU4ZDMtMWQyYS03Y2RmLTk1MzMtOWRjYTk4MDUxZDBmLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1491,7 +1491,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:57 GMT
+      - Wed, 05 Jun 2024 14:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1511,7 +1511,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cb09b14cc18e4e74894e3213ff533413
+      - b9d6d3cbca724856a24e4b4e82289442
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1519,12 +1519,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTcwOTQtN2Zj
-        Mi1hYzY4LTI4NmMyYzhjNTBiYy8ifQ==
-  recorded_at: Tue, 07 May 2024 21:07:57 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTIzY2UtN2Fi
+        My1hZmQ2LTFlYWY5YTQ1NzgwMy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:02 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-6b31-7519-91b3-90ee49d25229/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-1fab-730b-ad51-8e995090cf9b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1532,7 +1532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1545,7 +1545,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:57 GMT
+      - Wed, 05 Jun 2024 14:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1565,7 +1565,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9b192abe7e584c48b59db98559de5b28
+      - 07d88a0e3f9440d983b316b50e02a904
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1573,12 +1573,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTcxMTAtNzQ3
-        NS05NTZkLTM0ZmU3M2E4YjhkMi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:07:57 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTI0MzYtNzA3
+        OC1iOTdkLTVlNGZlZGU2Y2IyYS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:02 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-62a7-7036-9218-bb9b0fc1cb23/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d3-1b30-7786-bc38-b2153833ddf0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1586,7 +1586,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1599,7 +1599,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:57 GMT
+      - Wed, 05 Jun 2024 14:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1619,7 +1619,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0f985e8ade114eae8cebe1bb2575f1d9
+      - 872ac7e8c61c4a80855986337628337a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1627,12 +1627,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTcxZmMtN2Yw
-        OC04YzMxLTIzYjI5YzE2NmY2OS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:07:57 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTI1MDEtNzU2
+        OC05YWY0LWY0MTM4Y2I0NzNhZS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:02 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-71fc-7f08-8c31-23b29c166f69/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-2501-7568-9af4-f4138cb473ae/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1640,7 +1640,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1653,7 +1653,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:57 GMT
+      - Wed, 05 Jun 2024 14:35:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1673,7 +1673,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1e08cf224b7a42c8b1e553341e2c0195
+      - 27a2605452d84c5cb49fe376b87620b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1681,28 +1681,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItNzFm
-        Yy03ZjA4LThjMzEtMjNiMjljMTY2ZjY5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDc6NTcuNTY0NjYxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowNzo1Ny41NjQ2NzZaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMjUw
+        MS03NTY4LTlhZjQtZjQxMzhjYjQ3M2FlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MDIuNzg1NTc3WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNTowMi43ODU1OTBaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjBmOTg1ZThhZGUxMTRlYWU4Y2Vi
-        ZTFiYjI1NzVmMWQ5IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDc6NTcuNTc2
-        NDc3WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA3OjU3LjYzMTY1
-        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDc6NTcuNjg1MjI4
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6Ijg3MmFjN2U4YzYxYzRhODA4NTU5
+        ODYzMzc2MjgzMzdhIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDIuNzk3
+        MTkyWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjAyLjgyOTEz
+        NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDIuODcyMTI0
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGMxLTcxNzUtYTM3Yi1iNjMzMjI1NWEyMGEvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVtb3Rlcy9ycG0vcnBtLzAxOGY1NGUyLTYyYTctNzAzNi05MjE4LWJi
-        OWIwZmMxY2IyMy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4
-        ZjU0ZGYtN2ZkMi03NWZhLTliMzUtYzI3NTEzZmY5OGY0LyJdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:57 GMT
+        djMvcmVtb3Rlcy9ycG0vcnBtLzAxOGZlOGQzLTFiMzAtNzc4Ni1iYzM4LWIy
+        MTUzODMzZGRmMC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4
+        ZmUzYzktNzBhYS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:02 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018f54e2-638f-7f56-bf42-8c0cf9bc8a86/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018fe8d3-1bb3-759e-a40a-07d910e5378f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1710,7 +1710,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1723,7 +1723,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:57 GMT
+      - Wed, 05 Jun 2024 14:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1743,7 +1743,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 272294e4cf9644b3b460412fd2424501
+      - ee5b095e370543eab41f62da60f280b0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1751,12 +1751,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTczMzItNzU3
-        OC1hNDg5LTIyYmVlZWNkNjBmNi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:07:57 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTI1ZjUtNzNm
+        Zi04YzZkLTY0NDhhMzk1NGI5MC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:03 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-7332-7578-a489-22beeecd60f6/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-25f5-73ff-8c6d-6448a3954b90/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1764,7 +1764,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1777,7 +1777,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:58 GMT
+      - Wed, 05 Jun 2024 14:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1797,7 +1797,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3dce58b559784d82b52ff23b9d72d773
+      - dad7bacc8e324bb7afb5b853b572ac1b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1805,25 +1805,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItNzMz
-        Mi03NTc4LWE0ODktMjJiZWVlY2Q2MGY2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDc6NTcuODc1MDAyWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowNzo1Ny44NzUwMTdaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMjVm
+        NS03M2ZmLThjNmQtNjQ0OGEzOTU0YjkwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MDMuMDMwMTM2WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNTowMy4wMzAxNTBaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjI3MjI5NGU0Y2Y5NjQ0YjNiNDYw
-        NDEyZmQyNDI0NTAxIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDc6NTcuODg2
-        NjEwWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA3OjU3LjkzMjc2
-        MloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDc6NTguMTEwMDc2
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImVlNWIwOTVlMzcwNTQzZWFiNDFm
+        NjJkYTYwZjI4MGIwIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDMuMDQz
+        MDUzWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjAzLjA3NjEz
+        OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDMuMjE0MDg5
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGMxLTcxNzUtYTM3Yi1iNjMzMjI1NWEyMGEvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItNjM4Zi03ZjU2LWJm
-        NDItOGMwY2Y5YmM4YTg2LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlu
-        cy8wMThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:07:58 GMT
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMWJiMy03NTllLWE0
+        MGEtMDdkOTEwZTUzNzhmLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlu
+        cy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:35:03 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -1834,7 +1834,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1847,7 +1847,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:58 GMT
+      - Wed, 05 Jun 2024 14:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1867,7 +1867,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2e768450fd474eba9e8f77cf79d6cec3
+      - d13ca04e90404eaabf76d5ad9d8359bb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1877,7 +1877,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:58 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:03 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
@@ -1888,7 +1888,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.21.3/ruby
+      - OpenAPI-Generator/0.21.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -1901,7 +1901,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:58 GMT
+      - Wed, 05 Jun 2024 14:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1921,7 +1921,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 17671e3176004c6e9c283e6ad703b294
+      - b020b33814c4416db1c89e732d5d0552
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1931,7 +1931,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:58 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:03 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -1955,7 +1955,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:58 GMT
+      - Wed, 05 Jun 2024 14:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1975,7 +1975,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 46bcbfcb3d19482ea20f5c0ce529f389
+      - 635a1a7ffae14b66b6860ea1343a8633
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1985,7 +1985,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:58 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:03 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -2009,7 +2009,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:58 GMT
+      - Wed, 05 Jun 2024 14:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2029,7 +2029,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ec7201627e5146acb902d1260d0e9391
+      - 8cc9b1f58356445d85b9288c4e7bc75a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2039,7 +2039,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:58 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:03 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -2050,7 +2050,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2063,7 +2063,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:58 GMT
+      - Wed, 05 Jun 2024 14:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2083,7 +2083,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '09cc22a2adac4357856951569e059ea1'
+      - 8886697ed09147a2bf3b4006baf67c02
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2093,7 +2093,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:58 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:03 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -2117,7 +2117,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:58 GMT
+      - Wed, 05 Jun 2024 14:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2137,7 +2137,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3288609698994e43abbb1426ec862007
+      - 04db48a65e374c58b3af6678e7ebf8bf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2147,7 +2147,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:58 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:03 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -2171,7 +2171,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:58 GMT
+      - Wed, 05 Jun 2024 14:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2191,7 +2191,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - aa84150e9aff4b1c84da2a08b33efd6b
+      - 37ecb26febdb4d0798faffb3d7452931
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2201,7 +2201,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:07:58 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:03 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
@@ -2214,7 +2214,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2227,7 +2227,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:58 GMT
+      - Wed, 05 Jun 2024 14:35:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2247,7 +2247,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bdb90c2731924e94b9c8612207109edc
+      - 9ac5e1dd6a114f5782bd8eb257a13ff7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2255,12 +2255,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTc2YmUtNzhj
-        Mi1iYzQ5LWNiZGE4NjZlN2UwMS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:07:58 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTI5NDktN2Q2
+        ZS1hNjJlLWVkODk1ZWY0NTQyMC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:03 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-76be-78c2-bc49-cbda866e7e01/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-2949-7d6e-a62e-ed895ef45420/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2268,7 +2268,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2281,7 +2281,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:07:59 GMT
+      - Wed, 05 Jun 2024 14:35:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2301,7 +2301,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - de8d9afbbd43445c87220be2a647ad3d
+      - 300bc7feacdd410587bd883604d609f6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2309,18 +2309,18 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItNzZi
-        ZS03OGMyLWJjNDktY2JkYTg2NmU3ZTAxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDc6NTguNzgzMDMxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowNzo1OC43ODMwNDZaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMjk0
+        OS03ZDZlLWE2MmUtZWQ4OTVlZjQ1NDIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MDMuODgxNjI5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNTowMy44ODE2NDJaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLm9ycGhhbi5vcnBo
-        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiYmRiOTBjMjczMTkyNGU5NGI5
-        Yzg2MTIyMDcxMDllZGMiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
-        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMTowNzo1OC43
-        OTY2OTZaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDc6NTguODM5
-        MTk1WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMTowNzo1OS4wNzQy
-        NjRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzAxOGY1NGUwLWE0YzEtNzE3NS1hMzdiLWI2MzMyMjU1YTIwYS8iLCJw
+        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiOWFjNWUxZGQ2YTExNGY1Nzgy
+        YmQ4ZWIyNTdhMTNmZjciLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
+        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozNTowMy44
+        OTUxMjFaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDMuOTI5
+        NzAzWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozNTowNC4wNzc3
+        NjhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzAxOGZlM2NiLTBkNDMtNzczMS05ODUyLTg3MjlkMDA4MTk2My8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xlYW4g
         dXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIs
@@ -2330,7 +2330,63 @@ http_interactions:
         ZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
         IjpbIi9hcGkvdjMvb3JwaGFucy9jbGVhbnVwLyIsInNoYXJlZDovcHVscC9h
-        cGkvdjMvZG9tYWlucy8wMThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNm
-        Zjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:07:59 GMT
+        cGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2Fk
+        MzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:35:04 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/purge/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJmaW5pc2hlZF9iZWZvcmUiOiIzMDAwLTAxLTAxVDAwOjAwOjAwLjAwMCsw
+        MDowMCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:35:04 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - fff0ea57bcc441d3a652ec688a45f095
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTJhN2UtN2Uw
+        ZC1hYTNiLWRhYWFkODlmNzA4Yy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:04 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_unset_unprotected.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_unset_unprotected.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:15 GMT
+      - Wed, 05 Jun 2024 14:35:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8515dfc93ad04eebb2a59869e37e2957
+      - 38a1dbe9089a47aab37e8eecacec1805
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:15 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:04 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:16 GMT
+      - Wed, 05 Jun 2024 14:35:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7dc4914dc44a42589a3e30db50774677
+      - 875fe9f6c21d467fb69ff1db89578ce6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:16 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:04 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -118,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:16 GMT
+      - Wed, 05 Jun 2024 14:35:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e0ad8c2b8f2d4d14bdd3e5fd1f0be2ac
+      - 4d679ac4ea0e450ab717be8cd6aacee0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:16 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:04 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -172,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:16 GMT
+      - Wed, 05 Jun 2024 14:35:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9c8bf3eff4a2476e83aa67900c32ddce
+      - 398137790d324b42bd96a730fb02f4f1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:16 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:04 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -234,7 +234,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -247,13 +247,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:16 GMT
+      - Wed, 05 Jun 2024 14:35:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/018f54e2-bb0b-7eff-931d-d0ceb7b3c98e/"
+      - "/pulp/api/v3/remotes/rpm/rpm/018fe8d3-2da8-7e84-be7b-5a1a215cd807/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -269,7 +269,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e3db588652b148bea7f8712625269dcc
+      - bf08756032de4ff0ac5552d122b68e2c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -278,9 +278,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OGY1NGUyLWJiMGItN2VmZi05MzFkLWQwY2ViN2IzYzk4ZS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjE2LjI2Nzg0NFoiLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MTYuMjY3ODYwWiIsIm5h
+        OGZlOGQzLTJkYTgtN2U4NC1iZTdiLTVhMWEyMTVjZDgwNy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM1OjA1LjAwMTI2NFoiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDUuMDAxMjc4WiIsIm5h
         bWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0dHA6Ly9teXJlcG8uY29tIiwi
         Y2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0
         aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwi
@@ -294,7 +294,7 @@ http_interactions:
         ZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InVzZXJuYW1lIiwiaXNfc2V0
         IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfV0s
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:16 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:05 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -307,7 +307,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -320,13 +320,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:16 GMT
+      - Wed, 05 Jun 2024 14:35:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/018f54e2-bba1-7aa7-ad34-a21e6acfe657/"
+      - "/pulp/api/v3/repositories/rpm/rpm/018fe8d3-2e3c-71aa-a1c6-9a9deae00d7a/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -342,7 +342,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d59e6e5d626c46de8bb340f692e12842
+      - 3081e9dde7404eabbb4b89a0206d5acc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -351,14 +351,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMDE4ZjU0ZTItYmJhMS03YWE3LWFkMzQtYTIxZTZhY2ZlNjU3LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MTYuNDE4NTc3WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoxNi40MjY2NjBa
+        cG0vMDE4ZmU4ZDMtMmUzYy03MWFhLWExYzYtOWE5ZGVhZTAwZDdhLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDUuMTQ4ODI0WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNTowNS4xNTUwNjVa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wMThmNTRlMi1iYmExLTdhYTctYWQzNC1hMjFlNmFjZmU2NTcv
+        cnBtL3JwbS8wMThmZThkMy0yZTNjLTcxYWEtYTFjNi05YTlkZWFlMDBkN2Ev
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzAxOGY1
-        NGUyLWJiYTEtN2FhNy1hZDM0LWEyMWU2YWNmZTY1Ny92ZXJzaW9ucy8wLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzAxOGZl
+        OGQzLTJlM2MtNzFhYS1hMWM2LTlhOWRlYWUwMGQ3YS92ZXJzaW9ucy8wLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -367,7 +367,7 @@ http_interactions:
         Y2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:16 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:05 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -375,13 +375,13 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE4ZjU0ZTItYmJhMS03YWE3LWFkMzQtYTIxZTZhY2Zl
-        NjU3L3ZlcnNpb25zLzAvIn0=
+        aWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMmUzYy03MWFhLWExYzYtOWE5ZGVhZTAw
+        ZDdhL3ZlcnNpb25zLzAvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -394,7 +394,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:16 GMT
+      - Wed, 05 Jun 2024 14:35:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -414,7 +414,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 85992c2ec2dc4de592c281f6ebc12cde
+      - f54a994e09d542bab0f6eb5149714e69
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -422,12 +422,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWJkMDItNzE0
-        Yi04YWQ5LWM3MjM3ODlmMzQyNS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:16 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTJmODAtN2Vh
+        MS05YTlmLTZhNGJlYjdmMDlmYy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:05 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-bd02-714b-8ad9-c723789f3425/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-2f80-7ea1-9a9f-6a4beb7f09fc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -435,7 +435,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -448,7 +448,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:17 GMT
+      - Wed, 05 Jun 2024 14:35:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -468,7 +468,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 47e3e0d6795343b3b062bf2d5ef8b68f
+      - a0183dd00d6f4c87bbbc14c9dd7a6082
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -476,30 +476,30 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItYmQw
-        Mi03MTRiLThhZDktYzcyMzc4OWYzNDI1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MTYuNzcwODE4WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoxNi43NzA4MzNaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMmY4
+        MC03ZWExLTlhOWYtNmE0YmViN2YwOWZjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MDUuNDczMjc0WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNTowNS40NzMyODZaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnB1Ymxpc2hpbmcu
-        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiODU5OTJjMmVjMmRjNGRlNTkyYzI4
-        MWY2ZWJjMTJjZGUiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
-        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMTowODoxNi43ODYz
-        NjhaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MTYuODM5OTUw
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMTowODoxNy4wNjczNTBa
+        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiZjU0YTk5NGUwOWQ1NDJiYWIwZjZl
+        YjUxNDk3MTRlNjkiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
+        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozNTowNS40ODM4
+        MzRaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDUuNTE4NDAx
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozNTowNS42ODczMjBa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzAxOGY1NGUwLWE0YzEtNzE3NS1hMzdiLWI2MzMyMjU1YTIwYS8iLCJwYXJl
+        LzAxOGZlM2NiLTBkNDMtNzczMS05ODUyLTg3MjlkMDA4MTk2My8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJhdGlu
         ZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2VuZXJh
         dGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEs
         ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTIt
-        YmQ2Ni03ZWE2LTgyNDktOThmM2JmNWIzOTMzLyJdLCJyZXNlcnZlZF9yZXNv
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDMt
+        MmZjMi03NzQzLTk4NDItYWUxYmJkMGRiNzAyLyJdLCJyZXNlcnZlZF9yZXNv
         dXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE4ZjU0ZTItYmJhMS03YWE3LWFkMzQtYTIxZTZhY2Zl
-        NjU3LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNTRkZi03
-        ZmQyLTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:17 GMT
+        aWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMmUzYy03MWFhLWExYzYtOWE5ZGVhZTAw
+        ZDdhLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03
+        MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:35:05 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -510,7 +510,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -523,7 +523,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:17 GMT
+      - Wed, 05 Jun 2024 14:35:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -543,7 +543,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fb1fc2d353c548f6badf79540e021a04
+      - 0e7da4b86260497396607003345fd115
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -553,10 +553,10 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:17 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:05 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-bd66-7ea6-8249-98f3bf5b3933/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d3-2fc2-7743-9842-ae1bbd0db702/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -564,7 +564,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -577,7 +577,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:17 GMT
+      - Wed, 05 Jun 2024 14:35:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -597,7 +597,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b1e5fa0042fa48feafebfba8c94d5970
+      - cba921b8f88d4544bc0129284df2e686
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -606,19 +606,19 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItYmQ2Ni03ZWE2LTgyNDktOThmM2JmNWIzOTMzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MTYuODcyMzExWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoxNy4wNTYxMjZa
+        cG0vMDE4ZmU4ZDMtMmZjMi03NzQzLTk4NDItYWUxYmJkMGRiNzAyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDUuNTM5Njc0WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNTowNS42ODE2OTFa
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLWJiYTEtN2FhNy1hZDM0LWEyMWU2YWNm
-        ZTY1Ny92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItYmJhMS03YWE3LWFkMzQt
-        YTIxZTZhY2ZlNjU3LyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQzLTJlM2MtNzFhYS1hMWM2LTlhOWRlYWUw
+        MGQ3YS92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMmUzYy03MWFhLWExYzYt
+        OWE5ZGVhZTAwZDdhLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:17 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:05 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/
@@ -628,13 +628,13 @@ http_interactions:
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTItYmQ2Ni03ZWE2LTgyNDktOThm
-        M2JmNWIzOTMzLyJ9
+        bGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDMtMmZjMi03NzQzLTk4NDItYWUx
+        YmJkMGRiNzAyLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -647,7 +647,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:17 GMT
+      - Wed, 05 Jun 2024 14:35:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -667,7 +667,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 835c6c770ffb4501a08cbeb8fb724975
+      - 783d78d8ff5b4376bf00f317e30c7e50
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -675,12 +675,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWJmNTUtNzY4
-        YS05ZGEyLWMyMDE1MDBiMjdkMS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:17 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTMxYjAtN2Y0
+        Zi1iYzMzLTI1NDVkMjg4MTczNy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:06 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-bf55-768a-9da2-c201500b27d1/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-31b0-7f4f-bc33-2545d2881737/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -688,7 +688,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -701,7 +701,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:17 GMT
+      - Wed, 05 Jun 2024 14:35:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -721,7 +721,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 489d909d08ff4920a1dbf7250e5cdaa2
+      - 9fab7e9c1df342e2bf5b6633596a025b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -729,29 +729,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItYmY1
-        NS03NjhhLTlkYTItYzIwMTUwMGIyN2QxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MTcuMzY2NDU0WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoxNy4zNjY0NzBaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMzFi
+        MC03ZjRmLWJjMzMtMjU0NWQyODgxNzM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MDYuMDMyOTk0WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNTowNi4wMzMwMDlaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6IjgzNWM2Yzc3MGZmYjQ1MDFhMDhj
-        YmViOGZiNzI0OTc1IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MTcuMzgy
-        ODY4WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjE3LjQ0Njc3
-        NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MTcuNzQzNTQ1
+        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6Ijc4M2Q3OGQ4ZmY1YjQzNzZiZjAw
+        ZjMxN2UzMGM3ZTUwIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDYuMDQ2
+        MDAxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjA2LjA4NDg1
+        N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDYuMzAzNTcx
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGU4LTc0ODctOWFhMC0zYzNlYzFhMTk5ZDcvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
-        IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDE4ZjU0
-        ZTItYzBiNi03NDdhLWI2NjYtMWEzZGJiOWMwMzU2LyJdLCJyZXNlcnZlZF9y
+        IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDE4ZmU4
+        ZDMtMzJiMS03NTIxLWI1N2ItOWNiMzcwMTA1Y2M0LyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iLCJz
-        aGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZjU0ZGYtN2ZkMi03NWZh
-        LTliMzUtYzI3NTEzZmY5OGY0LyJdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:17 GMT
+        aGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZmUzYzktNzBhYS03ODgz
+        LWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:06 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-c0b6-747a-b666-1a3dbb9c0356/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-32b1-7521-b57b-9cb370105cc4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -759,7 +759,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -772,7 +772,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:17 GMT
+      - Wed, 05 Jun 2024 14:35:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -792,7 +792,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e89ba57176da4d3d9376cd2b203acd69
+      - 202802903bb84bfe98e59d9bd2bfa4f0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -801,9 +801,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzAxOGY1NGUyLWMwYjYtNzQ3YS1iNjY2LTFhM2RiYjljMDM1Ni8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjE3LjcyMDE1OFoiLCJw
-        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MTcuNzIwMTc3
+        cnBtLzAxOGZlOGQzLTMyYjEtNzUyMS1iNTdiLTljYjM3MDEwNWNjNC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM1OjA2LjI5MDY5NVoiLCJw
+        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDYuMjkwNzEw
         WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
         N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
         OS1rYXRlbGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9wdWxwL2Nv
@@ -811,9 +811,9 @@ http_interactions:
         ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJoaWRkZW4iOmZhbHNl
         LCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInJlcG9z
         aXRvcnkiOm51bGwsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1Ymxp
-        Y2F0aW9ucy9ycG0vcnBtLzAxOGY1NGUyLWJkNjYtN2VhNi04MjQ5LTk4ZjNi
-        ZjViMzkzMy8iLCJnZW5lcmF0ZV9yZXBvX2NvbmZpZyI6ZmFsc2V9
-  recorded_at: Tue, 07 May 2024 21:08:17 GMT
+        Y2F0aW9ucy9ycG0vcnBtLzAxOGZlOGQzLTJmYzItNzc0My05ODQyLWFlMWJi
+        ZDBkYjcwMi8iLCJnZW5lcmF0ZV9yZXBvX2NvbmZpZyI6ZmFsc2V9
+  recorded_at: Wed, 05 Jun 2024 14:35:06 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -835,7 +835,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -848,13 +848,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:18 GMT
+      - Wed, 05 Jun 2024 14:35:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/018f54e2-c2b0-7664-84be-4d9d31b9db08/"
+      - "/pulp/api/v3/remotes/rpm/rpm/018fe8d3-33c1-738b-b462-2110cc5908b5/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -870,7 +870,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bbd3c74b12e346c98859e70b8ccc9314
+      - efad2ab15e8d473192fa473171b11c67
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -879,9 +879,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OGY1NGUyLWMyYjAtNzY2NC04NGJlLTRkOWQzMWI5ZGIwOC8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjE4LjIyNDY3OFoiLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MTguMjI0NjkzWiIsIm5h
+        OGZlOGQzLTMzYzEtNzM4Yi1iNDYyLTIxMTBjYzU5MDhiNS8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM1OjA2LjU2MTQ3MVoiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDYuNTYxNDg3WiIsIm5h
         bWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJsIjoiaHR0cDovL215cmVwby5j
         b20iLCJjYV9jZXJ0IjoiS0pMOktERiooREYmKigqJCYoKiMkSkxLSkQoRCgo
         RCIsImNsaWVudF9jZXJ0IjoiS0pMOktERiooREYmKigqJCYoKiMkSkxLSkQo
@@ -896,10 +896,10 @@ http_interactions:
         bWUiOiJwcm94eV9wYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6
         InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfV0sInNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:18 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:06 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-c2b0-7664-84be-4d9d31b9db08/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d3-33c1-738b-b462-2110cc5908b5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -907,7 +907,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -920,7 +920,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:18 GMT
+      - Wed, 05 Jun 2024 14:35:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -940,7 +940,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8e582897922e424ea957855740f4bfc8
+      - 36e31d881d764812b25a6088754ea7e9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -948,12 +948,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWMzMDEtNzUz
-        NS1iZDJhLTE1ZGRlZjY5YmJlYi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:18 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTMzZjgtN2Ex
+        Yi1iYWQ2LTI0NWIxMjQxMTNjZS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:06 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018f54e2-bba1-7aa7-ad34-a21e6acfe657/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018fe8d3-2e3c-71aa-a1c6-9a9deae00d7a/
     body:
       encoding: UTF-8
       base64_string: |
@@ -963,7 +963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -976,7 +976,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:18 GMT
+      - Wed, 05 Jun 2024 14:35:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -996,7 +996,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a57b647766794c45855088adea3722b4
+      - eca1277e63034a62babb779d50fa043f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1004,12 +1004,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWM0ODAtNzA1
-        NS05YmVjLWEyZjE4ZGQ0OTMxYS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:18 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTM0YTgtNzg5
+        YS1iNTNhLTZmYjNjY2NmZmIyNi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:06 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-bb0b-7eff-931d-d0ceb7b3c98e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d3-2da8-7e84-be7b-5a1a215cd807/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1028,7 +1028,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1041,7 +1041,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:19 GMT
+      - Wed, 05 Jun 2024 14:35:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1061,7 +1061,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c779da4ef67541e59bce30a4b291be03
+      - 163b6d667a55421994cd411ea2494a93
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1069,12 +1069,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWM1N2UtNzg4
-        OS05ZmJmLTNiNzgwNzQ5MDFhMy8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:19 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTM1MTEtN2U4
+        My1iYzRmLThjNjFhZmQ5MTgxZi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:06 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-c57e-7889-9fbf-3b78074901a3/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-3511-7e83-bc4f-8c61afd9181f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1082,7 +1082,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1095,7 +1095,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:19 GMT
+      - Wed, 05 Jun 2024 14:35:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1115,7 +1115,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e63b2714abb64de999574b48a0278d03
+      - 98e4b9944b194365abcc05726c25075a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1123,24 +1123,24 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItYzU3
-        ZS03ODg5LTlmYmYtM2I3ODA3NDkwMWEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MTguOTQzMzg4WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoxOC45NDM0MjRaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMzUx
+        MS03ZTgzLWJjNGYtOGM2MWFmZDkxODFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MDYuODk4MTQ5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNTowNi44OTgxNjBaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6ImM3NzlkYTRlZjY3NTQxZTU5YmNl
-        MzBhNGIyOTFiZTAzIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MTguOTY2
-        OTMzWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjE4Ljk3NTg5
-        MloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MTkuMDIzNzAx
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjE2M2I2ZDY2N2E1NTQyMTk5NGNk
+        NDExZWEyNDk0YTkzIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDYuOTA5
+        MzE3WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjA2LjkxMzMw
+        MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDYuOTIyODI3
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMv
-        cnBtL3JwbS8wMThmNTRlMi1iYjBiLTdlZmYtOTMxZC1kMGNlYjdiM2M5OGUv
-        Iiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGY1NGRmLTdmZDIt
-        NzVmYS05YjM1LWMyNzUxM2ZmOThmNC8iXX0=
-  recorded_at: Tue, 07 May 2024 21:08:19 GMT
+        cnBtL3JwbS8wMThmZThkMy0yZGE4LTdlODQtYmU3Yi01YTFhMjE1Y2Q4MDcv
+        Iiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGZlM2M5LTcwYWEt
+        Nzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:35:06 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
@@ -1151,7 +1151,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1164,7 +1164,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:19 GMT
+      - Wed, 05 Jun 2024 14:35:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1176,7 +1176,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '5887'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1184,7 +1184,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c8193b719b0d47b69a989c30b861bdc5
+      - 8d329d1a0cac4b4796fbfa7d0420b94f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1192,146 +1192,274 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:19 GMT
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
+        L2NlcnRndWFyZC9yaHNtLzAxOGZlOGQzLTBhZDUtNzZjNy05MWFkLWY0NjM4
+        NGQxMGIzZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM0OjU2
+        LjA4NjI4MloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6
+        MzQ6NTYuMDg2Mjk2WiIsIm5hbWUiOiJSSFNNQ2VydEd1YXJkIiwiZGVzY3Jp
+        cHRpb24iOm51bGwsImNhX2NlcnRpZmljYXRlIjoiQ2VydGlmaWNhdGU6XG4g
+        ICAgRGF0YTpcbiAgICAgICAgVmVyc2lvbjogMyAoMHgyKVxuICAgICAgICBT
+        ZXJpYWwgTnVtYmVyOlxuICAgICAgICAgICAgZmQ6YmE6YmM6NzE6NmU6MjU6
+        YTM6NzhcbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNB
+        RW5jcnlwdGlvblxuICAgICAgICBJc3N1ZXI6IEM9VVMsIFNUPU5vcnRoIENh
+        cm9saW5hLCBMPVJhbGVpZ2gsIE89S2F0ZWxsbywgT1U9U29tZU9yZ1VuaXQs
+        IENOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAg
+        IFZhbGlkaXR5XG4gICAgICAgICAgICBOb3QgQmVmb3JlOiBNYXkgIDcgMTQ6
+        MjE6NTAgMjAyMCBHTVRcbiAgICAgICAgICAgIE5vdCBBZnRlciA6IEphbiAx
+        OCAxNDoyMTo1MCAyMDM4IEdNVFxuICAgICAgICBTdWJqZWN0OiBDPVVTLCBT
+        VD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdoLCBPPUthdGVsbG8sIE9VPVNv
+        bWVPcmdVbml0LCBDTj1jZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNv
+        bVxuICAgICAgICBTdWJqZWN0IFB1YmxpYyBLZXkgSW5mbzpcbiAgICAgICAg
+        ICAgIFB1YmxpYyBLZXkgQWxnb3JpdGhtOiByc2FFbmNyeXB0aW9uXG4gICAg
+        ICAgICAgICAgICAgUHVibGljLUtleTogKDIwNDggYml0KVxuICAgICAgICAg
+        ICAgICAgIE1vZHVsdXM6XG4gICAgICAgICAgICAgICAgICAgIDAwOjlmOmQy
+        OmMxOjEwOmZmOjAxOjFhOjMzOjE5OjBlOjQzOjlkOjgzOmU1OlxuICAgICAg
+        ICAgICAgICAgICAgICA4YTo3MzpiYToyZDozYzo2NjpiMTo3ODpjZDo4OTo4
+        Yzo2MDplNTo4MTphNjpcbiAgICAgICAgICAgICAgICAgICAgZTg6NGQ6OTY6
+        NWQ6MDc6YzM6YmU6YTI6OWM6YzI6N2M6OTQ6MmQ6NmU6NDM6XG4gICAgICAg
+        ICAgICAgICAgICAgIDQ0OjQ2OmVmOmZkOjM2OjIwOjQ3OjNiOmQ2OjM1OmZk
+        Ojk3OmNkOjk3OjE3OlxuICAgICAgICAgICAgICAgICAgICBkNzozZjplNzo2
+        NzpmZTphOToyYTpmMTpiYzo0Nzo4Nzo2ZTplZDo2ZDpiNjpcbiAgICAgICAg
+        ICAgICAgICAgICAgOWU6ZjE6MGQ6NjM6NTM6YzE6M2Y6ZmQ6MTc6YWI6NWY6
+        MzU6N2E6ODQ6Y2Y6XG4gICAgICAgICAgICAgICAgICAgIDZiOmRkOmE2Ojhl
+        OjA5Ojk5OjU2OjM5OmRlOjI5OjZiOmZiOmMyOmRjOjhjOlxuICAgICAgICAg
+        ICAgICAgICAgICA1NjoyYToxMDpiMzowYTpjYTpiODo2YzpmYjpiODpjODpl
+        YjplNTplMjphZTpcbiAgICAgICAgICAgICAgICAgICAgZDU6NDE6MDU6NGM6
+        YTI6YzA6YmU6N2I6YjA6NmQ6MWQ6N2M6NjY6ODA6ODg6XG4gICAgICAgICAg
+        ICAgICAgICAgIDVhOmI3OjA3OjliOmQzOmI4OmZmOjkzOmYzOjE5OjMzOjYz
+        OjQ4Ojk1OjgzOlxuICAgICAgICAgICAgICAgICAgICAzNDoyNzpjNjphYzpj
+        YzphMDowYjo1NjphYjoyMjozNDo3MTo0Zjo3OTpiZjpcbiAgICAgICAgICAg
+        ICAgICAgICAgNmU6NGI6Yzk6ODk6NTk6ODc6OGI6N2I6MzU6Nzk6Yjg6MWM6
+        NzA6ZWU6NTg6XG4gICAgICAgICAgICAgICAgICAgIGU2OjdiOjIyOjc5OmE3
+        OjFlOmQ5OmIyOjU3OjNhOmUwOjU5OjhlOmIzOjZhOlxuICAgICAgICAgICAg
+        ICAgICAgICA5NzozZDo5YTo4MDpjYzozYjpkNTo3NzpkNDpmYTo3YTo1ODo2
+        OTpiNjpiMzpcbiAgICAgICAgICAgICAgICAgICAgYWE6OTU6NTQ6NTU6OWU6
+        MTM6NjU6N2Y6OTU6YzA6NzM6OTY6YzU6ZmI6Nzc6XG4gICAgICAgICAgICAg
+        ICAgICAgIGEwOjQ4OjIwOmE2OjdkOmY0OmM0OmQzOmU5OmFiOjk0OjkzOjRl
+        OjFhOmUyOlxuICAgICAgICAgICAgICAgICAgICA1ZDo5YjpjNTo4Nzo1MDpj
+        Nzo1NjpmMDo5MzphODpiOTowYTo3MzpjZjpmNzpcbiAgICAgICAgICAgICAg
+        ICAgICAgMDE6MGZcbiAgICAgICAgICAgICAgICBFeHBvbmVudDogNjU1Mzcg
+        KDB4MTAwMDEpXG4gICAgICAgIFg1MDl2MyBleHRlbnNpb25zOlxuICAgICAg
+        ICAgICAgWDUwOXYzIEJhc2ljIENvbnN0cmFpbnRzOlxuICAgICAgICAgICAg
+        ICAgIENBOlRSVUVcbiAgICAgICAgICAgIFg1MDl2MyBLZXkgVXNhZ2U6XG4g
+        ICAgICAgICAgICAgICAgRGlnaXRhbCBTaWduYXR1cmUsIEtleSBFbmNpcGhl
+        cm1lbnQsIENlcnRpZmljYXRlIFNpZ24sIENSTCBTaWduXG4gICAgICAgICAg
+        ICBYNTA5djMgRXh0ZW5kZWQgS2V5IFVzYWdlOlxuICAgICAgICAgICAgICAg
+        IFRMUyBXZWIgU2VydmVyIEF1dGhlbnRpY2F0aW9uLCBUTFMgV2ViIENsaWVu
+        dCBBdXRoZW50aWNhdGlvblxuICAgICAgICAgICAgTmV0c2NhcGUgQ2VydCBU
+        eXBlOlxuICAgICAgICAgICAgICAgIFNTTCBTZXJ2ZXIsIFNTTCBDQVxuICAg
+        ICAgICAgICAgTmV0c2NhcGUgQ29tbWVudDpcbiAgICAgICAgICAgICAgICBL
+        YXRlbGxvIFNTTCBUb29sIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZVxuICAgICAg
+        ICAgICAgWDUwOXYzIFN1YmplY3QgS2V5IElkZW50aWZpZXI6XG4gICAgICAg
+        ICAgICAgICAgOUI6RDI6RDk6Njk6ODg6OTk6MkM6MkU6NzA6MkI6Qjc6Njk6
+        NzY6N0E6N0Q6RDE6ODU6NEQ6NTM6NURcbiAgICAgICAgICAgIFg1MDl2MyBB
+        dXRob3JpdHkgS2V5IElkZW50aWZpZXI6XG4gICAgICAgICAgICAgICAga2V5
+        aWQ6OUI6RDI6RDk6Njk6ODg6OTk6MkM6MkU6NzA6MkI6Qjc6Njk6NzY6N0E6
+        N0Q6RDE6ODU6NEQ6NTM6NURcbiAgICAgICAgICAgICAgICBEaXJOYW1lOi9D
+        PVVTL1NUPU5vcnRoIENhcm9saW5hL0w9UmFsZWlnaC9PPUthdGVsbG8vT1U9
+        U29tZU9yZ1VuaXQvQ049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5j
+        b21cbiAgICAgICAgICAgICAgICBzZXJpYWw6RkQ6QkE6QkM6NzE6NkU6MjU6
+        QTM6NzhcblxuICAgIFNpZ25hdHVyZSBBbGdvcml0aG06IHNoYTI1NldpdGhS
+        U0FFbmNyeXB0aW9uXG4gICAgICAgICAzMjoxOTo2YzpjNjphZjphZTpjMjpi
+        ZTo2NDoxNjpiMDo3YzphMzo0YjoxMDplODo1YTpiNDpcbiAgICAgICAgIDE3
+        Ojc0OmZkOjc1OmM2OjI2OmQyOjg4OjAxOmZlOjk1OjJlOjNmOjBhOjFlOjg4
+        OmE1OjI1OlxuICAgICAgICAgMTM6NmI6NjA6MzQ6ZDA6MmM6ZGU6ZDg6NDg6
+        MTU6ZjU6Y2M6MWY6MDc6ODA6MmI6MWQ6Mjg6XG4gICAgICAgICA5MDplOTo4
+        Yjo0NzpjMTo3MToxYTpkYTo4NjphMDoyNzplODpjNDo4ODozNjphMzpmZjpk
+        YjpcbiAgICAgICAgIDE3OjJmOjBlOjliOmUxOjM5OmE3OjFmOmRjOjI2Ojk3
+        OjI5OjVlOjRiOjk5OjYwOmZhOjkyOlxuICAgICAgICAgMTI6MjQ6ZmM6YmM6
+        MDQ6OTQ6MjQ6NjU6ZjM6NjA6Y2M6NWU6ZWU6NDI6YmY6OWU6M2M6MzE6XG4g
+        ICAgICAgICBiOTozYzo5OTo4YTo0NDozZDoyOTo1ZDphNjo5OTphYTpkNTow
+        ZToxNTo5NDpjNDpjNToyMzpcbiAgICAgICAgIDhjOmI5OjZlOmU1OjA5OjEz
+        OjhjOjU2OjRiOjA0OjM1Ojk1Ojc5OjUwOjVjOjIyOjJkOjFmOlxuICAgICAg
+        ICAgM2E6Njg6ZDA6ZjM6M2U6ODg6N2Q6Mzg6Mjk6MzI6ZjI6NDc6YjE6MTc6
+        OTk6ZmQ6YTY6NDg6XG4gICAgICAgICAwMjowNDo2Yjo5ZjpiOTpkYTpjMjo2
+        ZTo2NTo5Yjo5OTplNDo2MDo3YTozMjpjZDowMjpmZTpcbiAgICAgICAgIDcx
+        OmRhOjE5OmUzOjkzOmJkOmM1OmE3OmEwOjQ2OjllOjI4OmQyOjkxOmFjOjhl
+        OjkxOmM3OlxuICAgICAgICAgYTc6NTE6NGU6ODE6MDk6ZDE6ZjE6Mzk6NWI6
+        MDc6ODc6NDE6M2I6Yjc6ZTM6MWI6YTg6N2U6XG4gICAgICAgICA1MTo1Mjo0
+        ZTo2NjoyMDpiMTpjZDpjNTphZTpkZToxNzozYTpkNzpjZTowNzozNzpkODo1
+        ZTpcbiAgICAgICAgIDg4OmVmOmUzOjk0OmMwOjk4OjNlOmMzOjBkOjUxOjQ0
+        OjNkOjUzOjUyOmZmOjVlOjBiOjFiOlxuICAgICAgICAgNWI6NmM6OWI6YTZc
+        bi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLVxuTUlJRkJ6Q0NBKytnQXdJ
+        QkFnSUpBUDI2dkhGdUphTjRNQTBHQ1NxR1NJYjNEUUVCQ3dVQU1JR0xNUXN3
+        Q1FZRFxuVlFRR0V3SlZVekVYTUJVR0ExVUVDQXdPVG05eWRHZ2dRMkZ5YjJ4
+        cGJtRXhFREFPQmdOVkJBY01CMUpoYkdWcFxuWjJneEVEQU9CZ05WQkFvTUIw
+        dGhkR1ZzYkc4eEZEQVNCZ05WQkFzTUMxTnZiV1ZQY21kVmJtbDBNU2t3SndZ
+        RFxuVlFRRERDQmpaVzUwYjNNM0xXUmxkbVZzTWk1ellXMXBjaTVsZUdGdGNH
+        eGxMbU52YlRBZUZ3MHlNREExTURjeFxuTkRJeE5UQmFGdzB6T0RBeE1UZ3hO
+        REl4TlRCYU1JR0xNUXN3Q1FZRFZRUUdFd0pWVXpFWE1CVUdBMVVFQ0F3T1xu
+        VG05eWRHZ2dRMkZ5YjJ4cGJtRXhFREFPQmdOVkJBY01CMUpoYkdWcFoyZ3hF
+        REFPQmdOVkJBb01CMHRoZEdWc1xuYkc4eEZEQVNCZ05WQkFzTUMxTnZiV1ZQ
+        Y21kVmJtbDBNU2t3SndZRFZRUUREQ0JqWlc1MGIzTTNMV1JsZG1Wc1xuTWk1
+        ellXMXBjaTVsZUdGdGNHeGxMbU52YlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVC
+        QlFBRGdnRVBBRENDQVFvQ1xuZ2dFQkFKL1N3UkQvQVJvekdRNURuWVBsaW5P
+        NkxUeG1zWGpOaVl4ZzVZR202RTJXWFFmRHZxS2N3bnlVTFc1RFxuUkVidi9U
+        WWdSenZXTmYyWHpaY1gxei9uWi82cEt2RzhSNGR1N1cyMm52RU5ZMVBCUC8w
+        WHExODFlb1RQYTkybVxuamdtWlZqbmVLV3Y3d3R5TVZpb1Fzd3JLdUd6N3VN
+        anI1ZUt1MVVFRlRLTEF2bnV3YlIxOFpvQ0lXcmNIbTlPNFxuLzVQekdUTmpT
+        SldETkNmR3JNeWdDMWFySWpSeFQzbS9ia3ZKaVZtSGkzczFlYmdjY081WTVu
+        c2llYWNlMmJKWFxuT3VCWmpyTnFsejJhZ013NzFYZlUrbnBZYWJhenFwVlVW
+        WjRUWlgrVndIT1d4ZnQzb0VnZ3BuMzB4TlBwcTVTVFxuVGhyaVhadkZoMURI
+        VnZDVHFMa0tjOC8zQVE4Q0F3RUFBYU9DQVdvd2dnRm1NQXdHQTFVZEV3UUZN
+        QU1CQWY4d1xuQ3dZRFZSMFBCQVFEQWdHbU1CMEdBMVVkSlFRV01CUUdDQ3NH
+        QVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakFSQmdsZ1xuaGtnQmh2aENBUUVFQkFN
+        Q0FrUXdOUVlKWUlaSUFZYjRRZ0VOQkNnV0prdGhkR1ZzYkc4Z1UxTk1JRlJ2
+        YjJ3Z1xuUjJWdVpYSmhkR1ZrSUVObGNuUnBabWxqWVhSbE1CMEdBMVVkRGdR
+        V0JCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUlxuaFUxVFhUQ0J3QVlEVlIwakJJ
+        RzRNSUcxZ0JTYjB0bHBpSmtzTG5BcnQybDJlbjNSaFUxVFhhR0JrYVNCampD
+        QlxuaXpFTE1Ba0dBMVVFQmhNQ1ZWTXhGekFWQmdOVkJBZ01EazV2Y25Sb0lF
+        TmhjbTlzYVc1aE1SQXdEZ1lEVlFRSFxuREFkU1lXeGxhV2RvTVJBd0RnWURW
+        UVFLREFkTFlYUmxiR3h2TVJRd0VnWURWUVFMREF0VGIyMWxUM0puVlc1cFxu
+        ZERFcE1DY0dBMVVFQXd3Z1kyVnVkRzl6Tnkxa1pYWmxiREl1YzJGdGFYSXVa
+        WGhoYlhCc1pTNWpiMjJDQ1FEOVxudXJ4eGJpV2plREFOQmdrcWhraUc5dzBC
+        QVFzRkFBT0NBUUVBTWhsc3hxK3V3cjVrRnJCOG8wc1E2RnEwRjNUOVxuZGNZ
+        bTBvZ0IvcFV1UHdvZWlLVWxFMnRnTk5BczN0aElGZlhNSHdlQUt4MG9rT21M
+        UjhGeEd0cUdvQ2ZveElnMlxuby8vYkZ5OE9tK0U1cHgvY0pwY3BYa3VaWVBx
+        U0VpVDh2QVNVSkdYellNeGU3a0svbmp3eHVUeVppa1E5S1YybVxubWFyVkRo
+        V1V4TVVqakxsdTVRa1RqRlpMQkRXVmVWQmNJaTBmT21qUTh6NklmVGdwTXZK
+        SHNSZVovYVpJQWdSclxubjduYXdtNWxtNW5rWUhveXpRTCtjZG9aNDVPOXhh
+        ZWdScDRvMHBHc2pwSEhwMUZPZ1FuUjhUbGJCNGRCTzdmalxuRzZoK1VWSk9a
+        aUN4emNXdTNoYzYxODRITjloZWlPL2psTUNZUHNNTlVVUTlVMUwvWGdzYlcy
+        eWJwZz09XG4tLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tIn1dfQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:07 GMT
 - request:
-    method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    method: patch
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/contentguards/certguard/rhsm/018fe8d3-0ad5-76c7-91ad-f46384d10b3e/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImNhX2NlcnRpZmljYXRlIjoiQ2Vy
-        dGlmaWNhdGU6XG4gICAgRGF0YTpcbiAgICAgICAgVmVyc2lvbjogMyAoMHgy
-        KVxuICAgICAgICBTZXJpYWwgTnVtYmVyOlxuICAgICAgICAgICAgZmQ6YmE6
-        YmM6NzE6NmU6MjU6YTM6NzhcbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBz
-        aGEyNTZXaXRoUlNBRW5jcnlwdGlvblxuICAgICAgICBJc3N1ZXI6IEM9VVMs
-        IFNUPU5vcnRoIENhcm9saW5hLCBMPVJhbGVpZ2gsIE89S2F0ZWxsbywgT1U9
-        U29tZU9yZ1VuaXQsIENOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUu
-        Y29tXG4gICAgICAgIFZhbGlkaXR5XG4gICAgICAgICAgICBOb3QgQmVmb3Jl
-        OiBNYXkgIDcgMTQ6MjE6NTAgMjAyMCBHTVRcbiAgICAgICAgICAgIE5vdCBB
-        ZnRlciA6IEphbiAxOCAxNDoyMTo1MCAyMDM4IEdNVFxuICAgICAgICBTdWJq
-        ZWN0OiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdoLCBPPUth
-        dGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWRldmVsMi5zYW1p
-        ci5leGFtcGxlLmNvbVxuICAgICAgICBTdWJqZWN0IFB1YmxpYyBLZXkgSW5m
-        bzpcbiAgICAgICAgICAgIFB1YmxpYyBLZXkgQWxnb3JpdGhtOiByc2FFbmNy
-        eXB0aW9uXG4gICAgICAgICAgICAgICAgUHVibGljLUtleTogKDIwNDggYml0
-        KVxuICAgICAgICAgICAgICAgIE1vZHVsdXM6XG4gICAgICAgICAgICAgICAg
-        ICAgIDAwOjlmOmQyOmMxOjEwOmZmOjAxOjFhOjMzOjE5OjBlOjQzOjlkOjgz
-        OmU1OlxuICAgICAgICAgICAgICAgICAgICA4YTo3MzpiYToyZDozYzo2Njpi
-        MTo3ODpjZDo4OTo4Yzo2MDplNTo4MTphNjpcbiAgICAgICAgICAgICAgICAg
-        ICAgZTg6NGQ6OTY6NWQ6MDc6YzM6YmU6YTI6OWM6YzI6N2M6OTQ6MmQ6NmU6
-        NDM6XG4gICAgICAgICAgICAgICAgICAgIDQ0OjQ2OmVmOmZkOjM2OjIwOjQ3
-        OjNiOmQ2OjM1OmZkOjk3OmNkOjk3OjE3OlxuICAgICAgICAgICAgICAgICAg
-        ICBkNzozZjplNzo2NzpmZTphOToyYTpmMTpiYzo0Nzo4Nzo2ZTplZDo2ZDpi
-        NjpcbiAgICAgICAgICAgICAgICAgICAgOWU6ZjE6MGQ6NjM6NTM6YzE6M2Y6
-        ZmQ6MTc6YWI6NWY6MzU6N2E6ODQ6Y2Y6XG4gICAgICAgICAgICAgICAgICAg
-        IDZiOmRkOmE2OjhlOjA5Ojk5OjU2OjM5OmRlOjI5OjZiOmZiOmMyOmRjOjhj
-        OlxuICAgICAgICAgICAgICAgICAgICA1NjoyYToxMDpiMzowYTpjYTpiODo2
-        YzpmYjpiODpjODplYjplNTplMjphZTpcbiAgICAgICAgICAgICAgICAgICAg
-        ZDU6NDE6MDU6NGM6YTI6YzA6YmU6N2I6YjA6NmQ6MWQ6N2M6NjY6ODA6ODg6
-        XG4gICAgICAgICAgICAgICAgICAgIDVhOmI3OjA3OjliOmQzOmI4OmZmOjkz
-        OmYzOjE5OjMzOjYzOjQ4Ojk1OjgzOlxuICAgICAgICAgICAgICAgICAgICAz
-        NDoyNzpjNjphYzpjYzphMDowYjo1NjphYjoyMjozNDo3MTo0Zjo3OTpiZjpc
-        biAgICAgICAgICAgICAgICAgICAgNmU6NGI6Yzk6ODk6NTk6ODc6OGI6N2I6
-        MzU6Nzk6Yjg6MWM6NzA6ZWU6NTg6XG4gICAgICAgICAgICAgICAgICAgIGU2
-        OjdiOjIyOjc5OmE3OjFlOmQ5OmIyOjU3OjNhOmUwOjU5OjhlOmIzOjZhOlxu
-        ICAgICAgICAgICAgICAgICAgICA5NzozZDo5YTo4MDpjYzozYjpkNTo3Nzpk
-        NDpmYTo3YTo1ODo2OTpiNjpiMzpcbiAgICAgICAgICAgICAgICAgICAgYWE6
-        OTU6NTQ6NTU6OWU6MTM6NjU6N2Y6OTU6YzA6NzM6OTY6YzU6ZmI6Nzc6XG4g
-        ICAgICAgICAgICAgICAgICAgIGEwOjQ4OjIwOmE2OjdkOmY0OmM0OmQzOmU5
-        OmFiOjk0OjkzOjRlOjFhOmUyOlxuICAgICAgICAgICAgICAgICAgICA1ZDo5
-        YjpjNTo4Nzo1MDpjNzo1NjpmMDo5MzphODpiOTowYTo3MzpjZjpmNzpcbiAg
-        ICAgICAgICAgICAgICAgICAgMDE6MGZcbiAgICAgICAgICAgICAgICBFeHBv
-        bmVudDogNjU1MzcgKDB4MTAwMDEpXG4gICAgICAgIFg1MDl2MyBleHRlbnNp
-        b25zOlxuICAgICAgICAgICAgWDUwOXYzIEJhc2ljIENvbnN0cmFpbnRzOlxu
-        ICAgICAgICAgICAgICAgIENBOlRSVUVcbiAgICAgICAgICAgIFg1MDl2MyBL
-        ZXkgVXNhZ2U6XG4gICAgICAgICAgICAgICAgRGlnaXRhbCBTaWduYXR1cmUs
-        IEtleSBFbmNpcGhlcm1lbnQsIENlcnRpZmljYXRlIFNpZ24sIENSTCBTaWdu
-        XG4gICAgICAgICAgICBYNTA5djMgRXh0ZW5kZWQgS2V5IFVzYWdlOlxuICAg
-        ICAgICAgICAgICAgIFRMUyBXZWIgU2VydmVyIEF1dGhlbnRpY2F0aW9uLCBU
-        TFMgV2ViIENsaWVudCBBdXRoZW50aWNhdGlvblxuICAgICAgICAgICAgTmV0
-        c2NhcGUgQ2VydCBUeXBlOlxuICAgICAgICAgICAgICAgIFNTTCBTZXJ2ZXIs
-        IFNTTCBDQVxuICAgICAgICAgICAgTmV0c2NhcGUgQ29tbWVudDpcbiAgICAg
-        ICAgICAgICAgICBLYXRlbGxvIFNTTCBUb29sIEdlbmVyYXRlZCBDZXJ0aWZp
-        Y2F0ZVxuICAgICAgICAgICAgWDUwOXYzIFN1YmplY3QgS2V5IElkZW50aWZp
-        ZXI6XG4gICAgICAgICAgICAgICAgOUI6RDI6RDk6Njk6ODg6OTk6MkM6MkU6
-        NzA6MkI6Qjc6Njk6NzY6N0E6N0Q6RDE6ODU6NEQ6NTM6NURcbiAgICAgICAg
-        ICAgIFg1MDl2MyBBdXRob3JpdHkgS2V5IElkZW50aWZpZXI6XG4gICAgICAg
-        ICAgICAgICAga2V5aWQ6OUI6RDI6RDk6Njk6ODg6OTk6MkM6MkU6NzA6MkI6
-        Qjc6Njk6NzY6N0E6N0Q6RDE6ODU6NEQ6NTM6NURcbiAgICAgICAgICAgICAg
-        ICBEaXJOYW1lOi9DPVVTL1NUPU5vcnRoIENhcm9saW5hL0w9UmFsZWlnaC9P
-        PUthdGVsbG8vT1U9U29tZU9yZ1VuaXQvQ049Y2VudG9zNy1kZXZlbDIuc2Ft
-        aXIuZXhhbXBsZS5jb21cbiAgICAgICAgICAgICAgICBzZXJpYWw6RkQ6QkE6
-        QkM6NzE6NkU6MjU6QTM6NzhcblxuICAgIFNpZ25hdHVyZSBBbGdvcml0aG06
-        IHNoYTI1NldpdGhSU0FFbmNyeXB0aW9uXG4gICAgICAgICAzMjoxOTo2Yzpj
-        NjphZjphZTpjMjpiZTo2NDoxNjpiMDo3YzphMzo0YjoxMDplODo1YTpiNDpc
-        biAgICAgICAgIDE3Ojc0OmZkOjc1OmM2OjI2OmQyOjg4OjAxOmZlOjk1OjJl
-        OjNmOjBhOjFlOjg4OmE1OjI1OlxuICAgICAgICAgMTM6NmI6NjA6MzQ6ZDA6
-        MmM6ZGU6ZDg6NDg6MTU6ZjU6Y2M6MWY6MDc6ODA6MmI6MWQ6Mjg6XG4gICAg
-        ICAgICA5MDplOTo4Yjo0NzpjMTo3MToxYTpkYTo4NjphMDoyNzplODpjNDo4
-        ODozNjphMzpmZjpkYjpcbiAgICAgICAgIDE3OjJmOjBlOjliOmUxOjM5OmE3
-        OjFmOmRjOjI2Ojk3OjI5OjVlOjRiOjk5OjYwOmZhOjkyOlxuICAgICAgICAg
-        MTI6MjQ6ZmM6YmM6MDQ6OTQ6MjQ6NjU6ZjM6NjA6Y2M6NWU6ZWU6NDI6YmY6
-        OWU6M2M6MzE6XG4gICAgICAgICBiOTozYzo5OTo4YTo0NDozZDoyOTo1ZDph
-        Njo5OTphYTpkNTowZToxNTo5NDpjNDpjNToyMzpcbiAgICAgICAgIDhjOmI5
-        OjZlOmU1OjA5OjEzOjhjOjU2OjRiOjA0OjM1Ojk1Ojc5OjUwOjVjOjIyOjJk
-        OjFmOlxuICAgICAgICAgM2E6Njg6ZDA6ZjM6M2U6ODg6N2Q6Mzg6Mjk6MzI6
-        ZjI6NDc6YjE6MTc6OTk6ZmQ6YTY6NDg6XG4gICAgICAgICAwMjowNDo2Yjo5
-        ZjpiOTpkYTpjMjo2ZTo2NTo5Yjo5OTplNDo2MDo3YTozMjpjZDowMjpmZTpc
-        biAgICAgICAgIDcxOmRhOjE5OmUzOjkzOmJkOmM1OmE3OmEwOjQ2OjllOjI4
-        OmQyOjkxOmFjOjhlOjkxOmM3OlxuICAgICAgICAgYTc6NTE6NGU6ODE6MDk6
-        ZDE6ZjE6Mzk6NWI6MDc6ODc6NDE6M2I6Yjc6ZTM6MWI6YTg6N2U6XG4gICAg
-        ICAgICA1MTo1Mjo0ZTo2NjoyMDpiMTpjZDpjNTphZTpkZToxNzozYTpkNzpj
-        ZTowNzozNzpkODo1ZTpcbiAgICAgICAgIDg4OmVmOmUzOjk0OmMwOjk4OjNl
-        OmMzOjBkOjUxOjQ0OjNkOjUzOjUyOmZmOjVlOjBiOjFiOlxuICAgICAgICAg
-        NWI6NmM6OWI6YTZcbi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLVxuTUlJ
-        RkJ6Q0NBKytnQXdJQkFnSUpBUDI2dkhGdUphTjRNQTBHQ1NxR1NJYjNEUUVC
-        Q3dVQU1JR0xNUXN3Q1FZRFxuVlFRR0V3SlZVekVYTUJVR0ExVUVDQXdPVG05
-        eWRHZ2dRMkZ5YjJ4cGJtRXhFREFPQmdOVkJBY01CMUpoYkdWcFxuWjJneEVE
-        QU9CZ05WQkFvTUIwdGhkR1ZzYkc4eEZEQVNCZ05WQkFzTUMxTnZiV1ZQY21k
-        VmJtbDBNU2t3SndZRFxuVlFRRERDQmpaVzUwYjNNM0xXUmxkbVZzTWk1ellX
-        MXBjaTVsZUdGdGNHeGxMbU52YlRBZUZ3MHlNREExTURjeFxuTkRJeE5UQmFG
-        dzB6T0RBeE1UZ3hOREl4TlRCYU1JR0xNUXN3Q1FZRFZRUUdFd0pWVXpFWE1C
-        VUdBMVVFQ0F3T1xuVG05eWRHZ2dRMkZ5YjJ4cGJtRXhFREFPQmdOVkJBY01C
-        MUpoYkdWcFoyZ3hFREFPQmdOVkJBb01CMHRoZEdWc1xuYkc4eEZEQVNCZ05W
-        QkFzTUMxTnZiV1ZQY21kVmJtbDBNU2t3SndZRFZRUUREQ0JqWlc1MGIzTTNM
-        V1JsZG1Wc1xuTWk1ellXMXBjaTVsZUdGdGNHeGxMbU52YlRDQ0FTSXdEUVlK
-        S29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ1xuZ2dFQkFKL1N3UkQvQVJv
-        ekdRNURuWVBsaW5PNkxUeG1zWGpOaVl4ZzVZR202RTJXWFFmRHZxS2N3bnlV
-        TFc1RFxuUkVidi9UWWdSenZXTmYyWHpaY1gxei9uWi82cEt2RzhSNGR1N1cy
-        Mm52RU5ZMVBCUC8wWHExODFlb1RQYTkybVxuamdtWlZqbmVLV3Y3d3R5TVZp
-        b1Fzd3JLdUd6N3VNanI1ZUt1MVVFRlRLTEF2bnV3YlIxOFpvQ0lXcmNIbTlP
-        NFxuLzVQekdUTmpTSldETkNmR3JNeWdDMWFySWpSeFQzbS9ia3ZKaVZtSGkz
-        czFlYmdjY081WTVuc2llYWNlMmJKWFxuT3VCWmpyTnFsejJhZ013NzFYZlUr
-        bnBZYWJhenFwVlVWWjRUWlgrVndIT1d4ZnQzb0VnZ3BuMzB4TlBwcTVTVFxu
-        VGhyaVhadkZoMURIVnZDVHFMa0tjOC8zQVE4Q0F3RUFBYU9DQVdvd2dnRm1N
-        QXdHQTFVZEV3UUZNQU1CQWY4d1xuQ3dZRFZSMFBCQVFEQWdHbU1CMEdBMVVk
-        SlFRV01CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakFSQmdsZ1xuaGtn
-        Qmh2aENBUUVFQkFNQ0FrUXdOUVlKWUlaSUFZYjRRZ0VOQkNnV0prdGhkR1Zz
-        Ykc4Z1UxTk1JRlJ2YjJ3Z1xuUjJWdVpYSmhkR1ZrSUVObGNuUnBabWxqWVhS
-        bE1CMEdBMVVkRGdRV0JCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUlxuaFUxVFhU
-        Q0J3QVlEVlIwakJJRzRNSUcxZ0JTYjB0bHBpSmtzTG5BcnQybDJlbjNSaFUx
-        VFhhR0JrYVNCampDQlxuaXpFTE1Ba0dBMVVFQmhNQ1ZWTXhGekFWQmdOVkJB
-        Z01EazV2Y25Sb0lFTmhjbTlzYVc1aE1SQXdEZ1lEVlFRSFxuREFkU1lXeGxh
-        V2RvTVJBd0RnWURWUVFLREFkTFlYUmxiR3h2TVJRd0VnWURWUVFMREF0VGIy
-        MWxUM0puVlc1cFxuZERFcE1DY0dBMVVFQXd3Z1kyVnVkRzl6Tnkxa1pYWmxi
-        REl1YzJGdGFYSXVaWGhoYlhCc1pTNWpiMjJDQ1FEOVxudXJ4eGJpV2plREFO
-        QmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBTWhsc3hxK3V3cjVrRnJCOG8wc1E2
-        RnEwRjNUOVxuZGNZbTBvZ0IvcFV1UHdvZWlLVWxFMnRnTk5BczN0aElGZlhN
-        SHdlQUt4MG9rT21MUjhGeEd0cUdvQ2ZveElnMlxuby8vYkZ5OE9tK0U1cHgv
-        Y0pwY3BYa3VaWVBxU0VpVDh2QVNVSkdYellNeGU3a0svbmp3eHVUeVppa1E5
-        S1YybVxubWFyVkRoV1V4TVVqakxsdTVRa1RqRlpMQkRXVmVWQmNJaTBmT21q
-        UTh6NklmVGdwTXZKSHNSZVovYVpJQWdSclxubjduYXdtNWxtNW5rWUhveXpR
-        TCtjZG9aNDVPOXhhZWdScDRvMHBHc2pwSEhwMUZPZ1FuUjhUbGJCNGRCTzdm
-        alxuRzZoK1VWSk9aaUN4emNXdTNoYzYxODRITjloZWlPL2psTUNZUHNNTlVV
-        UTlVMUwvWGdzYlcyeWJwZz09XG4tLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t
-        XG4ifQ==
+        eyJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4g
+        ICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJl
+        cjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAg
+        U2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25c
+        biAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1S
+        YWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3
+        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxu
+        ICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAg
+        R01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAg
+        MjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fy
+        b2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwg
+        Q049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAg
+        U3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMg
+        S2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAg
+        IFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1
+        bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjow
+        MToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAg
+        ICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6
+        YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJl
+        OmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAg
+        ICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5Nzox
+        NzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6
+        ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAg
+        IDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNm
+        OlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1Njoz
+        OTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAg
+        NTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6
+        XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdi
+        OmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1
+        YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4Mzpc
+        biAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6
+        YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZl
+        OjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4Olxu
+        ICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1
+        NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6
+        M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4g
+        ICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1
+        OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0
+        ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAg
+        ICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6
+        YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBm
+        XG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxu
+        ICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2
+        MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVF
+        XG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAg
+        ICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0
+        aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4
+        dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNl
+        cnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGlj
+        YXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAg
+        ICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5l
+        dHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wg
+        VG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2
+        MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlC
+        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
+        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtl
+        eSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5
+        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
+        OjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0
+        aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0
+        L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAg
+        ICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAg
+        ICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlv
+        blxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6
+        N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpj
+        NjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAg
+        ICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFm
+        OjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6
+        MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAg
+        ICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5
+        OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1
+        OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6
+        M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6
+        YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0Yjow
+        NDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQw
+        OmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4
+        OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6
+        ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5
+        MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAg
+        ICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNi
+        OmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6
+        Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAg
+        ICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1Mjpm
+        Zjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lO
+        IENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZI
+        RnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdF
+        d0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0Jn
+        TlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhG
+        REFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0Jq
+        Wlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVG
+        dzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdM
+        TVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJG
+        eWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9N
+        QjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNr
+        d0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVH
+        RnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURD
+        Q0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZ
+        eGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6
+        WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5
+        Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZU
+        S0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXln
+        QzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhc
+        bk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9X
+        eGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgv
+        M0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3
+        WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdn
+        ckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJ
+        WklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVa
+        WEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlK
+        a3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2Iw
+        dGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtH
+        QTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhN
+        UkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJs
+        Ykd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFV
+        RUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVq
+        YjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFF
+        QU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3
+        b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nm
+        b3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpH
+        WHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1
+        UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFn
+        UnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3Nq
+        cEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2
+        MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0t
+        LS1FTkQgQ0VSVElGSUNBVEUtLS0tLVxuIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1340,21 +1468,19 @@ http_interactions:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:19 GMT
+      - Wed, 05 Jun 2024 14:35:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
-      Location:
-      - "/pulp/api/v3/contentguards/certguard/rhsm/018f54e2-c6e5-7817-967e-44a9f2b4c19a/"
       Vary:
       - Accept,Cookie
       Allow:
-      - GET, POST, HEAD, OPTIONS
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
@@ -1366,7 +1492,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cf169fe07db3464fbfacdbc9e9c34042
+      - 2cceca2350e6444f9762acda0c533740
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1375,10 +1501,10 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudGd1YXJkcy9jZXJ0
-        Z3VhcmQvcmhzbS8wMThmNTRlMi1jNmU1LTc4MTctOTY3ZS00NGE5ZjJiNGMx
-        OWEvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoxOS4zMDIz
-        MzNaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjE5
-        LjMwMjM1MloiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
+        Z3VhcmQvcmhzbS8wMThmZThkMy0wYWQ1LTc2YzctOTFhZC1mNDYzODRkMTBi
+        M2UvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wNVQxNDozNDo1Ni4wODYy
+        ODJaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM1OjA3
+        LjA5MjkwN1oiLCJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9u
         IjpudWxsLCJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERh
         dGE6XG4gICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFs
         IE51bWJlcjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4
@@ -1504,7 +1630,7 @@ http_interactions:
         bzBwR3NqcEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpj
         V3UzaGM2MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9
         PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9
-  recorded_at: Tue, 07 May 2024 21:08:19 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:07 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -1515,7 +1641,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1528,7 +1654,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:19 GMT
+      - Wed, 05 Jun 2024 14:35:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1548,7 +1674,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e085157c9035468ca33b473c98f4cb43
+      - e6af13a71d5c456dab19e3e6f9815459
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1558,23 +1684,23 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMDE4ZjU0ZTItYzBiNi03NDdhLWI2NjYtMWEzZGJiOWMwMzU2
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MTcuNzIwMTU4
-        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoxNy43
-        MjAxNzdaIiwiYmFzZV9wYXRoIjoiQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVk
+        L3JwbS9ycG0vMDE4ZmU4ZDMtMzJiMS03NTIxLWI1N2ItOWNiMzcwMTA1Y2M0
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDYuMjkwNjk1
+        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNTowNi4y
+        OTA3MTBaIiwiYmFzZV9wYXRoIjoiQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVk
         b3JhXzE3X2R1cGxpY2F0ZV9sYWJlbCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9j
         ZW50b3M5LWthdGVsbG8tZGV2ZWwubWFuaWNvdHRvLmV4YW1wbGUuY29tL3B1
         bHAvY29udGVudC9BQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
         bGljYXRlX2xhYmVsLyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsImhpZGRlbiI6
         ZmFsc2UsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGljYXRlIiwi
         cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
-        cHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTItYmQ2Ni03ZWE2LTgyNDkt
-        OThmM2JmNWIzOTMzLyIsImdlbmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX1d
+        cHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDMtMmZjMi03NzQzLTk4NDIt
+        YWUxYmJkMGRiNzAyLyIsImdlbmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX1d
         fQ==
-  recorded_at: Tue, 07 May 2024 21:08:19 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:07 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-bd66-7ea6-8249-98f3bf5b3933/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d3-2fc2-7743-9842-ae1bbd0db702/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1582,7 +1708,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1595,7 +1721,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:19 GMT
+      - Wed, 05 Jun 2024 14:35:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1615,7 +1741,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 904545ca47724c9cbade68a2e275ae02
+      - 75ac012f58be4319b5b8c32f25bb8d52
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1624,36 +1750,36 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItYmQ2Ni03ZWE2LTgyNDktOThmM2JmNWIzOTMzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MTYuODcyMzExWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoxNy4wNTYxMjZa
+        cG0vMDE4ZmU4ZDMtMmZjMi03NzQzLTk4NDItYWUxYmJkMGRiNzAyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDUuNTM5Njc0WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNTowNS42ODE2OTFa
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLWJiYTEtN2FhNy1hZDM0LWEyMWU2YWNm
-        ZTY1Ny92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItYmJhMS03YWE3LWFkMzQt
-        YTIxZTZhY2ZlNjU3LyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQzLTJlM2MtNzFhYS1hMWM2LTlhOWRlYWUw
+        MGQ3YS92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMmUzYy03MWFhLWExYzYt
+        OWE5ZGVhZTAwZDdhLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:19 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:07 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-c0b6-747a-b666-1a3dbb9c0356/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-32b1-7521-b57b-9cb370105cc4/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
-        Y2VydGd1YXJkL3Joc20vMDE4ZjU0ZTItYzZlNS03ODE3LTk2N2UtNDRhOWYy
-        YjRjMTlhLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        Y2VydGd1YXJkL3Joc20vMDE4ZmU4ZDMtMGFkNS03NmM3LTkxYWQtZjQ2Mzg0
+        ZDEwYjNlLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMThmNTRlMi1iZDY2LTdl
-        YTYtODI0OS05OGYzYmY1YjM5MzMvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMThmZThkMy0yZmMyLTc3
+        NDMtOTg0Mi1hZTFiYmQwZGI3MDIvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1666,7 +1792,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:19 GMT
+      - Wed, 05 Jun 2024 14:35:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1686,7 +1812,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 24e9f914eba04a82826515c769ce54e1
+      - 57f9d50a3ee149abb8c094b4d23bbcdf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1694,12 +1820,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWM4MTctNzMy
-        NS1iZWZiLTJjMDRlNGFjNDhkMi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:19 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTM2OGYtN2Ni
+        YS1hYzc0LTZiMTIyYTRhNmI4ZC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:07 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-c817-7325-befb-2c04e4ac48d2/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-368f-7cba-ac74-6b122a4a6b8d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1707,7 +1833,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1720,7 +1846,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:19 GMT
+      - Wed, 05 Jun 2024 14:35:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1740,7 +1866,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7c39725bdb1e4385b417bf2e8762295e
+      - 773e1b58ea90415ba4b1ef958f0aad71
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1748,26 +1874,26 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItYzgx
-        Ny03MzI1LWJlZmItMmMwNGU0YWM0OGQyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MTkuNjA3NTM2WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoxOS42MDc1NTFaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMzY4
+        Zi03Y2JhLWFjNzQtNmIxMjJhNGE2YjhkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MDcuMjgwMTA5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNTowNy4yODAxMjJaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjI0ZTlmOTE0ZWJhMDRhODI4MjY1
-        MTVjNzY5Y2U1NGUxIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MTkuNjE4
-        OTc3WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjE5LjYyMTc1
-        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MTkuNjQwNjkw
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjU3ZjlkNTBhM2VlMTQ5YWJiOGMw
+        OTRiNGQyM2JiY2RmIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDcuMjg5
+        Njg0WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjA3LjI5Mjky
+        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDcuMzA4NDU4
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25z
-        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNTRkZi03ZmQy
-        LTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:19 GMT
+        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFh
+        LTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:35:07 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-bd66-7ea6-8249-98f3bf5b3933/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d3-2fc2-7743-9842-ae1bbd0db702/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1775,7 +1901,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1788,7 +1914,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:19 GMT
+      - Wed, 05 Jun 2024 14:35:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1808,7 +1934,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 244392c85ea7474db72d0fefb3c98482
+      - ebfbd441cf224bdebcff02a747c42319
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1817,36 +1943,36 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItYmQ2Ni03ZWE2LTgyNDktOThmM2JmNWIzOTMzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MTYuODcyMzExWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODoxNy4wNTYxMjZa
+        cG0vMDE4ZmU4ZDMtMmZjMi03NzQzLTk4NDItYWUxYmJkMGRiNzAyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDUuNTM5Njc0WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNTowNS42ODE2OTFa
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLWJiYTEtN2FhNy1hZDM0LWEyMWU2YWNm
-        ZTY1Ny92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItYmJhMS03YWE3LWFkMzQt
-        YTIxZTZhY2ZlNjU3LyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQzLTJlM2MtNzFhYS1hMWM2LTlhOWRlYWUw
+        MGQ3YS92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMmUzYy03MWFhLWExYzYt
+        OWE5ZGVhZTAwZDdhLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:19 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:07 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-c0b6-747a-b666-1a3dbb9c0356/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-32b1-7521-b57b-9cb370105cc4/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
-        Y2VydGd1YXJkL3Joc20vMDE4ZjU0ZTItYzZlNS03ODE3LTk2N2UtNDRhOWYy
-        YjRjMTlhLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        Y2VydGd1YXJkL3Joc20vMDE4ZmU4ZDMtMGFkNS03NmM3LTkxYWQtZjQ2Mzg0
+        ZDEwYjNlLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMThmNTRlMi1iZDY2LTdl
-        YTYtODI0OS05OGYzYmY1YjM5MzMvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMThmZThkMy0yZmMyLTc3
+        NDMtOTg0Mi1hZTFiYmQwZGI3MDIvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1859,7 +1985,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:19 GMT
+      - Wed, 05 Jun 2024 14:35:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1879,7 +2005,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a07cbe2704314ca3862b239881406c32
+      - 258e7a89e5d344c8903801cebb2e7450
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1887,12 +2013,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWM5MjYtNzUz
-        Zi1iOThiLTE2NDFmZDM2YWMzMS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:19 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTM3N2MtNzVh
+        OS1iMTY1LWU4MjI3Y2RlYTBkOS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:07 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-c0b6-747a-b666-1a3dbb9c0356/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d3-32b1-7521-b57b-9cb370105cc4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1900,7 +2026,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1913,7 +2039,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:20 GMT
+      - Wed, 05 Jun 2024 14:35:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1933,7 +2059,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 44155d82c7bd4b6cad7c7f2b945a84aa
+      - 2c8548fa40944600adb4075bd329d914
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1941,12 +2067,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWM5YWMtNzc5
-        Ni1iNjQwLTAxYThkMWQ5NmZjZS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:20 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTM3ZWMtN2Rj
+        OC04MTQwLTY2NmJiN2M4MWFiYy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:07 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-bb0b-7eff-931d-d0ceb7b3c98e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d3-2da8-7e84-be7b-5a1a215cd807/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1954,7 +2080,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1967,7 +2093,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:20 GMT
+      - Wed, 05 Jun 2024 14:35:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1987,7 +2113,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cc526a56b5db482aa35738f8a9955143
+      - 12201f323ad746d0b18d0fd433f3781e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1995,12 +2121,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWNhYjUtNzQ2
-        Zi05YTI1LWE0OGYxMjM3Yjk4YS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:20 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTM4YjItN2Nk
+        Yy1hNDU4LWMyYTA5N2ExZjBlYy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:07 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-cab5-746f-9a25-a48f1237b98a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-38b2-7cdc-a458-c2a097a1f0ec/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2008,7 +2134,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2021,7 +2147,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:20 GMT
+      - Wed, 05 Jun 2024 14:35:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2041,7 +2167,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0fcbc3072e1d4787bac66c39819ca752
+      - c60e9c7c2c53469894954909746db270
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2049,28 +2175,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItY2Fi
-        NS03NDZmLTlhMjUtYTQ4ZjEyMzdiOThhLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MjAuMjc4Mjc1WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoyMC4yNzgyOTBaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMzhi
+        Mi03Y2RjLWE0NTgtYzJhMDk3YTFmMGVjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MDcuODI2NDE1WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNTowNy44MjY0MjhaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImNjNTI2YTU2YjVkYjQ4MmFhMzU3
-        MzhmOGE5OTU1MTQzIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MjAuMjk1
-        MTY1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjIwLjM2MTk1
-        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MjAuNDIwMDIz
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjEyMjAxZjMyM2FkNzQ2ZDBiMThk
+        MGZkNDMzZjM3ODFlIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDcuODM3
+        NDI2WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjA3Ljg2NzY5
+        MloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDcuOTA3ODI4
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGMxLTcxNzUtYTM3Yi1iNjMzMjI1NWEyMGEvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVtb3Rlcy9ycG0vcnBtLzAxOGY1NGUyLWJiMGItN2VmZi05MzFkLWQw
-        Y2ViN2IzYzk4ZS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4
-        ZjU0ZGYtN2ZkMi03NWZhLTliMzUtYzI3NTEzZmY5OGY0LyJdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:20 GMT
+        djMvcmVtb3Rlcy9ycG0vcnBtLzAxOGZlOGQzLTJkYTgtN2U4NC1iZTdiLTVh
+        MWEyMTVjZDgwNy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4
+        ZmUzYzktNzBhYS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:07 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018f54e2-bba1-7aa7-ad34-a21e6acfe657/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018fe8d3-2e3c-71aa-a1c6-9a9deae00d7a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2078,7 +2204,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2091,7 +2217,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:20 GMT
+      - Wed, 05 Jun 2024 14:35:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2111,7 +2237,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 04ebff93c3984294a8da179b2045611a
+      - 83c25674116043d08a2285f9e6e1ed0b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2119,12 +2245,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWNjNzYtNzBi
-        Yi05ZGRhLTA4MTBmMzgzOTdiYi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:20 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTM5YWItN2Vi
+        MS04MTg0LWMxMTYyNzBmNWNjZC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:08 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-cc76-70bb-9dda-0810f38397bb/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-39ab-7eb1-8184-c116270f5ccd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2132,7 +2258,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2145,7 +2271,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:21 GMT
+      - Wed, 05 Jun 2024 14:35:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2165,7 +2291,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8769901db6f84f8cb7ddf7d4c9f442ea
+      - 4bb37050d9ef477db3b31dde5c4b2d9b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2173,25 +2299,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItY2M3
-        Ni03MGJiLTlkZGEtMDgxMGYzODM5N2JiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MjAuNzI2OTQxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoyMC43MjY5NTdaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtMzlh
+        Yi03ZWIxLTgxODQtYzExNjI3MGY1Y2NkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MDguMDc1NDcxWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNTowOC4wNzU0ODRaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjA0ZWJmZjkzYzM5ODQyOTRhOGRh
-        MTc5YjIwNDU2MTFhIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MjAuNzQz
-        NTI1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjIwLjc5NDYw
-        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MjAuOTkyNjYy
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjgzYzI1Njc0MTE2MDQzZDA4YTIy
+        ODVmOWU2ZTFlZDBiIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDguMDg1
+        Mjg2WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM1OjA4LjEyMTIz
+        MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDguMjYwNDQz
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGU4LTc0ODctOWFhMC0zYzNlYzFhMTk5ZDcvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItYmJhMS03YWE3LWFk
-        MzQtYTIxZTZhY2ZlNjU3LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlu
-        cy8wMThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:21 GMT
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDMtMmUzYy03MWFhLWEx
+        YzYtOWE5ZGVhZTAwZDdhLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlu
+        cy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:35:08 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -2202,7 +2328,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2215,7 +2341,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:21 GMT
+      - Wed, 05 Jun 2024 14:35:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2235,7 +2361,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2de012d517844c8ab84a3bb845416b1b
+      - 0c2f05823c47493e84b8c81435614a00
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2245,7 +2371,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:21 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:08 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
@@ -2256,7 +2382,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.21.3/ruby
+      - OpenAPI-Generator/0.21.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -2269,7 +2395,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:21 GMT
+      - Wed, 05 Jun 2024 14:35:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2289,7 +2415,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cca2c87dbdb64e3daf3a69969a6cf1aa
+      - e62327ce7936448ba5ddc98ec6126ed7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2299,7 +2425,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:21 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:08 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -2323,7 +2449,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:21 GMT
+      - Wed, 05 Jun 2024 14:35:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2343,7 +2469,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 81f3f1680c904ebc9fe5b29decbf51e0
+      - be908971f7d84ab9838e26d6aeb6cbf8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2353,7 +2479,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:21 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:08 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -2377,7 +2503,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:21 GMT
+      - Wed, 05 Jun 2024 14:35:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2397,7 +2523,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 439eff9582de47989dfdcd6364ad072e
+      - a1ce0e4d7b1b407c936b40eca6bdcc7d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2407,7 +2533,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:21 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:08 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -2418,7 +2544,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2431,7 +2557,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:21 GMT
+      - Wed, 05 Jun 2024 14:35:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2451,7 +2577,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6cf0aa7aae674630b7d2a486971474b1
+      - da332f701bad49a6bc8cb5bd1c877e72
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2461,7 +2587,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:21 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:08 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -2485,7 +2611,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:21 GMT
+      - Wed, 05 Jun 2024 14:35:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2505,7 +2631,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6ba8b2e8becc41958acdc8023bd19a22
+      - 1152d1a6edc34c7facaf4ad28a9a7ef9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2515,7 +2641,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:21 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:08 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -2539,7 +2665,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:21 GMT
+      - Wed, 05 Jun 2024 14:35:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2559,7 +2685,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 65f804ef41894e25ac9f414446beef9b
+      - '039404490bbc4651b3bc90e83b4d64bb'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2569,7 +2695,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:21 GMT
+  recorded_at: Wed, 05 Jun 2024 14:35:08 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
@@ -2582,7 +2708,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2595,7 +2721,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:22 GMT
+      - Wed, 05 Jun 2024 14:35:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2615,7 +2741,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d05ce8005bd64d66b9dd902489d616f3
+      - 9299d15553d4425ca5f4da45b4ce4e77
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2623,12 +2749,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWQxN2QtN2Ew
-        Zi1hZTk3LTMyZTliNzM0YTI5ZC8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:22 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTNjYTEtN2Mw
+        OS1iNzlmLTRkMmUxMDU4YTIzNy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:08 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-d17d-7a0f-ae97-32e9b734a29d/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d3-3ca1-7c09-b79f-4d2e1058a237/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2636,7 +2762,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2649,7 +2775,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:22 GMT
+      - Wed, 05 Jun 2024 14:35:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2669,7 +2795,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4e8046ffe26f437099bd6aff94be9613
+      - fdd3d46d2cae408b8fa7047384212573
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2677,18 +2803,18 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItZDE3
-        ZC03YTBmLWFlOTctMzJlOWI3MzRhMjlkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MjIuMDE0MzAyWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODoyMi4wMTQzMTdaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDMtM2Nh
+        MS03YzA5LWI3OWYtNGQyZTEwNThhMjM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzU6MDguODMzNTY1WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNTowOC44MzM1NzdaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLm9ycGhhbi5vcnBo
-        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiZDA1Y2U4MDA1YmQ2NGQ2NmI5
-        ZGQ5MDI0ODlkNjE2ZjMiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
-        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMTowODoyMi4w
-        NDY5OTFaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MjIuMDk5
-        NDE5WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMTowODoyMi4zMzQx
-        NzJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzAxOGY1NGUwLWE0YzEtNzE3NS1hMzdiLWI2MzMyMjU1YTIwYS8iLCJw
+        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiOTI5OWQxNTU1M2Q0NDI1Y2E1
+        ZjRkYTQ1YjRjZTRlNzciLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
+        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozNTowOC44
+        NDUxOTZaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzU6MDguODgx
+        NjgyWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozNTowOS4wNDA4
+        NjdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzAxOGZlM2NiLTBkZjItN2M4My1hN2VhLWUyNmExYTI4ZDdmOS8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xlYW4g
         dXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIs
@@ -2698,7 +2824,63 @@ http_interactions:
         ZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
         IjpbIi9hcGkvdjMvb3JwaGFucy9jbGVhbnVwLyIsInNoYXJlZDovcHVscC9h
-        cGkvdjMvZG9tYWlucy8wMThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNm
-        Zjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:22 GMT
+        cGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2Fk
+        MzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:35:09 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/purge/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJmaW5pc2hlZF9iZWZvcmUiOiIzMDAwLTAxLTAxVDAwOjAwOjAwLjAwMCsw
+        MDowMCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:35:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6117121b5da041399bfe45be40fc277b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQzLTNkZTEtNzA5
+        MS05NjEwLWUyM2Y5NGU3OTU5My8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:35:09 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_url.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_url.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:05 GMT
+      - Wed, 05 Jun 2024 14:34:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e5da85b6b3984608a17460cd7de8524a
+      - 0e8af374ef66455c922dd8fc5a10a457
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:05 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:48 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:05 GMT
+      - Wed, 05 Jun 2024 14:34:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 38eb1a5bd1614682ac0d51f1976ec286
+      - d2706b073f6547a7a5ed00b248cab08a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:05 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:48 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -118,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:05 GMT
+      - Wed, 05 Jun 2024 14:34:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bfe6d5bc01b84cd79cc172aa4b602803
+      - 0e1c2adb4063489a9a70c3770ac40e51
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:05 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:48 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -172,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:05 GMT
+      - Wed, 05 Jun 2024 14:34:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e7439b15471d41ac9da8f9764c2adad3
+      - d1a5cb46af2347dd90c12aed897efa69
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:05 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:48 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -234,7 +234,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -247,13 +247,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:05 GMT
+      - Wed, 05 Jun 2024 14:34:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/018f54e2-9189-7eea-9fa3-eafcad3216c6/"
+      - "/pulp/api/v3/remotes/rpm/rpm/018fe8d2-ee0a-71ed-9da1-a53a4b93243c/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -269,7 +269,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9b96837e6fb540c6bb047b79f1a8a826
+      - c00c29fe5313413392df6258e9fceb35
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -278,9 +278,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OGY1NGUyLTkxODktN2VlYS05ZmEzLWVhZmNhZDMyMTZjNi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjA1LjY0MTUyMVoiLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MDUuNjQxNTM2WiIsIm5h
+        OGZlOGQyLWVlMGEtNzFlZC05ZGExLWE1M2E0YjkzMjQzYy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM0OjQ4LjcxNTY4NVoiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NDguNzE1NzAyWiIsIm5h
         bWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0dHA6Ly9teXJlcG8uY29tIiwi
         Y2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0
         aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxzIjp7fSwi
@@ -294,7 +294,7 @@ http_interactions:
         ZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InVzZXJuYW1lIiwiaXNfc2V0
         IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfV0s
         InNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:05 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:48 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -307,7 +307,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -320,13 +320,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:05 GMT
+      - Wed, 05 Jun 2024 14:34:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/018f54e2-9224-7eac-9218-95aeb42df7e0/"
+      - "/pulp/api/v3/repositories/rpm/rpm/018fe8d2-eef9-7bf1-ac50-16e02286d755/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -342,7 +342,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b77e703f014340fba8bb751ea0230b28
+      - 3e056c304e7c4e60a8431feab909c836
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -351,14 +351,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMDE4ZjU0ZTItOTIyNC03ZWFjLTkyMTgtOTVhZWI0MmRmN2UwLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MDUuNzk3MzcwWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODowNS44MDUwNTZa
+        cG0vMDE4ZmU4ZDItZWVmOS03YmYxLWFjNTAtMTZlMDIyODZkNzU1LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NDguOTU0MjYyWiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNDo0OC45NjU2MDla
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wMThmNTRlMi05MjI0LTdlYWMtOTIxOC05NWFlYjQyZGY3ZTAv
+        cnBtL3JwbS8wMThmZThkMi1lZWY5LTdiZjEtYWM1MC0xNmUwMjI4NmQ3NTUv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzAxOGY1
-        NGUyLTkyMjQtN2VhYy05MjE4LTk1YWViNDJkZjdlMC92ZXJzaW9ucy8wLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzAxOGZl
+        OGQyLWVlZjktN2JmMS1hYzUwLTE2ZTAyMjg2ZDc1NS92ZXJzaW9ucy8wLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -367,7 +367,7 @@ http_interactions:
         Y2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:05 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:48 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -375,13 +375,13 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE4ZjU0ZTItOTIyNC03ZWFjLTkyMTgtOTVhZWI0MmRm
-        N2UwL3ZlcnNpb25zLzAvIn0=
+        aWVzL3JwbS9ycG0vMDE4ZmU4ZDItZWVmOS03YmYxLWFjNTAtMTZlMDIyODZk
+        NzU1L3ZlcnNpb25zLzAvIn0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -394,7 +394,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:06 GMT
+      - Wed, 05 Jun 2024 14:34:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -414,7 +414,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9dca6ca50a9245d295b390e7321d4e8f
+      - ab1ab7f7baa548328d23d46664fc1d9b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -422,12 +422,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTkzOTYtN2Y1
-        My04ZTJkLWZkZmUyMjYyMWYzNy8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:06 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLWYwYmUtNzFl
+        Zi1iZDJhLTYwOTJhYzJkMDU4Yi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:49 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-9396-7f53-8e2d-fdfe22621f37/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-f0be-71ef-bd2a-6092ac2d058b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -435,7 +435,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -448,7 +448,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:06 GMT
+      - Wed, 05 Jun 2024 14:34:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -468,7 +468,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9efe801218864b2ca5785ebe731513be
+      - 156b44889e214defab38ab73c285d508
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -476,30 +476,30 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItOTM5
-        Ni03ZjUzLThlMmQtZmRmZTIyNjIxZjM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MDYuMTY3MTI3WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODowNi4xNjcxNDNaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItZjBi
+        ZS03MWVmLWJkMmEtNjA5MmFjMmQwNThiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzQ6NDkuNDA3MzAyWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNDo0OS40MDczMjlaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscF9ycG0uYXBwLnRhc2tzLnB1Ymxpc2hpbmcu
-        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiOWRjYTZjYTUwYTkyNDVkMjk1YjM5
-        MGU3MzIxZDRlOGYiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
-        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMTowODowNi4xODEy
-        OTBaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDYuMjMzODU2
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMTowODowNi40NDAyODRa
+        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiYWIxYWI3ZjdiYWE1NDgzMjhkMjNk
+        NDY2NjRmYzFkOWIiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
+        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozNDo0OS40MjA1
+        OTBaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NDkuNDU0MTc4
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozNDo0OS42MTM4MDha
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzAxOGY1NGUwLWE0ZTgtNzQ4Ny05YWEwLTNjM2VjMWExOTlkNy8iLCJwYXJl
+        LzAxOGZlM2NiLTBkZjItN2M4My1hN2VhLWUyNmExYTI4ZDdmOS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiR2VuZXJhdGlu
         ZyByZXBvc2l0b3J5IG1ldGFkYXRhIiwiY29kZSI6InB1Ymxpc2guZ2VuZXJh
         dGluZ19tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEs
         ImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTIt
-        OTNmMi03M2YxLWE0NjMtNjc5YjZiNGQ4ZTIzLyJdLCJyZXNlcnZlZF9yZXNv
+        WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDIt
+        ZjBmZi03YWQ1LWEzOTgtNDJmY2U4YWJiYTE3LyJdLCJyZXNlcnZlZF9yZXNv
         dXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE4ZjU0ZTItOTIyNC03ZWFjLTkyMTgtOTVhZWI0MmRm
-        N2UwLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNTRkZi03
-        ZmQyLTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:06 GMT
+        aWVzL3JwbS9ycG0vMDE4ZmU4ZDItZWVmOS03YmYxLWFjNTAtMTZlMDIyODZk
+        NzU1LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03
+        MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:34:49 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -510,7 +510,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -523,7 +523,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:06 GMT
+      - Wed, 05 Jun 2024 14:34:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -543,7 +543,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f75fbd677df94012a07dc89abe68f996
+      - 72a08ea37dcb488a8fb6d5b6b0654086
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -553,10 +553,10 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:06 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:49 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-93f2-73f1-a463-679b6b4d8e23/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d2-f0ff-7ad5-a398-42fce8abba17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -564,7 +564,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -577,7 +577,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:06 GMT
+      - Wed, 05 Jun 2024 14:34:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -597,7 +597,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 976f495122d0425fa50dde6bc9eb7da2
+      - 9b6d317daee946dd8d8e5d74010434f4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -606,19 +606,19 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItOTNmMi03M2YxLWE0NjMtNjc5YjZiNGQ4ZTIzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MDYuMjYzNTI3WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODowNi40MzA1MzJa
+        cG0vMDE4ZmU4ZDItZjBmZi03YWQ1LWEzOTgtNDJmY2U4YWJiYTE3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NDkuNDczNzM1WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNDo0OS42MDg2MjBa
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLTkyMjQtN2VhYy05MjE4LTk1YWViNDJk
-        ZjdlMC92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItOTIyNC03ZWFjLTkyMTgt
-        OTVhZWI0MmRmN2UwLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQyLWVlZjktN2JmMS1hYzUwLTE2ZTAyMjg2
+        ZDc1NS92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDItZWVmOS03YmYxLWFjNTAt
+        MTZlMDIyODZkNzU1LyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:06 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:49 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/
@@ -628,13 +628,13 @@ http_interactions:
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTItOTNmMi03M2YxLWE0NjMtNjc5
-        YjZiNGQ4ZTIzLyJ9
+        bGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDItZjBmZi03YWQ1LWEzOTgtNDJm
+        Y2U4YWJiYTE3LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -647,7 +647,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:06 GMT
+      - Wed, 05 Jun 2024 14:34:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -667,7 +667,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3b947cffbc8144878ce747389cec08bf
+      - 876a8c3e66dd40ceb5b3017f0dbcd4e8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -675,12 +675,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTk1OTUtNzVm
-        MS05YWRkLWRiOGVmNjE1OTc1Yi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:06 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLWYyYjMtNzUx
+        NS05MDVjLTdiZDZjNjJkODMxOC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:49 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-9595-75f1-9add-db8ef615975b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-f2b3-7515-905c-7bd6c62d8318/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -688,7 +688,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -701,7 +701,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:07 GMT
+      - Wed, 05 Jun 2024 14:34:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -721,7 +721,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '0578dd4dc95043a297492f88c452bd35'
+      - '02815d0287834d13a1044808b01bd6e4'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -729,29 +729,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItOTU5
-        NS03NWYxLTlhZGQtZGI4ZWY2MTU5NzViLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MDYuNjc3NzQ5WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODowNi42Nzc3NjVaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItZjJi
+        My03NTE1LTkwNWMtN2JkNmM2MmQ4MzE4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzQ6NDkuOTA3ODMwWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNDo0OS45MDc4NDRaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6IjNiOTQ3Y2ZmYmM4MTQ0ODc4Y2U3
-        NDczODljZWMwOGJmIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDYuNjkw
-        MzA0WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjA2LjczNzQ0
-        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDcuMDI1OTc2
+        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6Ijg3NmE4YzNlNjZkZDQwY2ViNWIz
+        MDE3ZjBkYmNkNGU4IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NDkuOTE5
+        NzUwWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM0OjQ5Ljk1MTE2
+        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTAuMTY1OTMx
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGU4LTc0ODctOWFhMC0zYzNlYzFhMTk5ZDcvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
-        IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDE4ZjU0
-        ZTItOTZkYi03NzliLThhNTAtZGRiNDVlZTVlZTM5LyJdLCJyZXNlcnZlZF9y
+        IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDE4ZmU4
+        ZDItZjNhNi03OTUxLWJkNDktNjhjZTJkNmYzMDAzLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iLCJz
-        aGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZjU0ZGYtN2ZkMi03NWZh
-        LTliMzUtYzI3NTEzZmY5OGY0LyJdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:07 GMT
+        aGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZmUzYzktNzBhYS03ODgz
+        LWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:50 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-96db-779b-8a50-ddb45ee5ee39/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d2-f3a6-7951-bd49-68ce2d6f3003/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -759,7 +759,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -772,7 +772,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:07 GMT
+      - Wed, 05 Jun 2024 14:34:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -792,7 +792,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e541ba55c22844639704d79527f34fcf
+      - 5b482c293b324fefaa87823f17a12cf5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -801,9 +801,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzAxOGY1NGUyLTk2ZGItNzc5Yi04YTUwLWRkYjQ1ZWU1ZWUzOS8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjA3LjAwODU3N1oiLCJw
-        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MDcuMDA4NTk1
+        cnBtLzAxOGZlOGQyLWYzYTYtNzk1MS1iZDQ5LTY4Y2UyZDZmMzAwMy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM0OjUwLjE1MjEzOFoiLCJw
+        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTAuMTUyMTU2
         WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
         N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
         OS1rYXRlbGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9wdWxwL2Nv
@@ -811,9 +811,9 @@ http_interactions:
         ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJoaWRkZW4iOmZhbHNl
         LCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInJlcG9z
         aXRvcnkiOm51bGwsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1Ymxp
-        Y2F0aW9ucy9ycG0vcnBtLzAxOGY1NGUyLTkzZjItNzNmMS1hNDYzLTY3OWI2
-        YjRkOGUyMy8iLCJnZW5lcmF0ZV9yZXBvX2NvbmZpZyI6ZmFsc2V9
-  recorded_at: Tue, 07 May 2024 21:08:07 GMT
+        Y2F0aW9ucy9ycG0vcnBtLzAxOGZlOGQyLWYwZmYtN2FkNS1hMzk4LTQyZmNl
+        OGFiYmExNy8iLCJnZW5lcmF0ZV9yZXBvX2NvbmZpZyI6ZmFsc2V9
+  recorded_at: Wed, 05 Jun 2024 14:34:50 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -835,7 +835,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -848,13 +848,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:07 GMT
+      - Wed, 05 Jun 2024 14:34:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/018f54e2-97f2-7635-8ad5-afc85883c92b/"
+      - "/pulp/api/v3/remotes/rpm/rpm/018fe8d2-f4e8-7667-804a-07ed3038b858/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -870,7 +870,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e03a736f47c04e0fbe9544bf308ca780
+      - 4bdba28ea3294b7eaa14a237c09dc80b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -879,9 +879,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OGY1NGUyLTk3ZjItNzYzNS04YWQ1LWFmYzg1ODgzYzkyYi8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjA3LjI4Mjg4NVoiLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MDcuMjgyODk4WiIsIm5h
+        OGZlOGQyLWY0ZTgtNzY2Ny04MDRhLTA3ZWQzMDM4Yjg1OC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM0OjUwLjQ3MjkxNVoiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTAuNDcyOTMxWiIsIm5h
         bWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJsIjoiaHR0cDovL3dlYnNpdGUu
         Y29tLyIsImNhX2NlcnQiOiJLSkw6S0RGKihERiYqKCokJigqIyRKTEtKRChE
         KChEIiwiY2xpZW50X2NlcnQiOiJLSkw6S0RGKihERiYqKCokJigqIyRKTEtK
@@ -896,10 +896,10 @@ http_interactions:
         bmFtZSI6InByb3h5X3Bhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1l
         IjoidXNlcm5hbWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwYXNzd29y
         ZCIsImlzX3NldCI6ZmFsc2V9XSwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
-  recorded_at: Tue, 07 May 2024 21:08:07 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:50 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-97f2-7635-8ad5-afc85883c92b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d2-f4e8-7667-804a-07ed3038b858/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -907,7 +907,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -920,7 +920,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:07 GMT
+      - Wed, 05 Jun 2024 14:34:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -940,7 +940,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4f769d882db94be6b8d9118307e61e07
+      - 7de039b923fb40c793b3dec8676c4f22
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -948,12 +948,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTk4MzgtNzll
-        MS1hOTYxLWM3ZDRkMmMxNTg0ZC8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:07 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLWY1MjMtNzgy
+        OS05ZGQwLWZiMmM2YTc2NTMyMy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:50 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018f54e2-9224-7eac-9218-95aeb42df7e0/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018fe8d2-eef9-7bf1-ac50-16e02286d755/
     body:
       encoding: UTF-8
       base64_string: |
@@ -963,7 +963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -976,7 +976,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:07 GMT
+      - Wed, 05 Jun 2024 14:34:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -996,7 +996,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e3be2ec45f884b0ea49dcbd9246f2a00
+      - 68d22e56d45d44d1876b3dec8cd35321
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1004,12 +1004,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTk5MGItN2Yx
-        Yi04OWJhLTM3MmY2ODY4YTFlOS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:07 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLWY1Y2ItN2Nk
+        Zi1iYmYyLWNmYzAwN2M0Nzg2Yi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:50 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-9189-7eea-9fa3-eafcad3216c6/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d2-ee0a-71ed-9da1-a53a4b93243c/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1028,7 +1028,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1041,7 +1041,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:07 GMT
+      - Wed, 05 Jun 2024 14:34:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1061,7 +1061,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f4c5e4e105f84ebe9e0eca5fc366a44b
+      - c0fa95fff3c64c0ebc6fab31d0de57c1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1069,12 +1069,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTk5N2YtNzFj
-        Ni1iMzZlLWNiNjU5NDgyZjk5OC8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:07 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLWY2NDQtNzFk
+        My05NDkzLTViZWYwYTUxOWI4YS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:50 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-997f-71c6-b36e-cb659482f998/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-f644-71d3-9493-5bef0a519b8a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1082,7 +1082,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1095,7 +1095,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:07 GMT
+      - Wed, 05 Jun 2024 14:34:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1115,7 +1115,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c4263548aa99441aaa273aa582eb570b
+      - 451bc50423824375a33b8d6184515677
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1123,24 +1123,24 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItOTk3
-        Zi03MWM2LWIzNmUtY2I2NTk0ODJmOTk4LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MDcuNjgwMDY2WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODowNy42ODAwODBaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItZjY0
+        NC03MWQzLTk0OTMtNWJlZjBhNTE5YjhhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzQ6NTAuODIxMTQ2WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNDo1MC44MjExNjNaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6ImY0YzVlNGUxMDVmODRlYmU5ZTBl
-        Y2E1ZmMzNjZhNDRiIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDcuNjky
-        OTc3WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjA3LjY5NTg3
-        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDcuNzA3MjEw
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6ImMwZmE5NWZmZjNjNjRjMGViYzZm
+        YWIzMWQwZGU1N2MxIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTAuODM1
+        MjcxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM0OjUwLjgzNzYw
+        OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTAuODQ4MzQ2
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMv
-        cnBtL3JwbS8wMThmNTRlMi05MTg5LTdlZWEtOWZhMy1lYWZjYWQzMjE2YzYv
-        Iiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGY1NGRmLTdmZDIt
-        NzVmYS05YjM1LWMyNzUxM2ZmOThmNC8iXX0=
-  recorded_at: Tue, 07 May 2024 21:08:07 GMT
+        cnBtL3JwbS8wMThmZThkMi1lZTBhLTcxZWQtOWRhMS1hNTNhNGI5MzI0M2Mv
+        Iiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGZlM2M5LTcwYWEt
+        Nzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:34:50 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -1151,7 +1151,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1164,7 +1164,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:07 GMT
+      - Wed, 05 Jun 2024 14:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1184,7 +1184,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6beb109ebf72479fb2df418ad2afe59f
+      - d245af5a44e84bc897a15f93b6798785
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1194,23 +1194,23 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMDE4ZjU0ZTItOTZkYi03NzliLThhNTAtZGRiNDVlZTVlZTM5
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MDcuMDA4NTc3
-        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODowNy4w
-        MDg1OTVaIiwiYmFzZV9wYXRoIjoiQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVk
+        L3JwbS9ycG0vMDE4ZmU4ZDItZjNhNi03OTUxLWJkNDktNjhjZTJkNmYzMDAz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTAuMTUyMTM4
+        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNDo1MC4x
+        NTIxNTZaIiwiYmFzZV9wYXRoIjoiQUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVk
         b3JhXzE3X2R1cGxpY2F0ZV9sYWJlbCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9j
         ZW50b3M5LWthdGVsbG8tZGV2ZWwubWFuaWNvdHRvLmV4YW1wbGUuY29tL3B1
         bHAvY29udGVudC9BQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
         bGljYXRlX2xhYmVsLyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsImhpZGRlbiI6
         ZmFsc2UsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGljYXRlIiwi
         cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
-        cHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZjU0ZTItOTNmMi03M2YxLWE0NjMt
-        Njc5YjZiNGQ4ZTIzLyIsImdlbmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX1d
+        cHVibGljYXRpb25zL3JwbS9ycG0vMDE4ZmU4ZDItZjBmZi03YWQ1LWEzOTgt
+        NDJmY2U4YWJiYTE3LyIsImdlbmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX1d
         fQ==
-  recorded_at: Tue, 07 May 2024 21:08:07 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-93f2-73f1-a463-679b6b4d8e23/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d2-f0ff-7ad5-a398-42fce8abba17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1218,7 +1218,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1231,7 +1231,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:07 GMT
+      - Wed, 05 Jun 2024 14:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1251,7 +1251,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 43b750b8681e4a3db1be8f12534b8081
+      - 2a94cd37c7744216b21486f34df31f0f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1260,34 +1260,34 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItOTNmMi03M2YxLWE0NjMtNjc5YjZiNGQ4ZTIzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MDYuMjYzNTI3WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODowNi40MzA1MzJa
+        cG0vMDE4ZmU4ZDItZjBmZi03YWQ1LWEzOTgtNDJmY2U4YWJiYTE3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NDkuNDczNzM1WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNDo0OS42MDg2MjBa
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLTkyMjQtN2VhYy05MjE4LTk1YWViNDJk
-        ZjdlMC92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItOTIyNC03ZWFjLTkyMTgt
-        OTVhZWI0MmRmN2UwLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQyLWVlZjktN2JmMS1hYzUwLTE2ZTAyMjg2
+        ZDc1NS92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDItZWVmOS03YmYxLWFjNTAt
+        MTZlMDIyODZkNzU1LyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:07 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:51 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-96db-779b-8a50-ddb45ee5ee39/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d2-f3a6-7951-bd49-68ce2d6f3003/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4
-        ZjU0ZTItOTNmMi03M2YxLWE0NjMtNjc5YjZiNGQ4ZTIzLyJ9
+        ZmU4ZDItZjBmZi03YWQ1LWEzOTgtNDJmY2U4YWJiYTE3LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1300,7 +1300,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:08 GMT
+      - Wed, 05 Jun 2024 14:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1320,7 +1320,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5f32e3b0977f47929aa032842e4eda55
+      - 2d23e98190124617be1d51117442de3f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1328,12 +1328,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTlhYmMtNzZk
-        OS1hYzE0LWY0NzBkMGU1YmI0Zi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:08 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLWY3OGItN2E5
+        Ni04ZmU1LWQzYjI2M2NkNjAwNy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-9abc-76d9-ac14-f470d0e5bb4f/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-f78b-7a96-8fe5-d3b263cd6007/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1341,7 +1341,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1354,7 +1354,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:08 GMT
+      - Wed, 05 Jun 2024 14:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1374,7 +1374,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7f782d0b2b064fcb91fab71387674af4
+      - b0126d4fd00d41999196992a8fc64dcb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1382,26 +1382,26 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItOWFi
-        Yy03NmQ5LWFjMTQtZjQ3MGQwZTViYjRmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MDcuOTk3MDUxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODowNy45OTcwNjdaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItZjc4
+        Yi03YTk2LThmZTUtZDNiMjYzY2Q2MDA3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzQ6NTEuMTQ4MzQwWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNDo1MS4xNDgzNTdaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjVmMzJlM2IwOTc3ZjQ3OTI5YWEw
-        MzI4NDJlNGVkYTU1IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDguMDA4
-        MzM3WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjA4LjAxMDgw
-        M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDguMDI3Nzc2
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjJkMjNlOTgxOTAxMjQ2MTdiZTFk
+        NTExMTc0NDJkZTNmIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTEuMTU4
+        MDgyWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM0OjUxLjE2MDMx
+        MloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTEuMTczMjkx
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25z
-        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNTRkZi03ZmQy
-        LTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:08 GMT
+        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFh
+        LTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:34:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018f54e2-93f2-73f1-a463-679b6b4d8e23/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/rpm/rpm/018fe8d2-f0ff-7ad5-a398-42fce8abba17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1409,7 +1409,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1422,7 +1422,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:08 GMT
+      - Wed, 05 Jun 2024 14:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1442,7 +1442,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c6d4a5ba8dcc4542bb9b121c9473f68f
+      - d070f133148c4dc4a27e21b85ea684fb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1451,34 +1451,34 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE4ZjU0ZTItOTNmMi03M2YxLWE0NjMtNjc5YjZiNGQ4ZTIzLyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MDYuMjYzNTI3WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODowNi40MzA1MzJa
+        cG0vMDE4ZmU4ZDItZjBmZi03YWQ1LWEzOTgtNDJmY2U4YWJiYTE3LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NDkuNDczNzM1WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozNDo0OS42MDg2MjBa
         IiwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9ycG0vcnBtLzAxOGY1NGUyLTkyMjQtN2VhYy05MjE4LTk1YWViNDJk
-        ZjdlMC92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
-        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItOTIyNC03ZWFjLTkyMTgt
-        OTVhZWI0MmRmN2UwLyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
+        cmllcy9ycG0vcnBtLzAxOGZlOGQyLWVlZjktN2JmMS1hYzUwLTE2ZTAyMjg2
+        ZDc1NS92ZXJzaW9ucy8wLyIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDItZWVmOS03YmYxLWFjNTAt
+        MTZlMDIyODZkNzU1LyIsImNoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJtZXRh
         ZGF0YV9jaGVja3N1bV90eXBlIjoic2hhMjU2IiwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjoic2hhMjU2IiwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:08 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:51 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-96db-779b-8a50-ddb45ee5ee39/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d2-f3a6-7951-bd49-68ce2d6f3003/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE4
-        ZjU0ZTItOTNmMi03M2YxLWE0NjMtNjc5YjZiNGQ4ZTIzLyJ9
+        ZmU4ZDItZjBmZi03YWQ1LWEzOTgtNDJmY2U4YWJiYTE3LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1491,7 +1491,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:08 GMT
+      - Wed, 05 Jun 2024 14:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1511,7 +1511,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 037c078bc7f04c4c94ae2d3a843c5776
+      - 95def68ad68e47e3bbe5a5f9c487291c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1519,12 +1519,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTliYjktNzM3
-        Zi05MTJkLWZhNTliNjFmYmI0OC8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:08 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLWY4NjYtNzQ1
+        OC05NmU4LTJlMzRmMzRkNTc2Mi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:51 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e2-96db-779b-8a50-ddb45ee5ee39/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fe8d2-f3a6-7951-bd49-68ce2d6f3003/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1532,7 +1532,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1545,7 +1545,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:08 GMT
+      - Wed, 05 Jun 2024 14:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1565,7 +1565,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3610611cca304f359da16f2a262111e4
+      - '0482a1f0328642debacb51d489f252e9'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1573,12 +1573,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTljM2EtN2Zm
-        YS04NTkwLTljNDdiYzYwMWYxNi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:08 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLWY4ZDAtNzA5
+        NS04MDZmLTM5YjczZjUzYmQ3ZC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:51 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-9189-7eea-9fa3-eafcad3216c6/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fe8d2-ee0a-71ed-9da1-a53a4b93243c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1586,7 +1586,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1599,7 +1599,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:08 GMT
+      - Wed, 05 Jun 2024 14:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1619,7 +1619,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e30ae19519bc43d68918ebc8922ffc3a
+      - 9a0121be5a084be2a03f51479d073e21
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1627,12 +1627,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTlkMTMtNzlk
-        YS1iZWJiLWE5MDI2MzZlZTc1OS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:08 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLWY5YzMtNzBh
+        MC1iOGE2LWExOWViYTA3YjBhNy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-9d13-79da-bebb-a902636ee759/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-f9c3-70a0-b8a6-a19eba07b0a7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1640,7 +1640,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1653,7 +1653,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:08 GMT
+      - Wed, 05 Jun 2024 14:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1673,7 +1673,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fb0c01b921984c879ea1e47ac0700f77
+      - 58a0491da77744878d704d2e8e960c6e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1681,28 +1681,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItOWQx
-        My03OWRhLWJlYmItYTkwMjYzNmVlNzU5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MDguNTk2MzUwWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODowOC41OTYzNjdaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItZjlj
+        My03MGEwLWI4YTYtYTE5ZWJhMDdiMGE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzQ6NTEuNzE1ODY5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNDo1MS43MTU4ODFaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImUzMGFlMTk1MTliYzQzZDY4OTE4
-        ZWJjODkyMmZmYzNhIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDguNjA3
-        OTYzWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjA4LjY1NTYx
-        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDguNzEwNTE1
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjlhMDEyMWJlNWEwODRiZTJhMDNm
+        NTE0NzlkMDczZTIxIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTEuNzI3
+        NzMyWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM0OjUxLjc2MDY0
+        MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTEuNzk5OTM4
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGU4LTc0ODctOWFhMC0zYzNlYzFhMTk5ZDcvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVtb3Rlcy9ycG0vcnBtLzAxOGY1NGUyLTkxODktN2VlYS05ZmEzLWVh
-        ZmNhZDMyMTZjNi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4
-        ZjU0ZGYtN2ZkMi03NWZhLTliMzUtYzI3NTEzZmY5OGY0LyJdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:08 GMT
+        djMvcmVtb3Rlcy9ycG0vcnBtLzAxOGZlOGQyLWVlMGEtNzFlZC05ZGExLWE1
+        M2E0YjkzMjQzYy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4
+        ZmUzYzktNzBhYS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:51 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018f54e2-9224-7eac-9218-95aeb42df7e0/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018fe8d2-eef9-7bf1-ac50-16e02286d755/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1710,7 +1710,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1723,7 +1723,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:08 GMT
+      - Wed, 05 Jun 2024 14:34:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1743,7 +1743,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6e34c9d2cd98408ea0c0d3bfe2e29ac9
+      - acc12dacd8c249aaaddd787283053b2f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1751,12 +1751,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLTllNDMtN2Q1
-        YS05ZjhhLTMxM2I0ZjU0ZGQ0Yi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:08 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLWZhYmQtN2U1
+        Ni1hMjE2LWUzNjEwN2YxMjE0Zi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-9e43-7d5a-9f8a-313b4f54dd4b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-fabd-7e56-a216-e36107f1214f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1764,7 +1764,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1777,7 +1777,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:09 GMT
+      - Wed, 05 Jun 2024 14:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1797,7 +1797,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ae98c0759d7f41bcaac15cea52a42edf
+      - 8408d4144513485080040979db46e47a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1805,25 +1805,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItOWU0
-        My03ZDVhLTlmOGEtMzEzYjRmNTRkZDRiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MDguOTAwMzgxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODowOC45MDA0MjJaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItZmFi
+        ZC03ZTU2LWEyMTYtZTM2MTA3ZjEyMTRmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzQ6NTEuOTY1NzYxWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNDo1MS45NjU3ODFaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjZlMzRjOWQyY2Q5ODQwOGVhMGMw
-        ZDNiZmUyZTI5YWM5IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDguOTEy
-        MjI0WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjA4Ljk4NTMy
-        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDkuMTcwODg4
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImFjYzEyZGFjZDhjMjQ5YWFhZGRk
+        Nzg3MjgzMDUzYjJmIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTEuOTc3
+        MzU4WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM0OjUyLjAwODY3
+        OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTIuMTU2NzE5
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGMxLTcxNzUtYTM3Yi1iNjMzMjI1NWEyMGEvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItOTIyNC03ZWFjLTky
-        MTgtOTVhZWI0MmRmN2UwLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlu
-        cy8wMThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:09 GMT
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmU4ZDItZWVmOS03YmYxLWFj
+        NTAtMTZlMDIyODZkNzU1LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlu
+        cy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:34:52 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -1834,7 +1834,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1847,7 +1847,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:09 GMT
+      - Wed, 05 Jun 2024 14:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1867,7 +1867,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 605d2b4e000a49bf819a2affb9a63d00
+      - 846344d1c8d44051b521bbcf102441dd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1877,7 +1877,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:09 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:52 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
@@ -1888,7 +1888,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.21.3/ruby
+      - OpenAPI-Generator/0.21.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -1901,7 +1901,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:09 GMT
+      - Wed, 05 Jun 2024 14:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1921,7 +1921,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 37262318893243149c8da7539ad74f2f
+      - 3e0de2d248364f05a08b248d26902f58
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1931,7 +1931,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:09 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:52 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -1955,7 +1955,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:09 GMT
+      - Wed, 05 Jun 2024 14:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1975,7 +1975,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f30c068102974036a694d5cab585a3bf
+      - fb90c3821fbf488ba526b1129b13a3a1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1985,7 +1985,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:09 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:52 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -2009,7 +2009,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:09 GMT
+      - Wed, 05 Jun 2024 14:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2029,7 +2029,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 67572d0510064fb7b3046743a02cb70f
+      - 99d4eb7223f14069b8d2adafd6d7f2a0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2039,7 +2039,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:09 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:52 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -2050,7 +2050,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2063,7 +2063,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:09 GMT
+      - Wed, 05 Jun 2024 14:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2083,7 +2083,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - da2b48ecf25e4c989e828bf91ee4dbba
+      - ef2090cc24364b59b94989b01dff9aca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2093,7 +2093,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:09 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:52 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -2117,7 +2117,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:09 GMT
+      - Wed, 05 Jun 2024 14:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2137,7 +2137,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3761c0834a80478e91c8263db6f51202
+      - f71aa347a77a4b96909b13d187ca1478
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2147,7 +2147,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:09 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:52 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -2171,7 +2171,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:09 GMT
+      - Wed, 05 Jun 2024 14:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2191,7 +2191,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - dc4a2e2796c7453ab551233aad025cd6
+      - d1fe0c9484fa474e9b740b5169b0a130
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2201,7 +2201,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:09 GMT
+  recorded_at: Wed, 05 Jun 2024 14:34:52 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
@@ -2214,7 +2214,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2227,7 +2227,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:09 GMT
+      - Wed, 05 Jun 2024 14:34:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2247,7 +2247,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6b42d3874a974652a74c0641f502337d
+      - 548c582557af44bfadd39c4a87f616a1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2255,12 +2255,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWExYmItNzZj
-        OC04MzQzLTUzZWU4OTA5MzI3Zi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:09 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLWZlOWUtNzQ0
+        Yy1hYjY1LTZhY2ZhYTA5YWQ5NS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:52 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e2-a1bb-76c8-8343-53ee8909327f/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d2-fe9e-744c-ab65-6acfaa09ad95/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2268,7 +2268,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -2281,7 +2281,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:10 GMT
+      - Wed, 05 Jun 2024 14:34:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2301,7 +2301,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3c660f9ff29a4f8dacd9a514a99bce11
+      - c014fcefc27e47d4becc6793eb7647ef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2309,18 +2309,18 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTItYTFi
-        Yi03NmM4LTgzNDMtNTNlZTg5MDkzMjdmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MDkuNzg4MTY3WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODowOS43ODgxODJaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDItZmU5
+        ZS03NDRjLWFiNjUtNmFjZmFhMDlhZDk1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6MzQ6NTIuOTU4ODU5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozNDo1Mi45NTg4NzJaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLm9ycGhhbi5vcnBo
-        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiNmI0MmQzODc0YTk3NDY1MmE3
-        NGMwNjQxZjUwMjMzN2QiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
-        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMTowODowOS44
-        MDA3NDBaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MDkuODYx
-        NDU4WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMTowODoxMC4wNzky
-        OTZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzAxOGY1NGUwLWE0ZTgtNzQ4Ny05YWEwLTNjM2VjMWExOTlkNy8iLCJw
+        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiNTQ4YzU4MjU1N2FmNDRiZmFk
+        ZDM5YzRhODdmNjE2YTEiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
+        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozNDo1Mi45
+        NzA4NDVaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6MzQ6NTMuMDA5
+        NTkzWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozNDo1My4xNjc3
+        OThaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzAxOGZlM2NiLTBkNDMtNzczMS05ODUyLTg3MjlkMDA4MTk2My8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xlYW4g
         dXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIs
@@ -2330,7 +2330,63 @@ http_interactions:
         ZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
         IjpbIi9hcGkvdjMvb3JwaGFucy9jbGVhbnVwLyIsInNoYXJlZDovcHVscC9h
-        cGkvdjMvZG9tYWlucy8wMThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNm
-        Zjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:10 GMT
+        cGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2Fk
+        MzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:34:53 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/purge/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJmaW5pc2hlZF9iZWZvcmUiOiIzMDAwLTAxLTAxVDAwOjAwOjAwLjAwMCsw
+        MDowMCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:34:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 02a34dfa006f4c36a4f5cbc44964d84a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQyLWZmZGQtN2U2
+        ZC04N2VlLTcyYzQ5MTk1NDc4MC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:34:53 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/actions/pulp3/yum_update_no_url/addurl.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/yum_update_no_url/addurl.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:32 GMT
+      - Thu, 06 Jun 2024 15:30:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c42ee9b671d74cb2b77c7158cea34b8d
+      - 269efa4d374b498e92d8dd760b17f1a6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:32 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:53 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:32 GMT
+      - Thu, 06 Jun 2024 15:30:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -89,7 +89,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '52'
+      - '797'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5b70aa218b4b4143a47419c65eca8d95
+      - 624f6dd984c34814b272c4fb460af275
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -105,9 +105,149 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:32 GMT
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
+        cG0vMDE4ZmVlMTYtN2ExYS03NDVhLTg4YzAtNDcwZjM0OGRjN2Q0LyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDZUMTU6MDY6NDEuNTYyMzg1WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNlQxNTowNjo0MS41NjIzOTla
+        IiwibmFtZSI6IjJfZHVwbGljYXRlIiwidXJsIjoiaHR0cDovL3NvbWVvdGhl
+        cnVybCIsImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNf
+        dmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVs
+        cyI6e30sImRvd25sb2FkX2NvbmN1cnJlbmN5IjpudWxsLCJtYXhfcmV0cmll
+        cyI6bnVsbCwicG9saWN5IjoiaW1tZWRpYXRlIiwidG90YWxfdGltZW91dCI6
+        MzYwMC4wLCJjb25uZWN0X3RpbWVvdXQiOjYwLjAsInNvY2tfY29ubmVjdF90
+        aW1lb3V0Ijo2MC4wLCJzb2NrX3JlYWRfdGltZW91dCI6MzYwMC4wLCJoZWFk
+        ZXJzIjpudWxsLCJyYXRlX2xpbWl0IjowLCJoaWRkZW5fZmllbGRzIjpbeyJu
+        YW1lIjoiY2xpZW50X2tleSIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InBy
+        b3h5X3VzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicHJveHlf
+        cGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJ1c2VybmFtZSIs
+        ImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InBhc3N3b3JkIiwiaXNfc2V0Ijpm
+        YWxzZX1dLCJzbGVzX2F1dGhfdG9rZW4iOm51bGx9XX0=
+  recorded_at: Thu, 06 Jun 2024 15:30:53 GMT
+- request:
+    method: delete
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fee16-7a1a-745a-88c0-470f348dc7d4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.25.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 06 Jun 2024 15:30:53 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 87e0e1d4b6bf4ae2bcc7e03f4ceeec63
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlZTJjLWEyN2UtN2Yy
+        Mi1hYmQ5LWIwNGJlODI1MjA5My8ifQ==
+  recorded_at: Thu, 06 Jun 2024 15:30:53 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fee2c-a27e-7f22-abd9-b04be8252093/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 06 Jun 2024 15:30:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '802'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9fc2216c4c5a422083ddd663ec53187a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmVlMmMtYTI3
+        ZS03ZjIyLWFiZDktYjA0YmU4MjUyMDkzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDZUMTU6MzA6NTMuNjk0NzU2WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNlQxNTozMDo1My42OTQ3NzNaIiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6Ijg3ZTBlMWQ0YjZiZjRhZTJiY2M3
+        ZTAzZjRjZWVlYzYzIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDZUMTU6MzA6NTMuNzEz
+        MDk4WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA2VDE1OjMwOjUzLjc2OTU3
+        M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDZUMTU6MzA6NTMuODQ1NzUw
+        WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
+        cy8wMThmZWUwNi0xY2NmLTc5YTItYWZkNC1iYzAwZDc0MjA4MzAvIiwicGFy
+        ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
+        bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
+        IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
+        djMvcmVtb3Rlcy9ycG0vcnBtLzAxOGZlZTE2LTdhMWEtNzQ1YS04OGMwLTQ3
+        MGYzNDhkYzdkNC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4
+        ZmVlMDQtODZjOS03YmRkLTgzMDQtODBkOGY0YWZlYjVkLyJdfQ==
+  recorded_at: Thu, 06 Jun 2024 15:30:54 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -118,7 +258,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,7 +271,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:32 GMT
+      - Thu, 06 Jun 2024 15:30:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,7 +291,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2244f04660c248a79a1e8cb7d9b7c3b3
+      - 661f2e27da0e47d1a386310687b4426d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +301,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:32 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:54 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -172,7 +312,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,7 +325,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:32 GMT
+      - Thu, 06 Jun 2024 15:30:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,7 +345,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a877a0b96b2842f38b3eff91deada470
+      - fe9b2eb094d04ae7938414d2a521e859
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +355,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:32 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:54 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
@@ -226,7 +366,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -239,7 +379,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:32 GMT
+      - Thu, 06 Jun 2024 15:30:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -259,7 +399,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 50f6bf24e0a74448897e557a1c16fe6a
+      - 6a893b4a0b224677ae4753b8cf618dfd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -269,7 +409,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:32 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:54 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -280,7 +420,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -293,7 +433,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:32 GMT
+      - Thu, 06 Jun 2024 15:30:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -313,7 +453,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b0c49d13666a4bf8acf49bc135b47134
+      - 6087c487dc5f4de5bd9380dd301b55a4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -323,7 +463,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:32 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:54 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -334,7 +474,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -347,7 +487,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:33 GMT
+      - Thu, 06 Jun 2024 15:30:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -367,7 +507,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fa22db3157b947d7b4aa210dced1a785
+      - 5c13f3f2e6b147ebb88d842aa485b5ce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -377,7 +517,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:33 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:54 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -388,7 +528,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -401,7 +541,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:33 GMT
+      - Thu, 06 Jun 2024 15:30:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -421,7 +561,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - af7f41ea33aa46fcb32d57190d6ca0f1
+      - d71c67c0904b40f8abbfa5bf187204e1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -431,7 +571,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:33 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:54 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -444,7 +584,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -457,13 +597,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:33 GMT
+      - Thu, 06 Jun 2024 15:30:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/018f54e2-fd97-7ed1-90f0-981894658639/"
+      - "/pulp/api/v3/repositories/rpm/rpm/018fee2c-a6a7-7a56-b3ac-6d0f3678b7e2/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -479,7 +619,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0a786020f9cb4d8091960f7bbe4e9a5b
+      - 2c87852a673d4aec9718b6450c1620ec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -488,14 +628,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMDE4ZjU0ZTItZmQ5Ny03ZWQxLTkwZjAtOTgxODk0NjU4NjM5LyIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MzMuMzA0NjQzWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMTowODozMy4zMTIyMzBa
+        cG0vMDE4ZmVlMmMtYTZhNy03YTU2LWIzYWMtNmQwZjM2NzhiN2UyLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDZUMTU6MzA6NTQuNzYwNjY5WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNlQxNTozMDo1NC43NzEzODRa
         IiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cnBtL3JwbS8wMThmNTRlMi1mZDk3LTdlZDEtOTBmMC05ODE4OTQ2NTg2Mzkv
+        cnBtL3JwbS8wMThmZWUyYy1hNmE3LTdhNTYtYjNhYy02ZDBmMzY3OGI3ZTIv
         dmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9o
-        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzAxOGY1
-        NGUyLWZkOTctN2VkMS05MGYwLTk4MTg5NDY1ODYzOS92ZXJzaW9ucy8wLyIs
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9ycG0vcnBtLzAxOGZl
+        ZTJjLWE2YTctN2E1Ni1iM2FjLTZkMGYzNjc4YjdlMi92ZXJzaW9ucy8wLyIs
         Im5hbWUiOiIyX2R1cGxpY2F0ZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRh
         aW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVi
         bGlzaCI6ZmFsc2UsIm1ldGFkYXRhX3NpZ25pbmdfc2VydmljZSI6bnVsbCwi
@@ -504,7 +644,7 @@ http_interactions:
         Y2tzdW1fdHlwZSI6bnVsbCwiZ3BnY2hlY2siOm51bGwsInJlcG9fZ3BnY2hl
         Y2siOm51bGwsInNxbGl0ZV9tZXRhZGF0YSI6ZmFsc2UsInJlcG9fY29uZmln
         Ijp7fSwiY29tcHJlc3Npb25fdHlwZSI6bnVsbH0=
-  recorded_at: Tue, 07 May 2024 21:08:33 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:54 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -523,7 +663,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -536,13 +676,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:33 GMT
+      - Thu, 06 Jun 2024 15:30:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/018f54e2-fe87-740c-bdf7-6ac5e2a759a3/"
+      - "/pulp/api/v3/remotes/rpm/rpm/018fee2c-a81a-7fa7-b702-54bb504a1618/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -558,7 +698,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c46aa6221f314a40ac3cc488050972cf
+      - 9f16719b68c549a795d5eaa1591fd283
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -567,9 +707,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OGY1NGUyLWZlODctNzQwYy1iZGY3LTZhYzVlMmE3NTlhMy8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjMzLjU0MzYwNFoiLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MzMuNTQzNjE5WiIsIm5h
+        OGZlZTJjLWE4MWEtN2ZhNy1iNzAyLTU0YmI1MDRhMTYxOC8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI0LTA2LTA2VDE1OjMwOjU1LjEzMTEzNFoiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjQtMDYtMDZUMTU6MzA6NTUuMTMxMTQ2WiIsIm5h
         bWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJsIjoiaHR0cDovL3NvbWVvdGhl
         cnVybCIsImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNf
         dmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVs
@@ -583,10 +723,10 @@ http_interactions:
         cGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJ1c2VybmFtZSIs
         ImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InBhc3N3b3JkIiwiaXNfc2V0Ijpm
         YWxzZX1dLCJzbGVzX2F1dGhfdG9rZW4iOm51bGx9
-  recorded_at: Tue, 07 May 2024 21:08:33 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:55 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018f54e2-fe87-740c-bdf7-6ac5e2a759a3/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/018fee2c-a81a-7fa7-b702-54bb504a1618/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -594,7 +734,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -607,7 +747,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:33 GMT
+      - Thu, 06 Jun 2024 15:30:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -627,7 +767,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 833631491d9c48b2a7fe850e1841cbec
+      - e213d0a6378342a3afdd54fd166bbea3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -635,12 +775,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWZlZDUtNzcz
-        Yy04ZGYxLTI4MDM1ZTUxM2JiMS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:33 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlZTJjLWE4NzAtN2Q3
+        Mi04ZDE5LTJiM2ZlNDg5ZDdhYi8ifQ==
+  recorded_at: Thu, 06 Jun 2024 15:30:55 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018f54e2-fd97-7ed1-90f0-981894658639/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018fee2c-a6a7-7a56-b3ac-6d0f3678b7e2/
     body:
       encoding: UTF-8
       base64_string: |
@@ -650,7 +790,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -663,7 +803,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:33 GMT
+      - Thu, 06 Jun 2024 15:30:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -683,7 +823,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 437ad1c0b4644817b7ae8d10c6cadeb5
+      - 1a5dadae9d3e4221adebb1c9d8158064
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -691,9 +831,9 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUyLWZmOTgtNzhm
-        Yi1hNjc1LTY1OTMxNTI2MGQ1ZS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:33 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlZTJjLWE5MzgtNzk1
+        ZC1iYTU1LTIzMThkNThhZjM5OC8ifQ==
+  recorded_at: Thu, 06 Jun 2024 15:30:55 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -712,7 +852,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -725,13 +865,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:33 GMT
+      - Thu, 06 Jun 2024 15:30:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/018f54e3-000a-78e1-98e5-b3517db5b1fa/"
+      - "/pulp/api/v3/remotes/rpm/rpm/018fee2c-a9aa-77e6-ac19-3f57f3a17733/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -747,7 +887,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 59b3ea83c41143c690e30701e3958cdf
+      - 5e04aceb5bb04135be1e5ab5430352fa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -756,9 +896,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OGY1NGUzLTAwMGEtNzhlMS05OGU1LWIzNTE3ZGI1YjFmYS8iLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjMzLjkzMTE2MFoiLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MzMuOTMxMTc2WiIsIm5h
+        OGZlZTJjLWE5YWEtNzdlNi1hYzE5LTNmNTdmM2ExNzczMy8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI0LTA2LTA2VDE1OjMwOjU1LjUzMTA5MloiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjQtMDYtMDZUMTU6MzA6NTUuNTMxMTA4WiIsIm5h
         bWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0dHA6Ly9zb21lb3RoZXJ1cmwi
         LCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlk
         YXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMiOnt9
@@ -772,7 +912,7 @@ http_interactions:
         b3JkIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoidXNlcm5hbWUiLCJpc19z
         ZXQiOmZhbHNlfSx7Im5hbWUiOiJwYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9
         XSwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
-  recorded_at: Tue, 07 May 2024 21:08:33 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:55 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -783,7 +923,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -796,7 +936,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:34 GMT
+      - Thu, 06 Jun 2024 15:30:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -816,7 +956,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7e91fa0cdeca4752b891f364d7cb8196
+      - 32d314b8ea874ebe9fd88e0bd2512edc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -826,7 +966,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:34 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:55 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/
@@ -840,7 +980,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -853,7 +993,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:34 GMT
+      - Thu, 06 Jun 2024 15:30:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -873,7 +1013,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 26287b9fd886488298ff6abef9532623
+      - 3114cbcfdaf64ebfac6189847df07246
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -881,12 +1021,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUzLTAwYWQtNzY5
-        Ny1iNTNmLWI1Zjk5ZjI5NzliMS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:34 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlZTJjLWFhNWMtN2Iy
+        Ny1hOTlhLTFjOTY2MWQ1OTI3MC8ifQ==
+  recorded_at: Thu, 06 Jun 2024 15:30:55 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e3-00ad-7697-b53f-b5f99f2979b1/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fee2c-aa5c-7b27-a99a-1c9661d59270/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -894,7 +1034,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -907,7 +1047,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:34 GMT
+      - Thu, 06 Jun 2024 15:30:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -927,7 +1067,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c0463bc77b8b45b3a1d3755dcd51c3b1
+      - 81787c28bebe4c419a35a214b7a5b3d0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -935,29 +1075,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTMtMDBh
-        ZC03Njk3LWI1M2YtYjVmOTlmMjk3OWIxLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MzQuMDkzNjg2WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODozNC4wOTM3MDJaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmVlMmMtYWE1
+        Yy03YjI3LWE5OWEtMWM5NjYxZDU5MjcwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDZUMTU6MzA6NTUuNzA4NTAwWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNlQxNTozMDo1NS43MDg1MzRaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6IjI2Mjg3YjlmZDg4NjQ4ODI5OGZm
-        NmFiZWY5NTMyNjIzIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MzQuMTE3
-        NTQ4WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjM0LjE3MDA2
-        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MzQuMjUwMTU3
+        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6IjMxMTRjYmNmZGFmNjRlYmZhYzYx
+        ODk4NDdkZjA3MjQ2IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDZUMTU6MzA6NTUuNzIx
+        NzQxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA2VDE1OjMwOjU1Ljc3MDQ2
+        OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDZUMTU6MzA6NTUuODYwMTg4
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGU4LTc0ODctOWFhMC0zYzNlYzFhMTk5ZDcvIiwicGFy
+        cy8wMThmZWUwNi0xZDE3LTc3NzUtOWRiMC0wYTNlNjJiMTJkZWIvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
-        IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDE4ZjU0
-        ZTMtMDEzOC03MGM5LTljYTUtZGY2YTFkNTQ5NTgwLyJdLCJyZXNlcnZlZF9y
+        IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3JwbS9ycG0vMDE4ZmVl
+        MmMtYWFkOC03MzYxLThjMmItYTU0MTBkMDE1NTQwLyJdLCJyZXNlcnZlZF9y
         ZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iLCJz
-        aGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZjU0ZGYtN2ZkMi03NWZh
-        LTliMzUtYzI3NTEzZmY5OGY0LyJdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:34 GMT
+        aGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZmVlMDQtODZjOS03YmRk
+        LTgzMDQtODBkOGY0YWZlYjVkLyJdfQ==
+  recorded_at: Thu, 06 Jun 2024 15:30:55 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e3-0138-70c9-9ca5-df6a1d549580/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fee2c-aad8-7361-8c2b-a5410d015540/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -965,7 +1105,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -978,7 +1118,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:34 GMT
+      - Thu, 06 Jun 2024 15:30:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -998,7 +1138,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - aa13740bbde74ba387752681f5ebf169
+      - ebd897e19728484089cc8c21cb7e4274
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1007,9 +1147,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzAxOGY1NGUzLTAxMzgtNzBjOS05Y2E1LWRmNmExZDU0OTU4MC8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTA3VDIxOjA4OjM0LjIzNDQ3OFoiLCJw
-        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMDdUMjE6MDg6MzQuMjM0NDk4
+        cnBtLzAxOGZlZTJjLWFhZDgtNzM2MS04YzJiLWE1NDEwZDAxNTU0MC8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA2VDE1OjMwOjU1LjgzMzg2NloiLCJw
+        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDZUMTU6MzA6NTUuODMzODg2
         WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
         N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9z
         OS1rYXRlbGxvLWRldmVsLm1hbmljb3R0by5leGFtcGxlLmNvbS9wdWxwL2Nv
@@ -1018,10 +1158,10 @@ http_interactions:
         LCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInJlcG9z
         aXRvcnkiOm51bGwsInB1YmxpY2F0aW9uIjpudWxsLCJnZW5lcmF0ZV9yZXBv
         X2NvbmZpZyI6ZmFsc2V9
-  recorded_at: Tue, 07 May 2024 21:08:34 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:56 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018f54e3-0138-70c9-9ca5-df6a1d549580/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/018fee2c-aad8-7361-8c2b-a5410d015540/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1029,7 +1169,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1042,7 +1182,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:34 GMT
+      - Thu, 06 Jun 2024 15:30:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1062,7 +1202,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 78e2fb576be54cd9b7820d899ca56758
+      - 5b37fe2591b2475ba4e599e6f812c31a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1070,12 +1210,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUzLTAyNGYtNzI0
-        Zi1iNGY1LWRjZGRlNGNhYTY5OS8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:34 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlZTJjLWFiZmEtNzZi
+        YS05OTJmLTdmYjRmZDk1ZDMzYS8ifQ==
+  recorded_at: Thu, 06 Jun 2024 15:30:56 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018f54e2-fd97-7ed1-90f0-981894658639/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/018fee2c-a6a7-7a56-b3ac-6d0f3678b7e2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1083,7 +1223,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1096,7 +1236,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:34 GMT
+      - Thu, 06 Jun 2024 15:30:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1116,7 +1256,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f8faa0d36bbc4deab15b661016a7d319
+      - b38efc889f68447ab7c344882e662457
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1124,12 +1264,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUzLTAzNGEtN2E2
-        Ni1iOTdjLTEyYzUzZmUzNzMyMi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:34 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlZTJjLWFkMDEtNzcw
+        Mi05OGUyLThkM2FlMTQyZmUzMi8ifQ==
+  recorded_at: Thu, 06 Jun 2024 15:30:56 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e3-034a-7a66-b97c-12c53fe37322/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fee2c-ad01-7702-98e2-8d3ae142fe32/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1137,7 +1277,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1150,7 +1290,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:34 GMT
+      - Thu, 06 Jun 2024 15:30:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1170,7 +1310,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 883a0ff7dd814be19568b043557a7c32
+      - 52c849ccef9c4faf933d97378db2794b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1178,25 +1318,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTMtMDM0
-        YS03YTY2LWI5N2MtMTJjNTNmZTM3MzIyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MzQuNzYyOTI4WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODozNC43NjI5NDJaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmVlMmMtYWQw
+        MS03NzAyLTk4ZTItOGQzYWUxNDJmZTMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDZUMTU6MzA6NTYuMzg1NjE4WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNlQxNTozMDo1Ni4zODU2MzVaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImY4ZmFhMGQzNmJiYzRkZWFiMTVi
-        NjYxMDE2YTdkMzE5IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MzQuNzg0
-        OTk5WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIxOjA4OjM0Ljg0MDEz
-        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MzQuOTEyMTMy
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImIzOGVmYzg4OWY2ODQ0N2FiN2Mz
+        NDQ4ODJlNjYyNDU3IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDZUMTU6MzA6NTYuNDAz
+        NjUwWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA2VDE1OjMwOjU2LjQ0MDI0
+        NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDZUMTU6MzA6NTYuNTE3MDU5
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRlMC1hNGMxLTcxNzUtYTM3Yi1iNjMzMjI1NWEyMGEvIiwicGFy
+        cy8wMThmZWUwNi0xZDE3LTc3NzUtOWRiMC0wYTNlNjJiMTJkZWIvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZjU0ZTItZmQ5Ny03ZWQxLTkw
-        ZjAtOTgxODk0NjU4NjM5LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlu
-        cy8wMThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNmZjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:34 GMT
+        djMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE4ZmVlMmMtYTZhNy03YTU2LWIz
+        YWMtNmQwZjM2NzhiN2UyLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlu
+        cy8wMThmZWUwNC04NmM5LTdiZGQtODMwNC04MGQ4ZjRhZmViNWQvIl19
+  recorded_at: Thu, 06 Jun 2024 15:30:56 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -1207,7 +1347,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1220,7 +1360,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:35 GMT
+      - Thu, 06 Jun 2024 15:30:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1240,7 +1380,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 515957d45bee45a2be9a963a7e39d2b8
+      - a111417e946c492bb9d437d36fc8e0bc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1250,7 +1390,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:35 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:56 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
@@ -1261,7 +1401,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.21.3/ruby
+      - OpenAPI-Generator/0.21.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -1274,7 +1414,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:35 GMT
+      - Thu, 06 Jun 2024 15:30:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1294,7 +1434,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bcc2d1279e4d4d69922333d420a182df
+      - 06c8128b82044eb98b0981cb0545d9a0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1304,7 +1444,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:35 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:56 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -1328,7 +1468,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:35 GMT
+      - Thu, 06 Jun 2024 15:30:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1348,7 +1488,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 12d9596bdf694cddaedfb4716b31487d
+      - 3c40b77569c9443a8261f24b18ea3790
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1358,7 +1498,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:35 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:56 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -1382,7 +1522,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:35 GMT
+      - Thu, 06 Jun 2024 15:30:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1402,7 +1542,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e9359d2bd0544c49a9555bed1f290334
+      - 43e757c43ca54bafbb18070a25a3eae9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1412,7 +1552,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:35 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:57 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -1423,7 +1563,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1436,7 +1576,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:35 GMT
+      - Thu, 06 Jun 2024 15:30:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1456,7 +1596,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 91257a52a4ab41c0a3fdb507d3c943ab
+      - d4b7b85d6b5e47b8a7997712bf352d43
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1466,7 +1606,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:35 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:57 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -1490,7 +1630,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:35 GMT
+      - Thu, 06 Jun 2024 15:30:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1510,7 +1650,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cb1a4f707fd14cdd8c5027fb859782d8
+      - c229b77cea5d4ff0bf78af8a7eae1815
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1520,7 +1660,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:35 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:57 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -1544,7 +1684,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:35 GMT
+      - Thu, 06 Jun 2024 15:30:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1564,7 +1704,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4992564fe2ab4a9e9ff5c5da0167bed9
+      - 9e0eb1d887d24dbb954f6da25951e480
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1574,7 +1714,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 21:08:35 GMT
+  recorded_at: Thu, 06 Jun 2024 15:30:57 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
@@ -1587,7 +1727,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1600,7 +1740,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:35 GMT
+      - Thu, 06 Jun 2024 15:30:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1620,7 +1760,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 74c555de1f5d49839ce8252258bed863
+      - 2af6ed27e29447fa8ba91d93a070f8eb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1628,12 +1768,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGUzLTA2NzEtNzFj
-        MC04MjRmLTY1NzUwMmY3ZDFmYi8ifQ==
-  recorded_at: Tue, 07 May 2024 21:08:35 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlZTJjLWIwOTYtNzVm
+        Mi1iZTI1LWQ0MDg3ZGY2MzU4YS8ifQ==
+  recorded_at: Thu, 06 Jun 2024 15:30:57 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54e3-0671-71c0-824f-657502f7d1fb/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fee2c-b096-75f2-be25-d4087df6358a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1641,7 +1781,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1654,7 +1794,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 21:08:35 GMT
+      - Thu, 06 Jun 2024 15:30:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1674,7 +1814,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6a7851e7d0974579ba97f43991019e64
+      - 6d66cafcc8f044ca9f78f46604b66d1f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1682,18 +1822,18 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0ZTMtMDY3
-        MS03MWMwLTgyNGYtNjU3NTAyZjdkMWZiLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjE6MDg6MzUuNTY5NjMzWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMTowODozNS41Njk2NTFaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmVlMmMtYjA5
+        Ni03NWYyLWJlMjUtZDQwODdkZjYzNThhLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDZUMTU6MzA6NTcuMzAzMDQyWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNlQxNTozMDo1Ny4zMDMwNTdaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLm9ycGhhbi5vcnBo
-        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiNzRjNTU1ZGUxZjVkNDk4Mzlj
-        ZTgyNTIyNThiZWQ4NjMiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
-        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMTowODozNS41
-        ODMzMTVaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjE6MDg6MzUuNjM3
-        MDcwWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMTowODozNS44NTgw
-        NTVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzAxOGY1NGUwLWE0ZTgtNzQ4Ny05YWEwLTNjM2VjMWExOTlkNy8iLCJw
+        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiMmFmNmVkMjdlMjk0NDdmYThi
+        YTkxZDkzYTA3MGY4ZWIiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
+        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNlQxNTozMDo1Ny4z
+        Mjc1NzJaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDZUMTU6MzA6NTcuMzY5
+        MTI3WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNlQxNTozMDo1Ny41NzA4
+        MDVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzAxOGZlZTA2LTFjY2YtNzlhMi1hZmQ0LWJjMDBkNzQyMDgzMC8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xlYW4g
         dXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIs
@@ -1703,7 +1843,63 @@ http_interactions:
         ZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
         IjpbIi9hcGkvdjMvb3JwaGFucy9jbGVhbnVwLyIsInNoYXJlZDovcHVscC9h
-        cGkvdjMvZG9tYWlucy8wMThmNTRkZi03ZmQyLTc1ZmEtOWIzNS1jMjc1MTNm
-        Zjk4ZjQvIl19
-  recorded_at: Tue, 07 May 2024 21:08:35 GMT
+        cGkvdjMvZG9tYWlucy8wMThmZWUwNC04NmM5LTdiZGQtODMwNC04MGQ4ZjRh
+        ZmViNWQvIl19
+  recorded_at: Thu, 06 Jun 2024 15:30:57 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/purge/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJmaW5pc2hlZF9iZWZvcmUiOiIzMDAwLTAxLTAxVDAwOjAwOjAwLjAwMCsw
+        MDowMCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 06 Jun 2024 15:30:57 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - e856f6e5ca1140b5a21facfc60542ce8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlZTJjLWIyMGMtNzky
+        ZC04NjI4LWFjMTZiMDc3YjY2ZC8ifQ==
+  recorded_at: Thu, 06 Jun 2024 15:30:57 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/katello/pulp3/repository/ostree_type_sync/sync.yml
+++ b/test/fixtures/vcr_cassettes/katello/pulp3/repository/ostree_type_sync/sync.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/?name=2_duplicate-test-ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?name=2_duplicate-test-ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:18:59 GMT
+      - Wed, 05 Jun 2024 14:38:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,20 +43,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3a646f6d011f41eeb4bab67a77a3c4bb
+      - f52d249fa143470db485857c6eb2feb4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:18:59 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/ostree/ostree/?name=2_duplicate-test-ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/ostree/ostree/?name=2_duplicate-test-ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:18:59 GMT
+      - Wed, 05 Jun 2024 14:38:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,20 +97,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b9cc6aad63664b3eb088b36b057ae24a
+      - 8f682adb3e8c412dabf3331744eea763
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:18:59 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?name=2_duplicate-test-ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/?name=2_duplicate-test-ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:00 GMT
+      - Wed, 05 Jun 2024 14:38:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,20 +151,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b97db942686a4743bee24f2583753f36
+      - 5883849378cd4a73a14b46a846db8e8e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:00 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?base_path=integration_tests/ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/?base_path=integration_tests/ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:00 GMT
+      - Wed, 05 Jun 2024 14:38:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,20 +205,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b592b565873349a885a47e61ae670f6b
+      - c19c554adb0643a59c47df5b20bbe6e6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:00 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:59 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/ostree/ostree/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/ostree/ostree/
     body:
       encoding: UTF-8
       base64_string: |
@@ -248,13 +248,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:00 GMT
+      - Wed, 05 Jun 2024 14:38:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/ostree/ostree/018f62df-1cfb-7c96-9b9a-dfc6b5b3f24e/"
+      - "/pulp/api/v3/remotes/ostree/ostree/018fe8d6-c200-78d3-864a-41d5ce6af7b3/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -270,18 +270,18 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - eec8ddfa78ec45a79c88b7578aaa33a1
+      - 8552a60b9d274929b7a02c525155ff94
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9vc3RyZWUvb3N0
-        cmVlLzAxOGY2MmRmLTFjZmItN2M5Ni05YjlhLWRmYzZiNWIzZjI0ZS8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjAwLjIyMDM2NFoiLCJw
-        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDAuMjIwMzg4
+        cmVlLzAxOGZlOGQ2LWMyMDAtNzhkMy04NjRhLTQxZDVjZTZhZjdiMy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjU5LjU4NTA1NVoiLCJw
+        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTkuNTg1MDY2
         WiIsIm5hbWUiOiIyX2R1cGxpY2F0ZS10ZXN0LW9zdHJlZSIsInVybCI6Imh0
         dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL29zdHJlZS9zbWFsbC8i
         LCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlk
@@ -297,15 +297,15 @@ http_interactions:
         ZXQiOmZhbHNlfSx7Im5hbWUiOiJwYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9
         XSwiZGVwdGgiOjAsImluY2x1ZGVfcmVmcyI6WyJyYXdoaWRlIl0sImV4Y2x1
         ZGVfcmVmcyI6bnVsbH0=
-  recorded_at: Fri, 10 May 2024 14:19:00 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:59 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMl9kdXBsaWNhdGUtdGVzdC1vc3RyZWUifQ==
 
-'
+        '
     headers:
       Content-Type:
       - application/json
@@ -323,13 +323,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:00 GMT
+      - Wed, 05 Jun 2024 14:38:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/ostree/ostree/018f62df-1d82-793e-abc6-11209037d146/"
+      - "/pulp/api/v3/repositories/ostree/ostree/018fe8d6-c280-742b-8c08-19508e9b6b49/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -345,30 +345,30 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c61e7feda8434558b7d83d9dc23e7cbb
+      - c299bde174724e6b8394ea2bee540c62
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL29zdHJl
-        ZS9vc3RyZWUvMDE4ZjYyZGYtMWQ4Mi03OTNlLWFiYzYtMTEyMDkwMzdkMTQ2
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDAuMzU1MjE4
-        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOTowMC4z
-        NjIyMTFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvb3N0cmVlL29zdHJlZS8wMThmNjJkZi0xZDgyLTc5M2UtYWJjNi0x
-        MTIwOTAzN2QxNDYvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
+        ZS9vc3RyZWUvMDE4ZmU4ZDYtYzI4MC03NDJiLThjMDgtMTk1MDhlOWI2YjQ5
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTkuNzEzMzE3
+        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozODo1OS43
+        MTk3NjlaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvb3N0cmVlL29zdHJlZS8wMThmZThkNi1jMjgwLTc0MmItOGMwOC0x
+        OTUwOGU5YjZiNDkvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
         c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9v
-        c3RyZWUvb3N0cmVlLzAxOGY2MmRmLTFkODItNzkzZS1hYmM2LTExMjA5MDM3
-        ZDE0Ni92ZXJzaW9ucy8wLyIsIm5hbWUiOiIyX2R1cGxpY2F0ZS10ZXN0LW9z
+        c3RyZWUvb3N0cmVlLzAxOGZlOGQ2LWMyODAtNzQyYi04YzA4LTE5NTA4ZTli
+        NmI0OS92ZXJzaW9ucy8wLyIsIm5hbWUiOiIyX2R1cGxpY2F0ZS10ZXN0LW9z
         dHJlZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJjb21wdXRlX2RlbHRhIjp0cnVlfQ==
-  recorded_at: Fri, 10 May 2024 14:19:00 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:59 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?base_path=integration_tests/ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/?base_path=integration_tests/ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -389,7 +389,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:00 GMT
+      - Wed, 05 Jun 2024 14:38:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -409,28 +409,28 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0451d82914ea4d8b95324b3667badfbd
+      - 166c161ae1f8434994df3f2652cd59c7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:00 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:59 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/
     body:
       encoding: UTF-8
       base64_string: |
         eyJiYXNlX3BhdGgiOiJpbnRlZ3JhdGlvbl90ZXN0cy9vc3RyZWUiLCJjb250
         ZW50X2d1YXJkIjpudWxsLCJuYW1lIjoiMl9kdXBsaWNhdGUtdGVzdC1vc3Ry
         ZWUiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL29zdHJlZS9vc3RyZWUvMDE4ZjYyZGYtMWQ4Mi03OTNlLWFiYzYt
-        MTEyMDkwMzdkMTQ2L3ZlcnNpb25zLzAvIn0=
+        dG9yaWVzL29zdHJlZS9vc3RyZWUvMDE4ZmU4ZDYtYzI4MC03NDJiLThjMDgt
+        MTk1MDhlOWI2YjQ5L3ZlcnNpb25zLzAvIn0=
     headers:
       Content-Type:
       - application/json
@@ -448,7 +448,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:00 GMT
+      - Wed, 05 Jun 2024 14:39:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -468,20 +468,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fb3a9cba63664da586db04fb94ca5734
+      - c0443e6686594bd186149c165ec4418e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTFlY2YtNzRh
-        Yi05Zjc4LTcwODlkMTUwYWMzMi8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:00 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWMzYzItNzUx
+        YS04M2M5LWRmYTU0NzM2NjljZi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-1ecf-74ab-9f78-7089d150ac32/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-c3c2-751a-83c9-dfa5473669cf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -489,7 +489,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -502,7 +502,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:01 GMT
+      - Wed, 05 Jun 2024 14:39:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -522,37 +522,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ead6dee2d87f448cb49e88dd60c8c075
+      - 0e48d7500a6942e48e9de11471fc2c77
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtMWVj
-        Zi03NGFiLTlmNzgtNzA4OWQxNTBhYzMyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MDAuNjg3NDg1WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOTowMC42ODc0OTZaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYzNj
+        Mi03NTFhLTgzYzktZGZhNTQ3MzY2OWNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzk6MDAuMDM0NTEwWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozOTowMC4wMzQ1MjJaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6ImZiM2E5Y2JhNjM2NjRkYTU4NmRi
-        MDRmYjk0Y2E1NzM0IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDAuNzAy
-        ODQ3WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjAwLjc3ODUy
-        N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDAuOTg2NzE5
+        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6ImMwNDQzZTY2ODY1OTRiZDE4NjE0
+        OWMxNjVlYzQ0MThlIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDAuMDQ4
+        MTU4WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM5OjAwLjA4MDAz
+        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDAuMzQ3NjY5
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNWU4ZC01Zjc4LTc0NDAtYTAyZC1lODg3MzI0MjA5YmEvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL29zdHJlZS9vc3RyZWUv
-        MDE4ZjYyZGYtMWZlYS03YzFkLWFiNmItOGE4MWRjMTY0Njg1LyJdLCJyZXNl
+        MDE4ZmU4ZDYtYzRlNi03MTY1LTk0ZTItNDU1Yzg5MjEzZTg5LyJdLCJyZXNl
         cnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9u
-        cy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZjVlOGMtNGVk
-        NC03NzRhLTg0NzMtNTdjYzA0OGQ2YzQwLyJdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:01 GMT
+        cy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZmUzYzktNzBh
+        YS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/018f62df-1fea-7c1d-ab6b-8a81dc164685/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/018fe8d6-c4e6-7165-94e2-455c89213e89/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -573,7 +573,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:01 GMT
+      - Wed, 05 Jun 2024 14:39:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -585,7 +585,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '545'
+      - '548'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -593,31 +593,31 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 462abf2bffaf4e5d8230fe440faff03f
+      - 629c74bedbaa4e4ea3d834a4a991bdbb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9vc3Ry
-        ZWUvb3N0cmVlLzAxOGY2MmRmLTFmZWEtN2MxZC1hYjZiLThhODFkYzE2NDY4
-        NS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjAwLjk3MjAz
-        MloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDAu
-        OTcyMDQ3WiIsImJhc2VfcGF0aCI6ImludGVncmF0aW9uX3Rlc3RzL29zdHJl
-        ZSIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M4LWthdGVsbG8tZGV2ZWwt
-        c3RhYmxlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9pbnRlZ3JhdGlvbl90
-        ZXN0cy9vc3RyZWUvIiwiY29udGVudF9ndWFyZCI6bnVsbCwiaGlkZGVuIjpm
-        YWxzZSwicHVscF9sYWJlbHMiOnt9LCJuYW1lIjoiMl9kdXBsaWNhdGUtdGVz
-        dC1vc3RyZWUiLCJyZXBvc2l0b3J5IjpudWxsLCJyZXBvc2l0b3J5X3ZlcnNp
-        b24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL29zdHJlZS9vc3RyZWUv
-        MDE4ZjYyZGYtMWQ4Mi03OTNlLWFiYzYtMTEyMDkwMzdkMTQ2L3ZlcnNpb25z
-        LzAvIn0=
-  recorded_at: Fri, 10 May 2024 14:19:01 GMT
+        ZWUvb3N0cmVlLzAxOGZlOGQ2LWM0ZTYtNzE2NS05NGUyLTQ1NWM4OTIxM2U4
+        OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM5OjAwLjMyNzUw
+        MFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDAu
+        MzI3NTE2WiIsImJhc2VfcGF0aCI6ImludGVncmF0aW9uX3Rlc3RzL29zdHJl
+        ZSIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwu
+        bWFuaWNvdHRvLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9pbnRlZ3JhdGlv
+        bl90ZXN0cy9vc3RyZWUvIiwiY29udGVudF9ndWFyZCI6bnVsbCwiaGlkZGVu
+        IjpmYWxzZSwicHVscF9sYWJlbHMiOnt9LCJuYW1lIjoiMl9kdXBsaWNhdGUt
+        dGVzdC1vc3RyZWUiLCJyZXBvc2l0b3J5IjpudWxsLCJyZXBvc2l0b3J5X3Zl
+        cnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL29zdHJlZS9vc3Ry
+        ZWUvMDE4ZmU4ZDYtYzI4MC03NDJiLThjMDgtMTk1MDhlOWI2YjQ5L3ZlcnNp
+        b25zLzAvIn0=
+  recorded_at: Wed, 05 Jun 2024 14:39:00 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/ostree/ostree/018f62df-1cfb-7c96-9b9a-dfc6b5b3f24e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/ostree/ostree/018fe8d6-c200-78d3-864a-41d5ce6af7b3/
     body:
       encoding: UTF-8
       base64_string: |
@@ -647,7 +647,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:01 GMT
+      - Wed, 05 Jun 2024 14:39:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -667,20 +667,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8b25101bc15245fca3e4317c9ecd4462
+      - '0937f00d0c9045bd80b5dce01517a89b'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTIxZTUtNzM4
-        Ny1iZWQwLWUzODI5YWRjOWU3My8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:01 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWM3MGQtNzRh
+        MS1hNDNhLTA4Zjc3MTIxMTRlNS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:00 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-21e5-7387-bed0-e3829adc9e73/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-c70d-74a1-a43a-08f7712114e5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -688,7 +688,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -701,7 +701,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:01 GMT
+      - Wed, 05 Jun 2024 14:39:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -721,40 +721,40 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5ca20944bc084e13ad1f474cbc1dab70
+      - 1e7aba196d634832a3ca9d8815df826c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtMjFl
-        NS03Mzg3LWJlZDAtZTM4MjlhZGM5ZTczLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MDEuNDc3OTE2WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOTowMS40Nzc5MjhaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYzcw
+        ZC03NGExLWE0M2EtMDhmNzcxMjExNGU1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzk6MDAuODc4MjcxWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozOTowMC44NzgyODNaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjhiMjUxMDFiYzE1MjQ1ZmNhM2U0
-        MzE3YzllY2Q0NDYyIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDEuNDg4
-        MjQyWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjAxLjQ5MDcw
-        OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDEuNTAwOTM1
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjA5MzdmMDBkMGM5MDQ1YmQ4MGI1
+        ZGNlMDE1MTdhODliIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDAuODg5
+        OTc1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM5OjAwLjg5MjI2
+        NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDAuOTAxODI0
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMv
-        b3N0cmVlL29zdHJlZS8wMThmNjJkZi0xY2ZiLTdjOTYtOWI5YS1kZmM2YjVi
-        M2YyNGUvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGY1ZThj
-        LTRlZDQtNzc0YS04NDczLTU3Y2MwNDhkNmM0MC8iXX0=
-  recorded_at: Fri, 10 May 2024 14:19:01 GMT
+        b3N0cmVlL29zdHJlZS8wMThmZThkNi1jMjAwLTc4ZDMtODY0YS00MWQ1Y2U2
+        YWY3YjMvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGZlM2M5
+        LTcwYWEtNzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:39:00 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/018f62df-1d82-793e-abc6-11209037d146/sync/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/018fe8d6-c280-742b-8c08-19508e9b6b49/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9vc3RyZWUvb3N0cmVl
-        LzAxOGY2MmRmLTFjZmItN2M5Ni05YjlhLWRmYzZiNWIzZjI0ZS8iLCJtaXJy
+        LzAxOGZlOGQ2LWMyMDAtNzhkMy04NjRhLTQxZDVjZTZhZjdiMy8iLCJtaXJy
         b3IiOnRydWV9
     headers:
       Content-Type:
@@ -773,7 +773,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:01 GMT
+      - Wed, 05 Jun 2024 14:39:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -793,20 +793,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 68bc843e3ff34df49384293a8e2e1738
+      - 7e3d68d3dfa94c2f9392a5e5313287bc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTIyODUtN2Q0
-        Ny05M2VlLTc5YWE0MmI5NjVhNC8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:01 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWM3YzMtNzU1
+        Mi1hNTM2LThjMjVlODk5ZDg4OS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:01 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-2285-7d47-93ee-79aa42b965a4/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-c7c3-7552-a536-8c25e899d889/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -814,7 +814,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -827,7 +827,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:05 GMT
+      - Wed, 05 Jun 2024 14:39:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -847,51 +847,51 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1b98e12ab7b440fbb34582dbbf9c931c
+      - 7add5c35ae024dafa2b63e0d02b1b35c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtMjI4
-        NS03ZDQ3LTkzZWUtNzlhYTQyYjk2NWE0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MDEuNjM3MzYyWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOTowMS42MzczNzNaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYzdj
+        My03NTUyLWE1MzYtOGMyNWU4OTlkODg5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzk6MDEuMDYwMDg5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozOTowMS4wNjAxMDFaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscF9vc3RyZWUuYXBwLnRhc2tzLnN5bmNocm9u
-        aXppbmcuc3luY2hyb25pemUiLCJsb2dnaW5nX2NpZCI6IjY4YmM4NDNlM2Zm
-        MzRkZjQ5Mzg0MjkzYThlMmUxNzM4IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2Fw
-        aS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6
-        MTk6MDEuNjUyNzY5WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5
-        OjAxLjcwMjMyN1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6
-        MDUuMDMzNTMwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
-        djMvd29ya2Vycy8wMThmNWU4ZC01NjNhLTc0N2MtOWRmZS1lMTU2NjFlYzYz
-        OTcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
+        aXppbmcuc3luY2hyb25pemUiLCJsb2dnaW5nX2NpZCI6IjdlM2Q2OGQzZGZh
+        OTRjMmY5MzkyYTVlNTMxMzI4N2JjIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2Fw
+        aS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6
+        Mzk6MDEuMDcwNjc5WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM5
+        OjAxLjEwNDUxNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6
+        MDMuMzg5NzY3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkv
+        djMvd29ya2Vycy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3
+        ZjkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFz
         a19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6
-        IlBhcnNpbmcgTWV0YWRhdGEiLCJjb2RlIjoic3luYy5wYXJzaW5nX21ldGFk
-        YXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBBcnRpZmFj
-        dHMiLCJjb2RlIjoic3luYy5kb3dubG9hZGluZy5hcnRpZmFjdHMiLCJzdGF0
-        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgi
-        Om51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENvbnRlbnQiLCJj
-        b2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0
-        ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1l
-        c3NhZ2UiOiJBc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6ImFzc29jaWF0
-        aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxs
-        LCJkb25lIjo3LCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25sb2Fk
+        aW5nLmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51
+        bGwsImRvbmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNz
+        b2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1bmFzc29jaWF0aW5nLmNvbnRl
+        bnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjow
+        LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29jaWF0aW5nIENvbnRl
+        bnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29t
+        cGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjcsInN1ZmZpeCI6bnVsbH0s
+        eyJtZXNzYWdlIjoiUGFyc2luZyBNZXRhZGF0YSIsImNvZGUiOiJzeW5jLnBh
+        cnNpbmdfbWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjox
+        LCJkb25lIjoxLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9vc3RyZWUvb3N0cmVlLzAx
-        OGY2MmRmLTFkODItNzkzZS1hYmM2LTExMjA5MDM3ZDE0Ni92ZXJzaW9ucy8x
+        OGZlOGQ2LWMyODAtNzQyYi04YzA4LTE5NTA4ZTliNmI0OS92ZXJzaW9ucy8x
         LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvb3N0cmVlL29zdHJlZS8wMThmNjJkZi0xZDgyLTc5
-        M2UtYWJjNi0xMTIwOTAzN2QxNDYvIiwic2hhcmVkOi9wdWxwL2FwaS92My9y
-        ZW1vdGVzL29zdHJlZS9vc3RyZWUvMDE4ZjYyZGYtMWNmYi03Yzk2LTliOWEt
-        ZGZjNmI1YjNmMjRlLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8w
-        MThmNWU4Yy00ZWQ0LTc3NGEtODQ3My01N2NjMDQ4ZDZjNDAvIl19
-  recorded_at: Fri, 10 May 2024 14:19:05 GMT
+        My9yZXBvc2l0b3JpZXMvb3N0cmVlL29zdHJlZS8wMThmZThkNi1jMjgwLTc0
+        MmItOGMwOC0xOTUwOGU5YjZiNDkvIiwic2hhcmVkOi9wdWxwL2FwaS92My9y
+        ZW1vdGVzL29zdHJlZS9vc3RyZWUvMDE4ZmU4ZDYtYzIwMC03OGQzLTg2NGEt
+        NDFkNWNlNmFmN2IzLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8w
+        MThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:39:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?base_path=integration_tests/ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/?base_path=integration_tests/ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -912,7 +912,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:05 GMT
+      - Wed, 05 Jun 2024 14:39:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -924,7 +924,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '597'
+      - '600'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -932,39 +932,39 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 01e008a6aeec46ec8c83f1c347b2dcef
+      - b219b0001aa54c8f970dd2da6375f40d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L29zdHJlZS9vc3RyZWUvMDE4ZjYyZGYtMWZlYS03YzFkLWFiNmItOGE4MWRj
-        MTY0Njg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDAu
-        OTcyMDMyWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0xMFQxNDox
-        OTowMC45NzIwNDdaIiwiYmFzZV9wYXRoIjoiaW50ZWdyYXRpb25fdGVzdHMv
-        b3N0cmVlIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0ZWxsby1k
-        ZXZlbC1zdGFibGUuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L2ludGVncmF0
-        aW9uX3Rlc3RzL29zdHJlZS8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJoaWRk
-        ZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyX2R1cGxpY2F0
-        ZS10ZXN0LW9zdHJlZSIsInJlcG9zaXRvcnkiOm51bGwsInJlcG9zaXRvcnlf
-        dmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvb3N0cmVlL29z
-        dHJlZS8wMThmNjJkZi0xZDgyLTc5M2UtYWJjNi0xMTIwOTAzN2QxNDYvdmVy
-        c2lvbnMvMC8ifV19
-  recorded_at: Fri, 10 May 2024 14:19:05 GMT
+        L29zdHJlZS9vc3RyZWUvMDE4ZmU4ZDYtYzRlNi03MTY1LTk0ZTItNDU1Yzg5
+        MjEzZTg5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDAu
+        MzI3NTAwWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDoz
+        OTowMC4zMjc1MTZaIiwiYmFzZV9wYXRoIjoiaW50ZWdyYXRpb25fdGVzdHMv
+        b3N0cmVlIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1k
+        ZXZlbC5tYW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L2ludGVn
+        cmF0aW9uX3Rlc3RzL29zdHJlZS8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJo
+        aWRkZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyX2R1cGxp
+        Y2F0ZS10ZXN0LW9zdHJlZSIsInJlcG9zaXRvcnkiOm51bGwsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvb3N0cmVl
+        L29zdHJlZS8wMThmZThkNi1jMjgwLTc0MmItOGMwOC0xOTUwOGU5YjZiNDkv
+        dmVyc2lvbnMvMC8ifV19
+  recorded_at: Wed, 05 Jun 2024 14:39:03 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/018f62df-1fea-7c1d-ab6b-8a81dc164685/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/018fe8d6-c4e6-7165-94e2-455c89213e89/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJpbnRlZ3JhdGlv
         bl90ZXN0cy9vc3RyZWUiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL29zdHJlZS9vc3RyZWUvMDE4ZjYyZGYtMWQ4
-        Mi03OTNlLWFiYzYtMTEyMDkwMzdkMTQ2L3ZlcnNpb25zLzEvIn0=
+        cGkvdjMvcmVwb3NpdG9yaWVzL29zdHJlZS9vc3RyZWUvMDE4ZmU4ZDYtYzI4
+        MC03NDJiLThjMDgtMTk1MDhlOWI2YjQ5L3ZlcnNpb25zLzEvIn0=
     headers:
       Content-Type:
       - application/json
@@ -982,7 +982,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:05 GMT
+      - Wed, 05 Jun 2024 14:39:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1002,20 +1002,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 115c6ac5530845c3b02ea727c1e3b241
+      - 3b7fb0d7732446acb1874205bd8a50f0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTMwYTYtN2Qz
-        OS04NzMyLWM5YzAzNWE3OGJiMC8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:05 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWQxZDQtNzAx
+        NC05YWI2LTU5NWY4NDI5YTE4MS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-30a6-7d39-8732-c9c035a78bb0/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-d1d4-7014-9ab6-595f8429a181/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1023,7 +1023,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1036,7 +1036,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:05 GMT
+      - Wed, 05 Jun 2024 14:39:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1056,41 +1056,41 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e2ec0838a9934182b21b90a16ab84054
+      - 4c2faa0e4b47471c97e7a379a51b33c9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtMzBh
-        Ni03ZDM5LTg3MzItYzljMDM1YTc4YmIwLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MDUuMjU1MjMxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOTowNS4yNTUyNDNaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtZDFk
+        NC03MDE0LTlhYjYtNTk1Zjg0MjlhMTgxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzk6MDMuNjM2NTc0WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozOTowMy42MzY1ODdaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjExNWM2YWM1NTMwODQ1YzNiMDJl
-        YTcyN2MxZTNiMjQxIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDUuMjY0
-        NDg3WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjA1LjI2NzUz
-        MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDUuMzcxMjg2
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjNiN2ZiMGQ3NzMyNDQ2YWNiMTg3
+        NDIwNWJkOGE1MGYwIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDMuNjQ2
+        MzYzWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM5OjAzLjY0ODcw
+        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDMuNjYzMzU0
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25z
-        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNWU4Yy00ZWQ0
-        LTc3NGEtODQ3My01N2NjMDQ4ZDZjNDAvIl19
-  recorded_at: Fri, 10 May 2024 14:19:05 GMT
+        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFh
+        LTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:39:03 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/018f62df-1fea-7c1d-ab6b-8a81dc164685/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/018fe8d6-c4e6-7165-94e2-455c89213e89/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJpbnRlZ3JhdGlv
         bl90ZXN0cy9vc3RyZWUiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9h
-        cGkvdjMvcmVwb3NpdG9yaWVzL29zdHJlZS9vc3RyZWUvMDE4ZjYyZGYtMWQ4
-        Mi03OTNlLWFiYzYtMTEyMDkwMzdkMTQ2L3ZlcnNpb25zLzEvIn0=
+        cGkvdjMvcmVwb3NpdG9yaWVzL29zdHJlZS9vc3RyZWUvMDE4ZmU4ZDYtYzI4
+        MC03NDJiLThjMDgtMTk1MDhlOWI2YjQ5L3ZlcnNpb25zLzEvIn0=
     headers:
       Content-Type:
       - application/json
@@ -1108,7 +1108,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:05 GMT
+      - Wed, 05 Jun 2024 14:39:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1128,20 +1128,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4b4d89266bb74e98916b0f91cbf674ec
+      - 3b83dbefce1a47bd818c828e01d0d5ba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTMxYWUtNzRl
-        NS04ZmFhLTJmMmM5ODgxYWRlZS8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:05 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWQyN2EtNzFm
+        Yi05MTE2LWYyOTU0NGI4YmQyNi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/content/ostree/refs/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/ostree/ostree/018f62df-1d82-793e-abc6-11209037d146/versions/1/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/ostree/refs/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/ostree/ostree/018fe8d6-c280-742b-8c08-19508e9b6b49/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1162,7 +1162,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:05 GMT
+      - Wed, 05 Jun 2024 14:39:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1182,30 +1182,30 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 21fada2782bc406a9705ad13d0e7aeb1
+      - d33df2ecdaa1472fa8e0d824d1acaa02
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L29zdHJl
-        ZS9yZWZzLzAxOGY1ZTk2LTNhNGMtNzQ0YS04MDFkLWE2NjU4MWJiNzFhMC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTA5VDE4OjIwOjU1LjQ1NjIzOVoi
-        LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMDlUMTg6MjA6NTUuNDU2
-        MjUwWiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wMThm
-        NWU5Ni0zYTRkLTc5NjEtYjllOS1jMzhhZDQ3ZjliYzEvIiwicmVsYXRpdmVf
+        ZS9yZWZzLzAxOGZlOGQ2LWNmNTQtN2U2Ni04YTg1LTIxYTFkYTgxZWE4Mi8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM5OjAzLjMwMjQ4N1oi
+        LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDMuMzAy
+        NDk4WiIsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wMThm
+        ZThkNi1jZjU1LTc5MjMtYTJiNC05YmZlYjg3OTViMzkvIiwicmVsYXRpdmVf
         cGF0aCI6InJlZnMvaGVhZHMvcmF3aGlkZSIsImNvbW1pdCI6Ii9wdWxwL2Fw
-        aS92My9jb250ZW50L29zdHJlZS9jb21taXRzLzAxOGY1ZTk2LTM5OTMtNzhk
-        My05MmQwLTdlM2NkZDI5M2VjMi8iLCJjaGVja3N1bSI6ImQyMjEwMDViZmM0
+        aS92My9jb250ZW50L29zdHJlZS9jb21taXRzLzAxOGZlOGQ2LWNlYzItNzE1
+        NC05NThlLTQ1NmM1OTk5MjI5NS8iLCJjaGVja3N1bSI6ImQyMjEwMDViZmM0
         ZmY3MTllNGZjMjczMTE2OTRhMTdmNDEzYzVlYzhjYWU2YzVhNTkwMjAxZmM2
         OGY0MTNiZGEiLCJuYW1lIjoicmF3aGlkZSJ9XX0=
-  recorded_at: Fri, 10 May 2024 14:19:05 GMT
+  recorded_at: Wed, 05 Jun 2024 14:39:03 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/?name=2_duplicate-test-ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?name=2_duplicate-test-ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1226,7 +1226,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:06 GMT
+      - Wed, 05 Jun 2024 14:39:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1246,32 +1246,32 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2982e08152b24ace82ac5b9c4bd8d65c
+      - d3c72e2a4c9742e1b408394bef0c1133
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        b3N0cmVlL29zdHJlZS8wMThmNjJkZi0xZDgyLTc5M2UtYWJjNi0xMTIwOTAz
-        N2QxNDYvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOTowMC4z
-        NTUyMThaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5
-        OjA1LjAyMDgzNloiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9vc3RyZWUvb3N0cmVlLzAxOGY2MmRmLTFkODItNzkzZS1h
-        YmM2LTExMjA5MDM3ZDE0Ni92ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30s
+        b3N0cmVlL29zdHJlZS8wMThmZThkNi1jMjgwLTc0MmItOGMwOC0xOTUwOGU5
+        YjZiNDkvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wNVQxNDozODo1OS43
+        MTMzMTdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM5
+        OjAzLjM3NjU2N1oiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9vc3RyZWUvb3N0cmVlLzAxOGZlOGQ2LWMyODAtNzQyYi04
+        YzA4LTE5NTA4ZTliNmI0OS92ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30s
         ImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL29zdHJlZS9vc3RyZWUvMDE4ZjYyZGYtMWQ4Mi03OTNlLWFiYzYtMTEy
-        MDkwMzdkMTQ2L3ZlcnNpb25zLzEvIiwibmFtZSI6IjJfZHVwbGljYXRlLXRl
+        aWVzL29zdHJlZS9vc3RyZWUvMDE4ZmU4ZDYtYzI4MC03NDJiLThjMDgtMTk1
+        MDhlOWI2YjQ5L3ZlcnNpb25zLzEvIiwibmFtZSI6IjJfZHVwbGljYXRlLXRl
         c3Qtb3N0cmVlIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImNvbXB1dGVfZGVsdGEiOnRy
         dWV9XX0=
-  recorded_at: Fri, 10 May 2024 14:19:06 GMT
+  recorded_at: Wed, 05 Jun 2024 14:39:04 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/018f62df-1d82-793e-abc6-11209037d146/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/018fe8d6-c280-742b-8c08-19508e9b6b49/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1292,7 +1292,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:06 GMT
+      - Wed, 05 Jun 2024 14:39:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1312,20 +1312,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 259493b8ec464c7e862f6df1b019f057
+      - 5bc9996fbdbd4efc9525a62db6c163b6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTMzY2EtNzU5
-        Mi05YTA1LTQ4MDRmMjlhYzZjZS8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:06 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWQ0ODItNzZl
+        ZC05OGUxLTBjOThhMDAzMWRhNS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/ostree/ostree/?name=2_duplicate-test-ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/ostree/ostree/?name=2_duplicate-test-ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1346,7 +1346,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:06 GMT
+      - Wed, 05 Jun 2024 14:39:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1366,20 +1366,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 05e54798e81f48769e769708221ebd0b
+      - df3f874cfd02434aac7e110a712d33f3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL29zdHJl
-        ZS9vc3RyZWUvMDE4ZjYyZGYtMWNmYi03Yzk2LTliOWEtZGZjNmI1YjNmMjRl
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDAuMjIwMzY0
-        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOTowMS40
-        OTYyMTdaIiwibmFtZSI6IjJfZHVwbGljYXRlLXRlc3Qtb3N0cmVlIiwidXJs
+        ZS9vc3RyZWUvMDE4ZmU4ZDYtYzIwMC03OGQzLTg2NGEtNDFkNWNlNmFmN2Iz
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTkuNTg1MDU1
+        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozOTowMC44
+        OTgyMDRaIiwibmFtZSI6IjJfZHVwbGljYXRlLXRlc3Qtb3N0cmVlIiwidXJs
         IjoiaHR0cHM6Ly9maXh0dXJlcy5wdWxwcHJvamVjdC5vcmcvb3N0cmVlL3Nt
         YWxsLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNf
         dmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVs
@@ -1394,10 +1394,10 @@ http_interactions:
         ImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InBhc3N3b3JkIiwiaXNfc2V0Ijpm
         YWxzZX1dLCJkZXB0aCI6MCwiaW5jbHVkZV9yZWZzIjpbInJhd2hpZGUiXSwi
         ZXhjbHVkZV9yZWZzIjpudWxsfV19
-  recorded_at: Fri, 10 May 2024 14:19:06 GMT
+  recorded_at: Wed, 05 Jun 2024 14:39:04 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/ostree/ostree/018f62df-1cfb-7c96-9b9a-dfc6b5b3f24e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/ostree/ostree/018fe8d6-c200-78d3-864a-41d5ce6af7b3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1418,7 +1418,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:06 GMT
+      - Wed, 05 Jun 2024 14:39:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1438,20 +1438,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ebbf9a5595584f6783485e49600a84f9
+      - bf14dfb16ae7498db7196948b2db7c40
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTM0NjctNzVk
-        Mi05N2MxLTIwYTQ4MmY0MWU0NS8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:06 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWQ1MDgtNzg1
+        ZC05ZWVkLTc0OTNmMGQ0MmIzNS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-33ca-7592-9a05-4804f29ac6ce/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-d482-76ed-98e1-0c98a0031da5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1459,7 +1459,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1472,7 +1472,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:06 GMT
+      - Wed, 05 Jun 2024 14:39:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1492,37 +1492,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bf28e7ed0434405cbd1d59831470c70b
+      - 71606377a6514295aab211d142725d12
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtMzNj
-        YS03NTkyLTlhMDUtNDgwNGYyOWFjNmNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MDYuMDU5MDkzWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOTowNi4wNTkxMDRaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtZDQ4
+        Mi03NmVkLTk4ZTEtMGM5OGEwMDMxZGE1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzk6MDQuMzIzMDE5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozOTowNC4zMjMwMzNaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjI1OTQ5M2I4ZWM0NjRjN2U4NjJm
-        NmRmMWIwMTlmMDU3IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDYuMDcw
-        OTY1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjA2LjExMDMz
-        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDYuMTczMzk3
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjViYzk5OTZmYmRiZDRlZmM5NTI1
+        YTYyZGI2YzE2M2I2IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDQuMzM1
+        NDE5WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM5OjA0LjM3NjQy
+        OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDQuNDM4NTE1
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNWU4ZC01ZWM0LTdmMjYtOWFkNi02NWU1MWMwNjYwZTcvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL29zdHJlZS9vc3RyZWUvMDE4ZjYyZGYtMWQ4Mi03
-        OTNlLWFiYzYtMTEyMDkwMzdkMTQ2LyIsInNoYXJlZDovcHVscC9hcGkvdjMv
-        ZG9tYWlucy8wMThmNWU4Yy00ZWQ0LTc3NGEtODQ3My01N2NjMDQ4ZDZjNDAv
+        djMvcmVwb3NpdG9yaWVzL29zdHJlZS9vc3RyZWUvMDE4ZmU4ZDYtYzI4MC03
+        NDJiLThjMDgtMTk1MDhlOWI2YjQ5LyIsInNoYXJlZDovcHVscC9hcGkvdjMv
+        ZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEv
         Il19
-  recorded_at: Fri, 10 May 2024 14:19:06 GMT
+  recorded_at: Wed, 05 Jun 2024 14:39:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-3467-75d2-97c1-20a482f41e45/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-d508-785d-9eed-7493f0d42b35/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1530,7 +1530,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1543,7 +1543,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:06 GMT
+      - Wed, 05 Jun 2024 14:39:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1563,36 +1563,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3b9d5c04550949139b3f0642bddc2374
+      - ef912cfa270a4ce690a514cb830b5be5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtMzQ2
-        Ny03NWQyLTk3YzEtMjBhNDgyZjQxZTQ1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MDYuMjE1NTUxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOTowNi4yMTU1NjJaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtZDUw
+        OC03ODVkLTllZWQtNzQ5M2YwZDQyYjM1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzk6MDQuNDU2NzIzWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozOTowNC40NTY3MzhaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImViYmY5YTU1OTU1ODRmNjc4MzQ4
-        NWU0OTYwMGE4NGY5IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDYuMjI1
-        Mzg4WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjA2LjI4MjUy
-        MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDYuMzM5MjEz
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImJmMTRkZmIxNmFlNzQ5OGRiNzE5
+        Njk0OGIyZGI3YzQwIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDQuNDY4
+        NjE1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM5OjA0LjUwOTA0
+        MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDQuNTU4OTAy
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNWU4ZC01NjNhLTc0N2MtOWRmZS1lMTU2NjFlYzYzOTcvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVtb3Rlcy9vc3RyZWUvb3N0cmVlLzAxOGY2MmRmLTFjZmItN2M5Ni05
-        YjlhLWRmYzZiNWIzZjI0ZS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFp
-        bnMvMDE4ZjVlOGMtNGVkNC03NzRhLTg0NzMtNTdjYzA0OGQ2YzQwLyJdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:06 GMT
+        djMvcmVtb3Rlcy9vc3RyZWUvb3N0cmVlLzAxOGZlOGQ2LWMyMDAtNzhkMy04
+        NjRhLTQxZDVjZTZhZjdiMy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFp
+        bnMvMDE4ZmUzYzktNzBhYS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?name=2_duplicate-test-ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/?name=2_duplicate-test-ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1613,7 +1613,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:06 GMT
+      - Wed, 05 Jun 2024 14:39:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1625,7 +1625,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '511'
+      - '514'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1633,30 +1633,30 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ce96bd01e4904de8bbc637539d004a40
+      - 4dce9887ab594762a387615159f7a06f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L29zdHJlZS9vc3RyZWUvMDE4ZjYyZGYtMWZlYS03YzFkLWFiNmItOGE4MWRj
-        MTY0Njg1LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDAu
-        OTcyMDMyWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0xMFQxNDox
-        OTowNS41Mzk2MDdaIiwiYmFzZV9wYXRoIjoiaW50ZWdyYXRpb25fdGVzdHMv
-        b3N0cmVlIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0ZWxsby1k
-        ZXZlbC1zdGFibGUuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L2ludGVncmF0
-        aW9uX3Rlc3RzL29zdHJlZS8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJoaWRk
-        ZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyX2R1cGxpY2F0
-        ZS10ZXN0LW9zdHJlZSIsInJlcG9zaXRvcnkiOm51bGwsInJlcG9zaXRvcnlf
-        dmVyc2lvbiI6bnVsbH1dfQ==
-  recorded_at: Fri, 10 May 2024 14:19:06 GMT
+        L29zdHJlZS9vc3RyZWUvMDE4ZmU4ZDYtYzRlNi03MTY1LTk0ZTItNDU1Yzg5
+        MjEzZTg5LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDAu
+        MzI3NTAwWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDoz
+        OTowMy44MjMyNzdaIiwiYmFzZV9wYXRoIjoiaW50ZWdyYXRpb25fdGVzdHMv
+        b3N0cmVlIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1k
+        ZXZlbC5tYW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L2ludGVn
+        cmF0aW9uX3Rlc3RzL29zdHJlZS8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJo
+        aWRkZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyX2R1cGxp
+        Y2F0ZS10ZXN0LW9zdHJlZSIsInJlcG9zaXRvcnkiOm51bGwsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6bnVsbH1dfQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:04 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/018f62df-1fea-7c1d-ab6b-8a81dc164685/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/018fe8d6-c4e6-7165-94e2-455c89213e89/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1677,7 +1677,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:06 GMT
+      - Wed, 05 Jun 2024 14:39:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1697,20 +1697,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fa3ddcd8e319419db5bfc097f36643e9
+      - f69d7a9fe5f1484695c08bc1a784b4f3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTM1NzMtN2I2
-        ZC05ZTViLTU3Nzc2ZjExZjg1Yi8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:06 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWQ1ZmYtNzIz
+        ZS1hYjA0LTEzNGVkNTg2Y2YzYy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?base_path=integration_tests/ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/?base_path=integration_tests/ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1731,7 +1731,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:06 GMT
+      - Wed, 05 Jun 2024 14:39:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1751,20 +1751,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7636140b2dd045d3b97316fb4e5acae2
+      - 46819159d0eb4d8491e8a98131bbf234
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:06 GMT
+  recorded_at: Wed, 05 Jun 2024 14:39:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-3573-7b6d-9e5b-57776f11f85b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-d5ff-723e-ab04-134ed586cf3c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1772,7 +1772,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1785,7 +1785,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:06 GMT
+      - Wed, 05 Jun 2024 14:39:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1805,44 +1805,44 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3748da6d78184901886f4f3ec8fe7bd9
+      - 925b981ef69e4e70a251fbfee25df5b2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtMzU3
-        My03YjZkLTllNWItNTc3NzZmMTFmODViLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MDYuNDg0MzM3WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOTowNi40ODQzNDhaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtZDVm
+        Zi03MjNlLWFiMDQtMTM0ZWQ1ODZjZjNjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzk6MDQuNzAzNjM1WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozOTowNC43MDM2NDhaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImZhM2RkY2Q4ZTMxOTQxOWRiNWJm
-        YzA5N2YzNjY0M2U5IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDYuNDkz
-        NDA5WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjA2LjQ5Njg5
-        OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDYuNTA3NzAz
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImY2OWQ3YTlmZTVmMTQ4NDY5NWMw
+        OGJjMWE3ODRiNGYzIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDQuNzEz
+        NDEzWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM5OjA0LjcxNTg1
+        N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDQuNzMwMDYw
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25z
-        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNWU4Yy00ZWQ0
-        LTc3NGEtODQ3My01N2NjMDQ4ZDZjNDAvIl19
-  recorded_at: Fri, 10 May 2024 14:19:06 GMT
+        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFh
+        LTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:39:04 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/orphans/cleanup/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
     body:
       encoding: UTF-8
       base64_string: 'eyJvcnBoYW5fcHJvdGVjdGlvbl90aW1lIjowfQ==
 
-'
+        '
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1855,7 +1855,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:06 GMT
+      - Wed, 05 Jun 2024 14:39:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1875,20 +1875,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 88b32d39c34c4b8ab3c24c7a8513b648
+      - 88b7b35c72014ccabf9e18b77b518058
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTM2NmItN2Nh
-        Zi05NWE3LWE1YjkyZGI3MWY3Mi8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:06 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWQ3MGMtNzVh
+        MC1hN2JjLWEwYzcyN2FiMGU1MS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:04 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-366b-7caf-95a7-a5b92db71f72/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-d70c-75a0-a7bc-a0c727ab0e51/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1896,7 +1896,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1909,7 +1909,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:07 GMT
+      - Wed, 05 Jun 2024 14:39:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1929,36 +1929,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4c213a3b706f485aa9d0d13012ec9405
+      - aade14b3bb31447f86863f98f56f3983
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtMzY2
-        Yi03Y2FmLTk1YTctYTViOTJkYjcxZjcyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MDYuNzMyMDcxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOTowNi43MzIwODJaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtZDcw
+        Yy03NWEwLWE3YmMtYTBjNzI3YWIwZTUxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzk6MDQuOTcyOTg0WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozOTowNC45NzI5OTdaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLm9ycGhhbi5vcnBo
-        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiODhiMzJkMzljMzRjNGI4YWIz
-        YzI0YzdhODUxM2I2NDgiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
-        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0xMFQxNDoxOTowNi43
-        NDM5ODFaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDYuODE0
-        ODc3WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0xMFQxNDoxOTowNi45NjEz
-        ODFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzAxOGY1ZThkLTVlYzQtN2YyNi05YWQ2LTY1ZTUxYzA2NjBlNy8iLCJw
+        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiODhiN2IzNWM3MjAxNGNjYWJm
+        OWUxOGI3N2I1MTgwNTgiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
+        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozOTowNC45
+        ODM5MzRaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDUuMDIw
+        MjU4WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozOTowNS4zOTIw
+        NDNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzAxOGZlM2NiLTBkZjItN2M4My1hN2VhLWUyNmExYTI4ZDdmOS8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xlYW4g
         dXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZp
+        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjcsImRvbmUiOjcsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiQ2xlYW4gdXAgb3JwaGFuIEFydGlmYWN0
         cyIsImNvZGUiOiJjbGVhbi11cC5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNvbXBs
-        ZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3Jl
+        ZXRlZCIsInRvdGFsIjo3LCJkb25lIjo3LCJzdWZmaXgiOm51bGx9XSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
         IjpbIi9hcGkvdjMvb3JwaGFucy9jbGVhbnVwLyIsInNoYXJlZDovcHVscC9h
-        cGkvdjMvZG9tYWlucy8wMThmNWU4Yy00ZWQ0LTc3NGEtODQ3My01N2NjMDQ4
-        ZDZjNDAvIl19
-  recorded_at: Fri, 10 May 2024 14:19:07 GMT
+        cGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2Fk
+        MzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:39:05 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/katello/pulp3/repository/ostree_type_sync/upload_files.yml
+++ b/test/fixtures/vcr_cassettes/katello/pulp3/repository/ostree_type_sync/upload_files.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/?name=2_duplicate-test-ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?name=2_duplicate-test-ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:07 GMT
+      - Wed, 05 Jun 2024 14:39:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,20 +43,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 74498b5b2c624900aae2285e73e36036
+      - b223cc7d223c4dc2b238f16e7c2cd3e0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:07 GMT
+  recorded_at: Wed, 05 Jun 2024 14:39:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/ostree/ostree/?name=2_duplicate-test-ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/ostree/ostree/?name=2_duplicate-test-ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:07 GMT
+      - Wed, 05 Jun 2024 14:39:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,20 +97,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cca77ed6a7994d06a43366b0f1b4a8fc
+      - a2295e5c50cf478696d4f0cb5a55a602
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:07 GMT
+  recorded_at: Wed, 05 Jun 2024 14:39:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?name=2_duplicate-test-ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/?name=2_duplicate-test-ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:07 GMT
+      - Wed, 05 Jun 2024 14:39:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,20 +151,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8dc0674f7ee04f58aaa17c16ac74fad5
+      - 9d8c765552314409982d0999d56c4fbc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:07 GMT
+  recorded_at: Wed, 05 Jun 2024 14:39:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?base_path=integration_tests/ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/?base_path=integration_tests/ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:07 GMT
+      - Wed, 05 Jun 2024 14:39:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,20 +205,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '0549c7e2da0345d3ac61f44c9951467a'
+      - a7bc1f1e8360479ebae4c1e984668228
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:07 GMT
+  recorded_at: Wed, 05 Jun 2024 14:39:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/ostree/ostree/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/ostree/ostree/
     body:
       encoding: UTF-8
       base64_string: |
@@ -248,13 +248,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:07 GMT
+      - Wed, 05 Jun 2024 14:39:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/ostree/ostree/018f62df-3a4e-7024-addc-547b207c2f62/"
+      - "/pulp/api/v3/remotes/ostree/ostree/018fe8d6-dc63-78c4-b5df-4306bb6aab8e/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -270,18 +270,18 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b1335c826ec74a0f8e8513674a893623
+      - bcdee85113634346b34a502cb047bb92
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9vc3RyZWUvb3N0
-        cmVlLzAxOGY2MmRmLTNhNGUtNzAyNC1hZGRjLTU0N2IyMDdjMmY2Mi8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjA3LjcyNjk3OVoiLCJw
-        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDcuNzI2OTk1
+        cmVlLzAxOGZlOGQ2LWRjNjMtNzhjNC1iNWRmLTQzMDZiYjZhYWI4ZS8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM5OjA2LjMzOTk5MloiLCJw
+        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDYuMzQwMDA1
         WiIsIm5hbWUiOiIyX2R1cGxpY2F0ZS10ZXN0LW9zdHJlZSIsInVybCI6Imh0
         dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL29zdHJlZS9zbWFsbC8i
         LCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlk
@@ -297,15 +297,15 @@ http_interactions:
         ZXQiOmZhbHNlfSx7Im5hbWUiOiJwYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9
         XSwiZGVwdGgiOjAsImluY2x1ZGVfcmVmcyI6WyJyYXdoaWRlIl0sImV4Y2x1
         ZGVfcmVmcyI6bnVsbH0=
-  recorded_at: Fri, 10 May 2024 14:19:07 GMT
+  recorded_at: Wed, 05 Jun 2024 14:39:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMl9kdXBsaWNhdGUtdGVzdC1vc3RyZWUifQ==
 
-'
+        '
     headers:
       Content-Type:
       - application/json
@@ -323,13 +323,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:07 GMT
+      - Wed, 05 Jun 2024 14:39:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/ostree/ostree/018f62df-3acf-7de0-ab65-3adfe122d4f8/"
+      - "/pulp/api/v3/repositories/ostree/ostree/018fe8d6-dcf0-7d4f-9a33-f1e09d0c384d/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -345,30 +345,30 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4b4da4ec84ac4d3d9d4d6b628dd033e7
+      - ea51ea9b2bdb46cf993b767e00dbde47
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL29zdHJl
-        ZS9vc3RyZWUvMDE4ZjYyZGYtM2FjZi03ZGUwLWFiNjUtM2FkZmUxMjJkNGY4
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDcuODU2NDc1
-        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOTowNy44
-        NjIwODdaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvb3N0cmVlL29zdHJlZS8wMThmNjJkZi0zYWNmLTdkZTAtYWI2NS0z
-        YWRmZTEyMmQ0ZjgvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
+        ZS9vc3RyZWUvMDE4ZmU4ZDYtZGNmMC03ZDRmLTlhMzMtZjFlMDlkMGMzODRk
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDYuNDgxNTAw
+        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozOTowNi40
+        ODk1MTVaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvb3N0cmVlL29zdHJlZS8wMThmZThkNi1kY2YwLTdkNGYtOWEzMy1m
+        MWUwOWQwYzM4NGQvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
         c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9v
-        c3RyZWUvb3N0cmVlLzAxOGY2MmRmLTNhY2YtN2RlMC1hYjY1LTNhZGZlMTIy
-        ZDRmOC92ZXJzaW9ucy8wLyIsIm5hbWUiOiIyX2R1cGxpY2F0ZS10ZXN0LW9z
+        c3RyZWUvb3N0cmVlLzAxOGZlOGQ2LWRjZjAtN2Q0Zi05YTMzLWYxZTA5ZDBj
+        Mzg0ZC92ZXJzaW9ucy8wLyIsIm5hbWUiOiIyX2R1cGxpY2F0ZS10ZXN0LW9z
         dHJlZSIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJjb21wdXRlX2RlbHRhIjp0cnVlfQ==
-  recorded_at: Fri, 10 May 2024 14:19:07 GMT
+  recorded_at: Wed, 05 Jun 2024 14:39:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?base_path=integration_tests/ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/?base_path=integration_tests/ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -389,7 +389,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:08 GMT
+      - Wed, 05 Jun 2024 14:39:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -409,28 +409,28 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - caec1417f1004b6caa5ddadc5a503638
+      - 7fc95921bace48bc8d0ae759ff505605
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:08 GMT
+  recorded_at: Wed, 05 Jun 2024 14:39:06 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/
     body:
       encoding: UTF-8
       base64_string: |
         eyJiYXNlX3BhdGgiOiJpbnRlZ3JhdGlvbl90ZXN0cy9vc3RyZWUiLCJjb250
         ZW50X2d1YXJkIjpudWxsLCJuYW1lIjoiMl9kdXBsaWNhdGUtdGVzdC1vc3Ry
         ZWUiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL29zdHJlZS9vc3RyZWUvMDE4ZjYyZGYtM2FjZi03ZGUwLWFiNjUt
-        M2FkZmUxMjJkNGY4L3ZlcnNpb25zLzAvIn0=
+        dG9yaWVzL29zdHJlZS9vc3RyZWUvMDE4ZmU4ZDYtZGNmMC03ZDRmLTlhMzMt
+        ZjFlMDlkMGMzODRkL3ZlcnNpb25zLzAvIn0=
     headers:
       Content-Type:
       - application/json
@@ -448,7 +448,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:08 GMT
+      - Wed, 05 Jun 2024 14:39:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -468,20 +468,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ee854af703344de9989c52884b0fe4a6
+      - cf0e8b9bd07e44458ebc55b86219ae06
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTNjMDAtNzBm
-        NC1hNWVkLTU5NTcyYmY3N2JhOS8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:08 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWRlNDItNzU0
+        MS1hNGFhLWUxZDEzNGY2NTUzNy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:06 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-3c00-70f4-a5ed-59572bf77ba9/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-de42-7541-a4aa-e1d134f65537/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -489,7 +489,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -502,7 +502,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:08 GMT
+      - Wed, 05 Jun 2024 14:39:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -522,37 +522,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 35dec9ca44d047448e337bb9588b3aed
+      - 6764d6f3694f46c49f7eaa06e4aed990
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtM2Mw
-        MC03MGY0LWE1ZWQtNTk1NzJiZjc3YmE5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MDguMTYwODA1WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOTowOC4xNjA4MTZaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtZGU0
+        Mi03NTQxLWE0YWEtZTFkMTM0ZjY1NTM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzk6MDYuODE4OTQyWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozOTowNi44MTg5NjVaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6ImVlODU0YWY3MDMzNDRkZTk5ODlj
-        NTI4ODRiMGZlNGE2IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDguMTk1
-        NTIwWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjA4LjI2ODA1
-        MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDguNDc3NDU3
+        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6ImNmMGU4YjliZDA3ZTQ0NDU4ZWJj
+        NTViODYyMTlhZTA2IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDYuODMx
+        NTE5WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM5OjA2Ljg2NTA0
+        OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDcuMDk1MDk3
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNWU4ZC01ZTgxLTdkZTMtOWNiZi03ZGM5YzljMTNhMjcvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL29zdHJlZS9vc3RyZWUv
-        MDE4ZjYyZGYtM2QyZi03NGUzLWE5ZmUtMjEyNjhmMjRlM2E3LyJdLCJyZXNl
+        MDE4ZmU4ZDYtZGY0OC03YmRlLWFiMmUtYzM5ZDlkYjIwYWIzLyJdLCJyZXNl
         cnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9u
-        cy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZjVlOGMtNGVk
-        NC03NzRhLTg0NzMtNTdjYzA0OGQ2YzQwLyJdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:08 GMT
+        cy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMvMDE4ZmUzYzktNzBh
+        YS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/018f62df-3d2f-74e3-a9fe-21268f24e3a7/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/018fe8d6-df48-7bde-ab2e-c39d9db20ab3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -573,7 +573,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:08 GMT
+      - Wed, 05 Jun 2024 14:39:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -585,7 +585,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '545'
+      - '548'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -593,31 +593,31 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 774a7cd64dfc46698d8fa04b546cce8f
+      - 15cab2494fdb48898334bf022f6f0dc4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9vc3Ry
-        ZWUvb3N0cmVlLzAxOGY2MmRmLTNkMmYtNzRlMy1hOWZlLTIxMjY4ZjI0ZTNh
-        Ny8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjA4LjQ2NDI2
-        OFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDgu
-        NDY0MjgzWiIsImJhc2VfcGF0aCI6ImludGVncmF0aW9uX3Rlc3RzL29zdHJl
-        ZSIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M4LWthdGVsbG8tZGV2ZWwt
-        c3RhYmxlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9pbnRlZ3JhdGlvbl90
-        ZXN0cy9vc3RyZWUvIiwiY29udGVudF9ndWFyZCI6bnVsbCwiaGlkZGVuIjpm
-        YWxzZSwicHVscF9sYWJlbHMiOnt9LCJuYW1lIjoiMl9kdXBsaWNhdGUtdGVz
-        dC1vc3RyZWUiLCJyZXBvc2l0b3J5IjpudWxsLCJyZXBvc2l0b3J5X3ZlcnNp
-        b24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL29zdHJlZS9vc3RyZWUv
-        MDE4ZjYyZGYtM2FjZi03ZGUwLWFiNjUtM2FkZmUxMjJkNGY4L3ZlcnNpb25z
-        LzAvIn0=
-  recorded_at: Fri, 10 May 2024 14:19:08 GMT
+        ZWUvb3N0cmVlLzAxOGZlOGQ2LWRmNDgtN2JkZS1hYjJlLWMzOWQ5ZGIyMGFi
+        My8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM5OjA3LjA4MTgy
+        OVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDcu
+        MDgxODQ2WiIsImJhc2VfcGF0aCI6ImludGVncmF0aW9uX3Rlc3RzL29zdHJl
+        ZSIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwu
+        bWFuaWNvdHRvLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9pbnRlZ3JhdGlv
+        bl90ZXN0cy9vc3RyZWUvIiwiY29udGVudF9ndWFyZCI6bnVsbCwiaGlkZGVu
+        IjpmYWxzZSwicHVscF9sYWJlbHMiOnt9LCJuYW1lIjoiMl9kdXBsaWNhdGUt
+        dGVzdC1vc3RyZWUiLCJyZXBvc2l0b3J5IjpudWxsLCJyZXBvc2l0b3J5X3Zl
+        cnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL29zdHJlZS9vc3Ry
+        ZWUvMDE4ZmU4ZDYtZGNmMC03ZDRmLTlhMzMtZjFlMDlkMGMzODRkL3ZlcnNp
+        b25zLzAvIn0=
+  recorded_at: Wed, 05 Jun 2024 14:39:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/?name=2_duplicate-test-ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?name=2_duplicate-test-ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -638,7 +638,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:08 GMT
+      - Wed, 05 Jun 2024 14:39:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -658,32 +658,32 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9ab72625a8584040a9218a3f20cc1c8b
+      - 64a04c98e7844521855b03d1ab878f7e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        b3N0cmVlL29zdHJlZS8wMThmNjJkZi0zYWNmLTdkZTAtYWI2NS0zYWRmZTEy
-        MmQ0ZjgvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOTowNy44
-        NTY0NzVaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5
-        OjA3Ljg2MjA4N1oiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9vc3RyZWUvb3N0cmVlLzAxOGY2MmRmLTNhY2YtN2RlMC1h
-        YjY1LTNhZGZlMTIyZDRmOC92ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30s
+        b3N0cmVlL29zdHJlZS8wMThmZThkNi1kY2YwLTdkNGYtOWEzMy1mMWUwOWQw
+        YzM4NGQvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wNVQxNDozOTowNi40
+        ODE1MDBaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM5
+        OjA2LjQ4OTUxNVoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9vc3RyZWUvb3N0cmVlLzAxOGZlOGQ2LWRjZjAtN2Q0Zi05
+        YTMzLWYxZTA5ZDBjMzg0ZC92ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30s
         ImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL29zdHJlZS9vc3RyZWUvMDE4ZjYyZGYtM2FjZi03ZGUwLWFiNjUtM2Fk
-        ZmUxMjJkNGY4L3ZlcnNpb25zLzAvIiwibmFtZSI6IjJfZHVwbGljYXRlLXRl
+        aWVzL29zdHJlZS9vc3RyZWUvMDE4ZmU4ZDYtZGNmMC03ZDRmLTlhMzMtZjFl
+        MDlkMGMzODRkL3ZlcnNpb25zLzAvIiwibmFtZSI6IjJfZHVwbGljYXRlLXRl
         c3Qtb3N0cmVlIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImNvbXB1dGVfZGVsdGEiOnRy
         dWV9XX0=
-  recorded_at: Fri, 10 May 2024 14:19:08 GMT
+  recorded_at: Wed, 05 Jun 2024 14:39:07 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/018f62df-3acf-7de0-ab65-3adfe122d4f8/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/018fe8d6-dcf0-7d4f-9a33-f1e09d0c384d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -704,7 +704,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:08 GMT
+      - Wed, 05 Jun 2024 14:39:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -724,20 +724,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6e9d8bc685b4491d8ef6d93ccff7a317
+      - ad4c5952a8934c1e8e4c04498d34b9c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTNlMzAtNzk3
-        Zi1iNDFmLWM5OTgwZDY1ZTNlNS8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:08 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWUwNGQtN2Q4
+        YS1hYmQyLWRjMjY5NDViMjkyOS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/ostree/ostree/?name=2_duplicate-test-ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/ostree/ostree/?name=2_duplicate-test-ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -758,7 +758,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:08 GMT
+      - Wed, 05 Jun 2024 14:39:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -778,20 +778,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e2b7b82d78a84bc084cb4a3aa450c5c6
+      - b127d73001c54785893cea7b90093c3c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL29zdHJl
-        ZS9vc3RyZWUvMDE4ZjYyZGYtM2E0ZS03MDI0LWFkZGMtNTQ3YjIwN2MyZjYy
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDcuNzI2OTc5
-        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOTowNy43
-        MjY5OTVaIiwibmFtZSI6IjJfZHVwbGljYXRlLXRlc3Qtb3N0cmVlIiwidXJs
+        ZS9vc3RyZWUvMDE4ZmU4ZDYtZGM2My03OGM0LWI1ZGYtNDMwNmJiNmFhYjhl
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDYuMzM5OTky
+        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozOTowNi4z
+        NDAwMDVaIiwibmFtZSI6IjJfZHVwbGljYXRlLXRlc3Qtb3N0cmVlIiwidXJs
         IjoiaHR0cHM6Ly9maXh0dXJlcy5wdWxwcHJvamVjdC5vcmcvb3N0cmVlL3Nt
         YWxsLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNf
         dmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhYmVs
@@ -806,10 +806,10 @@ http_interactions:
         ImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InBhc3N3b3JkIiwiaXNfc2V0Ijpm
         YWxzZX1dLCJkZXB0aCI6MCwiaW5jbHVkZV9yZWZzIjpbInJhd2hpZGUiXSwi
         ZXhjbHVkZV9yZWZzIjpudWxsfV19
-  recorded_at: Fri, 10 May 2024 14:19:08 GMT
+  recorded_at: Wed, 05 Jun 2024 14:39:07 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/ostree/ostree/018f62df-3a4e-7024-addc-547b207c2f62/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/ostree/ostree/018fe8d6-dc63-78c4-b5df-4306bb6aab8e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -830,7 +830,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:08 GMT
+      - Wed, 05 Jun 2024 14:39:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -850,20 +850,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4483446b519645c5a0e05c250a20a9cc
+      - e382a51fa3924d0fa97d6db63f2765bc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTNlYzMtNzc2
-        Yi05NTI1LTRlMmRhYjIyZDFjNi8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:08 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWUwYzItNzQ5
+        NC05ODRmLWZjNTEyMzA0YTNmMS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-3e30-797f-b41f-c9980d65e3e5/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-e04d-7d8a-abd2-dc26945b2929/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -871,7 +871,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -884,7 +884,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:08 GMT
+      - Wed, 05 Jun 2024 14:39:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -904,37 +904,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 874109ada14a434c8632b56eb7b439d4
+      - 9d65a4454211423ebce43d298d0da66b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtM2Uz
-        MC03OTdmLWI0MWYtYzk5ODBkNjVlM2U1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MDguNzIwNjU5WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOTowOC43MjA2NzBaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtZTA0
+        ZC03ZDhhLWFiZDItZGMyNjk0NWIyOTI5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzk6MDcuMzQxNDc2WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozOTowNy4zNDE0ODlaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjZlOWQ4YmM2ODViNDQ5MWQ4ZWY2
-        ZDkzY2NmZjdhMzE3IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDguNzMy
-        NTMwWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjA4Ljc4MTc3
-        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDguODQ4NjAz
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImFkNGM1OTUyYTg5MzRjMWU4ZTRj
+        MDQ0OThkMzRiOWM0IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDcuMzU1
+        NDY4WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM5OjA3LjM4Nzcz
+        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDcuNDQ2OTE2
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNWU4ZC01ZWM0LTdmMjYtOWFkNi02NWU1MWMwNjYwZTcvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL29zdHJlZS9vc3RyZWUvMDE4ZjYyZGYtM2FjZi03
-        ZGUwLWFiNjUtM2FkZmUxMjJkNGY4LyIsInNoYXJlZDovcHVscC9hcGkvdjMv
-        ZG9tYWlucy8wMThmNWU4Yy00ZWQ0LTc3NGEtODQ3My01N2NjMDQ4ZDZjNDAv
+        djMvcmVwb3NpdG9yaWVzL29zdHJlZS9vc3RyZWUvMDE4ZmU4ZDYtZGNmMC03
+        ZDRmLTlhMzMtZjFlMDlkMGMzODRkLyIsInNoYXJlZDovcHVscC9hcGkvdjMv
+        ZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEv
         Il19
-  recorded_at: Fri, 10 May 2024 14:19:08 GMT
+  recorded_at: Wed, 05 Jun 2024 14:39:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-3ec3-776b-9525-4e2dab22d1c6/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-e0c2-7494-984f-fc512304a3f1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -942,7 +942,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -955,7 +955,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:09 GMT
+      - Wed, 05 Jun 2024 14:39:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -975,36 +975,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 82f7c6cd8b514d58b461d55293b08b8b
+      - 744fb059f18447218d43c0d188400d5d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtM2Vj
-        My03NzZiLTk1MjUtNGUyZGFiMjJkMWM2LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MDguODY5NTEyWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOTowOC44Njk1MjVaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtZTBj
+        Mi03NDk0LTk4NGYtZmM1MTIzMDRhM2YxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzk6MDcuNDU4NTE3WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozOTowNy40NTg1MjlaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjQ0ODM0NDZiNTE5NjQ1YzVhMGUw
-        NWMyNTBhMjBhOWNjIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDguODgx
-        NjQ1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjA4LjkzMjkz
-        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDguOTgyMzYx
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImUzODJhNTFmYTM5MjRkMGZhOTdk
+        NmRiNjNmMjc2NWJjIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDcuNDcw
+        MTAzWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM5OjA3LjUwNDEy
+        MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDcuNTQzMDQ4
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNWU4ZC01Zjc4LTc0NDAtYTAyZC1lODg3MzI0MjA5YmEvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVtb3Rlcy9vc3RyZWUvb3N0cmVlLzAxOGY2MmRmLTNhNGUtNzAyNC1h
-        ZGRjLTU0N2IyMDdjMmY2Mi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFp
-        bnMvMDE4ZjVlOGMtNGVkNC03NzRhLTg0NzMtNTdjYzA0OGQ2YzQwLyJdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:09 GMT
+        djMvcmVtb3Rlcy9vc3RyZWUvb3N0cmVlLzAxOGZlOGQ2LWRjNjMtNzhjNC1i
+        NWRmLTQzMDZiYjZhYWI4ZS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFp
+        bnMvMDE4ZmUzYzktNzBhYS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?name=2_duplicate-test-ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/?name=2_duplicate-test-ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1025,7 +1025,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:09 GMT
+      - Wed, 05 Jun 2024 14:39:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1037,7 +1037,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '511'
+      - '514'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1045,30 +1045,30 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8066c7cc46374e5c9a3140a1f5fd0f75
+      - a93548da2f6c45b781befda01ca4a657
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L29zdHJlZS9vc3RyZWUvMDE4ZjYyZGYtM2QyZi03NGUzLWE5ZmUtMjEyNjhm
-        MjRlM2E3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDgu
-        NDY0MjY4WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0xMFQxNDox
-        OTowOC40NjQyODNaIiwiYmFzZV9wYXRoIjoiaW50ZWdyYXRpb25fdGVzdHMv
-        b3N0cmVlIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczgta2F0ZWxsby1k
-        ZXZlbC1zdGFibGUuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L2ludGVncmF0
-        aW9uX3Rlc3RzL29zdHJlZS8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJoaWRk
-        ZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyX2R1cGxpY2F0
-        ZS10ZXN0LW9zdHJlZSIsInJlcG9zaXRvcnkiOm51bGwsInJlcG9zaXRvcnlf
-        dmVyc2lvbiI6bnVsbH1dfQ==
-  recorded_at: Fri, 10 May 2024 14:19:09 GMT
+        L29zdHJlZS9vc3RyZWUvMDE4ZmU4ZDYtZGY0OC03YmRlLWFiMmUtYzM5ZDlk
+        YjIwYWIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDcu
+        MDgxODI5WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDoz
+        OTowNy4wODE4NDZaIiwiYmFzZV9wYXRoIjoiaW50ZWdyYXRpb25fdGVzdHMv
+        b3N0cmVlIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1k
+        ZXZlbC5tYW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L2ludGVn
+        cmF0aW9uX3Rlc3RzL29zdHJlZS8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJo
+        aWRkZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiIyX2R1cGxp
+        Y2F0ZS10ZXN0LW9zdHJlZSIsInJlcG9zaXRvcnkiOm51bGwsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6bnVsbH1dfQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:07 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/018f62df-3d2f-74e3-a9fe-21268f24e3a7/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/018fe8d6-df48-7bde-ab2e-c39d9db20ab3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1089,7 +1089,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:09 GMT
+      - Wed, 05 Jun 2024 14:39:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1109,20 +1109,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5ac53040fedc43279f23525a49ae113c
+      - fabe14e716ea4fb58a3d3722d6278755
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTQwMmQtNzcx
-        OS1iMDJjLWY3MDllZWFlZDY4ZS8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:09 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWUxYjktN2Qw
+        MC1iYjUzLTU1ZTg0YzUyZjI4ZC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?base_path=integration_tests/ostree
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/?base_path=integration_tests/ostree
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1143,7 +1143,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:09 GMT
+      - Wed, 05 Jun 2024 14:39:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1163,20 +1163,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6ef419a1cf284779b5bbadf8a20d89f7
+      - 0764b1b8428f4f6eb6c6f2f0ade963a9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:09 GMT
+  recorded_at: Wed, 05 Jun 2024 14:39:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-402d-7719-b02c-f709eeaed68e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-e1b9-7d00-bb53-55e84c52f28d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1184,7 +1184,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1197,7 +1197,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:09 GMT
+      - Wed, 05 Jun 2024 14:39:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1217,44 +1217,44 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3086b4f11fd64a5c843ee802926d59d2
+      - ee74a05657bf4d30ba09606fb31ac772
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNDAy
-        ZC03NzE5LWIwMmMtZjcwOWVlYWVkNjhlLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MDkuMjI5NTYzWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOTowOS4yMjk1NzZaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtZTFi
+        OS03ZDAwLWJiNTMtNTVlODRjNTJmMjhkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzk6MDcuNzA1OTA2WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozOTowNy43MDU5MjFaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjVhYzUzMDQwZmVkYzQzMjc5ZjIz
-        NTI1YTQ5YWUxMTNjIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDkuMjM4
-        NzgwWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjA5LjI0MTI0
-        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDkuMjUzOTg4
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImZhYmUxNGU3MTZlYTRmYjU4YTNk
+        MzcyMmQ2Mjc4NzU1IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDcuNzE4
+        Njg1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM5OjA3LjcyMTM1
+        N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDcuNzM3MDQ3
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25z
-        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNWU4Yy00ZWQ0
-        LTc3NGEtODQ3My01N2NjMDQ4ZDZjNDAvIl19
-  recorded_at: Fri, 10 May 2024 14:19:09 GMT
+        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFh
+        LTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:39:07 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/orphans/cleanup/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
     body:
       encoding: UTF-8
       base64_string: 'eyJvcnBoYW5fcHJvdGVjdGlvbl90aW1lIjowfQ==
 
-'
+        '
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1267,7 +1267,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:09 GMT
+      - Wed, 05 Jun 2024 14:39:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1287,20 +1287,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 185d2dfc195840a0b065da1270663195
+      - 7a0d966b4a9e42c1866ce567643b1e64
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTQxNDAtNzRk
-        Mi05NjY0LTVjY2ZlNWZlMGQ5OS8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:09 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWUyYzYtNzJl
+        Mi04OGRiLTQ4NzZiNmM2YjVkOS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:39:07 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-4140-74d2-9664-5ccfe5fe0d99/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-e2c6-72e2-88db-4876b6c6b5d9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1308,7 +1308,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1321,7 +1321,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:09 GMT
+      - Wed, 05 Jun 2024 14:39:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1341,26 +1341,26 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1b02d952f44247b7b21eb3c9c17c1caf
+      - 6356356c85c248dc9f0a4973e8f92b63
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNDE0
-        MC03NGQyLTk2NjQtNWNjZmU1ZmUwZDk5LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MDkuNTA0NDQyWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOTowOS41MDQ0NTNaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtZTJj
+        Ni03MmUyLTg4ZGItNDg3NmI2YzZiNWQ5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzk6MDcuOTc1MTY5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozOTowNy45NzUxODJaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLm9ycGhhbi5vcnBo
-        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiMTg1ZDJkZmMxOTU4NDBhMGIw
-        NjVkYTEyNzA2NjMxOTUiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
-        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0xMFQxNDoxOTowOS41
-        MTU4NTlaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MDkuNTY3
-        NzE0WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0xMFQxNDoxOTowOS43MTQ3
-        MjRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzAxOGY1ZThkLTVlYzQtN2YyNi05YWQ2LTY1ZTUxYzA2NjBlNy8iLCJw
+        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiN2EwZDk2NmI0YTllNDJjMTg2
+        NmNlNTY3NjQzYjFlNjQiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
+        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozOTowNy45
+        ODY2ODRaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzk6MDguMDIx
+        Mzk3WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozOTowOC4xNzg0
+        MjlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzAxOGZlM2NiLTBkNDMtNzczMS05ODUyLTg3MjlkMDA4MTk2My8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xlYW4g
         dXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIs
@@ -1370,7 +1370,7 @@ http_interactions:
         ZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
         IjpbIi9hcGkvdjMvb3JwaGFucy9jbGVhbnVwLyIsInNoYXJlZDovcHVscC9h
-        cGkvdjMvZG9tYWlucy8wMThmNWU4Yy00ZWQ0LTc3NGEtODQ3My01N2NjMDQ4
-        ZDZjNDAvIl19
-  recorded_at: Fri, 10 May 2024 14:19:09 GMT
+        cGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2Fk
+        MzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:39:08 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/katello/pulp3/repository/python_type_sync/sync.yml
+++ b/test/fixtures/vcr_cassettes/katello/pulp3/repository/python_type_sync/sync.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?name=2_duplicate-test-python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?name=2_duplicate-test-python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:10 GMT
+      - Wed, 05 Jun 2024 14:38:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,20 +43,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ecb03c2ac217429aa98f36231c31889f
+      - 845998b0f67e4efc9501af83a68cd168
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:10 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/python/python/?name=2_duplicate-test-python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/python/python/?name=2_duplicate-test-python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:10 GMT
+      - Wed, 05 Jun 2024 14:38:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,20 +97,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a5fa1468f2844568840ddb12e0e1f53e
+      - 2f6cfde7c8ad49fbaad112fa108b14aa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:10 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?name=2_duplicate-test-python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/?name=2_duplicate-test-python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:10 GMT
+      - Wed, 05 Jun 2024 14:38:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,20 +151,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 16c7304188d141e78771c03949d15d51
+      - 37ee284db4b14e7ea83fc22aa4d4eb15
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:10 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?base_path=integration_tests/python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/?base_path=integration_tests/python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:10 GMT
+      - Wed, 05 Jun 2024 14:38:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,20 +205,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7891262bf6db49f7b268e997eff55a70
+      - 4ee3130ef890446f81eb4313bd24cfee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:10 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:47 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/python/python/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/python/python/
     body:
       encoding: UTF-8
       base64_string: |
@@ -249,13 +249,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:10 GMT
+      - Wed, 05 Jun 2024 14:38:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/python/python/018f62df-44da-7ade-b40f-0278896d4b37/"
+      - "/pulp/api/v3/remotes/python/python/018fe8d6-9221-7e9e-a430-7c78773e5037/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -271,18 +271,18 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6a87eaef95c24b7ba1c8cb57d8a894cb
+      - 78f558693d974b899de8e1e8a3f33f1a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9weXRob24vcHl0
-        aG9uLzAxOGY2MmRmLTQ0ZGEtN2FkZS1iNDBmLTAyNzg4OTZkNGIzNy8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjEwLjQyNjU5MVoiLCJw
-        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTAuNDI2NjAx
+        aG9uLzAxOGZlOGQ2LTkyMjEtN2U5ZS1hNDMwLTdjNzg3NzNlNTAzNy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjQ3LjMyOTg3NVoiLCJw
+        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NDcuMzI5ODg4
         WiIsIm5hbWUiOiIyX2R1cGxpY2F0ZS10ZXN0LXB5dGhvbiIsInVybCI6Imh0
         dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL3B5dGhvbi1weXBpLyIs
         ImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRh
@@ -299,15 +299,15 @@ http_interactions:
         LCJpbmNsdWRlcyI6WyJjZWxlcnkiXSwiZXhjbHVkZXMiOltdLCJwcmVyZWxl
         YXNlcyI6ZmFsc2UsInBhY2thZ2VfdHlwZXMiOltdLCJrZWVwX2xhdGVzdF9w
         YWNrYWdlcyI6MCwiZXhjbHVkZV9wbGF0Zm9ybXMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:10 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:47 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMl9kdXBsaWNhdGUtdGVzdC1weXRob24ifQ==
 
-'
+        '
     headers:
       Content-Type:
       - application/json
@@ -325,13 +325,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:10 GMT
+      - Wed, 05 Jun 2024 14:38:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/python/python/018f62df-454c-7df4-9ecd-f93bfddc9b51/"
+      - "/pulp/api/v3/repositories/python/python/018fe8d6-92b5-7df5-b0c6-8fff391e0aad/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -347,36 +347,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a5a4f07e6e6e4fd89e835a23fd43ec95
+      - 94a1ddb8ab10412395c35079eb8b872f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhv
-        bi9weXRob24vMDE4ZjYyZGYtNDU0Yy03ZGY0LTllY2QtZjkzYmZkZGM5YjUx
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTAuNTQxMzAx
-        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOToxMC41
-        NDMwNTNaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmNjJkZi00NTRjLTdkZjQtOWVjZC1m
-        OTNiZmRkYzliNTEvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
+        bi9weXRob24vMDE4ZmU4ZDYtOTJiNS03ZGY1LWIwYzYtOGZmZjM5MWUwYWFk
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NDcuNDc4NjM0
+        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozODo0Ny40
+        ODA3NDlaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmZThkNi05MmI1LTdkZjUtYjBjNi04
+        ZmZmMzkxZTBhYWQvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
         c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9w
-        eXRob24vcHl0aG9uLzAxOGY2MmRmLTQ1NGMtN2RmNC05ZWNkLWY5M2JmZGRj
-        OWI1MS92ZXJzaW9ucy8wLyIsIm5hbWUiOiIyX2R1cGxpY2F0ZS10ZXN0LXB5
+        eXRob24vcHl0aG9uLzAxOGZlOGQ2LTkyYjUtN2RmNS1iMGM2LThmZmYzOTFl
+        MGFhZC92ZXJzaW9ucy8wLyIsIm5hbWUiOiIyX2R1cGxpY2F0ZS10ZXN0LXB5
         dGhvbiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2V9
-  recorded_at: Fri, 10 May 2024 14:19:10 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:47 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/publications/python/pypi/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/python/pypi/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3B5dGhvbi9weXRob24vMDE4ZjYyZGYtNDU0Yy03ZGY0LTllY2QtZjkz
-        YmZkZGM5YjUxL3ZlcnNpb25zLzAvIn0=
+        aWVzL3B5dGhvbi9weXRob24vMDE4ZmU4ZDYtOTJiNS03ZGY1LWIwYzYtOGZm
+        ZjM5MWUwYWFkL3ZlcnNpb25zLzAvIn0=
     headers:
       Content-Type:
       - application/json
@@ -394,7 +394,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:10 GMT
+      - Wed, 05 Jun 2024 14:38:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -414,20 +414,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2031072012b84909aaf92e40c95b4951
+      - 328617877dbb46aeae333bc00c0c28c0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTQ2NGYtNzE1
-        OS1hZGM1LWJiYjQ4NThiZjFlNy8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:10 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LTkzZjEtNzI4
+        OC1hNDkxLWE2NmU3ZWQ2YzJiZC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-464f-7159-adc5-bbb4858bf1e7/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-93f1-7288-a491-a66e7ed6c2bd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -435,7 +435,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -448,7 +448,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:10 GMT
+      - Wed, 05 Jun 2024 14:38:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -468,38 +468,38 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - dc012ad0e82846f3b7d4f6c39f818a66
+      - 8b7f079127c74612b5d13d77b9d6f5ee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNDY0
-        Zi03MTU5LWFkYzUtYmJiNDg1OGJmMWU3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MTAuODAwMzI0WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOToxMC44MDAzMzVaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtOTNm
+        MS03Mjg4LWE0OTEtYTY2ZTdlZDZjMmJkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NDcuNzkzNTI4WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo0Ny43OTM1NDJaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscF9weXRob24uYXBwLnRhc2tzLnB1Ymxpc2gu
-        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiMjAzMTA3MjAxMmI4NDkwOWFhZjky
-        ZTQwYzk1YjQ5NTEiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
-        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0xMFQxNDoxOToxMC44MTA1
-        OTdaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTAuODc1MDc5
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0xMFQxNDoxOToxMC45MzU4MTla
+        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiMzI4NjE3ODc3ZGJiNDZhZWFlMzMz
+        YmMwMGMwYzI4YzAiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
+        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozODo0Ny44MDM5
+        MTRaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NDcuODM2NzAw
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozODo0Ny45MDMxNTZa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzAxOGY1ZThkLTU2M2EtNzQ3Yy05ZGZlLWUxNTY2MWVjNjM5Ny8iLCJwYXJl
+        LzAxOGZlM2NiLTBkNDMtNzczMS05ODUyLTg3MjlkMDA4MTk2My8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9weXRob24vcHlwaS8wMThm
-        NjJkZi00NmFhLTcxNjgtYjNiMS0yNDU5ZmVmOTZiNTgvIl0sInJlc2VydmVk
+        ZThkNi05NDI4LTczZGItYjExMC1iNjQ4YWNmZWM1ZGUvIl0sInJlc2VydmVk
         X3Jlc291cmNlc19yZWNvcmQiOlsic2hhcmVkOi9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmNjJkZi00NTRjLTdkZjQtOWVj
-        ZC1mOTNiZmRkYzliNTEvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5z
-        LzAxOGY1ZThjLTRlZDQtNzc0YS04NDczLTU3Y2MwNDhkNmM0MC8iXX0=
-  recorded_at: Fri, 10 May 2024 14:19:10 GMT
+        c2l0b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmZThkNi05MmI1LTdkZjUtYjBj
+        Ni04ZmZmMzkxZTBhYWQvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5z
+        LzAxOGZlM2M5LTcwYWEtNzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:47 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?base_path=integration_tests/python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/?base_path=integration_tests/python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -520,7 +520,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:11 GMT
+      - Wed, 05 Jun 2024 14:38:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -540,20 +540,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ae010660b3d8496fb4e15d60cc43847c
+      - 20f5ea401db747c6a1b513d30539b217
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:11 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/publications/python/pypi/018f62df-46aa-7168-b3b1-2459fef96b58/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/python/pypi/018fe8d6-9428-73db-b110-b648acfec5de/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -574,7 +574,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:11 GMT
+      - Wed, 05 Jun 2024 14:38:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -594,36 +594,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a4c589b353e5427f8dde0dca91fa2ca1
+      - 0a72e86d824e4fc3833efacd89ab2c09
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3B5dGhv
-        bi9weXBpLzAxOGY2MmRmLTQ2YWEtNzE2OC1iM2IxLTI0NTlmZWY5NmI1OC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjEwLjg5MjM0NFoi
-        LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTAuOTMw
-        NzM0WiIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmNjJkZi00NTRjLTdkZjQtOWVj
-        ZC1mOTNiZmRkYzliNTEvdmVyc2lvbnMvMC8iLCJyZXBvc2l0b3J5IjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9weXRob24vcHl0aG9uLzAxOGY2MmRm
-        LTQ1NGMtN2RmNC05ZWNkLWY5M2JmZGRjOWI1MS8iLCJkaXN0cmlidXRpb25z
+        bi9weXBpLzAxOGZlOGQ2LTk0MjgtNzNkYi1iMTEwLWI2NDhhY2ZlYzVkZS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjQ3Ljg1MDA1MVoi
+        LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NDcuODk3
+        NDAxWiIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmZThkNi05MmI1LTdkZjUtYjBj
+        Ni04ZmZmMzkxZTBhYWQvdmVyc2lvbnMvMC8iLCJyZXBvc2l0b3J5IjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9weXRob24vcHl0aG9uLzAxOGZlOGQ2
+        LTkyYjUtN2RmNS1iMGM2LThmZmYzOTFlMGFhZC8iLCJkaXN0cmlidXRpb25z
         IjpbXX0=
-  recorded_at: Fri, 10 May 2024 14:19:11 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:48 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/
     body:
       encoding: UTF-8
       base64_string: |
         eyJiYXNlX3BhdGgiOiJpbnRlZ3JhdGlvbl90ZXN0cy9weXRob24iLCJjb250
         ZW50X2d1YXJkIjpudWxsLCJuYW1lIjoiMl9kdXBsaWNhdGUtdGVzdC1weXRo
         b24iLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
-        cHl0aG9uL3B5cGkvMDE4ZjYyZGYtNDZhYS03MTY4LWIzYjEtMjQ1OWZlZjk2
-        YjU4LyIsImFsbG93X3VwbG9hZHMiOnRydWV9
+        cHl0aG9uL3B5cGkvMDE4ZmU4ZDYtOTQyOC03M2RiLWIxMTAtYjY0OGFjZmVj
+        NWRlLyIsImFsbG93X3VwbG9hZHMiOnRydWV9
     headers:
       Content-Type:
       - application/json
@@ -641,7 +641,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:11 GMT
+      - Wed, 05 Jun 2024 14:38:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -661,20 +661,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f5c293244ed74be888a890af0b79a5ca
+      - ec256703e86c462fa0997eb92ed6563f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTQ3YjQtN2Vk
-        NC1iMWEyLTI3OTYyNDQ1MmUzNC8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:11 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LTk1NDgtN2E5
+        MC1hOThkLTFlMzA3YTg5ODkzZC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-47b4-7ed4-b1a2-279624452e34/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-9548-7a90-a98d-1e307a89893d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -682,7 +682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -695,7 +695,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:11 GMT
+      - Wed, 05 Jun 2024 14:38:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -715,37 +715,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3f3117927aa34651af9c0214960c35c8
+      - 436cb4e7d6f443d3b5bad79242991dca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNDdi
-        NC03ZWQ0LWIxYTItMjc5NjI0NDUyZTM0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MTEuMTU2NzI5WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOToxMS4xNTY3NDFaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtOTU0
+        OC03YTkwLWE5OGQtMWUzMDdhODk4OTNkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NDguMTM3MzkyWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo0OC4xMzc0MDRaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6ImY1YzI5MzI0NGVkNzRiZTg4OGE4
-        OTBhZjBiNzlhNWNhIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTEuMTY3
-        NjEwWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjExLjIyMjEx
-        MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTEuNDA0NjE4
+        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6ImVjMjU2NzAzZTg2YzQ2MmZhMDk5
+        N2ViOTJlZDY1NjNmIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NDguMTUw
+        MzEyWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjQ4LjE4NDY5
+        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NDguMzkzMjc2
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNWU4ZC01Zjc4LTc0NDAtYTAyZC1lODg3MzI0MjA5YmEvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3B5dGhvbi9weXBpLzAx
-        OGY2MmRmLTQ4YTAtNzJhNC1hOTJkLTEzYTFhYzViYmQ4Zi8iXSwicmVzZXJ2
+        OGZlOGQ2LTk2M2EtNzg4Mi04ZWU4LWIzMzQ2YjBhM2UwZi8iXSwicmVzZXJ2
         ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
-        Iiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGY1ZThjLTRlZDQt
-        Nzc0YS04NDczLTU3Y2MwNDhkNmM0MC8iXX0=
-  recorded_at: Fri, 10 May 2024 14:19:11 GMT
+        Iiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGZlM2M5LTcwYWEt
+        Nzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/018f62df-48a0-72a4-a92d-13a1ac5bbd8f/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/018fe8d6-963a-7882-8ee8-b3346b0a3e0f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -766,7 +766,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:11 GMT
+      - Wed, 05 Jun 2024 14:38:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -778,7 +778,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '550'
+      - '553'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -786,31 +786,31 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 68407cf6b0804d02b3e1311fa090c25b
+      - 85636333d8cb44a5a3cd33406c905a40
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9weXRo
-        b24vcHlwaS8wMThmNjJkZi00OGEwLTcyYTQtYTkyZC0xM2ExYWM1YmJkOGYv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOToxMS4zOTMwOTha
-        IiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjExLjM5
-        MzExMloiLCJiYXNlX3BhdGgiOiJpbnRlZ3JhdGlvbl90ZXN0cy9weXRob24i
-        LCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9zOC1rYXRlbGxvLWRldmVsLXN0
-        YWJsZS5leGFtcGxlLmNvbS9weXBpL2ludGVncmF0aW9uX3Rlc3RzL3B5dGhv
-        bi8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJoaWRkZW4iOmZhbHNlLCJwdWxw
-        X2xhYmVscyI6e30sIm5hbWUiOiIyX2R1cGxpY2F0ZS10ZXN0LXB5dGhvbiIs
-        InJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3Yz
-        L3B1YmxpY2F0aW9ucy9weXRob24vcHlwaS8wMThmNjJkZi00NmFhLTcxNjgt
-        YjNiMS0yNDU5ZmVmOTZiNTgvIiwiYWxsb3dfdXBsb2FkcyI6dHJ1ZSwicmVt
-        b3RlIjpudWxsfQ==
-  recorded_at: Fri, 10 May 2024 14:19:11 GMT
+        b24vcHlwaS8wMThmZThkNi05NjNhLTc4ODItOGVlOC1iMzM0NmIwYTNlMGYv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wNVQxNDozODo0OC4zODAxMDNa
+        IiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjQ4LjM4
+        MDEyMFoiLCJiYXNlX3BhdGgiOiJpbnRlZ3JhdGlvbl90ZXN0cy9weXRob24i
+        LCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9zOS1rYXRlbGxvLWRldmVsLm1h
+        bmljb3R0by5leGFtcGxlLmNvbS9weXBpL2ludGVncmF0aW9uX3Rlc3RzL3B5
+        dGhvbi8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJoaWRkZW4iOmZhbHNlLCJw
+        dWxwX2xhYmVscyI6e30sIm5hbWUiOiIyX2R1cGxpY2F0ZS10ZXN0LXB5dGhv
+        biIsInJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBp
+        L3YzL3B1YmxpY2F0aW9ucy9weXRob24vcHlwaS8wMThmZThkNi05NDI4LTcz
+        ZGItYjExMC1iNjQ4YWNmZWM1ZGUvIiwiYWxsb3dfdXBsb2FkcyI6dHJ1ZSwi
+        cmVtb3RlIjpudWxsfQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:48 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/python/python/018f62df-44da-7ade-b40f-0278896d4b37/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/python/python/018fe8d6-9221-7e9e-a430-7c78773e5037/
     body:
       encoding: UTF-8
       base64_string: |
@@ -840,7 +840,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:11 GMT
+      - Wed, 05 Jun 2024 14:38:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -860,20 +860,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 76725d89fc6242a48de3b019a22e43d8
+      - d9eb4902e6324b0ab8ce39086f823f40
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTRhOGQtNzc5
-        OS05YTg5LTBlNjI2ZmVlMDJlYy8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:11 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LTk4NzAtN2M5
+        ZC1hZDYwLTg5NmVlMDkxNmZiOC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:48 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-4a8d-7799-9a89-0e626fee02ec/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-9870-7c9d-ad60-896ee0916fb8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -881,7 +881,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -894,7 +894,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:11 GMT
+      - Wed, 05 Jun 2024 14:38:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -914,40 +914,40 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e70cdbc6d5384033b795914f3f747316
+      - 89a9826c489d4700be680ecc5d042324
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNGE4
-        ZC03Nzk5LTlhODktMGU2MjZmZWUwMmVjLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MTEuODg1Mzg1WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOToxMS44ODUzOTZaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtOTg3
+        MC03YzlkLWFkNjAtODk2ZWUwOTE2ZmI4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NDguOTQ0OTUwWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo0OC45NDQ5ODNaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6Ijc2NzI1ZDg5ZmM2MjQyYTQ4ZGUz
-        YjAxOWEyMmU0M2Q4IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTEuODk1
-        NjIzWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjExLjg5ODMw
-        MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTEuOTA3OTg0
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6ImQ5ZWI0OTAyZTYzMjRiMGFiOGNl
+        MzkwODZmODIzZjQwIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NDguOTU2
+        MzkzWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjQ4Ljk1ODcy
+        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NDguOTY4Njc1
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90ZXMv
-        cHl0aG9uL3B5dGhvbi8wMThmNjJkZi00NGRhLTdhZGUtYjQwZi0wMjc4ODk2
-        ZDRiMzcvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGY1ZThj
-        LTRlZDQtNzc0YS04NDczLTU3Y2MwNDhkNmM0MC8iXX0=
-  recorded_at: Fri, 10 May 2024 14:19:11 GMT
+        cHl0aG9uL3B5dGhvbi8wMThmZThkNi05MjIxLTdlOWUtYTQzMC03Yzc4Nzcz
+        ZTUwMzcvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGZlM2M5
+        LTcwYWEtNzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:49 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/018f62df-454c-7df4-9ecd-f93bfddc9b51/sync/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/018fe8d6-92b5-7df5-b0c6-8fff391e0aad/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9weXRob24vcHl0aG9u
-        LzAxOGY2MmRmLTQ0ZGEtN2FkZS1iNDBmLTAyNzg4OTZkNGIzNy8iLCJtaXJy
+        LzAxOGZlOGQ2LTkyMjEtN2U5ZS1hNDMwLTdjNzg3NzNlNTAzNy8iLCJtaXJy
         b3IiOnRydWV9
     headers:
       Content-Type:
@@ -966,7 +966,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:12 GMT
+      - Wed, 05 Jun 2024 14:38:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -986,20 +986,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7415c562f7204019a732e22433a6e29d
+      - bcc9d2a657e94989936ce92e5840bc4e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTRiNDEtNzEy
-        My05MzUyLWU1YjMzNWQ3YmEzZi8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:12 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LTk5MjEtNzM0
+        MC1iYzBhLTg3YzAxMDE1ZTdhYy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:49 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-4b41-7123-9352-e5b335d7ba3f/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-9921-7340-bc0a-87c01015e7ac/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1007,7 +1007,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1020,7 +1020,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:13 GMT
+      - Wed, 05 Jun 2024 14:38:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1040,26 +1040,26 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3b2e72133fb14b54bc690572c0028f55
+      - ed59c9bddd9c4a818a0ed43188f124f9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNGI0
-        MS03MTIzLTkzNTItZTViMzM1ZDdiYTNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MTIuMDY1MzkwWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOToxMi4wNjU0MDJaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtOTky
+        MS03MzQwLWJjMGEtODdjMDEwMTVlN2FjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NDkuMTIyMTc3WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo0OS4xMjIxOTFaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscF9weXRob24uYXBwLnRhc2tzLnN5bmMuc3lu
-        YyIsImxvZ2dpbmdfY2lkIjoiNzQxNWM1NjJmNzIwNDAxOWE3MzJlMjI0MzNh
-        NmUyOWQiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJzLzEvIiwi
-        dW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0xMFQxNDoxOToxMi4wNzc5MDVaIiwi
-        c3RhcnRlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTIuMTQ5MjQ4WiIsImZp
-        bmlzaGVkX2F0IjoiMjAyNC0wNS0xMFQxNDoxOToxMy4wNTM4NDVaIiwiZXJy
-        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAxOGY1
-        ZThkLTVlODEtN2RlMy05Y2JmLTdkYzljOWMxM2EyNy8iLCJwYXJlbnRfdGFz
+        YyIsImxvZ2dpbmdfY2lkIjoiYmNjOWQyYTY1N2U5NDk4OTkzNmNlOTJlNTg0
+        MGJjNGUiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJzLzEvIiwi
+        dW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozODo0OS4xMzQ3OTJaIiwi
+        c3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NDkuMTY5MTc3WiIsImZp
+        bmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozODo1MC4wMDk0ODNaIiwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzAxOGZl
+        M2NiLTBkZjItN2M4My1hN2VhLWUyNmExYTI4ZDdmOS8iLCJwYXJlbnRfdGFz
         ayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJw
         cm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRmV0Y2hpbmcgUHJvamVj
         dCBNZXRhZGF0YSIsImNvZGUiOiJzeW5jLmZldGNoaW5nLnByb2plY3QiLCJz
@@ -1073,24 +1073,24 @@ http_interactions:
         ZSI6IkFzc29jaWF0aW5nIENvbnRlbnQiLCJjb2RlIjoiYXNzb2NpYXRpbmcu
         Y29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRv
         bmUiOjksInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vMDE4ZjYy
-        ZGYtNDU0Yy03ZGY0LTllY2QtZjkzYmZkZGM5YjUxL3ZlcnNpb25zLzEvIl0s
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vMDE4ZmU4
+        ZDYtOTJiNS03ZGY1LWIwYzYtOGZmZjM5MWUwYWFkL3ZlcnNpb25zLzEvIl0s
         InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9weXRob24vcHl0aG9uLzAxOGY2MmRmLTQ1NGMtN2RmNC05
-        ZWNkLWY5M2JmZGRjOWI1MS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlbW90
-        ZXMvcHl0aG9uL3B5dGhvbi8wMThmNjJkZi00NGRhLTdhZGUtYjQwZi0wMjc4
-        ODk2ZDRiMzcvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGY1
-        ZThjLTRlZDQtNzc0YS04NDczLTU3Y2MwNDhkNmM0MC8iXX0=
-  recorded_at: Fri, 10 May 2024 14:19:13 GMT
+        cG9zaXRvcmllcy9weXRob24vcHl0aG9uLzAxOGZlOGQ2LTkyYjUtN2RmNS1i
+        MGM2LThmZmYzOTFlMGFhZC8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlbW90
+        ZXMvcHl0aG9uL3B5dGhvbi8wMThmZThkNi05MjIxLTdlOWUtYTQzMC03Yzc4
+        NzczZTUwMzcvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGZl
+        M2M5LTcwYWEtNzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:50 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/publications/python/pypi/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/python/pypi/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3B5dGhvbi9weXRob24vMDE4ZjYyZGYtNDU0Yy03ZGY0LTllY2QtZjkz
-        YmZkZGM5YjUxL3ZlcnNpb25zLzEvIn0=
+        aWVzL3B5dGhvbi9weXRob24vMDE4ZmU4ZDYtOTJiNS03ZGY1LWIwYzYtOGZm
+        ZjM5MWUwYWFkL3ZlcnNpb25zLzEvIn0=
     headers:
       Content-Type:
       - application/json
@@ -1108,7 +1108,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:13 GMT
+      - Wed, 05 Jun 2024 14:38:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1128,20 +1128,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - de7d94bf58bd4c39b89621a4b88ed52e
+      - d393cdf378d24bb69d16aa292fe50b14
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTRmYzUtN2Ez
-        Ny04ZTZkLTliNzgzNTM2MTMxNy8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:13 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LTlkNGUtNzFh
+        ZC1hM2MyLWQ2MjE0ZDgzM2U5MS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-4fc5-7a37-8e6d-9b7835361317/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-9d4e-71ad-a3c2-d6214d833e91/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1149,7 +1149,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1162,7 +1162,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:13 GMT
+      - Wed, 05 Jun 2024 14:38:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1182,38 +1182,38 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fa4d6bdc87164822bc2de5fc5c15468b
+      - 8cab4583bf92437f9fb97d49eb4638ed
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNGZj
-        NS03YTM3LThlNmQtOWI3ODM1MzYxMzE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MTMuMjIxNTAxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOToxMy4yMjE1MTJaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtOWQ0
+        ZS03MWFkLWEzYzItZDYyMTRkODMzZTkxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NTAuMTkwNDc1WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo1MC4xOTA0ODdaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscF9weXRob24uYXBwLnRhc2tzLnB1Ymxpc2gu
-        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiZGU3ZDk0YmY1OGJkNGMzOWI4OTYy
-        MWE0Yjg4ZWQ1MmUiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
-        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0xMFQxNDoxOToxMy4yMzMy
-        MTNaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTMuMjgxMDc5
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0xMFQxNDoxOToxMy4zNjk1MTVa
+        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiZDM5M2NkZjM3OGQyNGJiNjlkMTZh
+        YTI5MmZlNTBiMTQiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
+        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozODo1MC4yMDAx
+        MDZaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTAuMjMxODA2
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozODo1MC4zMTk3ODha
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzAxOGY1ZThkLTVlYzQtN2YyNi05YWQ2LTY1ZTUxYzA2NjBlNy8iLCJwYXJl
+        LzAxOGZlM2NiLTBkZjItN2M4My1hN2VhLWUyNmExYTI4ZDdmOS8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9weXRob24vcHlwaS8wMThm
-        NjJkZi01MDBmLTc5NmYtODQyYy04OWI4NjJlNjE4MjMvIl0sInJlc2VydmVk
+        ZThkNi05ZDgyLTc3NzEtYTk5Yy1mMjM2MjUwY2I2OWUvIl0sInJlc2VydmVk
         X3Jlc291cmNlc19yZWNvcmQiOlsic2hhcmVkOi9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmNjJkZi00NTRjLTdkZjQtOWVj
-        ZC1mOTNiZmRkYzliNTEvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5z
-        LzAxOGY1ZThjLTRlZDQtNzc0YS04NDczLTU3Y2MwNDhkNmM0MC8iXX0=
-  recorded_at: Fri, 10 May 2024 14:19:13 GMT
+        c2l0b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmZThkNi05MmI1LTdkZjUtYjBj
+        Ni04ZmZmMzkxZTBhYWQvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5z
+        LzAxOGZlM2M5LTcwYWEtNzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?base_path=integration_tests/python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/?base_path=integration_tests/python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1234,7 +1234,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:13 GMT
+      - Wed, 05 Jun 2024 14:38:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1246,7 +1246,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '602'
+      - '605'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1254,32 +1254,32 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5a4e4683ef384776995ab76e82986072
+      - 5113a5ced6d7454a85281b0db4e4469c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3B5dGhvbi9weXBpLzAxOGY2MmRmLTQ4YTAtNzJhNC1hOTJkLTEzYTFhYzVi
-        YmQ4Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjExLjM5
-        MzA5OFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6
-        MTEuMzkzMTEyWiIsImJhc2VfcGF0aCI6ImludGVncmF0aW9uX3Rlc3RzL3B5
-        dGhvbiIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M4LWthdGVsbG8tZGV2
-        ZWwtc3RhYmxlLmV4YW1wbGUuY29tL3B5cGkvaW50ZWdyYXRpb25fdGVzdHMv
-        cHl0aG9uLyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsImhpZGRlbiI6ZmFsc2Us
-        InB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGljYXRlLXRlc3QtcHl0
-        aG9uIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9h
-        cGkvdjMvcHVibGljYXRpb25zL3B5dGhvbi9weXBpLzAxOGY2MmRmLTQ2YWEt
-        NzE2OC1iM2IxLTI0NTlmZWY5NmI1OC8iLCJhbGxvd191cGxvYWRzIjp0cnVl
-        LCJyZW1vdGUiOm51bGx9XX0=
-  recorded_at: Fri, 10 May 2024 14:19:13 GMT
+        L3B5dGhvbi9weXBpLzAxOGZlOGQ2LTk2M2EtNzg4Mi04ZWU4LWIzMzQ2YjBh
+        M2UwZi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjQ4LjM4
+        MDEwM1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6
+        NDguMzgwMTIwWiIsImJhc2VfcGF0aCI6ImludGVncmF0aW9uX3Rlc3RzL3B5
+        dGhvbiIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2
+        ZWwubWFuaWNvdHRvLmV4YW1wbGUuY29tL3B5cGkvaW50ZWdyYXRpb25fdGVz
+        dHMvcHl0aG9uLyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsImhpZGRlbiI6ZmFs
+        c2UsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGljYXRlLXRlc3Qt
+        cHl0aG9uIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVs
+        cC9hcGkvdjMvcHVibGljYXRpb25zL3B5dGhvbi9weXBpLzAxOGZlOGQ2LTk0
+        MjgtNzNkYi1iMTEwLWI2NDhhY2ZlYzVkZS8iLCJhbGxvd191cGxvYWRzIjp0
+        cnVlLCJyZW1vdGUiOm51bGx9XX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/publications/python/pypi/018f62df-500f-796f-842c-89b862e61823/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/python/pypi/018fe8d6-9d82-7771-a99c-f236250cb69e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1300,7 +1300,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:13 GMT
+      - Wed, 05 Jun 2024 14:38:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1320,35 +1320,35 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ad40ae06085d49769fa8e42f289e07aa
+      - 3fcae203c4b74f42b5b8bea88c8d11be
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3B5dGhv
-        bi9weXBpLzAxOGY2MmRmLTUwMGYtNzk2Zi04NDJjLTg5Yjg2MmU2MTgyMy8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjEzLjI5Njk4Nloi
-        LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTMuMzU3
-        NjMyWiIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmNjJkZi00NTRjLTdkZjQtOWVj
-        ZC1mOTNiZmRkYzliNTEvdmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9weXRob24vcHl0aG9uLzAxOGY2MmRm
-        LTQ1NGMtN2RmNC05ZWNkLWY5M2JmZGRjOWI1MS8iLCJkaXN0cmlidXRpb25z
+        bi9weXBpLzAxOGZlOGQ2LTlkODItNzc3MS1hOTljLWYyMzYyNTBjYjY5ZS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjUwLjI0NDA0MVoi
+        LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTAuMzEx
+        MjgyWiIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmZThkNi05MmI1LTdkZjUtYjBj
+        Ni04ZmZmMzkxZTBhYWQvdmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9weXRob24vcHl0aG9uLzAxOGZlOGQ2
+        LTkyYjUtN2RmNS1iMGM2LThmZmYzOTFlMGFhZC8iLCJkaXN0cmlidXRpb25z
         IjpbXX0=
-  recorded_at: Fri, 10 May 2024 14:19:13 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:50 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/018f62df-48a0-72a4-a92d-13a1ac5bbd8f/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/018fe8d6-963a-7882-8ee8-b3346b0a3e0f/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJpbnRlZ3JhdGlv
         bl90ZXN0cy9weXRob24iLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9w
-        dWJsaWNhdGlvbnMvcHl0aG9uL3B5cGkvMDE4ZjYyZGYtNTAwZi03OTZmLTg0
-        MmMtODliODYyZTYxODIzLyJ9
+        dWJsaWNhdGlvbnMvcHl0aG9uL3B5cGkvMDE4ZmU4ZDYtOWQ4Mi03NzcxLWE5
+        OWMtZjIzNjI1MGNiNjllLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1366,7 +1366,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:13 GMT
+      - Wed, 05 Jun 2024 14:38:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1386,20 +1386,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 71eafd3e53324fac8d38841d956cff00
+      - 59d25e9eabeb4607b1e992d41a1736c5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTUxMzUtN2Q2
-        ZS1iMGY5LTMwZTc4MjkzNWEzZC8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:13 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LTllYjMtNzBm
+        Yy1hYWIyLTcxZWQ0ZDYxNzYyMS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-5135-7d6e-b0f9-30e782935a3d/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-9eb3-70fc-aab2-71ed4d617621/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1407,7 +1407,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1420,7 +1420,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:13 GMT
+      - Wed, 05 Jun 2024 14:38:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1440,34 +1440,34 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f3430b8ea9b0476d873359aef67b5f9b
+      - aa50cedcfff44a688ef639c06a70789f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNTEz
-        NS03ZDZlLWIwZjktMzBlNzgyOTM1YTNkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MTMuNTkwMTM5WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOToxMy41OTAxNTBaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtOWVi
+        My03MGZjLWFhYjItNzFlZDRkNjE3NjIxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NTAuNTQ4MzY0WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo1MC41NDgzNzVaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjcxZWFmZDNlNTMzMjRmYWM4ZDM4
-        ODQxZDk1NmNmZjAwIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTMuNTk5
-        NDMxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjEzLjYwMjk3
-        NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTMuNjE2Mjc3
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjU5ZDI1ZTllYWJlYjQ2MDdiMWU5
+        OTJkNDFhMTczNmM1IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTAuNTU3
+        NjU3WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjUwLjU2MDk0
+        NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTAuNTc0MzA4
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25z
-        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNWU4Yy00ZWQ0
-        LTc3NGEtODQ3My01N2NjMDQ4ZDZjNDAvIl19
-  recorded_at: Fri, 10 May 2024 14:19:13 GMT
+        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFh
+        LTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:38:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/publications/python/pypi/018f62df-500f-796f-842c-89b862e61823/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/python/pypi/018fe8d6-9d82-7771-a99c-f236250cb69e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1488,7 +1488,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:13 GMT
+      - Wed, 05 Jun 2024 14:38:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1508,36 +1508,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a9470c01d4d642b28ab96c970affa24f
+      - 6eb68e0dada849079ae4a0591ede4f3d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3B5dGhv
-        bi9weXBpLzAxOGY2MmRmLTUwMGYtNzk2Zi04NDJjLTg5Yjg2MmU2MTgyMy8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjEzLjI5Njk4Nloi
-        LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTMuMzU3
-        NjMyWiIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmNjJkZi00NTRjLTdkZjQtOWVj
-        ZC1mOTNiZmRkYzliNTEvdmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9weXRob24vcHl0aG9uLzAxOGY2MmRm
-        LTQ1NGMtN2RmNC05ZWNkLWY5M2JmZGRjOWI1MS8iLCJkaXN0cmlidXRpb25z
+        bi9weXBpLzAxOGZlOGQ2LTlkODItNzc3MS1hOTljLWYyMzYyNTBjYjY5ZS8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjUwLjI0NDA0MVoi
+        LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTAuMzEx
+        MjgyWiIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmZThkNi05MmI1LTdkZjUtYjBj
+        Ni04ZmZmMzkxZTBhYWQvdmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9weXRob24vcHl0aG9uLzAxOGZlOGQ2
+        LTkyYjUtN2RmNS1iMGM2LThmZmYzOTFlMGFhZC8iLCJkaXN0cmlidXRpb25z
         IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3B5dGhvbi9weXBpLzAx
-        OGY2MmRmLTQ4YTAtNzJhNC1hOTJkLTEzYTFhYzViYmQ4Zi8iXX0=
-  recorded_at: Fri, 10 May 2024 14:19:13 GMT
+        OGZlOGQ2LTk2M2EtNzg4Mi04ZWU4LWIzMzQ2YjBhM2UwZi8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:50 GMT
 - request:
     method: patch
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/018f62df-48a0-72a4-a92d-13a1ac5bbd8f/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/018fe8d6-963a-7882-8ee8-b3346b0a3e0f/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJpbnRlZ3JhdGlv
         bl90ZXN0cy9weXRob24iLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9w
-        dWJsaWNhdGlvbnMvcHl0aG9uL3B5cGkvMDE4ZjYyZGYtNTAwZi03OTZmLTg0
-        MmMtODliODYyZTYxODIzLyJ9
+        dWJsaWNhdGlvbnMvcHl0aG9uL3B5cGkvMDE4ZmU4ZDYtOWQ4Mi03NzcxLWE5
+        OWMtZjIzNjI1MGNiNjllLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1555,7 +1555,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:13 GMT
+      - Wed, 05 Jun 2024 14:38:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1575,20 +1575,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 910929e34e84466090f06664f0af0d0f
+      - d04310a73fc4422e8e935563639495d1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTUyMDYtN2Ix
-        YS05OTlhLTBjMTk4ZDIzMGJmZi8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:13 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LTlmOGMtN2E4
+        OC1hY2JjLWQ3MzVlNWU2MjAwMC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/content/python/packages/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/python/python/018f62df-454c-7df4-9ecd-f93bfddc9b51/versions/1/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/python/packages/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/python/python/018fe8d6-92b5-7df5-b0c6-8fff391e0aad/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1609,7 +1609,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:13 GMT
+      - Wed, 05 Jun 2024 14:38:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1629,20 +1629,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ecc009fef3744d96bd53a3ac42766edd
+      - 224eb6a03110429b86705b38c2f5bbca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6OSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3B5dGhv
-        bi9wYWNrYWdlcy8wMThmNjJkZi00ZTJmLTdmNzctOTRkZC1mYzQ2NTcxYzBj
-        YmQvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOToxMi45Njg3
-        ODRaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjEy
-        Ljk2ODc5NFoiLCJhcnRpZmFjdCI6bnVsbCwiZmlsZW5hbWUiOiJjZWxlcnkt
+        bi9wYWNrYWdlcy8wMThmZThkNi05YmFmLTc5MzAtYmRkNi0zNTUyZDdmNjQ1
+        ZjQvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wNVQxNDozODo0OS45Mjc3
+        ODNaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjQ5
+        LjkyNzc5MloiLCJhcnRpZmFjdCI6bnVsbCwiZmlsZW5hbWUiOiJjZWxlcnkt
         NC4wLjAtcHkyLnB5My1ub25lLWFueS53aGwiLCJwYWNrYWdldHlwZSI6ImJk
         aXN0X3doZWVsIiwibmFtZSI6ImNlbGVyeSIsInZlcnNpb24iOiI0LjAuMCIs
         InNoYTI1NiI6ImVkZTNjNzViMjA1NTYwMDAwNDAzYThlNWYwYzczZjIwMTc3
@@ -2018,10 +2018,10 @@ http_interactions:
         b3BpYyA6OiBTb2Z0d2FyZSBEZXZlbG9wbWVudCA6OiBPYmplY3QgQnJva2Vy
         aW5nXCIsIFwiVG9waWMgOjogU3lzdGVtIDo6IERpc3RyaWJ1dGVkIENvbXB1
         dGluZ1wiXSJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
-        cHl0aG9uL3BhY2thZ2VzLzAxOGY2MmRmLTRlMjctN2NjZS05NGZkLTkxYTNm
-        Mzg2YzM4ZC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjEy
-        Ljk2NjYwN1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMTBUMTQ6
-        MTk6MTIuOTY2NjE2WiIsImFydGlmYWN0IjpudWxsLCJmaWxlbmFtZSI6ImNl
+        cHl0aG9uL3BhY2thZ2VzLzAxOGZlOGQ2LTliYTctNzdlMi1iNDA0LWFhNWU4
+        MmZhMzJjMi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjQ5
+        LjkyNTM4MFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6
+        Mzg6NDkuOTI1Mzk1WiIsImFydGlmYWN0IjpudWxsLCJmaWxlbmFtZSI6ImNl
         bGVyeS0yLjQuMS50YXIuZ3oiLCJwYWNrYWdldHlwZSI6InNkaXN0IiwibmFt
         ZSI6ImNlbGVyeSIsInZlcnNpb24iOiIyLjQuMSIsInNoYTI1NiI6ImM3NzY1
         MmNhMTc5ZDE0NDczOTc1ODIyZGJmYjFiNWRhYjk1MGM4OGMxNzFlZjZiYzIy
@@ -2397,9 +2397,9 @@ http_interactions:
         ZSBEZXZlbG9wbWVudCA6OiBPYmplY3QgQnJva2VyaW5nXCIsIFwiVG9waWMg
         OjogU3lzdGVtIDo6IERpc3RyaWJ1dGVkIENvbXB1dGluZ1wiXSJ9LHsicHVs
         cF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcHl0aG9uL3BhY2thZ2Vz
-        LzAxOGY2MmRmLTRlMzMtN2Q0Mi04OWYwLWMwZjg5M2UxZjZlMS8iLCJwdWxw
-        X2NyZWF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjEyLjk2NDQ0NloiLCJwdWxw
-        X2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTIuOTY0NDU2WiIs
+        LzAxOGZlOGQ2LTliYjMtNzM3MC1hNDY5LWU2YzlmMDYxNWVmMi8iLCJwdWxw
+        X2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjQ5LjkyMjQ1M1oiLCJwdWxw
+        X2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NDkuOTIyNDY1WiIs
         ImFydGlmYWN0IjpudWxsLCJmaWxlbmFtZSI6ImNlbGVyeS00LjEuMC1weTIu
         cHkzLW5vbmUtYW55LndobCIsInBhY2thZ2V0eXBlIjoiYmRpc3Rfd2hlZWwi
         LCJuYW1lIjoiY2VsZXJ5IiwidmVyc2lvbiI6IjQuMS4wIiwic2hhMjU2Ijoi
@@ -2776,10 +2776,10 @@ http_interactions:
         ZnR3YXJlIERldmVsb3BtZW50IDo6IE9iamVjdCBCcm9rZXJpbmdcIiwgXCJU
         b3BpYyA6OiBTeXN0ZW0gOjogRGlzdHJpYnV0ZWQgQ29tcHV0aW5nXCJdIn0s
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9weXRob24vcGFj
-        a2FnZXMvMDE4ZjYyZGYtNGUyZC03NGZmLWE5NzQtMjA5MTQ3OTMwNDI5LyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTIuOTYyMjIyWiIs
-        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOToxMi45NjIy
-        MzNaIiwiYXJ0aWZhY3QiOm51bGwsImZpbGVuYW1lIjoiY2VsZXJ5LTMuMS45
+        a2FnZXMvMDE4ZmU4ZDYtOWJhZC03NmQ0LTk1YWUtY2M2NGQ1ZDc2MjM5LyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NDkuOTE5Njk5WiIs
+        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozODo0OS45MTk3
+        MTJaIiwiYXJ0aWZhY3QiOm51bGwsImZpbGVuYW1lIjoiY2VsZXJ5LTMuMS45
         LXB5Mjctbm9uZS1hbnkud2hsIiwicGFja2FnZXR5cGUiOiJiZGlzdF93aGVl
         bCIsIm5hbWUiOiJjZWxlcnkiLCJ2ZXJzaW9uIjoiMy4xLjkiLCJzaGEyNTYi
         OiI4MDRkYWZmMjQ3YzlhYTYzY2EzYWVhYjk1ZDQ5ZWI1YzFmMTc0NDE2NTJk
@@ -3155,10 +3155,10 @@ http_interactions:
         U29mdHdhcmUgRGV2ZWxvcG1lbnQgOjogT2JqZWN0IEJyb2tlcmluZ1wiLCBc
         IlRvcGljIDo6IFN5c3RlbSA6OiBEaXN0cmlidXRlZCBDb21wdXRpbmdcIl0i
         fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3B5dGhvbi9w
-        YWNrYWdlcy8wMThmNjJkZi00ZTM1LTczYjUtOGI3MC1iZjI0YzE3ZjQ2Zjgv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOToxMi45NTk3NzVa
-        IiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjEyLjk1
-        OTc4NVoiLCJhcnRpZmFjdCI6bnVsbCwiZmlsZW5hbWUiOiJjZWxlcnktNC4x
+        YWNrYWdlcy8wMThmZThkNi05YmI1LTdhMTEtOTY2ZS0xN2RhM2VhN2FlZDAv
+        IiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wNVQxNDozODo0OS45MTY0NzVa
+        IiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjQ5Ljkx
+        NjQ4N1oiLCJhcnRpZmFjdCI6bnVsbCwiZmlsZW5hbWUiOiJjZWxlcnktNC4x
         LjEtcHkyLnB5My1ub25lLWFueS53aGwiLCJwYWNrYWdldHlwZSI6ImJkaXN0
         X3doZWVsIiwibmFtZSI6ImNlbGVyeSIsInZlcnNpb24iOiI0LjEuMSIsInNo
         YTI1NiI6IjZmYzQ2NzhkMTY5MmFmOTdlMTM3YjJhOWYxYzA0ZWZkOGU3ZTJm
@@ -3534,10 +3534,10 @@ http_interactions:
         YyA6OiBTb2Z0d2FyZSBEZXZlbG9wbWVudCA6OiBPYmplY3QgQnJva2VyaW5n
         XCIsIFwiVG9waWMgOjogU3lzdGVtIDo6IERpc3RyaWJ1dGVkIENvbXB1dGlu
         Z1wiXSJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcHl0
-        aG9uL3BhY2thZ2VzLzAxOGY2MmRmLTRlMjktNzQ5My05YWFmLTM4NDUyNzJk
-        OGUwZi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjEyLjk1
-        NzU4MFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6
-        MTIuOTU3NTg5WiIsImFydGlmYWN0IjpudWxsLCJmaWxlbmFtZSI6ImNlbGVy
+        aG9uL3BhY2thZ2VzLzAxOGZlOGQ2LTliYTktNzE2NC1hZWI1LTU2OGIyMTE5
+        ZmU5OS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjQ5Ljkx
+        Mzc5MFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6
+        NDkuOTEzODAxWiIsImFydGlmYWN0IjpudWxsLCJmaWxlbmFtZSI6ImNlbGVy
         eS0zLjEuMTItcHkyLnB5My1ub25lLWFueS53aGwiLCJwYWNrYWdldHlwZSI6
         ImJkaXN0X3doZWVsIiwibmFtZSI6ImNlbGVyeSIsInZlcnNpb24iOiIzLjEu
         MTIiLCJzaGEyNTYiOiIyMTFlNmYzZTliOTQyOTgzMWViYWNjYTNiZTAzYzA5
@@ -3913,10 +3913,10 @@ http_interactions:
         IFwiVG9waWMgOjogU29mdHdhcmUgRGV2ZWxvcG1lbnQgOjogT2JqZWN0IEJy
         b2tlcmluZ1wiLCBcIlRvcGljIDo6IFN5c3RlbSA6OiBEaXN0cmlidXRlZCBD
         b21wdXRpbmdcIl0ifSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50L3B5dGhvbi9wYWNrYWdlcy8wMThmNjJkZi00ZTM3LTcyYjMtOWRkNC0z
-        MjVhMTQ0M2NiYTkvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNS0xMFQxNDox
-        OToxMi45NTUzNDNaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTEw
-        VDE0OjE5OjEyLjk1NTM1MloiLCJhcnRpZmFjdCI6bnVsbCwiZmlsZW5hbWUi
+        ZW50L3B5dGhvbi9wYWNrYWdlcy8wMThmZThkNi05YmI3LTdlMTgtYTBiOC0w
+        NTVmNzViOWEwYjUvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wNVQxNDoz
+        ODo0OS45MTA4NzNaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTA1
+        VDE0OjM4OjQ5LjkxMDg5MVoiLCJhcnRpZmFjdCI6bnVsbCwiZmlsZW5hbWUi
         OiJjZWxlcnktNC4yLjAtcHkyLnB5My1ub25lLWFueS53aGwiLCJwYWNrYWdl
         dHlwZSI6ImJkaXN0X3doZWVsIiwibmFtZSI6ImNlbGVyeSIsInZlcnNpb24i
         OiI0LjIuMCIsInNoYTI1NiI6IjIwODJjYmQ4MmVmZmE4YWM4YThhNTg5Nzdk
@@ -4293,10 +4293,10 @@ http_interactions:
         LCBcIlRvcGljIDo6IFNvZnR3YXJlIERldmVsb3BtZW50IDo6IE9iamVjdCBC
         cm9rZXJpbmdcIiwgXCJUb3BpYyA6OiBTeXN0ZW0gOjogRGlzdHJpYnV0ZWQg
         Q29tcHV0aW5nXCJdIn0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9weXRob24vcGFja2FnZXMvMDE4ZjYyZGYtNGUyYi03ZTQxLTllMDkt
-        YWVlYmE4MDBjMmE3LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMTBUMTQ6
-        MTk6MTIuOTUzMTQ0WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0x
-        MFQxNDoxOToxMi45NTMxNTRaIiwiYXJ0aWZhY3QiOm51bGwsImZpbGVuYW1l
+        dGVudC9weXRob24vcGFja2FnZXMvMDE4ZmU4ZDYtOWJhYi03OWI0LWFiZDUt
+        OWYyMDU4NjM3MzY4LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6
+        Mzg6NDkuOTA2NjkwWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0w
+        NVQxNDozODo0OS45MDY3MDRaIiwiYXJ0aWZhY3QiOm51bGwsImZpbGVuYW1l
         IjoiY2VsZXJ5LTMuMS4yNS1weTIucHkzLW5vbmUtYW55LndobCIsInBhY2th
         Z2V0eXBlIjoiYmRpc3Rfd2hlZWwiLCJuYW1lIjoiY2VsZXJ5IiwidmVyc2lv
         biI6IjMuMS4yNSIsInNoYTI1NiI6IjE5NTRhMjI0ODA1ZjM4MzVlNWI2ZjU5
@@ -4672,10 +4672,10 @@ http_interactions:
         IFB5UHlcIiwgXCJUb3BpYyA6OiBTb2Z0d2FyZSBEZXZlbG9wbWVudCA6OiBP
         YmplY3QgQnJva2VyaW5nXCIsIFwiVG9waWMgOjogU3lzdGVtIDo6IERpc3Ry
         aWJ1dGVkIENvbXB1dGluZ1wiXSJ9LHsicHVscF9ocmVmIjoiL3B1bHAvYXBp
-        L3YzL2NvbnRlbnQvcHl0aG9uL3BhY2thZ2VzLzAxOGY2MmRmLTRlMzEtNzEx
-        YS1hYTUzLWEwOTFhZThhMThjOC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA1
-        LTEwVDE0OjE5OjEyLjk0OTk2MFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MTIuOTQ5OTc0WiIsImFydGlmYWN0IjpudWxsLCJm
+        L3YzL2NvbnRlbnQvcHl0aG9uL3BhY2thZ2VzLzAxOGZlOGQ2LTliYjEtNzQ2
+        Ny1hYTUzLTRhM2Y2YjY4Y2Q1Ni8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2
+        LTA1VDE0OjM4OjQ5LjkwMTQ3NVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NDkuOTAxNDg5WiIsImFydGlmYWN0IjpudWxsLCJm
         aWxlbmFtZSI6ImNlbGVyeS00LjAuMi1weTIucHkzLW5vbmUtYW55LndobCIs
         InBhY2thZ2V0eXBlIjoiYmRpc3Rfd2hlZWwiLCJuYW1lIjoiY2VsZXJ5Iiwi
         dmVyc2lvbiI6IjQuMC4yIiwic2hhMjU2IjoiMGU1YjdlMGQ3ZjAzYWEwMjA2
@@ -5051,10 +5051,10 @@ http_interactions:
         b24gOjogUHlQeVwiLCBcIlRvcGljIDo6IFNvZnR3YXJlIERldmVsb3BtZW50
         IDo6IE9iamVjdCBCcm9rZXJpbmdcIiwgXCJUb3BpYyA6OiBTeXN0ZW0gOjog
         RGlzdHJpYnV0ZWQgQ29tcHV0aW5nXCJdIn1dfQ==
-  recorded_at: Fri, 10 May 2024 14:19:13 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:50 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?name=2_duplicate-test-python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?name=2_duplicate-test-python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5075,7 +5075,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:14 GMT
+      - Wed, 05 Jun 2024 14:38:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -5095,32 +5095,32 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f2d756b05e414fbd981ff4a7b831b1bf
+      - d380e05f7d2a4895956c9daff39e6e63
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi8wMThmNjJkZi00NTRjLTdkZjQtOWVjZC1mOTNiZmRk
-        YzliNTEvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOToxMC41
-        NDEzMDFaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5
-        OjEzLjA0MTE2OVoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9weXRob24vcHl0aG9uLzAxOGY2MmRmLTQ1NGMtN2RmNC05
-        ZWNkLWY5M2JmZGRjOWI1MS92ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30s
+        cHl0aG9uL3B5dGhvbi8wMThmZThkNi05MmI1LTdkZjUtYjBjNi04ZmZmMzkx
+        ZTBhYWQvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wNVQxNDozODo0Ny40
+        Nzg2MzRaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4
+        OjQ5Ljk5NTczNloiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9weXRob24vcHl0aG9uLzAxOGZlOGQ2LTkyYjUtN2RmNS1i
+        MGM2LThmZmYzOTFlMGFhZC92ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30s
         ImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3B5dGhvbi9weXRob24vMDE4ZjYyZGYtNDU0Yy03ZGY0LTllY2QtZjkz
-        YmZkZGM5YjUxL3ZlcnNpb25zLzEvIiwibmFtZSI6IjJfZHVwbGljYXRlLXRl
+        aWVzL3B5dGhvbi9weXRob24vMDE4ZmU4ZDYtOTJiNS03ZGY1LWIwYzYtOGZm
+        ZjM5MWUwYWFkL3ZlcnNpb25zLzEvIiwibmFtZSI6IjJfZHVwbGljYXRlLXRl
         c3QtcHl0aG9uIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZX1dfQ==
-  recorded_at: Fri, 10 May 2024 14:19:14 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:51 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/018f62df-454c-7df4-9ecd-f93bfddc9b51/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/018fe8d6-92b5-7df5-b0c6-8fff391e0aad/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5141,7 +5141,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:14 GMT
+      - Wed, 05 Jun 2024 14:38:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -5161,20 +5161,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 88cd0da866684e1196be5c9b769e511e
+      - 23bf34143b124767ab8c6b1f338d1b35
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTUzZjgtNzdm
-        YS1hYTQzLTlmMmQ5NTdjODZhNS8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:14 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWExZGItN2I2
+        ZS04MWRiLWU5MTE0OTQ0ZGQ0Yy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/python/python/?name=2_duplicate-test-python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/python/python/?name=2_duplicate-test-python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5195,7 +5195,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:14 GMT
+      - Wed, 05 Jun 2024 14:38:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -5215,20 +5215,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8ca1cf0d0ce5415daac9b025c7f2c17f
+      - f88c0e9c3aa3466faf572c1f3b1c785d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3B5dGhv
-        bi9weXRob24vMDE4ZjYyZGYtNDRkYS03YWRlLWI0MGYtMDI3ODg5NmQ0YjM3
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTAuNDI2NTkx
-        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOToxMS45
-        MDQyNzVaIiwibmFtZSI6IjJfZHVwbGljYXRlLXRlc3QtcHl0aG9uIiwidXJs
+        bi9weXRob24vMDE4ZmU4ZDYtOTIyMS03ZTllLWE0MzAtN2M3ODc3M2U1MDM3
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NDcuMzI5ODc1
+        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozODo0OC45
+        NjUwNTFaIiwibmFtZSI6IjJfZHVwbGljYXRlLXRlc3QtcHl0aG9uIiwidXJs
         IjoiaHR0cHM6Ly9maXh0dXJlcy5wdWxwcHJvamVjdC5vcmcvcHl0aG9uLXB5
         cGkvIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192
         YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxz
@@ -5244,10 +5244,10 @@ http_interactions:
         bHNlfV0sImluY2x1ZGVzIjpbImNlbGVyeSJdLCJleGNsdWRlcyI6W10sInBy
         ZXJlbGVhc2VzIjpmYWxzZSwicGFja2FnZV90eXBlcyI6W10sImtlZXBfbGF0
         ZXN0X3BhY2thZ2VzIjowLCJleGNsdWRlX3BsYXRmb3JtcyI6W119XX0=
-  recorded_at: Fri, 10 May 2024 14:19:14 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:51 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/python/python/018f62df-44da-7ade-b40f-0278896d4b37/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/python/python/018fe8d6-9221-7e9e-a430-7c78773e5037/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5268,7 +5268,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:14 GMT
+      - Wed, 05 Jun 2024 14:38:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -5288,20 +5288,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c5d5699cf816447e95aeee4a33907ec4
+      - 4d562146898046c0b17604f2c0d3fdba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTU0NzgtNzg1
-        MS1hN2M1LTU3OTY5Y2Q5NjRjZC8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:14 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWEyNTUtNzVj
+        OS05ODkxLTFlNzVhOGQ1OWI4MC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-53f8-77fa-aa43-9f2d957c86a5/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-a1db-7b6e-81db-e9114944dd4c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5309,7 +5309,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -5322,7 +5322,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:14 GMT
+      - Wed, 05 Jun 2024 14:38:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -5342,37 +5342,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0dfd7d0e22dd44deb434fc2295b80498
+      - 4d7b002c30e24758a64e472731f952bc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNTNm
-        OC03N2ZhLWFhNDMtOWYyZDk1N2M4NmE1LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MTQuMjk2NDUxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOToxNC4yOTY0NjJaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYTFk
+        Yi03YjZlLTgxZGItZTkxMTQ5NDRkZDRjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NTEuMzU1NzM2WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo1MS4zNTU3NDhaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6Ijg4Y2QwZGE4NjY2ODRlMTE5NmJl
-        NWM5Yjc2OWU1MTFlIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTQuMzA3
-        OTEyWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjE0LjM2ODYx
-        NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTQuNTQ5ODMx
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjIzYmYzNDE0M2IxMjQ3NjdhYjhj
+        NmIxZjMzOGQxYjM1IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTEuMzY1
+        ODM2WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjUxLjM5NTEx
+        NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTEuNTMwNzg4
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNWU4ZC01NjNhLTc0N2MtOWRmZS1lMTU2NjFlYzYzOTcvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vMDE4ZjYyZGYtNDU0Yy03
-        ZGY0LTllY2QtZjkzYmZkZGM5YjUxLyIsInNoYXJlZDovcHVscC9hcGkvdjMv
-        ZG9tYWlucy8wMThmNWU4Yy00ZWQ0LTc3NGEtODQ3My01N2NjMDQ4ZDZjNDAv
+        djMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vMDE4ZmU4ZDYtOTJiNS03
+        ZGY1LWIwYzYtOGZmZjM5MWUwYWFkLyIsInNoYXJlZDovcHVscC9hcGkvdjMv
+        ZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEv
         Il19
-  recorded_at: Fri, 10 May 2024 14:19:14 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-5478-7851-a7c5-57969cd964cd/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-a255-75c9-9891-1e75a8d59b80/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5380,7 +5380,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -5393,7 +5393,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:14 GMT
+      - Wed, 05 Jun 2024 14:38:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -5413,36 +5413,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8462cafb33f84e2ba5cff42c44bd88ac
+      - b494e931de8f46eab6a21bbd1b9ef147
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNTQ3
-        OC03ODUxLWE3YzUtNTc5NjljZDk2NGNkLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MTQuNDI0NDg3WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOToxNC40MjQ0OTlaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYTI1
+        NS03NWM5LTk4OTEtMWU3NWE4ZDU5YjgwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NTEuNDc4MjQ3WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo1MS40NzgyNjFaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImM1ZDU2OTljZjgxNjQ0N2U5NWFl
-        ZWU0YTMzOTA3ZWM0IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTQuNDM1
-        MDI0WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjE0LjUwNzY4
-        OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTQuNTc2MjM1
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjRkNTYyMTQ2ODk4MDQ2YzBiMTc2
+        MDRmMmMwZDNmZGJhIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTEuNDg5
+        NjM4WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjUxLjUyOTM0
+        MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTEuNTgwNzUx
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNWU4ZC01Zjc4LTc0NDAtYTAyZC1lODg3MzI0MjA5YmEvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVtb3Rlcy9weXRob24vcHl0aG9uLzAxOGY2MmRmLTQ0ZGEtN2FkZS1i
-        NDBmLTAyNzg4OTZkNGIzNy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFp
-        bnMvMDE4ZjVlOGMtNGVkNC03NzRhLTg0NzMtNTdjYzA0OGQ2YzQwLyJdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:14 GMT
+        djMvcmVtb3Rlcy9weXRob24vcHl0aG9uLzAxOGZlOGQ2LTkyMjEtN2U5ZS1h
+        NDMwLTdjNzg3NzNlNTAzNy8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFp
+        bnMvMDE4ZmUzYzktNzBhYS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?name=2_duplicate-test-python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/?name=2_duplicate-test-python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5463,7 +5463,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:14 GMT
+      - Wed, 05 Jun 2024 14:38:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -5475,7 +5475,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '529'
+      - '532'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -5483,30 +5483,30 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 00bd8f8e2ff6440a8fe8daeb982becd9
+      - 42c398eb3c7b439990691ea38f30f374
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3B5dGhvbi9weXBpLzAxOGY2MmRmLTQ4YTAtNzJhNC1hOTJkLTEzYTFhYzVi
-        YmQ4Zi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjExLjM5
-        MzA5OFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6
-        MTMuODIzODM5WiIsImJhc2VfcGF0aCI6ImludGVncmF0aW9uX3Rlc3RzL3B5
-        dGhvbiIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M4LWthdGVsbG8tZGV2
-        ZWwtc3RhYmxlLmV4YW1wbGUuY29tL3B5cGkvaW50ZWdyYXRpb25fdGVzdHMv
-        cHl0aG9uLyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsImhpZGRlbiI6ZmFsc2Us
-        InB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGljYXRlLXRlc3QtcHl0
-        aG9uIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOm51bGwsImFs
-        bG93X3VwbG9hZHMiOnRydWUsInJlbW90ZSI6bnVsbH1dfQ==
-  recorded_at: Fri, 10 May 2024 14:19:14 GMT
+        L3B5dGhvbi9weXBpLzAxOGZlOGQ2LTk2M2EtNzg4Mi04ZWU4LWIzMzQ2YjBh
+        M2UwZi8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjQ4LjM4
+        MDEwM1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6
+        NTAuNzg4MzAxWiIsImJhc2VfcGF0aCI6ImludGVncmF0aW9uX3Rlc3RzL3B5
+        dGhvbiIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2
+        ZWwubWFuaWNvdHRvLmV4YW1wbGUuY29tL3B5cGkvaW50ZWdyYXRpb25fdGVz
+        dHMvcHl0aG9uLyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsImhpZGRlbiI6ZmFs
+        c2UsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGljYXRlLXRlc3Qt
+        cHl0aG9uIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOm51bGws
+        ImFsbG93X3VwbG9hZHMiOnRydWUsInJlbW90ZSI6bnVsbH1dfQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:51 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/018f62df-48a0-72a4-a92d-13a1ac5bbd8f/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/018fe8d6-963a-7882-8ee8-b3346b0a3e0f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5527,7 +5527,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:14 GMT
+      - Wed, 05 Jun 2024 14:38:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -5547,20 +5547,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9a6d08d049ae4d238eec789c6e2e775f
+      - 3f0422d3124e4e15a6f60b67ec8eeb8e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTU2MDktNzlj
-        NC04NDQzLTcwNzExNGUzZDk2NC8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:14 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWEzNTMtN2Mx
+        OC1iYzFhLWRhZGQwNTU3ZGI0MS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?base_path=integration_tests/python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/?base_path=integration_tests/python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5581,7 +5581,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:14 GMT
+      - Wed, 05 Jun 2024 14:38:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -5601,20 +5601,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6f2231775510485bb9ace295568d1a48
+      - 792ba080ac5d4671bcf70fe6e2da73ff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:14 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:51 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-5609-79c4-8443-707114e3d964/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-a353-7c18-bc1a-dadd0557db41/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5622,7 +5622,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -5635,7 +5635,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:14 GMT
+      - Wed, 05 Jun 2024 14:38:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -5655,44 +5655,44 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 47f01936041547ad81e2d536e2ee9e74
+      - 86db20dd9b8646288c7046c4d62fe3ab
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNTYw
-        OS03OWM0LTg0NDMtNzA3MTE0ZTNkOTY0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MTQuODI1NTk4WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOToxNC44MjU2MDlaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYTM1
+        My03YzE4LWJjMWEtZGFkZDA1NTdkYjQxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NTEuNzMxNzM1WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo1MS43MzE3NDhaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjlhNmQwOGQwNDlhZTRkMjM4ZWVj
-        Nzg5YzZlMmU3NzVmIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTQuODM0
-        NzU4WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjE0LjgzNzIy
-        OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTQuODQ4MzYx
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjNmMDQyMmQzMTI0ZTRlMTVhNmY2
+        MGI2N2VjOGVlYjhlIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTEuNzQw
+        Njg2WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjUxLjc0MzA2
+        NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTEuNzU1ODg4
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25z
-        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNWU4Yy00ZWQ0
-        LTc3NGEtODQ3My01N2NjMDQ4ZDZjNDAvIl19
-  recorded_at: Fri, 10 May 2024 14:19:14 GMT
+        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFh
+        LTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:38:51 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/orphans/cleanup/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
     body:
       encoding: UTF-8
       base64_string: 'eyJvcnBoYW5fcHJvdGVjdGlvbl90aW1lIjowfQ==
 
-'
+        '
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -5705,7 +5705,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:15 GMT
+      - Wed, 05 Jun 2024 14:38:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -5725,20 +5725,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 310e88ced4d24015b6ea3c8d94bb9e23
+      - e6f1be2a32224391b9c32938c2a1731a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTU2ZjMtN2Ey
-        Zi1iYjgyLTRiM2VlNjQxNDMzNC8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:15 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWE0NmEtNzMz
+        Mi1iNDk0LTE2ODdkYWRjYzkyYi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:52 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-56f3-7a2f-bb82-4b3ee6414334/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-a46a-7332-b494-1687dadcc92b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5746,7 +5746,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -5759,7 +5759,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:15 GMT
+      - Wed, 05 Jun 2024 14:38:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -5779,26 +5779,26 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2beb48d5848e44ce93332d55edf75827
+      - 6001098e117549b98c71b722e8c629d6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNTZm
-        My03YTJmLWJiODItNGIzZWU2NDE0MzM0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MTUuMDYwMjkxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOToxNS4wNjAzMDJaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYTQ2
+        YS03MzMyLWI0OTQtMTY4N2RhZGNjOTJiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NTIuMDEwNTEwWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo1Mi4wMTA1MjJaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLm9ycGhhbi5vcnBo
-        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiMzEwZTg4Y2VkNGQyNDAxNWI2
-        ZWEzYzhkOTRiYjllMjMiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
-        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0xMFQxNDoxOToxNS4w
-        NzA5MDhaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTUuMTE5
-        NTEzWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0xMFQxNDoxOToxNS40MDY1
-        NzJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzAxOGY1ZThkLTVlODEtN2RlMy05Y2JmLTdkYzljOWMxM2EyNy8iLCJw
+        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiZTZmMWJlMmEzMjIyNDM5MWI5
+        YzMyOTM4YzJhMTczMWEiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
+        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozODo1Mi4w
+        MjIwMTFaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTIuMDU1
+        OTk2WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozODo1Mi4zNjUz
+        NDFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzAxOGZlM2NiLTBkNDMtNzczMS05ODUyLTg3MjlkMDA4MTk2My8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xlYW4g
         dXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIs
@@ -5808,7 +5808,7 @@ http_interactions:
         ZXRlZCIsInRvdGFsIjozLCJkb25lIjozLCJzdWZmaXgiOm51bGx9XSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
         IjpbIi9hcGkvdjMvb3JwaGFucy9jbGVhbnVwLyIsInNoYXJlZDovcHVscC9h
-        cGkvdjMvZG9tYWlucy8wMThmNWU4Yy00ZWQ0LTc3NGEtODQ3My01N2NjMDQ4
-        ZDZjNDAvIl19
-  recorded_at: Fri, 10 May 2024 14:19:15 GMT
+        cGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2Fk
+        MzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:38:52 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/katello/pulp3/repository/python_type_sync/upload_files.yml
+++ b/test/fixtures/vcr_cassettes/katello/pulp3/repository/python_type_sync/upload_files.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?name=2_duplicate-test-python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?name=2_duplicate-test-python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:15 GMT
+      - Wed, 05 Jun 2024 14:38:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,20 +43,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1ceceadf31244a8a91c573f2faa2b102
+      - 20dc8830acec4b32a95033a4448f4be5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:15 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/python/python/?name=2_duplicate-test-python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/python/python/?name=2_duplicate-test-python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:15 GMT
+      - Wed, 05 Jun 2024 14:38:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,20 +97,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '068debfcc3a1463485bdebc0f4a25d02'
+      - bac5e4604a5f46029b04ce7e50759fd3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:15 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?name=2_duplicate-test-python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/?name=2_duplicate-test-python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:15 GMT
+      - Wed, 05 Jun 2024 14:38:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,20 +151,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3b683aa6b7464e3ab682641724d53a09
+      - 036532617e574f988619c99a5bd46ae2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:15 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?base_path=integration_tests/python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/?base_path=integration_tests/python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:16 GMT
+      - Wed, 05 Jun 2024 14:38:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,20 +205,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ec6d78a955bd407a9a25660e2ff0d142
+      - e8007f53f69f4ab7907964ccf6abdacf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:16 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:53 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/python/python/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/python/python/
     body:
       encoding: UTF-8
       base64_string: |
@@ -249,13 +249,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:16 GMT
+      - Wed, 05 Jun 2024 14:38:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/python/python/018f62df-5b1f-7fe0-bd51-256ed5b530ae/"
+      - "/pulp/api/v3/remotes/python/python/018fe8d6-a990-76ce-b3f5-14360ff8bbc6/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -271,18 +271,18 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 95808c5947824e569453a7433f2cb95e
+      - 2e74647777054547bc636f3c9d6aadcf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9weXRob24vcHl0
-        aG9uLzAxOGY2MmRmLTViMWYtN2ZlMC1iZDUxLTI1NmVkNWI1MzBhZS8iLCJw
-        dWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjE2LjEyODIxOFoiLCJw
-        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTYuMTI4MjI5
+        aG9uLzAxOGZlOGQ2LWE5OTAtNzZjZS1iM2Y1LTE0MzYwZmY4YmJjNi8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjUzLjMyODUwNloiLCJw
+        dWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTMuMzI4NTIw
         WiIsIm5hbWUiOiIyX2R1cGxpY2F0ZS10ZXN0LXB5dGhvbiIsInVybCI6Imh0
         dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL3B5dGhvbi1weXBpLyIs
         ImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRh
@@ -299,15 +299,15 @@ http_interactions:
         LCJpbmNsdWRlcyI6WyJjZWxlcnkiXSwiZXhjbHVkZXMiOltdLCJwcmVyZWxl
         YXNlcyI6ZmFsc2UsInBhY2thZ2VfdHlwZXMiOltdLCJrZWVwX2xhdGVzdF9w
         YWNrYWdlcyI6MCwiZXhjbHVkZV9wbGF0Zm9ybXMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:16 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:53 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiMl9kdXBsaWNhdGUtdGVzdC1weXRob24ifQ==
 
-'
+        '
     headers:
       Content-Type:
       - application/json
@@ -325,13 +325,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:16 GMT
+      - Wed, 05 Jun 2024 14:38:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/python/python/018f62df-5b94-7cab-9028-819ed290aa39/"
+      - "/pulp/api/v3/repositories/python/python/018fe8d6-aa10-77f0-8992-0cff9c9ebfde/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -347,36 +347,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f3bcf18fe78b4ab2a493e606536f9256
+      - d33a6c569d514b83805867bb84234e49
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhv
-        bi9weXRob24vMDE4ZjYyZGYtNWI5NC03Y2FiLTkwMjgtODE5ZWQyOTBhYTM5
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTYuMjQ0OTQz
-        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOToxNi4y
-        NDY2NTFaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmNjJkZi01Yjk0LTdjYWItOTAyOC04
-        MTllZDI5MGFhMzkvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
+        bi9weXRob24vMDE4ZmU4ZDYtYWExMC03N2YwLTg5OTItMGNmZjljOWViZmRl
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTMuNDU2Nzky
+        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozODo1My40
+        NTg3NzRaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmZThkNi1hYTEwLTc3ZjAtODk5Mi0w
+        Y2ZmOWM5ZWJmZGUvdmVyc2lvbnMvIiwicHVscF9sYWJlbHMiOnt9LCJsYXRl
         c3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9w
-        eXRob24vcHl0aG9uLzAxOGY2MmRmLTViOTQtN2NhYi05MDI4LTgxOWVkMjkw
-        YWEzOS92ZXJzaW9ucy8wLyIsIm5hbWUiOiIyX2R1cGxpY2F0ZS10ZXN0LXB5
+        eXRob24vcHl0aG9uLzAxOGZlOGQ2LWFhMTAtNzdmMC04OTkyLTBjZmY5Yzll
+        YmZkZS92ZXJzaW9ucy8wLyIsIm5hbWUiOiIyX2R1cGxpY2F0ZS10ZXN0LXB5
         dGhvbiIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9u
         cyI6bnVsbCwicmVtb3RlIjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2V9
-  recorded_at: Fri, 10 May 2024 14:19:16 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:53 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/publications/python/pypi/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/python/pypi/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3B5dGhvbi9weXRob24vMDE4ZjYyZGYtNWI5NC03Y2FiLTkwMjgtODE5
-        ZWQyOTBhYTM5L3ZlcnNpb25zLzAvIn0=
+        aWVzL3B5dGhvbi9weXRob24vMDE4ZmU4ZDYtYWExMC03N2YwLTg5OTItMGNm
+        ZjljOWViZmRlL3ZlcnNpb25zLzAvIn0=
     headers:
       Content-Type:
       - application/json
@@ -394,7 +394,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:16 GMT
+      - Wed, 05 Jun 2024 14:38:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -414,20 +414,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fcb40dd5eadb4bfba06f22ed74ea5639
+      - 4d62c23cef604b13a7a4db9db54e2fd1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTVjOTktNzFj
-        ZS1iMzc3LWJhYzAwZjQ4ZGVhZi8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:16 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWFiMjktNzc0
+        Ny1iOGIzLWU0M2NiZDJiM2Y3OS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-5c99-71ce-b377-bac00f48deaf/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-ab29-7747-b8b3-e43cbd2b3f79/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -435,7 +435,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -448,7 +448,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:16 GMT
+      - Wed, 05 Jun 2024 14:38:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -468,38 +468,38 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c0a0adab2c9341b6a37bebe6acb1b8a6
+      - 50dd4300968342c7a10d8676617cdb88
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNWM5
-        OS03MWNlLWIzNzctYmFjMDBmNDhkZWFmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MTYuNTA1NjgyWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOToxNi41MDU2OTNaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYWIy
+        OS03NzQ3LWI4YjMtZTQzY2JkMmIzZjc5LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NTMuNzM3NTEwWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo1My43Mzc1MjRaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscF9weXRob24uYXBwLnRhc2tzLnB1Ymxpc2gu
-        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiZmNiNDBkZDVlYWRiNGJmYmEwNmYy
-        MmVkNzRlYTU2MzkiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
-        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0xMFQxNDoxOToxNi41MTcx
-        OTdaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTYuNTUzNjM5
-        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0xMFQxNDoxOToxNi42MjUxMDla
+        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiNGQ2MmMyM2NlZjYwNGIxM2E3YTRk
+        YjlkYjU0ZTJmZDEiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
+        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozODo1My43NTQx
+        NjNaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTMuNzg4MjI4
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozODo1My44NDk1MjBa
         IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
-        LzAxOGY1ZThkLTU2M2EtNzQ3Yy05ZGZlLWUxNTY2MWVjNjM5Ny8iLCJwYXJl
+        LzAxOGZlM2NiLTBkNDMtNzczMS05ODUyLTg3MjlkMDA4MTk2My8iLCJwYXJl
         bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
         dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
         OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9weXRob24vcHlwaS8wMThm
-        NjJkZi01Y2RhLTcwZmQtYmIxNC1jMzMwNDkwZjMxMjAvIl0sInJlc2VydmVk
+        ZThkNi1hYjY2LTcwM2YtYjM0YS02YjZhY2QyMzBiOTYvIl0sInJlc2VydmVk
         X3Jlc291cmNlc19yZWNvcmQiOlsic2hhcmVkOi9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmNjJkZi01Yjk0LTdjYWItOTAy
-        OC04MTllZDI5MGFhMzkvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5z
-        LzAxOGY1ZThjLTRlZDQtNzc0YS04NDczLTU3Y2MwNDhkNmM0MC8iXX0=
-  recorded_at: Fri, 10 May 2024 14:19:16 GMT
+        c2l0b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmZThkNi1hYTEwLTc3ZjAtODk5
+        Mi0wY2ZmOWM5ZWJmZGUvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5z
+        LzAxOGZlM2M5LTcwYWEtNzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?base_path=integration_tests/python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/?base_path=integration_tests/python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -520,7 +520,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:16 GMT
+      - Wed, 05 Jun 2024 14:38:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -540,20 +540,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8910ddca7cdf4147b2eb5996aed343ef
+      - b561de037ff54b48af185709b9562ea0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:16 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:53 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/publications/python/pypi/018f62df-5cda-70fd-bb14-c330490f3120/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/python/pypi/018fe8d6-ab66-703f-b34a-6b6acd230b96/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -574,7 +574,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:16 GMT
+      - Wed, 05 Jun 2024 14:38:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -594,36 +594,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e93d84c5ff9e4ff08574cb95384e6353
+      - 553aecb3e65949c3aaee945078479218
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3B5dGhv
-        bi9weXBpLzAxOGY2MmRmLTVjZGEtNzBmZC1iYjE0LWMzMzA0OTBmMzEyMC8i
-        LCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjE2LjU3MzIzM1oi
-        LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTYuNjE5
-        NDI3WiIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmNjJkZi01Yjk0LTdjYWItOTAy
-        OC04MTllZDI5MGFhMzkvdmVyc2lvbnMvMC8iLCJyZXBvc2l0b3J5IjoiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9weXRob24vcHl0aG9uLzAxOGY2MmRm
-        LTViOTQtN2NhYi05MDI4LTgxOWVkMjkwYWEzOS8iLCJkaXN0cmlidXRpb25z
+        bi9weXBpLzAxOGZlOGQ2LWFiNjYtNzAzZi1iMzRhLTZiNmFjZDIzMGI5Ni8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjUzLjgwMDUwOVoi
+        LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTMuODQz
+        Njk0WiIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmZThkNi1hYTEwLTc3ZjAtODk5
+        Mi0wY2ZmOWM5ZWJmZGUvdmVyc2lvbnMvMC8iLCJyZXBvc2l0b3J5IjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9weXRob24vcHl0aG9uLzAxOGZlOGQ2
+        LWFhMTAtNzdmMC04OTkyLTBjZmY5YzllYmZkZS8iLCJkaXN0cmlidXRpb25z
         IjpbXX0=
-  recorded_at: Fri, 10 May 2024 14:19:16 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:54 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/
     body:
       encoding: UTF-8
       base64_string: |
         eyJiYXNlX3BhdGgiOiJpbnRlZ3JhdGlvbl90ZXN0cy9weXRob24iLCJjb250
         ZW50X2d1YXJkIjpudWxsLCJuYW1lIjoiMl9kdXBsaWNhdGUtdGVzdC1weXRo
         b24iLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
-        cHl0aG9uL3B5cGkvMDE4ZjYyZGYtNWNkYS03MGZkLWJiMTQtYzMzMDQ5MGYz
-        MTIwLyIsImFsbG93X3VwbG9hZHMiOnRydWV9
+        cHl0aG9uL3B5cGkvMDE4ZmU4ZDYtYWI2Ni03MDNmLWIzNGEtNmI2YWNkMjMw
+        Yjk2LyIsImFsbG93X3VwbG9hZHMiOnRydWV9
     headers:
       Content-Type:
       - application/json
@@ -641,7 +641,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:16 GMT
+      - Wed, 05 Jun 2024 14:38:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -661,20 +661,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 712766d2a74944b28b6ba6ea0eea46e2
+      - 2397ba0ae87b467a806baf007cc4f6bd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTVlMDEtNzQy
-        OC05ZWI4LTNjMGQxNTBjYzIxMS8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:16 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWFjODUtNzAz
+        My1hMTFmLWZmOGRhYWUyYjVhNy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-5e01-7428-9eb8-3c0d150cc211/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-ac85-7033-a11f-ff8daae2b5a7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -682,7 +682,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -695,7 +695,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:17 GMT
+      - Wed, 05 Jun 2024 14:38:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -715,37 +715,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5b6f178971b44658b3495574f668b429
+      - 83f77e2233384e36acbb3f5efdb02622
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNWUw
-        MS03NDI4LTllYjgtM2MwZDE1MGNjMjExLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MTYuODY1NDg4WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOToxNi44NjU0OTlaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYWM4
+        NS03MDMzLWExMWYtZmY4ZGFhZTJiNWE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NTQuMDg2MzEzWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo1NC4wODYzMjZaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6IjcxMjc2NmQyYTc0OTQ0YjI4YjZi
-        YTZlYTBlZWE0NmUyIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTYuODc4
-        MDAyWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjE2LjkyOTg0
-        OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTcuMTE4NDIw
+        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6IjIzOTdiYTBhZTg3YjQ2N2E4MDZi
+        YWYwMDdjYzRmNmJkIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTQuMDk4
+        NzkwWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjU0LjEzMjM1
+        OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTQuMzM2MTMw
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNWU4ZC01Zjc4LTc0NDAtYTAyZC1lODg3MzI0MjA5YmEvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3B5dGhvbi9weXBpLzAx
-        OGY2MmRmLTVlZWQtNzBiOS04ZWFkLTkyZGE4NDkyZGNlZS8iXSwicmVzZXJ2
+        OGZlOGQ2LWFkNzQtN2M0ZS04YzJiLWI5ZTVjMzQzYzMzYS8iXSwicmVzZXJ2
         ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
-        Iiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGY1ZThjLTRlZDQt
-        Nzc0YS04NDczLTU3Y2MwNDhkNmM0MC8iXX0=
-  recorded_at: Fri, 10 May 2024 14:19:17 GMT
+        Iiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5zLzAxOGZlM2M5LTcwYWEt
+        Nzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/018f62df-5eed-70b9-8ead-92da8492dcee/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/018fe8d6-ad74-7c4e-8c2b-b9e5c343c33a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -766,7 +766,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:17 GMT
+      - Wed, 05 Jun 2024 14:38:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -778,7 +778,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '550'
+      - '553'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -786,31 +786,31 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ab9b8a27ce2e4d7e83eabbe1f022f963
+      - f1e0e7f5ca444150a935c5a2635db244
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9weXRo
-        b24vcHlwaS8wMThmNjJkZi01ZWVkLTcwYjktOGVhZC05MmRhODQ5MmRjZWUv
-        IiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOToxNy4xMDIyNTBa
-        IiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjE3LjEw
-        MjI2NFoiLCJiYXNlX3BhdGgiOiJpbnRlZ3JhdGlvbl90ZXN0cy9weXRob24i
-        LCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9zOC1rYXRlbGxvLWRldmVsLXN0
-        YWJsZS5leGFtcGxlLmNvbS9weXBpL2ludGVncmF0aW9uX3Rlc3RzL3B5dGhv
-        bi8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJoaWRkZW4iOmZhbHNlLCJwdWxw
-        X2xhYmVscyI6e30sIm5hbWUiOiIyX2R1cGxpY2F0ZS10ZXN0LXB5dGhvbiIs
-        InJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3Yz
-        L3B1YmxpY2F0aW9ucy9weXRob24vcHlwaS8wMThmNjJkZi01Y2RhLTcwZmQt
-        YmIxNC1jMzMwNDkwZjMxMjAvIiwiYWxsb3dfdXBsb2FkcyI6dHJ1ZSwicmVt
-        b3RlIjpudWxsfQ==
-  recorded_at: Fri, 10 May 2024 14:19:17 GMT
+        b24vcHlwaS8wMThmZThkNi1hZDc0LTdjNGUtOGMyYi1iOWU1YzM0M2MzM2Ev
+        IiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wNVQxNDozODo1NC4zMjU5ODZa
+        IiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjU0LjMy
+        NjAwMloiLCJiYXNlX3BhdGgiOiJpbnRlZ3JhdGlvbl90ZXN0cy9weXRob24i
+        LCJiYXNlX3VybCI6Imh0dHBzOi8vY2VudG9zOS1rYXRlbGxvLWRldmVsLm1h
+        bmljb3R0by5leGFtcGxlLmNvbS9weXBpL2ludGVncmF0aW9uX3Rlc3RzL3B5
+        dGhvbi8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJoaWRkZW4iOmZhbHNlLCJw
+        dWxwX2xhYmVscyI6e30sIm5hbWUiOiIyX2R1cGxpY2F0ZS10ZXN0LXB5dGhv
+        biIsInJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBp
+        L3YzL3B1YmxpY2F0aW9ucy9weXRob24vcHlwaS8wMThmZThkNi1hYjY2LTcw
+        M2YtYjM0YS02YjZhY2QyMzBiOTYvIiwiYWxsb3dfdXBsb2FkcyI6dHJ1ZSwi
+        cmVtb3RlIjpudWxsfQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:54 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?name=2_duplicate-test-python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?name=2_duplicate-test-python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -831,7 +831,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:20 GMT
+      - Wed, 05 Jun 2024 14:38:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -851,32 +851,32 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 50838fdeeae14554a28087c47a78a427
+      - 40b1ff715f274f70b6435dd66da6ee5f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        cHl0aG9uL3B5dGhvbi8wMThmNjJkZi01Yjk0LTdjYWItOTAyOC04MTllZDI5
-        MGFhMzkvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOToxNi4y
-        NDQ5NDNaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5
-        OjE4LjYzOTMyMVoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
-        cG9zaXRvcmllcy9weXRob24vcHl0aG9uLzAxOGY2MmRmLTViOTQtN2NhYi05
-        MDI4LTgxOWVkMjkwYWEzOS92ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30s
+        cHl0aG9uL3B5dGhvbi8wMThmZThkNi1hYTEwLTc3ZjAtODk5Mi0wY2ZmOWM5
+        ZWJmZGUvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wNVQxNDozODo1My40
+        NTY3OTJaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4
+        OjU1Ljc5MjY1MVoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3Jl
+        cG9zaXRvcmllcy9weXRob24vcHl0aG9uLzAxOGZlOGQ2LWFhMTAtNzdmMC04
+        OTkyLTBjZmY5YzllYmZkZS92ZXJzaW9ucy8iLCJwdWxwX2xhYmVscyI6e30s
         ImxhdGVzdF92ZXJzaW9uX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3B5dGhvbi9weXRob24vMDE4ZjYyZGYtNWI5NC03Y2FiLTkwMjgtODE5
-        ZWQyOTBhYTM5L3ZlcnNpb25zLzEvIiwibmFtZSI6IjJfZHVwbGljYXRlLXRl
+        aWVzL3B5dGhvbi9weXRob24vMDE4ZmU4ZDYtYWExMC03N2YwLTg5OTItMGNm
+        ZjljOWViZmRlL3ZlcnNpb25zLzEvIiwibmFtZSI6IjJfZHVwbGljYXRlLXRl
         c3QtcHl0aG9uIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3Zl
         cnNpb25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxz
         ZX1dfQ==
-  recorded_at: Fri, 10 May 2024 14:19:20 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:57 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/018f62df-5b94-7cab-9028-819ed290aa39/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/018fe8d6-aa10-77f0-8992-0cff9c9ebfde/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -897,7 +897,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:20 GMT
+      - Wed, 05 Jun 2024 14:38:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -917,20 +917,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d6f10886d8374aac8b77ab2569f6bf88
+      - ba4265098ea9410cb2eb8ff851d48837
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTZiOTQtNzZm
-        OC1iYjVmLWI4NDFiNmNlZDQ4Mi8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:20 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWJhMWItN2Fl
+        Mi05ZWY2LTdlNzIxMTI1NjBlOC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/python/python/?name=2_duplicate-test-python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/python/python/?name=2_duplicate-test-python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -951,7 +951,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:20 GMT
+      - Wed, 05 Jun 2024 14:38:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -971,20 +971,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bbc387b39e5f4899ba52828fc2954e50
+      - 07a2446a7fcd420bb5f92423bc412ccb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3B5dGhv
-        bi9weXRob24vMDE4ZjYyZGYtNWIxZi03ZmUwLWJkNTEtMjU2ZWQ1YjUzMGFl
-        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTYuMTI4MjE4
-        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOToxNi4x
-        MjgyMjlaIiwibmFtZSI6IjJfZHVwbGljYXRlLXRlc3QtcHl0aG9uIiwidXJs
+        bi9weXRob24vMDE4ZmU4ZDYtYTk5MC03NmNlLWIzZjUtMTQzNjBmZjhiYmM2
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTMuMzI4NTA2
+        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozODo1My4z
+        Mjg1MjBaIiwibmFtZSI6IjJfZHVwbGljYXRlLXRlc3QtcHl0aG9uIiwidXJs
         IjoiaHR0cHM6Ly9maXh0dXJlcy5wdWxwcHJvamVjdC5vcmcvcHl0aG9uLXB5
         cGkvIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192
         YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFiZWxz
@@ -1000,10 +1000,10 @@ http_interactions:
         bHNlfV0sImluY2x1ZGVzIjpbImNlbGVyeSJdLCJleGNsdWRlcyI6W10sInBy
         ZXJlbGVhc2VzIjpmYWxzZSwicGFja2FnZV90eXBlcyI6W10sImtlZXBfbGF0
         ZXN0X3BhY2thZ2VzIjowLCJleGNsdWRlX3BsYXRmb3JtcyI6W119XX0=
-  recorded_at: Fri, 10 May 2024 14:19:20 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:57 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/remotes/python/python/018f62df-5b1f-7fe0-bd51-256ed5b530ae/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/python/python/018fe8d6-a990-76ce-b3f5-14360ff8bbc6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1024,7 +1024,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:20 GMT
+      - Wed, 05 Jun 2024 14:38:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1044,20 +1044,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8e8759158db94818beb6abd1ca3863ca
+      - 7d1a3656df4a400a8a8739163c3b4b61
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTZjMjQtNzhj
-        ZC04MzViLTUxM2I3MzMzMTdlZi8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:20 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWJhOTMtN2Q4
+        OC1iMzJmLWE2NWQ2YzY2ZWIzZC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-6b94-76f8-bb5f-b841b6ced482/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-ba1b-7ae2-9ef6-7e72112560e8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1065,7 +1065,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1078,7 +1078,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:20 GMT
+      - Wed, 05 Jun 2024 14:38:57 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1098,37 +1098,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 27cd82c26ba04b4b848cac1ddafab6e1
+      - 8a360daa4ca244048851e7afc726daa2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNmI5
-        NC03NmY4LWJiNWYtYjg0MWI2Y2VkNDgyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MjAuMzQwNzY2WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOToyMC4zNDA3NzhaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYmEx
+        Yi03YWUyLTllZjYtN2U3MjExMjU2MGU4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NTcuNTY0NDI5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo1Ny41NjQ0NDFaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImQ2ZjEwODg2ZDgzNzRhYWM4Yjc3
-        YWIyNTY5ZjZiZjg4IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MjAuMzUx
-        OTg3WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjIwLjQwMDY5
-        NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MjAuNTg1OTI3
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImJhNDI2NTA5OGVhOTQxMGNiMmVi
+        OGZmODUxZDQ4ODM3IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTcuNTc2
+        MzkzWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjU3LjYxMjA4
+        OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTcuNzY5MDU4
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNWU4ZC01ZWM0LTdmMjYtOWFkNi02NWU1MWMwNjYwZTcvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vMDE4ZjYyZGYtNWI5NC03
-        Y2FiLTkwMjgtODE5ZWQyOTBhYTM5LyIsInNoYXJlZDovcHVscC9hcGkvdjMv
-        ZG9tYWlucy8wMThmNWU4Yy00ZWQ0LTc3NGEtODQ3My01N2NjMDQ4ZDZjNDAv
+        djMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vMDE4ZmU4ZDYtYWExMC03
+        N2YwLTg5OTItMGNmZjljOWViZmRlLyIsInNoYXJlZDovcHVscC9hcGkvdjMv
+        ZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEv
         Il19
-  recorded_at: Fri, 10 May 2024 14:19:20 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:57 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-6c24-78cd-835b-513b733317ef/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-ba93-7d88-b32f-a65d6c66eb3d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1136,7 +1136,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1149,7 +1149,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:20 GMT
+      - Wed, 05 Jun 2024 14:38:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1169,36 +1169,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5ebde1723eb447a091ca93b69db3d96e
+      - 9b6d90b78a4e4a19baf778fa81ec014c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNmMy
-        NC03OGNkLTgzNWItNTEzYjczMzMxN2VmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MjAuNDg1Mjc5WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOToyMC40ODUyOTNaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYmE5
+        My03ZDg4LWIzMmYtYTY1ZDZjNjZlYjNkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NTcuNjg0NjkxWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo1Ny42ODQ3MDlaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjhlODc1OTE1OGRiOTQ4MThiZWI2
-        YWJkMWNhMzg2M2NhIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MjAuNDk3
-        ODAyWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjIwLjU0NDM4
-        MloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MjAuNjI2MzY2
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjdkMWEzNjU2ZGY0YTQwMGE4YTg3
+        MzkxNjNjM2I0YjYxIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTcuNjk3
+        NzA0WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjU3Ljc0NTg1
+        MloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTcuNzg2NTAz
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNWU4ZC01Zjc4LTc0NDAtYTAyZC1lODg3MzI0MjA5YmEvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVtb3Rlcy9weXRob24vcHl0aG9uLzAxOGY2MmRmLTViMWYtN2ZlMC1i
-        ZDUxLTI1NmVkNWI1MzBhZS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFp
-        bnMvMDE4ZjVlOGMtNGVkNC03NzRhLTg0NzMtNTdjYzA0OGQ2YzQwLyJdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:20 GMT
+        djMvcmVtb3Rlcy9weXRob24vcHl0aG9uLzAxOGZlOGQ2LWE5OTAtNzZjZS1i
+        M2Y1LTE0MzYwZmY4YmJjNi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFp
+        bnMvMDE4ZmUzYzktNzBhYS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?name=2_duplicate-test-python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/?name=2_duplicate-test-python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1219,7 +1219,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:20 GMT
+      - Wed, 05 Jun 2024 14:38:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1231,7 +1231,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '529'
+      - '532'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1239,30 +1239,30 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2f23eaaf3c044724b556d7150d04ab6d
+      - b4c778898f9c4bc8952d898ff22e3849
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3B5dGhvbi9weXBpLzAxOGY2MmRmLTVlZWQtNzBiOS04ZWFkLTkyZGE4NDky
-        ZGNlZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjE3LjEw
-        MjI1MFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6
-        MTkuNDgyNjA4WiIsImJhc2VfcGF0aCI6ImludGVncmF0aW9uX3Rlc3RzL3B5
-        dGhvbiIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M4LWthdGVsbG8tZGV2
-        ZWwtc3RhYmxlLmV4YW1wbGUuY29tL3B5cGkvaW50ZWdyYXRpb25fdGVzdHMv
-        cHl0aG9uLyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsImhpZGRlbiI6ZmFsc2Us
-        InB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGljYXRlLXRlc3QtcHl0
-        aG9uIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOm51bGwsImFs
-        bG93X3VwbG9hZHMiOnRydWUsInJlbW90ZSI6bnVsbH1dfQ==
-  recorded_at: Fri, 10 May 2024 14:19:20 GMT
+        L3B5dGhvbi9weXBpLzAxOGZlOGQ2LWFkNzQtN2M0ZS04YzJiLWI5ZTVjMzQz
+        YzMzYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjU0LjMy
+        NTk4NloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6
+        NTYuNjgxODgxWiIsImJhc2VfcGF0aCI6ImludGVncmF0aW9uX3Rlc3RzL3B5
+        dGhvbiIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2
+        ZWwubWFuaWNvdHRvLmV4YW1wbGUuY29tL3B5cGkvaW50ZWdyYXRpb25fdGVz
+        dHMvcHl0aG9uLyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsImhpZGRlbiI6ZmFs
+        c2UsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGljYXRlLXRlc3Qt
+        cHl0aG9uIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOm51bGws
+        ImFsbG93X3VwbG9hZHMiOnRydWUsInJlbW90ZSI6bnVsbH1dfQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:58 GMT
 - request:
     method: delete
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/018f62df-5eed-70b9-8ead-92da8492dcee/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/018fe8d6-ad74-7c4e-8c2b-b9e5c343c33a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1283,7 +1283,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:20 GMT
+      - Wed, 05 Jun 2024 14:38:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1303,20 +1303,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 521a218317af4248b94479cda7231009
+      - c8a606c1130c44ae969a5e5a77585c7a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTZlMDItNzlj
-        MS04OTAwLWJjYmI3Mzg3MDBkMi8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:21 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWJjMzEtN2Nm
+        YS05ZTk5LTYyMjVmM2JjZTBkMS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?base_path=integration_tests/python
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/?base_path=integration_tests/python
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1337,7 +1337,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:21 GMT
+      - Wed, 05 Jun 2024 14:38:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1357,20 +1357,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ff5f97ac6900462e9eb3f433880f2cac
+      - 863854c40ff5419480aa140e42748f1e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:21 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-6e02-79c1-8900-bcbb738700d2/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-bc31-7cfa-9e99-6225f3bce0d1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1378,7 +1378,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1391,7 +1391,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:21 GMT
+      - Wed, 05 Jun 2024 14:38:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1411,44 +1411,44 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e0fb516783c44526949a657b45fc627b
+      - bf87344ac9be449bb228fdc1f03b0fe5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNmUw
-        Mi03OWMxLTg5MDAtYmNiYjczODcwMGQyLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MjAuOTYyOTA2WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOToyMC45NjI5MThaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYmMz
+        MS03Y2ZhLTllOTktNjIyNWYzYmNlMGQxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NTguMDk4MjkwWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo1OC4wOTgzMDJaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjUyMWEyMTgzMTdhZjQyNDhiOTQ0
-        NzljZGE3MjMxMDA5IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MjAuOTcx
-        OTQwWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTEwVDE0OjE5OjIwLjk3NDU3
-        N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MjAuOTg4MDA0
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImM4YTYwNmMxMTMwYzQ0YWU5Njlh
+        NWU1YTc3NTg1YzdhIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTguMTA3
+        MTIxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjU4LjEwOTU0
+        MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTguMTIxNzE1
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
         dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
         ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
         dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25z
-        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmNWU4Yy00ZWQ0
-        LTc3NGEtODQ3My01N2NjMDQ4ZDZjNDAvIl19
-  recorded_at: Fri, 10 May 2024 14:19:21 GMT
+        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFh
+        LTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:38:58 GMT
 - request:
     method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/orphans/cleanup/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
     body:
       encoding: UTF-8
       base64_string: 'eyJvcnBoYW5fcHJvdGVjdGlvbl90aW1lIjowfQ==
 
-'
+        '
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1461,7 +1461,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:21 GMT
+      - Wed, 05 Jun 2024 14:38:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1481,20 +1481,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a5f78c35e0b543fb944a4e977b0bde5e
+      - 160eee47a2cc4dbdb06bfee333359f11
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTZlZmEtN2My
-        MS1iMTI0LWNjZDQ3YmQ2NjE1NC8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:21 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWJkMmUtN2Jk
+        Yi05YWJjLTY0ZTE3YjhlMWQ4Ni8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:58 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-6efa-7c21-b124-ccd47bd66154/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-bd2e-7bdb-9abc-64e17b8e1d86/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1502,7 +1502,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1515,7 +1515,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 May 2024 14:19:21 GMT
+      - Wed, 05 Jun 2024 14:38:58 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1535,26 +1535,26 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f52a4f3de0dc4524972b420ca7b89024
+      - 5763f5b4fdcd4bcca7c8b5ef7b692cad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos8-katello-devel-stable.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjYyZGYtNmVm
-        YS03YzIxLWIxMjQtY2NkNDdiZDY2MTU0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMTBUMTQ6MTk6MjEuMjExMzgxWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0xMFQxNDoxOToyMS4yMTEzOTJaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYmQy
+        ZS03YmRiLTlhYmMtNjRlMTdiOGUxZDg2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NTguMzUwOTI1WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo1OC4zNTA5MzZaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLm9ycGhhbi5vcnBo
-        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiYTVmNzhjMzVlMGI1NDNmYjk0
-        NGE0ZTk3N2IwYmRlNWUiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
-        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0xMFQxNDoxOToyMS4y
-        MjI1ODJaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMTBUMTQ6MTk6MjEuMjgz
-        MDY1WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0xMFQxNDoxOToyMS41NzA0
-        OTZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzAxOGY1ZThkLTVlYzQtN2YyNi05YWQ2LTY1ZTUxYzA2NjBlNy8iLCJw
+        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiMTYwZWVlNDdhMmNjNGRiZGIw
+        NmJmZWUzMzMzNTlmMTEiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
+        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozODo1OC4z
+        NjI3NzNaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTguMzk1
+        NDg0WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozODo1OC42Njcy
+        MzJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzAxOGZlM2NiLTBkZjItN2M4My1hN2VhLWUyNmExYTI4ZDdmOS8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xlYW4g
         dXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIs
@@ -1564,7 +1564,7 @@ http_interactions:
         ZXRlZCIsInRvdGFsIjo0LCJkb25lIjo0LCJzdWZmaXgiOm51bGx9XSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
         IjpbIi9hcGkvdjMvb3JwaGFucy9jbGVhbnVwLyIsInNoYXJlZDovcHVscC9h
-        cGkvdjMvZG9tYWlucy8wMThmNWU4Yy00ZWQ0LTc3NGEtODQ3My01N2NjMDQ4
-        ZDZjNDAvIl19
-  recorded_at: Fri, 10 May 2024 14:19:21 GMT
+        cGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2Fk
+        MzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:38:58 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/katello/pulp3/repository/python_type_sync/upload_files_binary.yml
+++ b/test/fixtures/vcr_cassettes/katello/pulp3/repository/python_type_sync/upload_files_binary.yml
@@ -59411,175 +59411,6 @@ http_interactions:
         NS1iNGJlLWVmYzY3MmRjYjJiMS8ifQ==
   recorded_at: Tue, 07 May 2024 20:33:12 GMT
 - request:
-    method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/content/python/packages/?sha256=2eceb1643c10c5e4a65970baf63bde43b79cbdac7de81dae853ce47ab05197e9
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.11.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 10 May 2024 14:19:17 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 739b78e935ce406998246224169ab997
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel-stable.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:17 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/artifacts/?sha256=2eceb1643c10c5e4a65970baf63bde43b79cbdac7de81dae853ce47ab05197e9
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 10 May 2024 14:19:17 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 990570b6256c4228be08c80dee79aec7
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel-stable.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:17 GMT
-- request:
-    method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjoyMjQ1NX0=
-
-'
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Fri, 10 May 2024 14:19:17 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/uploads/018f62df-6123-7b9f-add0-7e112cda576f/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '182'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 89a2f576c3b84ac3a530e1454c01fc8d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel-stable.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmNjJkZi02
-        MTIzLTdiOWYtYWRkMC03ZTExMmNkYTU3NmYvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyNC0wNS0xMFQxNDoxOToxNy42Njg2MDdaIiwicHVscF9sYXN0X3VwZGF0
-        ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjE3LjY2ODYxOFoiLCJzaXplIjoyMjQ1
-        NX0=
-  recorded_at: Fri, 10 May 2024 14:19:17 GMT
-- request:
     method: put
     uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/uploads/018f62df-6123-7b9f-add0-7e112cda576f/
     body:
@@ -60148,60 +59979,6 @@ http_interactions:
         NX0=
   recorded_at: Fri, 10 May 2024 14:19:17 GMT
 - request:
-    method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/artifacts/?sha256=2eceb1643c10c5e4a65970baf63bde43b79cbdac7de81dae853ce47ab05197e9
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 10 May 2024 14:19:17 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 50cd2832e15743438c934ca752e9f54e
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel-stable.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:17 GMT
-- request:
     method: post
     uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/uploads/018f62df-6123-7b9f-add0-7e112cda576f/commit/
     body:
@@ -60328,195 +60105,6 @@ http_interactions:
         LTdlMTEyY2RhNTc2Zi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMv
         MDE4ZjVlOGMtNGVkNC03NzRhLTg0NzMtNTdjYzA0OGQ2YzQwLyJdfQ==
   recorded_at: Fri, 10 May 2024 14:19:17 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/artifacts/?sha256=2eceb1643c10c5e4a65970baf63bde43b79cbdac7de81dae853ce47ab05197e9
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.7/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 10 May 2024 14:19:18 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '773'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - c7c8d2c141a543febf49aa35eaa7078d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel-stable.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE4
-        ZjYyZGYtNjIxMy03ZmMxLThkYTctMDdiYzdlYTZmYWVhLyIsInB1bHBfY3Jl
-        YXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6MTcuOTA4NDA2WiIsInB1bHBfbGFz
-        dF91cGRhdGVkIjoiMjAyNC0wNS0xMFQxNDoxOToxNy45MDg0MjFaIiwiZmls
-        ZSI6ImFydGlmYWN0LzJlL2NlYjE2NDNjMTBjNWU0YTY1OTcwYmFmNjNiZGU0
-        M2I3OWNiZGFjN2RlODFkYWU4NTNjZTQ3YWIwNTE5N2U5Iiwic2l6ZSI6MjI0
-        NTUsIm1kNSI6bnVsbCwic2hhMSI6ImUxNjM0MTc1NzUxMTdiNjQxNWQxMjYz
-        NGI4ZGJiYmY2YmU2MzgyOTAiLCJzaGEyMjQiOiI1N2M2MWE0NDNkNGI5OGMy
-        MmQwYjg3OTMyYjgxN2M5MmJjNDdmMmU2MDkwOGZmNDljMTA4Y2UxMiIsInNo
-        YTI1NiI6IjJlY2ViMTY0M2MxMGM1ZTRhNjU5NzBiYWY2M2JkZTQzYjc5Y2Jk
-        YWM3ZGU4MWRhZTg1M2NlNDdhYjA1MTk3ZTkiLCJzaGEzODQiOiJhOTE0ZTNk
-        YzA4NGEzNDViYzVkZmYxYTJjODQ0MWU2NzY5NjhmYTA4NjEyOWZkNzg4YjVk
-        YzQ3YTliYjlkZTUwMDRjYzhiNzE2MTBkYWU0ZDk2NGEzYTAzNTg3ZDJlZTEi
-        LCJzaGE1MTIiOiIxZTM4YWM4MDk4MDA5NGVhOWJiMzZhM2FiOWNiMzE0NzZh
-        Yzk2Yzc4Mzk3ODljYWFmOTlmNmJkMTcwYzFjMTJkZDgwMmY0NjI3MGUyNWYx
-        MzUyMzgwZjQwZmFjOGY2MmVmODVkZGMwY2EwM2JmMjU5MjJjMThhNGIxZWUw
-        NDE4NyJ9XX0=
-  recorded_at: Fri, 10 May 2024 14:19:18 GMT
-- request:
-    method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/content/python/packages/?sha256=2eceb1643c10c5e4a65970baf63bde43b79cbdac7de81dae853ce47ab05197e9
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.11.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 10 May 2024 14:19:18 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 9b9d6c795ded41f8af95261588fe27a1
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel-stable.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Fri, 10 May 2024 14:19:18 GMT
-- request:
-    method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/content/python/packages/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTkwZGQxMTI4NTA0YTA2
-        MzJjMDQzNzcyMzNlZjNhODMyDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnNoZWxmX3JlYWRlci0w
-        LjEtcHkyLW5vbmUtYW55LndobA0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBh
-        cnRQb3N0LTkwZGQxMTI4NTA0YTA2MzJjMDQzNzcyMzNlZjNhODMyDQpDb250
-        ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0K
-        DQovcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzAxOGY2MmRmLTYyMTMtN2ZjMS04
-        ZGE3LTA3YmM3ZWE2ZmFlYS8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0
-        UG9zdC05MGRkMTEyODUwNGEwNjMyYzA0Mzc3MjMzZWYzYTgzMi0tDQo=
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-90dd1128504a0632c04377233ef3a832
-      User-Agent:
-      - OpenAPI-Generator/3.11.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '401'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 10 May 2024 14:19:18 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 9bcc41d6517d4a4b9fb70b0fb74c8bef
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel-stable.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTYzMGEtN2Mw
-        OC05MzZiLTVmNjExY2U2MmI2MS8ifQ==
-  recorded_at: Fri, 10 May 2024 14:19:18 GMT
 - request:
     method: get
     uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/tasks/018f62df-630a-7c08-936b-5f611ce62b61/
@@ -60716,63 +60304,6 @@ http_interactions:
         NWI5NC03Y2FiLTkwMjgtODE5ZWQyOTBhYTM5LyIsInNoYXJlZDovcHVscC9h
         cGkvdjMvZG9tYWlucy8wMThmNWU4Yy00ZWQ0LTc3NGEtODQ3My01N2NjMDQ4
         ZDZjNDAvIl19
-  recorded_at: Fri, 10 May 2024 14:19:18 GMT
-- request:
-    method: post
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/publications/python/pypi/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3B5dGhvbi9weXRob24vMDE4ZjYyZGYtNWI5NC03Y2FiLTkwMjgtODE5
-        ZWQyOTBhYTM5L3ZlcnNpb25zLzEvIn0=
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.11.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Fri, 10 May 2024 14:19:18 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 9774e65ccefe40028b7ae0040462586f
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel-stable.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTY1OTQtN2Qy
-        Mi04MGQyLTdlMmIzZDE0NzVmNC8ifQ==
   recorded_at: Fri, 10 May 2024 14:19:18 GMT
 - request:
     method: get
@@ -61376,72 +60907,6 @@ http_interactions:
   recorded_at: Fri, 10 May 2024 14:19:19 GMT
 - request:
     method: get
-    uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?base_path=integration_tests/python
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.11.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 10 May 2024 14:19:19 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '602'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - f5c86dc49fb048e682ae79264939351c
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos8-katello-devel-stable.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3B5dGhvbi9weXBpLzAxOGY2MmRmLTVlZWQtNzBiOS04ZWFkLTkyZGE4NDky
-        ZGNlZS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA1LTEwVDE0OjE5OjE3LjEw
-        MjI1MFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDUtMTBUMTQ6MTk6
-        MTcuMTAyMjY0WiIsImJhc2VfcGF0aCI6ImludGVncmF0aW9uX3Rlc3RzL3B5
-        dGhvbiIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M4LWthdGVsbG8tZGV2
-        ZWwtc3RhYmxlLmV4YW1wbGUuY29tL3B5cGkvaW50ZWdyYXRpb25fdGVzdHMv
-        cHl0aG9uLyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsImhpZGRlbiI6ZmFsc2Us
-        InB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGljYXRlLXRlc3QtcHl0
-        aG9uIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9h
-        cGkvdjMvcHVibGljYXRpb25zL3B5dGhvbi9weXBpLzAxOGY2MmRmLTVjZGEt
-        NzBmZC1iYjE0LWMzMzA0OTBmMzEyMC8iLCJhbGxvd191cGxvYWRzIjp0cnVl
-        LCJyZW1vdGUiOm51bGx9XX0=
-  recorded_at: Fri, 10 May 2024 14:19:19 GMT
-- request:
-    method: get
     uri: https://centos8-katello-devel-stable.example.com/pulp/api/v3/publications/python/pypi/018f62df-65e5-7ae8-9a50-9bfd552fe1d5/
     body:
       encoding: US-ASCII
@@ -61749,4 +61214,2343 @@ http_interactions:
         eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY2MmRmLTY4MjUtNzU3
         Ni04NjUxLTkzMzkyMGYwY2M4Zi8ifQ==
   recorded_at: Fri, 10 May 2024 14:19:19 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/python/packages/?sha256=2eceb1643c10c5e4a65970baf63bde43b79cbdac7de81dae853ce47ab05197e9
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.11.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - bfb94fc66ce34876843f6a937354da4f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/artifacts/?sha256=2eceb1643c10c5e4a65970baf63bde43b79cbdac7de81dae853ce47ab05197e9
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1e56ecc40d9c446d97dea7fa818bb75f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:54 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjoyMjQ1NX0=
+
+        '
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/018fe8d6-afc4-7523-9164-fe80d9b86221/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '182'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6e3fae8081bd471cb0b222ab66ac41c4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmZThkNi1h
+        ZmM0LTc1MjMtOTE2NC1mZTgwZDliODYyMjEvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyNC0wNi0wNVQxNDozODo1NC45MTY2ODVaIiwicHVscF9sYXN0X3VwZGF0
+        ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjU0LjkxNjY5OVoiLCJzaXplIjoyMjQ1
+        NX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:54 GMT
+- request:
+    method: put
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/018fe8d6-afc4-7523-9164-fe80d9b86221/
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTBjZDVmMjA5N2Y0ODEy
+        YTRhY2ExZDEzOTNiNWQ2MmVmDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyNDA2
+        MDUtNDYwODAtd3ZhaTEzIg0KQ29udGVudC1MZW5ndGg6IDIyNDU1DQpDb250
+        ZW50LVR5cGU6IGFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbQ0KQ29udGVudC1U
+        cmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNClBLAwQUAAAACACblrNIAAAA
+        AAIAAAAAAAAAEwAAAGV4YW1wbGUvX19pbml0X18ucHkDAFBLAwQUAAAACACb
+        lrNIz41btS0BAAAgBAAAFAAAAHRlc3RzL3Rlc3RfdG9rZW5zLnB5nZFBT4Qw
+        EIXv/RW90U02TRZvxjUxq15NyEaPzQDD0lha0haj/noLiiILrGtPJW/6vTeP
+        wpqKNlp6j85TWdXGeroP9x04JKRoZVeiKoRFyNHyyuSo3PekeUZNCMkUONe9
+        ewQlc/DIesjqkhAaTo4FbU2E1C/tjMhKsI65wA4j9Ou0nzyw0PoEpEPHArDB
+        O2uNXX/arWkkotUICqouQTfV/3gxj5MjZKEM+DGve8GiDY+nI8zMPz0kt+2D
+        QVG7qh529AuVGl8KheGnHDcEdNtTIc3yQO2V9Ed5fXsfCIMS9rZBBvSKppPy
+        PSiHLA06jNeT2uNhOc9mOkx8OsrE+l39i248nvHjF+c6dmZ/aXzOcXnH68W6
+        JxNlUEsPSsBBG+dldn6om+USticydZnJB1BLAwQUAAAACACblrNIZCZRtEYB
+        AACuAwAAGQAAAHRlc3RzL3Rlc3RfY2FsbG51bWJlcnMucHmlkEtPg0AUhffz
+        K27YAElDeFR8RDYSVy2N0aYbY8gULkIcwMwMGv+9My1V7IOkcRbzyL3nu2dO
+        wdsauqaSEoWEqn5vuYSlusdUICGFLosSWZFypDlyp25zZGLXGVPGFl29Rk4I
+        yRgVYiNeUVblVKK1I9k3hIBaORagJ6UMm1dZWkKRVQ36pZ+OgiCXj7QSKCxF
+        6vCe85ZPBsMmYCSG/SP7LVhG4qnC31lV86H9pFlJufjPyHR1wGZttk8cuDET
+        L/SnzhXMg3ARmvviHD/xa0zuup7ju9cwCwNfqwcRL9s3bMRIwIfGMkVOm66G
+        aNTjkWSWvENLSG7tEDZEERjPZmJOwNzq9W2uN9cJQn0uto/QfDlI7ejHT9jb
+        y+Acd71U+5j1ZhRjY2eQZJw8nB8jPRni5d10YHPTvD7VPL14Gku8n3TbU2zy
+        DVBLAwQUAAAACACblrNIAAAAAAIAAAAAAAAAEQAAAHRlc3RzL19faW5pdF9f
+        LnB5AwBQSwMEFAAAAAgAm5azSAcibjM2AQAAvwMAABYAAABzaGVsZl9yZWFk
+        ZXIvbWl4aW5zLnB5rZA/T8MwEMX3foqjDEmkKgtbRSshxNABpu6Rk1waQ+wz
+        5ys03x43dWkbGHOT/9z73btXdcp7eCbjFKuyw1d90Dal8h0ryZYzCJUkyca4
+        Dg1a8cC6aoEcshJiDw0xKAsnQT70N0wGXC8t2QdHLNru8opMwMyG/xobKKph
+        IqYeu2YBJC3yAgwGUR3HHku4v1yOxSh7trFxEOdFZdwH9mkWMZeH7FeKhwqd
+        QPokwrrcC74wUxi47d3pmN2OuYcIAUsC+rw91mEGn03UummQwzNIwCxGAE+w
+        gUrZRCDuCt9aWpgPJuc5bLmHcAy0L2SPsUt7sv9t/Eayudi4CrLopCiuY7xa
+        JWpjTDHxmHWnTFkr8EG1BA+PQNkNFSehrkZY/JwCuxpjd5O4Xf/BThLtekS1
+        k5i9G8z+AFBLAwQUAAAACACblrNIkmQ5VfYAAAD6AQAAFQAAAHNoZWxmX3Jl
+        YWRlci91dGlscy5weW2Qz07DMAzG732KT91loHXadkK98ucJEFcUMpdGS5vI
+        cYC9PUla2GDzJbH9s/3ZCzS3DbTbm/G9RZSuucuRqtpTB92TPrzK0dPyQ9lI
+        N22FZHVdl/c+pwOkJ2QGLlcoVlqIs5MTZvRR1lXhW5+SA0qrNvknWNw0a+aY
+        JPIYMoMNTAdLkrAVdtkJXmlawTG22R3j8Eb8K6x8UrhMWZugrO/VclaebWqO
+        TQmQPUNL4yvobkYDXaS2wOJHwXQzEzrrlFw92AOlLQYzUsBnT+k8XG5U0FQI
+        hVL7p0b4eJp63vq/lGeONAn90uQFL5l6ZHZ8ofpJpV2+AVBLAwQUAAAACACb
+        lrNIs2ZsFpEAAACwAAAAGAAAAHNoZWxmX3JlYWRlci9fX2luaXRfXy5weTWN
+        zQrCMBCE7/sUIZe2l6DePRQrRVQovsCypqkNbbMlPz6/qeJpmG+GGSklNKzT
+        YlykaNkJHsRKeqKXUSBzapeVfRQcABBnq40LBlEcRdF2t0ORIaU4sv+xOoVo
+        nbiT7tnR3G/52/iQl78FuVN7CdDVp2vdnrG5PDLkoFaKo+qtd7SY8u/pGTYt
+        EQc759Oqgg9QSwMEFAAAAAgAm5azSNc3sEFQAAAAbAAAABYAAABzaGVsZl9y
+        ZWFkZXIvY29tcGF0LnB5y8wtyC8qUSiuLObiCog0UrBVyMwr0QBy9cpSi4oz
+        8/OiDWI1FWxtFYy4uDLTFIBKrLgUgKC0OLUoPjOvoLQEqKUosRzC5krNKU7F
+        ogAiCQBQSwMEFAAAAAgAm5azSCr/Dmj5AQAAzAQAABwAAABzaGVsZl9yZWFk
+        ZXIvc2hlbGZfcmVhZGVyLnB5nVRNj9MwEL3nVwzZwybQD/aGInJagcQFuKOV
+        5SaT1lJiR2On2wjx3/HYaZPScgAfUtvz8d68GffhzXawtN0pvUV9hH50B6OT
+        B1i/XUNlaqX3BQyuWX/gmyRRXW/IQWWP560dbZI0ZDrYdKbG1sJkeJZt+3Xo
+        dkiTeVBnk9KVIcLKreCy2aMTGk9OVD5Ox7gkqbGBilA6FLWqnDJa0pg1qkUt
+        O8yLBPxK0zT8PgdHCxJmXwjYkhkDh3lA7aTSvjBwB3+UTrZmD6aBnSRfsY9X
+        GkI+tjeKrK/XtEOnQeoamB5EfsGTnSz6rPXktQmx4VP0kmQHZ7oF3/GG0c6E
+        Ft6EbiBtg9u0FoUsGd4QietKjfB5Ve4Apkd90WwF3KbykR5zkFwBG6KOvLyE
+        NRKUzG8TD1n0yRc+zBN+knm1P96/FBA2Ty/QGAp71iXG/pp62HnJM9+uqCuN
+        M+BUU2gvw9402w/YRtL+6AEiBTxV2Dv4oms8fSIyNCfrSWmXpd9blNa3pcdK
+        NaPv/p+d/6uQ6VwlnpTLnq4hv93H+8zpU3gHC67+lII2zosy6PpO3nDB2EL6
+        uufXkt15CdlSpTyfQ3f/HBrH4hAEieAfyynXXNf0KrPosZrscw0X2tFwff+f
+        nC5/CjeoiWpACB5eIaAsIRWC50mIdBqoOF3Jb1BLAwQUAAAACACblrNIcKxr
+        UkUEAADnDAAAFgAAAHNoZWxmX3JlYWRlci9tb2RlbHMucHnVVktv4zYQvutX
+        TJMCkRtbcHrZNKiLTYP0gd0sFttFD01Tg5bGERuJFEgq3vTX7wwlWpTtIHso
+        CpQHPzic1zffDHkMs29mkOtCqvsLaN16ds47SSLrRhsHBpO10TVktfwklYV+
+        +0rXjTBiVeEN70N/qHWy2p7JS8wflu6pwSlIu660cAmtY2iMXpHqEyjEwh83
+        +hFrVC55e/3z5dvl1S+XH36DBTnPcnIkK0xP/roVs38uZ3/MZ9/Bn9nd6dcn
+        EzKWV8Ja+KgfUKU7MU0uEqB1dHTkvy+BhA70GgTkoqpAtfUKTUYCx+q0qWCF
+        gNKVaOhQgbmsRTgH2ngzAqwzhBUbqtA5NDYb+SlwDculVNItl6nFaj2FR1G1
+        2IfDi3ezJe3KQjhMO/FY6vcIAf+deNlr64STeY2u1MXgasfM4CUExOta2dag
+        BVcK5/NXhVcKqWvlBFdXK6qKt0jVIyxzzg/otNfcmiMQCILqsHqPCgHW/e/w
+        s8lW+4KrVHepXQQ4fWQbSXWhGlAFOjGjzH+8n4OZyTVEnMlq4fKyh4JIB++0
+        wgESXkZIi/A7n7g2Rpv05CqET97xnio+pM4cC4rHcNNaF/hBUQrwnOZERdWU
+        wuvZODKlXWB+iImx5G3/N5PWa6aTl2L8OAY6YOytdfiGUD0p8rp5wCdPvzEj
+        PqBrjfKY0gFoLRawpgRy3zvSarUDbgh/YOVurJ3FQZ48K8kqvUGTxoEuqfx9
+        n0R2922GTr+izn3nE36+3f2h0LbEASqMpsrmTmrFhJKqwAbpQ7mOWFEH/w9b
+        OBpmLzTy0L9EG2k9C0RDw7cxki1VqO5d+UKjGmwoDMJOBDxH8/S5JiXboQW+
+        h29foPtRVEELNbcd95sjK4J+u42OsjqKevS/mQavGTI07mlbwo5GB/pt+/tH
+        g+LBjrEiJjrd605hU8q8BGEQpKODTtcy93eW3d5RW2t+UPbFDhMpmrsiOFi1
+        zk+blXZlFhW2a7ALOlhJ6y/FbsDo1d/UJ/ZgBl2cS6+wgNu7rUDhZtldBIuI
+        +bfzu8EhjxhJ6RLe6h5TJkM0UGAGZztTJR/bkncjabEjhVM4i7zxOgZP8XDn
+        j+HrqTI8UNJ8AotFvFHsBDRO9HQBxUF/3FIrvJdK9W8EwVoH3GNlcd/DMbw3
+        +EjNRQQo+EnGV20jciI/c2ffzH4m2yAn8NVit9PCimqZ0QSgYZh2b6hBe5Ic
+        cpTuYTbv7rR0hB0LznqBhB/2yhtWzK94/apGfWLpOelnT1shdQqDvJaGeBjk
+        pW6rgoA/nCy1nqN7zkO4KTW9W3o9jo/drOl+0Bv2EGZOZ/GgOX6fDBb7V6LN
+        9uHi9RMRHz+JuqnoEXxzNj+DN6/OYdOHCzdToL0pvJnCPHt1/ixGBwXcBSfz
+        7ITYX+yfiLsyEn9R5cPh/h6OdP79N0Z813eOki9+HziT3vJHz3d20qUsRwbv
+        JslnUEsDBBQAAAAIAJuWs0h17RgXLgIAAIQHAAASAAAAc2hlbGZfcmVhZGVy
+        L3VpLnB5xVTBjpswEL3zFVN62KTacK6QkkN7ymW1f4AGYxKrYCPbJFtpP75j
+        GweTRtlUqlpfAPPmeWbe83yGzZcNMNUIeShhtO3mq9vJWq16qKp2tKPmVQWi
+        H5S2MGghLe1KZoWSAVUw1Q9oI2Q0XFdCDqPNsoa3xK01Z3bFsOsqfAb/rNdl
+        BrTyPPfPvWyV7g3YI/cE9EKM7kvphj6FiTxF5gPKATX2gQxLgFZoY/0nyLGv
+        KWQDUvlsGvBURGFFz6EeCafGroGae6rrFepASRVJ6NAS14lrQ/WaG4fXdLjh
+        TMnmz0+/cfzdw2PH/IuXYpVXH618ncLfb1Wcrvd7+O9Bg4fxD/B/lL7DByMJ
+        +besdGECJNkGrU6i4SEi0dB4OqNmJoYSGgUIPcoRO2BHzn48ashHrfP/Vd5f
+        2vNPVZ7xoYm/7dTpTnTFgdtK8jdbOUjo4KpGTRONV41g9sodrzSxBpu4g8xC
+        gk4R3g+a08yTAYIDuYMOpIuYalTAvvV0Fxo/8EzC5F1HXnNjgK6yA7p06CKj
+        /vmcBJqpKJeXmxYHFHLpqbQcssxMA6qNP41PfeHeQDFVU94QKZ1XPt0eLVna
+        JBVF+qUpY43bZNiv8m/T7m63A3dpHfJ8FB2P+KJTZ1JnDZ+28MTfhH0q5xHo
+        FZ6S2S5KLkjiKOl6DhDtImZq9YuSvFzM1dCAFHv5zTtzBZ78GktpFA+0Rzw5
+        cwAao5hzw6LXk3njmtuj8XyvO64HZORfUEsDBBQAAAAIAGOXs0gJ7rCSPB0A
+        AKhNAAAqAAAAc2hlbGZfcmVhZGVyLTAuMS5kaXN0LWluZm8vREVTQ1JJUFRJ
+        T04ucnN0pVxrc9vIsf2OXzGlulWWqmh67SSbrHyTW5RE2czKlEJS6/hbQHJI
+        IgYBBgNIy5vKf799unsGA5LybnJd+7DIefT09OP0Y2Suy92+ytab2pxfX5i3
+        P/zhhx7994e35ray1kzLVf2cVtbclk2xTOusLHpmVCz6PfPfm7reXb55s3Kr
+        flmt3/wpMb/DrLT4mmeFmdY0v+6Z22xVb8xtXpZVz1yVrsYKnwbmu3dv3373
+        +u1vvntrHqeDxAyfbLUvC2syZ3a22mZ1bZemLs2CCDRpsTTLzNVVNm9qa2js
+        nIjZ4svMusSUK1NvaGaeLWzhrFmWi2ZrC9qfxpvFJi3WWbE2WY3li7I2aZ6X
+        z3bZTxLzjT8PlU2389xi1Gxj/fLOrMrKbOkwxnkG4d+lddm6ELLr9Ct9+Jzu
+        zb5sqmRF3FiWW3zjNjyeTsR00YnrvjFXezpMUVepI6Jr2uvD+NF8sIWt0tw8
+        NHPaOrnT09EZsqK2xVK2Wjcpcb2m68JW5ltb4bvE0/z6NQ3Zgk7X0DBsGo5D
+        W2AsH5R4RTQ60zhbuT44kbmkS5rxpKW7XU43gs2ZP3wxtitMSStMr1zEwYJP
+        kxZ7U9Kcyuyqcl2lW/O8KbFyU2/KyhGXtiQcNDJpnNwpkXQ+LbdWp70kuJ3D
+        LUqSIWLffJ94Zt9ZRwc0LxwsK1xt02X/wpgvZWMWacFn3RuhhTmvBDu6wLJk
+        0fq8sYV5Jr7ubPoVzGCmekJ6+AoEVXZlqwqnIQbo/fUgp8muov3pgPfNS5S5
+        I9GLrzStIRTJJn2SC46EI9InUaMj+sy5ik61ZklIWMeISU+0tclWWNo8Z25z
+        0Qtb0VkWNnvCIk21wNJLupiKGba2pH914ieSzNKP0VSMUUHtCCNNJ9kzRONC
+        qMQihSnss9Dr+f5eZMgv97Uon8O6yxJrOqxMfHZ8O7MSU2u7qEVz2A46vpXC
+        RrysLDi1gBA5WZ6YMc+WCckqTBaYaQvWdN1EVgLhkGj3Vb4qcSsV9LbiA8qo
+        fjKTOZ1dSKNdnta8+MJWdUoHphE7+jKbZ3lWZ2qGsLJwNDl5ozEne6BI2b8t
+        l9kK4susuKUv7M/pdpfTIB1xcjnXLDYm9SwnXm0stC6hn+qMT8wmw6wsLcT7
+        NGQG1pnKH0lHRksVxByYlZYLzFeokYGs9kXLeO6BONOUPStYL4haJF70bRJJ
+        Hq0zIJEIdLgNiQSN2XphIE8DE8SrisDQ37Iq8VcDHbanpITknvxa/Ux3Wtud
+        uzTnby/YV4kz7XKdxDI5f3dB/CM9VzGJvNXzJiOmgkeOv8ztmtScvaBzsFzq
+        BnvxDdOab9gL8TXG+zHVg9wRh3AXNsWNsfUkc6tHwapQFjqQCDxroxd4FbiE
+        GW69Z24guK6maS5chVjToqT5FZzQnrfk03V8DV3EaHXkYpj4jM0wfb612MXm
+        TnzBLiV7TBQWoC9Ra+FiCSJy9cqImGcvHCxA3s9jx5KuJCvSvEd7yJHgY4gR
+        5Nm37EqrctkshAz2Ibhdkk4sQKY5x9XjFqK1EnVHr2jArqnZwYi43OLrfN/j
+        TWLzBJLqDSEK8ty0F3l78LImF8KnV9+4w9c13CzJHWwrW5CnMlvy/ktYx0pO
+        TP7LiwMcIylnKkwPjhOHyIpl9pQtGxBlyjkbEtkkwBnS+MJYks0Faxv7oU27
+        DP2f3JCt02rfV6NJMgFxoWtm4WGOb9MlsIxZ5DZVCokFeiBRv3mAUEsRTRWt
+        V4o2YOXpY/A9jEsZrPU9BNvh/oPmsn8q6YRiNbEmFIVO0GvNl8p6ItK2EDCw
+        KoEAX8B/jL2G4+FkcGceHq/uRteG/h2Op0MMnw0nn6ZmML4x1/fjm9FsdD+e
+        mtv7Cf348GU0/tAzN6PpbDK6esRXPPDT/c3odnQ9wAfY8rs+o6hTsEllkzlP
+        xxFM81xWX9VMACXSHbokBZ/giHd5qsILCWlt0KbM4WlculfsuyU0SlfQGpFl
+        0gRnJAz1QPo01ujLHZw9CH1nBK8tcbGXMIAJ5LOPiM4A6tkIkoCe8VHmqag2
+        7+xXS7aWnJ6xGR85+gZrYF0iNXui6yNh41WE+PbAefp8KQqeMS10ctpWxirb
+        VLY7K5tdWbFMMLLoJUpACDJwAhj7WH6ct7/BUS9hSHB+vrEkJ0Vt0jVYdv6R
+        zCRZhRWxuBcmYEMG8ou8AZDHFmUDwSd4q18Xib8ZcxbvfgYYOoRdVzVhe5cu
+        l5Vlm5k6c0aO5IzEe0C2/knQQql8Bcp6SUk6h2RkCRTaomWRDhWH92JvGaI1
+        tctY/8md0upeVFKYzlVSNcUR69VCe9hjlz2Fb7waGVWyCeU2npJEwL0sgL1X
+        vCHulh0C29SsZvdojgQt8Tufk020O+CwgiMUMl8gbm4JrLMVo3OeoPiin3wW
+        tGOCkFUNsDfWctjFO6FwyGVpxS287QuiSfe/JqL1wE2XeeViUIPrjZE2MHRW
+        sIZsySU0hMpI+cjm2xYMJ2DNLls0ZeNy2Z1sDht2kl36ZAdFJ29Dh2DAoETG
+        o5JW09Ty6CEWeZptiStEtIcB781Xa3dQCUiAQr1EpjnvvgCGECp3LKFEgTh8
+        One2oF3g2OhsYekEYxhRtrFihAq6rCNB4KN4w6b7JGle0u0KiGtH01WFW5Kw
+        h5GsghoytZu9I+XIVa5FmX3sJjsJ2tvrKqmCxnKnFgZnDlgpAmPwwD/7KN0j
+        aJacd63kKNjjFeVU1WmB8RZTLVsilo1GNOwkt0Lui6a4p45V5DRGnWzau4ZQ
+        Dbw54Uqmeri3STonvT0hlyQahL631oqQyCmcjZz6pbjo9KKNCBZp4yScCABy
+        leXiPhfEW2YsnRHqrSLHazjYVdZpH3Ayv8XmyAreAi0ReqngySiFCvMjOlg2
+        wYCwbMQvYo5qlsa5ZNOxzDM5Z/6W0VhVB7fOnzlxdTjXgQnUi+U1eB5j8HKF
+        iKgDr8hGpLpLCi54eYaLYm3MqmVYBQL0EhLwrl+Ov7jwOD6w3jv6guSKQSZB
+        3KXkaThUQKqqSuGGyM7o4cnQkoGNAkRhJWSUv6SbquBSvRWGRkD0eHq0ICPG
+        rFCCkG+qluRpK1gLjhKJugxGvsKlEFCCQIs8FUXZkHVBllCdMCtFx+KZkxYv
+        5QX0g5cDoXMAXApmeh6BBflQLRA6woSLNnvBmTbW+Ajji8R7bvN18QqHCqNu
+        1Oa5919YznDkW5qnzD4f2ERepUV458OfF5bN1SUcbMdl187mK59/9HdAtPES
+        8HXs0oMkCPMlZVB0WN4TI9axQP40xwjhH01WST5GVjxYrH+RhBwKD91KgoHz
+        c+pMgrjylq12cGCaZIAC9H1KIaFxVpMwzB+EljxFsNCLmtljt4Q8xBx0pK4s
+        aDXO6gIZVQwQW9iBwc6S8kHMsIFTuLclFj8hJquhCLEKysUC8LCG9pDT4lx2
+        e86SPFsgnzXpwB5x7iN1B1sj/9zUYUJyIHMu3UZcodlseTjeFAsjkUnmOj4l
+        OfQpbFdjvKk+S9bwAaLO8kYo6XJAcsFtakRiPsEAHgtTCPEzsuN69QmuttJt
+        PMZs2FlIaoQ+4EBUjlXZdVotyRfw/dMk8wwvLYmyGU3sRWUEUMqp+DrYS+UT
+        +yLgoigXyDjV1UmcRqJhEtxVqHgQCGBiJSlA494buqUNxw3tVhzdJPZnW0ko
+        7JNokidCOiM/yewofiorQnM5Mhs+mnInkQCdeVQgssik9rOFoUvXa3DJL6sh
+        j5wDXDm1UHIItdg+8offACIX+Dk1T2XeIL+/oqDX1WVFcZWa9PZ8An1bIzSv
+        vPmLqBOryTKNIOWkk/vNt5H64REOqUcEKb7Uo593F3BR5fzvyK/4fDjd3qKp
+        2d4AkJ1wv8nUa9xbpuGdYRD1EoYiY4D0meqUpDeIAy18GizIJe+AVkh+w23g
+        s9yyq6skv8x+cEuaQQDqNXw5iBT81MYgPdV5r7VRTuEbQFBcTfc4fMF6eQta
+        rdymVUby3/gkUZswhM8RMPaeWNgLgOz4ZGnQJ0bcPfOU5pksRzzLyTrXnIuT
+        c+1tWnHRpo0qGB+xQdj3FI8rgCpQ2ZJkdCG1PcZFWuzyAQKcn6081FbGxfLa
+        YycsvOcVDjkeuejDy+ncA+M+8b+/7g5e5r+c5D+4g8VL0pUVYIFYiihkZXiq
+        jpkvSFz/QU3qhSMDonDyLM2JlkLsmaIYLetKdmDFqcQCQBSWkqK2o2yHzyLA
+        6WF+oC+GWr+svHzegE/TIHWIyokvlWR3zLSZe+8wF+4rcukUy1atUZGEmNDC
+        JUK5jm3wnBiEwpxmbbuBGfGTi6O3HDPEREtCLqi+7J7w7rKlr80c0UWf0yYN
+        QqWsDVoosMsbx4FJ6ly5yHw+jFQgheDbVVZkkndFmKXjxQ5X2U6Ky3DYifdf
+        IC7TNBnDHmTL8zyNgUN7IjrlR7r4JzAd2C5xO8s3bj2W7R2dJ1YXLvfBa2g6
+        DpU9LhSGTE/AtPG0c0Ttki3UlYlHcw5AEtzTRasJ2/TvjAC2JNGMTs/lhKD4
+        K4mxzQWaOJjxCz1hQj6qkpjV7V1N0I1zTDC83fMjUCKuNgXjFqY5bJUoak9V
+        QznP3OUeOfnVEVqIVgfEijQAlRtNk7GgE30Jrc5ba8MGo+NUy9IsDZylVlTr
+        ZxnAdTLNoPJggSPp83CbwSgvRl80jPNdcgpWdqwkChbAx816E9n2TKvnkuPc
+        7ihmippOokUOskURMxgy/LaFDBAiSQNJsoaiP06hC3yNQUsHSiQiqBBe+/MO
+        aVwOn9TTe2seIRUUNpFeIqHY1QlDnGcGg+WL27+8O8wnSkwiglw2Sht4gVp9
+        GZxIhnvslEBPkJUENfT8BYLm+lCwrZKxYmb4ijvfLhyEB2hRRjCU4nwTQ1a1
+        jTiBMNYcviVENzDFngAKB1Hzon9WTS6GJc9SCh356n4nV+ejuzjWhETu6oMQ
+        zGVISfo6NUuOdl6wrQ3HByZmCUc5c40AX5K23aquJvTIgr9wMcgG1e6w8iFd
+        OAh4Ux+UVVyv22TzrJZEfZ4+h0K+xonH55F1yLeUKFPP91Ij42xFB18fpO7P
+        Nb34Yor9QlI7qD0ugtTI/qmmdDt3XDN+RcUa+UbfcPTv1PiE4kB+csDEgwhH
+        ux6+70sVpc62VvHJt5D+L5y4jvsbDhRIhR8RstdGb9ESX1PWb6RpRJS4m0mM
+        av2eLtJuNkU1Ktv2hbqo76ZQ85SRY9C85aqpuFrV6T3REKxNqb8yIdZU26oG
+        gOWaWLHhAlc/6WqSNqsISKLAlv67wD21GqgFpcga8zkOArLf981oJX6dsymk
+        oqEuAB9AQfvfm+WaM3mCUaLgVMrPCQFROBzrB630Pn31AOkacy6F522mrYda
+        uiZ1bay76CWRFDIWZj6yIEB2zrUVBocSqgj4MSChaNlv3FrqC++m0fRHalIr
+        0A9bHOhIT4ptostwF0h9Yt/gGV+eK90X2gqF6XFGv1Qw7tDAQ+Llsm2Tk5pa
+        KRVJ+YJ8yFphZWv1k7hoE/XtWbpLTr5H09TzH10ikLcXzBd0TzsAjpuUUn+7
+        oZGmbHLBcdJCaqpyT1HC/jV3F0TKHcEEvwsZP0G9JXfklKG8pgWWJbmFBbo1
+        OGkffqIokkEFnUOOyJaH4wpt/oQwEFWevXNiErCz5KFiP8fD5jCGqKdXcFoh
+        G8SX/A3yBcJFJZ+jfBT9dWNzAGmJhdFUV4hSWgZ54np5CSjjoslTsrRZtWi2
+        jq22WLh5mrcm3MbLRz2pieQkfTXFD4qKEgc9rNpLWYgIJfG2qJ+OOhm3XVOx
+        BTuRcqObadQ/80+i9VEjimubKpDmJ1Hda/KMs3W+Z09TdZI3yOq91oISzmXL
+        yPfdzTepBjQ4XUShr/FpUw0Ova50xVo7Mtv4unPFgvl7Ib2aZBB9WBJx8Ttp
+        zvDSv+OEPBhmzCe+R1vS+LY7J1mjq4PUWqyObhMi8WcU8CuuQKLR74gku0y8
+        tLPp0pCEGxPVnpeF5LsdG07uallEIVtKYIknvdccarMLxV7up3qzLAu5gCV5
+        nyU3mXLXlXEblhmAQXbvnVxBoNXT1xojJVKaT0K3hJpB9YRiiDdlxphwdqA1
+        sZhydxwIxS5I7nOv07PGiHNig30SBZjbY28lXtXVR+YZXu4PfV9ZO8xSvNH+
+        1wODlbmodwLFA98mymFRBZulsSlEpRX++b4ta8VRupjoFo0cNRLBKHLg5Tp0
+        HEcBbNDT5VKyDpABuu21xfDdhsvnnSNGHS/k1qQQl4gdDkfpSZNmWnendh4L
+        SDKnYAywpUggaRkhlqNxuoFdwiMWUplapOJcI1NMGL8kBUaBxLE9j0gkNSeh
+        9OlFrT3Oy+VRiwHf6g99boN5sScdnPKtF5V9yrh0K1eO9mYKJbjKkejdv9Cc
+        LhAAIBbaRP+n401xtngN1h3IJTn4DLadaHe7rOIGdp9kctBbnSGPJ0AhwU70
+        LdCEpSURy9nCS7cRbxF6KaXIQYLIzZCMrXUxXBWyq8g24grpjhs6NMyiH1E0
+        27mt2k5RHxpzLmfFsfrB2KM4Qixl1E2njvYMthtdWpVf4azXBnHssX2DRps6
+        j9KnXTztO8R8fdATVVa+ZaCzlb/gtkcP4pCcEIejs7flDGHC/hQLDkpk+9DA
+        UnqY76cgND1NzanHGdK39F3fY0ffjRppB0OFo+YTboQT8xv3ozqt3nU0+ABT
+        i6RxgRgqZrvuIdFueqD3NpBWZBicQKhGxmbuFzh/sN1L+vqeH3OUWwslcwm7
+        g5BidKH3WR9swIcx3zmFQZpHIr9saUHz+LpMc9Zu1r3qyYudoAIyOY009tL8
+        NgfAH/mnPp0HNLJSuS1DyI4nQNLYsCQDo24kTFmLPcn3v/AQanxvPg8mk8F4
+        9oWF4m3fXA2vB4/ToZl9HJqHyf2HyeCTGU19n+yNuZ0Mh+b+1lx/HEw+DHsY
+        NxliRLwWumajBWjUPf88/OtsOJ6Zh+Hk02g2o9WuvpjBwwMtPri6G5q7wWdi
+        8fCv18OHmfn8cThO7rH85xHRM50NMGE0Np8no9lo/IEXRGvuZPTh48x8vL+7
+        GU64f/cN7c4TzcNgMhsNpwnR8dPopnuos8GUyD4zn0ezj/ePs0A8DjcYfzE/
+        jsY3PTMc8ULDvz5MhlM6f0Jrjz4RxUP6cjS+vnu84dbgK1phfD8jPtHJiM7Z
+        PbPGj/WrEzG0fvJpOCH+jWeDq9HdiLZEL/HtaDamLbjjeCCUXz/eDegQj5OH
+        ++kQOR2wkBYhhk9G0x/NYJooY//yOAgLEXdpjU+D8TVf1MFF4rjmy/0jXAmd
+        ++4GAxI/AIwampvh7fB6NvqJrpdG0jbTx09D5fd0xgy6uzPj4TXRO5h8MdPh
+        5KfRNfiQTIYPgxGxH13TkwlWuR+LwXnXx+WRlAx/ggw8ju9w2snwL490nhOS
+        gDUGH0jawMzo3pPPI9ocN3R4+T2eQl+0l/+FxOjefBp8kVbtLyoeRGbo5e5K
+        BQlFK52Dq3vw4IroGTFZRAgYgiu6GXwafBhOe0kQAt5a28t7ZvowvB7hL/Q9
+        iR7d9Z1whbToL4+4RfpAFzEDuk4cDXKoVwYdhKyNvYzQ3od6ed7ufSB/kIu7
+        +ymEjTaZDQxTTP+/GmL0ZDgmfrE6Da6vHyekWhiBGUTN9JGUbTTmS0lwXtbm
+        0eTG6xPz2dwORnePkyMZo53viYVYkmUtXIgXsulFj2XAjG5pq+uPenumo7Vf
+        zEe6iqshDRvc/DSC5ZF9EtKF6Uh5cq8rKB9fsnZ0Wp59osG/O+OjNFMNOGqV
+        TOyMgQJ9+AWWeUyoSN2hw1R1oUvywHm5Iy+usKnttoyexGkvn3rVNT8ZcXVC
+        sYqk0xoXHJWEgBqZI7RA0oFz1xuEIoKOpBuenVVWJ12nIc4yvPFB/1InCRo9
+        Hg01ZZ9m9I/ofOq2rlOtTLUYKrT8eogp6QriCIdMLl3haKA4zN76wdwFyKUo
+        fKOlGBQQw/NSebQinYWEJJ7sXktbhPKd4rm2JZk7fbAUr+E2nHBhBOibAhjs
+        nwXccEbAv9D0ltmVHCpxxw73+/FBGylO8INIAABikkrXP5dWiptEx7/4k+5b
+        63+i7eBfNA5rFOnW/kvmcfwZvRnq3Nf78KCxc0sCc9v3YNInWZ9u6jz1trjt
+        v3YdgBh68l5GRO1zCeb4O7/JXVv04lXOu73QF8dAuX+aAXHFVeOtDZp3pDRb
+        B3RFakGs7ElXCEUu3mHDsHin/T68s9CKIKdxc24M9I2bhKixxKHvJeb+Ctc7
+        tSwYvMI32CwPyPnhLgIqp0dHAj2Wy7ZfotMO8q37Qw1MumylWtny8j0CV5LV
+        X4l19aE/r/Wfv+zHExS0JyEdEHeDIGMmRpSbCORxJZCxRVNaVRZ0JnkFSECf
+        bFeWS4qz05jR6UPteQvnn4+kYGUVWnfz7KvYw4T7HGkc2xcnbyc6Ha2kRFYb
+        pz4UhKafBMZ7Ef/+h96BLkOVDXSYwbrEKoezFxQ26LPRwdX0/o4Qxd2XGA2/
+        Z6lQgTD1nkT8b/xg9flVv1WMQ4vQeg825zbHPuDrgYHgFfTFVEgU+djrfbzd
+        4lVMSF86VDb7HSI6rme1vd2ePqYhzFYJ9o9tO29IOgHji6/M7ldcQtGqR7sf
+        l4gdspl7ZDJQW+PKLwVknEqInjidJE1fLElGni3A3CbbkpZ8vSAKvnIGY2uL
+        hhhmt+71a6T2OGp2TSYV3PDMX9+K6GG5Bw8vkHmIJZtS7mnauX/sHrqOdfbW
+        VhdGnm9XiUOsnktNo5C+dRSV8VyuzcK1D23O2vcoHkFkq6TA63gnjzQ/aj96
+        inaJXU5ug5uleA7EVF5VfCn35XJfWP8rPeDV5vuwkbQBtQSwhgBjqBHWzWmh
+        v0Vy/gqFMG4NJG108orXGW1IQb+LuwjZM9rsz6DGfEwXX23FRvCf0jGC994k
+        JbM9aRr5z555S2irynL+FSWAHfJFD7+jw2X+JddPJEGawX3BPoaEilaI2mQG
+        5Ce+X05jJNHj1/B7BkI5rYpNUYpibFWiFg1jM69oSsjGJL4NnN9hwvCLt+Iy
+        o1BCtpWbuOIdowy6C+0niS7us0ViFJ59N6h/yb0kSObfyRz/fovk9O+3OJHE
+        vGlhzKXp98lfpmt7eWnw+1/c5Zs3dZXSzb9eZPxrYFK3TRfL8g3hh3zFzYx0
+        r+5p/T9EcrHY/HFLKEv7/fyfyxqNlfW/s2KYH/7yx+hP+HCKKWbSnXJy5Mkp
+        cqs1qSYrnLA9a9+vIbeMbAzMkKbj9NdTIBcalvQF2qwy87SSF3zoKbbSvGKd
+        PrOQl5SqXNz+uNAact9cWX4hE9ZE8x0ZOUd+h1SN9Miv3PbUSTOk86IIb7da
+        qcMtsHTakuhnC3cx6B8NmUP/UnCxaCp5Juiwq5wF9/Gkv4RCTsxsCWvqs1Cu
+        gaFq0D9mNisqJ4x3ocBHgRF32KOehrwyP6Lgp5lpBWyiHTjtZcztWt/0MFZF
+        YWhNXu1/fa8QsZGY6CSbPQptO7rmXKKJVcYYnz0rYcuipVHDjlB609To0VlG
+        0qAYfn4tf44HkgqB16/nebn4Sno0T93meBT+/JfZZTvf+Wi+Lf8TaVxy5mFP
+        6KMwf/qjedf//fG4x0iITpL3AU/xzLLZ7nBzKhiaAY/lnJsVNXvORUCCqO5J
+        QitYqkPZcl6yc7uCM8ibbXG8qo5hh9M3pySG/Q73vFT+yEUpb3BtsYBAnGsv
+        XYFkc/zLZgCKGv+8xNXuItrh09EvzRFJ2Qk79RLQ84mp2hb9rv+99FL3f39x
+        klre8PL/JwPxvaOOt3lTl2/AZjjyPvH8eKKvw0UXfVoWPzzcmXftxz/a/TN0
+        5TIYDW8YoksSgox/PlIWyQNFcUD2l+Zx/OP4/vM4uc7J7aNmU12aG8l5cAPM
+        VDLadOLfmtdk1Oq0M3TkS62DZplx1fQyzCfp6Iz1jotG3E9HSMVUJSIl+vkb
+        4dHTO3NOh356d9FZbAzAQaPv9NU+VhkWa4TBnXGa0uGm/nisKh397d2/O56U
+        NJ4xLJ4yin6YW/T1NTn+MrfJ/wFQSwMEFAAAAAgAY5ezSCBJkjgxAAAAQQAA
+        ACsAAABzaGVsZl9yZWFkZXItMC4xLmRpc3QtaW5mby9lbnRyeV9wb2ludHMu
+        dHh0i07OzyvOz0mNL04uyiwoKY7lKs5IzUnTLUpNTEktUrBVAHPjIVw9ZI5V
+        bmJmHhcXAFBLAwQUAAAACABjl7NIKbnBt5ABAADdAgAAKAAAAHNoZWxmX3Jl
+        YWRlci0wLjEuZGlzdC1pbmZvL21ldGFkYXRhLmpzb26dUk1v2zAM/SuCTivQ
+        OR+35LS2M7oMbVa0ay9bYSgSF2uTJY+S1gZB/ntJKxtcYKca8IFP5ON7JPcS
+        nhP4aIOPcin2st+lNvhKh65T3hTsCVXfaMoIDgYgtuB+vEdQBpCAEjclrsbB
+        slPWy8PhVPwlNpCUdYWXKJPSiYNvewmU65hNxU5pEz5sGWAlksq96ri3PMsx
+        WS+uOcMrZ/gNiy6pMrVAeXgkzASdO/Cp4cLSzkDUaPtEXjn7Y313cbu6+br6
+        sq4wJjmIxPATdGoyHiV+CqVtm1Ifl5PJ1qY2b1jU5Chz8moYY6vw3AdM/6zy
+        9JqiIL5tisy9BQ+oUhgqNsbG1Dy1AE68m1bzRTU94YE4q2mng/DL9b24rNf1
+        7dmVuLk/v1pdCPrr9V393Yv/fw+AfA9ifio+Zw9itljMmLWj1RmVVPOnJDD9
+        vJqOt/PKEuEx0xnhjp+u1S8QMSOIXcgodHCOJs13JxSBtFOtnBM+dxtAEZCH
+        wBQJyCLC72wRjpcyjqQPZPRx2PlI17SaycMLUEsDBBQAAAAIAGOXs0iI4w+4
+        HQAAABsAAAAoAAAAc2hlbGZfcmVhZGVyLTAuMS5kaXN0LWluZm8vdG9wX2xl
+        dmVsLnR4dEutSMwtyEnlKs5IzUmLL0pNTEkt4ipJLS4p5gIAUEsDBBQAAAAI
+        AGOXs0iwmITLXAAAAFwAAAAgAAAAc2hlbGZfcmVhZGVyLTAuMS5kaXN0LWlu
+        Zm8vV0hFRUwLz0hNzdENSy0qzszPs1Iw1DPgck/NSy1KLMkvslJISsksLokv
+        B6lR0DDQM7LUM9DkCsrPL9H1LNYNKC1KzclMslIoKSpN5QpJTLdSKKg00s3L
+        z0vVTcyr5OICAFBLAwQUAAAACABjl7NIWR+Zx7odAADZTgAAIwAAAHNoZWxm
+        X3JlYWRlci0wLjEuZGlzdC1pbmZvL01FVEFEQVRBpVxtcxrJtf4+v6LLlSpL
+        VQivndeVb3IvlpBNVkIKoHX8LQM0MPEwQ6ZnpOWm8t/vec453dMDyLvJdVWy
+        NvTreX3OS3Nn63SZ1unFj7ZyWVlcmnf975JxurWXxm1svrqobLq0VRK+/67/
+        Npk2221a7S/NXfrVGtdU1uzLpjKLMs/toqZxzqT0YVaYRZrnpmi2c1uZsqKV
+        +smncmsvdumattjU9c5dvnmzzupNM+8vyu2b1G3TxbJ809l90NSbsro0g8bV
+        tOgdRhRpvtQvLuw2zfJLo3P/Z41/YrXkNlvYwtFOH8eP5uNwPJwMbs3D44fb
+        0ZWh/w3H02FiTv/RG5t3PfPnprDm7fffv00Sc1Xu9lW23tTm7OqcPvzD9z3+
+        ytxU1pppuaqfcfWbsimIsLRAz4yKRb9n/guXpbuu3KpfVus3f0rMbzErLb7m
+        dKdpTfPrnrnJVvXG3ORlWfXMh9LVWOFuYL579/btdxdvf/3dW/M4HSRm+GSr
+        fUnnypzZ2Wqb1bVdmrokJuz2Ji2WZpm5usrmTW0NjZ3TYbb4MrMuMeXK1Bua
+        mQt9zLJcNFtb0P403iw2abHOirXJaixflLUhNpbPdtlPXiIX/3kgfm3nucWo
+        2cb65Z1ZlZXZ0mWM8wTC/5bWZetCjl1DlNLndM+ilKyIGstyi2/chsfTjfhc
+        dOO6b8yHPV2mqKvU0aFr2os5bAtbpbl5aOa0tec+7pAVtS2WstW6SYnqtVWp
+        /dZW+C7xZ764oCHbIPLYNFyHtsBYvihEPqudaRyJUB+UyFzSPZrxR0t3u5w4
+        gs2ZPswY2xWmpBWm1y6iYMG3SYu9KWlOZXZVua7SrXnelFiZVcMRlbYkHDQy
+        aZzwlI50NiUl1GkvCW7ncouSZIjIN98nnti31tEFzQsXywpXk/L2z435UjZk
+        Bwq+697IWZjyemBHDCxLFq3PG1uYZ6LrzqZfQQwmqj9ID1/hQJVd2arCbYgA
+        yr8e5DTZVbQ/XfC+eelk7kj0YpamNYQi2aRPwuBIOCJ9EjU6Op85U9Gp1iwJ
+        CesYEemJtjbZCkub58xtznthK7rLwmZPWKSpFlh6SYypmGBrS/pXJ34iySz9
+        M5qKMSqoHWGk6SR7hs64kFNikcIU9lnO6+n+XmTIL/e1KJ/DussSazqsTHR2
+        zJ1Ziak1mXjRHLaDjrlS2IiWlQWl1BHw8kSMebZMSFZhskBMW7Cm6yayEg4O
+        iXZf5asSXKmgtxVfUEb1k5nM6exCGu3ytObFF7aqU7owjdjRl9k8y7M6UzOE
+        lYWiyUmOxpTs4URK/m25zFYQXybFDX1hf0q3u5wG6YiTy7lmsTGpJznRamOh
+        dQn9q874xmwyzMrSQrwP+TizzlT+SDoyWqog4sCstFRgukKNDGS1L1rGcw/E
+        mabsWcF6QdQi8aJvk0jyaJ0BiUQ4h9uQSNCYrRcG8jQwQbyqCAz9LasSzxro
+        sD0lJST35NfqZ+Jpbcnpm7O35+yrxJl2qU5imZy9Oyf6kZ6rmETe6nmTEVFB
+        I8df5nZNas5e0LHPVjfYizlMa75hL8RsjPfjUw9yRxQCL2wKjrH1JHOrV8Gq
+        UBa6kAg8a6MXeBW4hAluvWduILiupmkusEKsaVHS/ApOaM9b8u06voYYMVod
+        uRg+fMZmmD7fWuxicye+YJeSPaYTFjhfotbCxRJEx1WW0WGevXCwAHk/jx1L
+        YklG8KpHe8iV4GOIEOTZt+xKq3LZLOQY7EPAXeA8WoBMMzCgAReitRJ1R69p
+        wK6p2cGIuNzg63zf401i84Qj1RtCFOS5aS/y9qBlTS6Eb6++cYeva7hZkjvY
+        VrYgT2W25P2XsI6V3Jj8lxcHOEZSzlSIHhwnLpEVy+wpWzY4lCnnbEhkkwBn
+        ekC2lmRzwdrGfmjTLkP/JTdEyLra99VokkxAXIjNLDxM8S1BW3jDRW5TPSGR
+        QC8k6jcPEGopoqmi9VrRBqw8fQy6h3Epg7W+h2A78D9oLvunkm4oVhNrQlHo
+        Br3WfKmsJyJtCwEDqxII8AX89210PRtO7qZmML42V/fj69FsdD+empv7Cf3z
+        4cto/LFnrkfT2WT04RFf8cC7++vRzehqgA+w5Xd9RlGnYJPKJlOeriOY5rms
+        vqqZAEokHrokBZ3giHd5qsILCWlt0KbM4WlculfsuyU0SixojcgyaYIzEoJ6
+        IH0aa/SFB68e5HyvCF5bomIvYQATjs8+IroDTs9GkAT0FV9lnopq885+tWRr
+        yekZm/GVo2+wBtalo2ZPxD4SNl5FDt9eOE+fL0XBMz4L3Zy2lbFKNpXtzspm
+        V1YsE4wseokeIAQZuAGMfSw/ztvf4KiXMCS4P3MsyUlRGwoKAU4/kZkkq7Ai
+        EvfCBGzIQH6RNwDy2KJsIPgEb/XrIvGcMa/i3V8Bhg5h11VN2N6ly2Vl2Wam
+        zrwiR/KKxHtAtv5J0EKpdAXKeklJOpdkZAkU2qJlkQ4Vh/dibxmiNbXLWP/J
+        ndLqXlRSmM5VUjXFEenVQnvYY5c9hW+8GhlVsgnlNp6SRMC9LIC9V7wheMsO
+        gW1qVrN7NEeClvidz8gm2h1wWMERCpkvHG5uCayzFaN7njjxeT/5LGjHBCGr
+        GmBvrOWwi3dC4ZLL0opbeNsXRJPuf0lE64GbLvPaxaAG7I2RNjB0VrCGbMkl
+        NITKSPnI5tsWDCcgzS5bNGXjctmdbA4bdpJd+mQHRSdvQ5dgwKCHjEclraap
+        5dFLLPI02yIhsgow4L35au0OKgEJUKiXyDTn3RfAEELljiWUKBCXT+fOFrQL
+        HBvdLSydYAwjyjZWjFBBl3QkCHwVb9h0nyTNS+KugLh2NLEqcEnCHkayCmrI
+        1G72jpQjV7kWZfaxm+wkaG+vq6QKGsudWhjcOWClCIzBA//ko3SPoFly3rWS
+        o2BPk1O4VXVaYLzFVMuWiGWjEQ07ya0c90VT3FPHKnIao0427V1DqAbenHAl
+        U73c2ySdk96ekEsSDULfW2tFSOQWzkZO/VJcdHreRgSLtHESTgQAucpycZ8L
+        oi0Tlu4I9VaR4zUc7CrrtA84md5ic2QFb4GWCL1U8GSUQoX50TlYNkGAsGxE
+        LyKOapbGuWTTscwzOWf+ltFYVQe3zp85cXW414EJVMbyGjyPMXi5QkTUgVdk
+        I1LdJQUVvDzDRbE2ZtUyrAIBegkJeNcv11+cexwfSO8dfUFyxSATSU7J03Co
+        gFRVlcINkZ3Ry5OhJQMbBYhCSsgof0mcquBSvRWGRkD0eHq0ICPGrNADId9U
+        LcnTVrAWHCXS6TIY+QpMIaAEgRZ5KoqyIeuCLKE6YVaKjsUzJy1eygvoBy8H
+        QmcAuBTM9DwCC/KhWiDnCBPO2+wFZ9pY4yOMLxLvqc3s4hUOFUbdqM1z77+w
+        nOHItzRPmX0+sIm8SovwzoY/LSybq0s42I7Lrp3NVz7/6HlAZ+Ml4OvYpQdJ
+        EOJLyqDokLwnRqxjgfxtjhHCP5qsknyMrHiwWP88CTkUHrqVBAPn59SZBHHl
+        LVvt4MA0yQAF6PuUQkLjfM6f6YPQkqcIFnpRM3vslpCHmOMcqSsLWo2zukBG
+        FQPEFnZgsLOkfBAzbOAU7m2JxE+IyWooQqyCwlgAHtbQHnJanMtu71mSZwvH
+        Z006sEec+0jdwdbIPzd1mJAcyJxLtxFVaDZbHo43xcJIZJK5jk9JDn0K29UY
+        b6rPkjV8gKizvBFKuhSQXHCbGpGYTzCAx8IUQvyE7LiyPgFrK93GY8yGnYWk
+        RugDDkTlWpVdp9WSfAHznyaZZ3hpSZTNaGIvKiPgpJyKr4O9VDqxLwIuinKB
+        jFNdncRpJBomwV2FigeBAD6sJAVo3HtDXNpw3NBuxdFNYn+ylYTCPokmeSKk
+        M/KTxI7ip7JKfHXrycvfKSRAdx4ViCwyqf1sYejS9RpU8stqyCP3AFVOLZQc
+        Qi22j/zhN4DIOf6dmqcyb5DfX1HQ6+qyorhKTXp7P4G+rRGaV978RacTq8ky
+        jSDlpJP79beR+uEVDk+PCFJ8qUc/787hosr535Ff8flw4t6iqdneAJCdcL/J
+        1GvcWz7DO8Mg6iUMRcYA6TPVKUlvEAVa+DRYkEveAa2Q/AZu4LPcsqurJL/M
+        fnBLmkEAiguWOKTgpzYG6anOe62NcgrfAILiarrXYQYr8xa0WrlNq4zkv/FJ
+        ojZhCJ8jYOw9kbAXANnxzdKgT4y4e+YpzTNZjmiWk3WuORcn99rbtOKiTRtV
+        MD5ig7DvKR5XAFWgsiXJ6EJqe4yLtNjlAwQ4P1t5qK2Ei+W1x05YaM8rHFI8
+        ctGHzOnwgXGf+N9fxoOX6S83+Q94sHhJurICJBBLEYWsDE/VMTODxPUf1KRe
+        uDIgCifP0pzOUog9UxSjZV3JDqw4lVgAiMJSUtR2lO3wWQQ4PcwP54uh1s8r
+        L9834NM0SB2icqJLJdkdM23m3jvMhfqKXDrFslVrVCQhJmfhEqGwYxs8Jwah
+        MKdZ225gRvTk4ugNxwzxoSUhF1Rfdk94d9nS12aOzkWf0yYNQqWsDVoosMsb
+        x4FJ6ly5yHw+jFQgheDbVVZkkndFmKXjxQ5X2U6Ky3DYifdfOFymaTKGPciW
+        53kaA4f2RnTLT8T4JxAd2C5xO8sctx7L9o7uE6sLl/vgNTQdh8oeFwpDpidg
+        2njaGaJ2yRbqykSjOQcgCfh03mrCNv07I4AtSTSj0zO5IU78lcTY5gJNHMz4
+        ud4wIR9VSczq9q4m6MY5Jhje7v0RKBFVm4JxC585bJUoak9VQznP3KUeOfnV
+        EVqIVgfEijQAlRtNk7Gg0/kSWp231oYNRseplqVZGjhLrajWzzKA62SaccqD
+        BY6kz8NtBqO8GH3RMM53ySlY2bGSKFgAHzfrTWTbM62eS45zu6OYKWo6iRY5
+        yBZFxGDI8JsWMkCIJA0kyRqK/jiFLvA1Bi0dKJGIoEJ47U87pHE5fFJP7615
+        hFRQ2ER6iYRiVycMcZ4ZDJYvbv/y7jCfKDGJCHLZKG3gBWr1ZXAiGfjYKYGe
+        OFYS1NDTFwia60PBtkrGionhK+7MXTgID9CijGAoxfkmhqxqG3HCwVhzmEuI
+        bmCK/QEqdFNxgm3V5GJY8iyl0JFZ91thnY/u4lgTErmrD0IwlyEl6evULDna
+        ecG2NlwfmJglHOXMNQJ8Sdp2q7qa0CML/gJjkA2q3WHlQ7pwEPCmbXsa6nWb
+        bJ7VkqjP0+dQyNc48fg+sg75lhJl6vleamScrejg64PU/ZmmF19MsZ9Lage1
+        x0WQGtk/1ZRuh8c141dUrJFv9A1H/06NT04cjp8cEPEgwtGuh9/1pYpSZ1ur
+        +ORbSP9nblzH/Q0HCqTCjwjZa6O3aImvKes30jQiStzNJEa1fn8u0m42RTUq
+        2/aFuqjvplDzlJFj0Lzlqqm4WtXpPdEQrE2pvzYh1lTbqgaA5ZpIseECVz/p
+        apI2qwhIosCW/n8BPrUaqAWlyBrzPQ4Cst/3zWglfp2zKaSioS4AH0BB+9+b
+        5ZozeYJRouBUys8JAVE4HOsHrZSfvnqAdI05k8LzNtPWQy1dk7o21p33kkgK
+        GQszHVkQIDtn2gqDS8mpuEGUDk7Rst+4tdTn3k2j6Y/UpFagH7Y40JGeFNtE
+        l+EukPrEvsEzvjxXui+0FQrT44x+qWDcoYGHxMtl2yYnNbVSKpLyBfmQtcLK
+        1uoncdEm6tuzxEtOvkfT1PMfMRHI2wvmC7qnHQDHTUqp525opCmbXHCctJCa
+        qtxTlLC/4O6CSLkjmOB3IeMnqLfkjpwylNe0wLIkt7BAtwYn7cO/KIpkUEH3
+        kCuy5eG4Qps/IQx0Kk/eOREJ2FnyULGf42FzGEPU0ys4rZANYiZ/4/gC4aKS
+        z1E+iv66sTmAtMTCaKorRCktgzxxvbwElHHR5ClZ2qxaNFvHVlss3DzNWxNu
+        4+WjntREcpK+muIHRUWJgx5W7aUsRISSeFvUT0edjNuuqdiCnUi5EWca9c/8
+        L9H6qBHFtU0VSPOTqO41ecbZOt+zp6k6yRtk9V5rQQnnsmXk++7mm1QDGtwu
+        OqGv8WlTDS69rnTFWjsy2/i6w2LB/L2QXk0yiD4sibj4nTRneOnfcUIeBDPm
+        jvloSxrfducka3R1kFqL1dFtQiT+jAJ+xRVINPodHckuEy/tbLo0JOHGRLXn
+        ZSH5bseGk7taFlHIlhJY4knvNYfa7EKxl/up3izLQhiwJO+z5CZT7rpC9z4m
+        AAyye+/kCsJZ/flaY6SHlOaT0C2hZlA9oRjiTZkxJpwdaE0sptwdh4NiFyT3
+        udfpWWPEOZHBPokCzO2xtxKv6uoj8wwv94e+r6wdZineaP/rgcHKXNQ7geKB
+        bxPlsKiCzdLYFKLSCv9835a14ihdTHSLRo4aiWAUOfBynXMcRwFs0NPlUrIO
+        kAHi9tpi+G7D5fPOFaOOF3JrUohLxA6Hq/SkSTOtu1M7jwUkmVMwBthSJJC0
+        hBDL0TjdwC7hEQupTC1Sca6RKSaMX5ICo0Di2J5HRyQ1J6H06UWtPc7L5VGL
+        AXP1+z63wbzYkw5K+daLyj5lXLoVlqO9+UkebbhEef9Cc7pAAIBYaBP9l643
+        xd3iNVh3IJfk4DPYdjq722UVN7D7JJOD3uoMeTyBExLsRN8CTVhaErGcLbx0
+        G/EWoZdSihwkiNwMydhaFwOrkF1FthEsJB43dGmYRT9CntW0naI+NOZczopj
+        9YOxR3GEWMqom04d7SvYbnRpVX6FV702iGOP7Rs02tR5lD7t4mnfIebrg/5Q
+        ZeVbBjpbeQa3PXoQh+SEOBzdvS1nCBH2p0hwUCLbhwaW0sN8PwWh6enTnHqc
+        IX1L3/U9dvTdqJF2MFQ4aj7hRjgxv3E/qtPqXUeDDzC1SBoXiKFituseEu2m
+        B3pvA2lFhsEJhGpkbOZ+hvIH272kr+/5MUe5tVAyl7A7CClGF3qf9cEGfBjT
+        nVMYpHkk8sv2LGgeX5dpztrNulc9ebETVEAmp5HGXprf5gD4I//Up/OARlYq
+        t2UI2fEESBoblmRg1I2EKWuxJ/n+Zx5Cje/N58FkMhjPvrBQvO2bD8OrweN0
+        aGafhuZhcv9xMrgzo6nvk702N5Ph0NzfmKtPg8nHYQ/jJkOMiNdC12y0AI26
+        538P/zobjmfmYTi5G81mtNqHL2bw8ECLDz7cDs3t4DORePjXq+HDzHz+NBwn
+        91j+84jOM50NMGE0Np8no9lo/JEXRGvuZPTx08x8ur+9Hk64f/cN7c4TzcNg
+        MhsNpwmd48fRdfdSrwZTOvYr83k0+3T/OAuHx+UG4y/mh9H4umeGI15o+NeH
+        yXBK909o7dEdnXhIX47GV7eP19wa/IFWGN/PiE50Mzrn7J5J48f61ekwtH5y
+        N5wQ/cazwYfR7Yi2RC/xzWg2pi2443ggJ796vB3QJR4nD/fTIXI6ICEtQgSf
+        jKY/mME0UcL+5XEQFiLq0hp3g/EVM+qAkbiu+XL/CFdC9769xoDEDwChhuZ6
+        eDO8mo1+JPbSSNpm+ng3VHpPZ0yg21szHl7ReQeTL2Y6nPw4ugIdksnwYTAi
+        8qNrejLBKvdjMTjv+mAeScnwR8jA4/gWt50M//JI9zkhCVhj8JGkDcSM+J58
+        HtHm4NAh83s8hb5omf+FxOje3A2+SKv2FxUPOmbo5e5KBQlFK52DD/egwQc6
+        z4iPRQcBQcCi68Hd4ONw2kuCEPDW2l7eM9OH4dUIf6HvSfSI17dCFdKivzyC
+        i/SBLmIGxE5cDXKoLIMOQtbGXkZo70O9PGv3PpA/yMXt/RTCRpvMBoZPTP/9
+        MMToyXBM9GJ1GlxdPU5ItTACM+g000dSttGYmZLgvqzNo8m11yems7kZjG4f
+        J0cyRjvfEwmxJMtaYIgXsul5j2XAjG5oq6tPyj3T0dov5hOx4sOQhg2ufxzB
+        8sg+CenCdKQ0udcVlI4vWTu6Lc8+0eDfnfFJmqkGHLVKJnbGQIE+/ALLPCZU
+        pO7QYaq60CV54LzckRdX2NR2W0ZP4rSXT73qmp+MuDqhWEXSaY0LjkpCQI3M
+        EVog6cC56w1CEUFH0g3Pziqrk67TEGcZ3vigf6mTBI0ej4aask8z+kd0PnVb
+        16lWploMFVp+PcSUdAVRhEMml65wNZw4zN76wdwFyKUofKOlGBQQw/NSebQi
+        nYWEJJ7sXktbhPKd4rm2JZk7fbAUr+E2nHBhBOibAhjsvwq44RUB/0LTW2ZX
+        cqjEHTvc78cXbaQ4wQ8iAQCISCpd/1xaKW7SOf7Fn3TfWv8TbQf/onFYo0i3
+        9l8yj+PP6M1Qh1/vw4PGDpcE5rbvwaRPsj7d1HnqbXHbf+06ADH05L2MiNrn
+        EvK+3G9y2xa9eJWzbi/0+TFQ7p8mQFxx1Xhrg+YdKc3WAV2RWhApe9IVQpGL
+        d9gwLN5pvw/vLLQiyGncnBsDfeMmIWosceh7ibi/wPVOLQsGr/ANMssDcn64
+        i4DK6dWRQI/lsu2X6LSDfIt/qIFJl61UK1tavkfgSrL6C7GuPvTntf7zl/14
+        goL2JKQD4m4QZMzEiHITgTyuBDK2aEqryoLuJK8ACegb/gEETnF2GjM6fag9
+        b+H885EUpKxC626efRV7mHCfI41j++Lk7USno5WUyGrj1MeC0PSTwHgv4r/7
+        vnegy1BlAx1msC6xyuHsBYUN+mx08GF6f0uI4vZLjIbfs1SoQJh6TyL+N36w
+        +vy63yrGoUVovQebc5tjH9D1wEDwCvpiKiSKfOz1Pt5u8To+SF86VDb7HSI6
+        rme1vd3+fHyGMFsl2D+27bwh6QSML74yu19xCUWrHu1+XCJ2yGbukclAbY0r
+        vxSQcSoheuJ08mj6Ykky8mwB5jbZlrTkxYJO8JUzGFtbNEQwu3UXF0jtcdTs
+        mkwquOGZv74V0ctyDx5eIPMQSzal3NO0M//YPXQd6+ytrc6NPN+uEodYPZea
+        RiF96ygq47lcm4VrH9q8at+jeASRrZICr+OdPNL8pP3oKdoldjm5DW6W4jkQ
+        U3lV8aXcl8t9Yf1PesCrzfdhI2kDag/AGgKMoUZYN6eF/hbJ+WsUwrg1kLTR
+        ySteZ7QhBf0u7jxkz2izP+M05lO6+IrfUqG1/ikdI3jvTVIy25Omkf/smbeE
+        tqos558oAeyQL3r4jQ6X+ZdcP5IEaQb3BfsYEipaIWqTGZCfmL+cxkiix6/h
+        dwZCOa2KTVGKYmxVohYNYzOvaErIxiS+DZzfYcLwi7fiMqOchGwrN3HFO0YZ
+        dBfaTxJd3GeLxCg8+25Q/5J7SZDMv5M5/n2L5PTvW5xIYl63MObS9PvkL/Fb
+        N+2P3dRVSpy/WGT8MzCnfu+m757W/01HLhabP24JZWm/n/9zWaOxsv53Vgzz
+        w1/+GP0JH04xxUy6U06OPDlFuFqTarLCCdmz9v0acsvIxkQ/CqQ/T4FcaFjS
+        F2izyszTSl7woafYSvOKdfrMYu9/ZKj2HZ8LrSH3zQfLL2TCmmi+IyPnyO+Q
+        qpEe+ZXbnjpphnReFOHtVit1uAWWTtsj+tlCXQz6R0Pm0L8UXCyaSp4JOuwq
+        dwE/nvRHKOTGTJawpj4L5RoYqgb9Y2KzonLCeBcKfBQYcYc96mnIK/MjCn6a
+        mVbAJtqB0zJjbtf6poexKgpDa/Jq/+t7hYiMREQn2exRaNvRNecSTawyxvjs
+        WQlbFu0ZNewIpTdNjR7dZSQNiuHfF/LneCCpEGh9Mc/LxVfSo3nqNsej8OdX
+        ZpftfOej+bb8T6RxyZmHPaGPwvzpj+Zd//fH4x4jITp5vI94imeWzXYHzqlg
+        aAY8lnNuVtTsORcBCaK6JwmtYKkOZct5yc7tCs4gb7bF8ao6hh1O35ySGPY7
+        3PNS+SsXpbzBtcUCAnGmvXQFks3xj80AFDX+eYmr3Xm0w93Rj+aIpOyEnMoE
+        9HxiqrZFv+v/Tnqp+78/P3la3vDy/ycDMd9Rx9u8qcs3IDMceZ9ofjzR1+Ei
+        Rp+WxY8Pt+Zd+/EPdv8MXbkMRsMbhvh3z/hA0Y+jJQ8UxQHZX5rH8Q/j+8/j
+        5Cont4+aTXVpriXnwQ0wU8lo041/Yy7IqNVpZ+jIl1oHzTLjqullmE/S0Rnr
+        HReNuJ+OkIqpSkRKl5ffCo+e3pkzuvTTu/POYmMADhp9q6/2scqwWCMM7ozT
+        lA439cdjVenob+/+3fGkpPGMYfGUUfTD1KKvr8jxl7lN/g9QSwMEFAAAAAgA
+        Y5ezSMRHQXQ7AwAAxQUAACEAAABzaGVsZl9yZWFkZXItMC4xLmRpc3QtaW5m
+        by9SRUNPUkStlEvPokgUhved9D8BGwoRWMyCmwjKhwJycVPhpnIpCqRQ9NeP
+        k8nXsc3E1WwqOUnlec97bsWUoK4pfkFYtiWBcNbdqeGcAH7x11zQ9F1XiSvF
+        S2jomyikeUstxl3h1oj/sjsrPBjc2RuXe4r5+WM4F80RXookLy7/hVNc4KfR
+        jVuU0FHV+rHFB2/Z00JG37eV4npDOIhM3gh3HFOssHgDZhh1CXnBCQ2zpT0x
+        zTj9tOrbc+pog0gmzITL2+JgBJ4jbw4MuK3JiWIZ8Q2HyqlshxfcV7XkK5SG
+        D4FMDN4HOtIDkXVY0boKnmTVMb0ZA/ayPbsMJfHSOw7nRfOKs+bRoBz5WBPF
+        YESVRsvYDHpbHReWs+rl2gXmNl/eTjyzpziO4d54r8Frkld//QiEW86pTFre
+        k9YXPWe9NITshOB5rmm6d7h4D3hsniUE4N30WL6wsjOqJVHwcla7SuloQ60f
+        AzOG7LadaLW+H3gJBYyjAGBTrATm7yxS/mF4PmLpbD1OQXxuHU1eYwHZWbjV
+        S6ZNxqkTmolVl1ObwAhTPPPWXZqZsbO8HAhdtkf862lDdc2tbzpfs8tAviVs
+        i+4mnDzoQNsOOZiMorDhaa2N7W4/xUaj9w+AOWHwB/GZsSgyH0Vs3Zc12Zd/
+        z5P/LEGq5DldP3BQcGZDZIf0yYa3pyoqGAPE49iWixsrU4BhRf4j3dVVx9Uo
+        6uOncKXrm2/9tCh4qc+2VX2PjnYyfYVVA1QDk/44onCSOpU9N8HmApBNSeAj
+        t2jJ5Q47XLZkmJHpdwFL0524Prnt0yohOKqqvUUQvVRI4psQgHbVEuPKfdns
+        wqQWn/2hgiR5QpJZNeD2m48bvEtBsIToEJJEqSOX7snKKaHCQ8OU3cMYXZ5r
+        ho0dpgSO+yhAcAeb4lo0rwbCa3O4LRenNHZZIk9+HKNeneI4xOktPLbt3YmQ
+        wm/QwqopIPz8QYqBDP/DafuX888Ls6Rp2hGlxeV1+iX7cds8B8i2dtaBn9su
+        GaI+I5vSYGiY9KDPlGwIe+zEz+bNwR9Eguvij1OU983oeJDfG5cTOsr+6tgL
+        Shqq2dg+UpNp1/7YobVgBVH9vGz8c5f+BlBLAQIUAxQAAAAIAJuWs0gAAAAA
+        AgAAAAAAAAATAAAAAAAAAAAAAACkgQAAAABleGFtcGxlL19faW5pdF9fLnB5
+        UEsBAhQDFAAAAAgAm5azSM+NW7UtAQAAIAQAABQAAAAAAAAAAAAAAKSBMwAA
+        AHRlc3RzL3Rlc3RfdG9rZW5zLnB5UEsBAhQDFAAAAAgAm5azSGQmUbRGAQAA
+        rgMAABkAAAAAAAAAAAAAAKSBkgEAAHRlc3RzL3Rlc3RfY2FsbG51bWJlcnMu
+        cHlQSwECFAMUAAAACACblrNIAAAAAAIAAAAAAAAAEQAAAAAAAAAAAAAApIEP
+        AwAAdGVzdHMvX19pbml0X18ucHlQSwECFAMUAAAACACblrNIByJuMzYBAAC/
+        AwAAFgAAAAAAAAAAAAAApIFAAwAAc2hlbGZfcmVhZGVyL21peGlucy5weVBL
+        AQIUAxQAAAAIAJuWs0iSZDlV9gAAAPoBAAAVAAAAAAAAAAAAAACkgaoEAABz
+        aGVsZl9yZWFkZXIvdXRpbHMucHlQSwECFAMUAAAACACblrNIs2ZsFpEAAACw
+        AAAAGAAAAAAAAAAAAAAApIHTBQAAc2hlbGZfcmVhZGVyL19faW5pdF9fLnB5
+        UEsBAhQDFAAAAAgAm5azSNc3sEFQAAAAbAAAABYAAAAAAAAAAAAAAKSBmgYA
+        AHNoZWxmX3JlYWRlci9jb21wYXQucHlQSwECFAMUAAAACACblrNIKv8OaPkB
+        AADMBAAAHAAAAAAAAAAAAAAApIEeBwAAc2hlbGZfcmVhZGVyL3NoZWxmX3Jl
+        YWRlci5weVBLAQIUAxQAAAAIAJuWs0hwrGtSRQQAAOcMAAAWAAAAAAAAAAAA
+        AACkgVEJAABzaGVsZl9yZWFkZXIvbW9kZWxzLnB5UEsBAhQDFAAAAAgAm5az
+        SHXtGBcuAgAAhAcAABIAAAAAAAAAAAAAAKSByg0AAHNoZWxmX3JlYWRlci91
+        aS5weVBLAQIUAxQAAAAIAGOXs0gJ7rCSPB0AAKhNAAAqAAAAAAAAAAAAAACk
+        gSgQAABzaGVsZl9yZWFkZXItMC4xLmRpc3QtaW5mby9ERVNDUklQVElPTi5y
+        c3RQSwECFAMUAAAACABjl7NIIEmSODEAAABBAAAAKwAAAAAAAAAAAAAApIGs
+        LQAAc2hlbGZfcmVhZGVyLTAuMS5kaXN0LWluZm8vZW50cnlfcG9pbnRzLnR4
+        dFBLAQIUAxQAAAAIAGOXs0gpucG3kAEAAN0CAAAoAAAAAAAAAAAAAACkgSYu
+        AABzaGVsZl9yZWFkZXItMC4xLmRpc3QtaW5mby9tZXRhZGF0YS5qc29uUEsB
+        AhQDFAAAAAgAY5ezSIjjD7gdAAAAGwAAACgAAAAAAAAAAAAAAKSB/C8AAHNo
+        ZWxmX3JlYWRlci0wLjEuZGlzdC1pbmZvL3RvcF9sZXZlbC50eHRQSwECFAMU
+        AAAACABjl7NIsJiEy1wAAABcAAAAIAAAAAAAAAAAAAAApIFfMAAAc2hlbGZf
+        cmVhZGVyLTAuMS5kaXN0LWluZm8vV0hFRUxQSwECFAMUAAAACABjl7NIWR+Z
+        x7odAADZTgAAIwAAAAAAAAAAAAAApIH5MAAAc2hlbGZfcmVhZGVyLTAuMS5k
+        aXN0LWluZm8vTUVUQURBVEFQSwECFAMUAAAACABjl7NIxEdBdDsDAADFBQAA
+        IQAAAAAAAAAAAAAApIH0TgAAc2hlbGZfcmVhZGVyLTAuMS5kaXN0LWluZm8v
+        UkVDT1JEUEsFBgAAAAASABIAMwUAAG5SAAAAAA0KLS0tLS0tLS0tLS0tLVJ1
+        YnlNdWx0aXBhcnRQb3N0LTBjZDVmMjA5N2Y0ODEyYTRhY2ExZDEzOTNiNWQ2
+        MmVmLS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-0cd5f2097f4812a4aca1d1393b5d62ef
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-22454/22455
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '22777'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '182'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - b97138688d9e42f6b3beb4428c059571
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmZThkNi1h
+        ZmM0LTc1MjMtOTE2NC1mZTgwZDliODYyMjEvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyNC0wNi0wNVQxNDozODo1NC45MTY2ODVaIiwicHVscF9sYXN0X3VwZGF0
+        ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjU0LjkxNjY5OVoiLCJzaXplIjoyMjQ1
+        NX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/artifacts/?sha256=2eceb1643c10c5e4a65970baf63bde43b79cbdac7de81dae853ce47ab05197e9
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 55f0c698fbd44e60a0a60b59e705ff88
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:55 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/018fe8d6-afc4-7523-9164-fe80d9b86221/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiIyZWNlYjE2NDNjMTBjNWU0YTY1OTcwYmFmNjNiZGU0M2I3
+        OWNiZGFjN2RlODFkYWU4NTNjZTQ3YWIwNTE5N2U5In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 51787baf05e54317982f66de9306a87f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWIwNTAtNzhj
+        ZS05MmFjLTZhYjU4NzA3YjZlZC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:55 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-b050-78ce-92ac-6ab58707b6ed/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '850'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 77608292134f43679ac30394fbf6faa2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYjA1
+        MC03OGNlLTkyYWMtNmFiNTg3MDdiNmVkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NTUuMDU3MjI2WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo1NS4wNTcyNDBaIiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLnVwbG9hZC5jb21t
+        aXQiLCJsb2dnaW5nX2NpZCI6IjUxNzg3YmFmMDVlNTQzMTc5ODJmNjZkZTkz
+        MDZhODdmIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vycy8xLyIs
+        InVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTUuMDY4MDA2WiIs
+        InN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjU1LjA5ODY5OFoiLCJm
+        aW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTUuMTUwMTEyWiIsImVy
+        cm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMThm
+        ZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFyZW50X3Rh
+        c2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVsbCwi
+        cHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9w
+        dWxwL2FwaS92My9hcnRpZmFjdHMvMDE4ZmU4ZDYtYjA5MC03ZTRiLThlMmYt
+        MzFkNDk5NTgwODdiLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpb
+        Ii9wdWxwL2FwaS92My91cGxvYWRzLzAxOGZlOGQ2LWFmYzQtNzUyMy05MTY0
+        LWZlODBkOWI4NjIyMS8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMv
+        MDE4ZmUzYzktNzBhYS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:55 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/artifacts/?sha256=2eceb1643c10c5e4a65970baf63bde43b79cbdac7de81dae853ce47ab05197e9
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '773'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - e5f1ff84006145ba8721d027486d91a0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE4
+        ZmU4ZDYtYjA5MC03ZTRiLThlMmYtMzFkNDk5NTgwODdiLyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTUuMTIxNzkyWiIsInB1bHBfbGFz
+        dF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozODo1NS4xMjE4MTJaIiwiZmls
+        ZSI6ImFydGlmYWN0LzJlL2NlYjE2NDNjMTBjNWU0YTY1OTcwYmFmNjNiZGU0
+        M2I3OWNiZGFjN2RlODFkYWU4NTNjZTQ3YWIwNTE5N2U5Iiwic2l6ZSI6MjI0
+        NTUsIm1kNSI6bnVsbCwic2hhMSI6ImUxNjM0MTc1NzUxMTdiNjQxNWQxMjYz
+        NGI4ZGJiYmY2YmU2MzgyOTAiLCJzaGEyMjQiOiI1N2M2MWE0NDNkNGI5OGMy
+        MmQwYjg3OTMyYjgxN2M5MmJjNDdmMmU2MDkwOGZmNDljMTA4Y2UxMiIsInNo
+        YTI1NiI6IjJlY2ViMTY0M2MxMGM1ZTRhNjU5NzBiYWY2M2JkZTQzYjc5Y2Jk
+        YWM3ZGU4MWRhZTg1M2NlNDdhYjA1MTk3ZTkiLCJzaGEzODQiOiJhOTE0ZTNk
+        YzA4NGEzNDViYzVkZmYxYTJjODQ0MWU2NzY5NjhmYTA4NjEyOWZkNzg4YjVk
+        YzQ3YTliYjlkZTUwMDRjYzhiNzE2MTBkYWU0ZDk2NGEzYTAzNTg3ZDJlZTEi
+        LCJzaGE1MTIiOiIxZTM4YWM4MDk4MDA5NGVhOWJiMzZhM2FiOWNiMzE0NzZh
+        Yzk2Yzc4Mzk3ODljYWFmOTlmNmJkMTcwYzFjMTJkZDgwMmY0NjI3MGUyNWYx
+        MzUyMzgwZjQwZmFjOGY2MmVmODVkZGMwY2EwM2JmMjU5MjJjMThhNGIxZWUw
+        NDE4NyJ9XX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:55 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/python/packages/?sha256=2eceb1643c10c5e4a65970baf63bde43b79cbdac7de81dae853ce47ab05197e9
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.11.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 37af7ab26cd241cfa7f98ab2f7efc318
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:55 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/python/packages/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTBhYzYzMjNlYTdhZGMw
+        YTg4NTkwOTkyNzMwMTMyMTM3DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnNoZWxmX3JlYWRlci0w
+        LjEtcHkyLW5vbmUtYW55LndobA0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBh
+        cnRQb3N0LTBhYzYzMjNlYTdhZGMwYTg4NTkwOTkyNzMwMTMyMTM3DQpDb250
+        ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0K
+        DQovcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzAxOGZlOGQ2LWIwOTAtN2U0Yi04
+        ZTJmLTMxZDQ5OTU4MDg3Yi8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0
+        UG9zdC0wYWM2MzIzZWE3YWRjMGE4ODU5MDk5MjczMDEzMjEzNy0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-0ac6323ea7adc0a88590992730132137
+      User-Agent:
+      - OpenAPI-Generator/3.11.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '401'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - ff0903eb9f6c4ce9a0f62445770abf34
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWIxOTMtNzc5
+        My1hYzRmLWNiMjUxY2UwYTlhNy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:55 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-b193-7793-ac4f-cb251ce0a9a7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '809'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 18bdfa2f721b4d2fbda1d43dae142e9a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYjE5
+        My03NzkzLWFjNGYtY2IyNTFjZTBhOWE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NTUuMzc5ODcwWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo1NS4zNzk4ODBaIiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
+        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6ImZmMDkwM2ViOWY2YzRjZTlhMGY2
+        MjQ0NTc3MGFiZjM0IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTUuMzkw
+        MzQxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjU1LjQyMTM3
+        MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTUuNTc1MTI4
+        WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
+        ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
+        bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
+        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L3B5dGhvbi9wYWNrYWdlcy8wMThm
+        ZThkNi1iMjQxLTdjYjQtYjBiNy0wNDBkMWUxYzNhMjkvIl0sInJlc2VydmVk
+        X3Jlc291cmNlc19yZWNvcmQiOlsic2hhcmVkOi9wdWxwL2FwaS92My9kb21h
+        aW5zLzAxOGZlM2M5LTcwYWEtNzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:55 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/018fe8d6-aa10-77f0-8992-0cff9c9ebfde/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9w
+        eXRob24vcGFja2FnZXMvMDE4ZmU4ZDYtYjI0MS03Y2I0LWIwYjctMDQwZDFl
+        MWMzYTI5LyJdfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.11.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 02e41b0993304525a7a116395802b75e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWIyYmUtNzk4
+        ZS1iYjU3LTBlZDQyOWI3MTlhNy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:55 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-b2be-798e-bb57-0ed429b719a7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '909'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1f6347c0da354c9ea6fcb2e71aa921ba
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYjJi
+        ZS03OThlLWJiNTctMGVkNDI5YjcxOWE3LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NTUuNjc5MTU3WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo1NS42NzkxNzBaIiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnku
+        YWRkX2FuZF9yZW1vdmUiLCJsb2dnaW5nX2NpZCI6IjAyZTQxYjA5OTMzMDQ1
+        MjVhN2ExMTYzOTU4MDJiNzVlIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92
+        My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6
+        NTUuNjkwMTI4WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjU1
+        LjcyNjIzMVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTUu
+        ODEyNTgwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3Zjkv
+        IiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19n
+        cm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
+        b3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcHl0aG9uL3B5
+        dGhvbi8wMThmZThkNi1hYTEwLTc3ZjAtODk5Mi0wY2ZmOWM5ZWJmZGUvdmVy
+        c2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3B5dGhvbi9weXRob24vMDE4ZmU4ZDYt
+        YWExMC03N2YwLTg5OTItMGNmZjljOWViZmRlLyIsInNoYXJlZDovcHVscC9h
+        cGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2Fk
+        MzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:38:55 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/python/pypi/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL3B5dGhvbi9weXRob24vMDE4ZmU4ZDYtYWExMC03N2YwLTg5OTItMGNm
+        ZjljOWViZmRlL3ZlcnNpb25zLzEvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.11.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - ae34edbf25b24c87a67957dc0f984662
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWIzZDktN2Q2
+        YS05ODg2LWI3MGJmYWY2Y2I0OC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:55 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/python/packages/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/python/python/018fe8d6-aa10-77f0-8992-0cff9c9ebfde/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.11.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '21376'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - e38368cdef5f43a1872afefb301fd619
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L3B5dGhv
+        bi9wYWNrYWdlcy8wMThmZThkNi1iMjQxLTdjYjQtYjBiNy0wNDBkMWUxYzNh
+        MjkvIiwicHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wNVQxNDozODo1NS41NTQ5
+        NTBaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjU1
+        LjU1NDk4NVoiLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        MDE4ZmU4ZDYtYjA5MC03ZTRiLThlMmYtMzFkNDk5NTgwODdiLyIsImZpbGVu
+        YW1lIjoic2hlbGZfcmVhZGVyLTAuMS1weTItbm9uZS1hbnkud2hsIiwicGFj
+        a2FnZXR5cGUiOiJiZGlzdF93aGVlbCIsIm5hbWUiOiJzaGVsZi1yZWFkZXIi
+        LCJ2ZXJzaW9uIjoiMC4xIiwic2hhMjU2IjoiMmVjZWIxNjQzYzEwYzVlNGE2
+        NTk3MGJhZjYzYmRlNDNiNzljYmRhYzdkZTgxZGFlODUzY2U0N2FiMDUxOTdl
+        OSIsIm1ldGFkYXRhX3ZlcnNpb24iOiIyLjAiLCJzdW1tYXJ5IjoiTWFrZSBz
+        dXJlIHlvdXIgY29sbGVjdGlvbnMgYXJlIGluIGNhbGwgbnVtYmVyIG9yZGVy
+        LiIsImRlc2NyaXB0aW9uIjoiIENvcHlyaWdodCAoQykgMTk4OSwgMTk5MSBG
+        cmVlIFNvZnR3YXJlIEZvdW5kYXRpb24sIEluYy4sIDxodHRwOi8vZnNmLm9y
+        Zy8+XG4gNTEgRnJhbmtsaW4gU3RyZWV0LCBGaWZ0aCBGbG9vciwgQm9zdG9u
+        LCBNQSAwMjExMC0xMzAxIFVTQVxuIEV2ZXJ5b25lIGlzIHBlcm1pdHRlZCB0
+        byBjb3B5IGFuZCBkaXN0cmlidXRlIHZlcmJhdGltIGNvcGllc1xuIG9mIHRo
+        aXMgbGljZW5zZSBkb2N1bWVudCwgYnV0IGNoYW5naW5nIGl0IGlzIG5vdCBh
+        bGxvd2VkLlxuXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgUHJlYW1i
+        bGVcblxuICBUaGUgbGljZW5zZXMgZm9yIG1vc3Qgc29mdHdhcmUgYXJlIGRl
+        c2lnbmVkIHRvIHRha2UgYXdheSB5b3VyXG5mcmVlZG9tIHRvIHNoYXJlIGFu
+        ZCBjaGFuZ2UgaXQuICBCeSBjb250cmFzdCwgdGhlIEdOVSBHZW5lcmFsIFB1
+        YmxpY1xuTGljZW5zZSBpcyBpbnRlbmRlZCB0byBndWFyYW50ZWUgeW91ciBm
+        cmVlZG9tIHRvIHNoYXJlIGFuZCBjaGFuZ2UgZnJlZVxuc29mdHdhcmUtLXRv
+        IG1ha2Ugc3VyZSB0aGUgc29mdHdhcmUgaXMgZnJlZSBmb3IgYWxsIGl0cyB1
+        c2Vycy4gIFRoaXNcbkdlbmVyYWwgUHVibGljIExpY2Vuc2UgYXBwbGllcyB0
+        byBtb3N0IG9mIHRoZSBGcmVlIFNvZnR3YXJlXG5Gb3VuZGF0aW9uJ3Mgc29m
+        dHdhcmUgYW5kIHRvIGFueSBvdGhlciBwcm9ncmFtIHdob3NlIGF1dGhvcnMg
+        Y29tbWl0IHRvXG51c2luZyBpdC4gIChTb21lIG90aGVyIEZyZWUgU29mdHdh
+        cmUgRm91bmRhdGlvbiBzb2Z0d2FyZSBpcyBjb3ZlcmVkIGJ5XG50aGUgR05V
+        IExlc3NlciBHZW5lcmFsIFB1YmxpYyBMaWNlbnNlIGluc3RlYWQuKSAgWW91
+        IGNhbiBhcHBseSBpdCB0b1xueW91ciBwcm9ncmFtcywgdG9vLlxuXG4gIFdo
+        ZW4gd2Ugc3BlYWsgb2YgZnJlZSBzb2Z0d2FyZSwgd2UgYXJlIHJlZmVycmlu
+        ZyB0byBmcmVlZG9tLCBub3RcbnByaWNlLiAgT3VyIEdlbmVyYWwgUHVibGlj
+        IExpY2Vuc2VzIGFyZSBkZXNpZ25lZCB0byBtYWtlIHN1cmUgdGhhdCB5b3Vc
+        bmhhdmUgdGhlIGZyZWVkb20gdG8gZGlzdHJpYnV0ZSBjb3BpZXMgb2YgZnJl
+        ZSBzb2Z0d2FyZSAoYW5kIGNoYXJnZSBmb3JcbnRoaXMgc2VydmljZSBpZiB5
+        b3Ugd2lzaCksIHRoYXQgeW91IHJlY2VpdmUgc291cmNlIGNvZGUgb3IgY2Fu
+        IGdldCBpdFxuaWYgeW91IHdhbnQgaXQsIHRoYXQgeW91IGNhbiBjaGFuZ2Ug
+        dGhlIHNvZnR3YXJlIG9yIHVzZSBwaWVjZXMgb2YgaXRcbmluIG5ldyBmcmVl
+        IHByb2dyYW1zOyBhbmQgdGhhdCB5b3Uga25vdyB5b3UgY2FuIGRvIHRoZXNl
+        IHRoaW5ncy5cblxuICBUbyBwcm90ZWN0IHlvdXIgcmlnaHRzLCB3ZSBuZWVk
+        IHRvIG1ha2UgcmVzdHJpY3Rpb25zIHRoYXQgZm9yYmlkXG5hbnlvbmUgdG8g
+        ZGVueSB5b3UgdGhlc2UgcmlnaHRzIG9yIHRvIGFzayB5b3UgdG8gc3VycmVu
+        ZGVyIHRoZSByaWdodHMuXG5UaGVzZSByZXN0cmljdGlvbnMgdHJhbnNsYXRl
+        IHRvIGNlcnRhaW4gcmVzcG9uc2liaWxpdGllcyBmb3IgeW91IGlmIHlvdVxu
+        ZGlzdHJpYnV0ZSBjb3BpZXMgb2YgdGhlIHNvZnR3YXJlLCBvciBpZiB5b3Ug
+        bW9kaWZ5IGl0LlxuXG4gIEZvciBleGFtcGxlLCBpZiB5b3UgZGlzdHJpYnV0
+        ZSBjb3BpZXMgb2Ygc3VjaCBhIHByb2dyYW0sIHdoZXRoZXJcbmdyYXRpcyBv
+        ciBmb3IgYSBmZWUsIHlvdSBtdXN0IGdpdmUgdGhlIHJlY2lwaWVudHMgYWxs
+        IHRoZSByaWdodHMgdGhhdFxueW91IGhhdmUuICBZb3UgbXVzdCBtYWtlIHN1
+        cmUgdGhhdCB0aGV5LCB0b28sIHJlY2VpdmUgb3IgY2FuIGdldCB0aGVcbnNv
+        dXJjZSBjb2RlLiAgQW5kIHlvdSBtdXN0IHNob3cgdGhlbSB0aGVzZSB0ZXJt
+        cyBzbyB0aGV5IGtub3cgdGhlaXJcbnJpZ2h0cy5cblxuICBXZSBwcm90ZWN0
+        IHlvdXIgcmlnaHRzIHdpdGggdHdvIHN0ZXBzOiAoMSkgY29weXJpZ2h0IHRo
+        ZSBzb2Z0d2FyZSwgYW5kXG4oMikgb2ZmZXIgeW91IHRoaXMgbGljZW5zZSB3
+        aGljaCBnaXZlcyB5b3UgbGVnYWwgcGVybWlzc2lvbiB0byBjb3B5LFxuZGlz
+        dHJpYnV0ZSBhbmQvb3IgbW9kaWZ5IHRoZSBzb2Z0d2FyZS5cblxuICBBbHNv
+        LCBmb3IgZWFjaCBhdXRob3IncyBwcm90ZWN0aW9uIGFuZCBvdXJzLCB3ZSB3
+        YW50IHRvIG1ha2UgY2VydGFpblxudGhhdCBldmVyeW9uZSB1bmRlcnN0YW5k
+        cyB0aGF0IHRoZXJlIGlzIG5vIHdhcnJhbnR5IGZvciB0aGlzIGZyZWVcbnNv
+        ZnR3YXJlLiAgSWYgdGhlIHNvZnR3YXJlIGlzIG1vZGlmaWVkIGJ5IHNvbWVv
+        bmUgZWxzZSBhbmQgcGFzc2VkIG9uLCB3ZVxud2FudCBpdHMgcmVjaXBpZW50
+        cyB0byBrbm93IHRoYXQgd2hhdCB0aGV5IGhhdmUgaXMgbm90IHRoZSBvcmln
+        aW5hbCwgc29cbnRoYXQgYW55IHByb2JsZW1zIGludHJvZHVjZWQgYnkgb3Ro
+        ZXJzIHdpbGwgbm90IHJlZmxlY3Qgb24gdGhlIG9yaWdpbmFsXG5hdXRob3Jz
+        JyByZXB1dGF0aW9ucy5cblxuICBGaW5hbGx5LCBhbnkgZnJlZSBwcm9ncmFt
+        IGlzIHRocmVhdGVuZWQgY29uc3RhbnRseSBieSBzb2Z0d2FyZVxucGF0ZW50
+        cy4gIFdlIHdpc2ggdG8gYXZvaWQgdGhlIGRhbmdlciB0aGF0IHJlZGlzdHJp
+        YnV0b3JzIG9mIGEgZnJlZVxucHJvZ3JhbSB3aWxsIGluZGl2aWR1YWxseSBv
+        YnRhaW4gcGF0ZW50IGxpY2Vuc2VzLCBpbiBlZmZlY3QgbWFraW5nIHRoZVxu
+        cHJvZ3JhbSBwcm9wcmlldGFyeS4gIFRvIHByZXZlbnQgdGhpcywgd2UgaGF2
+        ZSBtYWRlIGl0IGNsZWFyIHRoYXQgYW55XG5wYXRlbnQgbXVzdCBiZSBsaWNl
+        bnNlZCBmb3IgZXZlcnlvbmUncyBmcmVlIHVzZSBvciBub3QgbGljZW5zZWQg
+        YXQgYWxsLlxuXG4gIFRoZSBwcmVjaXNlIHRlcm1zIGFuZCBjb25kaXRpb25z
+        IGZvciBjb3B5aW5nLCBkaXN0cmlidXRpb24gYW5kXG5tb2RpZmljYXRpb24g
+        Zm9sbG93LlxuXG4gICAgICAgICAgICAgICAgICAgIEdOVSBHRU5FUkFMIFBV
+        QkxJQyBMSUNFTlNFXG4gICBURVJNUyBBTkQgQ09ORElUSU9OUyBGT1IgQ09Q
+        WUlORywgRElTVFJJQlVUSU9OIEFORCBNT0RJRklDQVRJT05cblxuICAwLiBU
+        aGlzIExpY2Vuc2UgYXBwbGllcyB0byBhbnkgcHJvZ3JhbSBvciBvdGhlciB3
+        b3JrIHdoaWNoIGNvbnRhaW5zXG5hIG5vdGljZSBwbGFjZWQgYnkgdGhlIGNv
+        cHlyaWdodCBob2xkZXIgc2F5aW5nIGl0IG1heSBiZSBkaXN0cmlidXRlZFxu
+        dW5kZXIgdGhlIHRlcm1zIG9mIHRoaXMgR2VuZXJhbCBQdWJsaWMgTGljZW5z
+        ZS4gIFRoZSBcIlByb2dyYW1cIiwgYmVsb3csXG5yZWZlcnMgdG8gYW55IHN1
+        Y2ggcHJvZ3JhbSBvciB3b3JrLCBhbmQgYSBcIndvcmsgYmFzZWQgb24gdGhl
+        IFByb2dyYW1cIlxubWVhbnMgZWl0aGVyIHRoZSBQcm9ncmFtIG9yIGFueSBk
+        ZXJpdmF0aXZlIHdvcmsgdW5kZXIgY29weXJpZ2h0IGxhdzpcbnRoYXQgaXMg
+        dG8gc2F5LCBhIHdvcmsgY29udGFpbmluZyB0aGUgUHJvZ3JhbSBvciBhIHBv
+        cnRpb24gb2YgaXQsXG5laXRoZXIgdmVyYmF0aW0gb3Igd2l0aCBtb2RpZmlj
+        YXRpb25zIGFuZC9vciB0cmFuc2xhdGVkIGludG8gYW5vdGhlclxubGFuZ3Vh
+        Z2UuICAoSGVyZWluYWZ0ZXIsIHRyYW5zbGF0aW9uIGlzIGluY2x1ZGVkIHdp
+        dGhvdXQgbGltaXRhdGlvbiBpblxudGhlIHRlcm0gXCJtb2RpZmljYXRpb25c
+        Ii4pICBFYWNoIGxpY2Vuc2VlIGlzIGFkZHJlc3NlZCBhcyBcInlvdVwiLlxu
+        XG5BY3Rpdml0aWVzIG90aGVyIHRoYW4gY29weWluZywgZGlzdHJpYnV0aW9u
+        IGFuZCBtb2RpZmljYXRpb24gYXJlIG5vdFxuY292ZXJlZCBieSB0aGlzIExp
+        Y2Vuc2U7IHRoZXkgYXJlIG91dHNpZGUgaXRzIHNjb3BlLiAgVGhlIGFjdCBv
+        ZlxucnVubmluZyB0aGUgUHJvZ3JhbSBpcyBub3QgcmVzdHJpY3RlZCwgYW5k
+        IHRoZSBvdXRwdXQgZnJvbSB0aGUgUHJvZ3JhbVxuaXMgY292ZXJlZCBvbmx5
+        IGlmIGl0cyBjb250ZW50cyBjb25zdGl0dXRlIGEgd29yayBiYXNlZCBvbiB0
+        aGVcblByb2dyYW0gKGluZGVwZW5kZW50IG9mIGhhdmluZyBiZWVuIG1hZGUg
+        YnkgcnVubmluZyB0aGUgUHJvZ3JhbSkuXG5XaGV0aGVyIHRoYXQgaXMgdHJ1
+        ZSBkZXBlbmRzIG9uIHdoYXQgdGhlIFByb2dyYW0gZG9lcy5cblxuICAxLiBZ
+        b3UgbWF5IGNvcHkgYW5kIGRpc3RyaWJ1dGUgdmVyYmF0aW0gY29waWVzIG9m
+        IHRoZSBQcm9ncmFtJ3NcbnNvdXJjZSBjb2RlIGFzIHlvdSByZWNlaXZlIGl0
+        LCBpbiBhbnkgbWVkaXVtLCBwcm92aWRlZCB0aGF0IHlvdVxuY29uc3BpY3Vv
+        dXNseSBhbmQgYXBwcm9wcmlhdGVseSBwdWJsaXNoIG9uIGVhY2ggY29weSBh
+        biBhcHByb3ByaWF0ZVxuY29weXJpZ2h0IG5vdGljZSBhbmQgZGlzY2xhaW1l
+        ciBvZiB3YXJyYW50eTsga2VlcCBpbnRhY3QgYWxsIHRoZVxubm90aWNlcyB0
+        aGF0IHJlZmVyIHRvIHRoaXMgTGljZW5zZSBhbmQgdG8gdGhlIGFic2VuY2Ug
+        b2YgYW55IHdhcnJhbnR5O1xuYW5kIGdpdmUgYW55IG90aGVyIHJlY2lwaWVu
+        dHMgb2YgdGhlIFByb2dyYW0gYSBjb3B5IG9mIHRoaXMgTGljZW5zZVxuYWxv
+        bmcgd2l0aCB0aGUgUHJvZ3JhbS5cblxuWW91IG1heSBjaGFyZ2UgYSBmZWUg
+        Zm9yIHRoZSBwaHlzaWNhbCBhY3Qgb2YgdHJhbnNmZXJyaW5nIGEgY29weSwg
+        YW5kXG55b3UgbWF5IGF0IHlvdXIgb3B0aW9uIG9mZmVyIHdhcnJhbnR5IHBy
+        b3RlY3Rpb24gaW4gZXhjaGFuZ2UgZm9yIGEgZmVlLlxuXG4gIDIuIFlvdSBt
+        YXkgbW9kaWZ5IHlvdXIgY29weSBvciBjb3BpZXMgb2YgdGhlIFByb2dyYW0g
+        b3IgYW55IHBvcnRpb25cbm9mIGl0LCB0aHVzIGZvcm1pbmcgYSB3b3JrIGJh
+        c2VkIG9uIHRoZSBQcm9ncmFtLCBhbmQgY29weSBhbmRcbmRpc3RyaWJ1dGUg
+        c3VjaCBtb2RpZmljYXRpb25zIG9yIHdvcmsgdW5kZXIgdGhlIHRlcm1zIG9m
+        IFNlY3Rpb24gMVxuYWJvdmUsIHByb3ZpZGVkIHRoYXQgeW91IGFsc28gbWVl
+        dCBhbGwgb2YgdGhlc2UgY29uZGl0aW9uczpcblxuICAgIGEpIFlvdSBtdXN0
+        IGNhdXNlIHRoZSBtb2RpZmllZCBmaWxlcyB0byBjYXJyeSBwcm9taW5lbnQg
+        bm90aWNlc1xuICAgIHN0YXRpbmcgdGhhdCB5b3UgY2hhbmdlZCB0aGUgZmls
+        ZXMgYW5kIHRoZSBkYXRlIG9mIGFueSBjaGFuZ2UuXG5cbiAgICBiKSBZb3Ug
+        bXVzdCBjYXVzZSBhbnkgd29yayB0aGF0IHlvdSBkaXN0cmlidXRlIG9yIHB1
+        Ymxpc2gsIHRoYXQgaW5cbiAgICB3aG9sZSBvciBpbiBwYXJ0IGNvbnRhaW5z
+        IG9yIGlzIGRlcml2ZWQgZnJvbSB0aGUgUHJvZ3JhbSBvciBhbnlcbiAgICBw
+        YXJ0IHRoZXJlb2YsIHRvIGJlIGxpY2Vuc2VkIGFzIGEgd2hvbGUgYXQgbm8g
+        Y2hhcmdlIHRvIGFsbCB0aGlyZFxuICAgIHBhcnRpZXMgdW5kZXIgdGhlIHRl
+        cm1zIG9mIHRoaXMgTGljZW5zZS5cblxuICAgIGMpIElmIHRoZSBtb2RpZmll
+        ZCBwcm9ncmFtIG5vcm1hbGx5IHJlYWRzIGNvbW1hbmRzIGludGVyYWN0aXZl
+        bHlcbiAgICB3aGVuIHJ1biwgeW91IG11c3QgY2F1c2UgaXQsIHdoZW4gc3Rh
+        cnRlZCBydW5uaW5nIGZvciBzdWNoXG4gICAgaW50ZXJhY3RpdmUgdXNlIGlu
+        IHRoZSBtb3N0IG9yZGluYXJ5IHdheSwgdG8gcHJpbnQgb3IgZGlzcGxheSBh
+        blxuICAgIGFubm91bmNlbWVudCBpbmNsdWRpbmcgYW4gYXBwcm9wcmlhdGUg
+        Y29weXJpZ2h0IG5vdGljZSBhbmQgYVxuICAgIG5vdGljZSB0aGF0IHRoZXJl
+        IGlzIG5vIHdhcnJhbnR5IChvciBlbHNlLCBzYXlpbmcgdGhhdCB5b3UgcHJv
+        dmlkZVxuICAgIGEgd2FycmFudHkpIGFuZCB0aGF0IHVzZXJzIG1heSByZWRp
+        c3RyaWJ1dGUgdGhlIHByb2dyYW0gdW5kZXJcbiAgICB0aGVzZSBjb25kaXRp
+        b25zLCBhbmQgdGVsbGluZyB0aGUgdXNlciBob3cgdG8gdmlldyBhIGNvcHkg
+        b2YgdGhpc1xuICAgIExpY2Vuc2UuICAoRXhjZXB0aW9uOiBpZiB0aGUgUHJv
+        Z3JhbSBpdHNlbGYgaXMgaW50ZXJhY3RpdmUgYnV0XG4gICAgZG9lcyBub3Qg
+        bm9ybWFsbHkgcHJpbnQgc3VjaCBhbiBhbm5vdW5jZW1lbnQsIHlvdXIgd29y
+        ayBiYXNlZCBvblxuICAgIHRoZSBQcm9ncmFtIGlzIG5vdCByZXF1aXJlZCB0
+        byBwcmludCBhbiBhbm5vdW5jZW1lbnQuKVxuXG5UaGVzZSByZXF1aXJlbWVu
+        dHMgYXBwbHkgdG8gdGhlIG1vZGlmaWVkIHdvcmsgYXMgYSB3aG9sZS4gIElm
+        XG5pZGVudGlmaWFibGUgc2VjdGlvbnMgb2YgdGhhdCB3b3JrIGFyZSBub3Qg
+        ZGVyaXZlZCBmcm9tIHRoZSBQcm9ncmFtLFxuYW5kIGNhbiBiZSByZWFzb25h
+        Ymx5IGNvbnNpZGVyZWQgaW5kZXBlbmRlbnQgYW5kIHNlcGFyYXRlIHdvcmtz
+        IGluXG50aGVtc2VsdmVzLCB0aGVuIHRoaXMgTGljZW5zZSwgYW5kIGl0cyB0
+        ZXJtcywgZG8gbm90IGFwcGx5IHRvIHRob3NlXG5zZWN0aW9ucyB3aGVuIHlv
+        dSBkaXN0cmlidXRlIHRoZW0gYXMgc2VwYXJhdGUgd29ya3MuICBCdXQgd2hl
+        biB5b3VcbmRpc3RyaWJ1dGUgdGhlIHNhbWUgc2VjdGlvbnMgYXMgcGFydCBv
+        ZiBhIHdob2xlIHdoaWNoIGlzIGEgd29yayBiYXNlZFxub24gdGhlIFByb2dy
+        YW0sIHRoZSBkaXN0cmlidXRpb24gb2YgdGhlIHdob2xlIG11c3QgYmUgb24g
+        dGhlIHRlcm1zIG9mXG50aGlzIExpY2Vuc2UsIHdob3NlIHBlcm1pc3Npb25z
+        IGZvciBvdGhlciBsaWNlbnNlZXMgZXh0ZW5kIHRvIHRoZVxuZW50aXJlIHdo
+        b2xlLCBhbmQgdGh1cyB0byBlYWNoIGFuZCBldmVyeSBwYXJ0IHJlZ2FyZGxl
+        c3Mgb2Ygd2hvIHdyb3RlIGl0LlxuXG5UaHVzLCBpdCBpcyBub3QgdGhlIGlu
+        dGVudCBvZiB0aGlzIHNlY3Rpb24gdG8gY2xhaW0gcmlnaHRzIG9yIGNvbnRl
+        c3RcbnlvdXIgcmlnaHRzIHRvIHdvcmsgd3JpdHRlbiBlbnRpcmVseSBieSB5
+        b3U7IHJhdGhlciwgdGhlIGludGVudCBpcyB0b1xuZXhlcmNpc2UgdGhlIHJp
+        Z2h0IHRvIGNvbnRyb2wgdGhlIGRpc3RyaWJ1dGlvbiBvZiBkZXJpdmF0aXZl
+        IG9yXG5jb2xsZWN0aXZlIHdvcmtzIGJhc2VkIG9uIHRoZSBQcm9ncmFtLlxu
+        XG5JbiBhZGRpdGlvbiwgbWVyZSBhZ2dyZWdhdGlvbiBvZiBhbm90aGVyIHdv
+        cmsgbm90IGJhc2VkIG9uIHRoZSBQcm9ncmFtXG53aXRoIHRoZSBQcm9ncmFt
+        IChvciB3aXRoIGEgd29yayBiYXNlZCBvbiB0aGUgUHJvZ3JhbSkgb24gYSB2
+        b2x1bWUgb2ZcbmEgc3RvcmFnZSBvciBkaXN0cmlidXRpb24gbWVkaXVtIGRv
+        ZXMgbm90IGJyaW5nIHRoZSBvdGhlciB3b3JrIHVuZGVyXG50aGUgc2NvcGUg
+        b2YgdGhpcyBMaWNlbnNlLlxuXG4gIDMuIFlvdSBtYXkgY29weSBhbmQgZGlz
+        dHJpYnV0ZSB0aGUgUHJvZ3JhbSAob3IgYSB3b3JrIGJhc2VkIG9uIGl0LFxu
+        dW5kZXIgU2VjdGlvbiAyKSBpbiBvYmplY3QgY29kZSBvciBleGVjdXRhYmxl
+        IGZvcm0gdW5kZXIgdGhlIHRlcm1zIG9mXG5TZWN0aW9ucyAxIGFuZCAyIGFi
+        b3ZlIHByb3ZpZGVkIHRoYXQgeW91IGFsc28gZG8gb25lIG9mIHRoZSBmb2xs
+        b3dpbmc6XG5cbiAgICBhKSBBY2NvbXBhbnkgaXQgd2l0aCB0aGUgY29tcGxl
+        dGUgY29ycmVzcG9uZGluZyBtYWNoaW5lLXJlYWRhYmxlXG4gICAgc291cmNl
+        IGNvZGUsIHdoaWNoIG11c3QgYmUgZGlzdHJpYnV0ZWQgdW5kZXIgdGhlIHRl
+        cm1zIG9mIFNlY3Rpb25zXG4gICAgMSBhbmQgMiBhYm92ZSBvbiBhIG1lZGl1
+        bSBjdXN0b21hcmlseSB1c2VkIGZvciBzb2Z0d2FyZSBpbnRlcmNoYW5nZTsg
+        b3IsXG5cbiAgICBiKSBBY2NvbXBhbnkgaXQgd2l0aCBhIHdyaXR0ZW4gb2Zm
+        ZXIsIHZhbGlkIGZvciBhdCBsZWFzdCB0aHJlZVxuICAgIHllYXJzLCB0byBn
+        aXZlIGFueSB0aGlyZCBwYXJ0eSwgZm9yIGEgY2hhcmdlIG5vIG1vcmUgdGhh
+        biB5b3VyXG4gICAgY29zdCBvZiBwaHlzaWNhbGx5IHBlcmZvcm1pbmcgc291
+        cmNlIGRpc3RyaWJ1dGlvbiwgYSBjb21wbGV0ZVxuICAgIG1hY2hpbmUtcmVh
+        ZGFibGUgY29weSBvZiB0aGUgY29ycmVzcG9uZGluZyBzb3VyY2UgY29kZSwg
+        dG8gYmVcbiAgICBkaXN0cmlidXRlZCB1bmRlciB0aGUgdGVybXMgb2YgU2Vj
+        dGlvbnMgMSBhbmQgMiBhYm92ZSBvbiBhIG1lZGl1bVxuICAgIGN1c3RvbWFy
+        aWx5IHVzZWQgZm9yIHNvZnR3YXJlIGludGVyY2hhbmdlOyBvcixcblxuICAg
+        IGMpIEFjY29tcGFueSBpdCB3aXRoIHRoZSBpbmZvcm1hdGlvbiB5b3UgcmVj
+        ZWl2ZWQgYXMgdG8gdGhlIG9mZmVyXG4gICAgdG8gZGlzdHJpYnV0ZSBjb3Jy
+        ZXNwb25kaW5nIHNvdXJjZSBjb2RlLiAgKFRoaXMgYWx0ZXJuYXRpdmUgaXNc
+        biAgICBhbGxvd2VkIG9ubHkgZm9yIG5vbmNvbW1lcmNpYWwgZGlzdHJpYnV0
+        aW9uIGFuZCBvbmx5IGlmIHlvdVxuICAgIHJlY2VpdmVkIHRoZSBwcm9ncmFt
+        IGluIG9iamVjdCBjb2RlIG9yIGV4ZWN1dGFibGUgZm9ybSB3aXRoIHN1Y2hc
+        biAgICBhbiBvZmZlciwgaW4gYWNjb3JkIHdpdGggU3Vic2VjdGlvbiBiIGFi
+        b3ZlLilcblxuVGhlIHNvdXJjZSBjb2RlIGZvciBhIHdvcmsgbWVhbnMgdGhl
+        IHByZWZlcnJlZCBmb3JtIG9mIHRoZSB3b3JrIGZvclxubWFraW5nIG1vZGlm
+        aWNhdGlvbnMgdG8gaXQuICBGb3IgYW4gZXhlY3V0YWJsZSB3b3JrLCBjb21w
+        bGV0ZSBzb3VyY2VcbmNvZGUgbWVhbnMgYWxsIHRoZSBzb3VyY2UgY29kZSBm
+        b3IgYWxsIG1vZHVsZXMgaXQgY29udGFpbnMsIHBsdXMgYW55XG5hc3NvY2lh
+        dGVkIGludGVyZmFjZSBkZWZpbml0aW9uIGZpbGVzLCBwbHVzIHRoZSBzY3Jp
+        cHRzIHVzZWQgdG9cbmNvbnRyb2wgY29tcGlsYXRpb24gYW5kIGluc3RhbGxh
+        dGlvbiBvZiB0aGUgZXhlY3V0YWJsZS4gIEhvd2V2ZXIsIGFzIGFcbnNwZWNp
+        YWwgZXhjZXB0aW9uLCB0aGUgc291cmNlIGNvZGUgZGlzdHJpYnV0ZWQgbmVl
+        ZCBub3QgaW5jbHVkZVxuYW55dGhpbmcgdGhhdCBpcyBub3JtYWxseSBkaXN0
+        cmlidXRlZCAoaW4gZWl0aGVyIHNvdXJjZSBvciBiaW5hcnlcbmZvcm0pIHdp
+        dGggdGhlIG1ham9yIGNvbXBvbmVudHMgKGNvbXBpbGVyLCBrZXJuZWwsIGFu
+        ZCBzbyBvbikgb2YgdGhlXG5vcGVyYXRpbmcgc3lzdGVtIG9uIHdoaWNoIHRo
+        ZSBleGVjdXRhYmxlIHJ1bnMsIHVubGVzcyB0aGF0IGNvbXBvbmVudFxuaXRz
+        ZWxmIGFjY29tcGFuaWVzIHRoZSBleGVjdXRhYmxlLlxuXG5JZiBkaXN0cmli
+        dXRpb24gb2YgZXhlY3V0YWJsZSBvciBvYmplY3QgY29kZSBpcyBtYWRlIGJ5
+        IG9mZmVyaW5nXG5hY2Nlc3MgdG8gY29weSBmcm9tIGEgZGVzaWduYXRlZCBw
+        bGFjZSwgdGhlbiBvZmZlcmluZyBlcXVpdmFsZW50XG5hY2Nlc3MgdG8gY29w
+        eSB0aGUgc291cmNlIGNvZGUgZnJvbSB0aGUgc2FtZSBwbGFjZSBjb3VudHMg
+        YXNcbmRpc3RyaWJ1dGlvbiBvZiB0aGUgc291cmNlIGNvZGUsIGV2ZW4gdGhv
+        dWdoIHRoaXJkIHBhcnRpZXMgYXJlIG5vdFxuY29tcGVsbGVkIHRvIGNvcHkg
+        dGhlIHNvdXJjZSBhbG9uZyB3aXRoIHRoZSBvYmplY3QgY29kZS5cblxuICA0
+        LiBZb3UgbWF5IG5vdCBjb3B5LCBtb2RpZnksIHN1YmxpY2Vuc2UsIG9yIGRp
+        c3RyaWJ1dGUgdGhlIFByb2dyYW1cbmV4Y2VwdCBhcyBleHByZXNzbHkgcHJv
+        dmlkZWQgdW5kZXIgdGhpcyBMaWNlbnNlLiAgQW55IGF0dGVtcHRcbm90aGVy
+        d2lzZSB0byBjb3B5LCBtb2RpZnksIHN1YmxpY2Vuc2Ugb3IgZGlzdHJpYnV0
+        ZSB0aGUgUHJvZ3JhbSBpc1xudm9pZCwgYW5kIHdpbGwgYXV0b21hdGljYWxs
+        eSB0ZXJtaW5hdGUgeW91ciByaWdodHMgdW5kZXIgdGhpcyBMaWNlbnNlLlxu
+        SG93ZXZlciwgcGFydGllcyB3aG8gaGF2ZSByZWNlaXZlZCBjb3BpZXMsIG9y
+        IHJpZ2h0cywgZnJvbSB5b3UgdW5kZXJcbnRoaXMgTGljZW5zZSB3aWxsIG5v
+        dCBoYXZlIHRoZWlyIGxpY2Vuc2VzIHRlcm1pbmF0ZWQgc28gbG9uZyBhcyBz
+        dWNoXG5wYXJ0aWVzIHJlbWFpbiBpbiBmdWxsIGNvbXBsaWFuY2UuXG5cbiAg
+        NS4gWW91IGFyZSBub3QgcmVxdWlyZWQgdG8gYWNjZXB0IHRoaXMgTGljZW5z
+        ZSwgc2luY2UgeW91IGhhdmUgbm90XG5zaWduZWQgaXQuICBIb3dldmVyLCBu
+        b3RoaW5nIGVsc2UgZ3JhbnRzIHlvdSBwZXJtaXNzaW9uIHRvIG1vZGlmeSBv
+        clxuZGlzdHJpYnV0ZSB0aGUgUHJvZ3JhbSBvciBpdHMgZGVyaXZhdGl2ZSB3
+        b3Jrcy4gIFRoZXNlIGFjdGlvbnMgYXJlXG5wcm9oaWJpdGVkIGJ5IGxhdyBp
+        ZiB5b3UgZG8gbm90IGFjY2VwdCB0aGlzIExpY2Vuc2UuICBUaGVyZWZvcmUs
+        IGJ5XG5tb2RpZnlpbmcgb3IgZGlzdHJpYnV0aW5nIHRoZSBQcm9ncmFtIChv
+        ciBhbnkgd29yayBiYXNlZCBvbiB0aGVcblByb2dyYW0pLCB5b3UgaW5kaWNh
+        dGUgeW91ciBhY2NlcHRhbmNlIG9mIHRoaXMgTGljZW5zZSB0byBkbyBzbywg
+        YW5kXG5hbGwgaXRzIHRlcm1zIGFuZCBjb25kaXRpb25zIGZvciBjb3B5aW5n
+        LCBkaXN0cmlidXRpbmcgb3IgbW9kaWZ5aW5nXG50aGUgUHJvZ3JhbSBvciB3
+        b3JrcyBiYXNlZCBvbiBpdC5cblxuICA2LiBFYWNoIHRpbWUgeW91IHJlZGlz
+        dHJpYnV0ZSB0aGUgUHJvZ3JhbSAob3IgYW55IHdvcmsgYmFzZWQgb24gdGhl
+        XG5Qcm9ncmFtKSwgdGhlIHJlY2lwaWVudCBhdXRvbWF0aWNhbGx5IHJlY2Vp
+        dmVzIGEgbGljZW5zZSBmcm9tIHRoZVxub3JpZ2luYWwgbGljZW5zb3IgdG8g
+        Y29weSwgZGlzdHJpYnV0ZSBvciBtb2RpZnkgdGhlIFByb2dyYW0gc3ViamVj
+        dCB0b1xudGhlc2UgdGVybXMgYW5kIGNvbmRpdGlvbnMuICBZb3UgbWF5IG5v
+        dCBpbXBvc2UgYW55IGZ1cnRoZXJcbnJlc3RyaWN0aW9ucyBvbiB0aGUgcmVj
+        aXBpZW50cycgZXhlcmNpc2Ugb2YgdGhlIHJpZ2h0cyBncmFudGVkIGhlcmVp
+        bi5cbllvdSBhcmUgbm90IHJlc3BvbnNpYmxlIGZvciBlbmZvcmNpbmcgY29t
+        cGxpYW5jZSBieSB0aGlyZCBwYXJ0aWVzIHRvXG50aGlzIExpY2Vuc2UuXG5c
+        biAgNy4gSWYsIGFzIGEgY29uc2VxdWVuY2Ugb2YgYSBjb3VydCBqdWRnbWVu
+        dCBvciBhbGxlZ2F0aW9uIG9mIHBhdGVudFxuaW5mcmluZ2VtZW50IG9yIGZv
+        ciBhbnkgb3RoZXIgcmVhc29uIChub3QgbGltaXRlZCB0byBwYXRlbnQgaXNz
+        dWVzKSxcbmNvbmRpdGlvbnMgYXJlIGltcG9zZWQgb24geW91ICh3aGV0aGVy
+        IGJ5IGNvdXJ0IG9yZGVyLCBhZ3JlZW1lbnQgb3Jcbm90aGVyd2lzZSkgdGhh
+        dCBjb250cmFkaWN0IHRoZSBjb25kaXRpb25zIG9mIHRoaXMgTGljZW5zZSwg
+        dGhleSBkbyBub3RcbmV4Y3VzZSB5b3UgZnJvbSB0aGUgY29uZGl0aW9ucyBv
+        ZiB0aGlzIExpY2Vuc2UuICBJZiB5b3UgY2Fubm90XG5kaXN0cmlidXRlIHNv
+        IGFzIHRvIHNhdGlzZnkgc2ltdWx0YW5lb3VzbHkgeW91ciBvYmxpZ2F0aW9u
+        cyB1bmRlciB0aGlzXG5MaWNlbnNlIGFuZCBhbnkgb3RoZXIgcGVydGluZW50
+        IG9ibGlnYXRpb25zLCB0aGVuIGFzIGEgY29uc2VxdWVuY2UgeW91XG5tYXkg
+        bm90IGRpc3RyaWJ1dGUgdGhlIFByb2dyYW0gYXQgYWxsLiAgRm9yIGV4YW1w
+        bGUsIGlmIGEgcGF0ZW50XG5saWNlbnNlIHdvdWxkIG5vdCBwZXJtaXQgcm95
+        YWx0eS1mcmVlIHJlZGlzdHJpYnV0aW9uIG9mIHRoZSBQcm9ncmFtIGJ5XG5h
+        bGwgdGhvc2Ugd2hvIHJlY2VpdmUgY29waWVzIGRpcmVjdGx5IG9yIGluZGly
+        ZWN0bHkgdGhyb3VnaCB5b3UsIHRoZW5cbnRoZSBvbmx5IHdheSB5b3UgY291
+        bGQgc2F0aXNmeSBib3RoIGl0IGFuZCB0aGlzIExpY2Vuc2Ugd291bGQgYmUg
+        dG9cbnJlZnJhaW4gZW50aXJlbHkgZnJvbSBkaXN0cmlidXRpb24gb2YgdGhl
+        IFByb2dyYW0uXG5cbklmIGFueSBwb3J0aW9uIG9mIHRoaXMgc2VjdGlvbiBp
+        cyBoZWxkIGludmFsaWQgb3IgdW5lbmZvcmNlYWJsZSB1bmRlclxuYW55IHBh
+        cnRpY3VsYXIgY2lyY3Vtc3RhbmNlLCB0aGUgYmFsYW5jZSBvZiB0aGUgc2Vj
+        dGlvbiBpcyBpbnRlbmRlZCB0b1xuYXBwbHkgYW5kIHRoZSBzZWN0aW9uIGFz
+        IGEgd2hvbGUgaXMgaW50ZW5kZWQgdG8gYXBwbHkgaW4gb3RoZXJcbmNpcmN1
+        bXN0YW5jZXMuXG5cbkl0IGlzIG5vdCB0aGUgcHVycG9zZSBvZiB0aGlzIHNl
+        Y3Rpb24gdG8gaW5kdWNlIHlvdSB0byBpbmZyaW5nZSBhbnlcbnBhdGVudHMg
+        b3Igb3RoZXIgcHJvcGVydHkgcmlnaHQgY2xhaW1zIG9yIHRvIGNvbnRlc3Qg
+        dmFsaWRpdHkgb2YgYW55XG5zdWNoIGNsYWltczsgdGhpcyBzZWN0aW9uIGhh
+        cyB0aGUgc29sZSBwdXJwb3NlIG9mIHByb3RlY3RpbmcgdGhlXG5pbnRlZ3Jp
+        dHkgb2YgdGhlIGZyZWUgc29mdHdhcmUgZGlzdHJpYnV0aW9uIHN5c3RlbSwg
+        d2hpY2ggaXNcbmltcGxlbWVudGVkIGJ5IHB1YmxpYyBsaWNlbnNlIHByYWN0
+        aWNlcy4gIE1hbnkgcGVvcGxlIGhhdmUgbWFkZVxuZ2VuZXJvdXMgY29udHJp
+        YnV0aW9ucyB0byB0aGUgd2lkZSByYW5nZSBvZiBzb2Z0d2FyZSBkaXN0cmli
+        dXRlZFxudGhyb3VnaCB0aGF0IHN5c3RlbSBpbiByZWxpYW5jZSBvbiBjb25z
+        aXN0ZW50IGFwcGxpY2F0aW9uIG9mIHRoYXRcbnN5c3RlbTsgaXQgaXMgdXAg
+        dG8gdGhlIGF1dGhvci9kb25vciB0byBkZWNpZGUgaWYgaGUgb3Igc2hlIGlz
+        IHdpbGxpbmdcbnRvIGRpc3RyaWJ1dGUgc29mdHdhcmUgdGhyb3VnaCBhbnkg
+        b3RoZXIgc3lzdGVtIGFuZCBhIGxpY2Vuc2VlIGNhbm5vdFxuaW1wb3NlIHRo
+        YXQgY2hvaWNlLlxuXG5UaGlzIHNlY3Rpb24gaXMgaW50ZW5kZWQgdG8gbWFr
+        ZSB0aG9yb3VnaGx5IGNsZWFyIHdoYXQgaXMgYmVsaWV2ZWQgdG9cbmJlIGEg
+        Y29uc2VxdWVuY2Ugb2YgdGhlIHJlc3Qgb2YgdGhpcyBMaWNlbnNlLlxuXG4g
+        IDguIElmIHRoZSBkaXN0cmlidXRpb24gYW5kL29yIHVzZSBvZiB0aGUgUHJv
+        Z3JhbSBpcyByZXN0cmljdGVkIGluXG5jZXJ0YWluIGNvdW50cmllcyBlaXRo
+        ZXIgYnkgcGF0ZW50cyBvciBieSBjb3B5cmlnaHRlZCBpbnRlcmZhY2VzLCB0
+        aGVcbm9yaWdpbmFsIGNvcHlyaWdodCBob2xkZXIgd2hvIHBsYWNlcyB0aGUg
+        UHJvZ3JhbSB1bmRlciB0aGlzIExpY2Vuc2Vcbm1heSBhZGQgYW4gZXhwbGlj
+        aXQgZ2VvZ3JhcGhpY2FsIGRpc3RyaWJ1dGlvbiBsaW1pdGF0aW9uIGV4Y2x1
+        ZGluZ1xudGhvc2UgY291bnRyaWVzLCBzbyB0aGF0IGRpc3RyaWJ1dGlvbiBp
+        cyBwZXJtaXR0ZWQgb25seSBpbiBvciBhbW9uZ1xuY291bnRyaWVzIG5vdCB0
+        aHVzIGV4Y2x1ZGVkLiAgSW4gc3VjaCBjYXNlLCB0aGlzIExpY2Vuc2UgaW5j
+        b3Jwb3JhdGVzXG50aGUgbGltaXRhdGlvbiBhcyBpZiB3cml0dGVuIGluIHRo
+        ZSBib2R5IG9mIHRoaXMgTGljZW5zZS5cblxuICA5LiBUaGUgRnJlZSBTb2Z0
+        d2FyZSBGb3VuZGF0aW9uIG1heSBwdWJsaXNoIHJldmlzZWQgYW5kL29yIG5l
+        dyB2ZXJzaW9uc1xub2YgdGhlIEdlbmVyYWwgUHVibGljIExpY2Vuc2UgZnJv
+        bSB0aW1lIHRvIHRpbWUuICBTdWNoIG5ldyB2ZXJzaW9ucyB3aWxsXG5iZSBz
+        aW1pbGFyIGluIHNwaXJpdCB0byB0aGUgcHJlc2VudCB2ZXJzaW9uLCBidXQg
+        bWF5IGRpZmZlciBpbiBkZXRhaWwgdG9cbmFkZHJlc3MgbmV3IHByb2JsZW1z
+        IG9yIGNvbmNlcm5zLlxuXG5FYWNoIHZlcnNpb24gaXMgZ2l2ZW4gYSBkaXN0
+        aW5ndWlzaGluZyB2ZXJzaW9uIG51bWJlci4gIElmIHRoZSBQcm9ncmFtXG5z
+        cGVjaWZpZXMgYSB2ZXJzaW9uIG51bWJlciBvZiB0aGlzIExpY2Vuc2Ugd2hp
+        Y2ggYXBwbGllcyB0byBpdCBhbmQgXCJhbnlcbmxhdGVyIHZlcnNpb25cIiwg
+        eW91IGhhdmUgdGhlIG9wdGlvbiBvZiBmb2xsb3dpbmcgdGhlIHRlcm1zIGFu
+        ZCBjb25kaXRpb25zXG5laXRoZXIgb2YgdGhhdCB2ZXJzaW9uIG9yIG9mIGFu
+        eSBsYXRlciB2ZXJzaW9uIHB1Ymxpc2hlZCBieSB0aGUgRnJlZVxuU29mdHdh
+        cmUgRm91bmRhdGlvbi4gIElmIHRoZSBQcm9ncmFtIGRvZXMgbm90IHNwZWNp
+        ZnkgYSB2ZXJzaW9uIG51bWJlciBvZlxudGhpcyBMaWNlbnNlLCB5b3UgbWF5
+        IGNob29zZSBhbnkgdmVyc2lvbiBldmVyIHB1Ymxpc2hlZCBieSB0aGUgRnJl
+        ZSBTb2Z0d2FyZVxuRm91bmRhdGlvbi5cblxuICAxMC4gSWYgeW91IHdpc2gg
+        dG8gaW5jb3Jwb3JhdGUgcGFydHMgb2YgdGhlIFByb2dyYW0gaW50byBvdGhl
+        ciBmcmVlXG5wcm9ncmFtcyB3aG9zZSBkaXN0cmlidXRpb24gY29uZGl0aW9u
+        cyBhcmUgZGlmZmVyZW50LCB3cml0ZSB0byB0aGUgYXV0aG9yXG50byBhc2sg
+        Zm9yIHBlcm1pc3Npb24uICBGb3Igc29mdHdhcmUgd2hpY2ggaXMgY29weXJp
+        Z2h0ZWQgYnkgdGhlIEZyZWVcblNvZnR3YXJlIEZvdW5kYXRpb24sIHdyaXRl
+        IHRvIHRoZSBGcmVlIFNvZnR3YXJlIEZvdW5kYXRpb247IHdlIHNvbWV0aW1l
+        c1xubWFrZSBleGNlcHRpb25zIGZvciB0aGlzLiAgT3VyIGRlY2lzaW9uIHdp
+        bGwgYmUgZ3VpZGVkIGJ5IHRoZSB0d28gZ29hbHNcbm9mIHByZXNlcnZpbmcg
+        dGhlIGZyZWUgc3RhdHVzIG9mIGFsbCBkZXJpdmF0aXZlcyBvZiBvdXIgZnJl
+        ZSBzb2Z0d2FyZSBhbmRcbm9mIHByb21vdGluZyB0aGUgc2hhcmluZyBhbmQg
+        cmV1c2Ugb2Ygc29mdHdhcmUgZ2VuZXJhbGx5LlxuXG4gICAgICAgICAgICAg
+        ICAgICAgICAgICAgICAgTk8gV0FSUkFOVFlcblxuICAxMS4gQkVDQVVTRSBU
+        SEUgUFJPR1JBTSBJUyBMSUNFTlNFRCBGUkVFIE9GIENIQVJHRSwgVEhFUkUg
+        SVMgTk8gV0FSUkFOVFlcbkZPUiBUSEUgUFJPR1JBTSwgVE8gVEhFIEVYVEVO
+        VCBQRVJNSVRURUQgQlkgQVBQTElDQUJMRSBMQVcuICBFWENFUFQgV0hFTlxu
+        T1RIRVJXSVNFIFNUQVRFRCBJTiBXUklUSU5HIFRIRSBDT1BZUklHSFQgSE9M
+        REVSUyBBTkQvT1IgT1RIRVIgUEFSVElFU1xuUFJPVklERSBUSEUgUFJPR1JB
+        TSBcIkFTIElTXCIgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRUlU
+        SEVSIEVYUFJFU1NFRFxuT1IgSU1QTElFRCwgSU5DTFVESU5HLCBCVVQgTk9U
+        IExJTUlURUQgVE8sIFRIRSBJTVBMSUVEIFdBUlJBTlRJRVMgT0Zcbk1FUkNI
+        QU5UQUJJTElUWSBBTkQgRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBP
+        U0UuICBUSEUgRU5USVJFIFJJU0sgQVNcblRPIFRIRSBRVUFMSVRZIEFORCBQ
+        RVJGT1JNQU5DRSBPRiBUSEUgUFJPR1JBTSBJUyBXSVRIIFlPVS4gIFNIT1VM
+        RCBUSEVcblBST0dSQU0gUFJPVkUgREVGRUNUSVZFLCBZT1UgQVNTVU1FIFRI
+        RSBDT1NUIE9GIEFMTCBORUNFU1NBUlkgU0VSVklDSU5HLFxuUkVQQUlSIE9S
+        IENPUlJFQ1RJT04uXG5cbiAgMTIuIElOIE5PIEVWRU5UIFVOTEVTUyBSRVFV
+        SVJFRCBCWSBBUFBMSUNBQkxFIExBVyBPUiBBR1JFRUQgVE8gSU4gV1JJVElO
+        R1xuV0lMTCBBTlkgQ09QWVJJR0hUIEhPTERFUiwgT1IgQU5ZIE9USEVSIFBB
+        UlRZIFdITyBNQVkgTU9ESUZZIEFORC9PUlxuUkVESVNUUklCVVRFIFRIRSBQ
+        Uk9HUkFNIEFTIFBFUk1JVFRFRCBBQk9WRSwgQkUgTElBQkxFIFRPIFlPVSBG
+        T1IgREFNQUdFUyxcbklOQ0xVRElORyBBTlkgR0VORVJBTCwgU1BFQ0lBTCwg
+        SU5DSURFTlRBTCBPUiBDT05TRVFVRU5USUFMIERBTUFHRVMgQVJJU0lOR1xu
+        T1VUIE9GIFRIRSBVU0UgT1IgSU5BQklMSVRZIFRPIFVTRSBUSEUgUFJPR1JB
+        TSAoSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRFxuVE8gTE9TUyBPRiBEQVRB
+        IE9SIERBVEEgQkVJTkcgUkVOREVSRUQgSU5BQ0NVUkFURSBPUiBMT1NTRVMg
+        U1VTVEFJTkVEIEJZXG5ZT1UgT1IgVEhJUkQgUEFSVElFUyBPUiBBIEZBSUxV
+        UkUgT0YgVEhFIFBST0dSQU0gVE8gT1BFUkFURSBXSVRIIEFOWSBPVEhFUlxu
+        UFJPR1JBTVMpLCBFVkVOIElGIFNVQ0ggSE9MREVSIE9SIE9USEVSIFBBUlRZ
+        IEhBUyBCRUVOIEFEVklTRUQgT0YgVEhFXG5QT1NTSUJJTElUWSBPRiBTVUNI
+        IERBTUFHRVMuXG5cbiAgICAgICAgICAgICAgICAgICAgIEVORCBPRiBURVJN
+        UyBBTkQgQ09ORElUSU9OU1xuXG4gICAgICAgICAgICBIb3cgdG8gQXBwbHkg
+        VGhlc2UgVGVybXMgdG8gWW91ciBOZXcgUHJvZ3JhbXNcblxuICBJZiB5b3Ug
+        ZGV2ZWxvcCBhIG5ldyBwcm9ncmFtLCBhbmQgeW91IHdhbnQgaXQgdG8gYmUg
+        b2YgdGhlIGdyZWF0ZXN0XG5wb3NzaWJsZSB1c2UgdG8gdGhlIHB1YmxpYywg
+        dGhlIGJlc3Qgd2F5IHRvIGFjaGlldmUgdGhpcyBpcyB0byBtYWtlIGl0XG5m
+        cmVlIHNvZnR3YXJlIHdoaWNoIGV2ZXJ5b25lIGNhbiByZWRpc3RyaWJ1dGUg
+        YW5kIGNoYW5nZSB1bmRlciB0aGVzZSB0ZXJtcy5cblxuICBUbyBkbyBzbywg
+        YXR0YWNoIHRoZSBmb2xsb3dpbmcgbm90aWNlcyB0byB0aGUgcHJvZ3JhbS4g
+        IEl0IGlzIHNhZmVzdFxudG8gYXR0YWNoIHRoZW0gdG8gdGhlIHN0YXJ0IG9m
+        IGVhY2ggc291cmNlIGZpbGUgdG8gbW9zdCBlZmZlY3RpdmVseVxuY29udmV5
+        IHRoZSBleGNsdXNpb24gb2Ygd2FycmFudHk7IGFuZCBlYWNoIGZpbGUgc2hv
+        dWxkIGhhdmUgYXQgbGVhc3RcbnRoZSBcImNvcHlyaWdodFwiIGxpbmUgYW5k
+        IGEgcG9pbnRlciB0byB3aGVyZSB0aGUgZnVsbCBub3RpY2UgaXMgZm91bmQu
+        XG5cbiAgICB7ZGVzY3JpcHRpb259XG4gICAgQ29weXJpZ2h0IChDKSB7eWVh
+        cn0gIHtmdWxsbmFtZX1cblxuICAgIFRoaXMgcHJvZ3JhbSBpcyBmcmVlIHNv
+        ZnR3YXJlOyB5b3UgY2FuIHJlZGlzdHJpYnV0ZSBpdCBhbmQvb3IgbW9kaWZ5
+        XG4gICAgaXQgdW5kZXIgdGhlIHRlcm1zIG9mIHRoZSBHTlUgR2VuZXJhbCBQ
+        dWJsaWMgTGljZW5zZSBhcyBwdWJsaXNoZWQgYnlcbiAgICB0aGUgRnJlZSBT
+        b2Z0d2FyZSBGb3VuZGF0aW9uOyBlaXRoZXIgdmVyc2lvbiAyIG9mIHRoZSBM
+        aWNlbnNlLCBvclxuICAgIChhdCB5b3VyIG9wdGlvbikgYW55IGxhdGVyIHZl
+        cnNpb24uXG5cbiAgICBUaGlzIHByb2dyYW0gaXMgZGlzdHJpYnV0ZWQgaW4g
+        dGhlIGhvcGUgdGhhdCBpdCB3aWxsIGJlIHVzZWZ1bCxcbiAgICBidXQgV0lU
+        SE9VVCBBTlkgV0FSUkFOVFk7IHdpdGhvdXQgZXZlbiB0aGUgaW1wbGllZCB3
+        YXJyYW50eSBvZlxuICAgIE1FUkNIQU5UQUJJTElUWSBvciBGSVRORVNTIEZP
+        UiBBIFBBUlRJQ1VMQVIgUFVSUE9TRS4gIFNlZSB0aGVcbiAgICBHTlUgR2Vu
+        ZXJhbCBQdWJsaWMgTGljZW5zZSBmb3IgbW9yZSBkZXRhaWxzLlxuXG4gICAg
+        WW91IHNob3VsZCBoYXZlIHJlY2VpdmVkIGEgY29weSBvZiB0aGUgR05VIEdl
+        bmVyYWwgUHVibGljIExpY2Vuc2UgYWxvbmdcbiAgICB3aXRoIHRoaXMgcHJv
+        Z3JhbTsgaWYgbm90LCB3cml0ZSB0byB0aGUgRnJlZSBTb2Z0d2FyZSBGb3Vu
+        ZGF0aW9uLCBJbmMuLFxuICAgIDUxIEZyYW5rbGluIFN0cmVldCwgRmlmdGgg
+        Rmxvb3IsIEJvc3RvbiwgTUEgMDIxMTAtMTMwMSBVU0EuXG5cbkFsc28gYWRk
+        IGluZm9ybWF0aW9uIG9uIGhvdyB0byBjb250YWN0IHlvdSBieSBlbGVjdHJv
+        bmljIGFuZCBwYXBlciBtYWlsLlxuXG5JZiB0aGUgcHJvZ3JhbSBpcyBpbnRl
+        cmFjdGl2ZSwgbWFrZSBpdCBvdXRwdXQgYSBzaG9ydCBub3RpY2UgbGlrZSB0
+        aGlzXG53aGVuIGl0IHN0YXJ0cyBpbiBhbiBpbnRlcmFjdGl2ZSBtb2RlOlxu
+        XG4gICAgR25vbW92aXNpb24gdmVyc2lvbiA2OSwgQ29weXJpZ2h0IChDKSB5
+        ZWFyIG5hbWUgb2YgYXV0aG9yXG4gICAgR25vbW92aXNpb24gY29tZXMgd2l0
+        aCBBQlNPTFVURUxZIE5PIFdBUlJBTlRZOyBmb3IgZGV0YWlscyB0eXBlIGBz
+        aG93IHcnLlxuICAgIFRoaXMgaXMgZnJlZSBzb2Z0d2FyZSwgYW5kIHlvdSBh
+        cmUgd2VsY29tZSB0byByZWRpc3RyaWJ1dGUgaXRcbiAgICB1bmRlciBjZXJ0
+        YWluIGNvbmRpdGlvbnM7IHR5cGUgYHNob3cgYycgZm9yIGRldGFpbHMuXG5c
+        blRoZSBoeXBvdGhldGljYWwgY29tbWFuZHMgYHNob3cgdycgYW5kIGBzaG93
+        IGMnIHNob3VsZCBzaG93IHRoZSBhcHByb3ByaWF0ZVxucGFydHMgb2YgdGhl
+        IEdlbmVyYWwgUHVibGljIExpY2Vuc2UuICBPZiBjb3Vyc2UsIHRoZSBjb21t
+        YW5kcyB5b3UgdXNlIG1heVxuYmUgY2FsbGVkIHNvbWV0aGluZyBvdGhlciB0
+        aGFuIGBzaG93IHcnIGFuZCBgc2hvdyBjJzsgdGhleSBjb3VsZCBldmVuIGJl
+        XG5tb3VzZS1jbGlja3Mgb3IgbWVudSBpdGVtcy0td2hhdGV2ZXIgc3VpdHMg
+        eW91ciBwcm9ncmFtLlxuXG5Zb3Ugc2hvdWxkIGFsc28gZ2V0IHlvdXIgZW1w
+        bG95ZXIgKGlmIHlvdSB3b3JrIGFzIGEgcHJvZ3JhbW1lcikgb3IgeW91clxu
+        c2Nob29sLCBpZiBhbnksIHRvIHNpZ24gYSBcImNvcHlyaWdodCBkaXNjbGFp
+        bWVyXCIgZm9yIHRoZSBwcm9ncmFtLCBpZlxubmVjZXNzYXJ5LiAgSGVyZSBp
+        cyBhIHNhbXBsZTsgYWx0ZXIgdGhlIG5hbWVzOlxuXG4gIFlveW9keW5lLCBJ
+        bmMuLCBoZXJlYnkgZGlzY2xhaW1zIGFsbCBjb3B5cmlnaHQgaW50ZXJlc3Qg
+        aW4gdGhlIHByb2dyYW1cbiAgYEdub21vdmlzaW9uJyAod2hpY2ggbWFrZXMg
+        cGFzc2VzIGF0IGNvbXBpbGVycykgd3JpdHRlbiBieSBKYW1lcyBIYWNrZXIu
+        XG5cbiAge3NpZ25hdHVyZSBvZiBUeSBDb29ufSwgMSBBcHJpbCAxOTg5XG4g
+        IFR5IENvb24sIFByZXNpZGVudCBvZiBWaWNlXG5cblRoaXMgR2VuZXJhbCBQ
+        dWJsaWMgTGljZW5zZSBkb2VzIG5vdCBwZXJtaXQgaW5jb3Jwb3JhdGluZyB5
+        b3VyIHByb2dyYW0gaW50b1xucHJvcHJpZXRhcnkgcHJvZ3JhbXMuICBJZiB5
+        b3VyIHByb2dyYW0gaXMgYSBzdWJyb3V0aW5lIGxpYnJhcnksIHlvdSBtYXlc
+        bmNvbnNpZGVyIGl0IG1vcmUgdXNlZnVsIHRvIHBlcm1pdCBsaW5raW5nIHBy
+        b3ByaWV0YXJ5IGFwcGxpY2F0aW9ucyB3aXRoIHRoZVxubGlicmFyeS4gIElm
+        IHRoaXMgaXMgd2hhdCB5b3Ugd2FudCB0byBkbywgdXNlIHRoZSBHTlUgTGVz
+        c2VyIEdlbmVyYWxcblB1YmxpYyBMaWNlbnNlIGluc3RlYWQgb2YgdGhpcyBM
+        aWNlbnNlLlxuXG5EZXNjcmlwdGlvbjogLi4gaW1hZ2U6OiBodHRwczovL3Ry
+        YXZpcy1jaS5vcmcvYXNtYWNkby9zaGVsZi1yZWFkZXIuc3ZnP2JyYW5jaD1t
+        YXN0ZXJcbiAgICAgICAgICAgIDp0YXJnZXQ6IGh0dHBzOi8vdHJhdmlzLWNp
+        Lm9yZy9hc21hY2RvL3NoZWxmLXJlYWRlclxuICAgICAgICBcbiAgICAgICAg
+        PT09PT09PT09PT09XG4gICAgICAgIFNoZWxmIFJlYWRlclxuICAgICAgICA9
+        PT09PT09PT09PT1cbiAgICAgICAgXG4gICAgICAgIFNoZWxmIFJlYWRlciBp
+        cyBhIHRvb2wgZm9yIGxpYnJhcmllcyB0aGF0IHJldHJpZXZlcyBjYWxsIG51
+        bWJlcnMgb2YgaXRlbXMgXG4gICAgICAgIGZyb20gdGhlaXIgYmFyY29kZSBh
+        bmQgZGV0ZXJtaW5lcyBpZiB0aGV5IGFyZSBpbiB0aGUgY29ycmVjdCBvcmRl
+        ci4gQmVjYXVzZVxuICAgICAgICBpdCBjYW4gc2VhcmNoIGJ5IGJhcmNvZGUg
+        dGhlIHNjcmlwdCBhbGxvd3MgbGlicmFyeSBzdGFmZiB0byBjb25uZWN0IGEg
+        XG4gICAgICAgIGJhcmNvZGUgcmVhZGVyIHRvIHF1aWNrbHkgYW5kIGFjY3Vy
+        YXRlbHkgc2NhbiB0aGVpciBzaGVsdmVzIGZvciBpdGVtcyB0aGF0IFxuICAg
+        ICAgICBhcmUgb3V0IG9mIHBsYWNlLlxuICAgICAgICBcbiAgICAgICAgVGhp
+        cyBjb25jZXB0IGlzIG5vdCBuZXcsIGl0IGhhcyBwcm9iYWJseSBiZWVuIGFy
+        b3VuZCBzaW5jZSBsaWJyYXJpZXMgYmVnYW5cbiAgICAgICAgdG8gZGlnaXRp
+        emUgdGhlaXIgcmVjb3JkcywgYnV0IEkgaGF2ZSBub3QgYmVlbiBhYmxlIHRv
+        IGZpbmQgYSBmcmVlIG9wZW4gXG4gICAgICAgIHNvdXJjZSBpbXBsZW1lbnRh
+        dGlvbi5cbiAgICAgICAgXG4gICAgICAgIEluc3RhbGxcbiAgICAgICAgLS0t
+        LS0tLVxuICAgICAgICBcbiAgICAgICAgLi4gY29kZS1ibG9jazo6IGJhc2hc
+        biAgICAgICAgXG4gICAgICAgICAgICAkIHBpcCBpbnN0YWxsIHNoZWxmLXJl
+        YWRlclxuICAgICAgICBcbiAgICAgICAgUmVxdWlyZXMgUHl0aG9uID49IDIu
+        N1xuICAgICAgICBcbiAgICAgICAgVXNlXG4gICAgICAgIC0tLVxuICAgICAg
+        ICBcbiAgICAgICAgR2V0IGEgZHVtcCBvZiBiYXJjb2RlcyBhbmQgY2FsbCBu
+        dW1iZXJzIGFuZCBzYXZlIHRoZW0gaW4gYSBjc3YgZmlsZSB3aXRoXG4gICAg
+        ICAgIGJhcmNvZGVzIGluIHRoZSBsZWZ0IGNvbHVtbiBhbmQgY2FsbCBudW1i
+        ZXJzIGluIHRoZSByaWdodC4gXG4gICAgICAgIFxuICAgICAgICBUaGUgcHJv
+        amVjdCByZXF1aXJlcyBubyBkZXBlbmVuY2llcyAoZXhjZXB0IG5vc2UgaWYg
+        eW91IHdhbnQgdG8gcnVuIHRoZSB0ZXN0cykuIFxuICAgICAgICBNYWtlIHN1
+        cmUgdGhhdCB5b3UgaGF2ZSBweXRob24gaW5zdGFsbGVkICh0ZXN0ZWQgZm9y
+        IDIuNiBhbmQgMi43KS4gXG4gICAgICAgIFxuICAgICAgICBUbyBydW46XG4g
+        ICAgICAgIFxuICAgICAgICAuLiBjb2RlLWJsb2NrOjogYmFzaFxuICAgICAg
+        ICBcbiAgICAgICAgICAgICQgc2hlbGYtcmVhZGVyIHBhdGgvdG8vZmlsZW5h
+        bWUuY3N2XG4gICAgICAgIFxuICAgICAgICBMaWNlbnNlXG4gICAgICAgIC0t
+        LS0tLS1cbiAgICAgICAgXG4gICAgICAgIEdQTCAyXG4gICAgICAgIFxuS2V5
+        d29yZHM6IGxpYnJhcnkgYmFyY29kZSBjYWxsIG51bWJlciBzaGVsZiBjb2xs
+        ZWN0aW9uXG5QbGF0Zm9ybTogVU5LTk9XTlxuQ2xhc3NpZmllcjogRGV2ZWxv
+        cG1lbnQgU3RhdHVzIDo6IDQgLSBCZXRhXG5DbGFzc2lmaWVyOiBJbnRlbmRl
+        ZCBBdWRpZW5jZSA6OiBEZXZlbG9wZXJzXG5DbGFzc2lmaWVyOiBMaWNlbnNl
+        IDo6IE9TSSBBcHByb3ZlZCA6OiBHTlUgR2VuZXJhbCBQdWJsaWMgTGljZW5z
+        ZSB2MiAoR1BMdjIpXG5DbGFzc2lmaWVyOiBOYXR1cmFsIExhbmd1YWdlIDo6
+        IEVuZ2xpc2hcbkNsYXNzaWZpZXI6IFByb2dyYW1taW5nIExhbmd1YWdlIDo6
+        IFB5dGhvbiA6OiAyXG5DbGFzc2lmaWVyOiBQcm9ncmFtbWluZyBMYW5ndWFn
+        ZSA6OiBQeXRob24gOjogMi43XG5DbGFzc2lmaWVyOiBFbnZpcm9ubWVudCA6
+        OiBDb25zb2xlXG4iLCJkZXNjcmlwdGlvbl9jb250ZW50X3R5cGUiOiIiLCJr
+        ZXl3b3JkcyI6IiIsImhvbWVfcGFnZSI6Imh0dHBzOi8vZ2l0aHViLmNvbS9h
+        c21hY2RvL3NoZWxmLXJlYWRlciIsImRvd25sb2FkX3VybCI6IiIsImF1dGhv
+        ciI6IkF1c3RpbiBNYWNkb25hbGQiLCJhdXRob3JfZW1haWwiOiJhc21hY2Rv
+        QGdtYWlsLmNvbSIsIm1haW50YWluZXIiOiIiLCJtYWludGFpbmVyX2VtYWls
+        IjoiIiwibGljZW5zZSI6IkdOVSBHRU5FUkFMIFBVQkxJQyBMSUNFTlNFIFZl
+        cnNpb24gMiwgSnVuZSAxOTkxIiwicmVxdWlyZXNfcHl0aG9uIjoiIiwicHJv
+        amVjdF91cmwiOiIiLCJwcm9qZWN0X3VybHMiOiJ7fSIsInBsYXRmb3JtIjoi
+        Iiwic3VwcG9ydGVkX3BsYXRmb3JtIjoiIiwicmVxdWlyZXNfZGlzdCI6Iltd
+        IiwicHJvdmlkZXNfZGlzdCI6IltdIiwib2Jzb2xldGVzX2Rpc3QiOiJbXSIs
+        InJlcXVpcmVzX2V4dGVybmFsIjoiW10iLCJjbGFzc2lmaWVycyI6IltdIn1d
+        fQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:56 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-b3d9-7d6a-9886-b70bfaf6cb48/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '896'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3cec3a5f7c5545c98f9cf5f3c62629c8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYjNk
+        OS03ZDZhLTk4ODYtYjcwYmZhZjZjYjQ4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NTUuOTYyMjc5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo1NS45NjIyOTJaIiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJuYW1lIjoicHVscF9weXRob24uYXBwLnRhc2tzLnB1Ymxpc2gu
+        cHVibGlzaCIsImxvZ2dpbmdfY2lkIjoiYWUzNGVkYmYyNWIyNGM4N2E2Nzk1
+        N2RjMGY5ODQ2NjIiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3VzZXJz
+        LzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozODo1NS45NzI2
+        NDFaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTYuMDA3ODA2
+        WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozODo1Ni4xMDM3NTZa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        LzAxOGZlM2NiLTBkNDMtNzczMS05ODUyLTg3MjlkMDA4MTk2My8iLCJwYXJl
+        bnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpu
+        dWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMi
+        OlsiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9weXRob24vcHlwaS8wMThm
+        ZThkNi1iNDE2LTcxYTUtYjY2Ni1hYTg5MzQ5MjhhOWIvIl0sInJlc2VydmVk
+        X3Jlc291cmNlc19yZWNvcmQiOlsic2hhcmVkOi9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmZThkNi1hYTEwLTc3ZjAtODk5
+        Mi0wY2ZmOWM5ZWJmZGUvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21haW5z
+        LzAxOGZlM2M5LTcwYWEtNzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:56 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/?base_path=integration_tests/python
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.11.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '605'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - bb9da56751ad45f2bd19c152194cbf65
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3B5dGhvbi9weXBpLzAxOGZlOGQ2LWFkNzQtN2M0ZS04YzJiLWI5ZTVjMzQz
+        YzMzYS8iLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjU0LjMy
+        NTk4NloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6
+        NTQuMzI2MDAyWiIsImJhc2VfcGF0aCI6ImludGVncmF0aW9uX3Rlc3RzL3B5
+        dGhvbiIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2
+        ZWwubWFuaWNvdHRvLmV4YW1wbGUuY29tL3B5cGkvaW50ZWdyYXRpb25fdGVz
+        dHMvcHl0aG9uLyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsImhpZGRlbiI6ZmFs
+        c2UsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IjJfZHVwbGljYXRlLXRlc3Qt
+        cHl0aG9uIiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVs
+        cC9hcGkvdjMvcHVibGljYXRpb25zL3B5dGhvbi9weXBpLzAxOGZlOGQ2LWFi
+        NjYtNzAzZi1iMzRhLTZiNmFjZDIzMGI5Ni8iLCJhbGxvd191cGxvYWRzIjp0
+        cnVlLCJyZW1vdGUiOm51bGx9XX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:56 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/python/pypi/018fe8d6-b416-71a5-b666-aa8934928a9b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.11.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '410'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - b5d4f7ffc43840e4974358dd477dcc06
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3B5dGhv
+        bi9weXBpLzAxOGZlOGQ2LWI0MTYtNzFhNS1iNjY2LWFhODkzNDkyOGE5Yi8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjU2LjAyNDY4M1oi
+        LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTYuMDk3
+        MzAzWiIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmZThkNi1hYTEwLTc3ZjAtODk5
+        Mi0wY2ZmOWM5ZWJmZGUvdmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9weXRob24vcHl0aG9uLzAxOGZlOGQ2
+        LWFhMTAtNzdmMC04OTkyLTBjZmY5YzllYmZkZS8iLCJkaXN0cmlidXRpb25z
+        IjpbXX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:56 GMT
+- request:
+    method: patch
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/018fe8d6-ad74-7c4e-8c2b-b9e5c343c33a/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJpbnRlZ3JhdGlv
+        bl90ZXN0cy9weXRob24iLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9w
+        dWJsaWNhdGlvbnMvcHl0aG9uL3B5cGkvMDE4ZmU4ZDYtYjQxNi03MWE1LWI2
+        NjYtYWE4OTM0OTI4YTliLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.11.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9d2eb2a5cec4447ab197a2540469b03c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWI1YWUtN2M2
+        Ni04YzliLWE0ZDNmZmEyMWI4ZC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:56 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-b5ae-7c66-8c9b-a4d3ffa21b8d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '702'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7d9c98ace20e40c0b3aa9f9ca3fa587f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtYjVh
+        ZS03YzY2LThjOWItYTRkM2ZmYTIxYjhkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6NTYuNDMwODk5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODo1Ni40MzA5MTJaIiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
+        bF91cGRhdGUiLCJsb2dnaW5nX2NpZCI6IjlkMmViMmE1Y2VjNDQ0N2FiMTk3
+        YTI1NDA0NjliMDNjIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTYuNDQw
+        MDUxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjU2LjQ0NDEw
+        OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTYuNDU4Mzcz
+        WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGwsInBhcmVudF90YXNrIjpu
+        dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
+        ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2Vy
+        dmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25z
+        LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFh
+        LTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:38:56 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/python/pypi/018fe8d6-b416-71a5-b666-aa8934928a9b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.11.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '488'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - f2505a692801407784e42777cc0a689a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3B5dGhv
+        bi9weXBpLzAxOGZlOGQ2LWI0MTYtNzFhNS1iNjY2LWFhODkzNDkyOGE5Yi8i
+        LCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjU2LjAyNDY4M1oi
+        LCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6NTYuMDk3
+        MzAzWiIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvcHl0aG9uL3B5dGhvbi8wMThmZThkNi1hYTEwLTc3ZjAtODk5
+        Mi0wY2ZmOWM5ZWJmZGUvdmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9weXRob24vcHl0aG9uLzAxOGZlOGQ2
+        LWFhMTAtNzdmMC04OTkyLTBjZmY5YzllYmZkZS8iLCJkaXN0cmlidXRpb25z
+        IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL3B5dGhvbi9weXBpLzAx
+        OGZlOGQ2LWFkNzQtN2M0ZS04YzJiLWI5ZTVjMzQzYzMzYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:56 GMT
+- request:
+    method: patch
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/018fe8d6-ad74-7c4e-8c2b-b9e5c343c33a/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJpbnRlZ3JhdGlv
+        bl90ZXN0cy9weXRob24iLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9w
+        dWJsaWNhdGlvbnMvcHl0aG9uL3B5cGkvMDE4ZmU4ZDYtYjQxNi03MWE1LWI2
+        NjYtYWE4OTM0OTI4YTliLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.11.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:56 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2e343c98da9440ecb4b9b5cb3f6ad152
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LWI2OTEtN2I2
+        Yi04YjE2LTMwOGRjM2NmYTAxNS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:56 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/content/chunk_upload.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/content/chunk_upload.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:31 GMT
+      - Wed, 05 Jun 2024 14:38:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 980983f7796e4651a4539a84bdc57f99
+      - b032075ae5144dd8ab1a84861fe43422
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:31 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:06 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:31 GMT
+      - Wed, 05 Jun 2024 14:38:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ff4da73aa26c4fb58e3fe8fa820671bc
+      - 5652171d704546f8b3da666622f1fe00
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:31 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:06 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
@@ -118,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:31 GMT
+      - Wed, 05 Jun 2024 14:38:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1c24bbd66ca84d5984fb3d743a1cfa42
+      - 531febfc40e946278e526bc81133d023
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:31 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:06 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
@@ -172,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:31 GMT
+      - Wed, 05 Jun 2024 14:38:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c5d440356d0e492cbfcc97df1f252260
+      - a630e1a660344467bc4020da51d8a53f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:31 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:06 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
@@ -235,7 +235,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -248,13 +248,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:31 GMT
+      - Wed, 05 Jun 2024 14:38:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/018f54ca-3f3c-7a5d-9382-d7df865d297f/"
+      - "/pulp/api/v3/remotes/file/file/018fe8d5-f462-75c5-9704-d7a416afb125/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -270,7 +270,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 83974629dd744f79b0f5087b9bec659a
+      - 4d9b7985981e455fb5036f9b00912821
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -279,9 +279,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE4ZjU0Y2EtM2YzYy03YTVkLTkzODItZDdkZjg2NWQyOTdmLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjQtMDUtMDdUMjA6NDE6MzEuNzA4NzA5WiIsInB1bHBf
-        bGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMDo0MTozMS43MDg3MjZaIiwi
+        MDE4ZmU4ZDUtZjQ2Mi03NWM1LTk3MDQtZDdhNDE2YWZiMTI1LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDYuOTQ3MjQ1WiIsInB1bHBf
+        bGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozODowNi45NDcyNTlaIiwi
         bmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMi
         LCJ1cmwiOiJodHRwOi8vdGVzdC90ZXN0Ly9QVUxQX01BTklGRVNUIiwiY2Ff
         Y2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9u
@@ -295,7 +295,7 @@ http_interactions:
         bWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwcm94eV9wYXNzd29yZCIs
         ImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InVzZXJuYW1lIiwiaXNfc2V0Ijpm
         YWxzZX0seyJuYW1lIjoicGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfV19
-  recorded_at: Tue, 07 May 2024 20:41:31 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:06 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/
@@ -308,7 +308,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -321,13 +321,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:31 GMT
+      - Wed, 05 Jun 2024 14:38:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/018f54ca-3fde-7701-9210-467d0f8d933a/"
+      - "/pulp/api/v3/repositories/file/file/018fe8d5-f4e5-7c52-8414-c614f3ebfc0f/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -343,7 +343,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1f92f2abe90b443e89d886988b367480
+      - 34c94255a3474c948dce45ff12d67478
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -352,19 +352,19 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMThmNTRjYS0zZmRlLTc3MDEtOTIxMC00NjdkMGY4ZDkzM2EvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyNC0wNS0wN1QyMDo0MTozMS44NzEzMzZaIiwi
-        cHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTA3VDIwOjQxOjMxLjg4MDE5
+        ZmlsZS8wMThmZThkNS1mNGU1LTdjNTItODQxNC1jNjE0ZjNlYmZjMGYvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wNVQxNDozODowNy4wNzgwMzRaIiwi
+        cHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjA3LjA4NTAy
         NVoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvMDE4ZjU0Y2EtM2ZkZS03NzAxLTkyMTAtNDY3ZDBmOGQ5
-        MzNhL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
+        cy9maWxlL2ZpbGUvMDE4ZmU4ZDUtZjRlNS03YzUyLTg0MTQtYzYxNGYzZWJm
+        YzBmL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
         b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzAxOGY1NGNhLTNmZGUtNzcwMS05MjEwLTQ2N2QwZjhkOTMzYS92ZXJzaW9u
+        LzAxOGZlOGQ1LWY0ZTUtN2M1Mi04NDE0LWM2MTRmM2ViZmMwZi92ZXJzaW9u
         cy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15
         X0ZpbGVzIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNp
         b25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwi
         bWFuaWZlc3QiOiJQVUxQX01BTklGRVNUIn0=
-  recorded_at: Tue, 07 May 2024 20:41:31 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:07 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
@@ -375,7 +375,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -388,7 +388,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:32 GMT
+      - Wed, 05 Jun 2024 14:38:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -408,7 +408,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 03fb7fd6fc984879b504c115fbea327a
+      - 56f02b0863594dc29d1457e92fedcac8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -418,7 +418,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:32 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:07 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/
@@ -431,7 +431,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -444,13 +444,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:32 GMT
+      - Wed, 05 Jun 2024 14:38:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/uploads/018f54ca-40e0-722e-9177-683aa2375f36/"
+      - "/pulp/api/v3/uploads/018fe8d5-f59c-7c56-b209-0109650e0022/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -466,7 +466,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 73a598eeb09e43d78577eeae790ea274
+      - 92e58db980a6470387367a4377fd0116
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -474,14 +474,14 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmNTRjYS00
-        MGUwLTcyMmUtOTE3Ny02ODNhYTIzNzVmMzYvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyNC0wNS0wN1QyMDo0MTozMi4xMjk2ODRaIiwicHVscF9sYXN0X3VwZGF0
-        ZWQiOiIyMDI0LTA1LTA3VDIwOjQxOjMyLjEyOTY5OVoiLCJzaXplIjo3NDB9
-  recorded_at: Tue, 07 May 2024 20:41:32 GMT
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmZThkNS1m
+        NTljLTdjNTYtYjIwOS0wMTA5NjUwZTAwMjIvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyNC0wNi0wNVQxNDozODowNy4yNjEyNDlaIiwicHVscF9sYXN0X3VwZGF0
+        ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjA3LjI2MTI2MVoiLCJzaXplIjo3NDB9
+  recorded_at: Wed, 05 Jun 2024 14:38:07 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/file/file/018f54ca-3fde-7701-9210-467d0f8d933a/versions/1/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/file/file/018fe8d5-f4e5-7c52-8414-c614f3ebfc0f/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -489,7 +489,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -502,7 +502,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:36 GMT
+      - Wed, 05 Jun 2024 14:38:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -522,7 +522,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f1abaa429e754f80825725abeeb6dc3e
+      - 582e58c51f014eeda5e676fc33b3cf65
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -532,11 +532,11 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
-        ZmlsZXMvMDE4ZjU0Y2EtNDgyNi03ZmY4LTg5MzMtM2JiYjM0MzAxOTg0LyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjQtMDUtMDdUMjA6NDE6MzMuOTkxODYxWiIs
-        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMDo0MTozMy45OTE4
-        ODBaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzAxOGY1
-        NGNhLTQ1OTQtN2ZjMC1iMThlLTg1ZTdiMTk3NTkzZS8iLCJyZWxhdGl2ZV9w
+        ZmlsZXMvMDE4ZmU4ZDUtZmIxOS03ZDg1LTg1ZWMtMmU5ZjEzNGVlYmIyLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDguNjY2NTQ5WiIs
+        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozODowOC42NjY1
+        NjRaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzAxOGZl
+        OGQ1LWY5NTMtNzRlNi04NDU1LWExOTQ5ZDY0MjkzZS8iLCJyZWxhdGl2ZV9w
         YXRoIjoidGVzdF9lcnJhdHVtLmpzb24iLCJtZDUiOm51bGwsInNoYTEiOiI2
         MDk4ODU3MTVmZDhkNmE3MDdmMThmYzU1OWQ2MWI4YmRlZTcxODBlIiwic2hh
         MjI0IjoiZTI5MzFmMDM2NjU2YmE2ZDAxN2I1MDZiOGZlYzU3Yjg3ZTU3ZWVj
@@ -548,10 +548,10 @@ http_interactions:
         YmY5MWU4MjMwZjVjZTE2OGJlMWQ4NTI3YWI3NjdmNTU3MTRlZTQ1ZGJjZDUw
         NWY3N2U4NDFhNTQxNzgyMjQ4N2ZkZTIyNWU2MjJmZDRmOWNkZjMzMzg0NWQ5
         MDE0MDA3ODYzYTk5YTE5YTdmNDkwMmVlMjgifV19
-  recorded_at: Tue, 07 May 2024 20:41:36 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:11 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018f54ca-3f3c-7a5d-9382-d7df865d297f/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018fe8d5-f462-75c5-9704-d7a416afb125/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -559,7 +559,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -572,7 +572,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:37 GMT
+      - Wed, 05 Jun 2024 14:38:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -592,7 +592,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ea6eaabfdb6547d493787071ac48207b
+      - 390ef500b7a147efbcee2c1b9066763d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -600,12 +600,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGNhLTU0ODgtNzM1
-        ZS05YWRiLWJhYjVhZmM4ZmY3NC8ifQ==
-  recorded_at: Tue, 07 May 2024 20:41:37 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LTA1MmItNzc5
+        OC05NDYwLTBmYThlZjc0NGEwOC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:11 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54ca-5488-735e-9adb-bab5afc8ff74/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-052b-7798-9460-0fa8ef744a08/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -613,7 +613,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -626,7 +626,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:37 GMT
+      - Wed, 05 Jun 2024 14:38:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -646,7 +646,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8dd0991e12ae4bb2a8941c283d95d678
+      - 77dc07a8025b4cd7bcf25651bb074730
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -654,28 +654,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0Y2EtNTQ4
-        OC03MzVlLTlhZGItYmFiNWFmYzhmZjc0LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6NDE6MzcuMTYxNTY1WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDo0MTozNy4xNjE1ODFaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtMDUy
+        Yi03Nzk4LTk0NjAtMGZhOGVmNzQ0YTA4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6MTEuMjQzNDcyWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODoxMS4yNDM0ODRaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImVhNmVhYWJmZGI2NTQ3ZDQ5Mzc4
-        NzA3MWFjNDgyMDdiIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjA6NDE6MzcuMTc2
-        MjIzWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjQxOjM3LjI1NDYw
-        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjA6NDE6MzcuMzIwMDg0
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjM5MGVmNTAwYjdhMTQ3ZWZiY2Vl
+        MmMxYjkwNjY3NjNkIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MTEuMjU0
+        MDY3WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjExLjI4NjA1
+        M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MTEuMzI2MDU4
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRiYS04MDE3LTdlMWMtOTUxMS04NmM0YTI0Nzc2ZmEvIiwicGFy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE4ZjU0Y2EtM2YzYy03YTVkLTkzODIt
-        ZDdkZjg2NWQyOTdmLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8w
-        MThmNTRiOS0zY2M1LTdmNzUtOWZhOS1lZmRkMjBhMWZjODMvIl19
-  recorded_at: Tue, 07 May 2024 20:41:37 GMT
+        djMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE4ZmU4ZDUtZjQ2Mi03NWM1LTk3MDQt
+        ZDdhNDE2YWZiMTI1LyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8w
+        MThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:38:11 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018f54ca-4e21-7c04-9eb6-60364fe57467/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018fe8d5-ff5a-7b6c-9b5e-5d195327106f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -683,7 +683,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -696,7 +696,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:37 GMT
+      - Wed, 05 Jun 2024 14:38:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -716,7 +716,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 49740ad09d534a288241803e3bc7cd26
+      - ab10b17d10964955bf0fecc626ff9a80
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -724,12 +724,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGNhLTU1YzUtNzc0
-        NS04MzQ4LTEzYmZmN2M2MzBmNC8ifQ==
-  recorded_at: Tue, 07 May 2024 20:41:37 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LTA2MDQtN2M3
+        MS05YzhkLTRkYzkxZTcxMzA5Zi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:11 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018f54ca-3fde-7701-9210-467d0f8d933a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018fe8d5-f4e5-7c52-8414-c614f3ebfc0f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -737,7 +737,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -750,7 +750,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:37 GMT
+      - Wed, 05 Jun 2024 14:38:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -770,7 +770,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 81999b7bc0664bbfb5df5ab6d2ba5fdf
+      - 10de57daeac94740adc477060c4c4df8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -778,12 +778,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGNhLTU2NTUtN2E1
-        Yy1hYmFkLWM0NzVlYjhiYTU1Yi8ifQ==
-  recorded_at: Tue, 07 May 2024 20:41:37 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LTA2NmQtNzMz
+        NC04OTQzLTg0NjdlZGMxODk2My8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:11 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54ca-5655-7a5c-abad-c475eb8ba55b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-066d-7334-8943-8467edc18963/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -791,7 +791,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -804,7 +804,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:38 GMT
+      - Wed, 05 Jun 2024 14:38:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -824,7 +824,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b6d2f07bd4f84a77a2180814705d6d2a
+      - 67050a364a1e4dcdb85e7868a3c278c5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -832,25 +832,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0Y2EtNTY1
-        NS03YTVjLWFiYWQtYzQ3NWViOGJhNTViLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6NDE6MzcuNjIyMjQ5WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDo0MTozNy42MjIyNjVaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtMDY2
+        ZC03MzM0LTg5NDMtODQ2N2VkYzE4OTYzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6MTEuNTY1NTIxWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODoxMS41NjU1MzVaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjgxOTk5YjdiYzA2NjRiYmZiNWRm
-        NWFiNmQyYmE1ZmRmIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjA6NDE6MzcuNjM4
-        OTc5WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjQxOjM3LjcxNzI2
-        NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjA6NDE6MzcuOTM3MDA0
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjEwZGU1N2RhZWFjOTQ3NDBhZGM0
+        NzcwNjBjNGM0ZGY4IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MTEuNTgx
+        Mjc1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjExLjYxMTg1
+        M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MTEuNzQxMDY2
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRiYS03ZmY1LTc3NDYtOGY0NC0zY2RiOTExNTk4OTEvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmNTRjYS0zZmRlLTc3MDEt
-        OTIxMC00NjdkMGY4ZDkzM2EvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21h
-        aW5zLzAxOGY1NGI5LTNjYzUtN2Y3NS05ZmE5LWVmZGQyMGExZmM4My8iXX0=
-  recorded_at: Tue, 07 May 2024 20:41:38 GMT
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmZThkNS1mNGU1LTdjNTIt
+        ODQxNC1jNjE0ZjNlYmZjMGYvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21h
+        aW5zLzAxOGZlM2M5LTcwYWEtNzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:11 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
@@ -861,7 +861,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.21.3/ruby
+      - OpenAPI-Generator/0.21.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -874,7 +874,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:38 GMT
+      - Wed, 05 Jun 2024 14:38:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -894,7 +894,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3be285bb878145089ef779ca79436815
+      - 1fc33e91ce6c47519fff3a6a930f8b68
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -904,7 +904,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:38 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:12 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -928,7 +928,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:38 GMT
+      - Wed, 05 Jun 2024 14:38:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -948,7 +948,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c32fe65baca54f1aa96b500363d406dd
+      - 58be69cfeb344b5ba33b30ae5262c36d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -958,7 +958,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:38 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:12 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -982,7 +982,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:38 GMT
+      - Wed, 05 Jun 2024 14:38:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1002,7 +1002,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7f184224076a4ce08888996df6f0f0ab
+      - 2e3671e3cefd4bc9b55a620f58a246ba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1012,7 +1012,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:38 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:12 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -1023,7 +1023,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1036,7 +1036,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:38 GMT
+      - Wed, 05 Jun 2024 14:38:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1056,7 +1056,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c2818dadede14ed9a74ac934fcc0608b
+      - 4b49a83bfe1940e1b7a3bb51335c3a8a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1066,7 +1066,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:38 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:12 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -1090,7 +1090,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:38 GMT
+      - Wed, 05 Jun 2024 14:38:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1110,7 +1110,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c1c7207944ad4f0f8c55fe8860c8c429
+      - 4b86d0d4e9fd4d0595ae62faa6f3f1b3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1120,7 +1120,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:38 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:12 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -1144,7 +1144,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:38 GMT
+      - Wed, 05 Jun 2024 14:38:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1164,7 +1164,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d3c21b5763ff47118ac329c597713e35
+      - f5d50b20fca3496bb7dcae7df9bee327
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1174,7 +1174,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:38 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:12 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -1185,7 +1185,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1198,7 +1198,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:38 GMT
+      - Wed, 05 Jun 2024 14:38:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1218,7 +1218,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d9fb58c10c57465289e204c2dba2d285
+      - e0e810f0551949e1a6538c77f579b6dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1228,7 +1228,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:38 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:12 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
@@ -1241,7 +1241,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1254,7 +1254,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:38 GMT
+      - Wed, 05 Jun 2024 14:38:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1274,7 +1274,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e30953d833f54f26be4769a304497f9f
+      - a9998d905e2a4e55a188c8bbda0b58e6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1282,12 +1282,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGNhLTVhODUtNzc5
-        ZS1hYTU5LTNlYWY3NjE1MWYxMy8ifQ==
-  recorded_at: Tue, 07 May 2024 20:41:38 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LTA5ODQtNzVj
+        Zi04OTU5LTgwNmY0MTI1N2Y3ZS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:12 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54ca-5a85-779e-aa59-3eaf76151f13/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d6-0984-75cf-8959-806f41257f7e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1295,7 +1295,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1308,7 +1308,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:47 GMT
+      - Wed, 05 Jun 2024 14:38:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1320,7 +1320,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1007'
+      - '999'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1328,7 +1328,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7ca504d956db497190a92fed37339969
+      - 469aef8af5904db1a3b4047bb001b782
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1336,28 +1336,84 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0Y2EtNWE4
-        NS03NzllLWFhNTktM2VhZjc2MTUxZjEzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6NDE6MzguNjk0MzE5WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDo0MTozOC42OTQzMzdaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDYtMDk4
+        NC03NWNmLTg5NTktODA2ZjQxMjU3ZjdlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6MTIuMzU2ODU0WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODoxMi4zNTY4NjVaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLm9ycGhhbi5vcnBo
-        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiZTMwOTUzZDgzM2Y1NGYyNmJl
-        NDc2OWEzMDQ0OTdmOWYiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
-        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMDo0MTozOC44
-        OTcyODVaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjA6NDE6MzguOTYw
-        MTE4WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMDo0MTo0Ny4xMDYz
-        NjZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzAxOGY1NGJhLTdmZjUtNzc0Ni04ZjQ0LTNjZGI5MTE1OTg5MS8iLCJw
+        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiYTk5OThkOTA1ZTJhNGU1NWEx
+        ODhjOGJiZGEwYjU4ZTYiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
+        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozODoxMi4z
+        NzU2NjFaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MTIuNDA4
+        MTkxWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozODoxMi42OTIx
+        ODhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzAxOGZlM2NiLTBkZjItN2M4My1hN2VhLWUyNmExYTI4ZDdmOS8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xlYW4g
         dXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjQ1OCwiZG9uZSI6NDU4LCJz
-        dWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkNsZWFuIHVwIG9ycGhhbiBBcnRp
-        ZmFjdHMiLCJjb2RlIjoiY2xlYW4tdXAuYXJ0aWZhY3RzIiwic3RhdGUiOiJj
-        b21wbGV0ZWQiLCJ0b3RhbCI6NDA2LCJkb25lIjo0MDYsInN1ZmZpeCI6bnVs
-        bH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL2FwaS92My9vcnBoYW5zL2NsZWFudXAvIiwic2hhcmVk
-        Oi9wdWxwL2FwaS92My9kb21haW5zLzAxOGY1NGI5LTNjYzUtN2Y3NS05ZmE5
-        LWVmZGQyMGExZmM4My8iXX0=
-  recorded_at: Tue, 07 May 2024 20:41:47 GMT
+        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEsInN1ZmZp
+        eCI6bnVsbH0seyJtZXNzYWdlIjoiQ2xlYW4gdXAgb3JwaGFuIEFydGlmYWN0
+        cyIsImNvZGUiOiJjbGVhbi11cC5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNvbXBs
+        ZXRlZCIsInRvdGFsIjoyLCJkb25lIjoyLCJzdWZmaXgiOm51bGx9XSwiY3Jl
+        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbIi9hcGkvdjMvb3JwaGFucy9jbGVhbnVwLyIsInNoYXJlZDovcHVscC9h
+        cGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2Fk
+        MzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:38:12 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/purge/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJmaW5pc2hlZF9iZWZvcmUiOiIzMDAwLTAxLTAxVDAwOjAwOjAwLjAwMCsw
+        MDowMCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:12 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - '0226391a6c3f48c4aaca0e849889c258'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ2LTBiMWUtN2U0
+        NC1hZjNmLTZlMzUwZTIxNjM1Yy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:12 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/content/chunk_upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/content/chunk_upload_binary.yml
@@ -43877,60 +43877,6 @@ http_interactions:
         ZWQiOiIyMDI0LTA1LTA3VDIwOjQxOjMyLjEyOTY5OVoiLCJzaXplIjo3NDB9
   recorded_at: Tue, 07 May 2024 20:41:32 GMT
 - request:
-    method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 07 May 2024 20:41:33 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 0fde144edd264884afe6541b4e083aed
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:33 GMT
-- request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/018f54ca-40e0-722e-9177-683aa2375f36/commit/
     body:
@@ -44056,195 +44002,6 @@ http_interactions:
         Ii9wdWxwL2FwaS92My91cGxvYWRzLzAxOGY1NGNhLTQwZTAtNzIyZS05MTc3
         LTY4M2FhMjM3NWYzNi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMv
         MDE4ZjU0YjktM2NjNS03Zjc1LTlmYTktZWZkZDIwYTFmYzgzLyJdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:33 GMT
-- request:
-    method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 07 May 2024 20:41:33 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '771'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - dc6acece85b54ab99117edb4e87f2594
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE4
-        ZjU0Y2EtNDU5NC03ZmMwLWIxOGUtODVlN2IxOTc1OTNlLyIsInB1bHBfY3Jl
-        YXRlZCI6IjIwMjQtMDUtMDdUMjA6NDE6MzMuMzMzNzA3WiIsInB1bHBfbGFz
-        dF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMDo0MTozMy4zMzM3MjlaIiwiZmls
-        ZSI6ImFydGlmYWN0L2VmLzBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3
-        ZjE4YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwic2l6ZSI6NzQw
-        LCJtZDUiOm51bGwsInNoYTEiOiI2MDk4ODU3MTVmZDhkNmE3MDdmMThmYzU1
-        OWQ2MWI4YmRlZTcxODBlIiwic2hhMjI0IjoiZTI5MzFmMDM2NjU2YmE2ZDAx
-        N2I1MDZiOGZlYzU3Yjg3ZTU3ZWVjMjdhZWFkMGRmN2FkOGVkM2MiLCJzaGEy
-        NTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4YWQzODFh
-        Y2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwic2hhMzg0IjoiZDNjNTI4ZDIx
-        MTBkODA2Njc1OWJlZDBjZGRjMDk5MTM5MWQ0NzcyN2Q3YmIwMDM4NjRlYTkz
-        NjIxM2E4ZWM0NGEzZGY1MmRkMWIyN2M3ODVjN2U2N2IxMDMyMmU5OWZkIiwi
-        c2hhNTEyIjoiY2ZiODUyM2U4N2M3YmY5MWU4MjMwZjVjZTE2OGJlMWQ4NTI3
-        YWI3NjdmNTU3MTRlZTQ1ZGJjZDUwNWY3N2U4NDFhNTQxNzgyMjQ4N2ZkZTIy
-        NWU2MjJmZDRmOWNkZjMzMzg0NWQ5MDE0MDA3ODYzYTk5YTE5YTdmNDkwMmVl
-        MjgifV19
-  recorded_at: Tue, 07 May 2024 20:41:33 GMT
-- request:
-    method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 07 May 2024 20:41:33 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - f6d8353e037f4d50b8aa4a3023a1f64d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:33 GMT
-- request:
-    method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTI2MGNjZjE4MTQyMzM5
-        NDZlY2Q5NzNjY2FhMDcxYjQ4DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bS5q
-        c29uDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtMjYwY2NmMTgx
-        NDIzMzk0NmVjZDk3M2NjYWEwNzFiNDgNCkNvbnRlbnQtRGlzcG9zaXRpb246
-        IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2FwaS92My9h
-        cnRpZmFjdHMvMDE4ZjU0Y2EtNDU5NC03ZmMwLWIxOGUtODVlN2IxOTc1OTNl
-        Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTI2MGNjZjE4MTQy
-        MzM5NDZlY2Q5NzNjY2FhMDcxYjQ4LS0NCg==
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-260ccf1814233946ecd973ccaa071b48
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '385'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 07 May 2024 20:41:33 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - d3478df36ef1495b9342fc9d39e31b29
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGNhLTQ2ZWUtN2Y3
-        ZS1hMzI0LTFhZjVhYmYzNTc0Zi8ifQ==
   recorded_at: Tue, 07 May 2024 20:41:33 GMT
 - request:
     method: get
@@ -44517,64 +44274,6 @@ http_interactions:
         MDE0MDA3ODYzYTk5YTE5YTdmNDkwMmVlMjgifV19
   recorded_at: Tue, 07 May 2024 20:41:34 GMT
 - request:
-    method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/file/file/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2ZpbGUvZmlsZS8wMThmNTRjYS0zZmRlLTc3MDEtOTIxMC00NjdkMGY4
-        ZDkzM2EvdmVyc2lvbnMvMS8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
-        fQ==
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 07 May 2024 20:41:34 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - c0027cf4bb94458fa433dd09a6206848
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGNhLTRhZmItNzg1
-        YS04OGI1LTgyZTc2MGVmOGUyNS8ifQ==
-  recorded_at: Tue, 07 May 2024 20:41:34 GMT
-- request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54ca-4afb-785a-88b5-82e760ef8e25/
     body:
@@ -44648,60 +44347,6 @@ http_interactions:
   recorded_at: Tue, 07 May 2024 20:41:34 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 07 May 2024 20:41:35 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - e5968aec725b41a19cfb25c3a3fe397f
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:35 GMT
-- request:
-    method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/file/file/018f54ca-4b57-7148-bf51-d9a517333de1/
     body:
       encoding: US-ASCII
@@ -44761,65 +44406,6 @@ http_interactions:
         L3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE4ZjU0Y2EtM2ZkZS03NzAx
         LTkyMTAtNDY3ZDBmOGQ5MzNhLyIsImRpc3RyaWJ1dGlvbnMiOltdLCJtYW5p
         ZmVzdCI6IlBVTFBfTUFOSUZFU1QifQ==
-  recorded_at: Tue, 07 May 2024 20:41:35 GMT
-- request:
-    method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L015
-        X0ZpbGVzIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6IkRlZmF1bHRf
-        T3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiLCJwdWJsaWNhdGlvbiI6
-        Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOGY1NGNh
-        LTRiNTctNzE0OC1iZjUxLWQ5YTUxNzMzM2RlMS8ifQ==
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 07 May 2024 20:41:35 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - cf9aaa4a98e545b4953fb5a119703512
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGNhLTRjZDYtN2Qx
-        My04MmQxLTQyMGFjZDk5Njk2MS8ifQ==
   recorded_at: Tue, 07 May 2024 20:41:35 GMT
 - request:
     method: get
@@ -44957,4 +44543,1643 @@ http_interactions:
         aS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOGY1NGNhLTRiNTctNzE0
         OC1iZjUxLWQ5YTUxNzMzM2RlMS8ifQ==
   recorded_at: Tue, 07 May 2024 20:41:35 GMT
+- request:
+    method: put
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/018fe8d5-f59c-7c56-b209-0109650e0022/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWJhYWRiMzY1MjM0OTQw
+        ZGMxOTZjY2QwNTI0MzNlMzQ2DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyNDA2
+        MDUtNDU3ODYtNTN4dHNhIg0KQ29udGVudC1MZW5ndGg6IDEwMA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQp7InVuaXRfa2V5IjogeyJpZCI6
+        ICJ0ZXN0In0sICJ1bml0X21ldGFkYXRhIjogeyJzdGF0dXMiOiAiZmluYWwi
+        LCAidXBkYXRlZCI6ICIyMDEyLTctMjUgMDA6MDA6MDAiLCAiDQotLS0tLS0t
+        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtYmFhZGIzNjUyMzQ5NDBkYzE5NmNj
+        ZDA1MjQzM2UzNDYtLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-baadb365234940dc196ccd052433e346
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-99/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '420'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '180'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - bb0be6dc9f3a4ae89d71e370a84d38d8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmZThkNS1m
+        NTljLTdjNTYtYjIwOS0wMTA5NjUwZTAwMjIvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyNC0wNi0wNVQxNDozODowNy4yNjEyNDlaIiwicHVscF9sYXN0X3VwZGF0
+        ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjA3LjI2MTI2MVoiLCJzaXplIjo3NDB9
+  recorded_at: Wed, 05 Jun 2024 14:38:07 GMT
+- request:
+    method: put
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/018fe8d5-f59c-7c56-b209-0109650e0022/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWU0NzA4OTcyMjE4OTQx
+        MzIzYzMzZDk2NGU0MzJkNjA2DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyNDA2
+        MDUtNDU3ODYtN2J0cHR5Ig0KQ29udGVudC1MZW5ndGg6IDEwMA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQpkZXNjcmlwdGlvbiI6IG51bGws
+        ICJpc3N1ZWQiOiAiMjAxMC0xMS03IDAwOjAwOjAwIiwgInB1c2hjb3VudCI6
+        ICIiLCAicmVmZXJlbmNlcyI6IFtdLCAiZnJvbSI6ICJwdWxwDQotLS0tLS0t
+        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtZTQ3MDg5NzIyMTg5NDEzMjNjMzNk
+        OTY0ZTQzMmQ2MDYtLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-e4708972218941323c33d964e432d606
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 100-199/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '420'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '180'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4ef539c6e3544ed2b783809913eae3cf
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmZThkNS1m
+        NTljLTdjNTYtYjIwOS0wMTA5NjUwZTAwMjIvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyNC0wNi0wNVQxNDozODowNy4yNjEyNDlaIiwicHVscF9sYXN0X3VwZGF0
+        ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjA3LjI2MTI2MVoiLCJzaXplIjo3NDB9
+  recorded_at: Wed, 05 Jun 2024 14:38:07 GMT
+- request:
+    method: put
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/018fe8d5-f59c-7c56-b209-0109650e0022/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTIxMzM4YTg0NTQ4Yzk2
+        YmViMWNjYjk0M2ZkNjkyMjBkDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyNDA2
+        MDUtNDU3ODYtZDY1N2t0Ig0KQ29udGVudC1MZW5ndGg6IDEwMA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQotbGlzdEByZWRoYXQuY29tIiwg
+        InNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJUZXN0IEVycmF0YSByZWZlcnJp
+        bmcgdG8gdGVzdC1wYWNrYWdlLTAuMiIsICJyaWdodHMiOiAiDQotLS0tLS0t
+        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtMjEzMzhhODQ1NDhjOTZiZWIxY2Ni
+        OTQzZmQ2OTIyMGQtLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-21338a84548c96beb1ccb943fd69220d
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 200-299/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '420'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '180'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1145e46f989740068531926dc2671a99
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmZThkNS1m
+        NTljLTdjNTYtYjIwOS0wMTA5NjUwZTAwMjIvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyNC0wNi0wNVQxNDozODowNy4yNjEyNDlaIiwicHVscF9sYXN0X3VwZGF0
+        ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjA3LjI2MTI2MVoiLCJzaXplIjo3NDB9
+  recorded_at: Wed, 05 Jun 2024 14:38:07 GMT
+- request:
+    method: put
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/018fe8d5-f59c-7c56-b209-0109650e0022/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTQyYmIyNTk4NTgwZGY4
+        NTUxODRiOTdmN2FmMGVjOTczDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyNDA2
+        MDUtNDU3ODYtMzZ0bGIzIg0KQ29udGVudC1MZW5ndGg6IDEwMA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQoiLCAic29sdXRpb24iOiAiIiwg
+        InN1bW1hcnkiOiAiIiwgInZlcnNpb24iOiAiMSIsICJyZWxlYXNlIjogIiIs
+        ICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogDQotLS0tLS0t
+        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtNDJiYjI1OTg1ODBkZjg1NTE4NGI5
+        N2Y3YWYwZWM5NzMtLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-42bb2598580df855184b97f7af0ec973
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 300-399/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '420'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '180'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8a38e1993b2a471b8bd2210122fea98d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmZThkNS1m
+        NTljLTdjNTYtYjIwOS0wMTA5NjUwZTAwMjIvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyNC0wNi0wNVQxNDozODowNy4yNjEyNDlaIiwicHVscF9sYXN0X3VwZGF0
+        ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjA3LjI2MTI2MVoiLCJzaXplIjo3NDB9
+  recorded_at: Wed, 05 Jun 2024 14:38:07 GMT
+- request:
+    method: put
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/018fe8d5-f59c-7c56-b209-0109650e0022/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTlhYzUxMzkxZjMyZWQx
+        MTYzZGE2ODQzMTE2YzMxM2NiDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyNDA2
+        MDUtNDU3ODYtdnI5YWc2Ig0KQ29udGVudC1MZW5ndGg6IDEwMA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQoiZW5oYW5jZW1lbnRzIiwgInBr
+        Z2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJ0ZXN0LXBhY2thZ2Ut
+        MC4yLTEuZWw2LnNyYy5ycG0iLCAibmFtZSI6ICJ0ZXN0LXBhDQotLS0tLS0t
+        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtOWFjNTEzOTFmMzJlZDExNjNkYTY4
+        NDMxMTZjMzEzY2ItLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-9ac51391f32ed1163da6843116c313cb
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 400-499/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '420'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '180'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 62796c67832c413ebc966e7c6eddf33c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmZThkNS1m
+        NTljLTdjNTYtYjIwOS0wMTA5NjUwZTAwMjIvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyNC0wNi0wNVQxNDozODowNy4yNjEyNDlaIiwicHVscF9sYXN0X3VwZGF0
+        ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjA3LjI2MTI2MVoiLCJzaXplIjo3NDB9
+  recorded_at: Wed, 05 Jun 2024 14:38:07 GMT
+- request:
+    method: put
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/018fe8d5-f59c-7c56-b209-0109650e0022/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTVkNTZiZTVhNTI4NzA0
+        ZGU3ODMwZmFiMjE4YTE3YzlhDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyNDA2
+        MDUtNDU3ODYtMWQxNmszIg0KQ29udGVudC1MZW5ndGg6IDEwMA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQpja2FnZSIsICJzdW0iOiBbIm1k
+        NSIsICI1YjU5MGNjOTVmZGZmMTQ1NjAwMzRhMWYzMzRhNDc1MyJdLCAiZmls
+        ZW5hbWUiOiAidGVzdC1wYWNrYWdlLTAuMi0xLmVsNi5ub2FyDQotLS0tLS0t
+        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtNWQ1NmJlNWE1Mjg3MDRkZTc4MzBm
+        YWIyMThhMTdjOWEtLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-5d56be5a528704de7830fab218a17c9a
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 500-599/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '420'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '180'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 13b6c13b53174d43a39cd615b3b42e5a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmZThkNS1m
+        NTljLTdjNTYtYjIwOS0wMTA5NjUwZTAwMjIvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyNC0wNi0wNVQxNDozODowNy4yNjEyNDlaIiwicHVscF9sYXN0X3VwZGF0
+        ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjA3LjI2MTI2MVoiLCJzaXplIjo3NDB9
+  recorded_at: Wed, 05 Jun 2024 14:38:07 GMT
+- request:
+    method: put
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/018fe8d5-f59c-7c56-b209-0109650e0022/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTcyOTQxN2IxMTdhOWUw
+        OTY3ZDFjNzEzOTdhNmZhYjBiDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyNDA2
+        MDUtNDU3ODYtZGN1MXRtIg0KQ29udGVudC1MZW5ndGg6IDEwMA0KQ29udGVu
+        dC1UeXBlOiBhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0NCkNvbnRlbnQtVHJh
+        bnNmZXItRW5jb2Rpbmc6IGJpbmFyeQ0KDQpjaC5ycG0iLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNlIjogIjEuZWw2IiwgImFy
+        Y2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJQdWxwIFRlc3QgDQotLS0tLS0t
+        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtNzI5NDE3YjExN2E5ZTA5NjdkMWM3
+        MTM5N2E2ZmFiMGItLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-729417b117a9e0967d1c71397a6fab0b
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 600-699/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '420'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '180'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4f4590d0b309467997b2e6015908d9a6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmZThkNS1m
+        NTljLTdjNTYtYjIwOS0wMTA5NjUwZTAwMjIvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyNC0wNi0wNVQxNDozODowNy4yNjEyNDlaIiwicHVscF9sYXN0X3VwZGF0
+        ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjA3LjI2MTI2MVoiLCJzaXplIjo3NDB9
+  recorded_at: Wed, 05 Jun 2024 14:38:07 GMT
+- request:
+    method: put
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/018fe8d5-f59c-7c56-b209-0109650e0022/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWNlNWIyYjk0YmFhOGUx
+        NjMyYWZkYWZkOWMwOWUwZTM1DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyNDA2
+        MDUtNDU3ODYtdjZxcnkiDQpDb250ZW50LUxlbmd0aDogNDANCkNvbnRlbnQt
+        VHlwZTogYXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtDQpDb250ZW50LVRyYW5z
+        ZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KUGFja2FnZXMiLCAic2hvcnQiOiAi
+        VGVzdENvbGxlY3Rpb24ifV19fQ0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBh
+        cnRQb3N0LWNlNWIyYjk0YmFhOGUxNjMyYWZkYWZkOWMwOWUwZTM1LS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-ce5b2b94baa8e1632afdafd9c09e0e35
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 700-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '358'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:07 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '180'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9a1b4999414547a994b37940ea924aee
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmZThkNS1m
+        NTljLTdjNTYtYjIwOS0wMTA5NjUwZTAwMjIvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyNC0wNi0wNVQxNDozODowNy4yNjEyNDlaIiwicHVscF9sYXN0X3VwZGF0
+        ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjA3LjI2MTI2MVoiLCJzaXplIjo3NDB9
+  recorded_at: Wed, 05 Jun 2024 14:38:07 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 73ff91c7bb14400eb48af8dac14de169
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:08 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/018fe8d5-f59c-7c56-b209-0109650e0022/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4ed99c5e15f14f838cea50e318b945d8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ1LWY5MDctN2I3
+        OS04NzczLTQ1ZTYzMjk3ZjgyZC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:08 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d5-f907-7b79-8773-45e63297f82d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '850'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - dbb393bb8e3e4e6988b4e99fdf0e49a7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDUtZjkw
+        Ny03Yjc5LTg3NzMtNDVlNjMyOTdmODJkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6MDguMTM2MDQxWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODowOC4xMzYwNTNaIiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLnVwbG9hZC5jb21t
+        aXQiLCJsb2dnaW5nX2NpZCI6IjRlZDk5YzVlMTVmMTRmODM4Y2VhNTBlMzE4
+        Yjk0NWQ4IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vycy8xLyIs
+        InVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDguMTQ5MjM1WiIs
+        InN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjA4LjE4NjE3OVoiLCJm
+        aW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDguMjQ3Njk0WiIsImVy
+        cm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMThm
+        ZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFyZW50X3Rh
+        c2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVsbCwi
+        cHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9w
+        dWxwL2FwaS92My9hcnRpZmFjdHMvMDE4ZmU4ZDUtZjk1My03NGU2LTg0NTUt
+        YTE5NDlkNjQyOTNlLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpb
+        Ii9wdWxwL2FwaS92My91cGxvYWRzLzAxOGZlOGQ1LWY1OWMtN2M1Ni1iMjA5
+        LTAxMDk2NTBlMDAyMi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2RvbWFpbnMv
+        MDE4ZmUzYzktNzBhYS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:08 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '771'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 58443c512b64409d82d1b7d382d87dcd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE4
+        ZmU4ZDUtZjk1My03NGU2LTg0NTUtYTE5NDlkNjQyOTNlLyIsInB1bHBfY3Jl
+        YXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDguMjE1MjkwWiIsInB1bHBfbGFz
+        dF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozODowOC4yMTUzMTRaIiwiZmls
+        ZSI6ImFydGlmYWN0L2VmLzBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3
+        ZjE4YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwic2l6ZSI6NzQw
+        LCJtZDUiOm51bGwsInNoYTEiOiI2MDk4ODU3MTVmZDhkNmE3MDdmMThmYzU1
+        OWQ2MWI4YmRlZTcxODBlIiwic2hhMjI0IjoiZTI5MzFmMDM2NjU2YmE2ZDAx
+        N2I1MDZiOGZlYzU3Yjg3ZTU3ZWVjMjdhZWFkMGRmN2FkOGVkM2MiLCJzaGEy
+        NTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4YWQzODFh
+        Y2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwic2hhMzg0IjoiZDNjNTI4ZDIx
+        MTBkODA2Njc1OWJlZDBjZGRjMDk5MTM5MWQ0NzcyN2Q3YmIwMDM4NjRlYTkz
+        NjIxM2E4ZWM0NGEzZGY1MmRkMWIyN2M3ODVjN2U2N2IxMDMyMmU5OWZkIiwi
+        c2hhNTEyIjoiY2ZiODUyM2U4N2M3YmY5MWU4MjMwZjVjZTE2OGJlMWQ4NTI3
+        YWI3NjdmNTU3MTRlZTQ1ZGJjZDUwNWY3N2U4NDFhNTQxNzgyMjQ4N2ZkZTIy
+        NWU2MjJmZDRmOWNkZjMzMzg0NWQ5MDE0MDA3ODYzYTk5YTE5YTdmNDkwMmVl
+        MjgifV19
+  recorded_at: Wed, 05 Jun 2024 14:38:08 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 45d4c212ce4c42408d0d6f466c742fdb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:08 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTRiNTc5MTgyN2UzZWJh
+        MmZmN2QwMzE1NmEyODdlNjI0DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bS5q
+        c29uDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtNGI1NzkxODI3
+        ZTNlYmEyZmY3ZDAzMTU2YTI4N2U2MjQNCkNvbnRlbnQtRGlzcG9zaXRpb246
+        IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2FwaS92My9h
+        cnRpZmFjdHMvMDE4ZmU4ZDUtZjk1My03NGU2LTg0NTUtYTE5NDlkNjQyOTNl
+        Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTRiNTc5MTgyN2Uz
+        ZWJhMmZmN2QwMzE1NmEyODdlNjI0LS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-4b5791827e3eba2ff7d03156a287e624
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '385'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6bbf276710fa4025b0a336e114db301c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ1LWZhNjItN2M4
+        Ni1iNDY3LTkwZGUyYzVjZGFiNC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:08 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d5-fa62-7c86-b467-90de2c5cdab4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '804'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 49a05455d1584541bd96ca60e715f590
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDUtZmE2
+        Mi03Yzg2LWI0NjctOTBkZTJjNWNkYWI0LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6MDguNDgyOTk4WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODowOC40ODMwMDhaIiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
+        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6IjZiYmYyNzY3MTBmYTQwMjViMGEz
+        MzZlMTE0ZGIzMDFjIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDguNDk0
+        MTE1WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjA4LjUzMjU3
+        NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDguNjc5ODgx
+        WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
+        ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
+        bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
+        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvMDE4ZmU4ZDUt
+        ZmIxOS03ZDg1LTg1ZWMtMmU5ZjEzNGVlYmIyLyJdLCJyZXNlcnZlZF9yZXNv
+        dXJjZXNfcmVjb3JkIjpbInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8w
+        MThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:38:08 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018fe8d5-f4e5-7c52-8414-c614f3ebfc0f/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzAxOGZlOGQ1LWZiMTktN2Q4NS04NWVjLTJlOWYxMzRlZWJi
+        Mi8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 380a6a2d4c7b481fb7558289054b1951
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ1LWZiOWMtN2Jh
+        Yy05NGU4LWIwZGIwYWI2NWYyNi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:08 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d5-fb9c-7bac-94e8-b0db0ab65f26/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '901'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - '00398684c6c94f638eabc7e763544345'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDUtZmI5
+        Yy03YmFjLTk0ZTgtYjBkYjBhYjY1ZjI2LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6MDguNzk2NDIwWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODowOC43OTY0MzBaIiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnku
+        YWRkX2FuZF9yZW1vdmUiLCJsb2dnaW5nX2NpZCI6IjM4MGE2YTJkNGM3YjQ4
+        MWZiNzU1ODI4OTA1NGIxOTUxIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92
+        My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6
+        MDguODA2OTM3WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjA4
+        Ljg0MjU0MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDgu
+        OTIxMDU4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMv
+        IiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19n
+        cm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVz
+        b3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
+        LzAxOGZlOGQ1LWY0ZTUtN2M1Mi04NDE0LWM2MTRmM2ViZmMwZi92ZXJzaW9u
+        cy8xLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOGZlOGQ1LWY0ZTUtN2M1
+        Mi04NDE0LWM2MTRmM2ViZmMwZi8iLCJzaGFyZWQ6L3B1bHAvYXBpL3YzL2Rv
+        bWFpbnMvMDE4ZmUzYzktNzBhYS03ODgzLWI4NjYtMWVlZTdhZDM2ZGVhLyJd
+        fQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:08 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/file/file/018fe8d5-f4e5-7c52-8414-c614f3ebfc0f/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '795'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7566fb0c00b8440c8adc605553522a44
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
+        ZmlsZXMvMDE4ZmU4ZDUtZmIxOS03ZDg1LTg1ZWMtMmU5ZjEzNGVlYmIyLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDguNjY2NTQ5WiIs
+        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozODowOC42NjY1
+        NjRaIiwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzAxOGZl
+        OGQ1LWY5NTMtNzRlNi04NDU1LWExOTQ5ZDY0MjkzZS8iLCJyZWxhdGl2ZV9w
+        YXRoIjoidGVzdF9lcnJhdHVtLmpzb24iLCJtZDUiOm51bGwsInNoYTEiOiI2
+        MDk4ODU3MTVmZDhkNmE3MDdmMThmYzU1OWQ2MWI4YmRlZTcxODBlIiwic2hh
+        MjI0IjoiZTI5MzFmMDM2NjU2YmE2ZDAxN2I1MDZiOGZlYzU3Yjg3ZTU3ZWVj
+        MjdhZWFkMGRmN2FkOGVkM2MiLCJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRm
+        OTQzODUwZGY5NDQyMGU3ZjE4YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3
+        NzkxIiwic2hhMzg0IjoiZDNjNTI4ZDIxMTBkODA2Njc1OWJlZDBjZGRjMDk5
+        MTM5MWQ0NzcyN2Q3YmIwMDM4NjRlYTkzNjIxM2E4ZWM0NGEzZGY1MmRkMWIy
+        N2M3ODVjN2U2N2IxMDMyMmU5OWZkIiwic2hhNTEyIjoiY2ZiODUyM2U4N2M3
+        YmY5MWU4MjMwZjVjZTE2OGJlMWQ4NTI3YWI3NjdmNTU3MTRlZTQ1ZGJjZDUw
+        NWY3N2U4NDFhNTQxNzgyMjQ4N2ZkZTIyNWU2MjJmZDRmOWNkZjMzMzg0NWQ5
+        MDE0MDA3ODYzYTk5YTE5YTdmNDkwMmVlMjgifV19
+  recorded_at: Wed, 05 Jun 2024 14:38:09 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2ZpbGUvZmlsZS8wMThmZThkNS1mNGU1LTdjNTItODQxNC1jNjE0ZjNl
+        YmZjMGYvdmVyc2lvbnMvMS8iLCJtYW5pZmVzdCI6IlBVTFBfTUFOSUZFU1Qi
+        fQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6dfd34a9cdef47f5a5887b0b9b265d04
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ1LWZkMTQtN2Qz
+        Ny1hY2Q0LWM5Y2Y3M2I1Y2JlYy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:09 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d5-fd14-7d37-acd4-c9cf73b5cbec/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '891'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - e52fed0e8fcc498a80c3b5c1e5d97432
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDUtZmQx
+        NC03ZDM3LWFjZDQtYzljZjczYjVjYmVjLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6MDkuMTcyNTE1WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODowOS4xNzI1MzBaIiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJuYW1lIjoicHVscF9maWxlLmFwcC50YXNrcy5wdWJsaXNoaW5n
+        LnB1Ymxpc2giLCJsb2dnaW5nX2NpZCI6IjZkZmQzNGE5Y2RlZjQ3ZjVhNTg4
+        N2IwYjliMjY1ZDA0IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDkuMTg1
+        MDUwWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjA5LjIxNTYy
+        MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDkuMjg1NDY1
+        WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
+        ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
+        bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
+        IjpbIi9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOGZl
+        OGQ1LWZkNGEtN2IxMi05NTZkLTQ1NTY4NGYyZGQ0Yi8iXSwicmVzZXJ2ZWRf
+        cmVzb3VyY2VzX3JlY29yZCI6WyJzaGFyZWQ6L3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9maWxlL2ZpbGUvMDE4ZmU4ZDUtZjRlNS03YzUyLTg0MTQtYzYx
+        NGYzZWJmYzBmLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThm
+        ZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:38:09 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - d29327e7458e49ba88c1a01c0fcb659b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:09 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/publications/file/file/018fe8d5-fd4a-7b12-956d-455684f2dd4b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '427'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - daac29d881b14e70a7d8d63d8225ad92
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUv
+        ZmlsZS8wMThmZThkNS1mZDRhLTdiMTItOTU2ZC00NTU2ODRmMmRkNGIvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wNVQxNDozODowOS4yMjk2MThaIiwi
+        cHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjA5LjI4MDEw
+        OVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2ZpbGUvZmlsZS8wMThmZThkNS1mNGU1LTdjNTItODQxNC1jNjE0
+        ZjNlYmZjMGYvdmVyc2lvbnMvMS8iLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBp
+        L3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE4ZmU4ZDUtZjRlNS03YzUy
+        LTg0MTQtYzYxNGYzZWJmYzBmLyIsImRpc3RyaWJ1dGlvbnMiOltdLCJtYW5p
+        ZmVzdCI6IlBVTFBfTUFOSUZFU1QifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:09 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L015
+        X0ZpbGVzIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6IkRlZmF1bHRf
+        T3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiLCJwdWJsaWNhdGlvbiI6
+        Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOGZlOGQ1
+        LWZkNGEtN2IxMi05NTZkLTQ1NTY4NGYyZGQ0Yi8ifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9e8f09f6252b4ed1b8e237452637e302
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ1LWZlNzgtNzg5
+        Zi04NjViLWMzNmRhZWQ5MTNlMC8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:09 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d5-fe78-789f-865b-c36daed913e0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '834'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - d75dd614006046eb994da7ea7259df30
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDUtZmU3
+        OC03ODlmLTg2NWItYzM2ZGFlZDkxM2UwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6MDkuNTI4NjI2WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODowOS41Mjg2MzhaIiwic3RhdGUiOiJjb21w
+        bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
+        bF9jcmVhdGUiLCJsb2dnaW5nX2NpZCI6IjllOGYwOWY2MjUyYjRlZDFiOGUy
+        Mzc0NTI2MzdlMzAyIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDkuNTQx
+        MDA4WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjA5LjU3NTU1
+        MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDkuNzY4NTE1
+        WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
+        cy8wMThmZTNjYi0wZGYyLTdjODMtYTdlYS1lMjZhMWEyOGQ3ZjkvIiwicGFy
+        ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
+        bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
+        IjpbIi9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2ZpbGUvZmlsZS8wMThm
+        ZThkNS1mZjVhLTdiNmMtOWI1ZS01ZDE5NTMyNzEwNmYvIl0sInJlc2VydmVk
+        X3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRpb25zLyIs
+        InNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8wMThmZTNjOS03MGFhLTc4
+        ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:38:09 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/018fe8d5-ff5a-7b6c-9b5e-5d195327106f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '562'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8fc3c72f149f494cb9b06f0cde57e567
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
+        L2ZpbGUvMDE4ZmU4ZDUtZmY1YS03YjZjLTliNWUtNWQxOTUzMjcxMDZmLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDkuNzU1NTA0WiIs
+        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozODowOS43NTU1
+        MTlaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFy
+        eS9NeV9GaWxlcyIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVs
+        bG8tZGV2ZWwubWFuaWNvdHRvLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9E
+        ZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L015X0ZpbGVzLyIsImNvbnRl
+        bnRfZ3VhcmQiOm51bGwsImhpZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxzIjp7
+        fSwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmls
+        ZXMiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2Fw
+        aS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOGZlOGQ1LWZkNGEtN2Ix
+        Mi05NTZkLTQ1NTY4NGYyZGQ0Yi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:09 GMT
 recorded_with: VCR 6.2.0

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/content/create_upload.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/content/create_upload.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:48 GMT
+      - Wed, 05 Jun 2024 14:38:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5fb9cf49ca8648219618a41e1d461ce7
+      - b1e3da9c7f2a470494591a257349187e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:48 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:03 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:48 GMT
+      - Wed, 05 Jun 2024 14:38:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5cf634de714646ca9d234c415e32bffd
+      - 53899ffdcf0b4462a205c00d5fbc2fa4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:48 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:03 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
@@ -118,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:48 GMT
+      - Wed, 05 Jun 2024 14:38:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 96cea01bdb8246b383b5b938cb7df791
+      - 0477b67f523f45c4ab49b84db379909c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:48 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:03 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
@@ -172,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:48 GMT
+      - Wed, 05 Jun 2024 14:38:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 635fabf522284cfd921a38b4b3d0eaae
+      - e9261dd7d7144f5d95fdb7cc821cbf8c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:48 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:03 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
@@ -235,7 +235,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -248,13 +248,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:48 GMT
+      - Wed, 05 Jun 2024 14:38:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/018f54ca-804a-7aad-a30d-448521a4537d/"
+      - "/pulp/api/v3/remotes/file/file/018fe8d5-e965-7d97-abc5-36a64a5b5c33/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -270,7 +270,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e2813d67d7c247b6aa7428d01cfb8cd9
+      - 13237d36e73a4c0ba09525e62744bcf3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -279,9 +279,9 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE4ZjU0Y2EtODA0YS03YWFkLWEzMGQtNDQ4NTIxYTQ1MzdkLyIsInB1bHBf
-        Y3JlYXRlZCI6IjIwMjQtMDUtMDdUMjA6NDE6NDguMzYyNjg5WiIsInB1bHBf
-        bGFzdF91cGRhdGVkIjoiMjAyNC0wNS0wN1QyMDo0MTo0OC4zNjI3MDhaIiwi
+        MDE4ZmU4ZDUtZTk2NS03ZDk3LWFiYzUtMzZhNjRhNWI1YzMzLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDQuMTM0MjY3WiIsInB1bHBf
+        bGFzdF91cGRhdGVkIjoiMjAyNC0wNi0wNVQxNDozODowNC4xMzQyODBaIiwi
         bmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMi
         LCJ1cmwiOiJodHRwOi8vdGVzdC90ZXN0Ly9QVUxQX01BTklGRVNUIiwiY2Ff
         Y2VydCI6bnVsbCwiY2xpZW50X2NlcnQiOm51bGwsInRsc192YWxpZGF0aW9u
@@ -295,7 +295,7 @@ http_interactions:
         bWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwcm94eV9wYXNzd29yZCIs
         ImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InVzZXJuYW1lIiwiaXNfc2V0Ijpm
         YWxzZX0seyJuYW1lIjoicGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfV19
-  recorded_at: Tue, 07 May 2024 20:41:48 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:04 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/
@@ -308,7 +308,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -321,13 +321,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:48 GMT
+      - Wed, 05 Jun 2024 14:38:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/018f54ca-80f9-77ed-bbb3-e72303b0ba1d/"
+      - "/pulp/api/v3/repositories/file/file/018fe8d5-ea0d-70e8-899b-33f9d0cd2241/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -343,7 +343,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b15ad9c527b84df183a80c7b09b0251e
+      - f699a3c3758040968933af10cdc4285b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -352,19 +352,19 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMThmNTRjYS04MGY5LTc3ZWQtYmJiMy1lNzIzMDNiMGJhMWQvIiwi
-        cHVscF9jcmVhdGVkIjoiMjAyNC0wNS0wN1QyMDo0MTo0OC41Mzg2NjdaIiwi
-        cHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA1LTA3VDIwOjQxOjQ4LjU0NzAx
-        NFoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
-        cy9maWxlL2ZpbGUvMDE4ZjU0Y2EtODBmOS03N2VkLWJiYjMtZTcyMzAzYjBi
-        YTFkL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
+        ZmlsZS8wMThmZThkNS1lYTBkLTcwZTgtODk5Yi0zM2Y5ZDBjZDIyNDEvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAyNC0wNi0wNVQxNDozODowNC4zMDIxODlaIiwi
+        cHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjA0LjMwODI3
+        N1oiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy9maWxlL2ZpbGUvMDE4ZmU4ZDUtZWEwZC03MGU4LTg5OWItMzNmOWQwY2Qy
+        MjQxL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNp
         b25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxl
-        LzAxOGY1NGNhLTgwZjktNzdlZC1iYmIzLWU3MjMwM2IwYmExZC92ZXJzaW9u
+        LzAxOGZlOGQ1LWVhMGQtNzBlOC04OTliLTMzZjlkMGNkMjI0MS92ZXJzaW9u
         cy8wLyIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15
         X0ZpbGVzIiwiZGVzY3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNp
         b25zIjpudWxsLCJyZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwi
         bWFuaWZlc3QiOiJQVUxQX01BTklGRVNUIn0=
-  recorded_at: Tue, 07 May 2024 20:41:48 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:04 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/content/file/files/?sha256=99fc15572d2ee34c4baf5e7c1ae76c7180e2075f9ef69617853bc2767b226277
@@ -375,7 +375,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -388,7 +388,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:48 GMT
+      - Wed, 05 Jun 2024 14:38:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -408,7 +408,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 191ae41cdff34b2b9018b1e8fe51d696
+      - 5575b7ae6f3d4988b85566c42ed3268b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -418,7 +418,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:48 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:04 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/uploads/
@@ -431,7 +431,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -444,13 +444,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:48 GMT
+      - Wed, 05 Jun 2024 14:38:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/uploads/018f54ca-822f-7473-9e17-4091171b2003/"
+      - "/pulp/api/v3/uploads/018fe8d5-ead1-7471-89e5-a56926aedee8/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -466,7 +466,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ea91b8b7e9b74c4bb0203d4ada414822
+      - 69cffafb31f940e4958d745b5d75b902
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -474,14 +474,14 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmNTRjYS04
-        MjJmLTc0NzMtOWUxNy00MDkxMTcxYjIwMDMvIiwicHVscF9jcmVhdGVkIjoi
-        MjAyNC0wNS0wN1QyMDo0MTo0OC44NDc5ODRaIiwicHVscF9sYXN0X3VwZGF0
-        ZWQiOiIyMDI0LTA1LTA3VDIwOjQxOjQ4Ljg0ODAwMloiLCJzaXplIjo0Nn0=
-  recorded_at: Tue, 07 May 2024 20:41:48 GMT
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMThmZThkNS1l
+        YWQxLTc0NzEtODllNS1hNTY5MjZhZWRlZTgvIiwicHVscF9jcmVhdGVkIjoi
+        MjAyNC0wNi0wNVQxNDozODowNC40OTc2MTBaIiwicHVscF9sYXN0X3VwZGF0
+        ZWQiOiIyMDI0LTA2LTA1VDE0OjM4OjA0LjQ5NzYyNFoiLCJzaXplIjo0Nn0=
+  recorded_at: Wed, 05 Jun 2024 14:38:04 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018f54ca-804a-7aad-a30d-448521a4537d/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/018fe8d5-e965-7d97-abc5-36a64a5b5c33/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -489,7 +489,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -502,7 +502,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:49 GMT
+      - Wed, 05 Jun 2024 14:38:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -522,7 +522,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a5bca43593294ef7ac36a08d394f03ad
+      - cebe8600166744f8a0b9344df59a0050
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -530,12 +530,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGNhLTgzNDMtN2Q0
-        MC1iZDIyLTQ5M2VjN2E4NmVlZi8ifQ==
-  recorded_at: Tue, 07 May 2024 20:41:49 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ1LWViN2MtNzky
+        My1hZWM5LTgyNWI0NmRiN2MzZS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:04 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54ca-8343-7d40-bd22-493ec7a86eef/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d5-eb7c-7923-aec9-825b46db7c3e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -543,7 +543,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -556,7 +556,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:49 GMT
+      - Wed, 05 Jun 2024 14:38:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -576,7 +576,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e42d265e1d1743f4a191d911b6ddf166
+      - 555f45dc552a4670aa7844056eeda62b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -584,28 +584,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0Y2EtODM0
-        My03ZDQwLWJkMjItNDkzZWM3YTg2ZWVmLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6NDE6NDkuMTI0MTU1WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDo0MTo0OS4xMjQxNzNaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDUtZWI3
+        Yy03OTIzLWFlYzktODI1YjQ2ZGI3YzNlLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6MDQuNjY4OTQ2WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODowNC42Njg5NzVaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImE1YmNhNDM1OTMyOTRlZjdhYzM2
-        YTA4ZDM5NGYwM2FkIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjA6NDE6NDkuMTQ3
-        NzIyWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjQxOjQ5LjIxNzE3
-        N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjA6NDE6NDkuMjk1MzIx
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImNlYmU4NjAwMTY2NzQ0ZjhhMGI5
+        MzQ0ZGY1OWEwMDUwIiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDQuNjc5
+        NzE4WiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjA0LjcxNTcz
+        OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDQuNzU2NjM1
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRiYS04MDE3LTdlMWMtOTUxMS04NmM0YTI0Nzc2ZmEvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE4ZjU0Y2EtODA0YS03YWFkLWEzMGQt
-        NDQ4NTIxYTQ1MzdkLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8w
-        MThmNTRiOS0zY2M1LTdmNzUtOWZhOS1lZmRkMjBhMWZjODMvIl19
-  recorded_at: Tue, 07 May 2024 20:41:49 GMT
+        djMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE4ZmU4ZDUtZTk2NS03ZDk3LWFiYzUt
+        MzZhNjRhNWI1YzMzLyIsInNoYXJlZDovcHVscC9hcGkvdjMvZG9tYWlucy8w
+        MThmZTNjOS03MGFhLTc4ODMtYjg2Ni0xZWVlN2FkMzZkZWEvIl19
+  recorded_at: Wed, 05 Jun 2024 14:38:04 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018f54ca-80f9-77ed-bbb3-e72303b0ba1d/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/018fe8d5-ea0d-70e8-899b-33f9d0cd2241/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -613,7 +613,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -626,7 +626,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:49 GMT
+      - Wed, 05 Jun 2024 14:38:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -646,7 +646,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5b4f370672784c73b00f3787bdb885b9
+      - 92483f5fe323496587e616f584525755
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -654,12 +654,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGNhLTg1MzQtNzU3
-        My05MTc4LTE0ZjM3ZjVlZjUzNy8ifQ==
-  recorded_at: Tue, 07 May 2024 20:41:49 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ1LWVjNzQtN2Nj
+        OC1hM2ZlLWM1Mzc2ZjhkNDMxMS8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:04 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54ca-8534-7573-9178-14f37f5ef537/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d5-ec74-7cc8-a3fe-c5376f8d4311/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -667,7 +667,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -680,7 +680,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:49 GMT
+      - Wed, 05 Jun 2024 14:38:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -700,7 +700,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 22bf055d53a549f3a1624aeb9ada250a
+      - 5d3b25fe9b7846d5b93617a4bcb6a2e4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -708,25 +708,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0Y2EtODUz
-        NC03NTczLTkxNzgtMTRmMzdmNWVmNTM3LyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6NDE6NDkuNjIwNjcwWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDo0MTo0OS42MjA2ODhaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDUtZWM3
+        NC03Y2M4LWEzZmUtYzUzNzZmOGQ0MzExLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6MDQuOTE2NzQ0WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODowNC45MTY3NTZaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJh
-        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjViNGYzNzA2NzI3ODRjNzNiMDBm
-        Mzc4N2JkYjg4NWI5IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
-        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDUtMDdUMjA6NDE6NDkuNjM5
-        NjIxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA1LTA3VDIwOjQxOjQ5LjY5NzYx
-        MloiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDUtMDdUMjA6NDE6NDkuNzk0MjYw
+        bF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjkyNDgzZjVmZTMyMzQ5NjU4N2U2
+        MTZmNTg0NTI1NzU1IiwiY3JlYXRlZF9ieSI6Ii9wdWxwL2FwaS92My91c2Vy
+        cy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDQuOTI3
+        ODkwWiIsInN0YXJ0ZWRfYXQiOiIyMDI0LTA2LTA1VDE0OjM4OjA0Ljk2MjYy
+        MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDUuMDMyNjI3
         WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vy
-        cy8wMThmNTRiYS04MDE3LTdlMWMtOTUxMS04NmM0YTI0Nzc2ZmEvIiwicGFy
+        cy8wMThmZTNjYi0wZDQzLTc3MzEtOTg1Mi04NzI5ZDAwODE5NjMvIiwicGFy
         ZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6
         bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2Vz
         IjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIvcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmNTRjYS04MGY5LTc3ZWQt
-        YmJiMy1lNzIzMDNiMGJhMWQvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21h
-        aW5zLzAxOGY1NGI5LTNjYzUtN2Y3NS05ZmE5LWVmZGQyMGExZmM4My8iXX0=
-  recorded_at: Tue, 07 May 2024 20:41:49 GMT
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMThmZThkNS1lYTBkLTcwZTgt
+        ODk5Yi0zM2Y5ZDBjZDIyNDEvIiwic2hhcmVkOi9wdWxwL2FwaS92My9kb21h
+        aW5zLzAxOGZlM2M5LTcwYWEtNzg4My1iODY2LTFlZWU3YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:05 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
@@ -737,7 +737,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.21.3/ruby
+      - OpenAPI-Generator/0.21.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -750,7 +750,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:50 GMT
+      - Wed, 05 Jun 2024 14:38:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -770,7 +770,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8e8c64a9d63b420b83eeb1a5bb49e804
+      - 8e816ff919bc44af8de26d56342a1e33
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -780,7 +780,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:50 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:05 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -804,7 +804,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:50 GMT
+      - Wed, 05 Jun 2024 14:38:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -824,7 +824,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 358a81172b184ab49c45319a9e8462d5
+      - 1e145976252e4053a194cc478e82042c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -834,7 +834,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:50 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:05 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -858,7 +858,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:50 GMT
+      - Wed, 05 Jun 2024 14:38:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -878,7 +878,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 47abc25d72754c22b446db88397f4dcd
+      - a713ddd25ddb412fa51f83434fd535fa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -888,7 +888,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:50 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:05 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -899,7 +899,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -912,7 +912,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:50 GMT
+      - Wed, 05 Jun 2024 14:38:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -932,7 +932,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '083ffea3719549538b6a40bc8a83e088'
+      - e7467fe604e34f0989c52cd93d6b4028
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -942,7 +942,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:50 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:05 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -966,7 +966,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:50 GMT
+      - Wed, 05 Jun 2024 14:38:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -986,7 +986,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3a29a61f9d124f0b8eb172cf465de633
+      - 894a8d4a67154359a51b883b505c8cb1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -996,7 +996,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:50 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:05 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -1020,7 +1020,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:50 GMT
+      - Wed, 05 Jun 2024 14:38:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1040,7 +1040,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8473d098af554c4dacef6f50780c7f7f
+      - 240d02b3599c4b6190031340b293cc0c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1050,7 +1050,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:50 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:05 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -1061,7 +1061,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.25.3/ruby
+      - OpenAPI-Generator/3.25.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1074,7 +1074,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:50 GMT
+      - Wed, 05 Jun 2024 14:38:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1094,7 +1094,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6e661ff785d34e51aa5a13df6fcdf69e
+      - 5abe3754f93b4d6780fe19f354a06da7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1104,7 +1104,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Tue, 07 May 2024 20:41:50 GMT
+  recorded_at: Wed, 05 Jun 2024 14:38:05 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
@@ -1117,7 +1117,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1130,7 +1130,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:50 GMT
+      - Wed, 05 Jun 2024 14:38:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1150,7 +1150,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0f7c21f9547340088bbe7a514154960f
+      - 060f8734b0e54053860960210cf737f7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1158,12 +1158,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGY1NGNhLTg5Y2YtNzZh
-        OS1iMmQ5LWU0MzM0ZTRlNWE2My8ifQ==
-  recorded_at: Tue, 07 May 2024 20:41:50 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ1LWVmMzUtNzEz
+        Ni1hMWJjLTQ0NDcxYzU2NTUzZi8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:05 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018f54ca-89cf-76a9-b2d9-e4334e4e5a63/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/018fe8d5-ef35-7136-a1bc-44471c56553f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1171,7 +1171,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.49.6/ruby
+      - OpenAPI-Generator/3.49.10/ruby
       Accept:
       - application/json
       Authorization:
@@ -1184,7 +1184,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 May 2024 20:41:51 GMT
+      - Wed, 05 Jun 2024 14:38:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1196,7 +1196,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '999'
+      - '1001'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1204,7 +1204,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1a0786304b894e42baaa497a4f27a734
+      - 5af86f91c0f2461f8f748d4fa4c7f51d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1212,28 +1212,84 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZjU0Y2EtODlj
-        Zi03NmE5LWIyZDktZTQzMzRlNGU1YTYzLyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMDUtMDdUMjA6NDE6NTAuODAwNDQ5WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0wNS0wN1QyMDo0MTo1MC44MDA0NzNaIiwic3RhdGUiOiJjb21w
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE4ZmU4ZDUtZWYz
+        NS03MTM2LWExYmMtNDQ0NzFjNTY1NTNmLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjQtMDYtMDVUMTQ6Mzg6MDUuNjIxODQyWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNC0wNi0wNVQxNDozODowNS42MjE4NTZaIiwic3RhdGUiOiJjb21w
         bGV0ZWQiLCJuYW1lIjoicHVscGNvcmUuYXBwLnRhc2tzLm9ycGhhbi5vcnBo
-        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiMGY3YzIxZjk1NDczNDAwODhi
-        YmU3YTUxNDE1NDk2MGYiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
-        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNS0wN1QyMDo0MTo1MC44
-        MjE2MTlaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDUtMDdUMjA6NDE6NTAuODc2
-        ODM2WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNS0wN1QyMDo0MTo1MS4xNjA0
-        NTVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
-        ZXJzLzAxOGY1NGJhLTgwMTctN2UxYy05NTExLTg2YzRhMjQ3NzZmYS8iLCJw
+        YW5fY2xlYW51cCIsImxvZ2dpbmdfY2lkIjoiMDYwZjg3MzRiMGU1NDA1Mzg2
+        MDk2MDIxMGNmNzM3ZjciLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBpL3YzL3Vz
+        ZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0wNi0wNVQxNDozODowNS42
+        MzU2MzlaIiwic3RhcnRlZF9hdCI6IjIwMjQtMDYtMDVUMTQ6Mzg6MDUuNjcy
+        MTcxWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0wNi0wNVQxNDozODowNi4wMzg5
+        OTlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3Jr
+        ZXJzLzAxOGZlM2NiLTBkZjItN2M4My1hN2VhLWUyNmExYTI4ZDdmOS8iLCJw
         YXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3Vw
         IjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiQ2xlYW4g
         dXAgb3JwaGFuIENvbnRlbnQiLCJjb2RlIjoiY2xlYW4tdXAuY29udGVudCIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZp
+        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjIsImRvbmUiOjIsInN1ZmZp
         eCI6bnVsbH0seyJtZXNzYWdlIjoiQ2xlYW4gdXAgb3JwaGFuIEFydGlmYWN0
         cyIsImNvZGUiOiJjbGVhbi11cC5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNvbXBs
-        ZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbIi9hcGkvdjMvb3JwaGFucy9jbGVhbnVwLyIsInNoYXJlZDovcHVscC9h
-        cGkvdjMvZG9tYWlucy8wMThmNTRiOS0zY2M1LTdmNzUtOWZhOS1lZmRkMjBh
-        MWZjODMvIl19
-  recorded_at: Tue, 07 May 2024 20:41:51 GMT
+        ZXRlZCIsInRvdGFsIjoxMywiZG9uZSI6MTMsInN1ZmZpeCI6bnVsbH1dLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jlc291cmNlc19yZWNv
+        cmQiOlsiL2FwaS92My9vcnBoYW5zL2NsZWFudXAvIiwic2hhcmVkOi9wdWxw
+        L2FwaS92My9kb21haW5zLzAxOGZlM2M5LTcwYWEtNzg4My1iODY2LTFlZWU3
+        YWQzNmRlYS8iXX0=
+  recorded_at: Wed, 05 Jun 2024 14:38:06 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/purge/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJmaW5pc2hlZF9iZWZvcmUiOiIzMDAwLTAxLTAxVDAwOjAwOjAwLjAwMCsw
+        MDowMCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.49.10/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 05 Jun 2024 14:38:06 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7dab2f6eb58d4d7983bed0fe8fc03666
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOGZlOGQ1LWYxNTYtNzcw
+        Ny05OTAwLThkMTZmN2RkZmEyNy8ifQ==
+  recorded_at: Wed, 05 Jun 2024 14:38:06 GMT
 recorded_with: VCR 6.2.0

--- a/test/lib/tasks/delete_orphaned_content_test.rb
+++ b/test/lib/tasks/delete_orphaned_content_test.rb
@@ -20,6 +20,8 @@ module Katello
         assert_includes smart_proxies, parsed_stack
         smart_proxies.delete parsed_stack
       end
+
+      Setting[:completed_pulp_task_protection_days] = 0
       Rake.application.invoke_task('katello:delete_orphaned_content')
     end
 
@@ -29,6 +31,8 @@ module Katello
         assert_equal(::Actions::Katello::OrphanCleanup::RemoveOrphans, main_task)
         assert_equal @mirror, parsed_stack
       end
+
+      Setting[:completed_pulp_task_protection_days] = 0
       Rake.application.invoke_task('katello:delete_orphaned_content')
     end
   end

--- a/test/services/katello/pulp3/content_test.rb
+++ b/test/services/katello/pulp3/content_test.rb
@@ -23,7 +23,10 @@ module Katello
         def teardown
           ForemanTasks.sync_task(
               ::Actions::Pulp3::Orchestration::Repository::Delete, @repo, @primary) rescue "skipped repo delete"
+
           Setting[:orphan_protection_time] = 0
+          Setting[:completed_pulp_task_protection_days] = 0
+          DateTime.expects(:now).returns(DateTime.new(3000, 1, 1))
           ForemanTasks.sync_task(
               ::Actions::Pulp3::Orchestration::OrphanCleanup::RemoveOrphans, @primary) rescue "skipped remove orphans"
         end

--- a/test/services/katello/pulp3/repository_integration_test.rb
+++ b/test/services/katello/pulp3/repository_integration_test.rb
@@ -30,6 +30,9 @@ types.values.each do |repository_type|
       def teardown
         User.as_anonymous_admin do
           ensure_creatable(@repo, @primary)
+
+          Setting[:completed_pulp_task_protection_days] = 0
+          DateTime.expects(:now).returns(DateTime.new(3000, 1, 1))
           orphan_cleanup
         end
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds completed Pulp task purging to orphan cleanup. Also adds a setting for how long to wait before considering tasks purge-able. 

#### Considerations taken when implementing this change?
Pulp by default purges complete tasks, but could optionally purge ones that stopped due to errors, for example. I opted to not delete these to help track down bugs.

#### What are the testing steps for this pull request?
Make some complete tasks in Pulp and try purging them by playing with the new setting.