### PR TITLE
Fixes #37617 - Deletion of repository not working from "Products" page when repo in published CV

### DIFF
--- a/app/controllers/katello/api/v2/repositories_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_bulk_actions_controller.rb
@@ -6,7 +6,7 @@ module Katello
     param :ids, Array, :desc => N_("List of repository ids"), :required => true
     def destroy_repositories
       deletion_authorized_repositories = @repositories.deletable
-      unpromoted_repos = deletion_authorized_repositories.reject { |repo| repo.promoted? && repo.content_views.generated_for_none.exists? }
+      unpromoted_repos = Setting.find_by(name: 'delete_repo_across_cv')&.value ? deletion_authorized_repositories : deletion_authorized_repositories.reject { |repo| repo.promoted? && repo.content_views.generated_for_none.exists? }
       unpromoted_repos_non_last_affected_repo = unpromoted_repos.reject { |repo| repo.filters.any? { |filter| filter.repositories.size == 1 } }
       messages1 = format_bulk_action_messages(
           :success    => "",
@@ -33,7 +33,11 @@ module Katello
 
       task = nil
       if unpromoted_repos_non_last_affected_repo.any?
-        task = async_task(::Actions::BulkAction, ::Actions::Katello::Repository::Destroy, unpromoted_repos_non_last_affected_repo)
+        task = async_task(::Actions::BulkAction,
+                          ::Actions::Katello::Repository::Destroy,
+                          unpromoted_repos_non_last_affected_repo,
+                          remove_from_content_view_versions: Setting.find_by(name: 'delete_repo_across_cv')&.value
+        )
       else
         status = 400
       end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -791,6 +791,8 @@ module Katello
           return true
         elsif !self.custom? && self.redhat_deletable?(remove_from_content_view_versions)
           return true
+        elsif Setting.find_by(name: 'delete_repo_across_cv')&.value
+          return true
         else
           errors.add(:base, _("Repository cannot be deleted since it has already been included in a published Content View. " \
                               "Please delete all Content View versions containing this repository before attempting to delete it "\


### PR DESCRIPTION
[Redmine issue and reproducer](https://projects.theforeman.org/issues/37617)

When a user tries to delete a repository of a product, which is part of a published CV, an error is raised.
This happens despite the `delete_repo_across_cv`-setting being set to true. 
Deletion from the "details" page of the respective repository works as expected.

It appears like it was forgotten to adapt the `RepositoriesBulkActionsController` to account for the `delete_repo_across_cv` setting.

This PR adresses this by adding the missing logic.