### PR TITLE
Fixes #37634 - Prevent users from editing container push repositories

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -383,6 +383,7 @@ module Katello
           :not_found
         )
       end
+
       instance_repo.update!(version_href: latest_version_href)
       # The Pulp repository should not change after first creation
       if root_repository.repository_references.empty?

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -32,6 +32,8 @@ module Katello
 
     EXPORTABLE_TYPES = [YUM_TYPE, FILE_TYPE, ANSIBLE_COLLECTION_TYPE, DOCKER_TYPE, DEB_TYPE].freeze
 
+    ALLOWED_UPDATE_FIELDS = ['version_href', 'last_indexed'].freeze
+
     define_model_callbacks :sync, :only => :after
 
     belongs_to :root, :inverse_of => :repositories, :class_name => "Katello::RootRepository"
@@ -119,6 +121,7 @@ module Katello
 
     before_validation :set_pulp_id
     before_validation :set_container_repository_name, :unless => :skip_container_name?
+    before_update :prevent_updates, :unless => :allow_updates?
 
     scope :has_url, -> { joins(:root).where.not("#{RootRepository.table_name}.url" => nil) }
     scope :on_demand, -> { joins(:root).where("#{RootRepository.table_name}.download_policy" => ::Katello::RootRepository::DOWNLOAD_ON_DEMAND) }
@@ -179,7 +182,7 @@ module Katello
              :deb_components, :deb_architectures, :ssl_ca_cert_id, :ssl_ca_cert, :ssl_client_cert, :ssl_client_cert_id,
              :ssl_client_key_id, :os_versions, :ssl_client_key, :ignorable_content, :description, :include_tags, :exclude_tags,
              :ansible_collection_requirements, :ansible_collection_auth_url, :ansible_collection_auth_token,
-             :http_proxy_policy, :http_proxy_id, :to => :root
+             :http_proxy_policy, :http_proxy_id, :prevent_updates, :to => :root
 
     delegate :content_id, to: :root, allow_nil: true
     delegate :repository_type, to: :root
@@ -1009,6 +1012,7 @@ module Katello
         repository_type.index_additional_data_proc&.call(self)
       end
       self.update!(last_indexed: DateTime.now)
+
       true
     end
 
@@ -1048,6 +1052,12 @@ module Katello
         manifest.destroy
       end
       DockerMetaTag.cleanup_tags
+    end
+
+    def allow_updates?
+      # allow the update if this repo is not in the default view
+      return true unless in_default_view?
+      root.allow_updates?(::Katello::Repository::ALLOWED_UPDATE_FIELDS)
     end
 
     apipie :class, desc: "A class representing #{model_name.human} object" do

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -28,6 +28,8 @@ glue(@resource.root) do
   attributes :http_proxy_name
   attributes :retain_package_versions_count
   attributes :metadata_expire
+  attributes :allow_updates? => :allow_updates
+  attributes :is_container_push? => :is_container_push
 
   node :http_proxy do
     attributes :id => @resource.root&.http_proxy&.id, :name => @resource.root&.http_proxy&.name, :policy => @resource.root&.http_proxy_policy

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -8,7 +8,7 @@
       <dt translate>Name</dt>
       <dd bst-edit-text="repository.name"
           on-save="save(repository)"
-          readonly="product.redhat || denied('edit_products', product)">
+          readonly="product.redhat || denied('edit_products', product) || !repository.allow_updates || repository.is_container_push">
       </dd>
 
       <dt translate>Label</dt>
@@ -17,7 +17,7 @@
       <dt translate>Description</dt>
       <dd bst-edit-textarea="repository.description"
 	  on-save="save(repository)"
-	  readonly="product.redhat || denied('edit_products', product)">
+	  readonly="product.redhat || denied('edit_products', product) || !repository.allow_updates || repository.is_container_push">
       </dd>
 
       <dt translate>Backend Identifier</dt>
