### PR TITLE
Fixes #37555 - Move capsule index and show to correct :view_smart_proxies permission

### DIFF
--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -62,7 +62,8 @@ module Katello
       @plugin.permission :view_capsule_content,
                          {
                            'katello/api/v2/capsule_content' => [:counts, :lifecycle_environments, :available_lifecycle_environments, :sync_status],
-                           'smart_proxies' => [:pulp_storage, :pulp_status, :show_with_content]
+                           'smart_proxies' => [:pulp_storage, :pulp_status, :show_with_content],
+                           'katello/api/v2/capsules' => [:index, :show]
                          },
                          :resource_type => "SmartProxy"
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Viewing a smart proxy was giving the wrong permissions needed `manage_capsule_content`

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
* Check out PR
* Create a non-admin user
* Create a role with only `manage_capsule_content` and assign it to that user
* `curl -k -u test:pass https://localhost/katello/api/capsules/X`
* Verify you get the correct permission to add to see the smart proxies
* Once you add `view_capsule_content` see if the curl returns output