### PR TITLE
Fixes #37795 - set multiple Content Views via a single Activation key

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -390,6 +390,11 @@ module Katello
           activation_key = organization.activation_keys.find_by(:name => ak_name)
           fail HttpErrors::NotFound, _("Couldn't find activation key '%s'") % ak_name unless activation_key
 
+          if activation_key.multi_content_view_environment? && !Setting['allow_multiple_content_views']
+            fail HttpErrors::BadRequest, _("Activation key '%s' is associated to multiple environments"\
+                                           " and registering to multiple environments is not enabled.") % ak_name
+          end
+
           if !activation_key.unlimited_hosts && activation_key.usage_count >= activation_key.max_hosts
             fail Errors::MaxHostsReachedException, _("Max Hosts (%{limit}) reached for activation key '%{name}'") %
                 { :limit => activation_key.max_hosts, :name => activation_key.name }

--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -232,10 +232,7 @@ module Katello
         version_environment[:environments] << cve.environment unless version_environment[:environments].include?(cve.environment)
         version_environment[:next_version] ||= version.next_incremental_version
         version_environment[:content_host_count] ||= 0
-        version_environment[:content_host_count] += content_facets.in_content_views_and_environments(
-          content_views: [cve.content_view],
-          lifecycle_environments: [cve.environment]
-        ).count
+        version_environment[:content_host_count] += content_facets.with_content_view_environments(cve).count
 
         if version.content_view.composite?
           version_environment[:components] = version.components_needing_errata(@errata)

--- a/app/controllers/katello/concerns/authorization/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/concerns/authorization/api/v2/content_views_controller.rb
@@ -118,10 +118,7 @@ module Katello
       # and also ensure that the environments have the remove permission
       return deny_access unless KTEnvironment.promotable.where(:id => env_ids).count == env_ids.size && view.promotable_or_removable?
 
-      total_count = Katello::Host::ContentFacet.in_content_views_and_environments(
-        :content_views => [view],
-        :lifecycle_environments => ::Katello::KTEnvironment.where(id: env_ids)
-      ).count
+      total_count = Katello::Host::ContentFacet.with_content_views(view).with_environments(env_ids).count
       if total_count > 0
         unless options[:system_content_view_id] && options[:system_environment_id]
           fail _("Unable to reassign content hosts. Please provide system_content_view_id and system_environment_id.")
@@ -135,7 +132,7 @@ module Katello
         end
       end
 
-      if Katello::ActivationKey.where(:content_view_id => view, :environment_id => env_ids).count > 0
+      if Katello::ActivationKey.with_content_views(view).with_environments(env_ids).count > 0
         # if we are reassigning activation key environments/ cv
         # make sure the activation key using present environments or cv are editable.
         unless options[:key_content_view_id] && options[:key_environment_id]

--- a/app/lib/actions/katello/activation_key/reassign.rb
+++ b/app/lib/actions/katello/activation_key/reassign.rb
@@ -3,9 +3,10 @@ module Actions
     module ActivationKey
       class Reassign < Actions::Base
         def plan(activation_key, content_view_id, environment_id)
-          activation_key.content_view_id = content_view_id
-          activation_key.environment_id = environment_id
-          activation_key.save!
+          activation_key.assign_single_environment(
+            content_view: ::Katello::ContentView.find(content_view_id),
+            lifecycle_environment: ::Katello::KTEnvironment.find(environment_id)
+          )
         end
       end
     end

--- a/app/lib/actions/katello/content_view/remove.rb
+++ b/app/lib/actions/katello/content_view/remove.rb
@@ -119,11 +119,13 @@ module Actions
           end
           all_cv_envs = combined_cv_envs(cv_envs, versions)
 
-          if all_cv_envs.flat_map(&:hosts).any? && system_cve(options).nil?
+          if all_cv_envs.flat_map(&:hosts).any? && !cve_exists?(options[:system_environment_id],
+                                                                options[:system_content_view_id])
             fail _("Unable to reassign systems. Please check system_content_view_id and system_environment_id.")
           end
 
-          if all_cv_envs.flat_map(&:activation_keys).any? && activation_key_cve(options).nil?
+          if all_cv_envs.flat_map(&:activation_keys).any? && !cve_exists?(options[:key_environment_id],
+                                                                          options[:key_content_view_id])
             fail _("Unable to reassign activation_keys. Please check activation_key_content_view_id and activation_key_environment_id.")
           end
         end
