### PR TITLE
Fixes #37006 - Turn distribute_archived_cvv setting off by default

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -654,7 +654,7 @@ Foreman::Plugin.register :katello do
 
       setting 'distribute_archived_cvv',
         type: :boolean,
-        default: true,
+        default: false,
         full_name: N_('Distribute archived content view versions'),
         description: N_("If this is enabled, repositories of content view versions without environments (\"archived\") will be distributed at '/pulp/content/<organization>/content_views/<content view>/X.Y/...'.")
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Turn distribute_archived_cvv setting off by default
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Create repo and sync it.
Create CV with the repo and publish it.
With this change you won't see archived repo distributions like:
https://hostname/pulp/content/Default_Organization/content_views/cv_name/1.0/custom/product_name/repo_name/