### PR TITLE
Fixes #37354 - Reload host_traces when computing trace status

### DIFF
--- a/app/models/katello/trace_status.rb
+++ b/app/models/katello/trace_status.rb
@@ -36,7 +36,7 @@ module Katello
     end
 
     def to_status(_options = {})
-      traces = host.host_traces.pluck(:app_type)
+      traces = host.host_traces.reload.pluck(:app_type)
       traces.delete(Katello::HostTracer::TRACE_APP_TYPE_SESSION)
 
       if traces.include?(Katello::HostTracer::TRACE_APP_TYPE_STATIC)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

For some reason, during a tracer profile upload, `host.host_traces` was returning stale data, causing an incorrect tracer status to be saved. This change adds a `.reload` so that we can be sure to have fresh data.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Enable Tracer on a host
Get at least one Trace where reboot is needed (updating `kernel` is usually a good bet)
You will be able to see the traces on the Host details > Traces tab.

Search hosts for

```
trace_status = reboot_needed
```

The host should come up in the results, but doesn't.

Now check out the PR, and on the host, run

```
katello-tracer-upload
```

Now, repeat the search and the host will show up.