@@ -132,16 +134,10 @@ module Actions
           (cv_envs + versions.flat_map(&:content_view_environments)).uniq
         end
 
-        def system_cve(options)
-          ::Katello::ContentViewEnvironment.where(:environment_id => options[:system_environment_id],
-                                                  :content_view_id => options[:system_content_view_id]
-                                                 ).first
-        end
-
-        def activation_key_cve(options)
-          ::Katello::ContentViewEnvironment.where(:environment_id => options[:key_environment_id],
-                                                  :content_view_id => options[:key_content_view_id]
-                                                 ).first
+        def cve_exists?(environment_id, content_view_id)
+          ::Katello::ContentViewEnvironment.where(:environment_id => environment_id,
+                                                  :content_view_id => content_view_id
+                                                 ).exists?
         end
       end
     end

--- a/app/lib/katello/util/cveak_migrator.rb
+++ b/app/lib/katello/util/cveak_migrator.rb
@@ -1,0 +1,38 @@
+module Katello
+  module Util
+    class FakeActivationKey < ApplicationRecord
+      self.table_name = 'katello_activation_keys'
+    end
+
+    class CVEAKMigrator # used in db/migrate/20240730163043_add_content_view_environment_activation_key.rb
+      def execute!
+        aks_with_no_cve = []
+        aks_with_missing_cve = []
+
+        FakeActivationKey.all.each do |ak|
+          next if ak.content_view_id.blank? && ak.environment_id.blank?
+          if ::Katello::ContentView.exists?(id: ak.content_view_id) && ::Katello::KTEnvironment.exists?(ak.environment_id)
+            cve = ::Katello::ContentViewEnvironment.find_by(content_view_id: ak.content_view_id, environment_id: ak.environment_id)
+            if cve.blank?
+              aks_with_no_cve << ak
+            end
+          else
+            aks_with_missing_cve << ak
+          end
+        end
+
+        if aks_with_missing_cve.present? || aks_with_no_cve.present?
+          Rails.logger.warn "Found #{aks_with_no_cve.count} activation keys whose combination of content view and lifecycle environment does not have a corresponding ContentViewEnvironment"
+          Rails.logger.warn "Found #{aks_with_missing_cve.count} activation keys which are missing either content_view_id or lifecycle_environment_id"
+          Rails.logger.info "You may want to change the content view / lifecycle environment for these activation keys manually."
+        end
+        (aks_with_no_cve + aks_with_missing_cve).each do |ak|
+          default_content_view = ak.organization.default_content_view
+          library = ak.organization.library
+          Rails.logger.info "Updating activation key #{ak.name} with default content_view_id and lifecycle_environment_id"
+          ak&.update_columns(content_view_id: default_content_view&.id, environment_id: library&.id)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/katello/util/cvecf_migrator.rb
+++ b/app/lib/katello/util/cvecf_migrator.rb
@@ -1,6 +1,6 @@
 module Katello
   module Util
-    class CvecfMigrator # used in db/migrate/20220929204746_add_content_view_environment_content_facet.rb
+    class CVECFMigrator # used in db/migrate/20220929204746_add_content_view_environment_content_facet.rb
       def execute!
         hosts_with_no_cve = []
         hosts_with_missing_cve = []

--- a/app/lib/katello/validators/content_view_environment_org_validator.rb
+++ b/app/lib/katello/validators/content_view_environment_org_validator.rb
@@ -5,9 +5,10 @@ module Katello
         environment_id = record.respond_to?(:lifecycle_environment_id) ? record.lifecycle_environment_id : record.environment_id
         view = ContentView.where(:id => record.content_view_id).first
         environment = KTEnvironment.where(:id => environment_id).first
-        unless view && environment
+        if view.blank? || environment.blank?
           record.errors[:base] << _("Content view environments must have both a content view and an environment")
         end
+
         unless view&.organization == environment&.organization
           record.errors[:base] << _("%{view_label} could not be promoted to %{environment_label} because the content view and the environment are not in the same organization!") % {:view_label => view&.label, :environment_label => environment&.label}
         end

