### PR TITLE
Fixes #37595 - Drop defunct deb mirror_publication_options

### DIFF
--- a/app/services/katello/pulp3/repository/apt.rb
+++ b/app/services/katello/pulp3/repository/apt.rb
@@ -51,16 +51,6 @@ module Katello
           popts
         end
 
-        def mirror_publication_options
-          {
-            # Since we are synchronizing the "default" distribution from the simple publisher on the server,
-            # it will be included in the structured publish. Therefore, we MUST NOT use the simple publisher
-            # on the proxy, since this would collide!
-            #simple: true,
-            structured: true # publish real suites (e.g. 'stable')
-          }
-        end
-
         def distribution_options(path)
           {
             base_path: path,

--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -166,21 +166,13 @@ module Katello
         uri.to_s
       end
 
-      def publication_options(repository_version)
-        popts = {repository_version: repository_version}
-        if (type_specific_options = repo_service.try(:mirror_publication_options))
-          popts.merge!(type_specific_options)
-        end
-        popts
-      end
-
       def create_publication
         if (href = version_href)
           if repo_service.repo.content_type == "deb"
             publication_data = api.publication_verbatim_class.new({repository_version: href})
             api.publications_verbatim_api.create(publication_data)
           else
-            publication_data = api.publication_class.new(publication_options(href))
+            publication_data = api.publication_class.new(repository_version: href)
             api.publications_api.create(publication_data)
           end
         end


### PR DESCRIPTION
Ever since we switched to verbatim publications for deb content on smart proxies this code path has been unused. We could have cleaned it up as part of the change in 4a363fd945d56ad48f6a30446d9c16320819d4a5.
#### What are the changes introduced in this pull request?

Cleans up some dead code. From using git grep, it is clear only deb content has `mirror_publication_options` defined, but ever since https://projects.theforeman.org/issues/35959 deb content no longer uses those publication options, because a verbatim publication is used instead.

#### What are the testing steps for this pull request?

One could sync some deb content and some non deb content to smart proxy as a test, but it is pretty clear from the code that this change has no effect.