### PR TITLE
Fixes #37794 - Align deb-package details with rpm-package details

### DIFF
--- a/app/lib/katello/util/deb.rb
+++ b/app/lib/katello/util/deb.rb
@@ -1,0 +1,9 @@
+module Katello
+  module Util
+    module Deb
+      def self.parse_dependencies(deps)
+        deps&.split(',')&.collect { |d| d.strip }
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/deb.rb
+++ b/app/services/katello/pulp3/deb.rb
@@ -5,6 +5,8 @@ module Katello
       CONTENT_TYPE = "deb".freeze
       PULPCORE_CONTENT_TYPE = "deb.package".freeze
 
+      lazy_accessor :initializer => :backend_data
+
       def self.content_api
         PulpDebClient::ContentPackagesApi.new(Katello::Pulp3::Api::Apt.new(SmartProxy.pulp_primary!).api_client)
       end
@@ -34,8 +36,40 @@ module Katello
           name: unit[:package],
           version: unit[:version],
           description: unit[:description]&.truncate(255),
-          architecture: unit[:architecture]
+          architecture: unit[:architecture],
+          section: unit[:section],
+          maintainer: unit[:maintainer],
+          homepage: unit[:homepage],
+          installed_size: unit[:installed_size]
         }
+      end
+
+      def depends
+        Util::Deb.parse_dependencies(backend_data['depends'])
+      end
+
+      def pre_depends
+        Util::Deb.parse_dependencies(backend_data['pre_depends'])
+      end
+
+      def recommends
+        Util::Deb.parse_dependencies(backend_data['recommends'])
+      end
+
+      def suggests
+        Util::Deb.parse_dependencies(backend_data['suggests'])
+      end
+
+      def enhances
+        Util::Deb.parse_dependencies(backend_data['enhances'])
+      end
+
+      def breaks
+        Util::Deb.parse_dependencies(backend_data['breaks'])
+      end
+
+      def conflicts
+        Util::Deb.parse_dependencies(backend_data['conflicts'])
       end
     end
   end

--- a/app/views/katello/api/v2/debs/backend.json.rabl
+++ b/app/views/katello/api/v2/debs/backend.json.rabl
@@ -1,0 +1,7 @@
+attributes :depends
+attributes :pre_depends
+attributes :recommends
+attributes :suggests
+attributes :enhances
+attributes :breaks
+attributes :conflicts

--- a/app/views/katello/api/v2/debs/base.json.rabl
+++ b/app/views/katello/api/v2/debs/base.json.rabl
@@ -11,6 +11,10 @@ attributes :nav
 attributes :nva
 attributes :pulp_id
 attributes :pulp_id => :uuid
+attributes :section
+attributes :maintainer
+attributes :homepage
+attributes :installed_size
 
 node(:hosts_available_count) { |m| m.hosts_available(params[:organization_id]).count }
 node(:hosts_applicable_count) { |m| m.hosts_applicable(params[:organization_id]).count }

--- a/app/views/katello/api/v2/debs/show.json.rabl
+++ b/app/views/katello/api/v2/debs/show.json.rabl
@@ -1,3 +1,5 @@
 object @resource
 
 extends "katello/api/v2/debs/base"
+extends "katello/api/v2/debs/backend",
+  :object => SmartProxy.pulp_primary!.content_service("deb").new(@resource.pulp_id)

--- a/db/migrate/20240806130902_add_more_deb_fields.rb
+++ b/db/migrate/20240806130902_add_more_deb_fields.rb
@@ -1,0 +1,15 @@
+class AddMoreDebFields < ActiveRecord::Migration[6.1]
+  def up
+    add_column :katello_debs, :section, :string, :limit => 255
+    add_column :katello_debs, :maintainer, :string, :limit => 255
+    add_column :katello_debs, :homepage, :string, :limit => 255
+    add_column :katello_debs, :installed_size, :string, :limit => 255
+  end
+
+  def down
+    remove_column :katello_debs, :section
+    remove_column :katello_debs, :maintainer
+    remove_column :katello_debs, :homepage
+    remove_column :katello_debs, :installed_size
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/debs.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/debs.routes.js
@@ -40,6 +40,15 @@
                 parent: 'debs'
             }
         })
