### PR TITLE
Refs #37678 - Update evr migration to use DSL

### DIFF
--- a/db/migrate/20240624121212_katello_recreate_evr_constructs.rb
+++ b/db/migrate/20240624121212_katello_recreate_evr_constructs.rb
@@ -1,14 +1,7 @@
 class KatelloRecreateEvrConstructs < ActiveRecord::Migration[6.1]
-  def change
-    count = select_value <<~SQL
-      SELECT count(*) FROM pg_extension WHERE extname = 'evr';
-    SQL
-    if count.to_i == 0
-      return
-    else
-      execute <<~SQL
-        DROP EXTENSION evr CASCADE;
-      SQL
+  def up
+    if extension_enabled?('evr')
+      disable_extension('evr')
 
       execute <<~SQL
               create type evr_array_item as (
@@ -155,5 +148,9 @@ class KatelloRecreateEvrConstructs < ActiveRecord::Migration[6.1]
       create_trigger :evr_insert_trigger_katello_installed_packages, on: :katello_installed_packages
       create_trigger :evr_update_trigger_katello_installed_packages, on: :katello_installed_packages
     end
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
The evr migration was using SQL to drop the extension possibly causing privilege issues in EL8 upgrade pipeline in nightlies. 
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
To test new installs, run bundle exec rails katello:reset
To test upgrades:
You could follow this on the dev box:
git reset --hard 8fed606fdc2bcd783a8e875aef43273e686c80e5
bundle exec rails katello:reset
Create and sync a repo to test data migration. You could also have some host registered to test data migration on installed_packages table
git checkout this branch
run db:migrate and make sure everything works normally.