### PR TITLE
Fixes #37736 - Hide Upload package text for file repos

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -525,7 +525,7 @@
 
     <span ng-hide="(repository.content_type === 'deb' && repository.url)">
     <section class="well" ng-if="permitted('edit_products', product) && !product.redhat && repository.content_type !== 'docker' && repository.content_type !== 'ostree' && repository.content_type !== 'ansible_collection'">
-      <h5 translate ng-show="repository.content_type === 'yum' || 'deb'">Upload Package</h5>
+      <h5 translate ng-show="repository.content_type === 'yum' || repository.content_type === 'deb'">Upload Package</h5>
       <h5 translate ng-show="repository.content_type === 'file'">Upload File</h5>
 
       <form role="form"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Hide "Upload Package" text from file repo upload section
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Create a file repo
Verify that Upload package text is gone from the file upload section.
![Screenshot from 2024-08-15 10-04-57](https://github.com/user-attachments/assets/707afa53-6f86-4230-a3f5-3cb09994daad)
