### PR TITLE
Fixes #37709 - make sure content_source_id is not changed during host edit

### DIFF
--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -21,6 +21,7 @@
     <%= select_tag cs_select_id, content_source_options(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path},
                :class => 'form-control',  :name => cs_select_name %>
   <% else %>
+    <%= hidden_field_tag 'host[content_facet_attributes][content_source_id]', fetch_content_source(@host).try(:id) %>
     <%= select_tag cs_select_id, content_source_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cs_select_name, :disabled => cv_lce_disabled? %>
   <% end %>
 <% end %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The content_source_id is not transmitted if you edit a host and therefore the value of the host group is used.

#### Considerations taken when implementing this change?

Similar to Lifecycle / Content View implementation.

#### What are the testing steps for this pull request?

Works with new host and edit host. 
