### PR TITLE
Fixes #37572 - Extract logic and simplify initial AK selection

### DIFF
--- a/webpack/components/extensions/RegistrationCommands/fields/ActivationKeys.js
+++ b/webpack/components/extensions/RegistrationCommands/fields/ActivationKeys.js
@@ -62,12 +62,6 @@ const ActivationKeys = ({
     );
   }, [handleInvalidField, hostGroupId, hostGroupActivationKeys, pluginValues]);
 
-  useEffect(() => {
-    if (activationKeys?.length === 1) {
-      onChange({ activationKeys: [activationKeys[0].name] });
-    }
-  }, [activationKeys, onChange]);
-
   return (
     <FormGroup
       onFocus={() => setHasInteraction(true)}

--- a/webpack/components/extensions/RegistrationCommands/helpers.js
+++ b/webpack/components/extensions/RegistrationCommands/helpers.js
@@ -1,0 +1,15 @@
+export const determineInitialAKSelection = (activationKeys, initialAKSelection) => {
+  // If we've received the initialAKSelection from the URL, and it's a valid activation key, use it
+  if (initialAKSelection &&
+    (activationKeys ?? []).some(ak => ak.name === initialAKSelection)) {
+    return { activationKeys: initialAKSelection.split(',') };
+  }
+  // If there's only one activation key, use it
+  if (activationKeys?.length === 1) {
+    return { activationKeys: [activationKeys[0].name] };
+  }
+  // Otherwise, don't select any activation keys
+  return { activationKeys: [] };
+};
+
+export default determineInitialAKSelection;

--- a/webpack/components/extensions/RegistrationCommands/index.js
+++ b/webpack/components/extensions/RegistrationCommands/index.js
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'foremanReact/common/helpers';
 import { useUrlParams } from 'foremanReact/components/PF4/TableIndexPage/Table/TableHooks';
+import { determineInitialAKSelection } from './helpers';
 
 import ActivationKeys from './fields/ActivationKeys';
 import IgnoreSubmanErrors from './fields/IgnoreSubmanErrors';
@@ -51,15 +52,8 @@ export const RegistrationActivationKeys = ({
 }) => {
   const { initialAKSelection } = useUrlParams();
   useEffect(() => {
-    onChange({ activationKeys: [] });
-  }, [onChange, organizationId, hostGroupId]);
-
-  useEffect(() => {
-    if (initialAKSelection &&
-       (pluginData?.activationKeys ?? []).some(ak => ak.name === initialAKSelection)) {
-      onChange({ activationKeys: initialAKSelection.split(',') });
-    }
-  }, [initialAKSelection, onChange, pluginData?.activationKeys]);
+    onChange(determineInitialAKSelection(pluginData?.activationKeys, initialAKSelection));
+  }, [initialAKSelection, onChange, pluginData?.activationKeys, organizationId, hostGroupId]);
 
   return (
     <ActivationKeys


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This PR removes a few `useEffects` from the Activation key part of the global registration form, and extracts their logic into a single helper function. This makes it easier to reason about what will end up as the initial selected activation key, and also prevents a bug where the selection would get overwritten with an empty array.

#### Considerations taken when implementing this change?

I considered extracting it to a custom Hook instead (because of the useUrlParams) but this seemed better.

I also considered only running the effect if `hasInteraction` is false, but it seems it works fine without that.

#### What are the testing steps for this pull request?

You need to have only a single activation key in your organization. The bug is that on the Register Host page, that single AK should get filled in as the initial selection, but doesn't.

Reproducing the issue can be a bit tricky, but I found this flow pretty reliable:

1. go to All Hosts page via nav
2. go to Register Host page via nav

and go back and forth between them via nav. 

I found that these flows do not reproduce the issue:

1. loading the Register Host page from scratch
2. go to All Hosts page, then click the "Register" button


After you've reproduced the issue rather reliably, check out the PR and ensure that you can no longer reproduce.