### PR TITLE
Fixes #37546 - Disable BulkChangeHostCVModal when Any Organization is selected

### DIFF
--- a/webpack/components/extensions/Hosts/ActionsBar/index.js
+++ b/webpack/components/extensions/Hosts/ActionsBar/index.js
@@ -6,6 +6,7 @@ import { foremanUrl } from 'foremanReact/common/helpers';
 import { ForemanHostsIndexActionsBarContext } from 'foremanReact/components/HostsIndex';
 import { useForemanModal } from 'foremanReact/components/ForemanModal/ForemanModalHooks';
 import { addModal } from 'foremanReact/components/ForemanModal/ForemanModalActions';
+import { useForemanOrganization } from 'foremanReact/Root/Context/ForemanContext';
 
 const HostActionsBar = () => {
   const {
@@ -21,6 +22,8 @@ const HostActionsBar = () => {
     }));
   }, [dispatch]);
   const { setModalOpen } = useForemanModal({ id: 'bulk-change-cv-modal' });
+
+  const orgId = useForemanOrganization()?.id;
 
   let href = '';
   if (selectAllMode) {
@@ -44,7 +47,7 @@ const HostActionsBar = () => {
         ouiaId="bulk-change-cv-dropdown-item"
         key="bulk-change-cv-dropdown-item"
         onClick={setModalOpen}
-        isDisabled={selectedCount === 0}
+        isDisabled={selectedCount === 0 || !orgId}
       >
         {__('Change content view environments')}
       </DropdownItem>

--- a/webpack/components/extensions/Hosts/BulkActions/BulkChangeHostCVModal/index.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkChangeHostCVModal/index.js
@@ -5,9 +5,12 @@ import { useForemanModal } from 'foremanReact/components/ForemanModal/ForemanMod
 import BulkChangeHostCVModal from './BulkChangeHostCVModal';
 
 const BulkChangeHostCVModalScene = () => {
-  const org = useForemanOrganization();
+  const orgId = useForemanOrganization()?.id;
   const { selectedCount, fetchBulkParams } = useContext(ForemanActionsBarContext);
   const { modalOpen, setModalClosed } = useForemanModal({ id: 'bulk-change-cv-modal' });
+
+  if (!orgId) return null;
+
 
   return (
     <BulkChangeHostCVModal
@@ -16,7 +19,7 @@ const BulkChangeHostCVModalScene = () => {
       fetchBulkParams={fetchBulkParams}
       isOpen={modalOpen}
       closeModal={setModalClosed}
-      orgId={org?.id}
+      orgId={orgId}
     />
 
   );


### PR DESCRIPTION
Goes with https://github.com/theforeman/foreman/pull/10199 (not strictly required tho)

#### What are the changes introduced in this pull request?

The `BulkChangeHostCVModal` was throwing an error on the HostsIndex page when 'Any organization' was selected as the organization context.

We need to make sure the HostsIndex page handles 'Any organization' correctly. 

With this change, 'Change content view environments' is disabled and the modal does not render unless you have selected a specific organization.

#### Considerations taken when implementing this change?

You can't change the content view of a host to one from a different org, so that action should be disabled until you select an organization.

#### What are the testing steps for this pull request?

Select 'Any organization'
Make sure there are no JS console errors on HostsIndex page
Observe that 'Change content view environments' menu item is disabled
