### PR TITLE
Fixes #37784 - Switch remove packages UI to use installed packages model

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -498,7 +498,7 @@ module Katello
       end
 
       def package_names_for_job_template(action:, search:, versions: nil)
-        if self.operatingsystem.family == 'Debian'
+        if self&.operatingsystem&.family == 'Debian'
           deb_names_for_job_template(action: action, search: search)
         else
           yum_names_for_job_template(action: action, search: search, versions: versions)

--- a/app/views/katello/api/v2/host_packages/installed_packages.json.rabl
+++ b/app/views/katello/api/v2/host_packages/installed_packages.json.rabl
@@ -1,0 +1,6 @@
+object false
+
+extends "katello/api/v2/common/metadata"
+child @collection[:results] => :results do |_results|
+  attributes :name, :id
+end

--- a/config/routes/overrides.rb
+++ b/config/routes/overrides.rb
@@ -80,6 +80,7 @@ Foreman::Application.routes.draw do
             match '/bulk/module_streams' => 'hosts_bulk_actions#module_streams', :via => :post
             match '/bulk/change_content_source' => 'hosts_bulk_actions#change_content_source', :via => :put
             match '/subscriptions/' => 'host_subscriptions#create', :via => :post
+            match '/host_packages/installed_packages' => 'host_packages#installed_packages', :via => :get
           end
 
           resources :packages, :only => [:index], :controller => :host_packages do

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -279,7 +279,8 @@ module Katello
                                                         :repo_errata,
                                                         :repo_compare_errata,
                                                         :repo_compare_packages],
-                           'katello/api/v2/repository_sets' => [:index, :show, :available_repositories, :auto_complete_search]
+                           'katello/api/v2/repository_sets' => [:index, :show, :available_repositories, :auto_complete_search],
+                           'katello/api/v2/host_packages' => [:installed_packages]
                          },
                          :resource_type => 'Katello::Product',
                          :finder_scope => :readable

--- a/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RemoteExecutionActions.js
@@ -73,6 +73,14 @@ const katelloPackageRemoveParams = ({ hostname, packageName }) =>
     feature: REX_FEATURES.KATELLO_PACKAGE_REMOVE,
   });
 
+const katelloPackagesRemoveParams = ({ hostname, search, descriptionFormat }) =>
+  baseParams({
+    hostname,
+    inputs: { [PACKAGES_SEARCH_QUERY]: search },
+    feature: REX_FEATURES.KATELLO_PACKAGES_REMOVE_BY_SEARCH,
+    descriptionFormat,
+  });
+
 const katelloPackageRemoveBySearchParams = ({
   hostname, hostSearch, search, descriptionFormat,
 }) =>
@@ -205,6 +213,16 @@ export const removePackage = ({ hostname, packageName }) => post({
   key: REX_JOB_INVOCATIONS_KEY,
   url: foremanApi.getApiUrl('/job_invocations'),
   params: katelloPackageRemoveParams({ hostname, packageName }),
+  handleSuccess: showRexToast,
+  errorToast,
+});
+
+// Used by packages wizard
+export const removePackages = ({ hostname, search, descriptionFormat }) => post({
+  type: API_OPERATIONS.POST,
+  key: REX_JOB_INVOCATIONS_KEY,
+  url: foremanApi.getApiUrl('/job_invocations'),
+  params: katelloPackagesRemoveParams({ hostname, search, descriptionFormat }),
   handleSuccess: showRexToast,
   errorToast,
 });

--- a/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/02_BulkPackagesTable.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/02_BulkPackagesTable.js
@@ -93,7 +93,7 @@ const BulkPackagesTable = ({
     name: {
       title: __('Package'),
       wrapper: ({ name, id }) => (
-        <a target="_blank" href={`/packages/${id}`} rel="noreferrer">{name}</a>
+        <a target="_blank" href={tableType === 'remove' ? `/packages?search=${name}` : `/packages/${id}`} rel="noreferrer">{name}</a>
       ),
       isSorted: true,
       weight: 50,

--- a/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/BulkPackagesWizard.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/BulkPackagesWizard.js
@@ -12,7 +12,7 @@ import HostReview from '../HostReview';
 import { BulkPackagesReview, dropdownOptions } from './04_Review';
 import { BulkPackagesUpgradeTable, BulkPackagesInstallTable, BulkPackagesRemoveTable } from './02_BulkPackagesTable';
 import { BulkPackagesReviewFooter } from './04_ReviewFooter';
-import katelloApi from '../../../../../services/api';
+import katelloApi, { foremanApi } from '../../../../../services/api';
 
 export const UPGRADE_ALL = 'upgradeAll';
 export const UPGRADE = 'upgrade';
@@ -53,8 +53,13 @@ export const useHostsBulkSelect = ({ initialSelectedHosts, modalIsOpen }) => {
   };
 };
 
-export const getPackagesUrl = selectedAction =>
-  `${katelloApi.getApiUrl('/packages/thindex')}?per_page=7&include_permissions=true&packages_restrict_upgradable=${selectedAction === 'upgrade'}`;
+export const getPackagesUrl = (selectedAction) => {
+  if (selectedAction === REMOVE) {
+    return `${foremanApi.getApiUrl('/hosts/host_packages/installed_packages')}?per_page=7&include_permissions=true`;
+  }
+
+  return `${katelloApi.getApiUrl('/packages/thindex')}?per_page=7&include_permissions=true&packages_restrict_upgradable=${selectedAction === 'upgrade'}`;
+};
 
 const BulkPackagesWizard = () => {
   const { modalOpen, setModalClosed: closeModal } = useForemanModal({ id: 'bulk-packages-wizard' });


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Added a new API endpoint which does a distinct call on the installed packages list, so we only show one package in the list.
* Added back the `removePackages` function in Remote execution actions since it was still used by the packages tab when viewing a host
* Added tests for the new controller endpoint and cleaned up the test file to make it look cleaner
* Added an if condition for the new API URL if you chose `remove-packages` compared to the URL that we use for the other actions which come from `::Katello::RPM`

#### What are the testing steps for this pull request?
* Apply PR
* Have two hosts setup with remote execution, go to new all hosts page, select two and goto manage packages from the kebab
* Check to make sure we don't see any duplicate package names
* Try to remove packages on both hosts
* Goto a host and go to packages and try to remove a package and make sure the job starts correctly since I broke in in https://github.com/Katello/katello/pull/11070
