### PR TITLE
Fixes #37603 - Point API users to the correct content upload endpoint

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -439,7 +439,7 @@ Alternatively, use the 'force' parameter to regenerate metadata locally. On the 
       respond_for_async :resource => sync_task(::Actions::Katello::Repository::RemoveContent, @repository, @content, content_type: params[:content_type], sync_capsule: sync_capsule)
     end
 
-    api :POST, "/repositories/:id/upload_content", N_("Upload content into the repository")
+    api :POST, "/repositories/:id/upload_content", N_("This endpoint is primarily designed for UI interactions and uploading content into the repository. For API-based uploads, please use the 'content_uploads' endpoint instead.")
     param :id, :number, :required => true, :desc => N_("repository ID")
     param :content, File, :required => true, :desc => N_("Content files to upload. Can be a single file or array of files.")
     param :content_type, String, :required => false, :desc => N_("The type of content to upload (srpm, file, etc.). Check uploadable types here: /katello/api/repositories/repository_types")


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Update API desc to point to correct endpoint for uploading content.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
API description should read this:
![Screenshot from 2024-06-27 09-23-29](https://github.com/Katello/katello/assets/21146741/ca50a919-93aa-4bd7-8d31-69699d3470e8)
