### PR TITLE
Fixes #37598 - Fix missing kwargs on repo enable for ISS

### DIFF
--- a/app/lib/actions/katello/repository_set/enable_repository.rb
+++ b/app/lib/actions/katello/repository_set/enable_repository.rb
@@ -6,8 +6,7 @@ module Actions
           _("Enable")
         end
 
-        def plan(product, content, substitutions, override_url: nil,
-                 override_arch: nil)
+        def plan(product, content, substitutions, opts = {})
           mapper = ::Katello::Candlepin::RepositoryMapper.new(product,
                                                                content,
                                                                substitutions)
@@ -16,10 +15,10 @@ module Actions
             fail ::Katello::Errors::ConflictException, _("The repository is already enabled")
           end
           repository = mapper.build_repository
-          repository.root.arch = override_arch if override_arch.present?
-          if override_url
-            repository.root.url = override_url
-            repository.root.download_policy = ::Katello::RootRepository::DOWNLOAD_IMMEDIATE if URI(override_url).scheme == 'file'
+          repository.root.arch = opts[:override_arch] if opts[:override_arch].present?
+          if opts[:override_url]
+            repository.root.url = opts[:override_url]
+            repository.root.download_policy = ::Katello::RootRepository::DOWNLOAD_IMMEDIATE if URI(opts[:override_url]).scheme == 'file'
           end
           plan_action(Repository::Create, repository, clone: false)
           action_subject(repository)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Fixing kwargs missing on repo enable that we missed in Ruby 3

#### Considerations taken when implementing this change?

* Make sure it works on EL8/Ruby2

#### What are the testing steps for this pull request?

* Import a manifest
* Sync a repo and create a content view with it
* Export the CV with hammer
* Create a 2nd org
* Import a manifest
* Import the cvv into the new org and see if it fails
* Checkout PR
* Try the import again
* ???
* Profit