--- a/app/mailers/katello/errata_mailer.rb
+++ b/app/mailers/katello/errata_mailer.rb
@@ -33,10 +33,7 @@ module Katello
       ::User.as(user.login) do
         @content_view = options[:content_view]
         @environment = options[:environment]
-        @content_facets = Katello::Host::ContentFacet.in_content_views_and_environments(
-          :lifecycle_environments => [@environment],
-          :content_views => [@content_view]
-        )
+        @content_facets = Katello::Host::ContentFacet.with_content_views(@content_view).with_environments(@environment)
         @hosts = ::Host::Managed.authorized("view_hosts").where(:id => @content_facets.pluck(:host_id))
         @errata = @content_facets.map(&:installable_errata).flatten.uniq
 

--- a/app/models/katello/authorization/activation_key.rb
+++ b/app/models/katello/authorization/activation_key.rb
@@ -34,7 +34,7 @@ module Katello
       end
 
       def all_editable?(content_view, environments)
-        key_query = ActivationKey.where(:content_view_id => content_view, :environment_id => environments)
+        key_query = ActivationKey.with_content_views(content_view).with_environments(environments)
         key_query.count == key_query.editable.count
       end
     end

--- a/app/models/katello/authorization/content_view_environment.rb
+++ b/app/models/katello/authorization/content_view_environment.rb
@@ -5,5 +5,12 @@ module Katello
     def readable?
       self.content_view.readable? && self.environment.readable?
     end
+
+    module ClassMethods
+      def readable
+        where(:content_view_id => ::Katello::ContentView.readable,
+              :environment_id => ::Katello::KTEnvironment.readable)
+      end
+    end
   end
 end

--- a/app/models/katello/content_view_environment_activation_key.rb
+++ b/app/models/katello/content_view_environment_activation_key.rb
@@ -1,0 +1,20 @@
+module Katello
+  class ContentViewEnvironmentActivationKey < Katello::Model
+    belongs_to :content_view_environment, :class_name => "::Katello::ContentViewEnvironment", :inverse_of => :content_view_environment_activation_keys
+    belongs_to :activation_key, :class_name => "::Katello::ActivationKey", :inverse_of => :content_view_environment_activation_keys
+
+    default_scope { order(:priority => :asc) }
+
+    validates :content_view_environment_id, presence: true
+    validates :activation_key_id, presence: true, unless: :new_record?
+
+    def self.reprioritize_for_activation_key(activation_key, new_cves)
+      new_order = new_cves.map do |cve|
+        activation_key.content_view_environment_activation_keys.find_by(:content_view_environment_id => cve.id)
+      end
+      new_order.compact.each_with_index do |cveak, index|
+        cveak.update_column(:priority, index)
+      end
+    end
+  end
+end

--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -8,8 +8,6 @@ module Katello
     include Ext::LabelFromName
 
     belongs_to :organization, :class_name => "Organization", :inverse_of => :kt_environments
-    has_many :activation_keys, :class_name => "Katello::ActivationKey",
-                               :dependent => :restrict_with_exception, :foreign_key => :environment_id
 
     has_many :env_priors, :class_name => "Katello::EnvironmentPrior", :foreign_key => :environment_id, :dependent => :destroy
     has_many :priors, :class_name => "Katello::KTEnvironment", :through => :env_priors, :source => :env_prior
@@ -30,13 +28,20 @@ module Katello
     has_many :content_view_environments, :class_name => "Katello::ContentViewEnvironment",
              :foreign_key => :environment_id, :inverse_of => :environment, :dependent => :destroy
     has_many :content_view_environment_content_facets, :through => :content_view_environments,
-                          :class_name => "Katello::ContentViewEnvironmentContentFacet",
-                          :inverse_of => :lifecycle_environment
+                          :class_name => "Katello::ContentViewEnvironmentContentFacet"
+
     has_many :content_facets, :through => :content_view_environment_content_facets,
-                          :class_name => "Katello::Host::ContentFacet",
-                          :inverse_of => :lifecycle_environments
+                          :class_name => "Katello::Host::ContentFacet"
+
     has_many :content_views, :through => :content_view_environments
     has_many :content_view_versions, :through => :content_view_environments, :inverse_of => :environments
