### PR TITLE
Fixes #37543 - CV promote during host deletion fails

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -454,6 +454,8 @@ module Katello
           ).each do |facet|
             facet.update_applicability_counts
             facet.update_errata_status
+          rescue NoMethodError
+            Rails.logger.warn _('Errata statuses not updated for deleted content facet with UUID %s') % facet.uuid
           end
         end
       end

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -654,6 +654,22 @@ module Katello
       end
     end
 
+    def test_update_host_statuses_host_deleted
+      other_location = taxonomies(:location2)
+      facet = katello_content_facets(:content_facet_two)
+      org = facet.host.organization
+      ::Katello::Host::ContentFacet.any_instance.stubs(:host).returns(nil)
+      Rails.logger.expects(:warn).once
+
+      assert_nothing_raised do
+        Location.as_taxonomy(org, other_location) do
+          facet.content_view_environments.each do |cve|
+            cve.content_view.update_host_statuses(cve.lifecycle_environment)
+          end
+        end
+      end
+    end
+
     def test_unpublishable?
       default_content_view = ContentView.default.first
       import_only_content_view = FactoryBot.create(:katello_content_view, :import_only)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds a rescue to skip host applicability status updates when the host no longer exists.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Follow the reproducer steps in the redmine, or:

1) Stick a debugger right before `facet.update_applicability_counts`
2) Run `update_host_statuses` in a Rails console
3) When the breakpoint is reached, delete the Host via some other means (like the UI or hammer)
4) Continue the code
5) See that the code keeps working and the logger statement is triggered