@@ -54,7 +54,8 @@
           </dd>
 
           <dt ng-if="product.redhat != true" translate>Metadata Expiration (Seconds)</dt>
-          <dd bst-edit-number="repository.metadata_expire" on-save="save(repository)" readonly="product.redhat || denied('edit_products', product)"
+          <dd bst-edit-number="repository.metadata_expire" on-save="save(repository)" 
+              readonly="product.redhat || denied('edit_products', product) || !repository.allow_updates || repository.is_container_push"
               deletable="repository.metadata_expire !== null"
               on-delete="clearMetadataExpire()"
               min="1"
@@ -72,7 +73,7 @@
       <dt ng-show="repository.content_type === 'docker'" translate>Registry URL</dt>
       <dd bst-edit-text="repository.url"
           on-save="save(repository)"
-          readonly="product.redhat || denied('edit_products', product)">
+          readonly="product.redhat || denied('edit_products', product) || !repository.allow_updates || repository.is_container_push">
       </dd>
 
       <span ng-show="repository.generic_remote_options !== []">
@@ -93,21 +94,21 @@
         <dt translate>Releases/Distributions</dt>
         <dd bst-edit-text="repository.deb_releases"
             on-save="save(repository)"
-            readonly="denied('edit_products', product)">
+            readonly="denied('edit_products', product) || !repository.allow_updates || repository.is_container_push">
         </dd>
       </span>
       <span ng-if="repository.content_type == 'deb'">
         <dt translate>Components</dt>
         <dd bst-edit-text="repository.deb_components"
             on-save="save(repository)"
-            readonly="denied('edit_products', product)">
+            readonly="denied('edit_products', product) || !repository.allow_updates || repository.is_container_push">
         </dd>
       </span>
       <span ng-if="repository.content_type == 'deb'">
         <dt translate>Architectures</dt>
         <dd bst-edit-text="repository.deb_architectures"
             on-save="save(repository)"
-            readonly="denied('edit_products', product)">
+            readonly="denied('edit_products', product) || !repository.allow_updates || repository.is_container_push">
         </dd>
       </span>
 
@@ -115,7 +116,7 @@
         <dt translate>Upstream Repository Name</dt>
         <dd bst-edit-text="repository.docker_upstream_name"
             on-save="save(repository)"
-            readonly="product.redhat || denied('edit_products', product)">
+            readonly="product.redhat || denied('edit_products', product) || !repository.allow_updates || repository.is_container_push">
         </dd>
       </span>
 
@@ -135,13 +136,13 @@
         <dt translate>Requirements</dt>
         <dd class="overflow-span" bst-edit-textarea="repository.ansible_collection_requirements"
             on-save="save(repository)"
-            readonly="denied('edit_products', product)"
+            readonly="denied('edit_products', product) || !repository.allow_updates || repository.is_container_push"
             edit-trigger="uploadedFile">
         </dd>
 
         <dt translate>Ansible Collection Authorization</dt>
         <dd bst-edit-custom="repository.ansible_collection_auth_exists"
-            readonly="denied('edit_products', product)"
+            readonly="denied('edit_products', product) || !repository.allow_updates || repository.is_container_push"
             on-save="save(repository)"
             formatter="ansibleAuthFilter"
             formatter-options="repository"
@@ -166,13 +167,13 @@
       <dd bst-edit-checkbox="repository.verify_ssl_on_sync"
           formatter="booleanToYesNo"
           on-save="save(repository)"
-          readonly="denied('edit_products', product)">
+          readonly="denied('edit_products', product) || !repository.allow_updates || repository.is_container_push">
       </dd>
 
       <span ng-if="!product.redhat">
         <dt translate>Upstream Authorization</dt>
         <dd bst-edit-custom="repository.upstream_auth_exists"