+
+    has_many :content_view_environment_activation_keys, :through => :content_view_environments,
+                          :class_name => "Katello::ContentViewEnvironmentActivationKey",
+                          :dependent => :restrict_with_exception
+
+    has_many :activation_keys, :through => :content_view_environment_activation_keys,
+                          :class_name => "Katello::ActivationKey"
 
     has_many :hosts,      :class_name => "::Host::Managed", :through => :content_facets,
                           :inverse_of => :lifecycle_environments

--- a/app/services/katello/product_content_finder.rb
+++ b/app/services/katello/product_content_finder.rb
@@ -15,14 +15,7 @@ module Katello
 
     def product_content
       if match_environment
-        if consumable.is_a?(::Katello::ActivationKey) # TODO: remove this when AKs are refactored for multi CV
-          environment = consumable.lifecycle_environment
-          view = consumable.content_view
-          return ProductContent.none unless environment && view
-          versions = ContentViewVersion.in_environment(environment).where(:content_view_id => view).first
-        else # consumable is a SubscriptionFacet
-          versions = consumable.content_view_environments.select(:content_view_version_id).map(&:content_view_version_id)
-        end
+        versions = consumable.content_view_environments.select(:content_view_version_id).map(&:content_view_version_id)
       end
 
       considered_products = match_subscription ? consumable.products : consumable.organization.products.enabled.uniq

--- a/app/views/katello/api/v2/activation_keys/base.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/base.json.rabl
@@ -3,16 +3,21 @@ extends 'katello/api/v2/common/timestamps'
 
 attributes :id, :name, :description, :unlimited_hosts, :auto_attach
 
-attributes :content_view_id
-
-child :content_view => :content_view do
-  attributes :id, :name
+node :content_view_id do |ak|
+  ak.single_content_view&.id
 end
 
-child :environment => :environment do
-  attributes :name, :id
+node :content_view do |ak|
+  ak.single_content_view&.slice(:id, :name)
 end
-attributes :environment_id
+
+node :environment_id do |ak|
+  ak.single_lifecycle_environment&.id
+end
+
+node :environment do |ak|
+  ak.single_lifecycle_environment&.slice(:id, :name)
+end
 
 attributes :usage_count, :user_id, :max_hosts, :system_template_id, :release_version, :purpose_usage, :purpose_role
 

--- a/app/views/katello/api/v2/content_view_versions/base.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/base.json.rabl
@@ -70,7 +70,7 @@ child :environments => :environments do
   end
 
   node :activation_key_count do |env|
-    Katello::ActivationKey.where(:environment_id => env.id).where(:content_view_id => version.content_view_id).count
+    Katello::ActivationKey.with_content_views(version.content_view).with_environments(env).count
   end
 end
 

--- a/app/views/katello/api/v2/content_views/base.json.rabl
+++ b/app/views/katello/api/v2/content_views/base.json.rabl
@@ -44,7 +44,7 @@ node :environments do |cv|
       id: env.id,
       label: env.label,
       name: env.name,
-      activation_keys: cv&.activation_keys&.in_environment(env)&.ids,
+      activation_keys: cv&.activation_keys&.in_environments([env])&.ids,
       hosts: cv&.hosts&.in_environments([env])&.ids,
       permissions: {readable: env.readable?}
     }

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -2,7 +2,9 @@
 Rails.autoloaders.each do |autoloader|
   autoloader.inflector.inflect(
     'kt_environment' => 'KTEnvironment',
-    'cdn' => 'CDN'
+    'cdn' => 'CDN',
+    'cveak_migrator' => 'CVEAKMigrator',
+    'cvecf_migrator' => 'CVECFMigrator'
   )
 end
 

--- a/db/migrate/20220929204746_add_content_view_environment_content_facet.rb
+++ b/db/migrate/20220929204746_add_content_view_environment_content_facet.rb
@@ -8,7 +8,7 @@ class AddContentViewEnvironmentContentFacet < ActiveRecord::Migration[6.1]
       t.references :content_view_environment, :null => false, :index => false, :foreign_key => { :to_table => 'katello_content_view_environments' }
       t.references :content_facet, :null => false, :index => false, :foreign_key => { :to_table => 'katello_content_facets' }
     end
