### PR TITLE
[WIP] pf5

### DIFF
--- a/webpack/components/ActivationKeysSearch/index.js
+++ b/webpack/components/ActivationKeysSearch/index.js
@@ -5,13 +5,14 @@ import {
   FormGroup,
   Spinner,
   EmptyState,
-  Title,
   Button,
+  Alert, EmptyStateHeader,
+} from '@patternfly/react-core';
+import {
   Select,
   SelectOption,
   SelectVariant,
-  Alert,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/deprecated';
 import { FormattedMessage } from 'react-intl';
 import $ from 'jquery';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -134,9 +135,7 @@ const ActivationKeysSearch = () => {
   if (!(selectedEnvId && selectedContentViewId)) {
     return (
       <EmptyState>
-        <Title headingLevel="h4" size="lg" ouiaId="ak-empty-state-title">
-          {__('Please select a lifecycle environment and content view to view activation keys.')}
-        </Title>
+        <EmptyStateHeader titleText={<>{__('Please select a lifecycle environment and content view to view activation keys.')}</>} headingLevel="h4" />
       </EmptyState>
     );
   }
@@ -157,7 +156,7 @@ const ActivationKeysSearch = () => {
           <Select
             ouiaId="ak-select"
             variant={SelectVariant.typeaheadMulti}
-            onToggle={setIsOpen}
+            onToggle={(_event, val) => setIsOpen(val)}
             onSelect={onSelect}
             selections={selectedKeys}
             isOpen={isOpen}

--- a/webpack/components/Bookmark/AddBookmarkModal.js
+++ b/webpack/components/Bookmark/AddBookmarkModal.js
@@ -46,7 +46,7 @@ const AddBookmarkModal = ({ selectedItem, onClose, controller }) => {
             aria-label="input_name"
             name="name"
             value={name}
-            onChange={setName}
+            onChange={(_event, val) => setName(val)}
           />
         </FormGroup>
         <FormGroup label={__('Search Query')} isRequired fieldId="query">
@@ -58,7 +58,7 @@ const AddBookmarkModal = ({ selectedItem, onClose, controller }) => {
             aria-label="input_query"
             name="query"
             value={query}
-            onChange={setQuery}
+            onChange={(_event, val) => setQuery(val)}
           />
         </FormGroup>
         <FormGroup fieldId="public" isInline>
@@ -68,7 +68,7 @@ const AddBookmarkModal = ({ selectedItem, onClose, controller }) => {
             name="public"
             label={__('Public')}
             isChecked={isPublic}
-            onChange={setIsPublic}
+            onChange={(_event, val) => setIsPublic(val)}
           />
           <Tooltip
             position={TooltipPosition.top}

--- a/webpack/components/Bookmark/Bookmark.scss
+++ b/webpack/components/Bookmark/Bookmark.scss
@@ -1,4 +1,4 @@
-  .pf-c-dropdown__toggle-text {
+  .pf-v5-c-dropdown__toggle-text {
     padding: 0 5px;
 
     .fa-bookmark {
@@ -6,7 +6,7 @@
     }
   }
 
-  .pf-c-dropdown__toggle-icon {
+  .pf-v5-c-dropdown__toggle-icon {
     margin: 0;
   }
 
@@ -14,7 +14,7 @@
   .pf-m-inline {
     align-content: center;
 
-    .pf-c-check {
+    .pf-v5-c-check {
       input {
         margin-top: 2px;
       }

--- a/webpack/components/Bookmark/index.js
+++ b/webpack/components/Bookmark/index.js
@@ -3,7 +3,12 @@ import PropTypes from 'prop-types';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
-import { Dropdown, DropdownItem, DropdownToggle, DropdownSeparator } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+  DropdownSeparator,
+} from '@patternfly/react-core/deprecated';
 import { OutlinedBookmarkIcon } from '@patternfly/react-icons';
 import { getBookmarks } from './BookmarkActions';
 import { selectBookmarks, selectBookmarkStatus } from './BookmarkSelectors';
@@ -71,7 +76,7 @@ const Bookmark = ({
           <DropdownToggle
             ouiaId="bookmark-toggle"
             isDisabled={isDisabled || status !== STATUS.RESOLVED}
-            onToggle={setDropdownOpen}
+            onToggle={(_event, val) => setDropdownOpen(val)}
             id="toggle-id"
           >
             <OutlinedBookmarkIcon />

--- a/webpack/components/EditableSwitch.js
+++ b/webpack/components/EditableSwitch.js
@@ -18,7 +18,7 @@ const EditableSwitch = ({
       aria-label={identifier}
       ouiaId={`switch-${identifier}`}
       isChecked={value}
-      onChange={onSwitch}
+      onChange={(_event, val) => onSwitch(val)}
       disabled={disabled}
     />
   );

--- a/webpack/components/EditableTextInput/EditableTextInput.js
+++ b/webpack/components/EditableTextInput/EditableTextInput.js
@@ -69,7 +69,7 @@ const EditableTextInput = ({
     onKeyUp,
     component,
     value: inputValue || '',
-    onChange: setInputValue,
+    onChange: (e, v) => setInputValue(v),
   };
 
   return editing ? (

--- a/webpack/components/Errata/index.js
+++ b/webpack/components/Errata/index.js
@@ -199,7 +199,7 @@ export const ErrataToggleGroupItem = ({
     <ToggleGroupItem
       text={text}
       isSelected={isSelected}
-      onChange={onChange}
+      onChange={(e, v) => onChange(v)}
       {...toggleGroupItemProps}
     />
   </Tooltip>

--- a/webpack/components/Loading.js
+++ b/webpack/components/Loading.js
@@ -7,6 +7,8 @@ import {
   EmptyStateIcon,
   Spinner,
   Skeleton,
+  EmptyStateHeader,
+  EmptyStateFooter,
 } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 
@@ -19,11 +21,14 @@ const Loading = ({
   return (
     <Bullseye>
       <EmptyState>
-        <EmptyStateIcon size={size} variant="container" component={Spinner} />
-        {showText && (
-        <Title size={size} headingLevel="h4" ouiaId="loading-title">
-          {loadingText || __('Loading')}
-        </Title>)}
+        <EmptyStateHeader icon={<EmptyStateIcon size={size} icon={Spinner} />} />
+        <EmptyStateFooter>
+          {showText && (
+            <Title size={size} headingLevel="h4" ouiaId="loading-title">
+              {loadingText || __('Loading')}
+            </Title>
+          )}
+        </EmptyStateFooter>
       </EmptyState>
     </Bullseye>
   );
@@ -42,6 +47,5 @@ Loading.defaultProps = {
   loadingText: null,
   skeleton: false,
 };
-
 
 export default Loading;

--- a/webpack/components/Packages/index.js
+++ b/webpack/components/Packages/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Icon } from '@patternfly/react-core';
 import { TableText } from '@patternfly/react-table';
 import { translate as __ } from 'foremanReact/common/I18n';
 import {
@@ -25,7 +26,7 @@ const PackagesStatus = ({ upgradable_versions: upgradableVersions }) => {
 
   return (
     <TableText wrapModifier="nowrap">
-      {color && <PackagesIcon color={color} title={label} />} {label}
+      {color && <Icon color={color} title={label}><PackagesIcon /></Icon>} {label}
     </TableText>
   );
 };

--- a/webpack/components/SelectAllCheckbox/index.js
+++ b/webpack/components/SelectAllCheckbox/index.js
@@ -1,7 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Dropdown, DropdownToggle, DropdownToggleCheckbox,
-  DropdownItem } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownToggle,
+  DropdownToggleCheckbox,
+  DropdownItem,
+} from '@patternfly/react-core/deprecated';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { noop } from 'foremanReact/common/helpers';
 
@@ -95,7 +99,7 @@ const SelectAllCheckbox = ({
               key="tablewrapper-select-all-checkbox"
               ouiaId="select-all-checkbox-dropdown-toggle-checkbox"
               aria-label="Select all"
-              onChange={checked => onSelectAllCheckboxChange(checked)}
+              onChange={(_event, checked) => onSelectAllCheckboxChange(checked)}
               isChecked={selectionToggle}
               isDisabled={totalCount === 0 && selectedCount === 0}
             >

--- a/webpack/components/SelectableDropdown/SelectableDropdown.js
+++ b/webpack/components/SelectableDropdown/SelectableDropdown.js
@@ -1,6 +1,15 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Spinner, Select, SelectOption, SelectVariant, Level, LevelItem } from '@patternfly/react-core';
+import {
+  Spinner,
+  Level,
+  LevelItem,
+} from '@patternfly/react-core';
+import {
+  Select,
+  SelectOption,
+  SelectVariant,
+} from '@patternfly/react-core/deprecated';
 import { ErrorCircleOIcon } from '@patternfly/react-icons';
 
 
@@ -37,7 +46,7 @@ const SelectableDropdown = ({
           aria-label={`select ${title}`}
           key="type-dropdown"
           variant={SelectVariant.single}
-          onToggle={onToggle}
+          onToggle={(_event, open) => onToggle(open)}
           onSelect={onSelect}
           selections={selected}
           isOpen={isOpen}

--- a/webpack/components/Table/EmptyStateMessage.js
+++ b/webpack/components/Table/EmptyStateMessage.js
@@ -4,10 +4,8 @@ import {
   EmptyStateBody,
   EmptyStateIcon,
   EmptyStateVariant,
-  EmptyStateSecondaryActions,
   Bullseye,
-  Title,
-  Button,
+  Button, EmptyStateActions, EmptyStateHeader, EmptyStateFooter,
 } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -77,7 +75,7 @@ const EmptyStateMessage = ({
   return (
     <Bullseye>
       <EmptyState
-        variant={happy ? EmptyStateVariant.xl : EmptyStateVariant.small}
+        variant={happy ? EmptyStateVariant.xl : EmptyStateVariant.sm}
       >
         <KatelloEmptyStateIcon
           error={!!error}
@@ -85,15 +83,14 @@ const EmptyStateMessage = ({
           customIcon={PlusCircleIcon}
           happyIcon={happy}
         />
-        <Title headingLevel="h2" size="lg" ouiaId="empty-state-title">
-          {emptyStateTitle}
-        </Title>
+        <EmptyStateHeader titleText={<>{emptyStateTitle}</>} headingLevel="h2" />
         <EmptyStateBody>
           {emptyStateBody}
         </EmptyStateBody>
-        {showPrimaryAction && actionButton}
-        {showSecondaryActionAnchor &&
-          <EmptyStateSecondaryActions>
+        <EmptyStateFooter>
+          {showPrimaryAction && actionButton}
+          {showSecondaryActionAnchor &&
+          <EmptyStateActions>
             <Button variant="link" ouiaId="empty-state-secondary-action-link">
               {extraTableProps.secondaryActionTargetBlank ? (
                 <a href={secondaryActionLink} target="_blank" rel="noreferrer" style={{ textDecoration: 'none' }} >{secondaryActionTitle}</a>
@@ -101,17 +98,18 @@ const EmptyStateMessage = ({
                 <a href={secondaryActionLink} style={{ textDecoration: 'none' }} >{secondaryActionTitle}</a>
               )}
             </Button>
-          </EmptyStateSecondaryActions>
+          </EmptyStateActions>
         }
 
-        {(!showSecondaryActionAnchor &&
+          {(!showSecondaryActionAnchor &&
           (showSecondaryActionButton || searchIsActive || !!filtersAreActive)) &&
-          <EmptyStateSecondaryActions>
+          <EmptyStateActions>
             <Button variant="link" onClick={handleClick} ouiaId="empty-state-secondary-action-router-link">
               {secondaryActionText}
             </Button>
-          </EmptyStateSecondaryActions>
+          </EmptyStateActions>
         }
+        </EmptyStateFooter>
       </EmptyState>
     </Bullseye>
   );

--- a/webpack/components/Table/MainTable.js
+++ b/webpack/components/Table/MainTable.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
+
 import {
-  Table,
+  Table as TableDeprecated,
   TableHeader,
   TableBody,
-  TableComposable,
-} from '@patternfly/react-table';
+  Table,
+} from '@patternfly/react-table/deprecated';
 import { STATUS } from 'foremanReact/constants';
 import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
@@ -96,18 +97,18 @@ const MainTable = ({
   const tableProps = { cells, rows, ...extraTableProps };
   if (children) {
     return (
-      <TableComposable
+      <Table
         ouiaId="content-view-table-composable"
         aria-label="Content View Table"
         className="katello-pf4-table"
         {...extraTableProps}
       >
         {children}
-      </TableComposable>
+      </Table>
     );
   }
   return (
-    <Table
+    <TableDeprecated
       ouiaId="Content-View-table"
       aria-label="Content View Table"
       className="katello-pf4-table"
@@ -115,7 +116,7 @@ const MainTable = ({
     >
       <TableHeader />
       <TableBody />
-    </Table>
+    </TableDeprecated>
   );
 };
 

--- a/webpack/components/Table/MainTable.scss
+++ b/webpack/components/Table/MainTable.scss
@@ -1,18 +1,18 @@
 .katello-pf4-table {
-  .pf-c-dropdown.pf-m-align-right {
+  .pf-v5-c-dropdown.pf-m-align-right {
     width: 100%;
     justify-content: flex-end;
     display: flex;
   }
 
-  .pf-c-dropdown__menu {
+  .pf-v5-c-dropdown__menu {
     min-width: 0;
   }
-  .pf-c-wizard__footer {
+  .pf-v5-c-wizard__footer {
     z-index: 1;
   }
 
-  .pf-c-table tbody tr td {
+  .pf-v5-c-table tbody tr td {
     vertical-align: inherit;
   }
 

--- a/webpack/components/extensions/HostDetails/ActionsBar/index.js
+++ b/webpack/components/extensions/HostDetails/ActionsBar/index.js
@@ -1,6 +1,9 @@
 import React, { useContext } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { DropdownItem, DropdownSeparator } from '@patternfly/react-core';
+import {
+  DropdownItem,
+  DropdownSeparator,
+} from '@patternfly/react-core/deprecated';
 import { CubeIcon, UndoIcon, RedoIcon } from '@patternfly/react-icons';
 
 import { translate as __ } from 'foremanReact/common/I18n';

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ChangeHostCVModal.js
@@ -229,7 +229,7 @@ const ChangeHostCVModal = ({
       </TextContent>
       <Checkbox
         isChecked={forceProfileUpload}
-        onChange={setForceProfileUpload}
+        onChange={(_event, val) => setForceProfileUpload(val)}
         label={__('Update the host immediately via remote execution')}
         id="force-profile-upload-checkbox"
         ouiaId="force-profile-upload-checkbox"

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -4,15 +4,17 @@ import {
   CardHeader,
   CardTitle,
   CardBody,
-  Dropdown,
-  DropdownItem,
   Flex,
   FlexItem,
   GridItem,
-  KebabToggle,
   Label,
   Tooltip,
 } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+} from '@patternfly/react-core/deprecated';
 import { FormattedMessage } from 'react-intl';
 
 import { urlBuilder } from 'foremanReact/common/urlHelpers';
@@ -58,7 +60,7 @@ export const ContentViewEnvironmentDisplay = ({
             }}
           />}
         >
-          <Label isTruncated color="purple" href={`/lifecycle_environments/${lifecycleEnvironment.id}`}>{lifecycleEnvironment.name}</Label>
+          <Label color="purple" href={`/lifecycle_environments/${lifecycleEnvironment.id}`}>{lifecycleEnvironment.name}</Label>
         </Tooltip>
         <ContentViewIcon composite={contentView.composite} style={{ marginRight: '2px' }} position="left" />
         {contentViewDefault ? <span>{contentView.name}</span> :

--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.scss
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.scss
@@ -1,5 +1,5 @@
 #errata-card {
-  .pf-c-empty-state {
+  .pf-v5-c-empty-state {
     margin-top: 0;
   }
   .piechart-overflow {

--- a/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsCard.js
@@ -6,14 +6,16 @@ import {
   CardHeader,
   CardTitle,
   CardBody,
-  Dropdown,
   ExpandableSection,
-  KebabToggle,
   Flex,
   FlexItem,
   GridItem,
-  DropdownItem,
 } from '@patternfly/react-core';
+import {
+  Dropdown,
+  KebabToggle,
+  DropdownItem,
+} from '@patternfly/react-core/deprecated';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { propsToCamelCase } from 'foremanReact/common/helpers';

--- a/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsCard.scss
+++ b/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsCard.scss
@@ -3,13 +3,13 @@
     position: relative;
     top: -20px;
   }
-  .pf-c-empty-state__icon {
+  .pf-v5-c-empty-state__icon {
     font-size: 2em;
   }
   .pf-m-lg {
     margin: -20px;
   }
-  .pf-c-empty-state__body {
+  .pf-v5-c-empty-state__body {
     font-size: smaller;
     margin-top: 1.4em;
     margin-bottom: 1em;

--- a/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsModal.js
@@ -192,7 +192,7 @@ export const HostCollectionsModal = ({
               <Tr key={id} ouiaId={`row-${id}`}>
                 <Td
                   select={{
-                    disable: isDisabled,
+                    isDisabled,
                     isSelected: isSelected(id),
                     onSelect: (_event, selected) => selectOne(selected, id, hostCollection),
                     rowIndex,

--- a/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/__tests__/hostCollectionsModal.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/__tests__/hostCollectionsModal.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
+import { renderWithRedux, patientlyWaitFor, fireEvent,act } from 'react-testing-lib-wrapper';
 import mockAvailableHostCollections from './availableHostCollections.fixtures.json';
 import mockRemovableHostCollections from './removableHostCollections.fixtures.json';
 import { REMOVABLE_HOST_COLLECTIONS_KEY } from '../HostCollectionsConstants';
@@ -99,10 +99,14 @@ describe('HostCollectionsAddModal', () => {
     await patientlyWaitFor(() =>
       expect(getAllByText(firstHostCollection.name)[0]).toBeInTheDocument());
     const checkbox = getByRole('checkbox', { name: 'Select row 0' });
-    fireEvent.click(checkbox);
+    await act(async () => {
+      fireEvent.click(checkbox);
+    });
     const addButton = getByRole('button', { name: 'Add' });
     expect(addButton).toHaveAttribute('aria-disabled', 'false');
-    fireEvent.click(addButton);
+    await act(async () => {
+      fireEvent.click(addButton);
+    });
 
     assertNockRequest(autocompleteScope);
     assertNockRequest(scope);
@@ -204,12 +208,15 @@ describe('HostCollectionsRemoveModal', () => {
     await patientlyWaitFor(() =>
       expect(getAllByText(firstRemovableHostCollection.name)[0]).toBeInTheDocument());
     const checkbox = getByRole('checkbox', { name: 'Select row 0' });
-    fireEvent.click(checkbox);
+    await act(async () => {
+      fireEvent.click(checkbox);
+    });
     expect(getAllByText('1 selected')).toHaveLength(1);
     const removeButton = getByRole('button', { name: 'Remove' });
     expect(removeButton).toHaveAttribute('aria-disabled', 'false');
-    fireEvent.click(removeButton);
-
+    await act(async () => {
+      fireEvent.click(removeButton);
+    });
     assertNockRequest(autocompleteScope);
     assertNockRequest(scope);
     assertNockRequest(alterScope);

--- a/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeCard.js
@@ -22,6 +22,7 @@ import {
   Tooltip,
   Skeleton,
   CardExpandableContent,
+  Icon,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -104,14 +105,16 @@ const SystemPurposeCard = ({ hostDetails, akDetails }) => {
                     enableFlip
                     isContentLeftAligned
                   >
-                    <OutlinedQuestionCircleIcon style={{ marginTop: '7px' }} color="gray" />
+                    <Icon color="gray">
+                      <OutlinedQuestionCircleIcon style={{ marginTop: '7px' }} />
+                    </Icon>
                   </Tooltip>
                 </FlexItem>
               </Flex>
             </FlexItem>
             {showEditButton && (
               <FlexItem>
-                <Button variant="link" isSmall ouiaId="syspurpose-edit-button" onClick={() => setEditing(val => !val)}>{__('Edit')}</Button>
+                <Button variant="link" size="sm" ouiaId="syspurpose-edit-button" onClick={() => setEditing(val => !val)}>{__('Edit')}</Button>
               </FlexItem>)
             }
           </Flex>

--- a/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeCard.scss
+++ b/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeCard.scss
@@ -1,12 +1,12 @@
 .system-purpose-card-body {
   font-size: small;
-  .pf-c-label {
+  .pf-v5-c-label {
     font-size: smaller;
   }
 }
 
 #system-purpose-card {
-  .pf-c-card__header-toggle {
+  .pf-v5-c-card__header-toggle {
     margin-top: -2px;
   }
 }

--- a/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeEditModal.js
+++ b/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeEditModal.js
@@ -11,10 +11,12 @@ import {
   FormGroup,
   FormSelect,
   FormSelectOption,
+} from '@patternfly/react-core';
+import {
   Select,
   SelectOption,
   SelectVariant,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/deprecated';
 import { FormattedMessage } from 'react-intl';
 import { translate as __ } from 'foremanReact/common/I18n';
 import {
@@ -215,7 +217,7 @@ const SystemPurposeEditModal = ({
             name="role"
             ouiaId="role-select"
             value={selectedRole}
-            onChange={setSelectedRole}
+            onChange={(_event, val) => setSelectedRole(val)}
           >
             {roleOptions.map(option => (
               <FormSelectOption
@@ -232,7 +234,7 @@ const SystemPurposeEditModal = ({
             name="serviceLevel"
             ouiaId="service-level-select"
             value={selectedServiceLevel}
-            onChange={setSelectedServiceLevel}
+            onChange={(_event, val) => setSelectedServiceLevel(val)}
           >
             {serviceLevelOptions.map(option => (
               <FormSelectOption
@@ -249,7 +251,7 @@ const SystemPurposeEditModal = ({
             name="usage"
             ouiaId="usage-select"
             value={selectedUsage}
-            onChange={setSelectedUsage}
+            onChange={(_event, val) => setSelectedUsage(val)}
           >
             {usageOptions.map(option => (
               <FormSelectOption
@@ -266,7 +268,7 @@ const SystemPurposeEditModal = ({
             name="release_version"
             ouiaId="release-version-select"
             value={selectedReleaseVersion}
-            onChange={setSelectedReleaseVersion}
+            onChange={(_event, val) => setSelectedReleaseVersion(val)}
           >
             {releaseVersionOptions.map(option => (
               <FormSelectOption
@@ -285,7 +287,7 @@ const SystemPurposeEditModal = ({
             variant={SelectVariant.typeaheadMulti}
             aria-label="syspurpose-addons"
             ouiaId="syspurpose-addons-select"
-            onToggle={toggleAddonSelect}
+            onToggle={(_event, isOpenState) => toggleAddonSelect(isOpenState)}
             onSelect={onAddonSelect}
             selections={selectedAddons}
             isOpen={addonSelectOpen}

--- a/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/__tests__/SystemPurposeEditModal.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/__tests__/SystemPurposeEditModal.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
-import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
+import { renderWithRedux, patientlyWaitFor, fireEvent, act } from 'react-testing-lib-wrapper';
 import HOST_DETAILS from '../../../HostDetailsConstants';
 import SystemPurposeEditModal from '../SystemPurposeEditModal';
 import { assertNockRequest, nockInstance } from '../../../../../../test-utils/nockWrapper';
@@ -163,8 +163,9 @@ describe('SystemPurposeEditModal', () => {
 
     // Save button should now be enabled
     expect(saveButton).toHaveAttribute('aria-disabled', 'false');
-    fireEvent.click(saveButton);
-
+    await act(async () => {
+      fireEvent.click(saveButton);
+    });
     await patientlyWaitFor(() => {
       expect(baseAttributes.closeModal).toHaveBeenCalled();
     });
@@ -217,8 +218,9 @@ describe('SystemPurposeEditModal', () => {
 
     // Save button should now be enabled
     expect(saveButton).toHaveAttribute('aria-disabled', 'false');
-    fireEvent.click(saveButton);
-
+    await act(async () => {
+      fireEvent.click(saveButton);
+    });
     await patientlyWaitFor(() => {
       expect(baseAttributes.closeModal).toHaveBeenCalled();
     });
@@ -246,8 +248,9 @@ describe('SystemPurposeEditModal', () => {
       />, renderOptions());
 
     const releaseVersionDropdown = getByLabelText('Release version');
-    fireEvent.click(releaseVersionDropdown);
-
+    await act(async () => {
+      fireEvent.click(releaseVersionDropdown);
+    });
     await patientlyWaitFor(() => {
       expect(getByText('8')).toBeInTheDocument();
       expect(getByText('9')).toBeInTheDocument();
@@ -276,8 +279,9 @@ describe('SystemPurposeEditModal', () => {
       />, renderOptions(ACTIVATION_KEY));
 
     const releaseVersionDropdown = getByLabelText('Release version');
-    fireEvent.click(releaseVersionDropdown);
-
+    await act(async () => {
+      fireEvent.click(releaseVersionDropdown);
+    });
     await patientlyWaitFor(() => {
       expect(getByText('8')).toBeInTheDocument();
       expect(getByText('9')).toBeInTheDocument();

--- a/webpack/components/extensions/HostDetails/Tabs/DebsTab/DebInstallModal.js
+++ b/webpack/components/extensions/HostDetails/Tabs/DebsTab/DebInstallModal.js
@@ -1,5 +1,15 @@
 import React, { useState } from 'react';
-import { Modal, Button, Dropdown, DropdownItem, DropdownToggle, DropdownDirection, DropdownToggleAction } from '@patternfly/react-core';
+import {
+  Modal,
+  Button,
+} from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+  DropdownDirection,
+  DropdownToggleAction,
+} from '@patternfly/react-core/deprecated';
 import { CaretDownIcon, CaretUpIcon } from '@patternfly/react-icons';
 import { useSelector } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
@@ -213,7 +223,7 @@ const DebInstallModal = ({
               <Tr key={id} ouiaId={`row-${id}`}>
                 <Td
                   select={{
-                    disable: false,
+                    isDisabled: false,
                     isSelected: isSelected(id),
                     onSelect: (_event, selected) => selectOne(selected, id, pkg),
                     rowIndex,

--- a/webpack/components/extensions/HostDetails/Tabs/DebsTab/DebInstallModal.scss
+++ b/webpack/components/extensions/HostDetails/Tabs/DebsTab/DebInstallModal.scss
@@ -1,3 +1,3 @@
-#deb-install-modal .pf-c-input-group input {
+#deb-install-modal .pf-v5-c-input-group input {
   min-width: 15em;
 }

--- a/webpack/components/extensions/HostDetails/Tabs/DebsTab/DebsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/DebsTab/DebsTab.js
@@ -3,6 +3,11 @@ import { useSelector } from 'react-redux';
 import {
   ActionList,
   ActionListItem,
+  Skeleton,
+  Split,
+  SplitItem,
+} from '@patternfly/react-core';
+import {
   Dropdown,
   DropdownItem,
   DropdownSeparator,
@@ -12,10 +17,7 @@ import {
   Select,
   SelectOption,
   SelectVariant,
-  Skeleton,
-  Split,
-  SplitItem,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/deprecated';
 import { TableVariant, Thead, Tbody, Tr, Th, Td, TableText } from '@patternfly/react-table';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -72,7 +74,7 @@ const UpdateVersionsSelect = ({
           variant={SelectVariant.single}
           aria-label="upgradable-version-select"
           ouiaId="upgradable-version-select"
-          onToggle={isOpen => toggleUpgradableVersionSelect(isOpen, rowIndex)}
+          onToggle={(_event, isOpen) => toggleUpgradableVersionSelect(isOpen, rowIndex)}
           onSelect={(event, selected) => {
             onUpgradableVersionSelect(event, selected, rowIndex, packageName);
           }}
@@ -525,7 +527,7 @@ export const DebsTab = () => {
                   {showActions ? (
                     <Td
                       select={{
-                        disable: actionInProgress,
+                        isDisabled: actionInProgress,
                         isSelected: isSelected(id),
                         onSelect: (event, selected) => selectOne(selected, id, pkg),
                         rowIndex,

--- a/webpack/components/extensions/HostDetails/Tabs/DebsTab/DebsTab.scss
+++ b/webpack/components/extensions/HostDetails/Tabs/DebsTab/DebsTab.scss
@@ -6,7 +6,7 @@
   margin: 16px 24px;
 }
 
-#style-select-id .pf-c-select button.pf-c-select__toggle {
+#style-select-id .pf-v5-c-select button.pf-v5-c-select__toggle {
   font-size: 1em;
   margin-left: -0.5rem;
 }

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -2,10 +2,21 @@ import React, { useCallback, useState, useMemo } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { useSelector, useDispatch } from 'react-redux';
 import {
-  Split, SplitItem, ActionList, ActionListItem, Dropdown,
-  DropdownItem, KebabToggle, Skeleton, Tooltip, ToggleGroup,
-  DropdownToggle, DropdownToggleAction,
+  Split,
+  SplitItem,
+  ActionList,
+  ActionListItem,
+  Skeleton,
+  Tooltip,
+  ToggleGroup,
 } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+  DropdownToggle,
+  DropdownToggleAction,
+} from '@patternfly/react-core/deprecated';
 import { TimesIcon, CheckIcon } from '@patternfly/react-icons';
 import {
   TableVariant,
@@ -250,7 +261,7 @@ export const ErrataTab = () => {
   const disabledReason = __('A remote execution job is in progress');
 
   const tdSelect = useCallback((errataId, rowIndex, rexJobInProgress) => ({
-    disable: rexJobInProgress || !isSelectable(errataId),
+    isDisabled: rexJobInProgress || !isSelectable(errataId),
     isSelected: isSelected(errataId),
     onSelect: (event, selected) => selectOne(selected, errataId),
     rowIndex,

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.scss
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.scss
@@ -6,6 +6,6 @@
   margin: 16px 24px;
 }
 
-.pf-c-toggle-group__text {
+.pf-v5-c-toggle-group__text {
   color: black;
 }

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -2,21 +2,26 @@ import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { Skeleton,
+import {
+  Skeleton,
   Label,
   Button,
   Split,
   SplitItem,
   Checkbox,
-  Dropdown,
   Text,
   TextVariants,
+  Modal,
+  ModalVariant,
+  Icon,
+} from '@patternfly/react-core';
+import {
+  Dropdown,
   DropdownItem,
   KebabToggle,
   DropdownPosition,
   DropdownSeparator,
-  Modal,
-  ModalVariant } from '@patternfly/react-core';
+} from '@patternfly/react-core/deprecated';
 import PropTypes from 'prop-types';
 import { upperFirst, lowerCase } from 'lodash';
 import { TableText, TableVariant, Thead, Tbody, Tr, Td } from '@patternfly/react-table';
@@ -54,9 +59,9 @@ const EnabledIcon = ({ streamText, streamInstallStatus, upgradable }) => {
   case (streamInstallStatus?.length > 0 && streamText === 'disabled'):
     return <TableText wrapModifier="nowrap">{INSTALLED_STATE.INSTALLED}</TableText>;
   case (streamInstallStatus?.length > 0 && streamText === 'enabled' && upgradable !== true):
-    return <><CheckIcon color="green" /> {INSTALLED_STATE.UPTODATE}</>;
+    return <><Icon color="green" ><CheckIcon /></Icon>{INSTALLED_STATE.UPTODATE}</>;
   case (streamInstallStatus?.length > 0 && streamText === 'enabled' && upgradable):
-    return <><LongArrowAltUpIcon color="blue" /> {INSTALLED_STATE.UPGRADEABLE}</>;
+    return <><Icon color="blue"><LongArrowAltUpIcon /></Icon> {INSTALLED_STATE.UPGRADEABLE}</>;
   default:
     return <InactiveText text={INSTALLED_STATE.NOTINSTALLED} />;
   }
@@ -432,7 +437,7 @@ export const ModuleStreamsTab = () => {
                     id={`Checkbox${id}`}
                     label={__('Customize with Rex')}
                     isChecked={id === useCustomizedRex}
-                    onChange={checked => (checked ? setUseCustomizedRex(id) : setUseCustomizedRex(''))}
+                    onChange={(_event, checked) => (checked ? setUseCustomizedRex(id) : setUseCustomizedRex(''))}
                   />
                 </DropdownItem>,
                 <DropdownSeparator key={`separator-${id}`} ouiaId={`separator-${id}`} />,

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.js
@@ -1,5 +1,15 @@
 import React, { useState } from 'react';
-import { Modal, Button, Dropdown, DropdownItem, DropdownToggle, DropdownDirection, DropdownToggleAction } from '@patternfly/react-core';
+import {
+  Modal,
+  Button,
+} from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+  DropdownDirection,
+  DropdownToggleAction,
+} from '@patternfly/react-core/deprecated';
 import { CaretDownIcon, CaretUpIcon } from '@patternfly/react-icons';
 import { useSelector } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
@@ -213,7 +223,7 @@ const PackageInstallModal = ({
               <Tr key={id} ouiaId={`row-${id}`}>
                 <Td
                   select={{
-                    disable: false,
+                    isDisabled: false,
                     isSelected: isSelected(id),
                     onSelect: (_event, selected) => selectOne(selected, id, pkg),
                     rowIndex,

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.scss
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.scss
@@ -1,3 +1,3 @@
-#package-install-modal .pf-c-input-group input {
+#package-install-modal .pf-v5-c-input-group input {
   min-width: 15em;
 }

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -3,6 +3,11 @@ import { useSelector, useDispatch } from 'react-redux';
 import {
   ActionList,
   ActionListItem,
+  Skeleton,
+  Split,
+  SplitItem,
+} from '@patternfly/react-core';
+import {
   Dropdown,
   DropdownItem,
   DropdownSeparator,
@@ -12,10 +17,7 @@ import {
   Select,
   SelectOption,
   SelectVariant,
-  Skeleton,
-  Split,
-  SplitItem,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/deprecated';
 import { TableVariant, Thead, Tbody, Tr, Th, Td, TableText } from '@patternfly/react-table';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -74,7 +76,7 @@ const UpdateVersionsSelect = ({
           variant={SelectVariant.single}
           aria-label="upgradable-version-select"
           ouiaId="upgradable-version-select"
-          onToggle={isOpen => toggleUpgradableVersionSelect(isOpen, rowIndex)}
+          onToggle={(_event, isOpen) => toggleUpgradableVersionSelect(isOpen, rowIndex)}
           onSelect={(event, selected) => {
             onUpgradableVersionSelect(event, selected, rowIndex, packageName);
           }}
@@ -568,7 +570,7 @@ export const PackagesTab = () => {
                   {showActions ? (
                     <Td
                       select={{
-                        disable: actionInProgress,
+                        isDisabled: actionInProgress,
                         isSelected: isSelected(id),
                         onSelect: (event, selected) => selectOne(selected, id, pkg),
                         rowIndex,

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.scss
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.scss
@@ -6,7 +6,7 @@
   margin: 16px 24px;
 }
 
-#style-select-id .pf-c-select button.pf-c-select__toggle {
+#style-select-id .pf-v5-c-select button.pf-v5-c-select__toggle {
   font-size: 1em;
   margin-left: -0.5rem;
 }

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -22,9 +22,6 @@ import {
   ActionListItem,
   Alert,
   AlertActionCloseButton,
-  Dropdown,
-  DropdownItem,
-  KebabToggle,
   Label,
   Skeleton,
   Split,
@@ -33,6 +30,11 @@ import {
   ToggleGroupItem,
   Tooltip,
 } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+} from '@patternfly/react-core/deprecated';
 import { FlagIcon } from '@patternfly/react-icons';
 import {
   TableVariant,
@@ -616,7 +618,7 @@ const RepositorySetsTab = () => {
                 <Tr key={id} ouiaId={`tr-${rowIndex}`}>
                   {canDoContentOverrides ? (
                     <Td select={{
-                      disable: !isSelectable(id),
+                      isDisabled: !isSelectable(id),
                       isSelected: isSelected(id),
                       onSelect: (event, selected) => selectOne(selected, id),
                       rowIndex,

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.js
@@ -6,15 +6,17 @@ import {
   FlexItem,
   Modal,
   ModalVariant,
-  Dropdown,
-  DropdownItem,
-  DropdownToggle,
   Text,
   TextContent,
   TextList,
   TextListItem,
   Alert,
 } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+} from '@patternfly/react-core/deprecated';
 import { CaretDownIcon, ArrowRightIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { useSelector } from 'react-redux';

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.scss
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.scss
@@ -1,4 +1,4 @@
-.pf-c-content {
+.pf-v5-c-content {
   ul {
       margin-top: 1rem;
       li svg {

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesEnabler.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesEnabler.js
@@ -4,12 +4,11 @@ import {
   EmptyState,
   EmptyStateIcon,
   EmptyStateBody,
-  Title,
   EmptyStateVariant,
   Button,
   Flex,
   FlexItem,
-  Spinner,
+  Spinner, EmptyStateHeader, EmptyStateFooter,
 } from '@patternfly/react-core';
 import { WrenchIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -67,14 +66,12 @@ const TracesEnabler = ({ hostname, tracerRpmAvailable }) => {
   } = useRexJobPolling(initialAction, successAction);
 
   return (
-    <EmptyState variant={EmptyStateVariant.small}>
+    <EmptyState variant={EmptyStateVariant.sm}>
       {pollingStarted ?
         <Spinner /> :
         <EmptyStateIcon icon={WrenchIcon} />
       }
-      <Title ouiaId="enable-tracer-title" headingLevel="h2" size="lg">
-        {pollingStarted ? enablingTitle : title}
-      </Title>
+      <EmptyStateHeader titleText={<>{pollingStarted ? enablingTitle : title}</>} headingLevel="h2" />
       <EmptyStateBody>
         <Flex direction={{ default: 'column' }}>
           <FlexItem>{body}</FlexItem>
@@ -90,13 +87,15 @@ const TracesEnabler = ({ hostname, tracerRpmAvailable }) => {
           </FlexItem>
         </Flex>
       </EmptyStateBody>
-      <EnableTracerModal
-        key={hostname}
-        isOpen={enableTracerModalOpen}
-        setIsOpen={setEnableTracerModalOpen}
-        triggerJobStart={triggerJobStart}
-        tracerRpmAvailable={tracerRpmAvailable}
-      />
+      <EmptyStateFooter>
+        <EnableTracerModal
+          key={hostname}
+          isOpen={enableTracerModalOpen}
+          setIsOpen={setEnableTracerModalOpen}
+          triggerJobStart={triggerJobStart}
+          tracerRpmAvailable={tracerRpmAvailable}
+        />
+      </EmptyStateFooter>
     </EmptyState>
   );
 };

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
@@ -1,9 +1,19 @@
 import React, { useState, useCallback } from 'react';
 import { FormattedMessage } from 'react-intl';
 import {
-  Skeleton, Split, SplitItem, ActionList, ActionListItem, Dropdown,
-  DropdownItem, DropdownToggle, DropdownToggleAction, Alert,
+  Skeleton,
+  Split,
+  SplitItem,
+  ActionList,
+  ActionListItem,
+  Alert,
 } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+  DropdownToggleAction,
+} from '@patternfly/react-core/deprecated';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { TableVariant, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
@@ -270,7 +280,7 @@ const TracesTab = () => {
                 {showActions ? (
                   <Td
                     select={{
-                      disable: actionInProgress || resolveDisabled,
+                      isDisabled: actionInProgress || resolveDisabled,
                       props: {
                         'aria-label': `check-${application}`,
                       },

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/debsTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/debsTab.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
+import { renderWithRedux, patientlyWaitFor, fireEvent, act } from 'react-testing-lib-wrapper';
 import * as hooks from 'foremanReact/components/PF4/TableIndexPage/Table/TableHooks';
 import { nockInstance, assertNockRequest, mockForemanAutocomplete } from '../../../../../test-utils/nockWrapper';
 import { foremanApi } from '../../../../../services/api';
@@ -132,7 +132,9 @@ test('Can filter by package status', async (done) => {
 
   const statusDropdown = queryByText('Status', { ignore: 'th' });
   expect(statusDropdown).toBeInTheDocument();
-  fireEvent.click(statusDropdown);
+  await act(async () => {
+    fireEvent.click(statusDropdown);
+  });
   const upgradable = getByRole('option', { name: 'select Upgradable' });
   fireEvent.click(upgradable);
   await patientlyWaitFor(() => {
@@ -182,20 +184,26 @@ test('Can upgrade a package via remote execution', async (done) => {
 
   const statusDropdown = getByText('Status', { ignore: 'th' });
   expect(statusDropdown).toBeInTheDocument();
-  fireEvent.click(statusDropdown);
+  await act(async () => {
+    fireEvent.click(statusDropdown);
+  });
   const upgradable = getByRole('option', { name: 'select Upgradable' });
   fireEvent.click(upgradable);
   await patientlyWaitFor(() => {
     expect(getByText('libmagic1')).toBeInTheDocument();
     expect(getByText('libapt-pkg6.0')).toBeInTheDocument();
   });
-
-  const kebabDropdown = getAllByLabelText('Actions');
-  kebabDropdown[0].click();
+  const kebabDropdown = getAllByLabelText('Kebab toggle');
+  await act(async () => {
+    kebabDropdown[0].click();
+  });
 
   const rexAction = getByText('Upgrade via remote execution');
   await patientlyWaitFor(() => expect(rexAction).toBeInTheDocument());
-  fireEvent.click(rexAction);
+
+  await act(async () => {
+    fireEvent.click(rexAction);
+  });
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope);
@@ -227,7 +235,9 @@ test('Can upgrade a package via customized remote execution', async (done) => {
 
   const statusDropdown = getByText('Status', { ignore: 'th' });
   expect(statusDropdown).toBeInTheDocument();
-  fireEvent.click(statusDropdown);
+  await act(async () => {
+    fireEvent.click(statusDropdown);
+  });
   const upgradable = getByRole('option', { name: 'select Upgradable' });
   fireEvent.click(upgradable);
   await patientlyWaitFor(() => {
@@ -235,8 +245,10 @@ test('Can upgrade a package via customized remote execution', async (done) => {
     expect(getByText('libmagic1')).toBeInTheDocument();
   });
 
-  const kebabDropdown = getAllByLabelText('Actions');
-  kebabDropdown[0].click();
+  const kebabDropdown = getAllByLabelText('Kebab toggle');
+  await act(async () => {
+    kebabDropdown[0].click();
+  });
 
   const rexAction = getByText('Upgrade via customized remote execution');
   const feature = REX_FEATURES.KATELLO_PACKAGE_UPDATE;
@@ -248,7 +260,9 @@ test('Can upgrade a package via customized remote execution', async (done) => {
     `/job_invocations/new?feature=${feature}&search=name%20%5E%20(${hostname})&inputs%5Bpackage%5D=${packageName}`,
   );
 
-  fireEvent.click(rexAction);
+  await act(async () => {
+    fireEvent.click(rexAction);
+  });
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope);
@@ -295,7 +309,9 @@ test('Can bulk upgrade via remote execution', async (done) => {
 
   const rexAction = getByLabelText('bulk_upgrade_rex');
   expect(rexAction).toBeInTheDocument();
-  fireEvent.click(rexAction);
+  await act(async () => {
+    fireEvent.click(rexAction);
+  });
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope);

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderWithRedux, patientlyWaitFor, within, fireEvent } from 'react-testing-lib-wrapper';
+import { renderWithRedux, patientlyWaitFor, within, fireEvent, act } from 'react-testing-lib-wrapper';
 import { nockInstance, assertNockRequest, mockForemanAutocomplete } from '../../../../../test-utils/nockWrapper';
 import { foremanApi } from '../../../../../services/api';
 import { HOST_ERRATA_KEY, ERRATA_SEARCH_QUERY } from '../ErrataTab/HostErrataConstants';
@@ -815,7 +815,7 @@ test('Can filter by severity', async (done) => {
   await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
   // the Bugfix text in the table is just a text node, while the dropdown is a button
   expect(getByText('Moderate', { ignore: ['button', 'title'] })).toBeInTheDocument();
-  expect(getByText('Important', { ignore: ['.pf-c-select__toggle-text', 'title'] })).toBeInTheDocument();
+  expect(getByText('Important', { ignore: ['.pf-v5-c-select__toggle-text', 'title'] })).toBeInTheDocument();
   expect(getByText('Critical', { ignore: ['button', 'title'] })).toBeInTheDocument();
   const severityContainer = queryByLabelText('select Severity container', { ignore: 'th' });
   const severityDropdown = within(severityContainer).queryByText('Severity');
@@ -824,11 +824,11 @@ test('Can filter by severity', async (done) => {
   const important = getByRole('option', { name: 'select Important' });
   fireEvent.click(important);
   await patientlyWaitFor(() => {
-    expect(queryByText('Moderate', { ignore: ['.pf-c-select__toggle-text'] })).not.toBeInTheDocument();
-    expect(queryByText('Critical', { ignore: ['.pf-c-select__toggle-text'] })).not.toBeInTheDocument();
+    expect(queryByText('Moderate', { ignore: ['.pf-v5-c-select__toggle-text'] })).not.toBeInTheDocument();
+    expect(queryByText('Critical', { ignore: ['.pf-v5-c-select__toggle-text'] })).not.toBeInTheDocument();
   });
   await patientlyWaitFor(() => {
-    expect(getByText('Important', { ignore: ['.pf-c-select__toggle-text', 'title'] })).toBeInTheDocument();
+    expect(getByText('Important', { ignore: ['.pf-v5-c-select__toggle-text', 'title'] })).toBeInTheDocument();
   });
 
 
@@ -871,7 +871,9 @@ test('Can bulk apply via remote execution', async (done) => {
   actionMenu.click();
   const viaRexAction = queryByText('Apply via remote execution');
   expect(viaRexAction).toBeInTheDocument();
-  viaRexAction.click();
+  await act(async () => {
+    viaRexAction.click();
+  });
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(resolveErrataScope);
@@ -911,7 +913,9 @@ test('Can select all, exclude and bulk apply via remote execution', async (done)
   actionMenu.click();
   const viaRexAction = queryByText('Apply via remote execution');
   expect(viaRexAction).toBeInTheDocument();
-  viaRexAction.click();
+  await act(async () => {
+    viaRexAction.click();
+  });
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(resolveErrataScope);
@@ -947,7 +951,9 @@ test('Can apply errata in bulk via customized remote execution', async (done) =>
     `/job_invocations/new?feature=${feature}&search=name%20%5E%20(${hostName})&inputs%5BErrata%20search%20query%5D=errata_id%20%5E%20(${errata})`,
   );
 
-  viaRexAction.click();
+  await act(async () => {
+    viaRexAction.click();
+  });
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done);
 });
@@ -973,16 +979,20 @@ test('Can apply a single erratum to the host via remote execution', async (done)
     renderOptions(cfWithErrataTotal(mockErrata.total)),
   );
   await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
-  const erratumActionMenu = within(getByLabelText('Select row 0').closest('tr')).getByLabelText('Actions');
-  expect(erratumActionMenu).toHaveAttribute('aria-label', 'Actions');
-  erratumActionMenu.click();
-
+  const erratumActionMenu = within(getByLabelText('Select row 0').closest('tr')).getByLabelText('Kebab toggle');
+  expect(erratumActionMenu).toHaveAttribute('aria-label', 'Kebab toggle');
+  await act(async () => {
+    erratumActionMenu.click();
+  });
+  
   let viaRexAction;
   await patientlyWaitFor(() => {
     viaRexAction = getByText('Apply via remote execution');
     expect(viaRexAction).toBeInTheDocument();
   });
-  viaRexAction.click();
+  await act(async () => {
+    viaRexAction.click();
+  });
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(resolveErrataScope);
@@ -1005,16 +1015,19 @@ test('Can apply a single erratum to the host via customized remote execution', a
     renderOptions(cfWithErrataTotal(mockErrata.total)),
   );
   await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
-  const erratumActionMenu = within(getByLabelText('Select row 0').closest('tr')).getByLabelText('Actions');
-  expect(erratumActionMenu).toHaveAttribute('aria-label', 'Actions');
-  erratumActionMenu.click();
-
+  const erratumActionMenu = within(getByLabelText('Select row 0').closest('tr')).getByLabelText('Kebab toggle');
+  expect(erratumActionMenu).toHaveAttribute('aria-label', 'Kebab toggle');
+  await act(async () => {
+    erratumActionMenu.click();
+  });
   let viaRexAction;
   await patientlyWaitFor(() => {
     viaRexAction = getByText('Apply via customized remote execution');
     expect(viaRexAction).toBeInTheDocument();
   });
-  viaRexAction.click();
+  await act(async () => {
+    viaRexAction.click();
+  });
   expect(viaRexAction).toHaveAttribute(
     'href',
     `/job_invocations/new?feature=${feature}&search=name%20%5E%20(${hostName})&inputs%5BErrata%20search%20query%5D=errata_id%20=%20${errataId}`,

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/packagesTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/packagesTab.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
+import { renderWithRedux, patientlyWaitFor, fireEvent, act, screen } from 'react-testing-lib-wrapper';
 import * as hooks from 'foremanReact/components/PF4/TableIndexPage/Table/TableHooks';
 import { nockInstance, assertNockRequest, mockForemanAutocomplete } from '../../../../../test-utils/nockWrapper';
 import { foremanApi } from '../../../../../services/api';
@@ -135,9 +135,13 @@ test('Can filter by package status', async (done) => {
 
   const statusDropdown = queryByText('Status', { ignore: 'th' });
   expect(statusDropdown).toBeInTheDocument();
-  fireEvent.click(statusDropdown);
+  await act(async () => {
+    fireEvent.click(statusDropdown);
+  });
   const upgradable = getByRole('option', { name: 'select Upgradable' });
-  fireEvent.click(upgradable);
+  await act(async () => {
+    fireEvent.click(upgradable);
+  });
   await patientlyWaitFor(() => {
     expect(queryByText('coreutils')).toBeInTheDocument();
     expect(queryByText('acl')).not.toBeInTheDocument();
@@ -184,19 +188,27 @@ test('Can upgrade a package via remote execution', async (done) => {
 
   const statusDropdown = getByText('Status', { ignore: 'th' });
   expect(statusDropdown).toBeInTheDocument();
-  fireEvent.click(statusDropdown);
+  await act(async () => {
+    fireEvent.click(statusDropdown);
+  });
   const upgradable = getByRole('option', { name: 'select Upgradable' });
-  fireEvent.click(upgradable);
+  await act(async () => {
+    fireEvent.click(upgradable);
+  });
   await patientlyWaitFor(() => {
     expect(getByText('coreutils')).toBeInTheDocument();
   });
-
-  const kebabDropdown = getByLabelText('Actions');
-  kebabDropdown.click();
+  
+  const kebabDropdown = getByLabelText('Kebab toggle');
+  await act(async () => {
+    kebabDropdown.click();
+  });
 
   const rexAction = getByText('Upgrade via remote execution');
   await patientlyWaitFor(() => expect(rexAction).toBeInTheDocument());
-  fireEvent.click(rexAction);
+  await act(async () => {
+    fireEvent.click(rexAction);
+  });
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope);
@@ -228,15 +240,21 @@ test('Can upgrade a package via customized remote execution', async (done) => {
 
   const statusDropdown = getByText('Status', { ignore: 'th' });
   expect(statusDropdown).toBeInTheDocument();
-  fireEvent.click(statusDropdown);
+  await act(async () => {
+    fireEvent.click(statusDropdown);
+  });
   const upgradable = getByRole('option', { name: 'select Upgradable' });
-  fireEvent.click(upgradable);
+  await act(async () => {
+    fireEvent.click(upgradable);
+  });
   await patientlyWaitFor(() => {
     expect(getByText('coreutils')).toBeInTheDocument();
   });
 
-  const kebabDropdown = getByLabelText('Actions');
-  kebabDropdown.click();
+  const kebabDropdown = getByLabelText('Kebab toggle');
+  await act(async () => {
+    kebabDropdown.click();
+  });
 
   const rexAction = getByText('Upgrade via customized remote execution');
   const feature = REX_FEATURES.KATELLO_PACKAGE_UPDATE;
@@ -247,8 +265,9 @@ test('Can upgrade a package via customized remote execution', async (done) => {
     'href',
     `/job_invocations/new?feature=${feature}&search=name%20%5E%20(${hostname})&inputs%5Bpackage%5D=${packageName}`,
   );
-
-  fireEvent.click(rexAction);
+  await act(async () => {
+    fireEvent.click(rexAction);
+  });
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope);
@@ -292,11 +311,14 @@ test('Can bulk upgrade via remote execution', async (done) => {
   expect(getByLabelText('Select row 1').checked).toEqual(true);
 
   const upgradeDropdown = getAllByRole('button', { name: 'Select' })[1];
-  fireEvent.click(upgradeDropdown);
-
+  await act(async () => {
+    fireEvent.click(upgradeDropdown);
+  });
   const rexAction = getByLabelText('bulk_upgrade_rex');
   expect(rexAction).toBeInTheDocument();
-  fireEvent.click(rexAction);
+  await act(async () => {
+    fireEvent.click(rexAction);
+  });
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope);
@@ -331,7 +353,9 @@ test('Can bulk upgrade via customized remote execution', async (done) => {
   expect(getByLabelText('Select row 1').checked).toEqual(true);
 
   const upgradeDropdown = getAllByRole('button', { name: 'Select' })[1];
-  fireEvent.click(upgradeDropdown);
+  await act(async () => {
+    fireEvent.click(upgradeDropdown);
+  });
   expect(upgradeDropdown).not.toHaveAttribute('disabled');
 
   const rexAction = getByLabelText('bulk_upgrade_customized_rex');

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySetsTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/repositorySetsTab.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderWithRedux, patientlyWaitFor, within, fireEvent } from 'react-testing-lib-wrapper';
+import { renderWithRedux, patientlyWaitFor, within, fireEvent, act } from 'react-testing-lib-wrapper';
 import { nockInstance, assertNockRequest, mockAutocomplete } from '../../../../../test-utils/nockWrapper';
 import katelloApi, { foremanApi } from '../../../../../services/api';
 import { REPOSITORY_SETS_KEY } from '../RepositorySetsTab/RepositorySetsConstants';
@@ -244,9 +244,10 @@ test('Can override to disabled', async (done) => {
   expect(getAllByText('Enabled')).toHaveLength(2);
   expect(getAllByText('Disabled')).toHaveLength(1);
   // Find the first action menu and click it
-  const actionMenu = getAllByLabelText('Actions')[0].closest('button');
-  fireEvent.click(actionMenu);
-
+  const actionMenu = getAllByLabelText('Kebab toggle')[0].closest('button');
+  await act(async () => {
+    fireEvent.click(actionMenu);
+  });
   const overrideMenuItem = getByText('Override to disabled');
   expect(overrideMenuItem).toBeInTheDocument();
   fireEvent.click(overrideMenuItem);
@@ -284,8 +285,10 @@ test('Can override to enabled', async (done) => {
   expect(getAllByText('Enabled')).toHaveLength(2);
   expect(getAllByText('Disabled')).toHaveLength(1);
   // The second item is overridden to disabled; we're going to override to enabled
-  const actionMenu = getAllByLabelText('Actions')[1].closest('button');
-  fireEvent.click(actionMenu);
+  const actionMenu = getAllByLabelText('Kebab toggle')[1].closest('button');
+  await act(async () => {
+    fireEvent.click(actionMenu);
+  });
 
   const overrideMenuItem = getByText('Override to enabled');
   expect(overrideMenuItem).toBeInTheDocument();
@@ -323,8 +326,10 @@ test('Can reset to default', async (done) => {
   expect(getAllByText('Disabled')).toHaveLength(1);
 
   // The second item is overridden to disabled but would normally be enabled; we're going to reset
-  const actionMenu = getAllByLabelText('Actions')[1].closest('button');
-  fireEvent.click(actionMenu);
+  const actionMenu = getAllByLabelText('Kebab toggle')[1].closest('button');
+  await act(async () => {
+    fireEvent.click(actionMenu);
+  });
 
   const overrideMenuItem = getByText('Reset to default');
   expect(overrideMenuItem).toBeInTheDocument();
@@ -358,7 +363,9 @@ test('Can override in bulk', async (done) => {
   getByLabelText('Select row 0').click();
   getByLabelText('Select row 1').click();
   const actionMenu = getByLabelText('bulk_actions');
-  actionMenu.click();
+  await act(async () => {
+    fireEvent.click(actionMenu);
+  });
   const resetToDefault = queryByText('Reset to default');
   expect(resetToDefault).toBeInTheDocument();
   resetToDefault.click();
@@ -391,7 +398,9 @@ test('Can override in bulk when limited to environment', async (done) => {
   await patientlyWaitFor(() => expect(getByText(firstRepoSet.contentUrl)).toBeInTheDocument());
   getByLabelText('Select all').click();
   const actionMenu = getByLabelText('bulk_actions');
-  actionMenu.click();
+  await act(async () => {
+    fireEvent.click(actionMenu);
+  });
   const resetToDefault = queryByText('Reset to default');
   expect(resetToDefault).toBeInTheDocument();
   resetToDefault.click();
@@ -422,7 +431,9 @@ test('Can filter by status', async (done) => {
   const statusContainer = queryByLabelText('select Status container', { ignore: 'th' });
   const statusDropdown = within(statusContainer).queryByText('Status');
   expect(statusDropdown).toBeInTheDocument();
-  fireEvent.click(statusDropdown);
+  await act(async () => {
+    fireEvent.click(statusDropdown);
+  });
   const overridden = getByRole('option', { name: 'select Overridden' });
   fireEvent.click(overridden);
   await patientlyWaitFor(() => {

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
@@ -49,7 +49,7 @@ const renderOptions = isTracerInstalled => ({ // sets initial Redux state
   },
 });
 
-const actionMenuToTheRightOf = node => node.nextElementSibling.firstElementChild.firstElementChild;
+const actionMenuToTheRightOf = node => node.nextElementSibling.firstElementChild;
 
 const hostTraces = foremanApi.getApiUrl('/hosts/1/traces');
 const autocompleteUrl = '/hosts/1/traces/auto_complete_search';
@@ -227,7 +227,10 @@ describe('With tracer installed', () => {
     fireEvent.click(traceCheckbox);
     expect(traceCheckbox.checked).toEqual(true);
     const actionMenu = getByLabelText('bulk_actions');
-    actionMenu.click();
+  
+    await act(async () => {
+      actionMenu.click();
+    });
     const viaRexAction = queryByText('Restart via remote execution');
     expect(viaRexAction).toBeInTheDocument();
     viaRexAction.click();
@@ -268,13 +271,18 @@ describe('With tracer installed', () => {
 
 
     const selectAllCheckbox = getByLabelText('Select all');
-    fireEvent.click(selectAllCheckbox);
+    
+    await act(async () => { 
+      fireEvent.click(selectAllCheckbox);
+    });
     expect(traceCheckbox.checked).toEqual(true);
 
     fireEvent.click(getByLabelText('Select row 0')); // de select
     fireEvent.click(getByLabelText('Select row 2')); // de select
 
-    fireEvent.click(getByText('Reboot host'));
+    await act(async () => { 
+      fireEvent.click(getByText('Reboot host'));
+    });
 
     assertNockRequest(autocompleteScope);
     assertNockRequest(resolveTracesScope);
@@ -301,17 +309,19 @@ describe('With tracer installed', () => {
     await patientlyWaitFor(() => {
       const traceNameNode = getByText(firstTrace.helper);
       traceActionMenu = actionMenuToTheRightOf(traceNameNode);
-      expect(traceActionMenu).toHaveAttribute('aria-label', 'Actions');
+      expect(traceActionMenu).toHaveAttribute('aria-label', 'Kebab toggle');
     });
-    traceActionMenu.click();
-
+    await act(async () => {
+      traceActionMenu.click();
+    });
     let viaRexAction;
     await patientlyWaitFor(() => {
       viaRexAction = getByText('Restart via remote execution');
       expect(viaRexAction).toBeInTheDocument();
     });
-    viaRexAction.click();
-
+    await act(async () => {
+      viaRexAction.click();
+    });
     assertNockRequest(autocompleteScope);
     assertNockRequest(resolveTracesScope);
     assertNockRequest(scope, done);
@@ -334,10 +344,11 @@ describe('With tracer installed', () => {
     await patientlyWaitFor(() => {
       const traceNameNode = getByText(firstTrace.helper);
       traceActionMenu = actionMenuToTheRightOf(traceNameNode);
-      expect(traceActionMenu).toHaveAttribute('aria-label', 'Actions');
+      expect(traceActionMenu).toHaveAttribute('aria-label', 'Kebab toggle');
     });
-    fireEvent.click(traceActionMenu);
-
+    await act(async () => {
+      fireEvent.click(traceActionMenu);
+    });
     let viaCustomizedRexAction;
     await patientlyWaitFor(() => {
       viaCustomizedRexAction = getByText('Restart via customized remote execution');
@@ -372,7 +383,9 @@ describe('With tracer installed', () => {
     expect(traceCheckbox.checked).toEqual(true);
 
     const actionMenu = getByLabelText('bulk_actions');
-    fireEvent.click(actionMenu);
+    await act(async () => {
+      fireEvent.click(actionMenu);
+    });
     const viaCustomizedRexAction = queryByText('Restart via customized remote execution');
 
     expect(viaCustomizedRexAction).toBeInTheDocument();

--- a/webpack/components/extensions/Hosts/BulkActions/BulkErrataWizard/04_Review.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkErrataWizard/04_Review.js
@@ -1,8 +1,22 @@
 import React, { useContext, useState } from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { FormattedMessage } from 'react-intl';
-import { TreeView, Button, Text, TextContent, TextVariants, Flex, FlexItem, Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
-import { useWizardContext } from '@patternfly/react-core/next';
+import {
+  TreeView,
+  Button,
+  Text,
+  TextContent,
+  TextVariants,
+  Flex,
+  FlexItem,
+  useWizardContext, /* data-codemods */
+} from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+} from '@patternfly/react-core/deprecated';
+
 import { CaretDownIcon } from '@patternfly/react-icons';
 import { BulkErrataWizardContext } from './BulkErrataWizard';
 

--- a/webpack/components/extensions/Hosts/BulkActions/BulkErrataWizard/04_ReviewFooter.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkErrataWizard/04_ReviewFooter.js
@@ -1,7 +1,11 @@
 import React, { useContext } from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { Button } from '@patternfly/react-core';
-import { WizardFooterWrapper, useWizardContext } from '@patternfly/react-core/next';
+import {
+  Button,
+  WizardFooterWrapper /* data-codemods */,
+  useWizardContext, /* data-codemods */
+} from '@patternfly/react-core';
+
 import { BulkErrataWizardContext } from './BulkErrataWizard';
 import { dropdownOptions } from './04_Review';
 import { errataInstallUrl } from '../../../HostDetails/Tabs/customizedRexUrlHelpers';

--- a/webpack/components/extensions/Hosts/BulkActions/BulkErrataWizard/BulkErrataWizard.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkErrataWizard/BulkErrataWizard.js
@@ -1,5 +1,11 @@
 import React, { useState, createContext, useContext } from 'react';
-import { Wizard, WizardHeader, WizardStep } from '@patternfly/react-core/next';
+import {
+  Wizard /* data-codemods */,
+  WizardHeader, /* data-codemods */
+} from '@patternfly/react-core';
+import {
+  WizardStep,
+} from '@patternfly/react-core/deprecated';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { useForemanModal } from 'foremanReact/components/ForemanModal/ForemanModalHooks';
 import { useBulkSelect } from 'foremanReact/components/PF4/TableIndexPage/Table/TableHooks';

--- a/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/04_Review.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/04_Review.js
@@ -1,8 +1,22 @@
 import React, { useContext, useState } from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { FormattedMessage } from 'react-intl';
-import { TreeView, Button, Text, TextContent, TextVariants, Flex, FlexItem, Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
-import { useWizardContext } from '@patternfly/react-core/next';
+import {
+  TreeView,
+  Button,
+  Text,
+  TextContent,
+  TextVariants,
+  Flex,
+  FlexItem,
+  useWizardContext, /* data-codemods */
+} from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+} from '@patternfly/react-core/deprecated';
+
 import { CaretDownIcon } from '@patternfly/react-icons';
 import { BulkPackagesWizardContext, UPGRADE_ALL, INSTALL, REMOVE, UPGRADE } from './BulkPackagesWizard';
 

--- a/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/04_ReviewFooter.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/04_ReviewFooter.js
@@ -1,7 +1,11 @@
 import React, { useContext } from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { Button } from '@patternfly/react-core';
-import { WizardFooterWrapper, useWizardContext } from '@patternfly/react-core/next';
+import {
+  Button,
+  WizardFooterWrapper /* data-codemods */,
+  useWizardContext, /* data-codemods */
+} from '@patternfly/react-core';
+
 import { BulkPackagesWizardContext, INSTALL, UPGRADE, UPGRADE_ALL, REMOVE } from './BulkPackagesWizard';
 import { dropdownOptions } from './04_Review';
 import { katelloPackageInstallBySearchUrl, packagesUpdateUrl, katelloPackageRemoveBySearchUrl } from '../../../HostDetails/Tabs/customizedRexUrlHelpers';

--- a/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/BulkPackagesWizard.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/BulkPackagesWizard.js
@@ -1,6 +1,17 @@
 import React, { useState, createContext, useContext } from 'react';
-import { Radio, Text, TextVariants, TextContent, Alert } from '@patternfly/react-core';
-import { Wizard, WizardHeader, WizardStep } from '@patternfly/react-core/next';
+import {
+  Radio,
+  Text,
+  TextVariants,
+  TextContent,
+  Alert,
+  Wizard /* data-codemods */,
+  WizardHeader, /* data-codemods */
+} from '@patternfly/react-core';
+import {
+  WizardStep,
+} from '@patternfly/react-core/deprecated';
+
 import { translate as __ } from 'foremanReact/common/I18n';
 import { useForemanModal } from 'foremanReact/components/ForemanModal/ForemanModalHooks';
 import { useBulkSelect } from 'foremanReact/components/PF4/TableIndexPage/Table/TableHooks';

--- a/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/ActivationKeys.test.js.snap
+++ b/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/ActivationKeys.test.js.snap
@@ -3,21 +3,6 @@
 exports[`ActivationKeys renders 1`] = `
 <FormGroup
   fieldId="activation_keys_field"
-  helperText="From host group: "
-  helperTextInvalid={
-    <a
-      href="/activation_keys/new"
-    >
-      Create new activation key
-    </a>
-  }
-  helperTextInvalidIcon={
-    <ExclamationCircleIcon
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
-    />
-  }
   isRequired={true}
   label="Activation Keys"
   labelIcon={
@@ -26,7 +11,6 @@ exports[`ActivationKeys renders 1`] = `
     />
   }
   onFocus={[Function]}
-  validated="error"
 >
   <Select
     aria-describedby=""
@@ -70,7 +54,6 @@ exports[`ActivationKeys renders 1`] = `
     ouiaSafe={true}
     placeholderText="No Activation keys to select"
     position="left"
-    removeFindDomNode={false}
     removeSelectionAriaLabel="Remove"
     selections={Array []}
     shouldResetOnSelect={true}
@@ -85,5 +68,19 @@ exports[`ActivationKeys renders 1`] = `
     width=""
     zIndex={9999}
   />
+  <FormHelperText>
+    <HelperText>
+      <HelperTextItem
+        icon={<ExclamationCircleIcon />}
+        variant="error"
+      >
+        <a
+          href="/activation_keys/new"
+        >
+          Create new activation key
+        </a>
+      </HelperTextItem>
+    </HelperText>
+  </FormHelperText>
 </FormGroup>
 `;

--- a/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/Force.test.js.snap
+++ b/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/Force.test.js.snap
@@ -6,10 +6,10 @@ exports[`Force renders 1`] = `
 >
   <Checkbox
     className=""
-    component="div"
     id="reg_katello_force"
     isChecked={false}
     isDisabled={false}
+    isLabelWrapped={false}
     isRequired={false}
     isValid={true}
     label={

--- a/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/IgnoreSubmanErrors.test.js.snap
+++ b/webpack/components/extensions/RegistrationCommands/__tests__/__snapshots__/IgnoreSubmanErrors.test.js.snap
@@ -6,10 +6,10 @@ exports[`IgnoreSubmanErrors renders 1`] = `
 >
   <Checkbox
     className=""
-    component="div"
     id="reg_katello_ignore"
     isChecked={false}
     isDisabled={false}
+    isLabelWrapped={false}
     isRequired={false}
     isValid={true}
     label={

--- a/webpack/components/extensions/RegistrationCommands/fields/ActivationKeys.js
+++ b/webpack/components/extensions/RegistrationCommands/fields/ActivationKeys.js
@@ -1,21 +1,14 @@
 /* eslint-disable max-len, react/forbid-prop-types */
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import {
-  FormGroup,
-  Select,
-  SelectOption,
-  SelectVariant,
-} from '@patternfly/react-core';
+import { FormGroup, FormHelperText, HelperText, HelperTextItem } from '@patternfly/react-core';
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core/deprecated';
 
 import LabelIcon from 'foremanReact/components/common/LabelIcon';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 
-import {
-  validateAKField,
-  akHasValidValue,
-} from '../RegistrationCommandsPageHelpers';
+import { validateAKField, akHasValidValue } from '../RegistrationCommandsPageHelpers';
 
 const ActivationKeys = ({
   activationKeys,
@@ -34,11 +27,7 @@ const ActivationKeys = ({
     onChange({ activationKeys: keys });
     handleInvalidField(
       'Activation Keys',
-      akHasValidValue(
-        hostGroupId,
-        pluginValues?.activationKeys,
-        hostGroupActivationKeys,
-      ),
+      akHasValidValue(hostGroupId, pluginValues?.activationKeys, hostGroupActivationKeys),
     );
   };
 
@@ -54,11 +43,7 @@ const ActivationKeys = ({
   useEffect(() => {
     handleInvalidField(
       'Activation Keys',
-      akHasValidValue(
-        hostGroupId,
-        pluginValues?.activationKeys,
-        hostGroupActivationKeys,
-      ),
+      akHasValidValue(hostGroupId, pluginValues?.activationKeys, hostGroupActivationKeys),
     );
   }, [handleInvalidField, hostGroupId, hostGroupActivationKeys, pluginValues]);
 
@@ -68,33 +53,20 @@ const ActivationKeys = ({
     }
   }, [activationKeys, onChange]);
 
+  const isError =
+    validateAKField(
+      hasInteraction,
+      hostGroupId,
+      activationKeys,
+      pluginValues?.activationKeys,
+      hostGroupActivationKeys,
+    ) === 'error';
   return (
     <FormGroup
       onFocus={() => setHasInteraction(true)}
       label={__('Activation Keys')}
       fieldId="activation_keys_field"
-      helperText={
-        hostGroupActivationKeys &&
-        sprintf('From host group: %s', hostGroupActivationKeys)
-      }
-      helperTextInvalid={
-        activationKeys?.length === 0 ? (
-          <a href="/activation_keys/new">{__('Create new activation key')}</a>
-        ) : (
-          __('No Activation Keys selected')
-        )
-      }
-      helperTextInvalidIcon={<ExclamationCircleIcon />}
-      labelIcon={
-        <LabelIcon text={__('Activation key(s) to use during registration')} />
-      }
-      validated={validateAKField(
-        hasInteraction,
-        hostGroupId,
-        activationKeys,
-        pluginValues?.activationKeys,
-        hostGroupActivationKeys,
-      )}
+      labelIcon={<LabelIcon text={__('Activation key(s) to use during registration')} />}
       isRequired
     >
       <Select
@@ -122,9 +94,7 @@ const ActivationKeys = ({
         id="activation_keys_field"
         className="without_select2"
         isDisabled={isLoading || activationKeys?.length === 0}
-        placeholderText={
-          activationKeys?.length === 0 ? __('No Activation keys to select') : ''
-        }
+        placeholderText={activationKeys?.length === 0 ? __('No Activation keys to select') : ''}
       >
         {activationKeys &&
           activationKeys.map(ack => (
@@ -135,6 +105,28 @@ const ActivationKeys = ({
             />
           ))}
       </Select>
+      {isError && (
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem variant="error" icon={<ExclamationCircleIcon />}>
+              {activationKeys?.length === 0 ? (
+                <a href="/activation_keys/new">{__('Create new activation key')}</a>
+              ) : (
+                __('No Activation Keys selected')
+              )}
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      )}
+      {!isError && hostGroupActivationKeys && (
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem>
+              {sprintf('From host group: %s', hostGroupActivationKeys)}
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      )}
     </FormGroup>
   );
 };
@@ -142,10 +134,7 @@ const ActivationKeys = ({
 ActivationKeys.propTypes = {
   activationKeys: PropTypes.array,
   selectedKeys: PropTypes.array,
-  hostGroupActivationKeys: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.array,
-  ]),
+  hostGroupActivationKeys: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   hostGroupId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   pluginValues: PropTypes.shape({
     activationKeys: PropTypes.array,

--- a/webpack/containers/Application/overrides.scss
+++ b/webpack/containers/Application/overrides.scss
@@ -122,7 +122,7 @@ html .pagination-pf-pagesize.btn-group {
 }
 
 // Modal sizing fix
-.pf-l-bullseye .pf-c-modal-box {
+.pf-l-bullseye .pf-v5-c-modal-box {
   margin-top: 76px;
   max-height: calc(100vh - 76px);
 
@@ -168,24 +168,24 @@ html .pagination-pf-pagesize.btn-group {
 
 .primary-detail-border {
   border-top: 0.2px;
-  border-top-color: var(--pf-c-table--BorderColor);
+  border-top-color: var(--pf-v5-c-table--BorderColor);
   border-top-style: inset;
 }
 
 .primary-detail-stack-items-border {
   border-bottom: 0.2px;
-  border-bottom-color: var(--pf-c-table--BorderColor);
+  border-bottom-color: var(--pf-v5-c-table--BorderColor);
   border-bottom-style: inset;
 }
 
 .border-left {
   border-left: 0.2px;
-  border-left-color: var(--pf-c-table--BorderColor);
+  border-left-color: var(--pf-v5-c-table--BorderColor);
   border-left-style: inset;
 }
 
 .border-right {
   border-right: 0.2px;
-  border-right-color: var(--pf-c-table--BorderColor);
+  border-right-color: var(--pf-v5-c-table--BorderColor);
   border-right-style: inset;
 }

--- a/webpack/ouia_id_check.js
+++ b/webpack/ouia_id_check.js
@@ -7,12 +7,6 @@ import {
   Checkbox,
   Chip,
   ChipGroup,
-  ContextSelector,
-  Dropdown,
-  DropdownItem,
-  DropdownSeparator,
-  DropdownToggle,
-  DropdownToggleCheckbox,
   FormSelect,
   Menu,
   Modal,
@@ -20,10 +14,8 @@ import {
   Nav,
   NavExpandable,
   NavItem,
-  OptionsMenu,
   Pagination,
   Radio,
-  Select,
   Switch,
   TabButton,
   TabContent,
@@ -34,10 +26,22 @@ import {
   Toolbar,
 } from '@patternfly/react-core';
 import {
-  Table,
-  TableComposable,
+  ContextSelector,
+  Dropdown,
+  DropdownItem,
+  DropdownSeparator,
+  DropdownToggle,
+  DropdownToggleCheckbox,
+  OptionsMenu,
+  Select,
+} from '@patternfly/react-core/deprecated';
+import {
   Tr,
 } from '@patternfly/react-table';
+import {
+  Table as TableDeprecated,
+  Table,
+} from '@patternfly/react-table/deprecated';
 
 const checkForOuiaIds = () => {
   const ouiaSupportedPFComponents = [
@@ -74,7 +78,7 @@ const checkForOuiaIds = () => {
     Title,
     Toolbar,
     Table,
-    TableComposable,
+    TableDeprecated,
     Tr,
   ];
   beforeEach(() => {

--- a/webpack/scenes/ActivationKeys/Details/components/DeleteMenu.js
+++ b/webpack/scenes/ActivationKeys/Details/components/DeleteMenu.js
@@ -2,7 +2,17 @@ import React, {
   useState,
 } from 'react';
 import PropTypes from 'prop-types';
-import { Dropdown, DropdownItem, KebabToggle, DropdownPosition, Split, Icon, Text } from '@patternfly/react-core';
+import {
+  Split,
+  Icon,
+  Text,
+} from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+  DropdownPosition,
+} from '@patternfly/react-core/deprecated';
 import { UndoIcon, TrashIcon } from '@patternfly/react-icons';
 import { noop } from 'foremanReact/common/helpers';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -56,7 +66,7 @@ const DeleteMenu = ({ handleModalToggle, akId }) => {
       ouiaId="dekete-action"
       onSelect={onSelect}
       position={DropdownPosition.right}
-      toggle={<KebabToggle id="toggle-kebab" aria-label="delete-toggle" onToggle={onToggle} />}
+      toggle={<KebabToggle id="toggle-kebab" aria-label="delete-toggle" onToggle={(_event, isOpenValue) => onToggle(isOpenValue)} />}
       isOpen={isOpen}
       isPlain
       dropdownItems={dropdownItems}

--- a/webpack/scenes/ActivationKeys/Details/components/EditModal.js
+++ b/webpack/scenes/ActivationKeys/Details/components/EditModal.js
@@ -131,7 +131,7 @@ const EditModal = ({ akDetails, akId }) => {
               id="ak-name-input"
               type="text"
               value={nameValue}
-              onChange={handleNameInputChange}
+              onChange={(_event, value) => handleNameInputChange(value)}
             />
           </FormGroup>
           <FormGroup
@@ -150,7 +150,7 @@ const EditModal = ({ akDetails, akId }) => {
                   minusBtnAriaLabel="minus"
                   plusBtnAriaLabel="plus"
                   isDisabled={isUnlimited}
-                  allowEmptyInput
+
                 />
               </StackItem>
               <StackItem>
@@ -172,7 +172,7 @@ const EditModal = ({ akDetails, akId }) => {
               type="text"
               placeholder={__('Description')}
               value={descriptionValue || ''}
-              onChange={handleDescriptionInputChange}
+              onChange={(_event, value) => handleDescriptionInputChange(value)}
             />
           </FormGroup>
         </Form>

--- a/webpack/scenes/AlternateContentSources/Create/ACSCreateWizard.js
+++ b/webpack/scenes/AlternateContentSources/Create/ACSCreateWizard.js
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Wizard } from '@patternfly/react-core';
+import {
+  Wizard,
+} from '@patternfly/react-core/deprecated';
 import { translate as __ } from 'foremanReact/common/I18n';
 import ACSCreateContext from './ACSCreateContext';
 import SelectSource from './Steps/SelectSource';

--- a/webpack/scenes/AlternateContentSources/Create/Steps/ACSCreateFinish.js
+++ b/webpack/scenes/AlternateContentSources/Create/Steps/ACSCreateFinish.js
@@ -3,7 +3,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { WizardContextConsumer } from '@patternfly/react-core';
+import {
+  WizardContextConsumer,
+} from '@patternfly/react-core/deprecated';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
 import ACSCreateContext from '../ACSCreateContext';

--- a/webpack/scenes/AlternateContentSources/Create/Steps/ACSCredentials.js
+++ b/webpack/scenes/AlternateContentSources/Create/Steps/ACSCredentials.js
@@ -76,7 +76,7 @@ const ACSCredentials = () => {
                 name="acs_username_field"
                 aria-label="acs_username_field"
                 value={username}
-                onChange={(value) => { setUsername(value); }}
+                onChange={(_event, value) => { setUsername(value); }}
               />
 
             </FormGroup>
@@ -93,7 +93,7 @@ const ACSCredentials = () => {
                 name="acs_password_field"
                 aria-label="acs_password_field"
                 value={password}
-                onChange={(value) => { setPassword(value); }}
+                onChange={(_event, value) => { setPassword(value); }}
               />
             </FormGroup>
           </>
@@ -122,7 +122,10 @@ const ACSCredentials = () => {
               ouiaId="sslCert-select"
               isRequired
               value={sslCert}
-              onChange={(value) => { setSslCert(value); setSslCertName(getCertName(value)); }}
+              onChange={(_event, value) => {
+                setSslCert(value);
+                setSslCertName(getCertName(value));
+              }}
               aria-label="sslCert_select"
             >
               {
@@ -152,7 +155,7 @@ const ACSCredentials = () => {
               ouiaId="sslKey-select"
               isRequired
               value={sslKey}
-              onChange={(value) => { setSslKey(value); setSslKeyName(getCertName(value)); }}
+              onChange={(_event, value) => { setSslKey(value); setSslKeyName(getCertName(value)); }}
               aria-label="sslKey_select"
             >
               {
@@ -198,7 +201,7 @@ const ACSCredentials = () => {
             ouiaId="verify-ssl-switch"
             aria-label="verify-ssl-switch"
             isChecked={verifySSL}
-            onChange={checked => setVerifySSL(checked)}
+            onChange={(_event, checked) => setVerifySSL(checked)}
           />
         </FormGroup>
         <FormGroup
@@ -211,7 +214,7 @@ const ACSCredentials = () => {
             isDisabled={!verifySSL}
             isRequired
             value={caCert}
-            onChange={(value) => { setCACert(value); setCACertName(getCertName(value)); }}
+            onChange={(_event, value) => { setCACert(value); setCACertName(getCertName(value)); }}
             aria-label="sslCAcert_select"
           >
             {

--- a/webpack/scenes/AlternateContentSources/Create/Steps/ACSSmartProxies.js
+++ b/webpack/scenes/AlternateContentSources/Create/Steps/ACSSmartProxies.js
@@ -58,7 +58,7 @@ const ACSSmartProxies = () => {
           ouiaId="use-http-proxies-switch"
           aria-label="use-http-proxies-switch"
           isChecked={useHttpProxies}
-          onChange={checked => setUseHttpProxies(checked)}
+          onChange={(_event, checked) => setUseHttpProxies(checked)}
         />
       </FormGroup>
     </>

--- a/webpack/scenes/AlternateContentSources/Create/Steps/AcsUrlPaths.js
+++ b/webpack/scenes/AlternateContentSources/Create/Steps/AcsUrlPaths.js
@@ -6,6 +6,9 @@ import {
   FormGroup,
   TextInput,
   TextArea,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
 } from '@patternfly/react-core';
 import ACSCreateContext from '../ACSCreateContext';
 import WizardHeader from '../../../ContentViews/components/WizardHeader';
@@ -41,8 +44,6 @@ const AcsUrlPaths = () => {
         <FormGroup
           label={__('Base URL')}
           fieldId="acs_base_url"
-          helperTextInvalid={helperTextInvalid}
-          validated={urlValidated}
           isRequired
         >
           <TextInput
@@ -55,8 +56,17 @@ const AcsUrlPaths = () => {
             placeholder={baseURLplaceholder}
             value={url}
             validated={urlValidated}
-            onChange={value => setUrl(value)}
+            onChange={(_event, value) => setUrl(value)}
           />
+          {urlValidated === 'error' && (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem variant="error">
+                  {helperTextInvalid}
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          )}
         </FormGroup>
         {acsType === 'rhui' &&
         <>
@@ -73,19 +83,24 @@ const AcsUrlPaths = () => {
         <FormGroup
           label={__('Subpaths')}
           type="string"
-          fieldId="acs_subpaths"
-          helperTextInvalid={__('Comma-separated list of subpaths. All subpaths must have a slash at the end and none at the front.')}
-          validated={subPathValidated}
         >
           <TextArea
             placeholder="test/repo1/, test/repo2/,"
             value={subpaths}
             validated={subPathValidated}
-            onChange={value => setSubpaths(value)}
+            onChange={(_event, value) => setSubpaths(value)}
             name="acs_subpath_field"
             id="acs_subpath_field"
             aria-label="acs_subpath_field"
           />
+          {subPathValidated === 'error' && (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem variant="error">
+                  {__('Comma-separated list of subpaths. All subpaths must have a slash at the end and none at the front.')}
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>)}
         </FormGroup>
       </Form>
     </>

--- a/webpack/scenes/AlternateContentSources/Create/Steps/NameACS.js
+++ b/webpack/scenes/AlternateContentSources/Create/Steps/NameACS.js
@@ -35,7 +35,7 @@ const NameACS = () => {
             name="acs_name_field"
             aria-label="acs_name_field"
             value={name}
-            onChange={(value) => { setName(value); }}
+            onChange={(_event, value) => { setName(value); }}
           />
         </FormGroup>
         <FormGroup
@@ -45,7 +45,7 @@ const NameACS = () => {
         >
           <TextArea
             value={description}
-            onChange={(value) => { setDescription(value); }}
+            onChange={(_event, value) => { setDescription(value); }}
             name="acs_description_field"
             id="acs_description_field"
           />

--- a/webpack/scenes/AlternateContentSources/Create/Steps/SelectSource.js
+++ b/webpack/scenes/AlternateContentSources/Create/Steps/SelectSource.js
@@ -111,7 +111,7 @@ const SelectSource = () => {
             isRequired
             isDisabled={acsType === 'rhui'}
             value={contentType}
-            onChange={(value) => {
+            onChange={(_event, value) => {
               setContentType(value);
             }}
             aria-label="FormSelect Input"

--- a/webpack/scenes/AlternateContentSources/Details/ACSExpandableDetails.js
+++ b/webpack/scenes/AlternateContentSources/Details/ACSExpandableDetails.js
@@ -114,7 +114,7 @@ const ACSExpandableDetails = ({ expandedId }) => {
                 ouiaId="edit-details-pencil-edit"
                 aria-label="edit-details-pencil-edit"
                 variant="link"
-                isSmall
+                size="sm"
                 icon={<PencilAltIcon />}
                 onClick={() => setEditDetailsModalOpen(true)}
               >{__('Edit')}
@@ -194,7 +194,7 @@ const ACSExpandableDetails = ({ expandedId }) => {
                 ouiaId="edit-smart-proxies-pencil-edit"
                 aria-label="edit-smart-proxies-pencil-edit"
                 variant="link"
-                isSmall
+                size="sm"
                 icon={<PencilAltIcon />}
                 onClick={() => setEditSmartProxiesModalOpen(true)}
               >{__('Edit')}
@@ -265,7 +265,7 @@ const ACSExpandableDetails = ({ expandedId }) => {
                   ouiaId="edit-products-pencil-edit"
                   aria-label="edit-products-pencil-edit"
                   variant="link"
-                  isSmall
+                  size="sm"
                   icon={<PencilAltIcon />}
                   onClick={() => setEditProductsModalOpen(true)}
                 >{__('Edit')}
@@ -319,7 +319,7 @@ const ACSExpandableDetails = ({ expandedId }) => {
                   ouiaId="edit-urls-pencil-edit"
                   aria-label="edit-urls-pencil-edit"
                   variant="link"
-                  isSmall
+                  size="sm"
                   icon={<PencilAltIcon />}
                   onClick={() => setEditUrlModalOpen(true)}
                 >{__('Edit')}
@@ -380,7 +380,7 @@ const ACSExpandableDetails = ({ expandedId }) => {
                   ouiaId="edit-credentials-pencil-edit"
                   aria-label="edit-credentials-pencil-edit"
                   variant="link"
-                  isSmall
+                  size="sm"
                   icon={<PencilAltIcon />}
                   onClick={() => setEditCredentialsModalOpen(true)}
                 >{__('Edit')}

--- a/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditCredentials.js
+++ b/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditCredentials.js
@@ -135,7 +135,7 @@ const ACSEditCredentials = ({ onClose, acsId, acsDetails }) => {
             id="verify-ssl-switch"
             aria-label="verify-ssl-switch"
             isChecked={acsVerifySSL}
-            onChange={checked => setAcsVerifySSL(checked)}
+            onChange={(_event, checked) => setAcsVerifySSL(checked)}
           />
         </FormGroup>
         <FormGroup
@@ -148,7 +148,7 @@ const ACSEditCredentials = ({ onClose, acsId, acsDetails }) => {
             isRequired
             isDisabled={!acsVerifySSL}
             value={acsCAcert}
-            onChange={value => setAcsCAcert(value)}
+            onChange={(_event, value) => setAcsCAcert(value)}
             aria-label="sslCAcert_select"
           >
             {
@@ -197,7 +197,7 @@ const ACSEditCredentials = ({ onClose, acsId, acsDetails }) => {
               name="acs_username_field"
               aria-label="acs_username_field"
               value={acsUsername}
-              onChange={(value) => {
+              onChange={(_event, value) => {
                 setAcsUsername(value);
               }}
             />
@@ -216,7 +216,7 @@ const ACSEditCredentials = ({ onClose, acsId, acsDetails }) => {
               name="acs_password_field"
               aria-label="acs_password_field"
               value={acsPassword}
-              onChange={(value) => {
+              onChange={(_event, value) => {
                 setAcsPassword(value);
               }}
             />
@@ -247,7 +247,7 @@ const ACSEditCredentials = ({ onClose, acsId, acsDetails }) => {
               ouiaId="ssl-client-cert-select"
               isRequired
               value={acsSslClientCert}
-              onChange={value => setAcsSslClientCert(value)}
+              onChange={(_event, value) => setAcsSslClientCert(value)}
               aria-label="ssl_client_cert_select"
             >
               {
@@ -276,7 +276,7 @@ const ACSEditCredentials = ({ onClose, acsId, acsDetails }) => {
               ouiaId="ssl_client_key_select"
               isRequired
               value={acsSslClientKey}
-              onChange={value => setAcsSslClientKey(value)}
+              onChange={(_event, value) => setAcsSslClientKey(value)}
               aria-label="ssl_client_key_select"
             >
               {

--- a/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditDetails.js
+++ b/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditDetails.js
@@ -50,7 +50,7 @@ const ACSEditDetails = ({ onClose, acsId, acsDetails }) => {
             name="acs_name_field"
             aria-label="acs_name_field"
             value={acsName}
-            onChange={(value) => {
+            onChange={(_event, value) => {
               setACSName(value);
             }}
           />
@@ -62,7 +62,7 @@ const ACSEditDetails = ({ onClose, acsId, acsDetails }) => {
         >
           <TextArea
             value={acsDescription}
-            onChange={(value) => {
+            onChange={(_event, value) => {
               setAcsDescription(value);
             }}
             name="acs_description_field"

--- a/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditSmartProxies.js
+++ b/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditSmartProxies.js
@@ -113,7 +113,7 @@ const ACSEditSmartProxies = ({ onClose, acsId, acsDetails }) => {
             aria-label="use-http-proxies-switch"
             ouiaId="use-http-proxies-switch"
             isChecked={acsUseHttpProxies}
-            onChange={checked => setAcsUseHttpProxies(checked)}
+            onChange={(_event, checked) => setAcsUseHttpProxies(checked)}
           />
         </FormGroup>
         <ActionGroup>

--- a/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditURLPaths.js
+++ b/webpack/scenes/AlternateContentSources/Details/EditModals/ACSEditURLPaths.js
@@ -2,7 +2,19 @@ import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { ActionGroup, Button, Form, FormGroup, Modal, ModalVariant, TextArea, TextInput } from '@patternfly/react-core';
+import {
+  ActionGroup,
+  Button,
+  Form,
+  FormGroup,
+  Modal,
+  ModalVariant,
+  TextArea,
+  TextInput,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+} from '@patternfly/react-core';
 import { editACS, getACSDetails } from '../../ACSActions';
 import { areSubPathsValid, isValidUrl } from '../../helpers';
 
@@ -63,8 +75,6 @@ const ACSEditURLPaths = ({ onClose, acsId, acsDetails }) => {
           label={__('Base URL')}
           type="string"
           fieldId="acs_base_url"
-          helperTextInvalid={helperTextInvalid}
-          validated={urlValidated}
           isRequired
         >
           <TextInput
@@ -77,25 +87,41 @@ const ACSEditURLPaths = ({ onClose, acsId, acsDetails }) => {
             placeholder={baseURLplaceholder}
             value={acsUrl}
             validated={urlValidated}
-            onChange={value => setAcsUrl(value)}
+            onChange={(_event, value) => setAcsUrl(value)}
           />
+          {urlValidated === 'error' && (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem variant="error">
+                  {helperTextInvalid}
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          )}
         </FormGroup>
         <FormGroup
           label={__('Subpaths')}
           type="string"
           fieldId="acs_subpaths"
-          helperTextInvalid={__('Comma-separated list of subpaths. All subpaths must have a slash at the end and none at the front.')}
-          validated={subPathValidated}
         >
           <TextArea
             placeholder="test/repo1/, test/repo2/,"
             value={acsSubpath}
             validated={subPathValidated}
-            onChange={value => setAcsSubpath(value)}
+            onChange={(_event, value) => setAcsSubpath(value)}
             name="acs_subpath_field"
             id="acs_subpath_field"
             aria-label="acs_subpath_field"
           />
+          {subPathValidated === 'error' && (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem variant="error">
+                  {__('Comma-separated list of subpaths. All subpaths must have a slash at the end and none at the front.')}
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          )}
         </FormGroup>
         <ActionGroup>
           <Button

--- a/webpack/scenes/AlternateContentSources/MainTable/ACSTable.js
+++ b/webpack/scenes/AlternateContentSources/MainTable/ACSTable.js
@@ -15,9 +15,6 @@ import {
   DrawerHead,
   DrawerPanelContent,
   DrawerPanelBody,
-  Dropdown,
-  DropdownItem,
-  KebabToggle,
   Text,
   TextContent,
   TextList,
@@ -26,6 +23,11 @@ import {
   TextListVariants,
   TextVariants,
 } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+} from '@patternfly/react-core/deprecated';
 import { TableVariant, Tbody, Td, Th, Thead, Tr, ActionsColumn } from '@patternfly/react-table';
 import { useSelectionSet } from 'foremanReact/components/PF4/TableIndexPage/Table/TableHooks';
 import { useTableSort } from 'foremanReact/components/PF4/Helpers/useTableSort';
@@ -196,14 +198,14 @@ const ACSTable = () => {
                 ouiaId="refresh-acs"
                 onClick={() => onRefresh(acs?.id)}
                 variant="secondary"
-                isSmall
+                size="sm"
                 aria-label="refresh_acs"
               >
                 {__('Refresh source')}
               </Button>
               <Dropdown
                 style={{ paddingRight: '0px' }}
-                toggle={<KebabToggle aria-label="details_actions" onToggle={setDetailsKebabOpen} style={{ paddingRight: '0px' }} />}
+                toggle={<KebabToggle aria-label="details_actions" onToggle={(_event, val) => setDetailsKebabOpen(val)} style={{ paddingRight: '0px' }} />}
                 isOpen={detailsKebabOpen}
                 ouiaId="acs-details-actions"
                 isPlain
@@ -344,7 +346,7 @@ const ACSTable = () => {
                   </Button>}
                   {renderActionButtons && (canEdit || canDelete) &&
                   <Dropdown
-                    toggle={<KebabToggle aria-label="bulk_actions" onToggle={setKebabOpen} />}
+                    toggle={<KebabToggle aria-label="bulk_actions" onToggle={(_event, val) => setKebabOpen(val)} />}
                     isOpen={kebabOpen}
                     ouiaId="acs-bulk-actions"
                     isPlain
@@ -430,7 +432,7 @@ const ACSTable = () => {
                           id={id}
                           aria-label={`Select ACS ${id}`}
                           isChecked={isSelected(id)}
-                          onChange={selected => selectOne(selected, id)}
+                          onChange={(_event, selected) => selectOne(selected, id)}
                         />
                       </Td>
                       <Td>

--- a/webpack/scenes/ContentViews/Copy/CopyContentViewForm.js
+++ b/webpack/scenes/ContentViews/Copy/CopyContentViewForm.js
@@ -55,7 +55,7 @@ const CopyContentViewForm = ({ cvId, setModalOpen }) => {
           ouiaId="input_name"
           name="name"
           value={name}
-          onChange={setName}
+          onChange={(_event, val) => setName(val)}
         />
       </FormGroup>
       <ActionGroup>

--- a/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
+++ b/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
@@ -4,9 +4,27 @@ import { STATUS } from 'foremanReact/constants';
 import { translate as __ } from 'foremanReact/common/I18n';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
-import { Form, FormGroup, TextInput, TextArea, Checkbox, ActionGroup, Button, Tile, Grid, GridItem } from '@patternfly/react-core';
+import {
+  Form,
+  FormGroup,
+  TextInput,
+  TextArea,
+  Checkbox,
+  ActionGroup,
+  Button,
+  Tile,
+  Grid,
+  GridItem,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+} from '@patternfly/react-core';
 import { createContentView } from '../ContentViewsActions';
-import { selectCreateContentViews, selectCreateContentViewStatus, selectCreateContentViewError } from './ContentViewCreateSelectors';
+import {
+  selectCreateContentViews,
+  selectCreateContentViewStatus,
+  selectCreateContentViewError,
+} from './ContentViewCreateSelectors';
 import { LabelDependencies, LabelAutoPublish } from './ContentViewFormComponents';
 import ContentViewIcon from '../components/ContentViewIcon';
 import './CreateContentViewForm.scss';
@@ -57,23 +75,25 @@ const CreateContentViewForm = ({ setModalOpen }) => {
       description,
       composite,
       solve_dependencies: dependencies,
-      auto_publish: (autoPublish && composite),
+      auto_publish: autoPublish && composite,
     }));
   };
 
-  useEffect(
-    () => {
-      setLabel(name.replace(/[^A-Za-z0-9_-]/g, '_'));
-    },
-    [name],
-  );
+  useEffect(() => {
+    setLabel(name.replace(/[^A-Za-z0-9_-]/g, '_'));
+  }, [name]);
 
   if (redirect) {
     const { id } = response;
-    if (composite) { window.location.assign(`/content_views/${id}#/contentviews`); } else { window.location.assign(`/content_views/${id}#/repositories`); }
+    if (composite) {
+      window.location.assign(`/content_views/${id}#/contentviews`);
+    } else {
+      window.location.assign(`/content_views/${id}#/repositories`);
+    }
   }
 
-  const submitDisabled = !name?.length || !label?.length || saving || redirect || labelValidated === 'error';
+  const submitDisabled =
+    !name?.length || !label?.length || saving || redirect || labelValidated === 'error';
 
   return (
     <Form
@@ -92,15 +112,13 @@ const CreateContentViewForm = ({ setModalOpen }) => {
           ouiaId="input_name"
           name="name"
           value={name}
-          onChange={value => setName(value)}
+          onChange={(_event, value) => setName(value)}
         />
       </FormGroup>
       <FormGroup
         label={__('Label')}
         isRequired
         fieldId="label"
-        helperTextInvalid="Must be Ascii alphanumeric, '_' or '-'"
-        validated={labelValidated}
       >
         <TextInput
           isRequired
@@ -111,8 +129,17 @@ const CreateContentViewForm = ({ setModalOpen }) => {
           name="label"
           value={label}
           validated={labelValidated}
-          onChange={handleLabelChange}
+          onChange={(_event, newLabel) => handleLabelChange(newLabel, _event)}
         />
+        {labelValidated === 'error' && (
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem variant="error">
+                {__('Label must be Ascii alphanumeric, "_" or "-"')}
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        )}
       </FormGroup>
       <FormGroup label={__('Description')} fieldId="description">
         <TextArea
@@ -122,7 +149,7 @@ const CreateContentViewForm = ({ setModalOpen }) => {
           name="description"
           aria-label="input_description"
           value={description}
-          onChange={value => setDescription(value)}
+          onChange={(_event, value) => setDescription(value)}
         />
       </FormGroup>
       <FormGroup isInline fieldId="type" label={__('Type')}>
@@ -135,7 +162,10 @@ const CreateContentViewForm = ({ setModalOpen }) => {
               icon={<ContentViewIcon composite={false} />}
               id="component"
               title={__('Content view')}
-              onClick={() => { setComponent(true); setComposite(false); }}
+              onClick={() => {
+                setComponent(true);
+                setComposite(false);
+              }}
               isSelected={component}
             >
               {__('Single content view consisting of e.g. repositories')}
@@ -149,7 +179,10 @@ const CreateContentViewForm = ({ setModalOpen }) => {
               icon={<ContentViewIcon composite />}
               id="composite"
               title={__('Composite content view')}
-              onClick={() => { setComposite(true); setComponent(false); }}
+              onClick={() => {
+                setComposite(true);
+                setComponent(false);
+              }}
               isSelected={composite}
             >
               {__('Consisting of multiple content views')}
@@ -157,7 +190,7 @@ const CreateContentViewForm = ({ setModalOpen }) => {
           </GridItem>
         </Grid>
       </FormGroup>
-      {!composite &&
+      {!composite && (
         <FormGroup isInline fieldId="dependencies">
           <Checkbox
             id="dependencies"
@@ -165,10 +198,11 @@ const CreateContentViewForm = ({ setModalOpen }) => {
             name="dependencies"
             label={LabelDependencies()}
             isChecked={dependencies}
-            onChange={checked => setDependencies(checked)}
+            onChange={(_event, checked) => setDependencies(checked)}
           />
-        </FormGroup>}
-      {composite &&
+        </FormGroup>
+      )}
+      {composite && (
         <FormGroup isInline fieldId="autoPublish">
           <Checkbox
             id="autoPublish"
@@ -176,9 +210,10 @@ const CreateContentViewForm = ({ setModalOpen }) => {
             name="autoPublish"
             label={LabelAutoPublish()}
             isChecked={autoPublish}
-            onChange={checked => setAutoPublish(checked)}
+            onChange={(_event, checked) => setAutoPublish(checked)}
           />
-        </FormGroup>}
+        </FormGroup>
+      )}
       <ActionGroup>
         <Button
           ouiaId="create-content-view-form-submit"
@@ -190,7 +225,11 @@ const CreateContentViewForm = ({ setModalOpen }) => {
         >
           {__('Create content view')}
         </Button>
-        <Button ouiaId="create-content-view-form-cancel" variant="link" onClick={() => setModalOpen(false)}>
+        <Button
+          ouiaId="create-content-view-form-cancel"
+          variant="link"
+          onClick={() => setModalOpen(false)}
+        >
           {__('Cancel')}
         </Button>
       </ActionGroup>

--- a/webpack/scenes/ContentViews/Create/CreateContentViewForm.scss
+++ b/webpack/scenes/ContentViews/Create/CreateContentViewForm.scss
@@ -1,9 +1,9 @@
 #create-content-view-form {
-  .pf-c-tile__title {
+  .pf-v5-c-tile__title {
     font-size: 16px;
   }
 
-  .pf-c-tile__icon {
+  .pf-v5-c-tile__icon {
     min-height: 38px;
   }
 }

--- a/webpack/scenes/ContentViews/Delete/ContentViewDeleteWizard.js
+++ b/webpack/scenes/ContentViews/Delete/ContentViewDeleteWizard.js
@@ -2,7 +2,9 @@ import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { Wizard } from '@patternfly/react-core';
+import {
+  Wizard,
+} from '@patternfly/react-core/deprecated';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
 import CVDeleteEnvironmentSelection from './Steps/CVDeleteEnvironmentsSelection';

--- a/webpack/scenes/ContentViews/Delete/Steps/CVDeleteEnvironmentsSelection.js
+++ b/webpack/scenes/ContentViews/Delete/Steps/CVDeleteEnvironmentsSelection.js
@@ -1,7 +1,7 @@
 import React, { useContext, useState, useEffect } from 'react';
 import { ExpandableSection, Flex, FlexItem } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-import { TableVariant, TableComposable, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { TableVariant, Table /* data-codemods */, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
 import CVDeleteContext from '../CVDeleteContext';
@@ -60,11 +60,11 @@ const CVDeleteEnvironmentSelection = () => {
             <ExpandableSection
               key={version.id}
               toggleText={__(`Version ${version.version}`)}
-              onToggle={expanded => setExpanded(index, expanded)}
+              onToggle={(_event, expanded) => setExpanded(index, expanded)}
               isExpanded={versionExpanded[index]}
             >
               {(version?.environments.length !== 0) ?
-                <TableComposable ouiaId="cv-delete-env-select-table" variant={TableVariant.compact}>
+                <Table ouiaId="cv-delete-env-select-table" variant={TableVariant.compact}>
                   <Thead>
                     <Tr ouiaId="cv-delete-env-select-table-header">
                       <Th />
@@ -84,7 +84,7 @@ const CVDeleteEnvironmentSelection = () => {
                             select={{
                               rowIndex,
                               isSelected: true,
-                              disable: true,
+                              isDisabled: true,
                             }}
                           />
                           <Td>
@@ -96,7 +96,7 @@ const CVDeleteEnvironmentSelection = () => {
                       );
                     })}
                   </Tbody>
-                </TableComposable> :
+                </Table> :
                 <InactiveText text={__('This version is not promoted to any environments.')} />
               }
             </ExpandableSection>

--- a/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignActivationKeysForm.js
+++ b/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignActivationKeysForm.js
@@ -1,7 +1,12 @@
 import React, { useContext, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { ExpandableSection, SelectOption } from '@patternfly/react-core';
+import {
+  ExpandableSection,
+} from '@patternfly/react-core';
+import {
+  SelectOption,
+} from '@patternfly/react-core/deprecated';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
 import getContentViews from '../../ContentViewsActions';
@@ -117,7 +122,7 @@ const CVDeletionReassignActivationKeysForm = () => {
         toggleText={showActivationKeys ?
           'Hide activation keys' :
           'Show activation keys'}
-        onToggle={expanded => setShowActivationKeys(expanded)}
+        onToggle={(_event, expanded) => setShowActivationKeys(expanded)}
         isExpanded={showActivationKeys}
       >
         <AffectedActivationKeys

--- a/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignHostsForm.js
+++ b/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReassignHostsForm.js
@@ -1,7 +1,12 @@
 import React, { useState, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { ExpandableSection, SelectOption } from '@patternfly/react-core';
+import {
+  ExpandableSection,
+} from '@patternfly/react-core';
+import {
+  SelectOption,
+} from '@patternfly/react-core/deprecated';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
 import getContentViews from '../../ContentViewsActions';
@@ -117,7 +122,7 @@ const CVDeletionReassignHostsForm = () => {
       </ContentViewSelect>
       <ExpandableSection
         toggleText={showHosts ? 'Hide hosts' : 'Show hosts'}
-        onToggle={expanded => setShowHosts(expanded)}
+        onToggle={(_event, expanded) => setShowHosts(expanded)}
         isExpanded={showHosts}
       >
         <AffectedHosts

--- a/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReview.js
+++ b/webpack/scenes/ContentViews/Delete/Steps/CVDeletionReview.js
@@ -36,7 +36,7 @@ const CVDeletionReview = () => {
           </Flex>
           <Flex>
             {cvEnvironments?.map(({ name, id }) =>
-              <FlexItem key={name}><Label isTruncated color="purple" href={`/lifecycle_environments/${id}`}>{name}</Label></FlexItem>)}
+              <FlexItem key={name}><Label color="purple" href={`/lifecycle_environments/${id}`}>{name}</Label></FlexItem>)}
           </Flex>
         </>}
       {affectedHosts &&
@@ -45,7 +45,7 @@ const CVDeletionReview = () => {
           <Flex>
             <FlexItem><ExclamationTriangleIcon /></FlexItem>
             <FlexItem><p>{__(`${pluralize(hostResponse.length, 'host')} will be moved to content view ${selectedCVNameForHosts} in `)}</p></FlexItem>
-            <FlexItem><Label isTruncated color="purple" href={`/lifecycle_environments/${selectedEnvForHost[0].id}`}>{selectedEnvForHost[0].name}</Label></FlexItem>
+            <FlexItem><Label color="purple" href={`/lifecycle_environments/${selectedEnvForHost[0].id}`}>{selectedEnvForHost[0].name}</Label></FlexItem>
           </Flex>
         </>}
       {affectedActivationKeys &&
@@ -54,7 +54,7 @@ const CVDeletionReview = () => {
           <Flex>
             <FlexItem><ExclamationTriangleIcon /></FlexItem>
             <FlexItem><p>{__(`${pluralize(akResponse.length, 'activation key')} will be moved to content view ${selectedCVNameForAK} in `)}</p></FlexItem>
-            <FlexItem><Label isTruncated color="purple" href={`/lifecycle_environments/${selectedEnvForAK[0].id}`}>{selectedEnvForAK[0].name}</Label></FlexItem>
+            <FlexItem><Label color="purple" href={`/lifecycle_environments/${selectedEnvForAK[0].id}`}>{selectedEnvForAK[0].name}</Label></FlexItem>
           </Flex>
         </>}
     </>

--- a/webpack/scenes/ContentViews/Delete/Steps/CVEnvironmentSelectionForm.scss
+++ b/webpack/scenes/ContentViews/Delete/Steps/CVEnvironmentSelectionForm.scss
@@ -1,5 +1,5 @@
 #content-view-delete-wizard {
-  .pf-c-expandable-section__content {
+  .pf-v5-c-expandable-section__content {
     margin-bottom: 1em;
     margin-top: 1em;
   }

--- a/webpack/scenes/ContentViews/Delete/__tests__/contentViewDelete.test.js
+++ b/webpack/scenes/ContentViews/Delete/__tests__/contentViewDelete.test.js
@@ -72,9 +72,9 @@ test('Can call API for CVs and show Delete Wizard for the row', async (done) => 
   expect(queryByText(firstCV.name)).toBeNull();
   // Assert that the CV name is now showing on the screen, but wait for it to appear.
   await patientlyWaitFor(() => expect(queryByText(firstCV.name)).toBeInTheDocument());
-  expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'false');
-  fireEvent.click(getAllByLabelText('Actions')[0]);
-  expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'true');
+  expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'false');
+  fireEvent.click(getAllByLabelText('Kebab toggle')[0]);
+  expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'true');
   fireEvent.click(getByText('Delete'));
   await patientlyWaitFor(() => expect(getAllByText('Remove versions from environments')[1]).toBeInTheDocument());
 
@@ -152,9 +152,9 @@ test('Can open Delete wizard and delete CV with all steps', async (done) => {
   expect(queryByText(firstCV.name)).toBeNull();
   // Assert that the CV name is now showing on the screen, but wait for it to appear.
   await patientlyWaitFor(() => expect(queryByText(firstCV.name)).toBeInTheDocument());
-  expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'false');
-  fireEvent.click(getAllByLabelText('Actions')[0]);
-  expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'true');
+  expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'false');
+  fireEvent.click(getAllByLabelText('Kebab toggle')[0]);
+  expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'true');
   fireEvent.click(getByText('Delete'));
   await patientlyWaitFor(() => {
     expect(getAllByText('Remove versions from environments')[1]).toBeInTheDocument();

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewAddModal.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewAddModal.js
@@ -1,10 +1,21 @@
 import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Flex, Modal, ModalVariant, Select, SelectVariant,
-  SelectOption, Checkbox, Form, FormGroup,
-  ActionGroup, Button, Tooltip,
+  Flex,
+  Modal,
+  ModalVariant,
+  Checkbox,
+  Form,
+  FormGroup,
+  ActionGroup,
+  Button,
+  Tooltip,
 } from '@patternfly/react-core';
+import {
+  Select,
+  SelectVariant,
+  SelectOption,
+} from '@patternfly/react-core/deprecated';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -105,7 +116,7 @@ const ComponentContentViewAddModal = ({
             id="horzontal-form-title"
             name="horizontal-form-title"
             isOpen={cvVersionSelectOpen}
-            onToggle={isExpanded => setCvVersionSelectOpen(isExpanded)}
+            onToggle={(_event, isExpanded) => setCvVersionSelectOpen(isExpanded)}
             aria-label="CvVersion"
             ouiaId="select-cv-version"
             menuAppendTo="parent"
@@ -131,7 +142,7 @@ const ComponentContentViewAddModal = ({
               name="latest"
               label={__('Always update to latest version')}
               isChecked={formLatest}
-              onChange={checked => updateLatest(checked)}
+              onChange={(_event, checked) => updateLatest(checked)}
             />
             <Tooltip
               position="top"

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewBulkAddModal.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentContentViewBulkAddModal.js
@@ -1,10 +1,24 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Flex, Modal, ModalVariant, Select, SelectVariant,
-  SelectOption, Checkbox, Form, FormGroup,
-  ActionGroup, Button, Card, CardTitle, CardBody, Tooltip,
+  Flex,
+  Modal,
+  ModalVariant,
+  Checkbox,
+  Form,
+  FormGroup,
+  ActionGroup,
+  Button,
+  Card,
+  CardTitle,
+  CardBody,
+  Tooltip,
 } from '@patternfly/react-core';
+import {
+  Select,
+  SelectVariant,
+  SelectOption,
+} from '@patternfly/react-core/deprecated';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { useDispatch } from 'react-redux';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -78,7 +92,7 @@ const ComponentContentViewBulkAddModal = ({ cvId, rowsToAdd, onClose }) => {
                   }
                   }
                   isOpen={cvVersionSelectOpen === componentCvName}
-                  onToggle={isExpanded => setCvVersionSelectOpen(isExpanded ? componentCvName : '')}
+                  onToggle={(_event, isExpanded) => setCvVersionSelectOpen(isExpanded ? componentCvName : '')}
                   id={`horzontal-form-title-${componentCvName}-${cvVersionSelectOpen[componentCvName]}`}
                   name="horizontal-form-title"
                   aria-label={`version-select-${componentCvName}`}
@@ -106,7 +120,7 @@ const ComponentContentViewBulkAddModal = ({ cvId, rowsToAdd, onClose }) => {
                     name="latest"
                     label={__('Always update to latest version')}
                     isChecked={selectedComponentLatest[componentCvName]}
-                    onChange={(checked) => {
+                    onChange={(_event, checked) => {
                       setSelectedComponentLatest({
                         ...selectedComponentLatest,
                         ...{ [componentCvName]: checked },

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentEnvironments.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ComponentEnvironments.js
@@ -8,7 +8,7 @@ const ComponentEnvironments = ({ environments }) => environments.map((env, index
     style={{ margin: `4px 0 4px ${index > 0 ? '4px' : '0'}` }}
     color="purple"
     href={`/lifecycle_environments/${env.id}`}
-    isTruncated
+
   >
     {env.name}
   </Label>

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/ContentViewComponents.js
@@ -2,9 +2,18 @@ import React, { useState, useCallback } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-  Bullseye, Split, SplitItem, Button, ActionList,
-  ActionListItem, Dropdown, DropdownItem, KebabToggle,
+  Bullseye,
+  Split,
+  SplitItem,
+  Button,
+  ActionList,
+  ActionListItem,
 } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+} from '@patternfly/react-core/deprecated';
 import { TableVariant, fitContent, TableText } from '@patternfly/react-table';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import { STATUS } from 'foremanReact/constants';

--- a/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.test.js
+++ b/webpack/scenes/ContentViews/Details/ComponentContentViews/__tests__/contentViewComponents.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
+import { renderWithRedux, patientlyWaitFor, fireEvent, act } from 'react-testing-lib-wrapper';
 import { nockInstance, assertNockRequest, mockAutocomplete } from '../../../../../test-utils/nockWrapper';
 import api from '../../../../../services/api';
 import CONTENT_VIEWS_KEY from '../../../ContentViewsConstants';
@@ -216,27 +216,39 @@ test('Can add published component views to content view with modal', async (done
     .reply(200, compositeCvDetails);
 
   const {
-    getByText, getByLabelText, queryByLabelText, getAllByLabelText,
+    getByText, getByLabelText, queryByLabelText, getAllByLabelText,findAllByLabelText
   } = renderWithRedux(
     <ContentViewComponents cvId={4} details={cvDetails} />,
     renderOptions,
   );
   await patientlyWaitFor(() => {
-    expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Kebab toggle')[2]).toHaveAttribute('aria-expanded', 'false');
   });
-  fireEvent.click(getAllByLabelText('Actions')[2]);
-  expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'true');
+  await act(async () => {
+    await findAllByLabelText('Kebab toggle')
+    fireEvent.click(getAllByLabelText('Kebab toggle')[2]);
+  });
+  
   await patientlyWaitFor(() => {
     expect(getByText('Add')).toBeInTheDocument();
   });
-  fireEvent.click(getByText('Add'));
+  
+  await act(async () => {
+    fireEvent.click(getByText('Add'));
+  });
+  
   await patientlyWaitFor(() => {
     expect(getByText('Add content view')).toBeInTheDocument();
   });
-  fireEvent.click(getByLabelText('add_component'));
+  
+  await act(async () => {
+    fireEvent.click(getByLabelText('add_component'));
+  });
+  
   await patientlyWaitFor(() => {
     expect(queryByLabelText('add_component')).not.toBeInTheDocument();
   });
+  
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope);
   assertNockRequest(publishedComponentVersionsScope);
@@ -274,10 +286,12 @@ test('Can add unpublished component views to content view', async (done) => {
     renderOptions,
   );
   await patientlyWaitFor(() => {
-    expect(getAllByLabelText('Actions').slice(-1)[0]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Kebab toggle').slice(-1)[0]).toHaveAttribute('aria-expanded', 'false');
   });
-  fireEvent.click(getAllByLabelText('Actions').slice(-1)[0]);
-  expect(getAllByLabelText('Actions').slice(-1)[0]).toHaveAttribute('aria-expanded', 'true');
+  await act(async () => {
+    fireEvent.click(getAllByLabelText('Kebab toggle').slice(-1)[0]);
+  });
+  expect(getAllByLabelText('Kebab toggle').slice(-1)[0]).toHaveAttribute('aria-expanded', 'true');
   await patientlyWaitFor(() => expect(getByText('Add')).toBeInTheDocument());
   fireEvent.click(getByText('Add'));
   assertNockRequest(autocompleteScope);
@@ -316,10 +330,12 @@ test('Can remove component views from content view', async (done) => {
     renderOptions,
   );
   await patientlyWaitFor(() => {
-    expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'false');
   });
-  fireEvent.click(getAllByLabelText('Actions')[0]);
-  expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'true');
+  await act(async () => {
+    fireEvent.click(getAllByLabelText('Kebab toggle')[0]);
+  });
+  expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'true');
   await patientlyWaitFor(() => expect(getByText('Remove')).toBeInTheDocument());
   fireEvent.click(getByText('Remove'));
   assertNockRequest(autocompleteScope);
@@ -329,7 +345,7 @@ test('Can remove component views from content view', async (done) => {
   assertNockRequest(cvDetailsScope, done);
 });
 
-test('Can bulk add component views to content view with modal', async (done) => {
+test.only('Can bulk add component views to content view with modal', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl, autocompleteQuery);
   const scope = nockInstance
     .get(cvComponentsWithoutSearch)
@@ -363,20 +379,38 @@ test('Can bulk add component views to content view with modal', async (done) => 
     expect(getByLabelText('Select row 2')).toBeInTheDocument();
     expect(getByLabelText('bulk_add_components')).toHaveAttribute('aria-disabled', 'true');
   });
-  fireEvent.click(getByLabelText('Select row 2'));
-  fireEvent.click(getByLabelText('Select row 3'));
+  await act(async () => {
+    fireEvent.click(getByLabelText('Select row 2'));
+  });
+  
+  await act(async () => {
+    fireEvent.click(getByLabelText('Select row 3'));
+  });
+  
   await patientlyWaitFor(() => {
     expect(getByLabelText('bulk_add_components')).toHaveAttribute('aria-disabled', 'false');
   });
-  fireEvent.click(getByLabelText('bulk_add_components'));
+  
+  await act(async () => {
+    fireEvent.click(getByLabelText('bulk_add_components'));
+  });
+  
   await patientlyWaitFor(() => {
     expect(getAllByText('Add content views')[1]).toBeInTheDocument();
     expect(getAllByRole('textbox')[0]).toHaveValue('Version 4.0 (3 days ago)');
   });
-  fireEvent.click(getAllByRole('textbox')[0]);
-  fireEvent.click(queryByText('Version 3.0'));
-
-  fireEvent.click(getByLabelText('add_components'));
+  
+  await act(async () => {
+    fireEvent.click(getAllByRole('textbox')[0]);
+  });
+  
+  await act(async () => {
+    fireEvent.click(queryByText('Version 3.0'));
+  });
+  
+  await act(async () => {
+    fireEvent.click(getByLabelText('add_components'));
+  });
   await patientlyWaitFor(() => {
     expect(queryByText('Select available version of content views to use')).not.toBeInTheDocument();
     expect(getByLabelText('bulk_add_components')).toHaveAttribute('aria-disabled', 'false');

--- a/webpack/scenes/ContentViews/Details/ContentViewDetails.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewDetails.js
@@ -10,11 +10,13 @@ import {
   Button,
   Flex,
   FlexItem,
+} from '@patternfly/react-core';
+import {
   Dropdown,
   DropdownItem,
   KebabToggle,
   DropdownPosition,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/deprecated';
 import { STATUS } from 'foremanReact/constants';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -211,7 +213,7 @@ export default () => {
                   position={DropdownPosition.right}
                   ouiaId="cv-details-actions"
                   style={{ marginLeft: 'auto' }}
-                  toggle={<KebabToggle onToggle={setDropdownOpen} id="toggle-dropdown" />}
+                  toggle={<KebabToggle onToggle={(_event, val) => setDropdownOpen(val)} id="toggle-dropdown" />}
                   isOpen={dropDownOpen}
                   isPlain
                   dropdownItems={dropDownItems}

--- a/webpack/scenes/ContentViews/Details/Filters/Add/CVFilterAddModal.js
+++ b/webpack/scenes/ContentViews/Details/Filters/Add/CVFilterAddModal.js
@@ -6,9 +6,22 @@ import { STATUS } from 'foremanReact/constants';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
 import {
-  Modal, ModalVariant, Form, FormGroup, TextInput, ActionGroup, Button, Radio, TextArea,
-  Split, SplitItem, Select, SelectOption,
+  Modal,
+  ModalVariant,
+  Form,
+  FormGroup,
+  TextInput,
+  ActionGroup,
+  Button,
+  Radio,
+  TextArea,
+  Split,
+  SplitItem,
 } from '@patternfly/react-core';
+import {
+  Select,
+  SelectOption,
+} from '@patternfly/react-core/deprecated';
 import { addCVFilterRule, createContentViewFilter, getRepositoryTypes } from '../../ContentViewDetailActions';
 import { selectCreateContentViewFilter, selectCreateContentViewFilterStatus,
   selectCreateContentViewFilterError, selectCreateFilterRule,
@@ -129,7 +142,7 @@ const CVFilterAddModal = ({ cvId, onClose }) => {
             ouiaId="input_name"
             name="name"
             value={name}
-            onChange={value => setName(value)}
+            onChange={(_event, value) => setName(value)}
           />
         </FormGroup>
         <FormGroup label={__('Content type')} isRequired fieldId="content_type">
@@ -137,7 +150,7 @@ const CVFilterAddModal = ({ cvId, onClose }) => {
             selections={type}
             onSelect={onSelect}
             isOpen={typeSelectOpen}
-            onToggle={setTypeSelectOpen}
+            onToggle={(_event, val) => setTypeSelectOpen(val)}
             ouiaId="content_type"
             id="content_type"
             name="content_type"
@@ -152,7 +165,7 @@ const CVFilterAddModal = ({ cvId, onClose }) => {
               <Radio
                 isChecked={inclusion}
                 name="radio-1"
-                onChange={checked => setInclusion(checked)}
+                onChange={(_event, checked) => setInclusion(checked)}
                 label={__('Include filter')}
                 id="include_filter"
                 ouiaId="include_filter"
@@ -164,7 +177,7 @@ const CVFilterAddModal = ({ cvId, onClose }) => {
               <Radio
                 isChecked={!inclusion}
                 name="radio-1"
-                onChange={checked => setInclusion(!checked)}
+                onChange={(_event, checked) => setInclusion(!checked)}
                 label={__('Exclude filter')}
                 id="exclude_filter"
                 ouiaId="exclude_filter"
@@ -184,7 +197,7 @@ const CVFilterAddModal = ({ cvId, onClose }) => {
             resizeOrientation="vertical"
             autoResize
             style={{ maxHeight: '200px', minHeight: '36px' }}
-            onChange={value => setDescription(value)}
+            onChange={(_event, value) => setDescription(value)}
           />
         </FormGroup>
         <ActionGroup>

--- a/webpack/scenes/ContentViews/Details/Filters/AffectedRepositories/AffectedRepositorySelection.js
+++ b/webpack/scenes/ContentViews/Details/Filters/AffectedRepositories/AffectedRepositorySelection.js
@@ -1,7 +1,10 @@
 import React, { useState } from 'react';
 import { shallowEqual, useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Select, SelectOption } from '@patternfly/react-core';
+import {
+  Select,
+  SelectOption,
+} from '@patternfly/react-core/deprecated';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { selectCVFilterDetails } from '../../ContentViewDetailSelectors';
 import { editCVFilter, getCVFilterDetails } from '../../ContentViewDetailActions';
@@ -41,7 +44,7 @@ const AffectedRepositorySelection = ({
       selections={type}
       onSelect={onSelect}
       isOpen={typeSelectOpen}
-      onToggle={isExpanded => setTypeSelectOpen(isExpanded)}
+      onToggle={(_event, isExpanded) => setTypeSelectOpen(isExpanded)}
       id="affected_repos"
       name="affected_repos"
       aria-label="affected_repos"

--- a/webpack/scenes/ContentViews/Details/Filters/AffectedRepositories/AffectedRepositoryTable.js
+++ b/webpack/scenes/ContentViews/Details/Filters/AffectedRepositories/AffectedRepositoryTable.js
@@ -8,10 +8,12 @@ import {
   Button,
   ActionList,
   ActionListItem,
+} from '@patternfly/react-core';
+import {
   Dropdown,
   DropdownItem,
   KebabToggle,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/deprecated';
 import { TableVariant, fitContent } from '@patternfly/react-table';
 import { omit } from 'lodash';
 import { STATUS } from 'foremanReact/constants';

--- a/webpack/scenes/ContentViews/Details/Filters/ArtifactsWithNoErrata.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ArtifactsWithNoErrata.js
@@ -44,7 +44,7 @@ export const ArtifactsWithNoErrataRenderer = ({ filterDetails }) => {
     label={getLabel()}
     isChecked={artifactsNoErrata}
     isDisabled={isLoading}
-    onChange={checked => setArtifactsNoErrata(checked)}
+    onChange={(_event, checked) => setArtifactsNoErrata(checked)}
   />);
 };
 

--- a/webpack/scenes/ContentViews/Details/Filters/CVContainerImageFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVContainerImageFilterContent.js
@@ -10,11 +10,13 @@ import {
   TabTitleText,
   Split,
   SplitItem,
+  Button,
+} from '@patternfly/react-core';
+import {
   Dropdown,
   DropdownItem,
   KebabToggle,
-  Button,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/deprecated';
 import { STATUS } from 'foremanReact/constants';
 import { translate as __ } from 'foremanReact/common/I18n';
 import onSelect from '../../../../components/Table/helpers';

--- a/webpack/scenes/ContentViews/Details/Filters/CVDebFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVDebFilterContent.js
@@ -3,7 +3,19 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 import PropTypes from 'prop-types';
 import { shallowEqual, useSelector, useDispatch } from 'react-redux';
 import { TableVariant } from '@patternfly/react-table';
-import { Tabs, Tab, TabTitleText, Split, SplitItem, Button, Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
+import {
+  Tabs,
+  Tab,
+  TabTitleText,
+  Split,
+  SplitItem,
+  Button,
+} from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+} from '@patternfly/react-core/deprecated';
 import { STATUS } from 'foremanReact/constants';
 import { translate as __ } from 'foremanReact/common/I18n';
 import onSelect from '../../../../components/Table/helpers';

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataDateFilterContent.js
@@ -4,11 +4,27 @@ import { isEqual, sortBy, capitalize } from 'lodash';
 import { shallowEqual, useSelector, useDispatch } from 'react-redux';
 import { Link, useHistory } from 'react-router-dom';
 import {
-  Tooltip, Form, ActionGroup, Flex, FlexItem, Select,
-  SelectOption, SelectVariant, ChipGroup, Chip,
-  Tabs, Tab, TabTitleText, Button, DatePicker, Bullseye,
-  Divider, Text,
+  Tooltip,
+  Form,
+  ActionGroup,
+  Flex,
+  FlexItem,
+  ChipGroup,
+  Chip,
+  Tabs,
+  Tab,
+  TabTitleText,
+  Button,
+  DatePicker,
+  Bullseye,
+  Divider,
+  Text,
 } from '@patternfly/react-core';
+import {
+  Select,
+  SelectOption,
+  SelectVariant,
+} from '@patternfly/react-core/deprecated';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { selectCVFilterDetails } from '../ContentViewDetailSelectors';
@@ -136,7 +152,7 @@ const CVErrataDateFilterContent = ({
               <FlexItem span={2}>
                 <Select
                   variant={SelectVariant.checkbox}
-                  onToggle={setTypeSelectOpen}
+                  onToggle={(_event, val) => setTypeSelectOpen(val)}
                   onSelect={(_event, selection) => onTypeSelect(selection)}
                   selections={selectedTypes}
                   isOpen={typeSelectOpen}
@@ -185,7 +201,7 @@ const CVErrataDateFilterContent = ({
                   </Tooltip>
                 }
               </FlexItem>
-              <Divider isVertical />
+              <Divider orientation={{ default: 'vertical' }} />
               <FlexItem span={2} spacer={{ default: 'spacerNone' }}>
                 <Select
                   selections={dateType}
@@ -194,7 +210,7 @@ const CVErrataDateFilterContent = ({
                     setDateTypeSelectOpen(false);
                   }}
                   isOpen={dateTypeSelectOpen}
-                  onToggle={setDateTypeSelectOpen}
+                  onToggle={(_event, val) => setDateTypeSelectOpen(val)}
                   id="date_type_selector"
                   ouiaId="date_type_selector"
                   name="date_type_selector"

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
@@ -5,10 +5,28 @@ import { shallowEqual, useSelector, useDispatch } from 'react-redux';
 import { capitalize, omit, isEqual } from 'lodash';
 import { TableVariant } from '@patternfly/react-table';
 import {
-  Tabs, Tab, TabTitleText, Split, SplitItem, Select, SelectVariant,
-  SelectOption, Button, Dropdown, DropdownItem, KebabToggle, Flex, FlexItem,
-  Bullseye, DatePicker, ChipGroup, Chip, Text,
+  Tabs,
+  Tab,
+  TabTitleText,
+  Split,
+  SplitItem,
+  Button,
+  Flex,
+  FlexItem,
+  Bullseye,
+  DatePicker,
+  ChipGroup,
+  Chip,
+  Text,
 } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+  Select,
+  SelectVariant,
+  SelectOption,
+} from '@patternfly/react-core/deprecated';
 import { STATUS } from 'foremanReact/constants';
 import { translate as __ } from 'foremanReact/common/I18n';
 
@@ -304,7 +322,7 @@ const CVErrataIDFilterContent = ({
                       aria-label="errata_type_selector"
                       ouiaId="errata_type_selector"
                       variant={SelectVariant.checkbox}
-                      onToggle={setTypeSelectOpen}
+                      onToggle={(_event, val) => setTypeSelectOpen(val)}
                       onSelect={(_event, selection) => onTypeSelect(selection)}
                       selections={selectedTypes}
                       isOpen={typeSelectOpen}
@@ -363,7 +381,7 @@ const CVErrataIDFilterContent = ({
                         setDateTypeSelectOpen(false);
                       }}
                       isOpen={dateTypeSelectOpen}
-                      onToggle={setDateTypeSelectOpen}
+                      onToggle={(_event, val) => setDateTypeSelectOpen(val)}
                       id="date_type_selector"
                       name="date_type_selector"
                       ouiaId="date_type_selector"

--- a/webpack/scenes/ContentViews/Details/Filters/CVModuleStreamFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVModuleStreamFilterContent.js
@@ -5,9 +5,21 @@ import { shallowEqual, useSelector, useDispatch } from 'react-redux';
 import { omit } from 'lodash';
 import { TableVariant } from '@patternfly/react-table';
 import {
-  Tabs, Tab, TabTitleText, Split, SplitItem, Button, Dropdown, DropdownItem,
-  KebabToggle, Select, SelectOption, SelectVariant,
+  Tabs,
+  Tab,
+  TabTitleText,
+  Split,
+  SplitItem,
+  Button,
 } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+  Select,
+  SelectOption,
+  SelectVariant,
+} from '@patternfly/react-core/deprecated';
 import { STATUS } from 'foremanReact/constants';
 import { translate as __ } from 'foremanReact/common/I18n';
 
@@ -245,7 +257,7 @@ const CVModuleStreamFilterContent = ({
                   <SplitItem data-testid="allAddedNotAdded">
                     <Select
                       variant={SelectVariant.single}
-                      onToggle={setSelectOpen}
+                      onToggle={(_event, val) => setSelectOpen(val)}
                       ouiaId="added-notAdded-selector"
                       onSelect={(_event, selection) => {
                         setSelectedIndex(allAddedNotAdded.indexOf(selection));

--- a/webpack/scenes/ContentViews/Details/Filters/CVPackageGroupFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVPackageGroupFilterContent.js
@@ -4,9 +4,21 @@ import PropTypes from 'prop-types';
 import { shallowEqual, useSelector, useDispatch } from 'react-redux';
 import { TableVariant } from '@patternfly/react-table';
 import {
-  Tabs, Tab, TabTitleText, Split, SplitItem, Button,
-  Select, SelectVariant, SelectOption, Dropdown, DropdownItem, KebabToggle,
+  Tabs,
+  Tab,
+  TabTitleText,
+  Split,
+  SplitItem,
+  Button,
 } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+  Select,
+  SelectVariant,
+  SelectOption,
+} from '@patternfly/react-core/deprecated';
 import { STATUS } from 'foremanReact/constants';
 import { translate as __ } from 'foremanReact/common/I18n';
 
@@ -235,7 +247,7 @@ const CVPackageGroupFilterContent = ({
                   <SplitItem data-testid="allAddedNotAdded">
                     <Select
                       variant={SelectVariant.single}
-                      onToggle={setSelectOpen}
+                      onToggle={(_event, val) => setSelectOpen(val)}
                       ouiaId="allAddedNotAdded"
                       onSelect={(_event, selection) => {
                         setSelectedIndex(allAddedNotAdded.indexOf(selection));

--- a/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVRpmFilterContent.js
@@ -3,7 +3,19 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 import PropTypes from 'prop-types';
 import { shallowEqual, useSelector, useDispatch } from 'react-redux';
 import { TableVariant } from '@patternfly/react-table';
-import { Tabs, Tab, TabTitleText, Split, SplitItem, Dropdown, DropdownItem, KebabToggle, Button } from '@patternfly/react-core';
+import {
+  Tabs,
+  Tab,
+  TabTitleText,
+  Split,
+  SplitItem,
+  Button,
+} from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+} from '@patternfly/react-core/deprecated';
 import { STATUS } from 'foremanReact/constants';
 import { translate as __ } from 'foremanReact/common/I18n';
 import onSelect from '../../../../components/Table/helpers';

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetailsHeader.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilterDetailsHeader.js
@@ -11,13 +11,15 @@ import {
   Text,
   TextVariants,
   Label,
+  Flex,
+  FlexItem,
+} from '@patternfly/react-core';
+import {
   Dropdown,
   DropdownItem,
   KebabToggle,
   DropdownPosition,
-  Flex,
-  FlexItem,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/deprecated';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { useDispatch } from 'react-redux';
 import getContentViewDetails, {
@@ -134,7 +136,7 @@ const ContentViewFilterDetailsHeader = ({
               ouiaId="cv-filter-actions-kebab"
               position={DropdownPosition.right}
               style={{ marginLeft: 'auto' }}
-              toggle={<KebabToggle onToggle={setDropdownOpen} id="toggle-dropdown" />}
+              toggle={<KebabToggle onToggle={(_event, val) => setDropdownOpen(val)} id="toggle-dropdown" />}
               isOpen={dropDownOpen}
               isPlain
               dropdownItems={dropDownItems}

--- a/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
+++ b/webpack/scenes/ContentViews/Details/Filters/ContentViewFilters.js
@@ -1,7 +1,17 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { shallowEqual, useSelector, useDispatch } from 'react-redux';
-import { Label, Split, SplitItem, Dropdown, DropdownItem, KebabToggle, Button } from '@patternfly/react-core';
+import {
+  Label,
+  Split,
+  SplitItem,
+  Button,
+} from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+} from '@patternfly/react-core/deprecated';
 import { TableVariant } from '@patternfly/react-table';
 import { STATUS } from 'foremanReact/constants';
 import LongDateTime from 'foremanReact/components/common/dates/LongDateTime';

--- a/webpack/scenes/ContentViews/Details/Filters/MatchContentModal/matchContentModal.scss
+++ b/webpack/scenes/ContentViews/Details/Filters/MatchContentModal/matchContentModal.scss
@@ -1,3 +1,3 @@
-.pf-c-empty-state {
+.pf-v5-c-empty-state {
   margin-top: 0;
 }

--- a/webpack/scenes/ContentViews/Details/Filters/Rules/DebPackage/AddEditDebPackageRuleModal.js
+++ b/webpack/scenes/ContentViews/Details/Filters/Rules/DebPackage/AddEditDebPackageRuleModal.js
@@ -81,7 +81,7 @@ const AddEditDebPackageRuleModal = ({ filterId, onClose, selectedFilterRuleData 
             aria-label="input_name"
             name="name"
             value={name}
-            onChange={value => setName(value)}
+            onChange={(_event, value) => setName(value)}
           />
         </FormGroup>
         <FormGroup label={__('Architecture')} fieldId="architecture">
@@ -92,7 +92,7 @@ const AddEditDebPackageRuleModal = ({ filterId, onClose, selectedFilterRuleData 
             aria-label="input_architecture"
             name="architecture"
             value={architecture}
-            onChange={value => setArchitecture(value)}
+            onChange={(_event, value) => setArchitecture(value)}
           />
         </FormGroup>
         <ActionGroup>

--- a/webpack/scenes/ContentViews/Details/Filters/Rules/Package/AddEditPackageRuleModal.js
+++ b/webpack/scenes/ContentViews/Details/Filters/Rules/Package/AddEditPackageRuleModal.js
@@ -181,7 +181,7 @@ const AddEditPackageRuleModal = ({
           <FormSelect
             ouiaId="version-comparator"
             value={versionComparator}
-            onChange={setVersionComparator}
+            onChange={(_event, val) => setVersionComparator(val)}
             id="version_comparator"
             name="version_comparator"
             aria-label="version_comparator"
@@ -201,7 +201,7 @@ const AddEditPackageRuleModal = ({
               aria-label="input_version"
               name="version"
               value={version}
-              onChange={setVersion}
+              onChange={(_event, val) => setVersion(val)}
             />
           </FormGroup>}
         {showMinVersion &&
@@ -213,7 +213,7 @@ const AddEditPackageRuleModal = ({
               aria-label="input_min_version"
               name="min_version"
               value={minVersion}
-              onChange={setMinVersion}
+              onChange={(_event, val) => setMinVersion(val)}
             />
           </FormGroup>}
         {showMaxVersion &&
@@ -225,7 +225,7 @@ const AddEditPackageRuleModal = ({
               aria-label="input_max_version"
               name="max_version"
               value={maxVersion}
-              onChange={setMaxVersion}
+              onChange={(_event, val) => setMaxVersion(val)}
             />
           </FormGroup>}
         <ActionGroup>

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/CVContainerImageFilterContent.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/CVContainerImageFilterContent.test.js
@@ -107,13 +107,13 @@ test('Can remove filter rules', async (done) => {
 
   await patientlyWaitFor(() => {
     expect(queryByText(firstResultName)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'false');
   });
 
-  fireEvent.click(getAllByLabelText('Actions')[0]);
+  fireEvent.click(getAllByLabelText('Kebab toggle')[0]);
 
   await patientlyWaitFor(() => {
-    expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'true');
+    expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'true');
     expect(queryByText('Remove')).toBeInTheDocument();
     fireEvent.click(queryByText('Remove'));
   });
@@ -239,13 +239,13 @@ test('Can edit filter rules', async (done) => {
 
   await patientlyWaitFor(() => {
     expect(queryByText(firstResultName)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'false');
   });
 
-  fireEvent.click(getAllByLabelText('Actions')[0]);
+  fireEvent.click(getAllByLabelText('Kebab toggle')[0]);
 
   await patientlyWaitFor(() => {
-    expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'true');
+    expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'true');
     expect(queryByText('Edit')).toBeInTheDocument();
     fireEvent.click(queryByText('Edit'));
   });

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/CVRpmFilterContent.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/CVRpmFilterContent.test.js
@@ -237,7 +237,7 @@ test('Can add package rules to filter in a self-closing modal', async (done) => 
   act(done);
 });
 
-test('Remove rpm filter rule in a self-closing modal', async (done) => {
+test.only('Remove rpm filter rule in a self-closing modal', async (done) => {
   const { name: cvFilterName } = cvFilterDetails;
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
@@ -270,11 +270,11 @@ test('Remove rpm filter rule in a self-closing modal', async (done) => {
   expect(queryByText(cvFilterName)).toBeNull();
   await patientlyWaitFor(() => {
     expect(getByText(cvFilterName)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[1]).toBeInTheDocument();
+    expect(getAllByLabelText('Kebab toggle')[1]).toBeInTheDocument();
   });
-
-  getAllByLabelText('Actions')[1].click();
-
+  await act(async () => {
+    getAllByLabelText('Kebab toggle')[1].click();
+  });
   await patientlyWaitFor(() => {
     expect(getByText('Remove')).toBeInTheDocument();
   });
@@ -282,7 +282,7 @@ test('Remove rpm filter rule in a self-closing modal', async (done) => {
   getByText('Remove').click();
   await patientlyWaitFor(() => {
     expect(getByText(cvFilterName)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[1]).toBeInTheDocument();
+    expect(getAllByLabelText('Kebab toggle')[1]).toBeInTheDocument();
   });
 
   assertNockRequest(autocompleteScope);
@@ -338,11 +338,11 @@ test('Edit rpm filter rule in a self-closing modal', async (done) => {
   expect(queryByText(cvFilterName)).toBeNull();
   await patientlyWaitFor(() => {
     expect(getByText(cvFilterName)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[1]).toBeInTheDocument();
+    expect(getAllByLabelText('Kebab toggle')[1]).toBeInTheDocument();
   });
-
-  getAllByLabelText('Actions')[1].click();
-
+  await act(async () => {
+    getAllByLabelText('Kebab toggle')[1].click();
+  });
   await patientlyWaitFor(() => {
     expect(getByText('Edit')).toBeInTheDocument();
   });

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/ContentViewPackageGroupFilter.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/ContentViewPackageGroupFilter.test.js
@@ -127,10 +127,10 @@ test('Can remove a filter rule', async (done) => {
 
   await patientlyWaitFor(() => {
     expect(getByText(name)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Kebab toggle')[2]).toHaveAttribute('aria-expanded', 'false');
   });
-  fireEvent.click(getAllByLabelText('Actions')[2]);
-  expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'true');
+  fireEvent.click(getAllByLabelText('Kebab toggle')[2]);
+  expect(getAllByLabelText('Kebab toggle')[2]).toHaveAttribute('aria-expanded', 'true');
   await patientlyWaitFor(() => expect(getByText('Remove')).toBeInTheDocument());
   fireEvent.click(getByText('Remove'));
 
@@ -186,10 +186,10 @@ test('Can add a filter rule', async (done) => {
 
   await patientlyWaitFor(() => {
     expect(getByText(name)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[3]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Kebab toggle')[3]).toHaveAttribute('aria-expanded', 'false');
   });
-  fireEvent.click(getAllByLabelText('Actions')[3]);
-  expect(getAllByLabelText('Actions')[3]).toHaveAttribute('aria-expanded', 'true');
+  fireEvent.click(getAllByLabelText('Kebab toggle')[3]);
+  expect(getAllByLabelText('Kebab toggle')[3]).toHaveAttribute('aria-expanded', 'true');
   await patientlyWaitFor(() => expect(getByText('Add')).toBeInTheDocument());
   fireEvent.click(getByText('Add'));
 

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilters.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/contentViewFilters.test.js
@@ -143,10 +143,10 @@ test('Can remove a filter', async (done) => {
   );
 
   await patientlyWaitFor(() => {
-    expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'false');
   });
-  fireEvent.click(getAllByLabelText('Actions')[0]);
-  expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'true');
+  fireEvent.click(getAllByLabelText('Kebab toggle')[0]);
+  expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'true');
   await patientlyWaitFor(() => expect(getByText('Remove')).toBeInTheDocument());
   fireEvent.click(getByText('Remove'));
 

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataDateFilterContent.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataDateFilterContent.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
+import { renderWithRedux, patientlyWaitFor, fireEvent, act } from 'react-testing-lib-wrapper';
 import * as reactRedux from 'react-redux';
 import {
   nockInstance,
@@ -51,7 +51,9 @@ test('Can display errata-date filter rule and edit', async (done) => {
     expect(getByText('08/15/2020')).toBeInTheDocument();
   });
   // Can clear date with chip
-  getByLabelText('08/15/1990').click();
+  await act(async () => {
+    getByLabelText('08/15/1990').click();
+  });
   await patientlyWaitFor(() => {
     expect(getByText('ANY')).toBeInTheDocument();
     expect(queryByText('08/15/1990')).not.toBeInTheDocument();
@@ -59,7 +61,9 @@ test('Can display errata-date filter rule and edit', async (done) => {
     // Enabled Edit rule button
     expect(getByLabelText('save_filter_rule')).toHaveAttribute('aria-disabled', 'false');
   });
-  getByLabelText('save_filter_rule').click();
+  await act(async () => {
+    getByLabelText('save_filter_rule').click();
+  });
 
   useSelectorMock.mockClear();
   assertNockRequest(ruleEditScope, done);

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataIDFilter.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataIDFilter.test.js
@@ -118,10 +118,10 @@ test('Can add a filter rule', async (done) => {
 
   await patientlyWaitFor(() => {
     expect(getByText(errataId)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[3]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Kebab toggle')[3]).toHaveAttribute('aria-expanded', 'false');
   });
-  fireEvent.click(getAllByLabelText('Actions')[3]);
-  expect(getAllByLabelText('Actions')[3]).toHaveAttribute('aria-expanded', 'true');
+  fireEvent.click(getAllByLabelText('Kebab toggle')[3]);
+  expect(getAllByLabelText('Kebab toggle')[3]).toHaveAttribute('aria-expanded', 'true');
   await patientlyWaitFor(() => expect(getByText('Add')).toBeInTheDocument());
   act(() => { fireEvent.click(getByText('Add')); });
 
@@ -176,10 +176,10 @@ test('Can remove a filter rule', async (done) => {
 
   await patientlyWaitFor(() => {
     expect(getByText(errataId)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Kebab toggle')[2]).toHaveAttribute('aria-expanded', 'false');
   });
-  fireEvent.click(getAllByLabelText('Actions')[2]);
-  expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'true');
+  fireEvent.click(getAllByLabelText('Kebab toggle')[2]);
+  expect(getAllByLabelText('Kebab toggle')[2]).toHaveAttribute('aria-expanded', 'true');
   await patientlyWaitFor(() => expect(getByText('Remove')).toBeInTheDocument());
   act(() => { fireEvent.click(getByText('Remove')); });
 

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/cvModuleStreamFilter.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/cvModuleStreamFilter.test.js
@@ -119,10 +119,10 @@ test('Can add a filter rule', async (done) => {
 
   await patientlyWaitFor(() => {
     expect(getByText(name)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[3]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Kebab toggle')[3]).toHaveAttribute('aria-expanded', 'false');
   });
-  fireEvent.click(getAllByLabelText('Actions')[3]);
-  expect(getAllByLabelText('Actions')[3]).toHaveAttribute('aria-expanded', 'true');
+  fireEvent.click(getAllByLabelText('Kebab toggle')[3]);
+  expect(getAllByLabelText('Kebab toggle')[3]).toHaveAttribute('aria-expanded', 'true');
   await patientlyWaitFor(() => expect(getByText('Add')).toBeInTheDocument());
   fireEvent.click(getByText('Add'));
 
@@ -175,10 +175,10 @@ test('Can remove a filter rule', async (done) => {
 
   await patientlyWaitFor(() => {
     expect(getByText(name)).toBeInTheDocument();
-    expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'false');
+    expect(getAllByLabelText('Kebab toggle')[2]).toHaveAttribute('aria-expanded', 'false');
   });
-  fireEvent.click(getAllByLabelText('Actions')[2]);
-  expect(getAllByLabelText('Actions')[2]).toHaveAttribute('aria-expanded', 'true');
+  fireEvent.click(getAllByLabelText('Kebab toggle')[2]);
+  expect(getAllByLabelText('Kebab toggle')[2]).toHaveAttribute('aria-expanded', 'true');
   await patientlyWaitFor(() => expect(getByText('Remove')).toBeInTheDocument());
   fireEvent.click(getByText('Remove'));
 

--- a/webpack/scenes/ContentViews/Details/Histories/ContentViewHistories.js
+++ b/webpack/scenes/ContentViews/Details/Histories/ContentViewHistories.js
@@ -49,9 +49,9 @@ const ContentViewHistories = ({ cvId }) => {
     const taskType = task ? task.label : taskTypes[action];
 
     if (taskType === taskTypes.removal) {
-      return <>{__('Deleted from ')} <Label isTruncated key="1" color="blue" href={`/lifecycle_environments/${environment?.id}`}>{environment?.name ?? __('all environments')}</Label></>;
+      return <>{__('Deleted from ')} <Label key="1" color="blue" href={`/lifecycle_environments/${environment?.id}`}>{environment?.name ?? __('all environments')}</Label></>;
     } else if (action === 'promotion' || taskType === taskTypes.promotion) {
-      return <>{__('Promoted to ')}<Label isTruncated key="2" color="blue" href={`/lifecycle_environments/${environment?.id}`}>{environment?.name}</Label></>;
+      return <>{__('Promoted to ')}<Label key="2" color="blue" href={`/lifecycle_environments/${environment?.id}`}>{environment?.name}</Label></>;
     } else if (taskType === taskTypes.publish) {
       return __('Published new version');
     } else if (taskType === taskTypes.export) {

--- a/webpack/scenes/ContentViews/Details/Promote/ContentViewVersionPromote.js
+++ b/webpack/scenes/ContentViews/Details/Promote/ContentViewVersionPromote.js
@@ -133,7 +133,7 @@ const ContentViewVersionPromote = ({
               aria-label="input_description"
               name="description"
               value={description}
-              onChange={value => setDescription(value)}
+              onChange={(_event, value) => setDescription(value)}
             />
           </FormGroup>
           {!alertDismissed && forcePromote.length > 0 && (

--- a/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/ContentViewRepositories.js
@@ -25,13 +25,15 @@ import {
   ActionListItem,
   Bullseye,
   Button,
-  Dropdown,
-  DropdownItem,
-  KebabToggle,
   Split,
   SplitItem,
   Checkbox,
 } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+} from '@patternfly/react-core/deprecated';
 import {
   TableVariant,
   Thead,
@@ -402,7 +404,7 @@ const ContentViewRepositories = ({ cvId, details }) => {
                     id={id}
                     ouiaId={`repository-checkbox-${id}`}
                     isChecked={isSelected(id)}
-                    onChange={selected =>
+                    onChange={(_event, selected) =>
                       selectOne(selected, id, repo)
                     }
                   />

--- a/webpack/scenes/ContentViews/Details/Versions/BulkDelete/ActionSummary.js
+++ b/webpack/scenes/ContentViews/Details/Versions/BulkDelete/ActionSummary.js
@@ -5,6 +5,7 @@ import {
   FlexItem,
   Label,
   Text,
+  Icon,
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import {
@@ -19,14 +20,14 @@ const ActionSummary = ({ title, text, selectedEnv: { name, id } }) => (
     {text &&
       <Flex>
         <FlexItem style={{ marginRight: '8px' }}>
-          <ExclamationTriangleIcon color={warningColor.value} />
+          <Icon color={warningColor.value}><ExclamationTriangleIcon /></Icon>
         </FlexItem>
         <FlexItem style={{ marginRight: '8px' }}>
           <Text ouiaId="action-summary-text">{text}</Text>
         </FlexItem>
         {name && id &&
           <FlexItem>
-            <Label isTruncated color="purple" href={`/lifecycle_environments/${id}`}>{name}</Label>
+            <Label color="purple" href={`/lifecycle_environments/${id}`}>{name}</Label>
           </FlexItem>
         }
       </Flex>

--- a/webpack/scenes/ContentViews/Details/Versions/BulkDelete/BulkDeleteModal.js
+++ b/webpack/scenes/ContentViews/Details/Versions/BulkDelete/BulkDeleteModal.js
@@ -4,7 +4,9 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import { PropTypes } from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
-import { Wizard } from '@patternfly/react-core';
+import {
+  Wizard,
+} from '@patternfly/react-core/deprecated';
 
 import BulkDeleteContextWrapper, {
   BulkDeleteContext,

--- a/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ConfirmBulkDelete.js
+++ b/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ConfirmBulkDelete.js
@@ -64,7 +64,7 @@ export default () => {
                   versionOrVersions: affectedVersions.length > 1 ? __('Versions ') : __('Version '),
                   envLabel: (() => {
                     const { id, name } = first(environments);
-                    return <Label isTruncated color="purple" href={`/lifecycle_environments/${id}`}>{name}</Label>;
+                    return <Label color="purple" href={`/lifecycle_environments/${id}`}>{name}</Label>;
                   })(),
                 }}
                 defaultMessage={pluralEnvironments ?
@@ -77,7 +77,7 @@ export default () => {
             <Flex>
               {environments.map(({ name, id }) => (
                 <FlexItem key={id}>
-                  <Label isTruncated color="purple" href={`/lifecycle_environments/${id}`}>{name}</Label>
+                  <Label color="purple" href={`/lifecycle_environments/${id}`}>{name}</Label>
                 </FlexItem>))
               }
             </Flex>}

--- a/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignActivationKeys.js
+++ b/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignActivationKeys.js
@@ -17,9 +17,11 @@ import {
   ExpandableSection,
   Popover,
   PopoverPosition,
+} from '@patternfly/react-core';
+import {
   SelectDirection,
   SelectOption,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/deprecated';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
 import EnvironmentPaths

--- a/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignHosts.js
+++ b/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReassignHosts.js
@@ -17,9 +17,11 @@ import {
   ExpandableSection,
   Popover,
   PopoverPosition,
+} from '@patternfly/react-core';
+import {
   SelectDirection,
   SelectOption,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/deprecated';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
 import EnvironmentPaths

--- a/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReviewEnvironments.js
+++ b/webpack/scenes/ContentViews/Details/Versions/BulkDelete/Steps/ReviewEnvironments.js
@@ -5,7 +5,7 @@ import { FormattedMessage } from 'react-intl';
 
 import { Label } from '@patternfly/react-core';
 import {
-  TableComposable,
+  Table /* data-codemods */,
   TableVariant,
   Tbody,
   Td,
@@ -64,7 +64,7 @@ export default () => {
               __('{versionOrVersions} {versionList} will be removed from the listed environment and will no longer be available for promotion.')}
           />}
       />
-      <TableComposable ouiaId="bulk-delete-env-table" variant={TableVariant.compact}>
+      <Table ouiaId="bulk-delete-env-table" variant={TableVariant.compact}>
         <Thead>
           <Tr ouiaId="bulk-delete-env-header">
             {columnHeaders.map(col =>
@@ -84,7 +84,7 @@ export default () => {
               <Td>
                 <Label
                   /* TODO: Add "isCompact" to this on update of patternfly */
-                  isTruncated
+
                   color="purple"
                 >
                   {name}
@@ -97,7 +97,7 @@ export default () => {
           )))
           }
         </Tbody>
-      </TableComposable>
+      </Table>
     </>
   );
 };

--- a/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompare.scss
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompare.scss
@@ -1,7 +1,7 @@
 .content-view-header-content {
   padding-top: 24px;
 
-  .pf-c-content {
+  .pf-v5-c-content {
     dl {
       margin: 0;
     }
@@ -20,25 +20,25 @@
   .compare-table-container {
     flex-grow: 4;
   }
-  .pf-c-tabs.pf-m-vertical {
+  .pf-v5-c-tabs.pf-m-vertical {
     max-width: 230px;
     border-right: 1px solid #d2d2d2;
     height: unset;
 
-    .pf-c-tabs__item {
+    .pf-v5-c-tabs__item {
       margin-top: 0;
 
       button {
         align-items: center;
 
-        .pf-c-label__content {
+        .pf-v5-c-label__content {
           &::before {
             border: none;
           }
         }
       }
 
-      &.pf-m-current .pf-c-label__content {
+      &.pf-m-current .pf-v5-c-label__content {
         font-weight: bold;
       }
     }
@@ -64,7 +64,7 @@
   th:nth-last-child(3) {
     margin-left: 2rem;
     border-right:  var(--pf-global--BorderWidth--sm);
-    border-right-color: var(--pf-c-table--BorderColor);
+    border-right-color: var(--pf-v5-c-table--BorderColor);
     border-right-style: inset;
   }
 }
@@ -72,7 +72,7 @@
 .cvv-compare-bordered-table-rows {
   td:nth-last-child(3) {
     border-right:  var(--pf-global--BorderWidth--sm);
-    border-right-color: var(--pf-c-table--BorderColor);
+    border-right-color: var(--pf-v5-c-table--BorderColor);
     border-right-style: inset;
   }
 

--- a/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareHeader.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompareHeader.js
@@ -3,9 +3,19 @@ import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { useSelector } from 'react-redux';
 import {
-  Grid, GridItem, TextContent, Text, TextVariants,
-  Select, SelectOption, SelectVariant, Flex, FlexItem,
+  Grid,
+  GridItem,
+  TextContent,
+  Text,
+  TextVariants,
+  Flex,
+  FlexItem,
 } from '@patternfly/react-core';
+import {
+  Select,
+  SelectOption,
+  SelectVariant,
+} from '@patternfly/react-core/deprecated';
 import { selectCVDetails } from '../../ContentViewDetailSelectors';
 import { HelpToolTip } from '../../../Create/ContentViewFormComponents';
 
@@ -97,7 +107,7 @@ const CVVersionCompareHeader = ({
                       placeholderText={__('Select an option')}
                       aria-label="Select version one"
                       ouiaId="select-version-one"
-                      onToggle={setIsOpenSelectVersionOne}
+                      onToggle={(_event, val) => setIsOpenSelectVersionOne(val)}
                       onSelect={onSelectVersionOne}
                       selections={versionOne}
                       isOpen={isOpenSelectVersionOne}
@@ -124,7 +134,7 @@ const CVVersionCompareHeader = ({
                       placeholderText="Select an option"
                       aria-label="Select version two"
                       ouiaId="select-version-two"
-                      onToggle={setIsOpenSelectVersionTwo}
+                      onToggle={(_event, val) => setIsOpenSelectVersionTwo(val)}
                       onSelect={onSelectVersionTwo}
                       selections={versionTwo}
                       isOpen={isOpenSelectVersionTwo}
@@ -154,7 +164,7 @@ const CVVersionCompareHeader = ({
                   placeholderText="Select an option"
                   aria-label="Select view by"
                   ouiaId="select-view-by"
-                  onToggle={setIsOpenSelectViewBy}
+                  onToggle={(_event, val) => setIsOpenSelectViewBy(val)}
                   onSelect={onSelectViewBy}
                   selections={selectedViewBy}
                   isOpen={isOpenSelectViewBy}

--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionEnvironments.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionEnvironments.js
@@ -15,7 +15,7 @@ const ContentViewVersionEnvironments = ({ environments }) => {
     <React.Fragment key={env.id}>
       <Flex style={{ margin: '4px 0' }} >
         <FlexItem>
-          <Label isTruncated color="purple" href={`/lifecycle_environments/${env.id}`}>{env.name}</Label>
+          <Label color="purple" href={`/lifecycle_environments/${env.id}`}>{env.name}</Label>
         </FlexItem>
         <FlexItem>
           <InactiveText text={` ${env.publish_date} ago`} />

--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
@@ -1,7 +1,17 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { TableVariant, TableText, Tbody, Thead, Td, Tr, Th } from '@patternfly/react-table';
-import { Checkbox, Dropdown, DropdownItem, Grid, KebabToggle, GridItem, Button } from '@patternfly/react-core';
+import {
+  Checkbox,
+  Grid,
+  GridItem,
+  Button,
+} from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+} from '@patternfly/react-core/deprecated';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { urlBuilder } from 'foremanReact/common/urlHelpers';
 import { STATUS } from 'foremanReact/constants';
@@ -151,7 +161,7 @@ const ContentViewVersions = ({ cvId, details }) => {
         id={versionId}
         aria-label={`Select version ${versionId}`}
         isChecked={isSelected(versionId)}
-        onChange={selected => selectOne(selected, versionId)}
+        onChange={(_event, selected) => selectOne(selected, versionId)}
       />,
       <>
         <Link to={`/versions/${versionId}`}>{__('Version ')}{version}</Link>
@@ -303,7 +313,7 @@ const ContentViewVersions = ({ cvId, details }) => {
               </GridItem>
               <GridItem md={4} sm={12}>
                 <Dropdown
-                  toggle={<KebabToggle aria-label="bulk_actions" onToggle={setKebabOpen} />}
+                  toggle={<KebabToggle aria-label="bulk_actions" onToggle={(_event, val) => setKebabOpen(val)} />}
                   isOpen={kebabOpen}
                   ouiaId="cv-versions-bulk-actions"
                   isPlain

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveCVVersionWizard.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveCVVersionWizard.js
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Wizard } from '@patternfly/react-core';
+import {
+  Wizard,
+} from '@patternfly/react-core/deprecated';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { useSet } from 'foremanReact/components/PF4/TableIndexPage/Table/TableHooks';
 import getEnvironmentPaths from '../../../components/EnvironmentPaths/EnvironmentPathActions';

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVEnvironmentSelectionForm.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVEnvironmentSelectionForm.js
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { Alert, Checkbox, EmptyState, EmptyStateVariant, Title, EmptyStateBody, AlertActionCloseButton } from '@patternfly/react-core';
-import { TableVariant, TableComposable, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { Alert, Checkbox, EmptyState, EmptyStateVariant, EmptyStateBody, AlertActionCloseButton, EmptyStateHeader } from '@patternfly/react-core';
+import { TableVariant, Table /* data-codemods */, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import { translate as __ } from 'foremanReact/common/I18n';
 import DeleteContext from '../DeleteContext';
 
@@ -73,12 +73,12 @@ const CVEnvironmentSelectionForm = () => {
               id="delete_version"
               label={__('Delete version')}
               isChecked={removeDeletionFlow}
-              onChange={checked => setRemoveDeletionFlow(checked)}
+              onChange={(_event, checked) => setRemoveDeletionFlow(checked)}
               style={{ margin: 0 }}
             />
           </Alert>)}
       {(versionEnvironments.length !== 0) &&
-        <TableComposable ouiaId="version-delete-env-table" variant={TableVariant.compact}>
+        <Table ouiaId="version-delete-env-table" variant={TableVariant.compact}>
           <Thead>
             <Tr ouiaId="version-delete-env-table-header">
               <Td
@@ -86,7 +86,7 @@ const CVEnvironmentSelectionForm = () => {
                   rowIndex: 0,
                   onSelect: onSelectAll,
                   isSelected: areAllSelected() || deleteFlow || removeDeletionFlow,
-                  disable: deleteFlow || removeDeletionFlow,
+                  isDisabled: deleteFlow || removeDeletionFlow,
                 }}
               />
               {columnHeaders.map(col =>
@@ -106,7 +106,7 @@ const CVEnvironmentSelectionForm = () => {
                       rowIndex,
                       onSelect: (event, isSelected) => onSelect(event, isSelected, id),
                       isSelected: selectedEnvSet.has(id) || deleteFlow || removeDeletionFlow,
-                      disable: deleteFlow || removeDeletionFlow,
+                      isDisabled: deleteFlow || removeDeletionFlow,
                     }}
                   />
                   <Td>
@@ -118,12 +118,10 @@ const CVEnvironmentSelectionForm = () => {
               ))
             }
           </Tbody>
-        </TableComposable>}
+        </Table>}
       {(versionEnvironments.length === 0) &&
         <EmptyState variant={EmptyStateVariant.xs}>
-          <Title headingLevel="h4" size="md" ouiaId="not-promoted-title">
-            {__('This version has not been promoted to any environments.')}
-          </Title>
+          <EmptyStateHeader titleText={<>{__('This version has not been promoted to any environments.')}</>} headingLevel="h4" />
           <EmptyStateBody>
             {versionEnvironmentsEmptyInfo}
           </EmptyStateBody>

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignActivationKeysForm.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignActivationKeysForm.js
@@ -1,7 +1,12 @@
 import React, { useState, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { ExpandableSection, SelectOption } from '@patternfly/react-core';
+import {
+  ExpandableSection,
+} from '@patternfly/react-core';
+import {
+  SelectOption,
+} from '@patternfly/react-core/deprecated';
 import { STATUS } from 'foremanReact/constants';
 import { translate as __ } from 'foremanReact/common/I18n';
 import EnvironmentPaths from '../../../../components/EnvironmentPaths/EnvironmentPaths';
@@ -126,7 +131,7 @@ const CVReassignActivationKeysForm = () => {
         toggleText={showActivationKeys ?
           'Hide activation keys' :
           'Show activation keys'}
-        onToggle={expanded => setShowActivationKeys(expanded)}
+        onToggle={(_event, expanded) => setShowActivationKeys(expanded)}
         isExpanded={showActivationKeys}
       >
         <AffectedActivationKeys

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignHostsForm.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignHostsForm.js
@@ -1,7 +1,12 @@
 import React, { useState, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { ExpandableSection, SelectOption } from '@patternfly/react-core';
+import {
+  ExpandableSection,
+} from '@patternfly/react-core';
+import {
+  SelectOption,
+} from '@patternfly/react-core/deprecated';
 import { STATUS } from 'foremanReact/constants';
 import { translate as __ } from 'foremanReact/common/I18n';
 import EnvironmentPaths from '../../../../components/EnvironmentPaths/EnvironmentPaths';
@@ -127,7 +132,7 @@ const CVReassignHostsForm = () => {
       </ContentViewSelect>
       <ExpandableSection
         toggleText={showHosts ? 'Hide hosts' : 'Show hosts'}
-        onToggle={expanded => setShowHosts(expanded)}
+        onToggle={(_event, expanded) => setShowHosts(expanded)}
         isExpanded={showHosts}
       >
         <AffectedHosts

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVVersionRemoveReview.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVVersionRemoveReview.js
@@ -47,7 +47,7 @@ const CVVersionRemoveReview = () => {
           </Flex>
           <Flex>
             {selectedEnv?.map(({ name, id }) =>
-              <FlexItem key={name}><Label isTruncated color="purple" href={`/lifecycle_environments/${id}`}>{name}</Label></FlexItem>)}
+              <FlexItem key={name}><Label color="purple" href={`/lifecycle_environments/${id}`}>{name}</Label></FlexItem>)}
           </Flex>
         </>}
       {affectedHosts &&
@@ -56,7 +56,7 @@ const CVVersionRemoveReview = () => {
           <Flex>
             <FlexItem><ExclamationTriangleIcon /></FlexItem>
             <FlexItem><p>{__(`${pluralize(hostResponse.length, 'host')} will be moved to content view ${selectedCVNameForHosts} in `)}</p></FlexItem>
-            <FlexItem><Label isTruncated color="purple" href={`/lifecycle_environments/${selectedEnvForHost[0].id}`}>{selectedEnvForHost[0].name}</Label></FlexItem>
+            <FlexItem><Label color="purple" href={`/lifecycle_environments/${selectedEnvForHost[0].id}`}>{selectedEnvForHost[0].name}</Label></FlexItem>
           </Flex>
         </>}
       {affectedActivationKeys &&
@@ -65,7 +65,7 @@ const CVVersionRemoveReview = () => {
           <Flex>
             <FlexItem><ExclamationTriangleIcon /></FlexItem>
             <FlexItem><p>{__(`${pluralize(akResponse.length, 'activation key')} will be moved to content view ${selectedCVNameForAK} in `)}</p></FlexItem>
-            <FlexItem><Label isTruncated color="purple" href={`/lifecycle_environments/${selectedEnvForAK[0].id}`}>{selectedEnvForAK[0].name}</Label></FlexItem>
+            <FlexItem><Label color="purple" href={`/lifecycle_environments/${selectedEnvForAK[0].id}`}>{selectedEnvForAK[0].name}</Label></FlexItem>
           </Flex>
         </>}
     </>

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/__tests__/cvVersionRemove.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/__tests__/cvVersionRemove.test.js
@@ -97,9 +97,9 @@ test('Can open Remove wizard and remove version from simple environment', async 
     expect(getByText(`Version ${firstVersion.version}`)).toBeTruthy();
   });
   // Expand Row Action
-  expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'false');
-  fireEvent.click(getAllByLabelText('Actions')[0]);
-  expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'true');
+  expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'false');
+  fireEvent.click(getAllByLabelText('Kebab toggle')[0]);
+  expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'true');
   fireEvent.click(getByText('Remove from environments'));
   await patientlyWaitFor(() => {
     expect(getByText('Remove Version')).toBeInTheDocument();
@@ -165,9 +165,9 @@ test('Can open Remove wizard and remove version from environment with hosts', as
     expect(getByText(`Version ${firstVersion.version}`)).toBeTruthy();
   });
   // Expand Row Action
-  expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'false');
-  fireEvent.click(getAllByLabelText('Actions')[0]);
-  expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'true');
+  expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'false');
+  fireEvent.click(getAllByLabelText('Kebab toggle')[0]);
+  expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'true');
   fireEvent.click(getByText('Remove from environments'));
   await patientlyWaitFor(() => {
     expect(getByText('Remove Version')).toBeInTheDocument();
@@ -251,9 +251,9 @@ test('Can open Remove wizard and remove version from environment with activation
     expect(getByText(`Version ${firstVersion.version}`)).toBeTruthy();
   });
   // Expand Row Action
-  expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'false');
-  fireEvent.click(getAllByLabelText('Actions')[0]);
-  expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'true');
+  expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'false');
+  fireEvent.click(getAllByLabelText('Kebab toggle')[0]);
+  expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'true');
   fireEvent.click(getByText('Remove from environments'));
   await patientlyWaitFor(() => {
     expect(getByText('Remove Version')).toBeInTheDocument();

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetails.scss
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetails.scss
@@ -1,7 +1,7 @@
 .content-view-header-content {
   padding-top: 24px;
 
-  .pf-c-content {
+  .pf-v5-c-content {
     dl {
       margin: 0;
     }
@@ -17,24 +17,24 @@
   margin-top: 24px;
   display: flex;
 
-  .pf-c-tabs.pf-m-vertical {
+  .pf-v5-c-tabs.pf-m-vertical {
     max-width: 230px;
     border-right: 1px solid #d2d2d2;
 
-    .pf-c-tabs__item {
+    .pf-v5-c-tabs__item {
       margin-top: 0;
 
       button {
         align-items: center;
 
-        .pf-c-label__content {
+        .pf-v5-c-label__content {
           &::before {
             border: none;
           }
         }
       }
 
-      &.pf-m-current .pf-c-label__content {
+      &.pf-m-current .pf-v5-c-label__content {
         font-weight: bold;
       }
     }

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsHeader.js
@@ -11,11 +11,13 @@ import {
   Label,
   Flex,
   FlexItem,
+} from '@patternfly/react-core';
+import {
   Dropdown,
   DropdownItem,
   KebabToggle,
   DropdownPosition,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/deprecated';
 import { useHistory } from 'react-router-dom';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { hasPermission } from '../../../helpers';
@@ -131,7 +133,7 @@ const ContentViewVersionDetailsHeader = ({
           style={{ width: 'inherit' }}
           position={DropdownPosition.right}
           toggle={
-            <KebabToggle onToggle={setDropdownOpen} id="toggle-dropdown" />
+            <KebabToggle onToggle={(_event, val) => setDropdownOpen(val)} id="toggle-dropdown" />
           }
           isOpen={dropdownOpen}
           dropdownItems={dropDownItems}
@@ -153,7 +155,7 @@ const ContentViewVersionDetailsHeader = ({
         <Flex>
           {environments?.map(({ name, id: envId }) => (
             <FlexItem key={name}>
-              <Label isTruncated color="purple" href={`/lifecycle_environments/${envId}`}>{name}</Label>
+              <Label color="purple" href={`/lifecycle_environments/${envId}`}>{name}</Label>
             </FlexItem>))}
         </Flex>
       </GridItem>

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsTable.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailsTable.js
@@ -9,10 +9,12 @@ import {
 } from 'react-redux';
 import {
   Grid,
+} from '@patternfly/react-core';
+import {
   Select,
   SelectOption,
   SelectVariant,
-} from '@patternfly/react-core';
+} from '@patternfly/react-core/deprecated';
 import {
   TableVariant,
   Tbody,
@@ -94,7 +96,7 @@ const ContentViewVersionDetailsTable = ({
         actionButtons={
           repoType &&
           <Select
-            onToggle={setOpen}
+            onToggle={(_event, val) => setOpen(val)}
             isOpen={open}
             ouiaId="repo-type-selector"
             variant={SelectVariant.single}

--- a/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersions.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersions.test.js
@@ -250,9 +250,9 @@ test('Can open Promote Modal', async (done) => {
     expect(getByText(`Version ${firstVersion.version}`)).toBeInTheDocument();
   });
   // Expand Row Action
-  expect(getAllByLabelText('Actions')[1]).toHaveAttribute('aria-expanded', 'false');
-  fireEvent.click(getAllByLabelText('Actions')[1]);
-  expect(getAllByLabelText('Actions')[1]).toHaveAttribute('aria-expanded', 'true');
+  expect(getAllByLabelText('Kebab toggle')[1]).toHaveAttribute('aria-expanded', 'false');
+  fireEvent.click(getAllByLabelText('Kebab toggle')[1]);
+  expect(getAllByLabelText('Kebab toggle')[1]).toHaveAttribute('aria-expanded', 'true');
   fireEvent.click(getByText('Promote'));
   await patientlyWaitFor(() => {
     expect(getByText('Select a lifecycle environment from the available promotion paths to promote new version.')).toBeInTheDocument();
@@ -340,9 +340,9 @@ test('Can open Promote Modal and show out of path warnings', async (done) => {
     expect(getByText(`Version ${firstVersion.version}`)).toBeInTheDocument();
   });
   // Expand Row Action
-  expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'false');
-  fireEvent.click(getAllByLabelText('Actions')[0]);
-  expect(getAllByLabelText('Actions')[0]).toHaveAttribute('aria-expanded', 'true');
+  expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'false');
+  fireEvent.click(getAllByLabelText('Kebab toggle')[0]);
+  expect(getAllByLabelText('Kebab toggle')[0]).toHaveAttribute('aria-expanded', 'true');
   fireEvent.click(getByText('Promote'));
   await patientlyWaitFor(() => {
     expect(getByText('Select a lifecycle environment from the available promotion paths to promote new version.')).toBeInTheDocument();

--- a/webpack/scenes/ContentViews/Publish/CVPublishFinish.js
+++ b/webpack/scenes/ContentViews/Publish/CVPublishFinish.js
@@ -7,8 +7,7 @@ import { useHistory } from 'react-router-dom';
 import {
   Bullseye, Button, Grid, GridItem,
   Progress, ProgressSize, ProgressMeasureLocation,
-  ProgressVariant, EmptyState, EmptyStateIcon, EmptyStateVariant,
-  Title,
+  ProgressVariant, EmptyState, EmptyStateIcon, EmptyStateVariant, EmptyStateHeader,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon, InProgressIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -101,11 +100,8 @@ const CVPublishFinish = ({
 
   return (
     <>
-      <EmptyState style={{ marginTop: '10px' }} variant={EmptyStateVariant.large}>
-        <EmptyStateIcon icon={InProgressIcon} />
-        <Title headingLevel="h2" size="lg" ouiaId="publish-cv-title">
-          {__('Publishing content view')}
-        </Title>
+      <EmptyState style={{ marginTop: '10px' }} variant={EmptyStateVariant.lg}>
+        <EmptyStateHeader titleText={<>{__('Publishing content view')}</>} icon={<EmptyStateIcon icon={InProgressIcon} />} headingLevel="h2" />
       </EmptyState>
       <Grid hasGutter>
         <GridItem span={12} rowSpan={19}>

--- a/webpack/scenes/ContentViews/Publish/CVPublishForm.js
+++ b/webpack/scenes/ContentViews/Publish/CVPublishForm.js
@@ -105,7 +105,7 @@ const CVPublishForm = ({
             aria-label="input_description"
             name="description"
             value={description}
-            onChange={setDescription}
+            onChange={(e, v) => setDescription(v)}
           />
         </FormGroup>
         <FormGroup label={__('Promote')} fieldId="promote">
@@ -114,7 +114,7 @@ const CVPublishForm = ({
             ouiaId="promote-switch"
             aria-label="promote-switch"
             isChecked={promote}
-            onChange={checkPromote}
+            onChange={(_event, checked) => checkPromote(checked)}
           />
         </FormGroup>
       </Form>

--- a/webpack/scenes/ContentViews/Publish/CVPublishReview.js
+++ b/webpack/scenes/ContentViews/Publish/CVPublishReview.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
-  TableComposable, Thead, Tbody, Tr, Th,
+  Table /* data-codemods */, Thead, Tbody, Tr, Th,
   Td,
 } from '@patternfly/react-table';
 import { EnterpriseIcon, RegistryIcon } from '@patternfly/react-icons';
@@ -67,7 +67,7 @@ const CVPublishReview = ({
           </>
           }
       />
-      <TableComposable ouiaId="cv-publish-review-table" aria-label="Review Table">
+      <Table ouiaId="cv-publish-review-table" aria-label="Review Table">
         <Thead>
           <Tr ouiaId="cv-publish-review-table-headers">
             <Th>{__('Content view name')}</Th>
@@ -93,7 +93,7 @@ const CVPublishReview = ({
             }
           </Tr>
         </Tbody>
-      </TableComposable>
+      </Table>
     </>
   );
 };

--- a/webpack/scenes/ContentViews/Publish/PublishContentViewWizard.js
+++ b/webpack/scenes/ContentViews/Publish/PublishContentViewWizard.js
@@ -2,7 +2,9 @@ import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { STATUS } from 'foremanReact/constants';
-import { Wizard } from '@patternfly/react-core';
+import {
+  Wizard,
+} from '@patternfly/react-core/deprecated';
 import { translate as __ } from 'foremanReact/common/I18n';
 import CVPublishForm from './CVPublishForm';
 import CVPublishFinish from './CVPublishFinish';

--- a/webpack/scenes/ContentViews/Publish/cvPublishForm.scss
+++ b/webpack/scenes/ContentViews/Publish/cvPublishForm.scss
@@ -1,15 +1,15 @@
 #content-view-publish-wizard {
-  .pf-c-switch {
-    --pf-c-switch__input--focus__toggle--OutlineWidth: 0;
+  .pf-v5-c-switch {
+    --pf-v5-c-switch__input--focus__toggle--OutlineWidth: 0;
   }
 
-  .pf-c-wizard__main-body {
+  .pf-v5-c-wizard__main-body {
     display: flex;
     grid-gap: 16px;
     flex-direction: column;
   }
 
-  .pf-c-content h4 {
+  .pf-v5-c-content h4 {
     margin-top: 0px;
   }
 }

--- a/webpack/scenes/ContentViews/components/ContentViewIcon.js
+++ b/webpack/scenes/ContentViews/components/ContentViewIcon.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
 import PropTypes from 'prop-types';
-import { Tooltip } from '@patternfly/react-core';
+import { Tooltip, Icon } from '@patternfly/react-core';
 import { EnterpriseIcon, RegistryIcon } from '@patternfly/react-icons';
 import './contentViewIcon.scss';
 
@@ -19,7 +19,15 @@ const ContentViewIcon = ({
       content={composite ? __('Composite content view') : __('Content view')}
       {...toolTipProps}
     >
-      {composite ? <RegistryIcon size="md" {...props} /> : <EnterpriseIcon size="sm" {...props} />}
+      {composite ? (
+        <Icon size="md">
+          <RegistryIcon {...props} />
+        </Icon>
+      ) : (
+        <Icon size="md">
+          <EnterpriseIcon {...props} />
+        </Icon>
+      )}
     </Tooltip>
   );
   return (

--- a/webpack/scenes/ContentViews/components/ContentViewSelect/ContentViewSelect.js
+++ b/webpack/scenes/ContentViews/components/ContentViewSelect/ContentViewSelect.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { Select, SelectVariant } from '@patternfly/react-core';
+import {
+  Select,
+  SelectVariant,
+} from '@patternfly/react-core/deprecated';
 import PropTypes from 'prop-types';
 
 const ContentViewSelect = ({

--- a/webpack/scenes/ContentViews/components/ContentViewSelect/ContentViewSelectOption.js
+++ b/webpack/scenes/ContentViews/components/ContentViewSelect/ContentViewSelectOption.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex, SelectOption } from '@patternfly/react-core';
+import {
+  Flex,
+} from '@patternfly/react-core';
+import {
+  SelectOption,
+} from '@patternfly/react-core/deprecated';
 import { FormattedMessage } from 'react-intl';
 import { translate as __ } from 'foremanReact/common/I18n';
 import {

--- a/webpack/scenes/ContentViews/components/EnvironmentLabels.js
+++ b/webpack/scenes/ContentViews/components/EnvironmentLabels.js
@@ -11,7 +11,7 @@ const EnvironmentLabels = (environments) => {
       <React.Fragment key={env.id} style={{ marginBottom: '5px' }}>
         <Label
           color={labelColor}
-          isTruncated
+
         >{env.name}
         </Label>
       </React.Fragment>
@@ -19,7 +19,7 @@ const EnvironmentLabels = (environments) => {
   default:
     return (
       <React.Fragment>
-        <Label color={labelColor} isTruncated>
+        <Label color={labelColor} >
           {name}
         </Label>
       </React.Fragment>

--- a/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.scss
+++ b/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.scss
@@ -1,5 +1,5 @@
 .env-path {
-  .pf-c-form__group {
+  .pf-v5-c-form__group {
     margin: 20px 0;
   }
 

--- a/webpack/scenes/ContentViews/components/FiltersAppliedIcon.js
+++ b/webpack/scenes/ContentViews/components/FiltersAppliedIcon.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { Tooltip } from '@patternfly/react-core';
+import { Tooltip, Icon } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
 
 const FiltersAppliedIcon = () => (
@@ -10,7 +10,9 @@ const FiltersAppliedIcon = () => (
     entryDelay={400}
     content={__('Filters were applied to this version.')}
   >
-    <FilterIcon size="sm" style={{ color: '#0081db', margin: '0 9px' }} />
+    <Icon size="sm">
+      <FilterIcon style={{ color: '#0081db', margin: '0 9px' }} />
+    </Icon>
   </Tooltip>
 );
 

--- a/webpack/scenes/ContentViews/components/NeedsPublishIcon.js
+++ b/webpack/scenes/ContentViews/components/NeedsPublishIcon.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
 import PropTypes from 'prop-types';
-import { Tooltip } from '@patternfly/react-core';
+import { Tooltip, Icon } from '@patternfly/react-core';
 import { ArrowCircleUpIcon } from '@patternfly/react-icons';
 import './NeedsPublishIcon.scss';
 
@@ -24,11 +24,12 @@ const NeedsPublishIcon = ({ composite, determinate }) => (
     entryDelay={400}
     content={tooltipContent(composite, determinate)}
   >
-    <ArrowCircleUpIcon
-      id={determinate ? 'determinate-needs-publish' : 'indeterminate-needs-publish'}
-      size="sm"
-      className={determinate ? 'determinate-needs-publish' : 'indeterminate-needs-publish'}
-    />
+    <Icon size="sm">
+      <ArrowCircleUpIcon
+        id={determinate ? 'determinate-needs-publish' : 'indeterminate-needs-publish'}
+        className={determinate ? 'determinate-needs-publish' : 'indeterminate-needs-publish'}
+      />
+    </Icon>
   </Tooltip>
 );
 

--- a/webpack/scenes/ContentViews/expansions/RelatedCompositeContentViewsModal.js
+++ b/webpack/scenes/ContentViews/expansions/RelatedCompositeContentViewsModal.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { translate as __ } from 'foremanReact/common/I18n';
 import PropTypes from 'prop-types';
 import { Modal, ModalVariant, Button, Flex, FlexItem } from '@patternfly/react-core';
-import { TableComposable, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { Table /* data-codemods */, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import { EnterpriseIcon } from '@patternfly/react-icons';
 import { urlBuilder } from '../../../__mocks__/foremanReact/common/urlHelpers';
 
@@ -44,7 +44,7 @@ const RelatedCompositeContentViewsModal = ({
         }}
         appendTo={document.body}
       >
-        <TableComposable
+        <Table
           aria-label={`${cvId}_table`}
           ouiaId={`${cvId}_table`}
           variant="compact"
@@ -65,7 +65,7 @@ const RelatedCompositeContentViewsModal = ({
               </Tr>
             ))}
           </Tbody>
-        </TableComposable>
+        </Table>
       </Modal>
     </>
   );

--- a/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/components/ContentSourceForm.js
@@ -8,12 +8,14 @@ import {
   Form,
   Grid,
   GridItem,
-  Select,
-  SelectOption,
-  SelectVariant,
   TextContent,
   Text,
 } from '@patternfly/react-core';
+import {
+  Select,
+  SelectOption,
+  SelectVariant,
+} from '@patternfly/react-core/deprecated';
 import { translate as __ } from 'foremanReact/common/I18n';
 import PropTypes from 'prop-types';
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';

--- a/webpack/scenes/Hosts/ChangeContentSource/components/FormField.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/components/FormField.js
@@ -16,7 +16,7 @@ const FormField = ({
       <FormSelect
         ouiaId={`${id}_select`}
         value={value}
-        onChange={v => onChange(v)}
+        onChange={(_event, v) => onChange(v)}
         className="without_select2"
         isDisabled={isDisabled}
         id={`${id}_select`}

--- a/webpack/scenes/Hosts/ChangeContentSource/components/HostsModal.js
+++ b/webpack/scenes/Hosts/ChangeContentSource/components/HostsModal.js
@@ -29,7 +29,7 @@ const HostsModal = ({
       <SearchInput
         placeholder={__('Search')}
         value={search}
-        onChange={v => setSearch(v)}
+        onChange={(e, v) => setSearch(v)}
         onClear={() => setSearch('')}
       />
       <List isPlain isBordered className="margin-top-16">

--- a/webpack/scenes/RedHatRepositories/index.scss
+++ b/webpack/scenes/RedHatRepositories/index.scss
@@ -33,7 +33,7 @@
         .foreman-search-bar {
           flex-grow: 1;
           margin-left: 0.7rem;
-          .pf-c-search-input {
+          .pf-v5-c-search-input {
             width: 100%;
           }
         }

--- a/webpack/scenes/SmartProxy/ExpandableCvDetails.js
+++ b/webpack/scenes/SmartProxy/ExpandableCvDetails.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { Table /* data-codemods */, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
 import LongDateTime from 'foremanReact/components/common/dates/LongDateTime';
 import { urlBuilder } from 'foremanReact/common/urlHelpers';
@@ -21,7 +21,7 @@ const ExpandableCvDetails = ({ contentViews, contentCounts, envId }) => {
   const tableRowIsExpanded = id => expandedTableRows.has(id);
 
   return (
-    <TableComposable
+    <Table
       aria-label="expandable-content-views"
       ouiaId="expandable-content-views"
     >
@@ -83,7 +83,7 @@ const ExpandableCvDetails = ({ contentViews, contentCounts, envId }) => {
         );
       })}
 
-    </TableComposable>
+    </Table>
 
   );
 };

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/CdnConfigurationForm.scss
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/CdnConfigurationForm.scss
@@ -1,5 +1,5 @@
 #cdn-configuration {
-  .pf-c-form__group.pf-m-action {
+  .pf-v5-c-form__group.pf-m-action {
     margin-top: 0px;
   }
 }

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/CustomCdnTypeForm.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/CustomCdnTypeForm.js
@@ -92,7 +92,7 @@ const CustomCdnTypeForm = ({
           aria-label="cdn-url"
           type="text"
           value={url || ''}
-          onChange={value => setUrl(value)}
+          onChange={(_event, value) => setUrl(value)}
           isDisabled={updatingCdnConfiguration}
         />
       </FormGroup>
@@ -105,7 +105,7 @@ const CustomCdnTypeForm = ({
           aria-label="cdn-ssl-ca-content-credential"
           value={sslCaCredentialValue || ''}
           isDisabled={updatingCdnConfiguration}
-          onChange={value => setSslCaCredentialId(value)}
+          onChange={(_event, value) => setSslCaCredentialId(value)}
         >
           <FormSelectOption label={__('N/A')} />
           {contentCredentials.map(cred =>

--- a/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/NetworkSyncForm.js
+++ b/webpack/scenes/Subscriptions/Manifest/CdnConfigurationTab/NetworkSyncForm.js
@@ -156,7 +156,7 @@ const NetworkSyncForm = ({
             aria-label="cdn-url"
             type="text"
             value={url || ''}
-            onChange={value => setUrl(value)}
+            onChange={(_event, value) => setUrl(value)}
             isDisabled={updatingCdnConfiguration}
           />
         </FormGroup>
@@ -169,7 +169,7 @@ const NetworkSyncForm = ({
             aria-label="cdn-username"
             type="text"
             value={username || ''}
-            onChange={value => setUsername(value)}
+            onChange={(_event, value) => setUsername(value)}
             isDisabled={updatingCdnConfiguration}
           />
         </FormGroup>
@@ -197,7 +197,7 @@ const NetworkSyncForm = ({
             type="text"
             value={upstreamOrganizationLabel || ''}
             isDisabled={updatingCdnConfiguration}
-            onChange={setUpstreamOrganizationLabel}
+            onChange={(_event, val) => setUpstreamOrganizationLabel(val)}
           />
         </FormGroup>
         <FormGroup
@@ -209,7 +209,7 @@ const NetworkSyncForm = ({
             type="text"
             value={upstreamLifecycleEnvironmentLabel || ''}
             isDisabled={updatingCdnConfiguration}
-            onChange={setUpstreamLifecycleEnvironmentLabel}
+            onChange={(_event, val) => setUpstreamLifecycleEnvironmentLabel(val)}
           />
         </FormGroup>
         <FormGroup
@@ -221,7 +221,7 @@ const NetworkSyncForm = ({
             type="text"
             value={upstreamContentViewLabel || ''}
             isDisabled={updatingCdnConfiguration}
-            onChange={setUpstreamContentViewLabel}
+            onChange={(_event, val) => setUpstreamContentViewLabel(val)}
           />
         </FormGroup>
         <FormGroup
@@ -233,7 +233,7 @@ const NetworkSyncForm = ({
             aria-label="cdn-ssl-ca-content-credential"
             value={sslCaCredentialValue || ''}
             isDisabled={updatingCdnConfiguration}
-            onChange={value => setSslCaCredentialId(value)}
+            onChange={(_event, value) => setSslCaCredentialId(value)}
           >
             <FormSelectOption label={__('Select one')} isDisabled isPlaceholder />
             {contentCredentials.map(cred =>


### PR DESCRIPTION
Updating pf4 to pf5 
some work is done by running

npx @patternfly/pf-codemods@latest webpack --fix

search& replace "pf-c-" to "pf-v5-c-"

Check all "onChange=\{[^(]" to make sure that pure pf5 are using the right arguments, as they changed order, and most onChange are onChange(event,value) and not onChange(value)

And adding act wrapper around tests.
To test this pr you will need the foreman core pf5 pr, foreman js pr, link foreman-js, and to remove any foreman-js/patternfly folder in the katello node_modules (as this breaks React shared context in tests).

This is a WIP since the other prs were just done and not polished, and also because some of the tests I had troubles fixing and dont have capacity currently to fix. These tests fail with ` Error: Uncaught [Error: Warning: An update to %s inside a test was not wrapped in act(...)` even if every line in the test is wrapped in act, or
```
 Error: Error: Nock: No match for request {
      "method": "GET",
      "url": "http://localhost/api/v2/hosts/1/subscriptions/available_release_versions",
      ...
```