### PR TITLE
Fixes #37697 - scan CDN fails silently

### DIFF
--- a/app/lib/katello/util/cdn_var_substitutor.rb
+++ b/app/lib/katello/util/cdn_var_substitutor.rb
@@ -68,7 +68,9 @@ module Katello
 
           futures.each do |future|
             resolved << future.value
-            Rails.logger.error("Failed at scanning for repository: #{future.reason}") if future.rejected?
+            if future.rejected?
+              fail Errors::CdnSubstitutionError, "Failed at scanning for repository: #{future.reason}"
+            end
           end
         end
 

--- a/test/lib/util/cdn_var_subsitutor_test.rb
+++ b/test/lib/util/cdn_var_subsitutor_test.rb
@@ -116,6 +116,18 @@ module Katello
           cdn_var.validate_substitutions(content, substitutions)
         end
       end
+
+      def test_substitute_vars_raises_error
+        cdn_var = CdnVarSubstitutor.new(@resource)
+
+        path = '/content/dist/rhel/server/5/$releasever/$basearch/os'
+
+        cdn_var.stubs(:resolve_path).raises(StandardError.new("Connection refused - connect(2) for \"cdn.redhat.com\" port 443"))
+
+        assert_raises(Errors::CdnSubstitutionError, "Failed at scanning for repository: Connection refused - connect(2) for \"cdn.redhat.com\" port 443") do
+          cdn_var.substitute_vars(path)
+        end
+      end
     end
   end
 end

--- a/webpack/redux/actions/RedHatRepositories/repositorySetRepositories.js
+++ b/webpack/redux/actions/RedHatRepositories/repositorySetRepositories.js
@@ -68,13 +68,12 @@ const loadRepositorySetRepos = (contentId, productId) => async (dispatch) => {
       productId,
       results: data.results,
     });
-  } catch (response) {
-    const error = response && response.data && response.data.error;
-    return dispatch({
-      type: REPOSITORY_SET_REPOSITORIES_FAILURE,
-      contentId,
+  } catch (error) {
+    return dispatch(apiError(
+      REPOSITORY_SET_REPOSITORIES_FAILURE,
       error,
-    });
+      { contentId },
+    ));
   }
 };
 

--- a/webpack/redux/reducers/RedHatRepositories/__tests__/repositorySetRepositories.test.js
+++ b/webpack/redux/reducers/RedHatRepositories/__tests__/repositorySetRepositories.test.js
@@ -39,7 +39,7 @@ describe('repositorySetRepositories reducer', () => {
   it('should have error on REPOSITORY_SET_REPOSITORIES_FAILURE', () => {
     expect(reducer(initialState, {
       type: types.REPOSITORY_SET_REPOSITORIES_FAILURE,
-      contentId,
+      payload: { contentId },
       error: 'Unable to process request.',
     })).toEqual(errorState);
   });

--- a/webpack/redux/reducers/RedHatRepositories/repositorySetRepositories.js
+++ b/webpack/redux/reducers/RedHatRepositories/repositorySetRepositories.js
@@ -81,7 +81,7 @@ export default (state = initialState, action) => {
     });
 
   case REPOSITORY_SET_REPOSITORIES_FAILURE:
-    return state.set(action.contentId, {
+    return state.set(action.payload.contentId, {
       loading: false,
       repositories: [],
       error: action.error,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

find_substitutions should raise Errors::CdnSubstitutionError

The associated foreman-task Actions::Katello::RepositorySet::ScanCdn should reach stopped/warning state with the error: `Katello::Errors::CdnSubstitutionError: Failed at scanning for repository: Failed to open TCP connection to cdn.redhat.com:443 (Connection refused - connect(2) for "cdn.redhat.com" port 443)`

#### What are the testing steps for this pull request?

1. sudo systemctl start firewalld

2. sudo firewall-cmd --add-service="RH-Satellite-6"

3. sudo firewall-cmd --direct --add-rule ipv4 filter OUTPUT 1 -p tcp -m tcp --dport=443 -j REJECT

4. expand a repository set on the Red Hat Repositories page

5. check the results of the associated Actions::Katello::RepositorySet::ScanCdn task
