### PR TITLE
Fixes #37522 - remove sha1 publication checksum and add newer values

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -48,7 +48,7 @@ Pass [] to make repo available for clients regardless of OS version. Maximum len
       param :ssl_client_cert_id, :number, :desc => N_("Identifier of the content credential containing the SSL Client Cert"), :allow_nil => true
       param :ssl_client_key_id, :number, :desc => N_("Identifier of the content credential containing the SSL Client Key"), :allow_nil => true
       param :unprotected, :bool, :desc => N_("true if this repository can be published via HTTP")
-      param :checksum_type, String, :desc => N_("Checksum of the repository, currently 'sha1' & 'sha256' are supported")
+      param :checksum_type, String, :desc => N_("Checksum used for published repository contents. Supported types: %s") % Katello::RootRepository::CHECKSUM_TYPES.join(', ')
       param :docker_upstream_name, String, :desc => N_("Name of the upstream docker repository")
       param :include_tags, Array, :desc => N_("Comma-separated list of tags to sync for a container image repository")
       param :exclude_tags, Array, :desc => N_("Comma-separated list of tags to exclude when syncing a container image repository. Default: any tag ending in \"-source\"")

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -17,7 +17,7 @@ module Katello
     DOWNLOAD_POLICIES = [DOWNLOAD_IMMEDIATE, DOWNLOAD_ON_DEMAND].freeze
 
     IGNORABLE_CONTENT_UNIT_TYPES = %w(srpm treeinfo).freeze
-    CHECKSUM_TYPES = %w(sha1 sha256).freeze
+    CHECKSUM_TYPES = %w(sha256 sha384 sha512).freeze
 
     SUBSCRIBABLE_TYPES = [Repository::YUM_TYPE, Repository::OSTREE_TYPE, Repository::DEB_TYPE].freeze
     SKIPABLE_METADATA_TYPES = [Repository::YUM_TYPE, Repository::DEB_TYPE].freeze

--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -22,12 +22,7 @@ module Katello
 
         def publication_options(repository_version)
           options = super(repository_version)
-          options.merge(
-            {
-              metadata_checksum_type: root.checksum_type,
-              package_checksum_type: root.checksum_type
-            }
-          )
+          options.merge(checksum_type: root.checksum_type)
         end
 
         def specific_create_options

