### PR TITLE
Fixes #37588 - Change UI wording for immediate REX

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.js
@@ -31,7 +31,7 @@ const EnableTracerModal = ({
   const [buttonLoading, setButtonLoading] = useState(false);
   const toggleDropdownOpen = () => setIsDropdownOpen(prev => !prev);
   const dropdownOptions = [
-    __('via remote execution'),
+    __('immediately'),
     __('via customized remote execution'),
   ];
   const [selectedOption, setSelectedOption] = useState(dropdownOptions[0]);

--- a/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/04_Review.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/04_Review.js
@@ -7,7 +7,7 @@ import { CaretDownIcon } from '@patternfly/react-icons';
 import { BulkPackagesWizardContext, INSTALL, UPGRADE_ALL } from './BulkPackagesWizard';
 
 export const dropdownOptions = [
-  __('via remote execution'),
+  __('immediately'),
   __('via customized remote execution'),
 ];
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

During community demo it was suggested that the options

- via remote execution
- via customized remote execution

are outdated because they come from a time when `katello-agent` was a third option. It was instead suggested to say 'immediately' for the first option.

I changed it in the two places where we have the wording above:

![image](https://github.com/Katello/katello/assets/22042343/2b15f55a-f559-4671-bfc9-6a77051ad6cb)
![image](https://github.com/Katello/katello/assets/22042343/4d916b1b-2dbd-4945-82de-376f4c5c1708)


#### Considerations taken when implementing this change?

There are also other places where the wording is slightly different:
![image](https://github.com/Katello/katello/assets/22042343/724f12e7-77ce-41e2-a0f3-7db0296df80d)

Should I change the wording in these places too? What should it say? "Install immediately?"

I'm also a bit uneasy because the change to the wording implies that "immediate" isn't remote execution, and "customized" is. Is this a legit concern? If so, what are possible solutions?

#### What are the testing steps for this pull request?

I mean, do whatever you want. No functional changes here.

