### PR TITLE
Fixes #37694 - Repo discovery should only return repos under the provided url tree

### DIFF
--- a/app/lib/katello/resources/discovery/yum.rb
+++ b/app/lib/katello/resources/discovery/yum.rb
@@ -22,7 +22,7 @@ module Katello
           if @uri.scheme == 'file'
             crawl_file_path(uri(resume_point))
           elsif %w(http https).include?(@uri.scheme)
-            spidr_crawl_pages(resume_point)
+            spidr_crawl_pages(uri(resume_point))
           end
         end
 
@@ -54,6 +54,7 @@ module Katello
         end
 
         def spidr_crawl_pages(url)
+          url = url.to_s
           user, password = @upstream_username, @upstream_password
           Spidr.site(url, proxy: spidr_proxy_details) do |spider|
             spider.authorized.add(url, user, password) if user && password
@@ -85,8 +86,7 @@ module Katello
           # * link ends with '/' so it should be a directory
           # * link doesn't end with '/Packages/', as this increases
           #       processing time and memory usage considerably
-
-          return url.hostname == @uri.hostname && !@crawled.include?(url.to_s) &&
+          return url.path.starts_with?(@uri.path) && url.hostname == @uri.hostname && !@crawled.include?(url.to_s) &&
             url.path.ends_with?('/') && !url.path.ends_with?('/Packages/')
         end
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Ensure that path of URL being crawled is child of the URL path passed.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Create 2 products and create and sync a repo in each of the products.
Run a repo discovery on the Published at URL for one of the repos/products.
(https://centos9-katello-devel.sajha.example.com/pulp/content/Default_Organization/Library/custom/product/)  

You should only see repos under that path and not all repos hosted under pulp/content.