-    ::Katello::Util::CvecfMigrator.new.execute!
+    ::Katello::Util::CVECFMigrator.new.execute!
     FakeContentFacet.all.each do |content_facet|
       cve_id = ::Katello::KTEnvironment.find(content_facet.lifecycle_environment_id)
           .content_view_environments

--- a/db/migrate/20240730163043_add_content_view_environment_activation_key.rb
+++ b/db/migrate/20240730163043_add_content_view_environment_activation_key.rb
@@ -1,0 +1,87 @@
+class AddContentViewEnvironmentActivationKey < ActiveRecord::Migration[6.1]
+  class FakeActivationKey < ApplicationRecord
+    self.table_name = 'katello_activation_keys'
+  end
+
+  def up
+    create_table :katello_content_view_environment_activation_keys do |t|
+      t.references :content_view_environment, :null => false, :index => false, :foreign_key => { :to_table => 'katello_content_view_environments' }
+      t.references :activation_key, :null => false, :index => false, :foreign_key => { :to_table => 'katello_activation_keys' }
+    end
+    ::Katello::Util::CVEAKMigrator.new.execute!
+    FakeActivationKey.all.each do |activation_key|
+      next if activation_key.environment_id.blank? && activation_key.content_view_id.blank?
+
+      cve_id = ::Katello::KTEnvironment.find(activation_key.environment_id)
+          .content_view_environments
+          .find_by(content_view_id: activation_key.content_view_id)
+          &.id
+      unless cve_id.present? && ::Katello::ContentViewEnvironmentActivationKey.create(
+        activation_key_id: activation_key.id,
+        content_view_environment_id: cve_id
+      )
+        Rails.logger.warn "Failed to create ContentViewEnvironmentActivationKey for activation_key #{activation_key.id}"
+      end
+    end
+
+    remove_column :katello_activation_keys, :content_view_id
+    remove_column :katello_activation_keys, :environment_id
+  end
+
+  def down
+    add_column :katello_activation_keys, :content_view_id, :integer, :index => true
+    add_column :katello_activation_keys, :environment_id, :integer, :index => true
+
+    add_foreign_key "katello_activation_keys", "katello_content_views",
+                    :name => "katello_activation_keys_content_view_id", :column => "content_view_id"
+
+    add_foreign_key "katello_activation_keys", "katello_environments",
+                    :name => "katello_activation_keys_environment_id", :column => "environment_id"
+
+    ::Katello::ActivationKey.reset_column_information
+
+    ::Katello::ContentViewEnvironmentActivationKey.unscoped.all.each do |cveak|
+      activation_key = cveak.activation_key
+      cve = cveak.content_view_environment
+      default_org = cve.environment&.organization
+      default_cv_id = default_org&.default_content_view&.id
+      default_lce_id = default_org&.library&.id
+      cv_id = cveak.content_view_environment.content_view_id || default_cv_id
+      lce_id = cveak.content_view_environment.environment_id || default_lce_id
+      say "Updating activation_key #{activation_key.id} with cv_id #{cv_id} and lce_id #{lce_id}"
+      activation_key.content_view_id = cv_id
+      activation_key.environment_id = lce_id
+      activation_key.save(validate: false)
+    end
+
+    ensure_no_null_cv_lce
+    change_column :katello_activation_keys, :content_view_id, :integer, :null => false
+    change_column :katello_activation_keys, :environment_id, :integer, :null => false
+
+    drop_table :katello_content_view_environment_activation_keys
+  end
+
+  def ensure_no_null_cv_lce
+    # The following is to try to prevent PG::NotNullViolation: ERROR:  column "content_view_id" contains null values
+    # since we add null constraints to the columns in the next step
+    activation_keys_without_cv = ::Katello::ActivationKey.where(content_view_id: nil)
+    if activation_keys_without_cv.any?
+      say "Found #{activation_keys_without_cv.count} activation_keys with nil content_view_id"
+      activation_keys_without_cv.each do |activation_key|
+        say "reassigning bad activation_key #{activation_key.id} to default content view"
+        activation_key.content_view_id = activation_key&.organization&.default_content_view&.id
+        activation_key.save(validate: false)
+      end
+    end
+
+    activation_keys_without_lce = ::Katello::ActivationKey.where(environment_id: nil)
+    if activation_keys_without_lce.any?
+      say "Found #{activation_keys_without_lce.count} activation_keys with nil environment_id"
+      activation_keys_without_lce.each do |activation_key|
+        say "reassigning bad activation_key #{activation_key.id} to default lifecycle environment"
+        activation_key.environment_id = activation_key&.organization&.library&.id
+        activation_key.save(validate: false)
+      end
+    end
+  end
+end

