### PR TITLE
Fixes #37762 - Don't send empty host search query to REX

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
@@ -9,11 +9,19 @@ import { PACKAGE_SEARCH_QUERY } from './PackagesTab/YumInstallablePackagesConsta
 import { PACKAGES_SEARCH_QUERY, SELECTED_UPDATE_VERSIONS } from './PackagesTab/HostPackagesConstants';
 
 // PARAM BUILDING
-const baseParams = (options) => {
+export const buildHostSearch = ({ hostname, hostSearch }) => {
+  let result = hostSearch ?? `name ^ (${hostname})`;
+  if (result === '') {
+    // user has selected all hosts
+    result = 'set? name'; // the name field is NOT NULL, so this will match all hosts
+  }
+  return result;
+};
+export const baseParams = (options) => {
   const {
     feature, hostname, hostSearch, descriptionFormat, inputs = {},
   } = options;
-  const search = hostSearch ?? `name ^ (${hostname})`;
+  const search = buildHostSearch({ hostname, hostSearch });
   return ({
     job_invocation: {
       feature,
@@ -89,7 +97,7 @@ const katelloPackagesUpdateParams = (options) => {
   const {
     hostname, search, hostSearch, versions, descriptionFormat,
   } = options;
-  const searchQuery = hostSearch ?? `name ^ (${hostname})`;
+  const searchQuery = buildHostSearch({ hostname, hostSearch });
   return ({
     job_invocation: {
       feature: REX_FEATURES.KATELLO_PACKAGES_UPDATE_BY_SEARCH,

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/remoteExecutionActions.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/remoteExecutionActions.test.js
@@ -1,0 +1,44 @@
+import { baseParams, buildHostSearch } from '../RemoteExecutionActions';
+
+describe('buildHostSearch', () => {
+  it('Replaces empty string with special search', () => {
+    const options = {
+      hostname: 'test',
+      hostSearch: '',
+    };
+    expect(buildHostSearch(options)).toEqual('set? name');
+  });
+  it('Composes hostname search when hostSearch is not passed', () => {
+    const options = {
+      hostname: 'test',
+    };
+    expect(buildHostSearch(options)).toEqual('name ^ (test)');
+  });
+  it('Composes hostSearch when hostname is not passed', () => {
+    const options = {
+      hostSearch: 'test',
+    };
+    expect(buildHostSearch(options)).toEqual('test');
+  });
+});
+
+describe('baseParams', () => {
+  it('Composes base params', () => {
+    const options = {
+      feature: 'feature',
+      hostname: 'hostname',
+      hostSearch: 'hostSearch',
+      descriptionFormat: 'descriptionFormat',
+      inputs: { input: 'input' },
+    };
+    expect(baseParams(options)).toEqual({
+      job_invocation: {
+        feature: 'feature',
+        inputs: { input: 'input' },
+        description_format: 'descriptionFormat',
+        search_query: 'hostSearch',
+      },
+    });
+  });
+});
+


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

If you're in select all mode and don't deselect any hosts, it sends a blank search to REX and breaks with an error

```
Validation failed: Targeting: Bookmark Must select a bookmark or enter a search query, Search query Must select a bookmark or enter a search query
```

This PR fixes that and also adds some unit tests around it.

```
PASS  webpack/components/extensions/HostDetails/Tabs/__tests__/remoteExecutionActions.test.js (180 MB heap size)
  buildHostSearch
    ✓ Replaces empty string with special search (2ms)
    ✓ Composes hostname search when hostSearch is not passed (1ms)
    ✓ Composes hostSearch when hostname is not passed
  baseParams
    ✓ Composes base params (1ms)
```

#### Considerations taken when implementing this change?

Rather than fixing it in each individual page or wizard, or fixing it in `fetchBulkParams`, fixing it right where we assemble `baseParams` made sense to me. This ensures that searches will only be transformed for REX hosts, and not for other inputs etc.

#### What are the testing steps for this pull request?

1. Have at least 2 hosts. Go to the new All Hosts page

2. Select both using the "Select All" checkbox at the top of the page. Do not deselect any hosts.

Try to perform any Errata or Package actions. Select "via remote execution" (immediate, not customized). You should no longer get the error.
