### PR TITLE
Refs #37481 - Update cached value for manifest expiration date during delete

### DIFF
--- a/app/lib/actions/katello/organization/manifest_delete.rb
+++ b/app/lib/actions/katello/organization/manifest_delete.rb
@@ -16,8 +16,13 @@ module Actions
             repositories.each do |repo|
               plan_action(Katello::Repository::RefreshRepository, repo)
             end
-            plan_self
+            plan_self(:organization_name => organization.name)
           end
+        end
+
+        def run
+          organization = ::Organization.find_by(name: input[:organization_name])
+          organization&.manifest_expiration_date(cached: false) # update organization.manifest_imported? value
         end
 
         def failure_notification(plan)

--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
@@ -200,7 +200,7 @@ class ManageManifestModal extends Component {
                           {getManifestName()}
                         </Col>
                       </Row>
-                      {isManifestImported && !!manifestExpirationDate &&
+                      {isManifestImported && Boolean(manifestExpirationDate) &&
                         <Row>
                           <Col sm={5} />
                           <Col sm={7}>

--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
@@ -137,6 +137,8 @@ class ManageManifestModal extends Component {
       return name;
     };
 
+    const manifestExpiredMessage = manifestExpirationDate ? __('Your manifest expired on {expirationDate}. To continue using Red Hat content, import a new manifest.') : __('Your manifest has expired. To continue using Red Hat content, import a new manifest.');
+
     return (
       <ForemanModal id={MANAGE_MANIFEST_MODAL_ID} title={__('Manage Manifest')}>
         <Tabs id="manifest-history-tabs">
@@ -181,7 +183,7 @@ class ManageManifestModal extends Component {
                           title={__('Manifest expired')}
                         >
                           <FormattedMessage
-                            defaultMessage={__('Your manifest expired on {expirationDate}. To continue using Red Hat content, import a new manifest.')}
+                            defaultMessage={manifestExpiredMessage}
                             values={{
                               expirationDate: new Date(manifestExpirationDate).toDateString(),
                             }}
@@ -198,7 +200,7 @@ class ManageManifestModal extends Component {
                           {getManifestName()}
                         </Col>
                       </Row>
-                      {isManifestImported && manifestExpirationDate &&
+                      {isManifestImported && !!manifestExpirationDate &&
                         <Row>
                           <Col sm={5} />
                           <Col sm={7}>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

In https://github.com/Katello/katello/pull/10999 we invalidated the cache of `manifest_expiration_date` and `manifest_imported?` when importing a new manifest, but neglected to do this for manifest deletes.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Import an expired manifest
Delete the manifest
Open Manage Manifest
Ensure it says "No manifest imported" and does not have an alert or a date