--- a/db/migrate/20240531193030_remove_sha1_repository_checksum_type.rb
+++ b/db/migrate/20240531193030_remove_sha1_repository_checksum_type.rb
@@ -1,0 +1,10 @@
+class RemoveSha1RepositoryChecksumType < ActiveRecord::Migration[6.1]
+  def up
+    ::Katello::Repository.where(saved_checksum_type: 'sha1').update(saved_checksum_type: nil)
+    ::Katello::RootRepository.where(checksum_type: 'sha1').update(checksum_type: nil)
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/checksum.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/checksum.service.js
@@ -10,7 +10,12 @@
 angular.module('Bastion.repositories').service('Checksum',
     ['translate', function (translate) {
 
-        this.checksums = [{name: translate('Default'), id: null}, {id: 'sha256', name: 'sha256'}, {id: 'sha1', name: 'sha1'}];
+        this.checksums = [
+            {name: translate('Default'), id: null},
+            {id: 'sha256', name: 'sha256'},
+            {id: 'sha384', name: 'sha384'},
+            {id: 'sha512', name: 'sha512'}
+        ];
 
         this.checksumType = function (checksum) {
             if (checksum === null) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -371,9 +371,6 @@
                 ng-model="repository.checksum_type"
                 ng-options="type.id as type.name for type in checksums">
         </select>
-        <p class="help-block" translate>
-          For older operating systems such as Red Hat Enterprise Linux 5 or CentOS 5 it is recommended to use sha1.
-        </p>
       </div>
 
       <div class="checkbox" ng-hide="repository.content_type === 'docker' || repository.content_type === 'ansible_collection'">

--- a/engines/bastion_katello/test/products/details/repositories/checksum.service.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/checksum.service.test.js
@@ -14,7 +14,8 @@ describe('Service: Checksum', function() {
     it("provides a method to convert a checksum to human readable version", function() {
         expect(Checksum.checksumType(null)).toBe('Default');
         expect(Checksum.checksumType('sha256')).toBe('sha256');
-        expect(Checksum.checksumType('sha1')).toBe('sha1');
+        expect(Checksum.checksumType('sha384')).toBe('sha384');
+        expect(Checksum.checksumType('sha512')).toBe('sha512');
     });
 
 });

--- a/test/actions/katello/repository/check_matching_content_test.rb
+++ b/test/actions/katello/repository/check_matching_content_test.rb
@@ -47,7 +47,7 @@ module Actions
       action_class.any_instance.stubs(:yum_metadata_files_match?).returns(true)
       #::Katello::Repository.any_instance.expects(:published?).returns(true)
 
-      yum_repo.update_attribute(:saved_checksum_type, "sha1")
+      yum_repo.update_attribute(:saved_checksum_type, "sha512")
       yum_repo2.update_attribute(:saved_checksum_type, "sha256")
 
       plan = plan_action(action, :source_repo_id => yum_repo.id, :target_repo_id => yum_repo2.id)

--- a/test/actions/katello/repository/multi_clone_contents_test.rb
+++ b/test/actions/katello/repository/multi_clone_contents_test.rb
@@ -29,7 +29,7 @@ module Actions
     end
 
     def test_metadata_generation_with_changed_checksum_type
-      @repo.update(saved_checksum_type: "sha1")
+      @repo.update(saved_checksum_type: "sha512")
       @repo_clone.update(saved_checksum_type: "sha256")
       task = ForemanTasks.sync_task(action_class, @repo_mapping, copy_contents: false)
       assert_equal "success", task.result

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -860,7 +860,7 @@ module ::Actions::Katello::Repository
     let(:action_class) { ::Actions::Katello::Repository::CloneContents }
 
     it 'plans' do
-      custom_repository.saved_checksum_type = "sha1"
+      custom_repository.saved_checksum_type = "sha512"
       repository.saved_checksum_type = "sha256"
       planned_action = plan_action action, [repository], custom_repository, :copy_contents => false
 

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -144,7 +144,7 @@ module Katello
 
     test_attributes :pid => 'c3678878-758a-4501-a038-a59503fee453'
     def test_create_with_checksum_type
-      %w[sha1 sha256].each do |checksum_type|
+      %w[sha256 sha384 sha512].each do |checksum_type|
         @root.checksum_type = checksum_type
         @root.download_policy = ::Katello::RootRepository::DOWNLOAD_IMMEDIATE
         assert @root.valid?, "Validation failed for create with valid checksum_type: '#{checksum_type}'"
@@ -153,7 +153,7 @@ module Katello
     end
 
     def test_create_with_on_demand_checksum
-      %w[sha1 sha256].each do |checksum_type|
+      %w[sha256 sha384 sha512].each do |checksum_type|
         @root.checksum_type = checksum_type
         refute @root.valid?, "Validation failed for create with valid checksum_type: '#{checksum_type}'"
         assert @root.errors.key?(:checksum_type)
@@ -369,7 +369,7 @@ module Katello
     test_attributes :pid => '205e6e59-33c6-4a58-9245-1cac3a4f550a'
     def test_update_checksum
       @root.download_policy = ::Katello::RootRepository::DOWNLOAD_IMMEDIATE
-      @root.checksum_type = 'sha1'
+      @root.checksum_type = 'sha512'
       assert @root.save
       @root.checksum_type = 'sha256'
       assert_valid @root

--- a/test/services/katello/pulp3/repository/generic_test.rb
+++ b/test/services/katello/pulp3/repository/generic_test.rb
@@ -15,7 +15,7 @@ module Katello
 
           def test_distribution_options_includes_publication_attribute_if_content_type_publishes
             @repo.publication_href = 'a_version_href'
-            @repo.root.checksum_type = 'sha1'
+            @repo.root.checksum_type = 'sha512'
 
             publication_options = @service.distribution_options('/')
 
@@ -25,7 +25,7 @@ module Katello
           def test_distribution_options_excludes_publication_attribute_if_content_type_skips_publish
             Katello::RepositoryTypeManager.find("yum").stubs(:pulp3_skip_publication).returns(true)
             @repo.publication_href = 'a_version_href'
-            @repo.root.checksum_type = 'sha1'
+            @repo.root.checksum_type = '512'
 
             publication_options = @service.distribution_options('/')
 

--- a/test/services/katello/pulp3/repository/yum/yum_test.rb
+++ b/test/services/katello/pulp3/repository/yum/yum_test.rb
@@ -70,12 +70,11 @@ module Katello
 
           def test_publication_options
             @repo.version_href = 'a_version_href'
-            @repo.root.checksum_type = 'sha1'
+            @repo.root.checksum_type = 'sha512'
             service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
             publication_options = service.publication_options(@repo.version_href)
             assert_equal 'a_version_href', publication_options[:repository_version]
-            assert_equal 'sha1', publication_options[:metadata_checksum_type]
-            assert_equal 'sha1', publication_options[:package_checksum_type]
+            assert_equal 'sha512', publication_options[:checksum_type]
           end
 
           def test_refresh_distributions_distribution_ref_wrong


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Removes SHA1 publication support because it was dropped in pulp-rpm 3.25. SHA1 content can still be synced, this only has to do with what Pulp publishes. EL6+ is still supported.

Also adds support for some more checksum types to match up with Pulp.

Removes the `ensure_no_checksum_on_demand` validation since that's from Pulp 2.

#### Considerations taken when implementing this change?
Deprecating the feature would've been better, but the amount of folks using SHA1 for a legitimate reason should be very rare. Hanging back a Pulp version just for this doesn't seem to make sense.

#### What are the testing steps for this pull request?
1) Ensure that repositories with a checksum type of SHA1 are migrated to "Default"
  -> To do this, it might be best to start with a Katello 4.12 and then upgrade it.
    -> This would also help test that repositories & CVs are still usable if the underlying publications used SHA1.
2) Ensure that all the new checksum types work
3) Ensure that the API help text makes sense (Hammer too)