### PR TITLE
Fixes #37684 - Add back UPGRADE_ALL in packages wizard

### DIFF
--- a/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/04_Review.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/04_Review.js
@@ -42,6 +42,7 @@ export const BulkPackagesReview = () => {
     [INSTALL]: __('Packages to install'),
     [REMOVE]: __('Packages to be removed'),
     [UPGRADE]: __('Packages to be updated'),
+    [UPGRADE_ALL]: __('Packages to be updated'),
   };
 
   const treeViewTitle = packageActionsDescriptions[selectedAction];

--- a/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/04_ReviewFooter.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/04_ReviewFooter.js
@@ -39,6 +39,7 @@ export const BulkPackagesReviewFooter = () => {
     [INSTALL]: katelloPackageInstallBySearchUrl,
     [REMOVE]: katelloPackageRemoveBySearchUrl,
     [UPGRADE]: packagesUpdateUrl,
+    [UPGRADE_ALL]: packagesUpdateUrl,
   };
   const getCustomizedRexUrl = packageRexUrls[selectedAction];
   const customizedRexUrl = getCustomizedRexUrl({


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

https://github.com/Katello/katello/pull/11070 had some refactoring which causes an issue: When you click 'Upgrade all packages,' and go to the Review step, you get 

```
'TypeError: getCustomizedRexUrl is not a function'
```

This should fix that.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

test all paths of the Packages wizard on the new all hosts page.

