### PR TITLE
Fixes #37779 - Handle empty CVE in InfoProvider content_view_info

### DIFF
--- a/app/models/katello/host/info_provider.rb
+++ b/app/models/katello/host/info_provider.rb
@@ -35,8 +35,11 @@ module Katello
       end
 
       def content_view_info(content_view_environment)
+        return {} if content_view_environment.blank?
+
         content_view = content_view_environment.content_view
         return {} if content_view.blank?
+
         {
           'label' => content_view.try(:label),
           'latest-version' => content_view.try(:latest_version),


### PR DESCRIPTION
Empty CVE in content_view_info causes a render error during host creation from the image.

(cherry picked from commit eddaf06bdbfb90f8540b38a4d4cf587e606b9a88)