### PR TITLE
Fixes #37133 - use asset pipeline to ascertain the url of spinner.gif

### DIFF
--- a/app/assets/javascripts/katello/common/katello.common.js
+++ b/app/assets/javascripts/katello/common/katello.common.js
@@ -65,7 +65,7 @@ KT.common = (function() {
             }
         },
         spinner_path : function() {
-          return "/assets/spinner.gif";
+          return document.querySelector('#sync_toggle_cont').dataset.spinnerAssetPath;
         },
         to_human_readable_bytes : function(bytes) {
             var sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'],

--- a/app/assets/javascripts/katello/sync_management/sync_management.js
+++ b/app/assets/javascripts/katello/sync_management/sync_management.js
@@ -386,7 +386,7 @@ $("#sync_product_form")
   });
 
 $("#sync_toggle").change(function () {
-  var img = "<img  src='" + KT.common.spinner_path() + "'>";
+  var img = "<img src='" + KT.common.spinner_path() + "'>";
   $("#sync_toggle_cont").append(img);
   if ($(this).is(":checked")) {
     KT.content.showOnlySyncing();

--- a/app/views/katello/sync_management/_controls.html.erb
+++ b/app/views/katello/sync_management/_controls.html.erb
@@ -21,7 +21,7 @@
       </a>
     </div>
   <% end %>
-  <div id="sync_toggle_cont" class="fl table-action">
+  <div id="sync_toggle_cont" class="fl table-action" data-spinner-asset-path="<%= asset_path('spinner.gif') %>">
     <input id="sync_toggle" type="checkbox"/>
     <label for="sync_toggle">
       <%= _('Active only') %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

[Long, long ago](https://projects.theforeman.org/issues/33956) assets were moved from Rails to Apache. Our beloved sync_management page, however, had a lone hard-coded url which has been broken ever since. This should fix that.

#### Considerations taken when implementing this change?

The spinner in question doesn't even show up long enough to be visible, so I'm not even sure why I'm doing this..

The Rails asset helpers aren't accessible via JS, so I ended up using ERB to put the path in the DOM via a data attribute, and then retrieving that.

#### What are the testing steps for this pull request?

Go to the Sync Status page and verify that the `#sync_toggle_cont` element (it's the "Active only" checkbox) has a `data-spinner-asset-path` that look like this:

![image](https://github.com/user-attachments/assets/9d68fb7e-09af-49cd-9e58-bcdf631d443f)

If you _really_ wanna see the spinner, you'll have to comment out this line:
https://github.com/Katello/katello/blob/c6f49111f4cb75d4f48e8ebaa6ab2cd241dfe160/app/assets/javascripts/katello/sync_management/sync_management.js#L396-L397