### PR TITLE
Fixes #37788 - Remove duplicate header in bulk host pkg+errata table

### DIFF
--- a/webpack/components/extensions/Hosts/BulkActions/BulkErrataWizard/02_BulkErrataTable.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkErrataWizard/02_BulkErrataTable.js
@@ -148,8 +148,6 @@ const BulkErrataTable = () => {
         showCheckboxes
         apiUrl={ERRATA_URL}
         apiOptions={apiOptions}
-        headerText={__('Errata')}
-        header={null}
         controller="errata"
         customSearchProps={customSearchProps}
         creatable={false}

--- a/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/02_BulkPackagesTable.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/02_BulkPackagesTable.js
@@ -133,8 +133,6 @@ const BulkPackagesTable = ({
         showCheckboxes
         apiUrl={PACKAGES_URL}
         apiOptions={apiOptions}
-        headerText={__('Packages')}
-        header={null}
         controller="packages"
         customSearchProps={customSearchProps}
         creatable={false}

--- a/webpack/components/extensions/Hosts/BulkActions/HostReview.js
+++ b/webpack/components/extensions/Hosts/BulkActions/HostReview.js
@@ -122,8 +122,6 @@ const HostReview = ({
         showCheckboxes
         apiUrl={HOSTS_API_PATH}
         apiOptions={apiOptions}
-        headerText={__('Hosts')}
-        header={null}
         controller="hosts"
         creatable={false}
         replacementResponse={response}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Removed the Duplicate header that was in the `packages` , `hosts`, and `errata` bulk host actions table, that was caused by a change in the `TableIndexPage` component in Foreman.
* Removed `headerText` and `header` to accomplish the above

#### Considerations taken when implementing this change?

* Made sure the pages in the table rendered without any errors
* Sketch for reference - https://www.sketch.com/s/61da8e36-f11c-44fd-a80a-9739efcff4d9/a/OeO7L2m

#### What are the testing steps for this pull request?

* Have a content host with packages and erratas registered
* On the new All hosts page click the host checkbox then do manage -> packages
* Check to make sure the duplicate `packages` header is gone, then click to review hosts and make sure the duplicate `hosts` header is gone
* Goto the all hosts page and click the host checkbox, select manage -> errata
* Make sure the duplicate `errata` header is removed

Without PR:

![Screenshot 2024-09-16 at 11-36-42 Errata](https://github.com/user-attachments/assets/afaa0291-ed8a-4a0d-92bf-bfad0917c04d)
![Screenshot 2024-09-16 at 11-36-18 Hosts](https://github.com/user-attachments/assets/fd82458f-ee2b-4cd4-8df5-c3c73e705dce)
![Screenshot 2024-09-16 at 11-36-09 Packages](https://github.com/user-attachments/assets/90d58fea-850e-481b-8755-a461f7b3a839)


With PR:

![Screenshot 2024-09-16 at 11-24-22 Hosts](https://github.com/user-attachments/assets/8ff36e58-1299-4837-af69-cb4054d1ac0d)
![Screenshot 2024-09-16 at 11-24-09 Hosts](https://github.com/user-attachments/assets/c0190813-961d-4d24-a0fa-bf6a823dc689)
![Screenshot 2024-09-16 at 11-23-51 Hosts](https://github.com/user-attachments/assets/387bc7cf-e440-42c8-911f-20b602067289)
