### PR TITLE
Fixes #37728 - Use new job wizard in RemoteExecutionController

### DIFF
--- a/app/controllers/katello/remote_execution_controller.rb
+++ b/app/controllers/katello/remote_execution_controller.rb
@@ -13,7 +13,7 @@ module Katello
         @composer.trigger
         redirect_to job_invocation_path(@composer.job_invocation)
       else
-        render :action => 'new'
+        redirect_to new_job_invocation_path({ feature: feature_name, host_ids: hosts.ids, inputs: inputs })
       end
     end
 

--- a/test/controllers/remote_execution_controller_test.rb
+++ b/test/controllers/remote_execution_controller_test.rb
@@ -28,12 +28,11 @@ module Katello
           }
         }.to_json
 
-      @controller.expects(:render).with(:action => "new")
       post :create, params: {
         :remote_action => "errata_install",
         bulk_host_ids: bulk_host_ids, customize: true }
 
-      assert_response :success
+      assert_response :found
     end
 
     def test_customized_errata_install_with_install_all_shows_new
@@ -44,13 +43,12 @@ module Katello
           }
         }.to_json
 
-      @controller.expects(:render).with(:action => "new")
       post :create, params: {
         :remote_action => "errata_install",
         bulk_host_ids: bulk_host_ids, customize: true,
         install_all: true }
 
-      assert_response :success
+      assert_response :found
     end
 
     def test_customized_errata_install_with_errata_id_shows_new
@@ -64,17 +62,16 @@ module Katello
       bulk_errata_ids =
         {
           included: {
-            ids: []
+            ids: [katello_errata(:security).errata_id]
           }
         }.to_json
 
-      @controller.expects(:render).with(:action => "new")
       post :create, params: {
         :remote_action => "errata_install",
         bulk_host_ids: bulk_host_ids, bulk_errata_ids: bulk_errata_ids,
         customize: true }
 
-      assert_response :success
+      assert_response :found
     end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The Katello remote execution controller is used with Angular pages, including

- host collection actions (errata / package etc.)
- legacy content host bulk actions

When you click 'via remote execution - customize first' it takes you to the old job invocation page. This is not ideal because that page is deprecated, and also has some bugs around duplicating form fields, etc. This PR alters the RemoteExecutionController to redirect to the new job wizard instead. The single-line change should affect all Angular pages that use the `POST katello/remote_execution` endpoint (including those listed above, and also any I forgot.)

#### Considerations taken when implementing this change?

This should be backported as far back as the new job wizard has been available.

I think there were some changes which would also have fixed the duplicate-form-field issue, and probably were not backported. But this solution (using the new job wizard) is so simple, I didn't bother digging too deep into that.

It uses `host_ids` via url param, which may cause problems if you have a very long list of hosts. Is this acceptable?

#### What are the testing steps for this pull request?

Test all pages, clicking 'via remote execution - customize first'
1. Template should be correct
2. Should resolve to the correct hosts
3. Inputs should carry over (not be blank, except for update all packages)

