### PR TITLE
Fixes #37696 - Add convert2rhel env fact to host subscription facet

### DIFF
--- a/app/models/katello/concerns/subscription_facet_host_extensions.rb
+++ b/app/models/katello/concerns/subscription_facet_host_extensions.rb
@@ -28,6 +28,7 @@ module Katello
         scoped_search :on => :registered_through, :relation => :subscription_facet, :complete_value => true, :only_explicit => true
         scoped_search :on => :registered_at, :relation => :subscription_facet, :rename => :registered_at, :only_explicit => true
         scoped_search :on => :uuid, :relation => :subscription_facet, :rename => :subscription_uuid, :only_explicit => true
+        scoped_search :on => :convert2rhel_through_foreman, :relation => :subscription_facet, :only_explicit => true
         scoped_search :relation => :activation_keys, :on => :name, :rename => :activation_key, :complete_value => true, :ext_method => :find_by_activation_key
         scoped_search :relation => :activation_keys, :on => :id, :rename => :activation_key_id, :complete_value => true, :ext_method => :find_by_activation_key_id,
                       :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER

--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -297,6 +297,18 @@ module Katello
         false
       end
 
+      def self.populate_fields_from_facts(host, parser, _type, _source_proxy)
+        has_convert2rhel = parser.facts.key?('conversions.env.CONVERT2RHEL_THROUGH_FOREMAN')
+        # Add in custom convert2rhel fact if system was converted using convert2rhel through Katello
+        # We want the value nil unless the custom fact is present otherwise we get a 0 in the database which if debugging
+        # might make you think it was converted2rhel but not with satellite, that is why I have the tenary below.
+        facet = host.subscription_facet || host.build_subscription_facet
+        facet.attributes = {
+          convert2rhel_through_foreman: has_convert2rhel ? ::Foreman::Cast.to_bool(parser.facts['conversions.env.CONVERT2RHEL_THROUGH_FOREMAN']) : nil
+        }.compact
+        facet.save unless facet.new_record?
+      end
+
       private
 
       def update_status(status_class, **args)

--- a/app/views/katello/api/v2/subscription_facet/base.json.rabl
+++ b/app/views/katello/api/v2/subscription_facet/base.json.rabl
@@ -1,4 +1,4 @@
-attributes :id, :uuid, :last_checkin, :service_level, :release_version, :autoheal, :registered_at, :registered_through, :purpose_role, :purpose_usage, :hypervisor
+attributes :id, :uuid, :last_checkin, :service_level, :release_version, :autoheal, :registered_at, :registered_through, :purpose_role, :purpose_usage, :hypervisor, :convert2rhel_through_foreman
 
 child :user => :user do
   attributes :id, :login

--- a/db/migrate/20240729192228_add_convert2rhel_to_host_facets.rb
+++ b/db/migrate/20240729192228_add_convert2rhel_to_host_facets.rb
@@ -1,0 +1,9 @@
+class AddConvert2rhelToHostFacets < ActiveRecord::Migration[6.1]
+  def up
+    add_column :katello_subscription_facets, :convert2rhel_through_foreman, :int4
+  end
+
+  def down
+    remove_column :subscription_facets, :convert2rhel_through_foreman
+  end
+end

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -41,6 +41,19 @@ module Katello
       assert_includes ::Host.search_for("role = satellite"), host
     end
 
+    def test_convert2rhel_through_foreman_on_host
+      subscription_facet.update(convert2rhel_through_foreman: 1)
+      assert_equal 1, host.subscription_facet.convert2rhel_through_foreman
+      assert_includes ::Host.search_for("convert2rhel_through_foreman = 1"), host
+    end
+
+    def test_convert2rhel_through_foreman_not_on_host
+      # We want the value nil unless the custom fact is present otherwise we get a 0 in the database which if debugging
+      # might make you think it was converted2rhel but not with satellite.
+      assert_nil host.subscription_facet.convert2rhel_through_foreman
+      refute_equal 0, host.subscription_facet.convert2rhel_through_foreman
+    end
+
     def test_search_addon
       host.subscription_facet.purpose_addons << katello_purpose_addons(:addon)
       assert_includes ::Host.search_for("addon = \"Test Addon\""), host


### PR DESCRIPTION
Convert2rhel creates a custom fact with an env variable, if it got converted through Satellite or through the Customer Portal. It looks like this:

```bash
[root@toledo8 ~]# cat /etc/rhsm/facts/convert2rhel.facts {
"conversions.version": "1",
"conversions.activity": "conversion",
"conversions.packages.0.nevra": "convert2rhel-0:2.0.0-1.el8.noarch",
"conversions.packages.0.signature": "RSA/SHA256, Thu May 30 13:31:33 2024, Key ID 199e2f91fd431d51",
"conversions.executed": "/usr/bin/convert2rhel",
"conversions.success": true,
"conversions.activity_started": "2024-07-11T17:28:54.281664Z",
"conversions.activity_ended": "2024-07-11T17:48:47.026664Z",
"conversions.source_os.id": "Cerulean Leopard",
"conversions.source_os.name": "AlmaLinux",
"conversions.source_os.version": "8.10",
"conversions.target_os.id": "Ootpa",
"conversions.target_os.name": "Red Hat Enterprise Linux",
"conversions.target_os.version": "8.10",
"conversions.env.CONVERT2RHEL_THROUGH_FOREMAN": "1", <- what we care about
"conversions.run_id": "null"
}
```

The env part of the fact is getting filtered out due to https://github.com/theforeman/foreman/blob/55d2a0d22a0fe738342804bcc4987fc24a3b0917/app/registries/foreman/settings/facts.rb#L23

We can see that the fact with this PR is present on the system when looking with pry:

```bash
[12] pry(main)> foo.subscription_facet
=> #<HostFacets::ReportedDataFacet:0x00007f6a30b9fb30
 id: 19,
 host_id: 18,
 boot_time: Thu, 11 Jul 2024 17:49:26.000000000 UTC +00:00,
 created_at: Mon, 29 Jul 2024 18:36:51.167876000 UTC +00:00,
 updated_at: Mon, 29 Jul 2024 19:30:23.632255000 UTC +00:00,
 virtual: true,
 sockets: 1,
 cores: 1,
 ram: 7953,
 disks_total: nil,
 kernel_version: "4.18.0-553.8.1.el8_10.x86_64",
 bios_vendor: nil,
 bios_release_date: nil,
 bios_version: nil,
 convert2rhel: 1>
```

The convert2rhel team wants that fact reported through RH cloud so they know if they should keep working on enhancing this process and to see how many people are using it.

Once this is in, I will make a PR to RH Cloud to add that into the report we send off.

To test this:
* Apply PR
* Run DB Migration
* On one host add the custom fact to subscription-manager in /etc/rhsm/facts
* On that host then run `subscription-manager facts --update`
* On a second host without the fact run `subscription-manager facts --update`
* Verify you see in the DB or rails console that the host with the convert2rhel fact has the value to set to 1/true and the host without the fact has a `nil` value for the fact