-            readonly="denied('edit_products', product)"
+            readonly="denied('edit_products', product) || !repository.allow_updates || repository.is_container_push"
             on-save="save(repository)"
             formatter="upstreamPasswordFilter"
             formatter-options="repository"
@@ -203,7 +204,7 @@
       <span ng-show="repository.content_type === 'yum'">
         <dt translate>Yum Metadata Checksum</dt>
         <dd bst-edit-select="checksumTypeDisplay(repository.checksum_type)"
-            readonly="product.redhat || denied('edit_products', product)"
+            readonly="product.redhat || denied('edit_products', product) || !repository.allow_updates || repository.is_container_push"
             selector="repository.checksum_type"
             options="checksums"
             on-save="save(repository)">
@@ -217,14 +218,14 @@
         <dt translate>Retain package versions</dt>
         <dd bst-edit-number="repository.retain_package_versions_count"
             on-save="save(repository)"
-            readonly="denied('edit_products', product)">
+            readonly="denied('edit_products', product) || !repository.allow_updates || repository.is_container_push">
         </dd>
       </span>
 
       <span>
         <dt translate>HTTP Proxy</dt>
         <dd bst-edit-custom="repository.http_proxy_policy"
-            readonly="denied('edit_products', product)"
+            readonly="denied('edit_products', product) || !repository.allow_updates || repository.is_container_push"
             on-save="save(repository)"
             formatter="httpProxyDetailsFilter"
             formatter-options="repository"
@@ -264,7 +265,7 @@
         <dd bst-edit-checkbox="repository.ignore_srpms"
             formatter="booleanToYesNo"
             on-save="save(repository)"
-            readonly="denied('edit_products', product)">
+            readonly="denied('edit_products', product) || !repository.allow_updates || repository.is_container_push">
         </dd>
       </span>
 
@@ -273,7 +274,7 @@
         <dd bst-edit-checkbox="repository.ignore_treeinfo"
             formatter="booleanToYesNo"
             on-save="save(repository)"
-            readonly="denied('edit_products', product)">
+            readonly="denied('edit_products', product) || !repository.allow_updates || repository.is_container_push">
         </dd>
       </span>
 
@@ -282,7 +283,7 @@
         <dd bst-edit-checkbox="repository.unprotected"
             formatter="booleanToYesNo"
             on-save="save(repository)"
-            readonly="product.redhat || denied('edit_products', product)">
+            readonly="product.redhat || denied('edit_products', product) || !repository.allow_updates || repository.is_container_push">
         </dd>
       </span>
 
@@ -301,7 +302,7 @@
       <span ng-if="(repository.content_type === 'yum' && !product.redhat) || repository.content_type === 'deb'">
         <dt translate>GPG Key</dt>
         <dd bst-edit-select="repository.gpg_key.name"
-            readonly="product.redhat ||denied('edit_products', product)"
+            readonly="product.redhat ||denied('edit_products', product) || !repository.allow_updates || repository.is_container_push"
             selector="repository.gpg_key_id"
             options="gpgKeys()"
             on-save="save(repository)">
@@ -309,21 +310,21 @@
       </span>
       <dt translate>SSL CA Cert</dt>
       <dd bst-edit-select="repository.ssl_ca_cert.name"
-          readonly="product.redhat ||denied('edit_products', product)"
+          readonly="product.redhat ||denied('edit_products', product) || !repository.allow_updates || repository.is_container_push"
           selector="repository.ssl_ca_cert_id"
           options="certs()"
           on-save="save(repository)">
       </dd>
       <dt translate>SSL Client Cert</dt>
       <dd bst-edit-select="repository.ssl_client_cert.name"
-          readonly="product.redhat ||denied('edit_products', product)"
+          readonly="product.redhat ||denied('edit_products', product) || !repository.allow_updates || repository.is_container_push"
           selector="repository.ssl_client_cert_id"
           options="certs()"
           on-save="save(repository)">
       </dd>
       <dt translate>SSL Client Key</dt>
       <dd bst-edit-select="repository.ssl_client_key.name"
