### PR TITLE
Fixes #37760 - Pass updateParamsByUrl: false to Pagination component

### DIFF
--- a/webpack/components/Table/PageControls.js
+++ b/webpack/components/Table/PageControls.js
@@ -21,6 +21,7 @@ const PageControls = ({
         perPage={perPage}
         onChange={onPaginationUpdate}
         variant={variant}
+        updateParamsByUrl={false}
       />
     </FlexItem>
   );


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Pass updateParamsByUrl as false from PageControls.js
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
To test:
Create some test data for CV UI.

```
100.times do |i|
  cv1 = cv.dup  
  cv1.label='test'+i.to_s  
  cv1.name = 'test'+i.to_s  
  cv1.save!
end 

```
Go to Content View page.
Try moving around pages of results using the pagination component on top and bottom of table.