### PR TITLE
Fixes #37288 - Host Collections widget now uses errata_status_installable Setting

### DIFF
--- a/app/views/dashboard/_host_collection_widget.html.erb
+++ b/app/views/dashboard/_host_collection_widget.html.erb
@@ -18,13 +18,14 @@
       </tr>
     </thead>
     <tbody>
+      <% installable_only = Setting['errata_status_installable'] %>
       <% host_collections.each do |host_collection| %>
         <tr>
           <td>
-            <% if host_collection.security_updates? %>
-              <a href="/host_collections/<%= host_collection.id %>" style="text-align: center"><i class="label label-danger">&nbsp;</i></a>
-            <% elsif host_collection.bugzilla_updates? || host_collection.enhancement_updates? %>
-              <a href="/host_collections/<%= host_collection.id %>" style="text-align: center"><i class="label label-warning">&nbsp;</i></a>
+            <% if host_collection.security_updates?(installable_only: installable_only) %>
+              <a href="/host_collections/<%= host_collection.id %>" style="text-align: center" title="<%= installable_only ? _('Installable security errata') : _('Applicable security errata') %>"><i class="label label-danger">&nbsp;</i></a>
+            <% elsif host_collection.bugzilla_updates?(installable_only: installable_only) || host_collection.enhancement_updates?(installable_only: installable_only) %>
+              <a href="/host_collections/<%= host_collection.id %>" style="text-align: center" title="<%= installable_only ? _('Installable bugfix/enhancement errata') : _('Applicable bugfix/enhancement errata') %>"><i class="label label-warning">&nbsp;</i></a>
             <% else %>
               <a href="/host_collections/<%= host_collection.id %>" style="text-align: center"><i class="label label-success">&nbsp;</i></a>
             <% end %>

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -459,7 +459,7 @@ Foreman::Plugin.register :katello do
         type: :boolean,
         default: false,
         full_name: N_('Generate errata status from directly-installable content'),
-        description: N_("If true, only errata that can be installed without an incremental update will affect the host's errata status.")
+        description: N_("If true, only errata that can be installed without an incremental update will affect the host's errata status. Also affects the Host Collections dashboard widget.")
 
       setting 'restrict_composite_view',
         type: :boolean,

--- a/spec/models/host_collection_spec.rb
+++ b/spec/models/host_collection_spec.rb
@@ -88,12 +88,12 @@ module Katello
 
       it "should retrieve errata for the hosts in the host collection" do
         errata = @host_collection.errata
-        errata.count.must_equal(2)
+        errata.length.must_equal(2)
       end
 
       it "should retrieve a specific type of errata for the hosts in the host collection" do
         errata = @host_collection.errata("security")
-        errata.count.must_equal(1)
+        errata.length.must_equal(1)
         errata.must_include(katello_errata("security"))
       end
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The Host Collections dashboard widget shows you a colored box:

red if there are security errata for the hosts in that host collection;
yellow if there are bugfix or enhancement errata;
and green otherwise.

With this PR, the Host Collections widget now uses the `errata_status_installable` Setting so that these colors can be based on installable errata and not just applicable, if desired by the user.

Also added some tooltips.
![image](https://github.com/Katello/katello/assets/22042343/65e6d908-95a9-4d93-b0c6-294c18fa59f0)



#### Considerations taken when implementing this change?

It made more sense to me to use `applicable_for_hosts` and `installable_for_hosts` side-by-side. Let me know if that's incorrect. also, I added keyword arguments to a method that already had a positional argument; hopefully that doesn't break any Ruby things

#### What are the testing steps for this pull request?

Get one or more hosts with applicable but not installable errata
Put those hosts in a host collection
With the `errata_status_installable` setting on: The host collections widget should show a green box if none of the errata are installable.
With the `errata_status_installable` setting off: The host collections widget should show a red or yellow box, depending on what errata types are applicable.


