### PR TITLE
Fixes #37674 - Change All Hosts kebab menu to match design [Katello]

### DIFF
--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -5,6 +5,7 @@ import { Modal, Button, Alert, Checkbox, TextContent, Text, TextVariants } from 
 import { translate as __ } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
+import { useUrlParams } from 'foremanReact/components/PF4/TableIndexPage/Table/TableHooks';
 import { selectAPIStatus } from 'foremanReact/redux/API/APISelectors';
 import EnvironmentPaths from '../../../../../scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths';
 import { ENVIRONMENT_PATHS_KEY } from '../../../../../scenes/ContentViews/components/EnvironmentPaths/EnvironmentPathConstants';
@@ -34,6 +35,7 @@ const ChangeHostCVModal = ({
   hostName,
   multiEnv,
 }) => {
+  const { content_view_assignment: initialCVModalOpen } = useUrlParams();
   const [selectedEnvForHost, setSelectedEnvForHost]
     = useState([]);
 
@@ -61,6 +63,13 @@ const ChangeHostCVModal = ({
     setSelectedCVForHost(null);
     setSelectedEnvForHost([]);
     closeModal();
+  };
+
+  const handleCancel = () => {
+    handleModalClose();
+    if (initialCVModalOpen) {
+      window.history.back();
+    }
   };
 
   const selectedEnv = selectedEnvForHost?.[0];
@@ -133,8 +142,8 @@ const ChangeHostCVModal = ({
     >
       {__('Save')}
     </Button>,
-    <Button key="cancel" ouiaId="change-host-cv-modal-cancel-button" variant="link" onClick={handleModalClose}>
-      Cancel
+    <Button key="cancel" ouiaId="change-host-cv-modal-cancel-button" variant="link" onClick={handleCancel}>
+      {__('Cancel')}
     </Button>,
   ]);
   return (

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -18,6 +18,7 @@ import { FormattedMessage } from 'react-intl';
 import { urlBuilder } from 'foremanReact/common/urlHelpers';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
+import { useUrlParams } from 'foremanReact/components/PF4/TableIndexPage/Table/TableHooks';
 import PropTypes from 'prop-types';
 import ContentViewIcon from '../../../../../scenes/ContentViews/components/ContentViewIcon';
 import { hasRequiredPermissions, hostIsRegistered } from '../../hostDetailsHelpers';
@@ -100,7 +101,8 @@ const HostContentViewDetails = ({
 }) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const toggleHamburger = () => setIsDropdownOpen(prev => !prev);
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { content_view_assignment: initialCVModalOpen } = useUrlParams();
+  const [isModalOpen, setIsModalOpen] = useState(!!initialCVModalOpen);
   const closeModal = () => setIsModalOpen(false);
   const openModal = () => {
     setIsDropdownOpen(false);

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/__tests__/contentViewDetailsCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/__tests__/contentViewDetailsCard.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from 'react-testing-lib-wrapper';
+import * as hooks from 'foremanReact/components/PF4/TableIndexPage/Table/TableHooks';
 import ContentViewDetailsCard from '../ContentViewDetailsCard';
 
 const baseHostDetails = {
@@ -40,6 +41,10 @@ const baseHostDetails = {
     uuid: '123',
   },
 };
+
+beforeEach(() => {
+  jest.spyOn(hooks, 'useUrlParams').mockImplementation(() => ({}));
+});
 
 test('shows content view details when host is registered', () => {
   const { getByText } = render(<ContentViewDetailsCard hostDetails={baseHostDetails} />);

--- a/webpack/components/extensions/Hosts/ActionsBar/ActionsBar.scss
+++ b/webpack/components/extensions/Hosts/ActionsBar/ActionsBar.scss
@@ -1,0 +1,14 @@
+.disabled-menu-item-span {
+  width: 25em;
+  display: flex;
+  flex-direction: row;
+}
+
+.disabled-menu-item-p {
+  margin-left: 0.6em;
+  word-break: normal;
+}
+
+.disabled-menu-item-icon {
+  font-size: small;
+}

--- a/webpack/components/extensions/Hosts/ActionsBar/index.js
+++ b/webpack/components/extensions/Hosts/ActionsBar/index.js
@@ -1,18 +1,37 @@
 import React, { useContext, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { DropdownItem } from '@patternfly/react-core';
+import { Menu, MenuItem } from '@patternfly/react-core';
+import { BanIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { foremanUrl } from 'foremanReact/common/helpers';
 import { ForemanHostsIndexActionsBarContext } from 'foremanReact/components/HostsIndex';
 import { useForemanModal } from 'foremanReact/components/ForemanModal/ForemanModalHooks';
 import { addModal } from 'foremanReact/components/ForemanModal/ForemanModalActions';
 import { useForemanOrganization } from 'foremanReact/Root/Context/ForemanContext';
+import './ActionsBar.scss';
+
+const DisabledMenuItemDescription = ({ disabledReason }) => (
+  <span className="disabled-menu-item-span">
+    <span className="disabled-menu-item-icon">
+      <BanIcon />
+    </span>
+    <p className="disabled-menu-item-p">
+      {disabledReason}
+    </p>
+  </span>
+);
+
+DisabledMenuItemDescription.propTypes = {
+  disabledReason: PropTypes.string.isRequired,
+};
 
 const HostActionsBar = () => {
   const {
     fetchBulkParams,
     selectedCount,
     selectAllMode,
+    setMenuOpen,
   } = useContext(ForemanHostsIndexActionsBarContext);
 
   const dispatch = useDispatch();
@@ -40,45 +59,51 @@ const HostActionsBar = () => {
   }
 
   return (
-    <>
-      <DropdownItem
-        ouiaId="change-content-s-dropdown-item"
-        key="change-content-source-dropdown-item"
-        href={href}
-        isDisabled={selectedCount === 0}
-      >
-        {__('Change content source')}
-      </DropdownItem>
-      <DropdownItem
-        ouiaId="bulk-change-cv-dropdown-item"
-        key="bulk-change-cv-dropdown-item"
-        onClick={openBulkChangeCVModal}
-        isDisabled={selectedCount === 0}
-        isAriaDisabled={!orgId}
-        tooltip={!orgId && __('To change content view environments, a specific organization must be selected from the organization context.')}
-      >
-        {__('Change content view environments')}
-      </DropdownItem>
-      <DropdownItem
-        ouiaId="bulk-packages-wizard-dropdown-item"
-        key="bulk-packages-wizard-dropdown-item"
-        onClick={openBulkPackagesWizardModal}
-        isDisabled={selectedCount === 0}
-        isAriaDisabled={!orgId}
-        tooltip={!orgId && __('To manage host packages, a specific organization must be selected from the organization context.')}
-      >
-        {__('Manage packages')}
-      </DropdownItem>
-      <DropdownItem
-        ouiaId="bulk-errata-wizard-dropdown-item"
-        key="bulk-errata-wizard-dropdown-item"
-        onClick={openBulkErrataWizardModal}
-        isDisabled={selectedCount === 0}
-      >
-        {__('Manage errata')}
-      </DropdownItem>
-
-    </>
+    <MenuItem
+      itemId="content-flyout-item"
+      key="content-flyout"
+      isDisabled={selectedCount === 0}
+      flyoutMenu={(
+        <Menu ouiaId="content-flyout-menu" onSelect={() => setMenuOpen(false)}>
+          <MenuItem
+            itemId="bulk-packages-wizard-dropdown-item"
+            key="bulk-packages-wizard-dropdown-item"
+            onClick={openBulkPackagesWizardModal}
+            isDisabled={selectedCount === 0 || !orgId}
+            description={!orgId && <DisabledMenuItemDescription disabledReason={__('To manage host packages, a specific organization must be selected from the organization context.')} />}
+          >
+            {__('Packages')}
+          </MenuItem>
+          <MenuItem
+            itemId="bulk-errata-wizard-dropdown-item"
+            key="bulk-errata-wizard-dropdown-item"
+            onClick={openBulkErrataWizardModal}
+            isDisabled={selectedCount === 0}
+          >
+            {__('Errata')}
+          </MenuItem>
+          <MenuItem
+            itemId="change-content-s-dropdown-item"
+            key="change-content-source-dropdown-item"
+            to={href}
+            isDisabled={selectedCount === 0}
+          >
+            {__('Content source')}
+          </MenuItem>
+          <MenuItem
+            itemId="bulk-change-cv-dropdown-item"
+            key="bulk-change-cv-dropdown-item"
+            onClick={openBulkChangeCVModal}
+            isDisabled={selectedCount === 0 || !orgId}
+            description={!orgId && <DisabledMenuItemDescription disabledReason={__('To change content view environments, a specific organization must be selected from the organization context.')} />}
+          >
+            {__('Content view environments')}
+          </MenuItem>
+        </Menu>
+        )}
+    >
+      {__('Manage content')}
+    </MenuItem>
   );
 };
 

--- a/webpack/components/extensions/Hosts/ActionsBar/index.js
+++ b/webpack/components/extensions/Hosts/ActionsBar/index.js
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { Menu, MenuItem } from '@patternfly/react-core';
+import { Menu, MenuItem, MenuContent, MenuList } from '@patternfly/react-core';
 import { BanIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { foremanUrl } from 'foremanReact/common/helpers';
@@ -65,40 +65,44 @@ const HostActionsBar = () => {
       isDisabled={selectedCount === 0}
       flyoutMenu={(
         <Menu ouiaId="content-flyout-menu" onSelect={() => setMenuOpen(false)}>
-          <MenuItem
-            itemId="bulk-packages-wizard-dropdown-item"
-            key="bulk-packages-wizard-dropdown-item"
-            onClick={openBulkPackagesWizardModal}
-            isDisabled={selectedCount === 0 || !orgId}
-            description={!orgId && <DisabledMenuItemDescription disabledReason={__('To manage host packages, a specific organization must be selected from the organization context.')} />}
-          >
-            {__('Packages')}
-          </MenuItem>
-          <MenuItem
-            itemId="bulk-errata-wizard-dropdown-item"
-            key="bulk-errata-wizard-dropdown-item"
-            onClick={openBulkErrataWizardModal}
-            isDisabled={selectedCount === 0}
-          >
-            {__('Errata')}
-          </MenuItem>
-          <MenuItem
-            itemId="change-content-s-dropdown-item"
-            key="change-content-source-dropdown-item"
-            to={href}
-            isDisabled={selectedCount === 0}
-          >
-            {__('Content source')}
-          </MenuItem>
-          <MenuItem
-            itemId="bulk-change-cv-dropdown-item"
-            key="bulk-change-cv-dropdown-item"
-            onClick={openBulkChangeCVModal}
-            isDisabled={selectedCount === 0 || !orgId}
-            description={!orgId && <DisabledMenuItemDescription disabledReason={__('To change content view environments, a specific organization must be selected from the organization context.')} />}
-          >
-            {__('Content view environments')}
-          </MenuItem>
+          <MenuContent>
+            <MenuList>
+              <MenuItem
+                itemId="bulk-packages-wizard-dropdown-item"
+                key="bulk-packages-wizard-dropdown-item"
+                onClick={openBulkPackagesWizardModal}
+                isDisabled={selectedCount === 0 || !orgId}
+                description={!orgId && <DisabledMenuItemDescription disabledReason={__('To manage host packages, a specific organization must be selected from the organization context.')} />}
+              >
+                {__('Packages')}
+              </MenuItem>
+              <MenuItem
+                itemId="bulk-errata-wizard-dropdown-item"
+                key="bulk-errata-wizard-dropdown-item"
+                onClick={openBulkErrataWizardModal}
+                isDisabled={selectedCount === 0}
+              >
+                {__('Errata')}
+              </MenuItem>
+              <MenuItem
+                itemId="change-content-s-dropdown-item"
+                key="change-content-source-dropdown-item"
+                to={href}
+                isDisabled={selectedCount === 0}
+              >
+                {__('Content source')}
+              </MenuItem>
+              <MenuItem
+                itemId="bulk-change-cv-dropdown-item"
+                key="bulk-change-cv-dropdown-item"
+                onClick={openBulkChangeCVModal}
+                isDisabled={selectedCount === 0 || !orgId}
+                description={!orgId && <DisabledMenuItemDescription disabledReason={__('To change content view environments, a specific organization must be selected from the organization context.')} />}
+              >
+                {__('Content view environments')}
+              </MenuItem>
+            </MenuList>
+          </MenuContent>
         </Menu>
         )}
     >

--- a/webpack/components/extensions/Hosts/BulkActions/BulkErrataWizard/BulkErrataWizard.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkErrataWizard/BulkErrataWizard.js
@@ -118,7 +118,6 @@ const BulkErrataWizard = () => {
   return (
     <BulkErrataWizardContext.Provider value={BulkErrataWizardContextData}>
       <Wizard
-        title="Manage errata wizard"
         header={<WizardHeader title={__('Manage errata')} onClose={closeModal} />}
       >
         <WizardStep

--- a/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/BulkPackagesWizard.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/BulkPackagesWizard.js
@@ -153,7 +153,6 @@ const BulkPackagesWizard = () => {
   return (
     <BulkPackagesWizardContext.Provider value={bulkPackagesWizardContextData}>
       <Wizard
-        title="Manage packages wizard"
         header={<WizardHeader title={__('Manage packages')} onClose={closeModal} />}
       >
         <WizardStep

--- a/webpack/components/extensions/Hosts/TableRowActions/index.js
+++ b/webpack/components/extensions/Hosts/TableRowActions/index.js
@@ -1,0 +1,17 @@
+import { translate as __ } from 'foremanReact/common/I18n';
+import { foremanUrl } from 'foremanReact/common/helpers';
+
+const hostTableRowActions = (hostDetails) => {
+  const hostIsRegistered = hostDetails?.subscription_facet_attributes?.uuid;
+  return [
+    {
+      title: __('Change content view environments'),
+      onClick: () => {
+        window.location.href = foremanUrl(`hosts/${hostDetails.display_name}#/Overview?content_view_assignment=true`);
+      },
+      isDisabled: !hostIsRegistered,
+    },
+  ];
+};
+
+export default hostTableRowActions;

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -4,8 +4,10 @@ import { registerReducer } from 'foremanReact/common/MountingService';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { registerColumns } from 'foremanReact/components/HostsIndex/Columns/core';
 import componentRegistry from 'foremanReact/components/componentRegistry';
+import { registerGetActions } from 'foremanReact/components/HostsIndex/TableRowActions/core';
 
 import hostsIndexColumnExtensions from './ForemanColumnExtensions/index';
+import hostTableRowActions from './components/extensions/Hosts/TableRowActions';
 import SystemStatuses from './components/extensions/about';
 import {
   RegistrationCommands,
@@ -94,7 +96,11 @@ addGlobalFill('_all-hosts-modals', 'BulkPackagesWizardModal', <BulkPackagesWizar
 addGlobalFill('_all-hosts-modals', 'BulkErrataWizardModal', <BulkErrataWizardModal key="bulk-errata-wizard-modal" />, 200);
 
 registerColumns(hostsIndexColumnExtensions);
-
+registerGetActions({
+  pluginName: 'katello',
+  getActionsFunc: hostTableRowActions,
+  tableName: 'hosts',
+});
 
 componentRegistry.register({
   name: 'ActivationKeysSearch',


### PR DESCRIPTION
Requires https://github.com/theforeman/foreman/pull/10252

#### What are the changes introduced in this pull request?

Rearrange the All Hosts kebab menu to match existing designs.
- [x] Main kebab with flyout menu
- [x] Single-host table row kebab

#### Considerations taken when implementing this change?

The fly-out menu in the design required a switch in Foreman from a `<Dropdown>` to a `<Menu>` component, which does not handle its own open/closed state. Therefore, I had to add `menuOpen` to the `ForemanActionsBarContext` so that Katello can close its own submenu when the user clicks on something.

Also, previously we had a solution in place for when users have the "Any Organization" context selected, which would disable menu items with a tooltip explaining why they are disabled. This was accomplished through `Dropdown`'s `isAriaDisabled` and `tooltip` properties, neither of which are available on `Menu`. So I had to come up with a different solution. I ended up using an icon and text in the menu item description.

For the single-host table row kebab menu, Katello must contribute 'Change content view environments' (renamed from 'Lifecycle environment' in the mockup.) Since the table row actions only take a plain object and not a React component (thanks, Patternfly..), I found that accessing the function to open the BulkChangeHostCVModal from the table row action was simply too hard, and React yelled at me. After much strife I went back to the drawing board and discovered that the easiest way to accomplish this was via a URL redirect to the host details page. 

#### What are the testing steps for this pull request?

make sure everything works as expected in the menu