### PR TITLE
Fixes #37585 - adjust id to bigint

### DIFF
--- a/db/migrate/20240621121212_katello_repository_debs_id_bigint.rb
+++ b/db/migrate/20240621121212_katello_repository_debs_id_bigint.rb
@@ -1,0 +1,6 @@
+class KatelloRepositoryDebsIdBigint < ActiveRecord::Migration[6.1]
+  def change
+    change_column :katello_repository_debs, :id, :bigint
+    execute 'ALTER SEQUENCE katello_repository_debs_id_seq AS bigint;'
+  end
+end


### PR DESCRIPTION
See similar problem with `katello_repository_rpms` and consider `katello_repository_debs` on of the "other tables" that were mentioned there: https://github.com/Katello/katello/pull/8537#issuecomment-576970642