### PR TITLE
Refs #37546 - Add disabled reason for Any Org actions

### DIFF
--- a/webpack/components/extensions/Hosts/ActionsBar/index.js
+++ b/webpack/components/extensions/Hosts/ActionsBar/index.js
@@ -51,7 +51,9 @@ const HostActionsBar = () => {
         ouiaId="bulk-change-cv-dropdown-item"
         key="bulk-change-cv-dropdown-item"
         onClick={openBulkChangeCVModal}
-        isDisabled={selectedCount === 0 || !orgId}
+        isDisabled={selectedCount === 0}
+        isAriaDisabled={!orgId}
+        tooltip={!orgId && __('To change content view environments, a specific organization must be selected from the organization context.')}
       >
         {__('Change content view environments')}
       </DropdownItem>
@@ -60,6 +62,8 @@ const HostActionsBar = () => {
         key="bulk-packages-wizard-dropdown-item"
         onClick={openBulkPackagesWizardModal}
         isDisabled={selectedCount === 0}
+        isAriaDisabled={!orgId}
+        tooltip={!orgId && __('To manage host packages, a specific organization must be selected from the organization context.')}
       >
         {__('Manage packages')}
       </DropdownItem>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Per [this Foreman PR comment](https://github.com/theforeman/foreman/pull/10199#issuecomment-2174449313), add a "disabled reason" mouseover tooltip to actions that are disabled because the 'Any Organization' context is selected. Followup of https://github.com/Katello/katello/pull/11023.

#### Considerations taken when implementing this change?

Seems the `isAriaDisabled` plus `tooltip` props of `DropdownItem` did the trick here.
I left the regular `isDisabled` for cases where `selectedCount === 0`, since I think that should be self-explanatory.

#### What are the testing steps for this pull request?

make sure everything works as expected