--- a/db/migrate/20240903194428_add_priority_to_content_view_environment_activation_key.rb
+++ b/db/migrate/20240903194428_add_priority_to_content_view_environment_activation_key.rb
@@ -1,0 +1,5 @@
+class AddPriorityToContentViewEnvironmentActivationKey < ActiveRecord::Migration[6.1]
+  def change
+    add_column :katello_content_view_environment_activation_keys, :priority, :integer, default: 0, null: false
+  end
+end

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -91,7 +91,7 @@ module Katello
 
     def test_create_protected
       dev_env_read_permission = {:name => :view_lifecycle_environments, :search => "id=\"#{@library.id}\"" }
-      view_read_permission = {:name => :view_lifecycle_environments, :search => "id=\"#{@view.id}\"" }
+      view_read_permission = {:name => :view_content_views, :search => "label=\"#{@view.label}\"" }
 
       allowed_perms = [[@create_permission, dev_env_read_permission, view_read_permission]]
       denied_perms = [@view_permission, @update_permission, @destroy_permission]

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -481,9 +481,11 @@ module Katello
                      ]
 
       env_ids = [@dev.id.to_s, @staging.id.to_s]
-      Katello::ActivationKey.expects(:where).at_least_once.returns([]).with do |args|
-        args[:content_view_id].id == @library_dev_staging_view.id && args[:environment_id] == env_ids
-      end
+      with_environments = mock
+      with_environments.expects(:with_environments).returns([]).with(env_ids).at_least_once
+
+      Katello::ActivationKey.expects(:with_content_views).with(@library_dev_staging_view).
+                            at_least_once.returns(with_environments)
 
       assert_protected_action(:remove, allowed_perms, denied_perms) do
         put :remove, params: { :id => @library_dev_staging_view.id, :environment_ids => env_ids }
@@ -555,12 +557,12 @@ module Katello
                       [host_edit_permission, host_cv_remove_permission, host_env_remove_permission,
                        alternate_env_read_permission, bad_cv_read_permission]
                      ]
-
       env_ids = [environment.id.to_s]
+      with_environments = mock
+      with_environments.expects(:with_environments).returns([]).with(env_ids).at_least_once
 
-      Katello::ActivationKey.expects(:where).at_least_once.returns([]).with do |args|
-        args[:content_view_id].id == content_view.id && args[:environment_id] == env_ids
-      end
+      Katello::ActivationKey.expects(:with_content_views).with(content_view).
+                            at_least_once.returns(with_environments)
 
       assert_protected_action(:remove, allowed_perms, denied_perms) do
         User.current.update_attribute(:organizations, [host.organization])

--- a/test/fixtures/models/katello_activation_keys.yml
+++ b/test/fixtures/models/katello_activation_keys.yml
@@ -2,32 +2,24 @@ simple_key:
   name: Simple Activation Key
   description: A simple activation key.
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
-  environment_id: <%= ActiveRecord::FixtureSet.identify(:library) %>
-  content_view_id: <%= ActiveRecord::FixtureSet.identify(:acme_default) %>
   auto_attach: true
 
 another_simple_key:
   name: Another Simple Activation Key
   description: Another simple activation key.
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
-  environment_id: <%= ActiveRecord::FixtureSet.identify(:library) %>
-  content_view_id: <%= ActiveRecord::FixtureSet.identify(:acme_default) %>
   auto_attach: true
 
 yet_another_simple_key:
   name: Yet Another Activation Key
   description: And another simple activation key!
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
-  environment_id: <%= ActiveRecord::FixtureSet.identify(:library) %>
-  content_view_id: <%= ActiveRecord::FixtureSet.identify(:acme_default) %>
   auto_attach: true
 
 and_yet_another_simple_key:
   name: And Yet Another Simple Activation Key
   description: Here we go again!
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
-  environment_id: <%= ActiveRecord::FixtureSet.identify(:library) %>
-  content_view_id: <%= ActiveRecord::FixtureSet.identify(:acme_default) %>
   auto_attach: true
 
 dev_key:
