### PR TITLE
Fixes #37732 - "Remove Repositories" button not shown for non-admins

### DIFF
--- a/app/models/katello/authorization/product.rb
+++ b/app/models/katello/authorization/product.rb
@@ -19,7 +19,7 @@ module Katello
 
       def deletable?
         promoted_repos = repositories.select { |repo| repo.promoted? }
-        authorized?(:destroy_products) && promoted_repos.empty?
+        authorized?(:destroy_products) && (promoted_repos.empty? || Setting[:delete_repo_across_cv])
       end
 
       module ClassMethods


### PR DESCRIPTION
[Redmine issue and reproducer](https://projects.theforeman.org/issues/37732)

This PR fixes a bug where the "Remove Repositories" button was not shown to non-admin users who had the `destroy_repositories` permission when a repository was part of a published content view.
This happened because the logic behind displaying the button did not take into account the _delete_repo_across_cv_ setting, which defaults to true.

Ideally, I should have fixed this in #11059 but I overlooked it.