### PR TITLE
Fixes #37569 - Upload profile - Katello Script Default 

### DIFF
--- a/app/views/foreman/job_templates/upload_profile.erb
+++ b/app/views/foreman/job_templates/upload_profile.erb
@@ -10,6 +10,8 @@ feature: katello_upload_profile
 #!/bin/sh
 <% if @host.operatingsystem.family == 'Redhat' -%>
 dnf uploadprofile --force-upload
+<% elsif @host.operatingsystem.family == 'Suse' -%>
+katello-package-upload --force
 <% else -%>
 package-profile-upload --force-upload
 <% end -%>


### PR DESCRIPTION
The condition under which the update package upload for SLES has been added

```
<% elsif @host.operatingsystem.family == 'Suse' -%>
katello-package-upload --force
```

Supersedes https://github.com/Katello/katello/pull/11038