### PR TITLE
Fixes #37779 - Handle empty CVE in InfoProvider content_view_info

### DIFF
--- a/app/models/katello/host/info_provider.rb
+++ b/app/models/katello/host/info_provider.rb
@@ -35,8 +35,11 @@ module Katello
       end
 
       def content_view_info(content_view_environment)
+        return {} if content_view_environment.blank?
+
         content_view = content_view_environment.content_view
         return {} if content_view.blank?
+
         {
           'label' => content_view.try(:label),
           'latest-version' => content_view.try(:latest_version),


### PR DESCRIPTION
Empty CVE in content_view_info causes a render error during host creation from the image.

### What are the changes introduced in this pull request?
Add a safeguard to catch empty CVE.

### What are the testing steps for this pull request?
1. Create an image associated with a compute resource. Select the "user data" checkbox.
2. Associate the template "Kickstart default user data" to the operating system used by the image
3. Try creating a host using the image above

**Actual results:**
Error in rendering the user data template.

**Expected results:**
Template to render successfully