### PR TITLE
Fixes #37356 - Allow turning automatic content count updates off

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync_capsule.rb
+++ b/app/lib/actions/katello/capsule_content/sync_capsule.rb
@@ -69,8 +69,13 @@ module Actions
         end
 
         def update_content_counts(_execution_plan)
-          smart_proxy = ::SmartProxy.unscoped.find(input[:smart_proxy_id])
-          ::ForemanTasks.async_task(::Actions::Katello::CapsuleContent::UpdateContentCounts, smart_proxy)
+          if Setting[:automatic_content_count_updates]
+            smart_proxy = ::SmartProxy.unscoped.find(input[:smart_proxy_id])
+            ::ForemanTasks.async_task(::Actions::Katello::CapsuleContent::UpdateContentCounts, smart_proxy)
+          else
+            Rails.logger.info "Skipping content counts update as automatic content count updates are disabled. To enable automatic content count updates, set the 'automatic_content_count_updates' setting to true.
+To update content counts manually, run the 'Update Content Counts' action."
+          end
         end
 
         def resource_locks

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -651,6 +651,12 @@ Foreman::Plugin.register :katello do
         default: true,
         full_name: N_('Distribute archived content view versions'),
         description: N_("If this is enabled, repositories of content view versions without environments (\"archived\") will be distributed at '/pulp/content/<organization>/content_views/<content view>/X.Y/...'.")
+
+      setting 'automatic_content_count_updates',
+        type: :boolean,
+        default: true,
+        full_name: N_('Calculate content counts on smart proxies automatically'),
+        description: N_("If this is enabled, content counts on smart proxies will be updated automatically after content sync.")
     end
   end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add a setting "automatic_content_count_updates" to control automatic invocation of Update content count task on proxies upon successful syncs. 
#### Considerations taken when implementing this change?
The Update content counts action is triggered asynchronously upon a successful sync on a proxy.
This task can be a long running task for large proxies on a slow connection and this can cause slowness in syncs in the queue.
#### What are the testing steps for this pull request?
1. Turn the setting "Calculate content counts on smart proxies automatically" on and off and check if Update content counts is run automatically or not depending on the value of the setting.