### PR TITLE
Remove leftover reference to distributor_versions Candlepin API

### DIFF
--- a/app/lib/katello/resources/candlepin/candlepin_ping.rb
+++ b/app/lib/katello/resources/candlepin/candlepin_ping.rb
@@ -7,11 +7,6 @@ module Katello
             response = get('/candlepin/status').body
             JSON.parse(response).with_indifferent_access
           end
-
-          def distributor_versions
-            response = get("/candlepin/distributor_versions").body
-            JSON.parse(response)
-          end
         end
       end
     end


### PR DESCRIPTION
- It seems all code related to distributor versions was removed in this PR: https://github.com/Katello/katello/pull/5458 and this was a leftover method that is not used any more.

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
