### PR TITLE
Fixes #37587 - Reuse API parameter handling from base

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -188,13 +188,6 @@ module Katello
       @organization
     end
 
-    def sort_params
-      options = {}
-      options[:sort_by] = params[:sort_by] if params[:sort_by]
-      options[:sort_order] = params[:sort_order] if params[:sort_order]
-      options
-    end
-
     def find_optional_organization
       org_id = organization_id
       return if org_id.nil?

--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -20,13 +20,10 @@ module Katello
     end
 
     def_param_group :search do
-      param :search, String, :desc => N_("Search string")
-      param :page, :number, :desc => N_("Page number, starting at 1")
-      param :per_page, :number, :desc => N_("Number of results per page to return")
-      param :order, String, :desc => N_("Sort field and order, eg. 'id DESC'")
-      param :full_result, :bool, :desc => N_("Whether or not to show all results")
-      param :sort_by, String, :desc => N_("Field to sort the results on")
-      param :sort_order, String, :desc => N_("How to order the sorted results (e.g. ASC for ascending)")
+      param_group :search_and_pagination, ::Api::V2::BaseController
+      param :full_result, :bool, :desc => N_("DEPRECATED, use `per_page=all`"), deprecated: true
+      param :sort_by, String, :desc => N_("DEPRECATED, use `order`"), deprecated: true
+      param :sort_order, String, :desc => N_("DEPRECATED, use `order`"), deprecated: true
     end
 
     param :object_root, String, :desc => N_("root-node of single-resource responses (optional)")
@@ -61,12 +58,10 @@ module Katello
       resource = options[:resource_class] || resource_class
       includes = options.fetch(:includes, [])
       group = options.fetch(:group, nil)
-      params[:full_result] = true if options[:csv]
+      params[:per_page] = 'all' if options[:csv]
       blank_query = resource.none
 
-      if params[:order]
-        (params[:sort_by], params[:sort_order]) = params[:order].split(' ')
-      else
+      unless params[:order]
         params[:order] = "#{params[:sort_by]} #{params[:sort_order]}"
       end
 
@@ -95,7 +90,7 @@ module Katello
         subtotal = dist_total
         selectable = dist_total
       end
-      if ::Foreman::Cast.to_bool(params[:full_result])
+      if params[:per_page] == 'all' || ::Foreman::Cast.to_bool(params[:full_result])
         params[:per_page] = total
       else
         query = query.paginate(paginate_options)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Foreman's API base controller provides a `search_and_pagination` parameter group that has all the fields needed. Then it also provides some helpers to parse these values properly.

This reuses those helpers. It also aligns on `per_page=all` handling instead of a separate `full_result=true`. That parameter is now deprecated.

#### Considerations taken when implementing this change?

This doesn't go all the way and reuse Foreman's `resource_scope_for_index` since that's a much bigger refactor. Katello's API method here is also bigger and allows more options. Whether that's a good thing is questionable, but one I didn't have time to look at.

Long term I'd like to see both APIs aligned. If Foreman's base controller should be extended, that's entirely possible.

Right now it's a very much untested idea based on what I saw in https://github.com/Katello/katello/pull/11124.

#### What are the testing steps for this pull request?

There should be no regressions in the API. Since it touches on the base API, that can be difficult to test.