@@ -35,24 +27,19 @@ dev_key:
   description: A simple activation key.
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
-  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
-  environment_id: <%= ActiveRecord::FixtureSet.identify(:dev) %>
   auto_attach: true
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
 
 library_dev_staging_view_key:
   name: Lib Dev Stating Activation Key
   description: Here we go again!
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
-  environment_id: <%= ActiveRecord::FixtureSet.identify(:dev) %>
-  content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_dev_staging_view) %>
   auto_attach: true
 
 purpose_attributes_key:
   name: Activation Key
   description: A simple activation key.
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
-  environment_id: <%= ActiveRecord::FixtureSet.identify(:library) %>
-  content_view_id: <%= ActiveRecord::FixtureSet.identify(:acme_default) %>
   auto_attach: true
   purpose_role: role name
   purpose_usage: usage name

--- a/test/fixtures/models/katello_content_view_environment_activation_keys.yml
+++ b/test/fixtures/models/katello_content_view_environment_activation_keys.yml
@@ -1,0 +1,26 @@
+simple_key_cveak:
+  content_view_environment_id: <%= ActiveRecord::FixtureSet.identify(:library_default_view_environment) %>
+  activation_key_id: <%= ActiveRecord::FixtureSet.identify(:simple_key) %>
+
+another_simple_key_cveak:
+  content_view_environment_id: <%= ActiveRecord::FixtureSet.identify(:library_default_view_environment) %>
+  activation_key_id: <%= ActiveRecord::FixtureSet.identify(:another_simple_key) %>
+
+yet_another_simple_key_cveak:
+  content_view_environment_id: <%= ActiveRecord::FixtureSet.identify(:library_default_view_environment) %>
+  activation_key_id: <%= ActiveRecord::FixtureSet.identify(:yet_another_simple_key) %>
+
+and_yet_another_simple_key_cveak:
+  content_view_environment_id: <%= ActiveRecord::FixtureSet.identify(:library_default_view_environment) %>
+  activation_key_id: <%= ActiveRecord::FixtureSet.identify(:and_yet_another_simple_key) %>
+
+purpose_attributes_key_cveak:
+  content_view_environment_id: <%= ActiveRecord::FixtureSet.identify(:library_default_view_environment) %>
+  activation_key_id: <%= ActiveRecord::FixtureSet.identify(:purpose_attributes_key) %>
+
+library_dev_staging_view_key_cveak:
+  content_view_environment_id: <%= ActiveRecord::FixtureSet.identify(:library_dev_staging_view_dev) %>
+  activation_key_id: <%= ActiveRecord::FixtureSet.identify(:library_dev_staging_view_key) %>
+
+
+

--- a/test/models/authorization/activation_key_authorization_test.rb
+++ b/test/models/authorization/activation_key_authorization_test.rb
@@ -79,7 +79,7 @@ module Katello
 
     def test_all_editable?
       ak = ActivationKey.find(katello_activation_keys(:library_dev_staging_view_key).id)
-      keys = ActivationKey.where(:content_view_id => ak.content_view_id, :environment_id => ak.environment)
+      keys = ActivationKey.with_content_views(ak.single_content_view).with_environments(ak.single_content_view)
 
       clause = keys.map { |key| "name=\"#{key.name}\"" }.join(" or ")
 

--- a/test/models/content_view_environment_activation_key_test.rb
+++ b/test/models/content_view_environment_activation_key_test.rb
@@ -1,0 +1,29 @@
+require 'katello_test_helper'
+
+module Katello
+  class ContentViewEnvironmentActivationKeyTest < ActiveSupport::TestCase
+    def setup
+      User.current = User.find(users(:admin).id)
+      @activation_key = katello_activation_keys(:simple_key)
+    end
+
+    def teardown
+      Setting['allow_multiple_content_views'] = false
+    end
+
+    def test_reprioritize_for_activation_key
+      Setting['allow_multiple_content_views'] = true
+      @activation_key.content_view_environments = [
+        katello_content_view_environments(:library_dev_view_dev),
+        katello_content_view_environments(:library_dev_staging_view_dev)]
+
+      cve1 = @activation_key.content_view_environments.first
+      cve2 = @activation_key.content_view_environments.last
+      new_cves = [cve2, cve1]
+      ContentViewEnvironmentActivationKey.reprioritize_for_activation_key(@activation_key, new_cves)
+      @activation_key.content_view_environments.reload
+      assert_equal 1, cve1.priority(@activation_key)
+      assert_equal 0, cve2.priority(@activation_key)
+    end
+  end
+end

