### PR TITLE
Fixes #37538 - Check orphaned content facet before CV deletion

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -710,6 +710,7 @@ module Katello
     end
 
     def check_remove_from_environment!(env)
+      check_orphaned_content_facets!(environments: [env])
       errors = []
 
       dependencies = { hosts: _("hosts"),
@@ -728,6 +729,7 @@ module Katello
     end
 
     def check_ready_to_destroy!
+      check_orphaned_content_facets!(environments: self.environments)
       errors = []
 
       dependencies = { environments: _("environments"),


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Check for orphaned content facet before CV deletion, removal from env
#### Considerations taken when implementing this change?
We have this check for CV publish and we should also prevent this error and inform users about the cleanup task during deletion/remove from environment.
#### What are the testing steps for this pull request?
1. Follow steps in https://github.com/Katello/katello/pull/10391 to get orphaned content host for a CV.
2. Try deleting the CV.

