### PR TITLE
Fixes #37657 - Prevent assigning multiple environments after registration

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -101,6 +101,10 @@ module Katello
       end
 
       def content_view_environments=(new_cves)
+        if new_cves.length > 1 && !Setting['allow_multiple_content_views']
+          fail ::Katello::Errors::MultiEnvironmentNotSupportedError,
+          _("Assigning a host to multiple content view environments is not enabled.")
+        end
         super(new_cves)
         Katello::ContentViewEnvironmentContentFacet.reprioritize_for_content_facet(self, new_cves)
         self.content_view_environments.reload unless self.new_record?

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -363,7 +363,7 @@ Foreman::Plugin.register :katello do
         type: :boolean,
         default: false,
         full_name: N_('Allow multiple content views'),
-        description: N_("Allow a host to be registered to multiple content view environments with 'subscription-manager register --environments'.") # TODO: update this description when AKs support this setting as well
+        description: N_("Allow a host to be assigned to multiple content view environments with 'subscription-manager register --environments' or 'subscription-manager environments --set'.") # TODO: update this description when AKs support this setting as well
 
       setting 'content_default_http_proxy',
         type: :string,

--- a/test/models/content_view_environment_content_facet_test.rb
+++ b/test/models/content_view_environment_content_facet_test.rb
@@ -7,7 +7,12 @@ module Katello
       @content_facet = katello_content_facets(:content_facet_one)
     end
 
+    def teardown
+      Setting['allow_multiple_content_views'] = false
+    end
+
     def test_reprioritize_for_content_facet
+      Setting['allow_multiple_content_views'] = true
       ::Host::Managed.any_instance.stubs(:update_candlepin_associations)
       @content_facet.content_view_environments = [
         katello_content_view_environments(:library_dev_view_dev),

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -63,10 +63,19 @@ module Katello
     end
 
     def test_content_view_environments=
+      Setting['allow_multiple_content_views'] = true
       Katello::ContentViewEnvironmentContentFacet.expects(:reprioritize_for_content_facet).twice
       content_facet.content_view_environments.reload
       content_facet.content_view_environments = [katello_content_view_environments(:library_dev_view_dev), katello_content_view_environments(:library_dev_staging_view_dev)]
       assert_equal 2, content_facet.content_view_environments.length
+    end
+
+    def test_multi_cv_not_enabled
+      Setting['allow_multiple_content_views'] = false
+      assert_equal 1, content_facet.content_view_environments.length
+      assert_raises(::Katello::Errors::MultiEnvironmentNotSupportedError) do
+        content_facet.content_view_environments = [katello_content_view_environments(:library_dev_view_dev), katello_content_view_environments(:library_dev_staging_view_dev)]
+      end
     end
 
     def test_audit_for_content_facet
@@ -439,6 +448,10 @@ module Katello
     def setup
       assert host #force lazy load
       assert host_one
+    end
+
+    def teardown
+      Setting['allow_multiple_content_views'] = false
     end
 
     def test_content_view_search


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add a check in `ContentFacet#content_view_environments=` to prevent assigning multiple content view environments unless `Setting['allow_multiple_content_views']` is turned on.

Also includes some small refactoring / cleanup and wording updates.

#### Considerations taken when implementing this change?

Putting the check in `content_view_environments=` allows us to cover both the current case (`subscription-manager environments --set`) and also API/Hammer, once that's built.

#### What are the testing steps for this pull request?

Have a registered host
Have at least 2 non-Library environments available to register to (`subscription-manager environments --list-enabled`)
Have the allow_multiple_content_views Setting set to off

Attempt to assign multiple environments:
```
subscription-manager environments --set dev/cv1,prod/cv2
```

Before:
```
# subscription-manager environments --set dev/cv1,prod/cv2 --username admin --password changeme
Environments updated.

# subscription-manager environments --list-enabled
+-------------------------------------------+
          Environments
+-------------------------------------------+
Name:        dev/cv1
Description: 

Name:        prod/cv2
Description: 

```

Now:
```
# subscription-manager environments --set dev/cv1,prod/cv2 --username admin --password changeme
Assigning a host to multiple content view environments is not enabled. (HTTP error code 400: Bad Request)
```

However, you can still go from multi-environment to single-environment, even with the setting off:
```
# subscription-manager environments --set Library --username admin --password changeme
Environments updated.
```




