### PR TITLE
Fixes # 37785- Race condition during container push

### DIFF
--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -137,10 +137,10 @@ module Katello
 
         # Container push may concurrently call root add several times before the db can update.
         if repo_param[:is_container_push]
-          RootRepository.create_or_find_by!(repo_param)
-        else
-          RootRepository.new(repo_param)
+          root = RootRepository.find_by(repo_param)
+          return root if root
         end
+        RootRepository.new(repo_param)
       end
     end
   end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -272,8 +272,10 @@ module Katello
       self.content_view_version.content_view
     end
 
+    # Skip setting container name if the repository is not container type or
+    # if it's a library instance of a container-push repo, indicating that the container name is set by the user.
     def skip_container_name?
-      self.library_instance? && self.root.docker? && self.root.is_container_push
+      !self.root.docker? || (self.root.is_container_push && self.library_instance?)
     end
 
     def library_instance?


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
In some cases, container push fails due to a race condition where the same push repo creation is triggered more than once during the push process.
Another issue noticed was that non-container repos were getting created with container_repository_name set.
#### Considerations taken when implementing this change?
Gracefully handle any race conditions.
Set container_repository_name only for container repositories that are not container_push repos in library environment.
#### What are the testing steps for this pull request?
1. Push a container image to katello.
```
podman pull quay.io/prometheus/busybox
podman login `hostname`
podman image list
podman push <img_id> <url>/<organization_label>/<product_label>/<container_name>
```
2. Try multiple times till you see the race condition happen. It might take a few attempts to reproduce this.
3. On this branch, you shouldn't see the race condition causing a container push failure. You may see a logger statement when the race condition happens and the push should proceed as normal afterwards.

Another thing to test is that non-container repos do not get the container_repository_name field set.