### PR TITLE
Fixes #37571 - Call 'bind_entitlement' with splatted kwargs

### DIFF
--- a/app/lib/actions/katello/upstream_subscriptions/bind_entitlement.rb
+++ b/app/lib/actions/katello/upstream_subscriptions/bind_entitlement.rb
@@ -4,7 +4,7 @@ module Actions
       class BindEntitlement < Actions::Base
         def run
           output[:response] = ::Katello::Resources::Candlepin::UpstreamConsumer
-            .bind_entitlement(pool)
+            .bind_entitlement(**pool)
         end
 
         def humanized_name

--- a/test/actions/katello/upstream_subscriptions/bind_entitlement_test.rb
+++ b/test/actions/katello/upstream_subscriptions/bind_entitlement_test.rb
@@ -13,7 +13,7 @@ describe ::Actions::Katello::UpstreamSubscriptions::BindEntitlement do
   end
 
   it 'runs' do
-    ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:bind_entitlement).with(@pool)
+    ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:bind_entitlement).with(**@pool)
 
     @action = run_action(@action)
   end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

See the title. Not doing this was breaking adding subscriptions to a manifest on EL9:

```
19:35:32 rails.1   | 2024-06-18T19:35:32 [E|bac|f4e9a8f2] wrong number of arguments (given 1, expected 0) (ArgumentError)
19:35:32 rails.1   |  f4e9a8f2 | /home/vagrant/katello/app/lib/katello/resources/candlepin/upstream_consumer.rb:70:in `bind_entitlement'
19:35:32 rails.1   |  f4e9a8f2 | /home/vagrant/katello/app/lib/actions/katello/upstream_subscriptions/bind_entitlement.rb:7:in `run'
```

#### Considerations taken when implementing this change?

Still needs testing to make sure it works on EL8 as well.

#### What are the testing steps for this pull request?

Add subscriptions to your manifest
make sure the task completes with no errors

