### PR TITLE
Fixes #37743 - Add repository status filter for activation keys

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-repository-sets.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-repository-sets.controller.js
@@ -38,6 +38,14 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyRepositorySet
 
         $scope.repositoryType = {};
 
+        $scope.repositoryStatuses = {
+            enabled: translate("Enabled"),
+            disabled: translate("Disabled"),
+            overridden: translate("Overridden")
+        };
+
+        $scope.repositoryStatus = {};
+
         $scope.contentAccessModes = {
             contentAccessModeAll: true,
             contentAccessModeEnv: true
@@ -47,6 +55,14 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyRepositorySet
             delete $scope.nutupane.table.params['repository_type'];
             if (!_.isEmpty($scope.repositoryType.value)) {
                 $scope.nutupane.table.params['repository_type'] = $scope.repositoryType.value;
+            }
+            $scope.nutupane.refresh();
+        };
+
+        $scope.selectRepositoryStatus = function () {
+            delete $scope.nutupane.table.params.status;
+            if (!_.isEmpty($scope.repositoryStatus.value)) {
+                $scope.nutupane.table.params.status = $scope.repositoryStatus.value;
             }
             $scope.nutupane.refresh();
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-repository-sets.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-repository-sets.html
@@ -33,6 +33,19 @@
           <option value="">{{'All' | translate}}</option>
       </select>
     </label>
+
+    <label class="repository-status-label">
+      <span translate>Status</span>
+      <select
+              id="repositoryStatuses"
+              name="repositoryStatuses"
+              ng-model="repositoryStatus.value"
+              ng-options="id as name for (id, name) in repositoryStatuses"
+              ng-change="selectRepositoryStatus()"
+              >
+          <option value="">{{'All' | translate}}</option>
+      </select>
+    </label>
   </div>
 
   <div data-block="list-actions">

--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/activation_keys.scss
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/activation_keys.scss
@@ -4,7 +4,7 @@
   margin-bottom:0.3rem
 }
 
-.repository-type-label {
+.repository-type-label, .repository-status-label {
   padding-left: 15px;
   font-weight: normal;
   span {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
It is handy to be able to filter for repository status in a repository set. It is already implemented in the Host Details page and people are asking for it on the Activation Keys page as well. 

I know I am pushing my luck adding new features to the Angular page. However, it is a really small one and it highly improves usability. 

![repo_status_activation_key_page](https://github.com/user-attachments/assets/91ab8a23-8397-4222-988a-7e432aea87b4)

#### Considerations taken when implementing this change?
Make it very simple such that it does not add a lot of overhead a) implementation-wise and b) testing-wise . And especially no additional overhead when moving to React at a later point in time. 

#### What are the testing steps for this pull request?
Enable/Disable/Override status on Activation Keys page.