### PR TITLE
Fixes #37815 - Fix convert2rhel DB down migration

### DIFF
--- a/db/migrate/20240729192228_add_convert2rhel_to_host_facets.rb
+++ b/db/migrate/20240729192228_add_convert2rhel_to_host_facets.rb
@@ -4,6 +4,6 @@ class AddConvert2rhelToHostFacets < ActiveRecord::Migration[6.1]
   end
 
   def down
-    remove_column :subscription_facets, :convert2rhel_through_foreman
+    remove_column :katello_subscription_facets, :convert2rhel_through_foreman
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The Down migration in AddConvert2rhelToHostFacets has wrong table name for subscription facets. This will cause a db:rollback to break.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Roll back the migrations to before this one and verify it runs without errors

