### PR TITLE
Fixes #37704 - Do not require content_facet_attributes for host updates

### DIFF
--- a/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
@@ -42,7 +42,8 @@ module Katello
         end
 
         def set_content_view_environments
-          return if @host&.content_facet.blank? ||
+          content_facet_attributes = params.dig(:host, :content_facet_attributes)
+          return if content_facet_attributes.blank? || @host&.content_facet.blank? ||
             (cve_params[:content_view_id].present? && cve_params[:lifecycle_environment_id].present?)
           new_cves = nil
           if cve_params[:content_view_environments].present? && cve_params[:content_view_environment_ids].blank?


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Do not require content_facet_attributes for host updates
#### Considerations taken when implementing this change?
Get nightlies green which are currently failing looking for the content_facet_attributes in host params when doing unrelated host updates
#### What are the testing steps for this pull request?
Update a host without updating cve on the API.
Ex: Update comments on the host details card on new host details page.

Without change:
You'll get the below error:
```
14:17:20 rails.1   | 2024-07-31T14:17:20 [I|app|e6e4e2bb] Started PUT "/api/hosts/centos9-host2.sajha.example.com" for 192.168.121.1 at 2024-07-31 14:17:20 +0000
14:17:20 rails.1   | 2024-07-31T14:17:20 [I|app|e6e4e2bb] Processing by Api::V2::HostsController#update as JSON
14:17:20 rails.1   | 2024-07-31T14:17:20 [I|app|e6e4e2bb]   Parameters: {"comment"=>"test", "apiv"=>"v2", "id"=>"centos9-host2.sajha.example.com", "host"=>{"comment"=>"test"}}
14:17:20 rails.1   | 2024-07-31T14:17:20 [W|app|e6e4e2bb] Action failed
14:17:20 rails.1   | 2024-07-31T14:17:20 [I|app|e6e4e2bb] Backtrace for 'Action failed' error (ActionController::ParameterMissing): param is missing or the value is empty: content_facet_attributes
14:17:20 rails.1   |  e6e4e2bb | Did you mean?  comment
14:17:20 rails.1   |  e6e4e2bb | /home/vagrant/foreman/.vendor/ruby/3.0.0/gems/actionpack-6.1.7.8/lib/action_controller/metal/strong_parameters.rb:507:in `require'
14:17:20 rails.1   |  e6e4e2bb | /home/vagrant/katello/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb:67:in `cve_params'
14:17:20 rails.1   |  e6e4e2bb | /home/vagrant/katello/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb:46:in `set_content_view_environments'

```

With change:
You should be able to successfully update non-cve params on hosts