### PR TITLE
Fixes #37777 - Pagination broken on redhat repos page

### DIFF
--- a/webpack/components/pf3Table/components/Table.js
+++ b/webpack/components/pf3Table/components/Table.js
@@ -45,6 +45,7 @@ const Table = ({
         <Pagination
           itemCount={itemCount}
           onChange={onPaginationChange}
+          updateParamsByUrl={false}
           {...pagination}
         />
       )}

--- a/webpack/components/pf3Table/components/__snapshots__/Table.test.js.snap
+++ b/webpack/components/pf3Table/components/__snapshots__/Table.test.js.snap
@@ -146,7 +146,7 @@ exports[`Table renders Table with pagination 1`] = `
     onSetPage={null}
     page={1}
     perPage={20}
-    updateParamsByUrl={true}
+    updateParamsByUrl={false}
     variant="bottom"
   />
 </div>

--- a/webpack/scenes/RedHatRepositories/__tests__/__snapshots__/RedHatRepositoriesPage.test.js.snap
+++ b/webpack/scenes/RedHatRepositories/__tests__/__snapshots__/RedHatRepositoriesPage.test.js.snap
@@ -122,7 +122,7 @@ exports[`RedHatRepositories page should render 1`] = `
               onSetPage={null}
               page={1}
               perPage={null}
-              updateParamsByUrl={true}
+              updateParamsByUrl={false}
               variant="bottom"
             />
           </div>

--- a/webpack/scenes/RedHatRepositories/helpers.js
+++ b/webpack/scenes/RedHatRepositories/helpers.js
@@ -36,6 +36,7 @@ export const getSetsComponent = (repoSetsState, onPaginationChange) => {
         <Pagination
           itemCount={itemCount}
           onChange={onPaginationChange}
+          updateParamsByUrl={false}
           isCompact
           {...pagination}
         />
@@ -67,6 +68,7 @@ export const getEnabledComponent = (enabledReposState, onPaginationChange) => {
           isCompact
           itemCount={itemCount}
           onChange={onPaginationChange}
+          updateParamsByUrl={false}
           {...pagination}
         />
       </div>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Use updateParamsByUrl as false in all Pagination components in katello
#### Considerations taken when implementing this change?
Passing this from redhat repos helper fixes the pagination issue on that page. I looked for other places this component was being used and found pf3Table component using this. Updated it to also pass updateParamsByUrl as false. Generic content pages use this component.
#### What are the testing steps for this pull request?
Import a manifest, add subs and go to Redhat repos page.
The pagination on the available/enabled repo list is broken.
After this PR, the pagination would work correctly.