### PR TITLE
Fixes #37658 - explicitly set type to CUSTOM_CDN_TYPE

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -59,7 +59,7 @@ module Katello
     param_group :resource
     def update
       if params[:redhat_repository_url]
-        sync_task(::Actions::Katello::CdnConfiguration::Update, @organization.cdn_configuration, url: params[:redhat_repository_url])
+        sync_task(::Actions::Katello::CdnConfiguration::Update, @organization.cdn_configuration, url: params[:redhat_repository_url], type: CdnConfiguration::CUSTOM_CDN_TYPE)
       end
       super
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When updating CdnConfiguration from the old, deprecated redhat_repository_url parameter, explicitly set the CdnConfiguration type to CUSTOM. If we don't do this, the URL gets reset to redhat.com automatically.

#### Considerations taken when implementing this change?

None. The param is deprecated, but I expect it to work until its removed.

#### What are the testing steps for this pull request?

Update redhat_repository_url via a PUT request to the org endpoint.
Verify the data changed in the DB -- not only the task was successful (this is what the unit test test and I didn't see a good way to assert the DB state)