### PR TITLE
Fixes #37772 - Add controller guardrails for multi-CV params on hosts and activation keys

### DIFF
--- a/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
@@ -3,6 +3,7 @@ module Katello
     module Api::V2::HostsControllerExtensions
       extend ActiveSupport::Concern
       include ForemanTasks::Triggers
+      include Katello::Concerns::Api::V2::MultiCVParamsHandling
 
       module Overrides
         def action_permission
@@ -49,8 +50,12 @@ module Katello
             labels: cve_params[:content_view_environments],
             ids: cve_params[:content_view_environment_ids],
             organization: @organization || @host&.organization)
-
-          @host.content_facet.content_view_environments = cves if cves.present?
+          if cves.present?
+            @host.content_facet.content_view_environments = cves
+          else
+            handle_errors(candlepin_names: cve_params[:content_view_environments],
+              ids: cve_params[:content_view_environment_ids])
+          end
         end
 
         def cve_params

--- a/app/controllers/katello/concerns/api/v2/multi_cv_params_handling.rb
+++ b/app/controllers/katello/concerns/api/v2/multi_cv_params_handling.rb
@@ -1,0 +1,24 @@
+module Katello
+  module Concerns
+    module Api::V2::MultiCVParamsHandling
+      extend ActiveSupport::Concern
+      include ::Katello::Api::V2::ErrorHandling
+
+      def handle_errors(candlepin_names: [], ids: [])
+        if candlepin_names.present?
+          fail HttpErrors::UnprocessableEntity, "No content view environments found with names: #{candlepin_names.join(',')}"
+        elsif ids.present?
+          fail HttpErrors::UnprocessableEntity, "No content view environments found with ids: #{ids}"
+        end
+      rescue HttpErrors::UnprocessableEntity => error
+        respond_for_exception(
+          error,
+          :status => :unprocessable_entity,
+          :text => error.message,
+          :errors => [error.message],
+          :with_logging => true
+        )
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/repository/update_cv_repository_cert_guard.rb
+++ b/app/lib/actions/pulp3/repository/update_cv_repository_cert_guard.rb
@@ -1,7 +1,7 @@
 module Actions
   module Pulp3
     module Repository
-      class UpdateCvRepositoryCertGuard < Pulp3::Abstract
+      class UpdateCVRepositoryCertGuard < Pulp3::Abstract
         def plan(repository, smart_proxy)
           root = repository.root
           cv_repositories = root.repositories - [root.library_instance]

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -19,4 +19,5 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.singular 'bases', 'base'
 
   inflect.acronym 'SCA' # Simple Content Access
+  inflect.acronym 'CV' # Content view
 end

--- a/test/models/content_view_environment_test.rb
+++ b/test/models/content_view_environment_test.rb
@@ -34,7 +34,28 @@ module Katello
       dev = katello_environments(:dev)
       view = katello_content_views(:library_dev_view)
       cve = Katello::ContentViewEnvironment.where(:environment_id => dev, :content_view_id => view).first
-      assert_equal cve, ContentViewEnvironment.with_candlepin_name('dev_label/published_dev_view')
+      assert_equal cve, ContentViewEnvironment.with_candlepin_name('published_dev_view_dev', organization: dev.organization)
+    end
+
+    def test_fetch_content_view_environments_candlepin_names
+      dev = katello_environments(:dev)
+      view = katello_content_views(:library_dev_view)
+      cve = Katello::ContentViewEnvironment.where(:environment_id => dev, :content_view_id => view).first
+      assert_equal [cve], ContentViewEnvironment.fetch_content_view_environments(labels: ['published_dev_view_dev'], organization: dev.organization)
+    end
+
+    def test_fetch_content_view_environments_ids
+      dev = katello_environments(:dev)
+      view = katello_content_views(:library_dev_view)
+      cve = Katello::ContentViewEnvironment.where(:environment_id => dev, :content_view_id => view).first
+      assert_equal [cve], ContentViewEnvironment.fetch_content_view_environments(ids: [cve.id], organization: dev.organization)
+    end
+
+    def test_fetch_content_view_environments_invalid_ids_does_not_mutate_array
+      dev = katello_environments(:dev)
+      input_ids = [0, 999]
+      assert_equal [], ContentViewEnvironment.fetch_content_view_environments(ids: input_ids, organization: dev.organization)
+      assert_equal [0, 999], input_ids # should not have a map! which mutates the input array
     end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Previously, the API hosts and activation keys controllers would allow invalid inputs for `content_view_environments` and `content_view_environment_ids`. This would result in failing silently and reassigning your host to have no content view environments. Bad.

Now we don't do that anymore. Also, I added quite a few tests.

#### Considerations taken when implementing this change?

Ended up doing some refactoring that made sense here, of the `with_candlepin_names` method. Turns out ContentViewEnvironment has a `label` field that we should have been using all along.

#### What are the testing steps for this pull request?

See https://community.theforeman.org/t/foreman-3-12-release-candidate-feedback/39258/5?u=jeremylenz

do stuff like that and make sure it errors correctly.