-          readonly="product.redhat ||denied('edit_products', product)"
+          readonly="product.redhat ||denied('edit_products', product) || !repository.allow_updates || repository.is_container_push"
           selector="repository.ssl_client_key_id"
           options="certs()"
           on-save="save(repository)">
@@ -331,7 +332,7 @@
       <span ng-if="repository.content_type == 'yum' || repository.content_type == 'deb' || repository.content_type == 'docker'">
         <dt translate>Download Policy</dt>
         <dd bst-edit-select="downloadPolicyDisplay(repository.download_policy)"
-            readonly="denied('edit_products', product)"
+            readonly="denied('edit_products', product) || !repository.allow_updates || repository.is_container_push"
             selector="repository.download_policy"
             options="downloadPolicies"
             options-format="id as name for (id, name) in options"
@@ -349,7 +350,7 @@
         <dt translate>Mirroring Policy</dt>
 
         <dd bst-edit-select="mirroringPolicyDisplay(repository.mirroring_policy, repository.content_type)"
-            readonly="denied('edit_products', product)"
+            readonly="denied('edit_products', product) || !repository.allow_updates || repository.is_container_push"
             selector="repository.mirroring_policy"
             options="mirroringPolicies(repository.content_type)"
             options-format="id as name for (id, name) in options"
@@ -360,12 +361,12 @@
         <dt translate>Include Tags</dt>
         <dd bst-edit-text="repository.commaIncludeTags"
             on-save="save(repository)"
-            readonly="denied('edit_products', product)">
+            readonly="denied('edit_products', product) || !repository.allow_updates || repository.is_container_push">
         </dd>
         <dt translate>Exclude Tags</dt>
         <dd bst-edit-text="repository.commaExcludeTags"
             on-save="save(repository)"
-            readonly="denied('edit_products', product)">
+            readonly="denied('edit_products', product) || !repository.allow_updates || repository.is_container_push">
         </dd>
       </span>
     </dl>

--- a/test/actions/katello/environment_test.rb
+++ b/test/actions/katello/environment_test.rb
@@ -22,7 +22,7 @@ module ::Actions::Katello::Environment
 
     it 'does not plan for container push library repos' do
       container_push_repo = ::Katello::RootRepository.find_by(name: 'busybox').library_instance
-      container_push_repo.root.update(is_container_push: true)
+      container_push_repo.root.update_column(:is_container_push, true)
       environment.stubs(:repositories).returns(::Katello::Repository.where(id: container_push_repo.id))
       container_push_repo.expects(:set_container_repository_name).never
       container_push_repo.expects(:clear_smart_proxy_sync_histories).never


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Aside from regular container push operations, users are now no longer able to update fields of container push root repositories and instance repositories. The repository edit page has all editable fields disabled for container push repos.

#### Considerations taken when implementing this change?
When Katello needs to internally update a root or instance repo of a container push repository, the developer must first run `root_repo.update!(allow_updates: true)` and then run `root_repo.update!(allow_updates: false)` after operations are complete. If the update operations fail midway, the root and instance repos will remain editable by the end user.

As of now, we only update root and instance repo properties during repo push commands. If the user's repo push fails, the repo remaining editable is moot anyways.

#### What are the testing steps for this pull request?

1. Download some container images. Create a product with a few regular repositories of different types.
2. `podman login` to Katello. Push the container to this product (`podman push <image> <url>/<org label lowercase>/<prod label lowercase>/<chosen name>`). The push should complete without error.
3. Push to the same location again. Updating the repo should work without error.
4. Try to edit this new repo using hammer / the API. It should fail with error message.
5. Try to edit this repo using the UI. All fields should have editing disabled.
6. Try to edit the new root repo and instance repo using rake console. Validation should fail with a clear error.
7. Editing the other regular non-container-push repositories should work normally without any errors.