### PR TITLE
Fixes #37771 - update Repository Sets banner text for multiCV

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -188,9 +188,13 @@ const RepositorySetsTab = () => {
     lifecycleEnvironmentLibrary,
     contentView,
     lifecycleEnvironment,
+    contentViewEnvironments = [],
   } = contentFacet;
   const { name: contentViewName } = contentView ?? {};
   const { name: lifecycleEnvironmentName } = lifecycleEnvironment ?? {};
+  const multiEnvHost = contentViewEnvironments.length > 1;
+  const contentViewEnvironmentNames =
+    contentViewEnvironments.map(({ candlepin_name: candlepinName }) => candlepinName).join(', ');
   const nonLibraryHost = contentViewDefault === false ||
     lifecycleEnvironmentLibrary === false;
   const [isBulkActionOpen, setIsBulkActionOpen] = useState(false);
@@ -497,7 +501,8 @@ const RepositorySetsTab = () => {
     </Split>
   ) : null;
 
-  const hostEnvText = 'the "{contentViewName}" content view and "{lifecycleEnvironmentName}" environment';
+  const hostEnvText = multiEnvHost ? 'the host\'s content view environments: {contentViewEnvironmentNames}'
+    : 'the "{contentViewName}" content view and "{lifecycleEnvironmentName}" lifecycle environment';
 
   const alertText = (toggleGroupState === LIMIT_TO_ENVIRONMENT ?
     `Showing only repositories in ${hostEnvText}.` :
@@ -531,6 +536,7 @@ const RepositorySetsTab = () => {
                   values={{
                     contentViewName,
                     lifecycleEnvironmentName,
+                    contentViewEnvironmentNames,
                   }}
                 />
               }


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Up until now, multi-environment hosts had incorrect banner text on the Repository Sets tab when you selected 'Limit to environment'.
![image](https://github.com/user-attachments/assets/ae5d6f4e-63d3-4d4f-84e6-b2f8b28c8223)

The repositories displayed would correctly reflect all of the host's assigned CVEs, but the banner text only mentioned the first one.

Now, the banner text has been updated for multi-CV hosts. 
![image](https://github.com/user-attachments/assets/e771a25c-d1ea-4430-846e-d0ce9d2daf0d)

Also, the single-environment banner text has been tweaked slightly.
![image](https://github.com/user-attachments/assets/508539c0-7c07-4367-affd-6a82341fd1e3)


#### Considerations taken when implementing this change?

No special considerations.

#### What are the testing steps for this pull request?

Have some synced content
Assign multiple content view environments to a host by using `subscription-manager environments --list` and then `--set`
Navigate to the Repository Sets tab and view the new banner messages
Reset the host in the web UI so it's single-environment again and confirm the new banner message
