### PR TITLE
Fixes #37530 - Very long CV names/labels display weirdly on CV UI

### DIFF
--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -22,6 +22,7 @@ import PropTypes from 'prop-types';
 import ContentViewIcon from '../../../../../scenes/ContentViews/components/ContentViewIcon';
 import { hasRequiredPermissions, hostIsRegistered } from '../../hostDetailsHelpers';
 import ChangeHostCVModal from './ChangeHostCVModal';
+import { truncate } from '../../../../../utils/helpers';
 
 const requiredPermissions = [
   'view_lifecycle_environments', 'view_content_views',
@@ -61,7 +62,7 @@ export const ContentViewEnvironmentDisplay = ({
         <ContentViewIcon composite={contentView.composite} style={{ marginRight: '2px' }} position="left" />
         {contentViewDefault ? <span>{contentView.name}</span> :
         <a style={{ fontSize: '14px' }} href={`/content_views/${contentView.id}`}>
-          {contentView.name}
+          {truncate(contentView.name)}
         </a>
         }
         {!contentViewDefault &&

--- a/webpack/scenes/ContentViews/Copy/CopyContentViewModal.js
+++ b/webpack/scenes/ContentViews/Copy/CopyContentViewModal.js
@@ -4,6 +4,7 @@ import { Modal, ModalVariant } from '@patternfly/react-core';
 import { FormattedMessage } from 'react-intl';
 import { translate as __ } from 'foremanReact/common/I18n';
 import CopyContentViewForm from './CopyContentViewForm';
+import { truncate } from '../../../utils/helpers';
 
 const CopyContentViewModal = ({
   cvId, cvName, show, setIsOpen,
@@ -11,7 +12,7 @@ const CopyContentViewModal = ({
   const description = (
     <FormattedMessage
       id="copy-cv-description"
-      values={{ cv: <b>{cvName}</b> }}
+      values={{ cv: <b>{truncate(cvName)}</b> }}
       defaultMessage={__('This will create a copy of {cv}, including details, repositories, and filters. Generated data such as history, tasks and versions will not be copied.')}
     />
   );

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewAddModal.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewAddModal.js
@@ -14,6 +14,7 @@ import {
   selectCVDetailStatus,
 } from '../../Details/ContentViewDetailSelectors';
 import getContentViewDetails, { addComponent } from '../ContentViewDetailActions';
+import { truncate } from '../../../../utils/helpers';
 
 const ComponentContentViewAddModal = ({
   cvId, componentCvId, componentId, latest, componentVersionId, show, setIsOpen,
@@ -84,7 +85,7 @@ const ComponentContentViewAddModal = ({
       variant={ModalVariant.small}
       isOpen={show}
       ouiaId="add-update-cv-modal"
-      description={__(`Select available version of ${cvName} to use`)}
+      description={__(`Select available version of ${truncate(cvName)} to use`)}
       onClose={() => {
         setIsOpen(false);
       }}

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewBulkAddModal.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewBulkAddModal.js
@@ -9,6 +9,7 @@ import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { useDispatch } from 'react-redux';
 import { translate as __ } from 'foremanReact/common/I18n';
 import getContentViewDetails, { addComponent } from '../ContentViewDetailActions';
+import { truncate } from '../../../../utils/helpers';
 
 const ComponentContentViewBulkAddModal = ({ cvId, rowsToAdd, onClose }) => {
   const dispatch = useDispatch();
@@ -62,7 +63,7 @@ const ComponentContentViewBulkAddModal = ({ cvId, rowsToAdd, onClose }) => {
             aria-label="componentCvName"
             key={componentCvName}
           >
-            <CardTitle aria-label={componentCvName}>{componentCvName}</CardTitle>
+            <CardTitle aria-label={componentCvName}>{truncate(componentCvName)}</CardTitle>
             <CardBody>
               <FormGroup label={__('Version')} isRequired fieldId="version">
                 <Select

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
@@ -36,6 +36,7 @@ import ComponentContentViewAddModal from './ComponentContentViewAddModal';
 import ComponentContentViewBulkAddModal from './ComponentContentViewBulkAddModal';
 import { hasPermission } from '../../helpers';
 import InactiveText from '../../components/InactiveText';
+import { truncate } from '../../../../utils/helpers';
 
 
 const ContentViewComponents = ({ cvId, details }) => {
@@ -144,7 +145,7 @@ const ContentViewComponents = ({ cvId, details }) => {
 
       const cells = [
         { title: <Bullseye><ContentViewIcon composite={false} /></Bullseye> },
-        { title: <a href={urlBuilder('content_views', '') + id}>{name}</a> },
+        { title: <a href={urlBuilder('content_views', '') + id}>{truncate(name)}</a> },
         {
           title: (
             <Split>

--- a/webpack/scenes/ContentViews/Details/ContentViewDetails.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetails.js
@@ -39,6 +39,7 @@ import ContentViewDeleteWizard from '../Delete/ContentViewDeleteWizard';
 import EmptyStateMessage from '../../../components/Table/EmptyStateMessage';
 import { CONTENT_VIEW_NEEDS_PUBLISH_RESET, cvVersionTaskPollingKey } from '../ContentViewsConstants';
 import { clearPollTaskData, stopPollingTask } from '../../Tasks/TaskActions';
+import { truncate } from '../../../utils/helpers';
 
 export default () => {
   const { id } = useParams();
@@ -161,7 +162,7 @@ export default () => {
               <FlexItem>
                 <TextContent>
                   <Text ouiaId="cv-details-header-name" component={TextVariants.h1}>
-                    <ContentViewIcon count={name} composite={composite} />
+                    <ContentViewIcon count={truncate(name)} composite={composite} />
                   </Text>
                 </TextContent>
               </FlexItem>

--- a/webpack/scenes/ContentViews/Publish/CVPublishForm.js
+++ b/webpack/scenes/ContentViews/Publish/CVPublishForm.js
@@ -12,6 +12,7 @@ import ComponentEnvironments from '../Details/ComponentContentViews/ComponentEnv
 import './cvPublishForm.scss';
 import WizardHeader from '../components/WizardHeader';
 import { selectCVNeedsPublish } from '../Details/ContentViewDetailSelectors';
+import { truncate } from '../../../utils/helpers';
 
 const CVPublishForm = ({
   description,
@@ -83,7 +84,7 @@ const CVPublishForm = ({
                   <TextContent>{__('Repositories common to the selected content view versions will merge, resulting in a composite content view that is a union of all content from each of the content view versions.')}</TextContent>
                 </Alert>)
             }
-            {__('A new version of ')}<b>{composite ? <RegistryIcon /> : <EnterpriseIcon />} {name}</b>
+            {__('A new version of ')}<b>{composite ? <RegistryIcon /> : <EnterpriseIcon />} {truncate(name)}</b>
             {__(' will be created and automatically promoted to the ' +
               'Library environment. You can promote to other environments as well. ')
             }

--- a/webpack/scenes/ContentViews/Publish/CVPublishReview.js
+++ b/webpack/scenes/ContentViews/Publish/CVPublishReview.js
@@ -16,6 +16,7 @@ import ComponentEnvironments from '../Details/ComponentContentViews/ComponentEnv
 import { selectEnvironmentPaths, selectEnvironmentPathsStatus } from '../components/EnvironmentPaths/EnvironmentPathSelectors';
 import WizardHeader from '../components/WizardHeader';
 import { selectCVFilters, selectCVFiltersStatus } from '../Details/ContentViewDetailSelectors';
+import { truncate } from '../../../utils/helpers';
 
 const CVPublishReview = ({
   details: {
@@ -53,7 +54,7 @@ const CVPublishReview = ({
         title={__('Review details')}
         description={
           <>
-            {__('Review your currently selected changes for ')}<b>{composite ? <RegistryIcon /> : <EnterpriseIcon />} {name}.</b>
+            {__('Review your currently selected changes for ')}<b>{composite ? <RegistryIcon /> : <EnterpriseIcon />} {truncate(name)}.</b>
             {filtered && (
             <Alert
               ouiaId="filters-applied-alert"
@@ -78,7 +79,7 @@ const CVPublishReview = ({
         <Tbody>
           <Tr ouiaId="cv-publish-review-table-row">
             <Td>
-              <><ContentViewIcon composite={composite} description={name} /><InactiveText text={__('Newly published')} /></>
+              <><ContentViewIcon composite={composite} description={truncate(name)} /><InactiveText text={__('Newly published')} /></>
             </Td>
             <Td>
               {__('Version')} {nextVersion}

--- a/webpack/scenes/ContentViews/Publish/PublishContentViewWizard.js
+++ b/webpack/scenes/ContentViews/Publish/PublishContentViewWizard.js
@@ -15,6 +15,7 @@ import {
 import { stopPollingTask } from '../../Tasks/TaskActions';
 import { cvVersionTaskPollingKey } from '../ContentViewsConstants';
 import { getContentViewFilters } from '../Details/ContentViewDetailActions';
+import { truncate } from '../../../utils/helpers';
 
 const PublishContentViewWizard = ({
   details, show, onClose,
@@ -108,7 +109,7 @@ const PublishContentViewWizard = ({
   return (
     <Wizard
       title={__('Publish')}
-      description={currentStep === 3 ? __(`Publishing ${name}`) : __(`Determining settings for ${name}`)}
+      description={currentStep === 3 ? __(`Publishing ${truncate(name)}`) : __(`Determining settings for ${truncate(name)}`)}
       steps={steps}
       startAtStep={currentStep}
       // Let the wizard handle step change

--- a/webpack/scenes/ContentViews/Table/ContentViewsTable.js
+++ b/webpack/scenes/ContentViews/Table/ContentViewsTable.js
@@ -24,6 +24,7 @@ import InactiveText from '../components/InactiveText';
 import ContentViewVersionCell from './ContentViewVersionCell';
 import DetailsExpansion from '../expansions/DetailsExpansion';
 import ContentViewDeleteWizard from '../Delete/ContentViewDeleteWizard';
+import { truncate } from '../../../utils/helpers';
 
 const ContentViewTable = () => {
   const response = useSelector(selectContentViews);
@@ -265,7 +266,7 @@ const ContentViewTable = () => {
                   }}
                 />
                 <Td><ContentViewIcon position="right" composite={composite} /></Td>
-                <Td><Link to={`${urlBuilder('content_views', '')}${cvId}`}>{name}</Link></Td>
+                <Td><Link to={`${urlBuilder('content_views', '')}${cvId}`}>{truncate(name)}</Link></Td>
                 <Td>{lastPublished ? <LongDateTime date={lastPublished} showRelativeTimeTooltip /> : <InactiveText text={__('Not yet published')} />}</Td>
                 <Td><LastSync startedAt={startedAt} lastSync={lastTask} lastSyncWords={lastSyncWords} emptyMessage="N/A" /></Td>
                 <Td>{latestVersion ?

--- a/webpack/scenes/ContentViews/components/CVBreadCrumb.js
+++ b/webpack/scenes/ContentViews/components/CVBreadCrumb.js
@@ -10,6 +10,7 @@ import {
   selectCVDetails, selectCVDetailStatus, selectCVFilterDetails, selectCVFilterDetailStatus,
   selectCVVersionDetails, selectCVVersionDetailsStatus,
 } from '../Details/ContentViewDetailSelectors';
+import { truncate } from '../../../utils/helpers';
 
 const CVBreadcrumb = () => {
   const { id } = useParams();
@@ -47,7 +48,7 @@ const CVBreadcrumb = () => {
       Object.keys(breadcrumbItems).length === 1) {
       const cvRecordCrumb = {
         [`b_${cvDetails?.name}`]: {
-          render: () => (<Link to={`/content_views/${cvId}`}>{cvDetails?.name}</Link>),
+          render: () => (<Link to={`/content_views/${cvId}`}>{truncate(cvDetails?.name)}</Link>),
         },
       };
       const tabName = splitHash[1];

--- a/webpack/scenes/ContentViews/components/ContentViewSelect/ContentViewSelectOption.js
+++ b/webpack/scenes/ContentViews/components/ContentViewSelect/ContentViewSelectOption.js
@@ -7,7 +7,7 @@ import {
   global_palette_black_600 as pfDescriptionColor,
 } from '@patternfly/react-tokens';
 import ContentViewIcon from '../../../../scenes/ContentViews/components/ContentViewIcon';
-import { uniq } from '../../../../utils/helpers';
+import { truncate, uniq } from '../../../../utils/helpers';
 
 export const ContentViewDescription = ({ cv, versionNumber }) => {
   const descriptionStyle = {
@@ -63,7 +63,7 @@ const ContentViewSelectOption = ({ cv, env, value }) => (
         flexWrap={{ default: 'nowrap' }}
         alignItems={{ default: 'alignItemsFlexStart', sm: 'alignItemsFlexStart' }}
       >
-        {cv.name}
+        {truncate(cv.name)}
         <ContentViewDescription
           cv={cv}
           versionNumber={relevantVersionFromCv(cv, env)}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds truncated name/labels to UI where necessary.
#### Considerations taken when implementing this change?
Truncate truncates by default to 50 chars which seems like enough information for a CV name. The full name is seen on the CV details tab.
#### What are the testing steps for this pull request?
Create a CV with a loooong name
Navigate around the CV UI and make sure the UI doesn't get weird with the long way and truncates and displays CV info properly.