### PR TITLE
Fixes #37549 - Failed to index content due to duplicate errata

### DIFF
--- a/app/services/katello/content_unit_indexer.rb
+++ b/app/services/katello/content_unit_indexer.rb
@@ -38,6 +38,12 @@ module Katello
             end
           end
 
+          # Even after this bug (https://github.com/pulp/pulp_rpm/issues/2821) is fixed,
+          # it is possible to have duplicate errata asosociated to a repo.
+          if @content_type.label == 'erratum'
+            to_insert.uniq! { |row| row["pulp_id"] || row[:pulp_id] }
+          end
+
           next if to_insert.empty?
           insert_timestamps(to_insert)
           if @content_type.mutable


### PR DESCRIPTION
Content Import task failed indexing errata from Pulp with the following error.

~~~
13: from katello (4.11.0.9) app/models/katello/repository.rb:960:in `index_content'
       12: from katello (4.11.0.9) app/models/katello/repository.rb:960:in `each'
       11: from katello (4.11.0.9) app/models/katello/repository.rb:961:in `block in index_content'
        7: from katello (4.11.0.9) app/services/katello/content_unit_indexer.rb:26:in `each'
        3: from katello (4.11.0.9) app/services/katello/pulp3/pulp_content_unit.rb:139:in `block (2 levels) in pulp_units_batch_for_repo'
        2: from katello (4.11.0.9) app/services/katello/pulp3/pulp_content_unit.rb:139:in `yield'
        1: from katello (4.11.0.9) app/services/katello/content_unit_indexer.rb:44:in `block in import_all'
ActiveRecord::StatementInvalid (PG::CardinalityViolation: ERROR:  ON CONFLICT DO UPDATE command cannot affect row a second time)
HINT:  Ensure that no rows proposed for insertion within the same command have duplicate constrained values.
~~~

 

Is this issue a regression from an earlier version:

Yes. The following bug is fixed in previous Satellite versions, but the code didn't brought forward after refactoring the index content codes.

https://bugzilla.redhat.com/show_bug.cgi?id=2070535

 

Additional info:

Due to some bugs in Pulp, it is still possible to have duplicate errata associated to a repository version. It is causing issue to Katello because Katello doesn't expect duplicate errata in a repository version. **

https://github.com/pulp/pulp_rpm/issues/2821

https://github.com/pulp/pulp_rpm/issues/3587
