### PR TITLE
Fixes #37533 - Stub date in test so it doesn't rely on real system clock

### DIFF
--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -463,6 +463,7 @@ module Katello
         Katello::Host::SubscriptionFacet.any_instance.stubs(:update_from_consumer_attributes)
         ::Host::Managed.any_instance.stubs(:refresh_global_status!)
         assert_equal ::Katello::RhelLifecycleStatus::UNKNOWN, @host.get_status(::Katello::RhelLifecycleStatus).status
+        Date.expects(:today).returns(Date.new(2024, 5, 30))
         facts = {
           "distribution.id" => "Ootpa",
           "distribution::version" => "8.6",


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

RHEL8 full support ended on 2024-05-31, which is causing some unit tests to fail in CI. This PR updates the relevant test to mock `Date.today`, so that the test doesn't rely on the real system clock.

#### Considerations taken when implementing this change?

I could have instead updated the test expectations, but then we'd just have to do it again once the next milestone date rolls around.

#### What are the testing steps for this pull request?

ensure that CI tests pass
