### PR TITLE
Fixes #37666 - Fix Candlepin reset in reset rake task

### DIFF
--- a/lib/katello/tasks/reset.rake
+++ b/lib/katello/tasks/reset.rake
@@ -30,10 +30,9 @@ namespace :katello do
       puts "\e[33mStarting Candlepin Reset\e[0m\n\n"
 
       system(service_stop.gsub("%s", 'tomcat'))
-      system("sudo runuser - postgres -c 'dropdb candlepin'")
-      system("sudo runuser - postgres -c 'createdb candlepin'")
-      system("sudo /usr/share/candlepin/cpdb --create --schema-only")
-      system("sudo /usr/share/candlepin/cpdb --update")
+      system("sudo /usr/share/candlepin/cpdb --drop -u postgres")
+      system("sudo /usr/share/candlepin/cpdb --create -u postgres")
+      system("sudo /usr/share/candlepin/cpdb --update-schema")
       system(service_start.gsub("%s", 'tomcat'))
       puts "\e[32mCandlepin Database Reset Complete\e[0m\n\n"
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* With the recent changes to Candlepin and `cpdb` we forgot to update the reset rake task
```bash
basically, instead of cpdb --create --schema-only you need to be now running cpdb --create  (--schema-only no longer exists), 

instead of cpdb --update the new command is now cpdb --update-schema  (although, cpdb --update
may still work, because bash knows --update is start of --update-schema)
```

* Instead of using `runuser postgres` cpdb can create and drop the database for us, so switched to that for all native candlepin db actions.

#### Considerations taken when implementing this change?
* Make sure the Candlepin database gets recreated still

#### What are the testing steps for this pull request?
* Check out PR
* Reset your devel box `bundle exec rake katello:reset --trace`
* Verify you do not see the error message anymore