### PR TITLE
Fixes #37561 - make sure katello-tracer-upload can run without sudo

### DIFF
--- a/app/views/foreman/job_templates/resolve_traces.erb
+++ b/app/views/foreman/job_templates/resolve_traces.erb
@@ -20,5 +20,9 @@ reboot = commands.delete('reboot')
 shutdown -r +1
 <% else -%>
 <%= commands.join("\n") %>
-sudo katello-tracer-upload
+RUN_TRACER_CMD='katello-tracer-upload'
+if [ "$(id -u)" -ne 0 ]; then
+  RUN_TRACER_CMD='sudo katello-tracer-upload'
+fi
+$RUN_TRACER_CMD
 <% end %>


### PR DESCRIPTION
Run cmd for root users without sudo to avoid unnecessary pkg dependency on sudo. sudo is not part of e.g. Debian default installation. 