### PR TITLE
Fixes #37587 - ensure page and per_page are integers

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -100,8 +100,8 @@ module Katello
       else
         query = query.paginate(paginate_options)
       end
-      page = params[:page] || 1
-      per_page = params[:per_page] || Setting[:entries_per_page]
+      page = metadata_page # from Foreman Api::V2::BaseController
+      per_page = metadata_per_page
       query = (total.zero? || subtotal.zero?) ? blank_query : query
 
       if options[:csv]

--- a/test/controllers/api/v2/api_controller_test.rb
+++ b/test/controllers/api/v2/api_controller_test.rb
@@ -55,6 +55,20 @@ module Katello
       assert_equal(2, response[:results].length)
     end
 
+    def test_scoped_search_casts_to_integer
+      params = { full_result: 'false', page: '1', per_page: '2' }
+      @controller.stubs(:params).returns(params)
+
+      response = @controller.scoped_search(@query, @default_sort[0], @default_sort[1], @options)
+      refute_empty response[:results], "results"
+      assert_nil response[:error], "error"
+      assert_equal 1, response[:page], "page"
+      assert_kind_of(Integer, response[:page])
+      assert_equal 2, response[:per_page], "per page"
+      assert_kind_of(Integer, response[:per_page])
+      assert_equal(2, response[:results].length)
+    end
+
     def test_scoped_search_no_results
       params = { :search => "asdfasdf" }
       @controller.stubs(:params).returns(params)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

(First attempt was https://github.com/theforeman/foreman/pull/10301 - see https://github.com/theforeman/foreman/pull/10301#issuecomment-2321679713)

Ensure `page` and `per_page` always get sent back from API as integers. Right now they can be sent back as strings if you send them as URL query params.

#### Considerations taken when implementing this change?

This is to fix the immediate issue and release blocker. We can do more extensive refactoring like https://github.com/Katello/katello/pull/11126 as well, but let's get this in for now.


#### What are the testing steps for this pull request?

Follow reproduction steps in the redmine