### PR TITLE
Fixes #37174 - Honor selected organizations in hg form

### DIFF
--- a/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
+++ b/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
@@ -36,15 +36,19 @@ KT.hosts.fetchEnvironments = function () {
   select.find('option').remove();
   if (content_source_id) {
     var url = tfm.tools.foremanUrl('/katello/api/capsules/' + content_source_id);
-    var orgId = $('#host_organization_id').val();
+    var orgIds = $("#hostgroup_organization_ids").val();
+    if(orgIds === undefined || orgIds === null || orgIds.length === 0) {
+        orgIds = [$("#host_organization_id").val()];
+    };
+    orgIds = orgIds.map(id => Number(id));
     $.get(url, function (content_source) {
-      $.each(content_source.lifecycle_environments, function(index, env) {
-    // Don't show environments that aren't in the selected org. See jQuery.each() docs    
-    if (orgId && env.organization_id != orgId) return true;
-	option = $("<option />").val(env.id).text(env.name);
-	select.append(option);
-      });
-      select.trigger('change');
+        $.each(content_source.lifecycle_environments, function(index, env) {
+            // Don't show environments that aren't in the selected org. See jQuery.each() docs    
+            if (!orgIds.includes(env.organization_id)) return true;
+            option = $("<option />").val(env.id).text(env.name);
+            select.append(option);
+        });
+        select.trigger('change');
     });
   }
 };


### PR DESCRIPTION
when generating options for lifecycle environment field.

A spiritual successor to https://github.com/Katello/katello/pull/10524

#### What are the changes introduced in this pull request?
When creating/editing a hostgroup, only lifecycle environments belonging to the hostgroup's organization are offered.

#### Considerations taken when implementing this change?
This is one of the things that seems to be conceptually broken. On one side we have a hostgroup which can belong to multiple (or none) organizations and we're trying to match it with a lifecycle environment which belongs to exactly one organization.

With current organization set when creating a hostgroup, the current organization gets pre-selected for the hostgroup, leading to what appears to be expected behavior. If the user add more organizations, they'll be able to pick LCEs from all of them.

#### What are the testing steps for this pull request?
1) Have 2 organizations
2) Go create a hostgroup
3) Set content source
4) Open the lifecycle environment picker
