### PR TITLE
Fixes #37633 - Newly published CV version shows need_published as true

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -864,7 +864,9 @@ module Katello
       }
 
       table = Audit.arel_table
-      repository_condition = table[:auditable_id].eq(id).and(audited_changes_like.call("repository_ids"))
+      repository_condition = table[:auditable_id].eq(id)
+                                                 .and(table[:auditable_type].eq('Katello::ContentView'))
+                                                 .and(audited_changes_like.call("repository_ids"))
 
       cv_repository_condition = table[:auditable_id].in(cv_repository_ids)
                                                     .and(table[:auditable_type].eq('Katello::Repository'))


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Scope audit query to auditable_type content views
#### Considerations taken when implementing this change?
For tracking audits on repository additions/removals on CV, we were not scoping the query to content view objects.
#### What are the testing steps for this pull request?
On a fresh box:
1. Create a custom repo.
2. Create a CV and publish
3. You'll see the ⬆️ next to newly published version and cv.needs_publish? will return true in console.
4. With this change, the version will correctly show as not needing publish.