### PR TITLE
Fixes #37618 - Update host content view environments from sub-man

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -259,6 +259,14 @@ module Katello
     def facts
       User.current = User.anonymous_admin
       @host.update_candlepin_associations(rhsm_params)
+      if params[:environments]
+        new_envs = params[:environments].map do |env|
+          get_content_view_environment("cp_id", env['id'])
+        end
+        new_envs.compact!
+        Rails.logger.debug "Setting new content view environments for host #{@host.to_label}: #{new_envs.map(&:label)}"
+        @host.content_facet.content_view_environments = new_envs
+      end
       update_host_registered_through(@host, request.headers)
       @host.refresh_statuses([::Katello::RhelLifecycleStatus])
       render :json => {:content => _("Facts successfully updated.")}, :status => :ok


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Normally, when changing a host's content view environment(s), you do it using Katello. However, it's also possible to do this from the host itself, using a command

```
subscription-manager environments --set
```

This can be used to set either a single or multiple environments. Until now, Katello didn't handle this at all, causing Candlepin to be out of sync with Katello's notion of a host's assigned content view environment(s). This change takes advantage of the fact that we already intercept subscription-manager's call to `PUT /consumers/:id`, and properly updates Katello's database.

#### Considerations taken when implementing this change?

This is a separate PR from https://github.com/Katello/katello/pull/11008 so it can be backported as a bugfix.

#### What are the testing steps for this pull request?

To work with single-environment hosts, no changes are needed. To work with multi-environment hosts (and change the order of environments), you'll have to cherry-pick this on top of https://github.com/Katello/katello/pull/11008, or wait til it's merged.

Register a host
Open up a Rails console window (with Foreman server still running)
On the host, run `subscription-manager environments --set xxxx/xxxx`
In the console, run
```
myhost.content_facet.content_view_environments.reload.map(&:label)
```
The host's content view environment should match the one you just set it to.

For multiple-environments, the order of CVEs should also match the order you set.

On the host, run
```
subscription-manager environments --list-enabled
```

and make sure that output (and order) matches as well.

