### PR TITLE
Fix Rails/HttpStatus cop

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -573,7 +573,7 @@ module Katello
     end
 
     def v1_ping
-      head 200
+      head :ok
     end
 
     def v1_search

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -537,7 +537,7 @@ Alternatively, use the 'force' parameter to regenerate metadata locally. On the 
       if @repository.root.gpg_key && @repository.root.gpg_key.content.present?
         render(:plain => @repository.root.gpg_key.content, :layout => false)
       else
-        head(404)
+        head(:not_found)
       end
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Base on https://github.com/Katello/katello/pull/11009
Addresses the Rails/HttpStatus rule by replacing numeric HTTP status codes with their corresponding symbol.

#### Considerations taken when implementing this change?
Reviewed and replaced all instances of numeric HTTP status codes with their symbolic equivalents. Check commit for more details.

#### What are the testing steps for this pull request?
Verify that all numeric HTTP status codes have been replaced with appropriate symbols and run test suite