### PR TITLE
Fixes #37703 - Use :default_location_subscribed_hosts in registration

### DIFF
--- a/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
@@ -31,6 +31,10 @@ module Katello
         super.merge(rhsm_url: smart_proxy.rhsm_url, pulp_content_url: smart_proxy.pulp_content_url)
       end
 
+      def default_location
+        Location.authorized(:view_locations).find_by(title: Setting[:default_location_subscribed_hosts]) || super
+      end
+
       private
 
       def smart_proxy


### PR DESCRIPTION
Required Foreman PR: https://github.com/theforeman/foreman/pull/10259

#### What are the changes introduced in this pull request?
In host registration, we ignored the value of the `default_location_subscribed_hosts` setting.
This PR is fixing it.

#### Considerations taken when implementing this change?
https://issues.redhat.com/browse/SAT-23047

#### What are the testing steps for this pull request?
* Create a new organization
* Set it in the `default_location_subscribed_hosts` setting
* Generate registration command, but **DO NOT SELECT** location in the form
* Register host
* Check that the host has a location from the setting
