### PR TITLE
Fixes #37820 - If a smart proxy sync task fails in plan, we don't report it in sync status

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -2,6 +2,7 @@ module Actions
   module Katello
     module CapsuleContent
       class Sync < ::Actions::EntryAction
+        middleware.do_not_use Dynflow::Middleware::Common::Transaction
         include ::Actions::ObservableAction
         def resource_locks
           :link


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
By default, plan phase and finalize phase in actions are wrapped in a single transaction. Any error in these phases rolls back all DB changes during the phase.
One of those changes is a link record to the task that links the resource (smart proxy in this action) and the task so we can query the tasks back using for_resource helper like here: https://github.com/Katello/katello/blob/746bda76b50cbe6a321f17994dcd0cd13d97c49b/app/models/katello/concerns/smart_proxy_extensions.rb#L460

The issue is when the action fails during the plan phase the link record is deleted as part of the transaction rollback.
#### Considerations taken when implementing this change?
We can turn the transaction middleware off for an action. Doing this for smart proxy sync means that any DB changes made during a failed plan/finalize phase will persist.
Looking at the capsule sync task, the only DB op we do in finalize is around audit records. We should be able to live without having it wrapped in a transaction.
#### What are the testing steps for this pull request?
1. Have a server and proxy.
2. Sync.
3. Turn the proxy off and start a proxy sync.
4. It will fail.
5. Refresh page and you'll not see the failed task being reported.
6. With this PR it ill show last task as failed.
7. Try the same with some error in run phase. Use fail "random error" in any planned action's run phase to mimic this for example.
8. Failed task should still show up in proxy details page.
 