### PR TITLE
Fixes #37668 - enable container push by default

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -84,7 +84,6 @@ module Katello
 
     def container_push_prop_validation(props = nil)
       # Handle validation and repo creation for container pushes before talking to pulp
-      return false unless confirm_push_settings
       props = parse_blob_push_props if props.nil?
       return false unless check_blob_push_field_syntax(props)
 
@@ -771,15 +770,6 @@ module Katello
       end
       render_error('custom_error', :status => :not_found,
                    :locals => { :message => "Registry not configured" })
-    end
-
-    def confirm_push_settings
-      return true if SETTINGS.dig(:katello, :container_image_registry, :allow_push)
-      render_podman_error(
-        "UNSUPPORTED",
-        _("Registry push is not enabled. To enable, add ':katello:'->':container_image_registry:'->':allow_push: true' in the katello settings file."),
-        :unprocessable_entity
-      )
     end
 
     def request_url

--- a/test/controllers/api/registry/registry_proxies_controller_test.rb
+++ b/test/controllers/api/registry/registry_proxies_controller_test.rb
@@ -29,7 +29,6 @@ module Katello
       setup_permissions
       setup_controller_defaults_api
 
-      SETTINGS[:katello][:container_image_registry] = {crane_url: 'https://localhost:5000', crane_ca_cert_file: '/etc/pki/katello/certs/katello-default-ca.crt', allow_push: true}
       File.delete("#{Rails.root}/tmp/manifest.json") if File.exist?("#{Rails.root}/tmp/manifest.json")
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Removes the necessity of having a setting for pushing container images into Katello. 

#### Considerations taken when implementing this change?
Requires https://github.com/Katello/katello/pull/11071

#### What are the testing steps for this pull request?
Try pushing a container without having the old allow_push setting, or any `:container_image_registry` setting at all.