### PR TITLE
Fix cop Style/TrailingCommaInHashLiteral

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -173,3 +173,6 @@ Rails/RedundantForeignKey:
 
 Rails/UniqueValidationWithoutIndex:
   Enabled: true
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: true


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Based on https://github.com/Katello/katello/pull/11009
This pull request addresses the `Style/TrailingCommaInHashLiteral` RuboCop offense by ensuring that all multiline hash literals in the codebase have a trailing comma after the last item. 

#### Considerations taken when implementing this change?
Consistency and Readability, ensured that all multiline hash literals are updated uniformly with trailing commas.
Also, that the changes do not impact existing functionality or cause syntax errors.

#### What are the testing steps for this pull request?
`bundle exec rubocop`