### PR TITLE
Fixes #37534 - Use ~ as default operator for repository content labels

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -166,7 +166,7 @@ module Katello
     scoped_search :on => :name, :relation => :product, :rename => :product_name
     scoped_search :on => :id, :relation => :product, :rename => :product_id, :only_explicit => true
     scoped_search :on => :label, :relation => :root, :complete_value => true, :only_explicit => true
-    scoped_search :on => :content_label, :ext_method => :search_by_content_label
+    scoped_search :on => :content_label, :ext_method => :search_by_content_label, :default_operator => :like
 
     delegate :product, :redhat?, :custom?, :to => :root
     delegate :yum?, :docker?, :deb?, :file?, :ostree?, :ansible_collection?, :generic?, :to => :root


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

On the Red Hat Repositories page, searching for a keyword only (without field names) does a preliminary SQL query to the `katello_contents` table:

```sql
SELECT "katello_contents"."cp_content_id" FROM "katello_contents" WHERE (label = 'coreservices')
```

The problem here is that the operator being used is `=`, which only matches exact results. Instead we should use the `~` operator.

This PR alters the scoped_search call to set the [`default_operator`](https://github.com/wvanbergen/scoped_search/wiki/search-definition#setting-the-default-operator) to `:like`, which changes the query to

```sql
SELECT "katello_contents"."cp_content_id" FROM "katello_contents" WHERE (label ILIKE '%%coreservices%%')
```

This should allow the Red Hat Repositories page to show the same results for both the left column, which searches `Katello::ProductContent`s, and the right column, which searches `Katello::Repository`s.

#### Considerations taken when implementing this change?

I don't foresee any detrimental side effects here (famous last words..)

#### What are the testing steps for this pull request?

Follow the steps in https://issues.redhat.com/browse/SAT-23768

If you like, you can enable SQL logging by adding the following to your Foreman's `config/settings.yaml`

```yaml
  :sql:
    :enabled: true
    :level: debug
```
