### PR TITLE
Fixes #37539 - replace deprecated webpack_asset_paths in smart proxies

### DIFF
--- a/app/views/foreman/smart_proxies/_content_tab.html.erb
+++ b/app/views/foreman/smart_proxies/_content_tab.html.erb
@@ -1,3 +1,5 @@
-<%= javascript_include_tag *webpack_asset_paths('katello', extension: 'js') %>
+<% content_for(:javascripts) do %>
+    <%= webpacked_plugins_js_for :katello %>
+<% end %>
 <% @smartProxyId= @smart_proxy.id %>
 <%= react_component('Content', smartProxyId: @smartProxyId, organizationId: Organization.current&.id,)  %>


### PR DESCRIPTION
Tested only on mock data by disabling the check on lib/katello/plugin.rb `:onlyif => proc { |proxy| proxy.pulp_mirror? }`  so a real test should be done as well.
'`webpack_asset_paths` is deprecated, use `content_for(:javascripts) { webpacked_plugins_js_for(plugin_name) }` instead.
It looks like the page didnt find the Content component, but it was not loaded since katello/index.js was not loaded. 