### PR TITLE
Fixes #37600 - Add params to skip Candlepin content on repository remove

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -410,12 +410,16 @@ Alternatively, use the 'force' parameter to regenerate metadata locally. On the 
 
     api :DELETE, "/repositories/:id", N_("Destroy a custom repository")
     param :id, :number, :required => true
+    param :skip_candlepin_environment_update, :bool, :required => false, :desc => N_('Skip updating the candlepin environment section in the destroy task.')
+    param :skip_candlepin_remove_content, :bool, :required => false, :desc => N_('Skip remove content in candlepin section in the destroy task.')
     param :remove_from_content_view_versions, :bool, :required => false, :desc => N_("Force delete the repository by removing it from all content view versions")
     param :delete_empty_repo_filters, :bool, :required => false, :desc => N_("Delete content view filters that have this repository as the last associated repository. Defaults to true. If false, such filters will now apply to all repositories in the content view.")
     def destroy
       sync_task(::Actions::Katello::Repository::Destroy, @repository,
                 remove_from_content_view_versions: ::Foreman::Cast.to_bool(params.fetch(:remove_from_content_view_versions, false)),
-                delete_empty_repo_filters: ::Foreman::Cast.to_bool(params.fetch(:delete_empty_repo_filters, true))
+                delete_empty_repo_filters: ::Foreman::Cast.to_bool(params.fetch(:delete_empty_repo_filters, true)),
+                skip_environment_update: ::Foreman::Cast.to_bool(params.fetch(:skip_candlepin_environment_update, false)),
+                destroy_content: ::Foreman::Cast.to_bool(params.fetch(:skip_candlepin_remove_content, true))
                 )
       respond_for_destroy
     end

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -767,6 +767,26 @@ module Katello
       assert_response :success
     end
 
+    def test_skip_candlepin_environment_update
+      assert_sync_task(::Actions::Katello::Repository::Destroy) do |repo|
+        repo.id == @repository.id
+      end
+
+      delete :destroy, params: { :id => @repository.id, :skip_candlepin_environment_update => true }
+
+      assert_response :success
+    end
+
+    def test_skip_candlepin_remove_content
+      assert_sync_task(::Actions::Katello::Repository::Destroy) do |repo|
+        repo.id == @repository.id
+      end
+
+      delete :destroy, params: { :id => @repository.id, :skip_candlepin_remove_content => true }
+
+      assert_response :success
+    end
+
     def test_destroy_protected
       allowed_perms = [@destroy_permission]
       denied_perms = [@read_permission, @create_permission, @update_permission]


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* We currently have 2 params available to skip Candlepin content during repo deletion `skip_environment_update` `destroy_content` these params were not exposed to the user.
* Added `skip_candlepin_environment_update` which maps to `skip_environment_update` and `skip_candlepin_remove_content` which maps to `destroy_content`
* Added unit tests

#### What are the testing steps for this pull request?

* SSH to reproducer(IP in Jira)
* Try to delete a repo that causes the error `hammer repository destroy --id 1457 --organization-id 1`
* Check out PR or apply patch file at bottom of PR since it's Katello 4.7
  * `cd /usr/share/gems/gems/katello-4.7.0.36`
  * `patch -p1 < <patchfile>`
  * `foreman-maintain service restart`
* Try to delete a repo that would throw an error with new params `hammer repository destroy --id 1458 --organization-id 1 --skip-candlepin-environment-update true --skip-candlepin-remove-content true`

Patch file:
[katello.patch](https://github.com/user-attachments/files/15994877/katello.patch)
