### PR TITLE
Fixes #37681 - sort content types in ACS error message

### DIFF
--- a/app/models/katello/alternate_content_source.rb
+++ b/app/models/katello/alternate_content_source.rb
@@ -54,7 +54,7 @@ module Katello
     validates :content_type, inclusion: {
       in: ->(_) { RepositoryTypeManager.defined_repository_types.keys & CONTENT_TYPES },
       allow_blank: false,
-      message: ->(_, _) { _("is not allowed for ACS. Must be one of the following: %s") % (RepositoryTypeManager.defined_repository_types.keys & CONTENT_TYPES).join(',') }
+      message: ->(_, _) { _("is not allowed for ACS. Must be one of the following: %s") % (RepositoryTypeManager.defined_repository_types.keys & CONTENT_TYPES).sort.join(',') }
     }
     validates :content_type, if: -> { rhui? }, inclusion: {
       in: [::Katello::Repository::YUM_TYPE],


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The content types are sorted before printing the message

#### Considerations taken when implementing this change?

None

#### What are the testing steps for this pull request?

CI is green on Ruby 2.7
