### PR TITLE
Fixes #37716 - Add an option to disable the 'Reclaim Space' warning

### DIFF
--- a/app/views/foreman/smart_proxies/_reclaim_space.html.erb
+++ b/app/views/foreman/smart_proxies/_reclaim_space.html.erb
@@ -1,10 +1,12 @@
 <div>
   <h3><%= _('Reclaim Space') %></h3>
-  <p translate>
-    <strong>Warning</strong>: reclaiming space will delete all cached content units in "On Demand" repositories on this Smart Proxy.<br>
-    Take precaution when cleaning custom repositories whose upstream parents don't keep old package versions.
-    Storage used by deleted repositories will be reclaimed during the next orphan cleanup run.
-  </p>
+  <% unless Setting[:hide_reclaim_space_warning] %>
+    <p translate>
+      <strong>Warning</strong>: reclaiming space will delete all cached content units in "On Demand" repositories on this Smart Proxy.<br>
+      Take precaution when cleaning custom repositories whose upstream parents don't keep old package versions.
+      Storage used by deleted repositories will be reclaimed during the next orphan cleanup run.
+    </p>
+  <% end %>
   <div class="button">
     <button class="btn btn-default" type="button" id="reclaimSpaceButton" ng-click="reclaimSpace()" translate>
       Reclaim Space

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -663,6 +663,12 @@ Foreman::Plugin.register :katello do
         default: true,
         full_name: N_('Calculate content counts on smart proxies automatically'),
         description: N_("If this is enabled, content counts on smart proxies will be updated automatically after content sync.")
+
+      setting 'hide_reclaim_space_warning',
+        type: :boolean,
+        default: false,
+        full_name: N_('Hide Reclaim Space Warning'),
+        description: N_('If this is enabled, the Smart Proxy page will suppress the warning message about reclaiming space.')
     end
   end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Adds a new setting to disable the 'reclaim space' warning on smart proxies page

#### What are the testing steps for this pull request?

1. Infrastructure -> Smart Proxies -> select primary Katello server

2. Observe the Warning text above the Reclaim Space button

3. Administer -> Settings -> Content -> Hide Reclaim Space Warning -> enable the setting

4. Observe that Warning text has disappeared