### PR TITLE
Fixes #37654 - Use custom pre/post snippets for errata templates

### DIFF
--- a/app/views/foreman/job_templates/install_errata.erb
+++ b/app/views/foreman/job_templates/install_errata.erb
@@ -14,6 +14,7 @@ foreign_input_sets:
 - template: Package Action - Script Default
   exclude: action,package
 %>
+<%= snippet_if_exists(template_name + " custom pre") %>
 <% if @host.operatingsystem.family == 'Suse' -%>
     <% advisories = input(:errata).split(',').join(' ') -%>
     <%= render_template('Package Action - Script Default', :action => 'install -n -t patch', :package => advisories) %>
@@ -21,3 +22,4 @@ foreign_input_sets:
     <% advisories = input(:errata).split(',').map { |e| "--advisory=#{e}" }.join(' ') -%>
     <%= render_template('Package Action - Script Default', :action => 'update-minimal', :package => advisories) %>
 <% end -%>
+<%= snippet_if_exists(template_name + " custom post") %>

--- a/app/views/foreman/job_templates/install_errata_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_errata_-_katello_ansible_default.erb
@@ -14,6 +14,7 @@ provider_type: Ansible
 kind: job_template
 %>
 
+<%= snippet_if_exists(template_name + " custom pre") %>
 <% if @host.operatingsystem.family == 'Suse' -%>
 <% advisories = input(:errata).split(',').join(' ') -%>
 <%= render_template('Run Command - Ansible Default', :command => "zypper -n install -t patch #{advisories}") %>
@@ -21,3 +22,4 @@ kind: job_template
 <% advisories = input(:errata).split(',').map { |e| "--advisory=#{e}" }.join(' ') -%>
 <%= render_template('Run Command - Ansible Default', :command => "yum -y update-minimal #{advisories}") %>
 <% end -%>
+<%= snippet_if_exists(template_name + " custom post") %>

--- a/app/views/foreman/job_templates/install_errata_by_search_query.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query.erb
@@ -19,9 +19,11 @@ foreign_input_sets:
 <% render_error(N_("No errata matching given search query")) if !input("Errata search query").blank? && advisory_ids.blank? -%>
 # RESOLVED_ERRATA_IDS=<%= advisory_ids.join(',') %>
 
+<%= snippet_if_exists(template_name + " custom pre") %>
 <% if @host.operatingsystem.family == 'Suse' -%>
     <%= render_template('Package Action - Script Default', :action => 'install -n -t patch', :package => advisory_ids.join(' ')) %>
 <% else -%>
     <% advisories = advisory_ids.map { |e| "--advisory=#{e}" }.join(' ') -%>
     <%= render_template('Package Action - Script Default', :action => 'update-minimal', :package => advisories) %>
 <% end -%>
+<%= snippet_if_exists(template_name + " custom post") %>

--- a/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
@@ -16,9 +16,11 @@ template_inputs:
 <% render_error(N_("No errata matching given search query")) if !input("Errata search query").blank? && advisory_ids.blank? -%>
 # RESOLVED_ERRATA_IDS=<%= advisory_ids.join(',') %>
 
+<%= snippet_if_exists(template_name + " custom pre") %>
 <% if @host.operatingsystem.family == 'Suse' -%>
 <%= render_template('Run Command - Ansible Default', :command => "zypper -n install -t patch #{advisory_ids.join(' ')}") %>
 <% else -%>
 <% advisories = advisory_ids.map { |e| "--advisory=#{e}" }.join(' ') -%>
 <%= render_template('Run Command - Ansible Default', :command => "yum -y update-minimal #{advisories}") %>
 <% end -%>
+<%= snippet_if_exists(template_name + " custom post") %>


### PR DESCRIPTION
Before and after Errata installation customers want to run certain tasks like taking a snapshot, write the current state to a 3rd party tool, etc.

