### PR TITLE
Refs #37696 - only create sub-facet for c2r hosts

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -299,6 +299,7 @@ module Katello
 
       def self.populate_fields_from_facts(host, parser, _type, _source_proxy)
         has_convert2rhel = parser.facts.key?('conversions.env.CONVERT2RHEL_THROUGH_FOREMAN')
+        return unless host.subscription_facet || has_convert2rhel
         # Add in custom convert2rhel fact if system was converted using convert2rhel through Katello
         # We want the value nil unless the custom fact is present otherwise we get a 0 in the database which if debugging
         # might make you think it was converted2rhel but not with satellite, that is why I have the tenary below.


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

We do have hosts that have no subscription facet, and should not have
one. Adjust the logic for the c2r fact to only create the missing facet
if the fact was sent, and leave hosts w/o the facet and w/o the fact
alone.

#### Considerations taken when implementing this change?

This is an alternative to #11109

#### What are the testing steps for this pull request?

Same as #11109