### PR TITLE
Fix Style/SlicingWithRange cop

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -515,7 +515,7 @@ module Katello
         key.match("^HTTP_.*")
       end
       env.each do |header|
-        headers[header[0].split('_')[1..-1].join('-')] = header[1]
+        headers[header[0].split('_')[1..].join('-')] = header[1]
       end
 
       if (manifest_response = redirect_client { Resources::Registry::Proxy.get(@_request.fullpath, headers) })
@@ -554,7 +554,7 @@ module Katello
         key.match("^HTTP_.*")
       end
       env.each do |header|
-        current_headers[header[0].split('_')[1..-1].join('-')] = header[1]
+        current_headers[header[0].split('_')[1..].join('-')] = header[1]
       end
       current_headers
     end
@@ -697,7 +697,7 @@ module Katello
       if manifest['schemaVersion'] == 1
         if manifest['fsLayers']
           files += manifest['fsLayers'].collect do |layer|
-            layerfile = "#{layer['blobSum'][7..-1]}.tar"
+            layerfile = "#{layer['blobSum'][7..]}.tar"
             force_include_layer(repository, layer['blobSum'], layerfile)
             layerfile
           end
@@ -705,12 +705,12 @@ module Katello
       elsif manifest['schemaVersion'] == 2
         if manifest['layers']
           files += manifest['layers'].collect do |layer|
-            layerfile = "#{layer['digest'][7..-1]}.tar"
+            layerfile = "#{layer['digest'][7..]}.tar"
             force_include_layer(repository, layer['digest'], layerfile)
             layerfile
           end
         end
-        files << "#{manifest['config']['digest'][7..-1]}.tar"
+        files << "#{manifest['config']['digest'][7..]}.tar"
       else
         render_error 'custom_error', :status => :internal_server_error,
                              :locals => { :message => "Unsupported schema #{manifest['schemaVersion']}" }

--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -145,7 +145,7 @@ module Katello
       def compare_same(collection, content_view_versions = nil)
         cv_version_first = content_view_versions[0]
         collection_ids = collection.in_repositories(Katello::Repository.where(:content_view_version_id => cv_version_first&.id))&.pluck(:id)
-        content_view_versions[1..-1].each do |version|
+        content_view_versions[1..].each do |version|
           collection_version_ids = collection.in_repositories(Katello::Repository.where(:content_view_version_id => version&.id))&.pluck(:id)
           collection_ids = collection_ids.intersection collection_version_ids
         end

--- a/app/lib/actions/pulp3/orchestration/repository/copy_all_units.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/copy_all_units.rb
@@ -23,7 +23,7 @@ module Actions
                   plan_action(Actions::Pulp3::Repository::SaveVersion, target_repo, tasks: action.output[:pulp_tasks])
                   copy_actions = []
                   #since we're creating a new version from the first repo, start copying at the 2nd
-                  source_repositories[1..-1].each do |source_repo|
+                  source_repositories[1..].each do |source_repo|
                     # TODO: In a future refactor, can :copy_all be utilized?  Filters should not be needed in this code segment.
                     copy_actions << plan_action(Actions::Pulp3::Repository::CopyContent, source_repo, smart_proxy, target_repo,
                                                 filter_ids: filter_ids, solve_dependencies: solve_dependencies,

--- a/app/lib/katello/resources/candlepin/owner.rb
+++ b/app/lib/katello/resources/candlepin/owner.rb
@@ -65,7 +65,7 @@ module Katello
             response = JSON.parse(response_json).with_indifferent_access
             if wait_until_complete && response['state'] == 'CREATED'
               while !response['state'].nil? && response['state'] != 'FINISHED' && response['state'] != 'ERROR'
-                path = join_path('candlepin', response['statusPath'][1..-1])
+                path = join_path('candlepin', response['statusPath'][1..])
                 response_json = self.get(path, self.default_headers)
                 response = JSON.parse(response_json).with_indifferent_access
               end

--- a/app/lib/katello/util/path_with_substitutions.rb
+++ b/app/lib/katello/util/path_with_substitutions.rb
@@ -25,7 +25,7 @@ module Katello
       def substitutions_needed
         # e.g. if content_url = "/content/dist/rhel/server/7/$releasever/$basearch/kickstart"
         #      return ['releasever', 'basearch']
-        split_path.map { |word| word.start_with?('$') ? word[1..-1] : nil }.compact
+        split_path.map { |word| word.start_with?('$') ? word[1..] : nil }.compact
       end
 
       def substitutable?

--- a/app/lib/katello/util/url_matcher.rb
+++ b/app/lib/katello/util/url_matcher.rb
@@ -63,7 +63,7 @@ module Katello
           self.parts.each_with_index do |part, i|
             a << @match.parts[i] if part[0] == ':'
           end
-          a << @match.ext[1..-1] if self.ext[1] == ':'
+          a << @match.ext[1..] if self.ext[1] == ':'
           a
         end
         alias_method :vars, :variables

--- a/app/models/katello/hash_util.rb
+++ b/app/models/katello/hash_util.rb
@@ -16,7 +16,7 @@ module Katello
       subhash = hash[params.first]
       # If we don't have a subhash don't try and recurse down
       if !subhash.nil? && !subhash.empty?
-        self.null_safe_get(subhash, default, params[1..-1])
+        self.null_safe_get(subhash, default, params[1..])
       else
         default
       end

--- a/test/support/auth_support.rb
+++ b/test/support/auth_support.rb
@@ -25,7 +25,7 @@ module Katello
     end
 
     def resource_type_from_name(name)
-      resource_name = name.to_s.split('_')[1..-1].join('_').singularize
+      resource_name = name.to_s.split('_')[1..].join('_').singularize
       mapping = {
         "capsule_content" => "SmartProxy",
         "manifest" => "Katello::Subscription",


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Base on https://github.com/Katello/katello/pull/11009
Addresses the Style/SlicingWithRange rule by replacing ary[n..-1] with ary[n..] for array slicing operations.

#### Considerations taken when implementing this change?
Reviewed all instances of ary[n..-1] and updated them to ary[n..].

#### What are the testing steps for this pull request?
`bundle exec rubocop`