### PR TITLE
Fixes #37804 - Unable to load gpg key using downloaded key file

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/new/views/new-content-credential.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/new/views/new-content-credential.html
@@ -9,7 +9,7 @@
           ng-upload="uploadContent(content)"
           upload-options-enable-rails-csrf>
 
-      <div bst-form-group label="{{ 'Name' | translate }}">
+      <div bst-form-group label="{{ 'Name *' | translate }}">
         <input id="name"
                name="name"
                ng-model="contentCredential.name"
@@ -28,7 +28,7 @@
         </select>
       </div>
 
-      <div bst-form-group label="{{ 'Content Credential Contents' | translate }}">
+      <div bst-form-group label="{{ 'Content Credential Contents *' | translate }}">
         <textarea name="content"
                   ng-model="contentCredential.pastedContent"
                   tabindex="1"
@@ -36,7 +36,7 @@
                   style="font-family: monospace"
                   rows="15"
                   placeholder="{{ 'Paste contents of Content Credential' | translate }}"
-                  required>
+                  >
         </textarea>
       </div>
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Allow saving new content credentials with uploaded content key.
Name and Content Credential Contents field labels will show a * next to them indicating required.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Go to Content > Content credentials
2. Create a new content credential by uploading a text file for the content field.
3. You should be able to save the record.
4. If you leave field blank and don't upload a file for the content , the error in saving record will come from the API and show up as an error notification.