### PR TITLE
drop Katello.with_remote_execution?

### DIFF
--- a/app/controllers/katello/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/hosts_controller_extensions.rb
@@ -94,10 +94,8 @@ module Katello
                                       .joins(:lifecycle_environments)
                                       .distinct
 
-          if Katello.with_remote_execution?
-            template_id = RemoteExecutionFeature.feature!(:katello_change_content_source).job_template_id
-            job_invocation_path = new_job_invocation_path(template_id: template_id, host_ids: content_hosts.map { |h| h[:id] }) if template_id
-          end
+          template_id = RemoteExecutionFeature.feature!(:katello_change_content_source).job_template_id
+          job_invocation_path = new_job_invocation_path(template_id: template_id, host_ids: content_hosts.map { |h| h[:id] }) if template_id
 
           render json: {
             content_hosts: content_hosts,

--- a/app/controllers/katello/remote_execution_controller.rb
+++ b/app/controllers/katello/remote_execution_controller.rb
@@ -1,75 +1,70 @@
 module Katello
-  if Katello.with_remote_execution?
-    class RemoteExecutionController < JobInvocationsController
-      include ::Api::V2::BulkHostsExtension
-      include Concerns::Api::V2::HostErrataExtensions
+  class RemoteExecutionController < JobInvocationsController
+    include ::Api::V2::BulkHostsExtension
+    include Concerns::Api::V2::HostErrataExtensions
 
-      def new
-        @composer = prepare_composer
-      end
+    def new
+      @composer = prepare_composer
+    end
 
-      def create
-        @composer = prepare_composer
-        if params[:customize] != 'true' && @composer.save
-          @composer.trigger
-          redirect_to job_invocation_path(@composer.job_invocation)
-        else
-          render :action => 'new'
-        end
-      end
-
-      # to overcome the isolated namespace engine difficulties with paths
-      helper Rails.application.routes.url_helpers
-      def _routes
-        Rails.application.routes
-      end
-
-      private
-
-      def prepare_composer
-        JobInvocationComposer.for_feature(feature_name, hosts, inputs)
-      end
-
-      def hosts
-        bulk_host_ids = ActiveSupport::JSON.decode(params[:bulk_host_ids]).deep_symbolize_keys
-
-        find_bulk_hosts('edit_hosts', bulk_host_ids)
-      end
-
-      def errata_inputs
-        if ::Foreman::Cast.to_bool(params[:install_all])
-          Erratum.installable_for_hosts(hosts).pluck(:errata_id).join(',')
-        elsif params[:bulk_errata_ids]
-          find_bulk_errata_ids(hosts, params[:bulk_errata_ids]).join(',')
-        else
-          params[:name]
-        end
-      end
-
-      def inputs
-        case feature_name
-        when 'katello_errata_install'
-          { :errata => errata_inputs }
-        when 'katello_service_restart'
-          { :helper => params[:name] }
-        when 'katello_module_stream_action'
-          fail HttpErrors::NotFound, _('module streams not found') if params[:module_spec].blank?
-          fail HttpErrors::NotFound, _('actions not found') if params[:module_stream_action].blank?
-          inputs = { :module_spec => params[:module_spec], :action => params[:module_stream_action] }
-          inputs[:options] = params[:options] if params[:options]
-          inputs
-        else
-          { :package => params[:name] }
-        end
-      end
-
-      def feature_name
-        # getting packageInstall from UI, translating to 'katello_package_install' feature
-        "katello_#{params[:remote_action].underscore}"
+    def create
+      @composer = prepare_composer
+      if params[:customize] != 'true' && @composer.save
+        @composer.trigger
+        redirect_to job_invocation_path(@composer.job_invocation)
+      else
+        render :action => 'new'
       end
     end
-  else
-    class RemoteExecutionController < ApplicationController
+
+    # to overcome the isolated namespace engine difficulties with paths
+    helper Rails.application.routes.url_helpers
+    def _routes
+      Rails.application.routes
+    end
+
+    private
+
+    def prepare_composer
+      JobInvocationComposer.for_feature(feature_name, hosts, inputs)
+    end
+
+    def hosts
+      bulk_host_ids = ActiveSupport::JSON.decode(params[:bulk_host_ids]).deep_symbolize_keys
+
+      find_bulk_hosts('edit_hosts', bulk_host_ids)
+    end
+
+    def errata_inputs
+      if ::Foreman::Cast.to_bool(params[:install_all])
+        Erratum.installable_for_hosts(hosts).pluck(:errata_id).join(',')
+      elsif params[:bulk_errata_ids]
+        find_bulk_errata_ids(hosts, params[:bulk_errata_ids]).join(',')
+      else
+        params[:name]
+      end
+    end
+
+    def inputs
+      case feature_name
+      when 'katello_errata_install'
+        { :errata => errata_inputs }
+      when 'katello_service_restart'
+        { :helper => params[:name] }
+      when 'katello_module_stream_action'
+        fail HttpErrors::NotFound, _('module streams not found') if params[:module_spec].blank?
+        fail HttpErrors::NotFound, _('actions not found') if params[:module_stream_action].blank?
+        inputs = { :module_spec => params[:module_spec], :action => params[:module_stream_action] }
+        inputs[:options] = params[:options] if params[:options]
+        inputs
+      else
+        { :package => params[:name] }
+      end
+    end
+
+    def feature_name
+      # getting packageInstall from UI, translating to 'katello_package_install' feature
+      "katello_#{params[:remote_action].underscore}"
     end
   end
 end

--- a/app/lib/katello/concerns/base_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/base_template_scope_extensions.rb
@@ -259,13 +259,9 @@ module Katello
         labels = 'label ^ (Actions::Katello::Host::Erratum::Install, Actions::Katello::Host::Erratum::ApplicableErrataInstall)'
         select = 'foreman_tasks_tasks.*'
 
-        if Katello.with_remote_execution?
-          new_labels = 'label = Actions::RemoteExecution::RunHostJob AND remote_execution_feature.label ^ (katello_errata_install, katello_errata_install_by_search)'
-          labels = [labels, new_labels].map { |label| "(#{label})" }.join(' OR ')
-          select += ',template_invocations.id AS template_invocation_id'
-        else
-          select += ',NULL AS template_invocation_id'
-        end
+        new_labels = 'label = Actions::RemoteExecution::RunHostJob AND remote_execution_feature.label ^ (katello_errata_install, katello_errata_install_by_search)'
+        labels = [labels, new_labels].map { |label| "(#{label})" }.join(' OR ')
+        select += ',template_invocations.id AS template_invocation_id'
 
         search = [search_up_to, search_since, search_result, "state = stopped", labels].compact.join(' and ')
 

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -85,7 +85,7 @@ module Katello
       end
 
       included do
-        prepend ::ForemanRemoteExecution::HostExtensions if ::Katello.with_remote_execution?
+        prepend ::ForemanRemoteExecution::HostExtensions
         prepend Overrides
 
         delegate :content_source_id, :single_content_view, :single_lifecycle_environment, :default_environment?, :single_content_view_environment?, :multi_content_view_environment?, :kickstart_repository_id, :bound_repositories,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,7 @@ Katello::Engine.routes.draw do
       end
     end
 
-    if Katello.with_remote_execution?
-      match '/remote_execution' => 'remote_execution#create', :via => [:post]
-    end
+    match '/remote_execution' => 'remote_execution#create', :via => [:post]
   end
 
   get '/katello/providers/redhat_provider', to: redirect('/redhat_repositories')

--- a/db/seeds.d/150-module_job_templates.rb
+++ b/db/seeds.d/150-module_job_templates.rb
@@ -1,12 +1,10 @@
-if Katello.with_remote_execution?
-  User.as_anonymous_admin do
-    JobTemplate.without_auditing do
-      module_template = JobTemplate.find_by(name: 'Module Action - Script Default')
-      if module_template
-        module_template.sync_feature('katello_module_stream_action')
-        module_template.organizations << Organization.unscoped.all if module_template.organizations.empty?
-        module_template.locations << Location.unscoped.all if module_template.locations.empty?
-      end
+User.as_anonymous_admin do
+  JobTemplate.without_auditing do
+    module_template = JobTemplate.find_by(name: 'Module Action - Script Default')
+    if module_template
+      module_template.sync_feature('katello_module_stream_action')
+      module_template.organizations << Organization.unscoped.all if module_template.organizations.empty?
+      module_template.locations << Location.unscoped.all if module_template.locations.empty?
     end
   end
 end

--- a/db/seeds.d/75-job_templates.rb
+++ b/db/seeds.d/75-job_templates.rb
@@ -1,20 +1,13 @@
-if Katello.with_remote_execution?
-  User.as_anonymous_admin do
-    JobTemplate.without_auditing do
-      template_files = Dir[File.join("#{Katello::Engine.root}/app/views/foreman/job_templates/**/*.erb")]
-      template_files.reject! { |file| file.end_with?('_ansible_default.erb') } unless Katello.with_ansible?
-      template_files.each do |template|
-        sync = !Rails.env.test? && Setting[:remote_execution_sync_templates]
-        # import! was renamed to import_raw! around 1.3.1
-        if JobTemplate.respond_to?('import_raw!')
-          template = JobTemplate.import_raw!(File.read(template), :default => true, :lock => true, :update => sync)
-        else
-          template = JobTemplate.import!(File.read(template), :default => true, :lock => true, :update => sync)
-        end
+User.as_anonymous_admin do
+  JobTemplate.without_auditing do
+    template_files = Dir[File.join("#{Katello::Engine.root}/app/views/foreman/job_templates/**/*.erb")]
+    template_files.reject! { |file| file.end_with?('_ansible_default.erb') } unless Katello.with_ansible?
+    template_files.each do |template|
+      sync = !Rails.env.test? && Setting[:remote_execution_sync_templates]
+      template = JobTemplate.import_raw!(File.read(template), :default => true, :lock => true, :update => sync)
 
-        template.organizations << Organization.unscoped.all if template&.organizations&.empty?
-        template.locations << Location.unscoped.all if template&.locations&.empty?
-      end
+      template.organizations << Organization.unscoped.all if template&.organizations&.empty?
+      template.locations << Location.unscoped.all if template&.locations&.empty?
     end
   end
 end

--- a/engines/bastion_katello/lib/bastion_katello/engine.rb
+++ b/engines/bastion_katello/lib/bastion_katello/engine.rb
@@ -34,8 +34,8 @@ module BastionKatello
         :config_generator =>  lambda do
           { 'consumerCertRPM' => consumer_cert_rpm,
             'defaultDownloadPolicy' => !Foreman.in_rake? && db_migrated && Setting['default_download_policy'],
-            'remoteExecutionPresent' => ::Katello.with_remote_execution?,
-            'hostToolingEnabled' => ::Katello.with_remote_execution?
+            'remoteExecutionPresent' => true,
+            'hostToolingEnabled' => true
           }
         end
       )

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -202,9 +202,7 @@ module Katello
 
       ::AuditSearch::ClassMethods.prepend Katello::Concerns::AuditSearch
 
