### PR TITLE
Fixes #37763 - environments should always be an array

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -332,9 +332,9 @@ module Katello
         end
       elsif params.key?(:organization_id) && !params.key?(:environment_id) && !params.key?(:environments)
         organization = Organization.current
-        environments = organization.library.content_view_environment
+        environments = [organization.library.content_view_environment]
       elsif User.current.default_organization.present?
-        environments = User.current.default_organization.library.content_view_environment
+        environments = [User.current.default_organization.library.content_view_environment]
       else
         fail HttpErrors::NotFound, _("User '%s' did not specify an organization ID and does not have a default organization.") % current_user.login
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When `POST /rhsm/consumers` is called without an `environments` param, Katello chooses the default environment. But we forgot to update that code path for the multi-CV world. This change fixes that, to avoid 
```
NoMethodError: undefined method `each' for #<Katello::ContentViewEnvironment
```

#### Considerations taken when implementing this change?

`subscription-manager register` will never hit this, since it always asks you interactively for environments when you don't pass them. But Anaconda uses the RHSM DBUS API, which makes that same POST call directly and non-interactively.

#### What are the testing steps for this pull request?

I'm honestly not sure. I can't think of anything other than a hack to delete `params[:environments]`..