### PR TITLE
Fixes #37544 - properly access host for hostgroup inheritance checks

### DIFF
--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -12,20 +12,20 @@ module Katello
       edit_action? && !using_discovered_hosts_page?
     end
 
-    def content_source_inherited?
-      !using_hostgroups_page? && @host.content_source.blank? && @host&.hostgroup&.content_source.present? && cv_lce_disabled?
+    def content_source_inherited?(host)
+      !using_hostgroups_page? && host&.content_source.blank? && host&.hostgroup&.content_source.present? && cv_lce_disabled?
     end
 
-    def lifecycle_environment_inherited?
-      !using_hostgroups_page? && @host.lifecycle_environments.empty? && @host&.hostgroup&.lifecycle_environment.present? && cv_lce_disabled?
+    def lifecycle_environment_inherited?(host)
+      !using_hostgroups_page? && host&.lifecycle_environments&.empty? && host&.hostgroup&.lifecycle_environment.present? && cv_lce_disabled?
     end
 
-    def content_view_inherited?
-      !using_hostgroups_page? && @host.content_views.empty? && @host&.hostgroup&.content_view.present? && cv_lce_disabled?
+    def content_view_inherited?(host)
+      !using_hostgroups_page? && host&.content_views&.empty? && host&.hostgroup&.content_view.present? && cv_lce_disabled?
     end
 
-    def kickstart_repo_inherited?
-      !using_hostgroups_page? && @host.kickstart_repository_id.blank? && @host&.hostgroup&.kickstart_repository.present? && cv_lce_disabled?
+    def kickstart_repo_inheritable?(host)
+      host&.kickstart_repository_id.blank?
     end
 
     def using_discovered_hosts_page?

--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -16,7 +16,7 @@
 <% cs_select_name =  using_hostgroups_page? ? 'hostgroup[content_source_id]' : 'host[content_facet_attributes][content_source_id]' %>
 <% cs_select_attr = using_hostgroups_page? ? 'content_source' : 'content_facet.content_source' %>
 
-<%= field(f, cs_select_attr, {:label => _("Content Source"), :help_inline => content_source_inherited? ? 'Inherited' : nil }) do %>
+<%= field(f, cs_select_attr, {:label => _("Content Source"), :help_inline => content_source_inherited?(@host) ? 'Inherited from host group' : nil }) do %>
   <% if using_hostgroups_page? %>
     <%= select_tag cs_select_id, content_source_options(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path},
                :class => 'form-control',  :name => cs_select_name %>
@@ -29,17 +29,13 @@
 <% env_select_name =  using_hostgroups_page? ? 'hostgroup[lifecycle_environment_id]' : 'host[content_facet_attributes][lifecycle_environment_id]' %>
 <% env_select_attr = using_hostgroups_page? ? 'lifecycle_environment' : 'content_facet.single_lifecycle_environment' %>
 
-<%= field(f, env_select_attr, {:label => _("Lifecycle Environment"), :help_inline => lifecycle_environment_inherited? ? 'Inherited' : nil}) do %>
+<%= field(f, env_select_attr, {:label => _("Lifecycle Environment"), :help_inline => lifecycle_environment_inherited?(@host) ? 'Inherited from host group' : nil}) do %>
   <% if using_hostgroups_page? %>
     <%= select_tag env_select_id, lifecycle_environment_options(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name %>
   <% elsif cv_lce_disabled? %>
     <% host_or_hostgroup_lce = (@host.lifecycle_environments.empty? && @host.hostgroup.present? && @host.hostgroup.lifecycle_environment.present?) ? fetch_lifecycle_environment(@host.hostgroup) : fetch_lifecycle_environment(@host) %>
     <%= hidden_field_tag 'host[content_facet_attributes][lifecycle_environment_id]', host_or_hostgroup_lce.try(:id) %>
-    <% if @host&.hostgroup&.lifecycle_environment.present? %>
-      <%= select_tag env_select_id, lifecycle_environment_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name, :disabled => true %>
-    <% else %>
-      <%= select_tag env_select_id, '<option></option>', :class => 'form-control',  :name => env_select_name, :disabled => true %>
-    <% end %>
+    <%= select_tag env_select_id, lifecycle_environment_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name, :disabled => true %>
   <% else %>
     <%= select_tag env_select_id, lifecycle_environment_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name %>
   <% end %>
@@ -49,7 +45,7 @@
 <% cv_select_name =  using_hostgroups_page? ? 'hostgroup[content_view_id]' : 'host[content_facet_attributes][content_view_id]' %>
 <% cv_select_attr = using_hostgroups_page? ? 'content_view' : 'content_facet.single_content_view' %>
 
-<%= field(f, cv_select_attr, {:label => _("Content View"), :help_inline => content_view_inherited? ? 'Inherited' : nil}) do %>
+<%= field(f, cv_select_attr, {:label => _("Content View"), :help_inline => content_view_inherited?(@host) ? 'Inherited from host group' : nil}) do %>
   <% if using_hostgroups_page? %>
     <%= select_tag cv_select_id,  content_views_for_host(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cv_select_name %>
   <% elsif cv_lce_disabled? %>

--- a/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
@@ -18,7 +18,7 @@
 
 <% spinner_path = asset_path('spinner.gif') %>
 
-<%= field(f, ks_repo_select_attr, {:label => _("Synced Content"), :help_inline => kickstart_repo_inherited? ? 'Inherited' : nil}) do %>
+<%= field(f, ks_repo_select_attr, {:label => _("Synced Content"), :help_inline => kickstart_repo_inheritable?(@host) ? 'Automatically selected from content source, lifecycle environment, content_view, architecture, and operating system' : nil}) do %>
   <%= select_tag ks_repo_select_id,  view_to_options(kickstart_options, kickstart_repo_id, blank_or_inherit_with_id(f, :kickstart_repository)), :data => {"spinner_path" => spinner_path, "kickstart-repository-id" => kickstart_repo_id},
              :class => 'form-control',  :name => ks_repo_select_name, :disabled => kickstart_options.empty? %>
 <% end %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
A continuation from https://github.com/Katello/katello/pull/11011, `@host` was being used where it shouldn't be.

I also adjusted the logic and help text for kickstart repositories. I realized that the kickstart repo is never truly inherited from the hostgroup for edited hosts. Instead, it come from the operating system and other selected fields.

I also noticed that the LCE selector was empty when editing hosts, so I fixed that too.

#### Considerations taken when implementing this change?
The new KS repo help text is a bit verbose, but I think it's best to be fully clear about where that value comes from. For a host with no existing kickstart repository, it's not completely clear how the field is generated. We do have a tool-tip next to to the Media Selection, but this makes it even more obvious.

#### What are the testing steps for this pull request?
Follow the steps from https://github.com/Katello/katello/pull/11011
Help verify that the help text makes sense based on the previously raised bugs.

Check new hosts + host groups, edited hosts + host groups.

Generally make sure the host and host group pages still work, they're so fragile... I've checked as much as I could think to check.