### PR TITLE
Fixes #37225 - Use new upload_profile template for UI subman refresh

### DIFF
--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/HostContentViewActions.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/HostContentViewActions.js
@@ -2,7 +2,7 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import { API_OPERATIONS, put } from 'foremanReact/redux/API';
 import { errorToast } from '../../../../../scenes/Tasks/helpers';
 import { foremanApi } from '../../../../../services/api';
-import { runCommand } from '../../Tabs/RemoteExecutionActions';
+import { uploadProfile } from '../../Tabs/RemoteExecutionActions';
 import HOST_CV_AND_ENV_KEY from './HostContentViewConstants';
 
 const updateHostContentViewAndEnvironment = (params, hostId, handleSuccess, handleError) => put({
@@ -17,9 +17,8 @@ const updateHostContentViewAndEnvironment = (params, hostId, handleSuccess, hand
 });
 
 export const runSubmanRepos =
-  (hostname, handleSuccess) => runCommand({
+  (hostname, handleSuccess) => uploadProfile({
     hostname,
-    command: 'subscription-manager repos',
     handleSuccess,
   });
 

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
@@ -31,6 +31,13 @@ const runCommandParams = ({ hostname, command }) =>
     feature: REX_FEATURES.RUN_COMMAND,
   });
 
+const uploadProfileParams = ({ hostname }) =>
+  baseParams({
+    hostname,
+    inputs: {},
+    feature: REX_FEATURES.KATELLO_UPLOAD_PROFILE,
+  });
+
 // used when we know the package name
 const katelloPackageInstallParams = ({ hostname, packageName }) =>
   baseParams({
@@ -141,6 +148,18 @@ export const runCommand = ({ hostname, command, handleSuccess }) => post({
   key: REX_JOB_INVOCATIONS_KEY,
   url: foremanApi.getApiUrl('/job_invocations'),
   params: runCommandParams({ hostname, command }),
+  handleSuccess: (response) => {
+    showRexToast(response);
+    if (handleSuccess) handleSuccess(response);
+  },
+  errorToast,
+});
+
+export const uploadProfile = ({ hostname, handleSuccess }) => post({
+  type: API_OPERATIONS.POST,
+  key: REX_JOB_INVOCATIONS_KEY,
+  url: foremanApi.getApiUrl('/job_invocations'),
+  params: uploadProfileParams({ hostname }),
   handleSuccess: (response) => {
     showRexToast(response);
     if (handleSuccess) handleSuccess(response);

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionConstants.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionConstants.js
@@ -10,4 +10,5 @@ export const REX_FEATURES = {
   KATELLO_HOST_ERRATA_INSTALL_BY_SEARCH: 'katello_errata_install_by_search',
   KATELLO_HOST_MODULE_STREAM_ACTION: 'katello_module_stream_action',
   RUN_COMMAND: 'run_script',
+  KATELLO_UPLOAD_PROFILE: 'katello_upload_profile',
 };


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Changed the `runSubmanRepos` action to use the new `upload_profile` job template
* Created a new REX action helper and added the new template into the constants

#### Considerations taken when implementing this change?
* Kept the `run_command` in case we need it

#### What are the testing steps for this pull request?

* Check out PR
* Goto all hosts and select a host that you have REX setup on
* Change the ENV/CV and do update host immediately with REX
* Check the job to make sure it used `upload_profile` instead of `run_command` and see the output