### PR TITLE
Fixes #37722 - open package host relations in new tab

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/details/views/deb-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/details/views/deb-info.html
@@ -9,10 +9,10 @@
       <dd>
         <i class="fa fa-spinner fa-spin" ng-show="installedDebCount === undefined"></i>
         <span ng-show="installedDebCount !== undefined">
-          <a ng-if="newHostDetailsUI" href="{{ '/hosts?search=' + createSearchString('installed_deb') }}" translate>
+          <a ng-if="newHostDetailsUI" href="{{ '/hosts?search=' + createSearchString('installed_deb') }}" target="_blank" rel="noreferrer noopener" translate>
             {{ installedDebCount }} Host(s)
           </a>
-          <a ng-if="!newHostDetailsUI" href="{{ '/content_hosts?search=' + createSearchString('installed_deb') }}" translate>
+          <a ng-if="!newHostDetailsUI" href="{{ '/content_hosts?search=' + createSearchString('installed_deb') }}" target="_blank" rel="noreferrer noopener" translate>
             {{ installedDebCount }} Host(s)
           </a>
         </span>
@@ -20,20 +20,20 @@
 
       <dt translate>Applicable To</dt>
       <dd>
-        <a ng-if="newHostDetailsUI" href="{{ '/hosts?search=' + createSearchString('applicable_debs') }}" translate>
+        <a ng-if="newHostDetailsUI" href="{{ '/hosts?search=' + createSearchString('applicable_debs') }}" target="_blank" rel="noreferrer noopener" translate>
           {{ deb.hosts_applicable_count }} Host(s)
         </a>
-        <a ng-if="!newHostDetailsUI" href="{{ '/content_hosts?search=' + createSearchString('applicable_debs') }}" translate>
+        <a ng-if="!newHostDetailsUI" href="{{ '/content_hosts?search=' + createSearchString('applicable_debs') }}" target="_blank" rel="noreferrer noopener" translate>
           {{ deb.hosts_applicable_count }} Host(s)
         </a>
       </dd>
 
       <dt translate>Upgradable For</dt>
       <dd>
-        <a ng-if="newHostDetailsUI" href="{{ '/hosts?search=' + createSearchString('upgradable_debs') }}" translate>
+        <a ng-if="newHostDetailsUI" href="{{ '/hosts?search=' + createSearchString('upgradable_debs') }}" target="_blank" rel="noreferrer noopener" translate>
           {{ deb.hosts_available_count }} Host(s)
         </a>
-        <a ng-if="!newHostDetailsUI" href="{{ '/content_hosts?search=' + createSearchString('upgradable_debs') }}" translate>
+        <a ng-if="!newHostDetailsUI" href="{{ '/content_hosts?search=' + createSearchString('upgradable_debs') }}" target="_blank" rel="noreferrer noopener" translate>
           {{ deb.hosts_available_count }} Host(s)
         </a>
       </dd>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-info.html
@@ -9,10 +9,10 @@
       <dd>
         <i class="fa fa-spinner fa-spin" ng-show="installedPackageCount === undefined"></i>
         <span ng-show="installedPackageCount !== undefined">
-          <a ng-if="newHostDetailsUI" href="{{ newHostUrl('installed_package') }}" translate>
+          <a ng-if="newHostDetailsUI" href="{{ newHostUrl('installed_package') }}" target="_blank" rel="noreferrer noopener" translate>
             {{ installedPackageCount }} Host(s)
           </a>
-          <a ng-if="!newHostDetailsUI" href="{{ encodedUrl('installed_package') }}" translate>
+          <a ng-if="!newHostDetailsUI" href="{{ encodedUrl('installed_package') }}" target="_blank" rel="noreferrer noopener" translate>
             {{ installedPackageCount }} Host(s)
           </a>
         </span>
@@ -20,20 +20,20 @@
 
       <dt translate>Applicable To</dt>
       <dd>
-        <a ng-if="newHostDetailsUI" href="{{ newHostUrl('applicable_rpms') }}" translate>
+        <a ng-if="newHostDetailsUI" href="{{ newHostUrl('applicable_rpms') }}" target="_blank" rel="noreferrer noopener" translate>
           {{ package.hosts_applicable_count }} Host(s)
         </a>
-        <a ng-if="!newHostDetailsUI" href="{{ encodedUrl('applicable_rpms') }}" translate>
+        <a ng-if="!newHostDetailsUI" href="{{ encodedUrl('applicable_rpms') }}" target="_blank" rel="noreferrer noopener" translate>
           {{ package.hosts_applicable_count }} Host(s)
         </a>
       </dd>
 
       <dt translate>Upgradable For</dt>
       <dd>
-        <a ng-if="newHostDetailsUI" href="{{ newHostUrl('upgradable_rpms') }}" translate>
+        <a ng-if="newHostDetailsUI" href="{{ newHostUrl('upgradable_rpms') }}" target="_blank" rel="noreferrer noopener" translate>
           {{ package.hosts_available_count }} Host(s)
         </a>
-        <a ng-if="!newHostDetailsUI" href="{{ encodedUrl('upgradable_rpms') }}" translate>
+        <a ng-if="!newHostDetailsUI" href="{{ encodedUrl('upgradable_rpms') }}" target="_blank" rel="noreferrer noopener" translate>
           {{ package.hosts_available_count }} Host(s)
         </a>
       </dd>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Opens host relation search links from packages in new tabs. For some reason, when opening it in the same window, the page gets loaded twice which breaks the URL encoding. This works around that issue.

#### Considerations taken when implementing this change?
We could find the root issue with the double reloads, but the old all hosts page is already being replaced.

#### What are the testing steps for this pull request?
Get some modular RPM applicable to a host. If you spin up an old RHEL 8 box and install the virt module stream, some should show up.

Click on the "Applicable To" etc links on the applicable package's page. Without the PR, note that the search has spaces in it incorrectly if you juts click the link. Note that it works fine if you open the link in a new tab, which this PR makes default.

Test all links for packages (like "Upgradable For"