### PR TITLE
Fixes #36310 - Migrate off ContentViews generated for repository export

### DIFF
--- a/db/migrate/20240815080259_migrate_off_generated_content_views.rb
+++ b/db/migrate/20240815080259_migrate_off_generated_content_views.rb
@@ -1,0 +1,40 @@
+class MigrateOffGeneratedContentViews < ActiveRecord::Migration[6.1]
+  def up
+    say_with_time "Migrating hosts off generated content views" do
+      migrate_hosts
+    end
+  end
+
+  def down
+    say "This migration cannot be reversed", true
+  end
+
+  private
+
+  def migrate_hosts
+    say_with_time "Migrating hosts..." do
+      generated_content_views = Katello::ContentView.where(generated_for: 'repository_export')
+
+      facets = Katello::Host::ContentFacet.joins(:content_view_environments)
+      facets = facets.where(katello_content_view_environments: { content_view_id: generated_content_views })
+      facets.find_each do |content_facet|
+        offending_cves = content_facet.content_view_environments.select { |cve| generated_content_views.include?(cve.content_view) }
+        valid_cves = content_facet.content_view_environments - offending_cves
+
+        if valid_cves.empty?
+          default_view = Katello::ContentView.find_by(name: "Default Organization View", organization: content_facet.host.organization)
+          if default_view
+            default_cve = default_view.content_view_environments.find_by(lifecycle_environment: content_facet.lifecycle_environments.first)
+            content_facet.update!(content_view_environments: [default_cve])
+            say "Replaced all content views with Default Organization View for host #{content_facet.host.name}", true
+          else
+            say "No Default Organization View found for host #{content_facet.host.name}. Skipping.", true
+          end
+        else
+          content_facet.update!(content_view_environments: valid_cves)
+          say "Removed offending content views for host #{content_facet.host.name}", true
+        end
+      end
+    end
+  end
+end

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -106,6 +106,16 @@ module Katello
       end
     end
 
+    test "should not allow generated content view to be associated with activation key" do
+      generated_cv = FactoryBot.create(:katello_content_view, :generated_for => :repository_export, :organization => @dev_view.organization)
+
+      exception = assert_raises(ActiveRecord::RecordInvalid) do
+        @dev_key.update!(content_view: generated_cv)
+      end
+
+      assert_match(/Generated content views cannot be assigned to hosts or activation keys/, exception.message)
+    end
+
     def test_search_name
       activation_keys = ActivationKey.search_for("name = \"#{@dev_staging_view_key.name}\"")
       assert_includes activation_keys, @dev_staging_view_key

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -93,6 +93,17 @@ module Katello
       content_facet_rec = host1.associated_audits.where(auditable_id: content_facet1.id)
       assert content_facet_rec, "No associated audit record for content_facet"
     end
+
+    def test_content_view_environments_not_generated_for_repository_export
+      generated_cv = FactoryBot.create(:katello_content_view, :generated_for => :repository_export, :organization => view.organization)
+      generated_cve = FactoryBot.create(:katello_content_view_environment, :content_view => generated_cv, :environment => library)
+
+      exception = assert_raises(ActiveRecord::RecordInvalid) do
+        content_facet.content_view_environments = [generated_cve]
+      end
+
+      assert_includes exception.message, "Content view '#{generated_cv.name}' is a generated content view, which cannot be assigned to hosts or activation keys."
+    end
   end
 
   class ContentFacetErrataTest < ContentFacetBase


### PR DESCRIPTION
Ensures no Hosts remain on ContentViews generated for repository export. If doing so would leave the Host without a valid ContentView, the Default Organization View is assigned to it.

Also implements additional filtering in the candlepin proxies controller, and several additional tests.

#### What considerations are taken in implementing this pull request?

At least some validation was already done with c33da7a3fa9

#### What are the testing steps for this pull request?

1. Export a Content View

2. Try assigning some hosts to the content view created for export

3. Apply patch

4. Run migration