-      if ::Katello.with_remote_execution?
-        ::RemoteExecutionProxySelector.prepend Katello::Concerns::RemoteExecutionProxySelectorExtensions
-      end
+      ::RemoteExecutionProxySelector.prepend Katello::Concerns::RemoteExecutionProxySelectorExtensions
 
       load 'katello/repository_types.rb'
       load 'katello/scheduled_jobs.rb'
@@ -221,11 +219,6 @@ module Katello
         load task if File.file?(task)
       end
     end
-  end
-
-  # check whether foreman_remote_execution to integrate is available in the system
-  def self.with_remote_execution?
-    Foreman::Plugin.installed?("foreman_remote_execution")
   end
 
   def self.with_ansible?

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -666,29 +666,27 @@ Foreman::Plugin.register :katello do
     end
   end
 
-  if Katello.with_remote_execution?
-    RemoteExecutionFeature.register(:katello_package_install, N_("Katello: Install Package"), :description => N_("Install package via Katello interface"), :provided_inputs => ['package'])
-    RemoteExecutionFeature.register(:katello_package_install_by_search, N_("Katello: Install packages by search query"), :description => N_("Install packages via Katello interface"), :provided_inputs => ['Package search query'])
-    RemoteExecutionFeature.register(:katello_package_update, N_("Katello: Update Package"), :description => N_("Update package via Katello interface"), :provided_inputs => ['package'])
-    RemoteExecutionFeature.register(:katello_packages_update_by_search, N_("Katello: Update Packages by search query"), :description => N_("Update packages via Katello interface"), :provided_inputs => ['Package search query'])
-    RemoteExecutionFeature.register(:katello_package_remove, N_("Katello: Remove Package"), :description => N_("Remove package via Katello interface"), :provided_inputs => ['package'])
-    RemoteExecutionFeature.register(:katello_packages_remove_by_search, N_("Katello: Remove Packages by search query"), :description => N_("Remove packages via Katello interface"), :provided_inputs => ['Package search query'])
-    RemoteExecutionFeature.register(:katello_group_install, N_("Katello: Install Package Group"), :description => N_("Install package group via Katello interface"), :provided_inputs => ['package'])
-    RemoteExecutionFeature.register(:katello_group_update, N_("Katello: Update Package Group"), :description => N_("Update package group via Katello interface"), :provided_inputs => ['package'])
-    RemoteExecutionFeature.register(:katello_group_remove, N_("Katello: Remove Package Group"), :description => N_("Remove package group via Katello interface"), :provided_inputs => ['package'])
-    RemoteExecutionFeature.register(:katello_errata_install, N_("Katello: Install Errata"), :description => N_("Install errata via Katello interface"), :provided_inputs => ['errata'])
-    RemoteExecutionFeature.register(:katello_errata_install_by_search, N_("Katello: Install errata by search query"), :description => N_("Install errata using scoped search query"), :provided_inputs => ['Errata search query'])
-    RemoteExecutionFeature.register(:katello_service_restart, N_("Katello: Service Restart"), :description => N_("Restart Services via Katello interface"), :provided_inputs => ['helpers'])
-    RemoteExecutionFeature.register(:katello_host_tracer_resolve, N_("Katello: Resolve Traces"), :description => N_("Resolve traces via Katello interface"), :provided_inputs => ['ids'])
-    RemoteExecutionFeature.register(:katello_change_content_source, N_("Katello: Configure host for new content source"), :description => N_("Replace content source on the target machine"), :provided_inputs => [])
-    RemoteExecutionFeature.register(:katello_upload_profile, N_("Katello: Upload Profile"), :description => N_("Upload package / repos profile"), :provided_inputs => [])
-    RemoteExecutionFeature.register(:katello_module_stream_action, N_("Katello: Module Stream Actions"),
-                                    :description => N_("Perform a module stream action via Katello interface"),
-                                    :provided_inputs => ['action', 'module_spec', 'options'])
-    allowed_template_helpers :errata
+  RemoteExecutionFeature.register(:katello_package_install, N_("Katello: Install Package"), :description => N_("Install package via Katello interface"), :provided_inputs => ['package'])
+  RemoteExecutionFeature.register(:katello_package_install_by_search, N_("Katello: Install packages by search query"), :description => N_("Install packages via Katello interface"), :provided_inputs => ['Package search query'])
+  RemoteExecutionFeature.register(:katello_package_update, N_("Katello: Update Package"), :description => N_("Update package via Katello interface"), :provided_inputs => ['package'])
+  RemoteExecutionFeature.register(:katello_packages_update_by_search, N_("Katello: Update Packages by search query"), :description => N_("Update packages via Katello interface"), :provided_inputs => ['Package search query'])
+  RemoteExecutionFeature.register(:katello_package_remove, N_("Katello: Remove Package"), :description => N_("Remove package via Katello interface"), :provided_inputs => ['package'])
+  RemoteExecutionFeature.register(:katello_packages_remove_by_search, N_("Katello: Remove Packages by search query"), :description => N_("Remove packages via Katello interface"), :provided_inputs => ['Package search query'])
+  RemoteExecutionFeature.register(:katello_group_install, N_("Katello: Install Package Group"), :description => N_("Install package group via Katello interface"), :provided_inputs => ['package'])
+  RemoteExecutionFeature.register(:katello_group_update, N_("Katello: Update Package Group"), :description => N_("Update package group via Katello interface"), :provided_inputs => ['package'])
+  RemoteExecutionFeature.register(:katello_group_remove, N_("Katello: Remove Package Group"), :description => N_("Remove package group via Katello interface"), :provided_inputs => ['package'])
+  RemoteExecutionFeature.register(:katello_errata_install, N_("Katello: Install Errata"), :description => N_("Install errata via Katello interface"), :provided_inputs => ['errata'])
+  RemoteExecutionFeature.register(:katello_errata_install_by_search, N_("Katello: Install errata by search query"), :description => N_("Install errata using scoped search query"), :provided_inputs => ['Errata search query'])
+  RemoteExecutionFeature.register(:katello_service_restart, N_("Katello: Service Restart"), :description => N_("Restart Services via Katello interface"), :provided_inputs => ['helpers'])
+  RemoteExecutionFeature.register(:katello_host_tracer_resolve, N_("Katello: Resolve Traces"), :description => N_("Resolve traces via Katello interface"), :provided_inputs => ['ids'])
+  RemoteExecutionFeature.register(:katello_change_content_source, N_("Katello: Configure host for new content source"), :description => N_("Replace content source on the target machine"), :provided_inputs => [])
+  RemoteExecutionFeature.register(:katello_upload_profile, N_("Katello: Upload Profile"), :description => N_("Upload package / repos profile"), :provided_inputs => [])
+  RemoteExecutionFeature.register(:katello_module_stream_action, N_("Katello: Module Stream Actions"),
+                                  :description => N_("Perform a module stream action via Katello interface"),
+                                  :provided_inputs => ['action', 'module_spec', 'options'])
+  allowed_template_helpers :errata
 
