### PR TITLE
Fixes #37822 - Re-raise non-container push repo validation errors

### DIFF
--- a/app/lib/actions/katello/repository/create_root.rb
+++ b/app/lib/actions/katello/repository/create_root.rb
@@ -5,11 +5,12 @@ module Actions
         def plan(root, relative_path = nil)
           begin
             root.save!
-          rescue ActiveRecord::RecordInvalid
-            if root.is_container_push
+          rescue ActiveRecord::RecordInvalid => e
+            if root.is_container_push && e.message.include?("Container Repository Name") && e.message.include?("conflicts with an existing repository")
               logger.warn("Skipping repository creation as container push repository already exists: #{root.container_push_name}")
               return
             end
+            raise e
           end
           repository = ::Katello::Repository.new(:environment => root.organization.library,
                                       :content_view_version => root.organization.library.default_content_view_version,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Re-raise non-container push name conflict validation errors on repository saves.
#### Considerations taken when implementing this change?
The earlier patch was catching *all* validation errors and rescuing silently. Too wide a net resulting in silenced errors on other validations.
#### What are the testing steps for this pull request?
1. Create a product and create a repo.
2. Try creating another repo of same name.
3. You should see a proper validation error.
4. Try any other validation errors to make sure error path looks good.

To test that the container push race condition suppression still works, use steps here: https://github.com/Katello/katello/pull/11129#issue-2505854718