### PR TITLE
Fixes #37816 - List view_smart_proxies as valid permission for non admin user

### DIFF
--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -51,6 +51,11 @@ module Katello
     end
 
     def capsule_content_permissions
+      @plugin.permission :view_smart_proxies,
+                         {
+                           'katello/api/v2/capsules' => [:index, :show]
+                         },
+                         :resource_type => "SmartProxy"
       @plugin.permission :manage_capsule_content,
                          {
                            'katello/api/v2/capsule_content' => [:add_lifecycle_environment, :remove_lifecycle_environment,
@@ -62,7 +67,7 @@ module Katello
       @plugin.permission :view_capsule_content,
                          {
                            'katello/api/v2/capsule_content' => [:counts, :lifecycle_environments, :available_lifecycle_environments, :sync_status],
-                           'smart_proxies' => [:pulp_storage, :pulp_status, :show_with_content],
+                           'smart_proxies' => [:pulp_storage, :pulp_status, :show_with_content, :index],
                            'katello/api/v2/capsules' => [:index, :show]
                          },
                          :resource_type => "SmartProxy"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* When trying to query smart proxies with curl or hammer on a user that is not an admin, the `view_smart_proxies` permission is needed from Foreman, we did not have this before and would only list Katello permissions. We hard code `view_smart_proxies` here when getting the proxies from Foreman https://github.com/Katello/katello/blob/746bda76b50cbe6a321f17994dcd0cd13d97c49b/app/controllers/katello/api/v2/capsules_controller.rb#L13

```bash
{"message":"Access denied","details":"Missing one of the required permissions: manage_capsule_content","missing_permissions":["manage_capsule_content"]}
}
```

#### Considerations taken when implementing this change?

* Make sure you can still see Smart Proxies

#### What are the testing steps for this pull request?
* Create a user with a role that only has `view_capsule_content` and `manage_capsule_content`
* Try to curl and see the error message `curl -k -u unauth:unauth https://localhost/katello/api/capsules/`
* Apply PR
* Try the curl again and see if it shows the missing `view_smart_proxies` permission
* Apply the permission and see if curl completes without an error