+        .state('deb.dependencies', {
+            url: '/dependencies',
+            permission: ['view_products', 'view_content_views'],
+            templateUrl: 'debs/details/views/deb-dependencies.html',
+            ncyBreadcrumb: {
+                label: "{{ 'Dependencies' | translate }}",
+                parent: 'deb.info'
+            }
+        })
         .state('deb.repositories', {
             url: '/repositories',
             permission: ['view_products'],

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/details/views/deb-dependencies.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/details/views/deb-dependencies.html
@@ -1,0 +1,54 @@
+<span page-title ng-model="deb">{{ 'Deb: ' | translate }} {{ deb.nva }}</span>
+
+<section>
+
+  <div ng-if="deb.depends.length > 0" class="details fl">
+    <h4 translate><b>Depends</b></h4>
+    <div ng-repeat="item in deb.depends | orderBy:'toString()'">
+      {{ item }}
+    </div>
+  </div>
+
+  <div ng-if="deb.pre_depends.length > 0" class="details fl">
+    <h4 translate><b>Pre-Depends</b></h4>
+    <div ng-repeat="item in deb.pre_depends | orderBy:'toString()'">
+      {{ item }}
+    </div>
+  </div>
+
+  <div ng-if="deb.recommends.length > 0" class="details fl">
+    <h4 translate><b>Recommends</b></h4>
+    <div ng-repeat="item in deb.recommends | orderBy:'toString()'">
+      {{ item }}
+    </div>
+  </div>
+
+  <div ng-if="deb.suggests.length > 0" class="details fl">
+    <h4 translate><b>Suggests</b></h4>
+    <div ng-repeat="item in deb.suggests | orderBy:'toString()'">
+      {{ item }}
+    </div>
+  </div>
+
+  <div ng-if="deb.enhances.length > 0" class="details fl">
+    <h4 translate><b>Enhances</b></h4>
+    <div ng-repeat="item in deb.enhances | orderBy:'toString()'">
+      {{ item }}
+    </div>
+  </div>
+
+  <div ng-if="deb.breaks.length > 0" class="details fl">
+    <h4 translate><b>Breaks</b></h4>
+    <div ng-repeat="item in deb.breaks | orderBy:'toString()'">
+      {{ item }}
+    </div>
+  </div>
+
+  <div ng-if="deb.conflicts.length > 0" class="details fl">
+    <h4 translate><b>Conflicts</b></h4>
+    <div ng-repeat="item in deb.conflicts | orderBy:'toString()'">
+      {{ item }}
+    </div>
+  </div>
+
+</section>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/details/views/deb-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/details/views/deb-info.html
@@ -2,7 +2,7 @@
 
 <div data-extend-template="layouts/full-page-details.html">
   <div data-block="content">
-    <h4 translate>Basic Information</h4>
+    <h4 translate>Package Information</h4>
 
     <dl class="dl-horizontal dl-horizontal-left">
       <dt translate>Installed On</dt>
@@ -46,6 +46,18 @@
 
       <dt translate>Description</dt>
       <dd>{{ deb.description }}</dd>
+
+      <dt translate>Section</dt>
+      <dd>{{ deb.section }}</dd>
+
+      <dt translate>Maintainer</dt>
+      <dd>{{ deb.maintainer }}</dd>
+
+      <dt translate>Homepage</dt>
+      <dd>{{ deb.homepage }}</dd>
+
+      <dt translate>Installed size</dt>
+      <dd>{{ deb.installed_size }} kB</dd>
     </dl>
     <div class="divider"></div>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/details/views/deb.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/details/views/deb.html
@@ -14,6 +14,13 @@
           </span>
         </a>
       </li>
+      <li ng-class="{active: isState('deb.dependencies')}">
+        <a ui-sref="deb.dependencies">
+          <span translate>
+            Dependencies
+          </span>
+        </a>
+      </li>
       <li ng-show="permitted('view_products')" ng-class="{active: isState('deb.repositories')}">
         <a ui-sref="deb.repositories">
           <span translate>


### PR DESCRIPTION
[Redmine issue](https://projects.theforeman.org/issues/37794)

This PR aims to align the debian-package details view to the rpm-package details view.
The following fields are added to the details page:

- Section
- Maintainer
- Homepage
- Installed size

Furthermore, similar to the rpm-package details view, package dependencies are now shown in a dedicated tab called "Dependencies".
The values shown on the "Dependencies"-Tab are:

- depends
- pre_depends
- recommends
- suggests
- enhances
- breaks
- conflicts

Since a lot of "dependency-relation" fields are often left empty on debian-packages, only populated fields are shown.

The full list of fields that may be used to describe a debian-package can be found [here](https://www.debian.org/doc/debian-policy/ch-controlfields.html#), though pulp_deb does not support all of these.

![image](https://github.com/user-attachments/assets/06624f8e-b79b-4372-8c25-f48447e8deb0)
![image](https://github.com/user-attachments/assets/1189ec0f-9f82-4a66-9b70-ed54717363f1)