--- a/test/models/content_view_environment_test.rb
+++ b/test/models/content_view_environment_test.rb
@@ -7,6 +7,14 @@ module Katello
       @content_facet = katello_content_facets(:content_facet_one)
     end
 
+    def test_activation_keys
+      cve = katello_content_view_environments(:library_dev_view_library)
+      ak = katello_activation_keys(:simple_key)
+      ak.update!(content_view_environments: [cve])
+      cve = Katello::ContentViewEnvironment.where(cve.slice(:environment_id, :content_view_id)).first
+      assert_includes cve.activation_keys, ak
+    end
+
     def test_for_content_facets
       cve = @content_facet.content_view_environments.first
       assert_includes ContentViewEnvironment.for_content_facets(@content_facet), cve

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -437,9 +437,7 @@ module Katello
     end
 
     def test_check_remove_from_environment!
-      facets = ::Katello::Host::ContentFacet.in_content_views_and_environments(
-        lifecycle_environments: [@dev]
-      )
+      facets = ::Katello::Host::ContentFacet.with_environments(@dev)
       host_ids = facets.joins(:host).select('hosts.id').pluck('hosts.id')
       facets.each do |facet|
         facet&.host&.subscription_facet&.destroy

--- a/test/services/product_content_finder_test.rb
+++ b/test/services/product_content_finder_test.rb
@@ -22,7 +22,7 @@ module Katello
   class ProductContentFinderActivationKeyTest < ProductContentFinderTestBase
     def setup
       super
-      @key = ActivationKey.new(:organization => @product1.organization)
+      @key = katello_activation_keys(:simple_key)
     end
 
     def test_all
@@ -44,8 +44,10 @@ module Katello
     end
 
     def test_match_environments
-      @key.environment = @repo2_cv.environment
-      @key.content_view = @repo2_cv.content_view
+      cves = ::Katello::ContentViewEnvironment.where(environment_id: @repo2_cv.environment,
+                                                      content_view_id: @repo2_cv.content_view)
+
+      @key.update!(content_view_environments: cves)
 
       Katello::Repository.where(:root => Katello::RootRepository.where(:content_id => @repo1.content_id),
                                 :content_view_version_id => @key.content_view.version(@key.environment)).destroy_all


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

- Can add multiple content view environments to Activation Keys.
- Can have a host register to multiple content view environments  via Activation Key
- Can have a host register to a composite of Activation Keys
- API bindings to see information about the content view environments
- API  bindings to set the content view environments
- Adds Content View Environment Activation Keys mapping table to manage multiple CVEs for an AK.

#### Considerations taken when implementing this change?
The approach largely mirrors what we did for content facets except 2 important changes

- If you have the multi cv setting on and you specified multiple activation key on host registration, the CVEs of each individual activation key will get added. If you have the setting off, the behavior will be the same as status quo - only the cve of the last activation key will be added. 
- Prior to migration if you have an activation key where only the lce environment was set and content view was blank, the migrator will ignore creating CVEs for those environments. The Activation Key will be associated to no content view environment (this could be useful if you are creating activation keys with system purpose attributes.) 

#### What are the testing steps for this pull request?

1. Create a few activation keys
2. Check out the PR and run the migration
3. Verify things migrated correctly.
4. You should then be able to use `hammer activation-key create --name=foo --organization-id=1 --content-view-environments='env_label1/cv_label1,env_label2/cv_label2'`
5. You can verify activation key foo has 2 content view environments on rails console
6. Try registering  a host to to this activation key via global registration.
7. You should notice repositories from `env1/cv1` and `env2/cv2`  in the redhat repos file.
8. Try testing things like deleting content views and have it reassigned to something else etc.