-    RemoteExecutionProvider.singleton_class.prepend(Katello::Concerns::RemoteExecutionProviderExtensions)
-  end
+  RemoteExecutionProvider.singleton_class.prepend(Katello::Concerns::RemoteExecutionProviderExtensions)
 
   tests_to_skip("AccessPermissionsTest" => [
                   'foreman_tasks/api/tasks/callback should have a permission that grants access',

--- a/test/controllers/remote_execution_controller_test.rb
+++ b/test/controllers/remote_execution_controller_test.rb
@@ -3,7 +3,6 @@ require 'katello_test_helper'
 module Katello
   class RemoteExecutionControllerTest < ActionController::TestCase
     def setup
-      skip "RemoteExecution not used" unless Katello.with_remote_execution?
       setup_controller_defaults
       login_user(User.find(users(:admin).id))
       models
@@ -22,7 +21,6 @@ module Katello
     end
 
     def test_customized_errata_install_shows_new
-      skip "RemoteExecution not used" unless Katello.with_remote_execution?
       bulk_host_ids =
         {
           included: {
@@ -39,7 +37,6 @@ module Katello
     end
 
     def test_customized_errata_install_with_install_all_shows_new
-      skip "RemoteExecution not used" unless Katello.with_remote_execution?
       bulk_host_ids =
         {
           included: {
@@ -57,7 +54,6 @@ module Katello
     end
 
     def test_customized_errata_install_with_errata_id_shows_new
-      skip "RemoteExecution not used" unless Katello.with_remote_execution?
       bulk_host_ids =
         {
           included: {

--- a/test/services/katello/host_trace_manager_test.rb
+++ b/test/services/katello/host_trace_manager_test.rb
@@ -1,10 +1,5 @@
 require 'katello_test_helper'
 
-unless Katello.with_remote_execution?
-  class JobInvocationComposer
-  end
-end
-
 module Katello
   class HostTraceManagerTest < ActiveSupport::TestCase
     def setup


### PR DESCRIPTION
katello depends on REX these days, so we can drop that helper

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
