### PR TITLE
Fixes #37798 - Fix AngularJS handling of AK CVEs and add warning banner for multi-env AKs

### DIFF
--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -137,6 +137,7 @@ module Katello
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
     def assign_single_environment(
       content_view_id: nil, lifecycle_environment_id: nil, environment_id: nil,
       content_view: nil, lifecycle_environment: nil, environment: nil
@@ -159,8 +160,14 @@ module Katello
       end
       fail _("Unable to create ContentViewEnvironment. Check the logs for more information.") if content_view_environment.nil?
 
-      self.content_view_environments = [content_view_environment]
+      if self.content_view_environments.include?(content_view_environment)
+        Rails.logger.info("Activation key '#{name}' already has the content view environment '#{content_view_environment.content_view_name}' and environment '#{content_view_environment.environment&.name}'.")
+      else
+        self.content_view_environments = [content_view_environment]
+      end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity
 
     def usage_count
       subscription_facet_activation_keys.count

--- a/app/views/katello/api/v2/activation_keys/base.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/base.json.rabl
@@ -3,6 +3,11 @@ extends 'katello/api/v2/common/timestamps'
 
 attributes :id, :name, :description, :unlimited_hosts, :auto_attach
 
+node :multi_content_view_environment do |ak|
+  ak.multi_content_view_environment?
+end
+
+# single cv/lce for backward compatibility
 node :content_view_id do |ak|
   ak.single_content_view&.id
 end

--- a/app/views/katello/api/v2/content_facet/base.json.rabl
+++ b/app/views/katello/api/v2/content_facet/base.json.rabl
@@ -32,6 +32,10 @@ child :content_view_environments => :content_view_environments do
   end
 end
 
+node :multi_content_view_environment do |content_facet|
+  content_facet.multi_content_view_environment?
+end
+
 # single cv/lce for backward compatibility
 node :content_view do |content_facet|
   content_view = content_facet.single_content_view

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-info.html
@@ -6,6 +6,12 @@
   </span>
 </div>
 
+<div bst-alert="warning" ng-if="activationKey.multi_content_view_environment">
+  <span translate>
+    This activation key has multiple content view environments, which are not yet displayed in the web UI. Changing the content view or lifecycle environment here will overwrite the activation key's multiple environments. To avoid this, update the activation key via Hammer.
+  </span>
+</div>
+
 <div data-extend-template="layouts/two-column-details.html">
   <div data-block="left-column">
     <h4 translate>Basic Information</h4>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

1. When you save an activation key, the AngularJS activation key details page has always sent incorrect `content_view_id` and `environment_id` params which didn't match the `environment` and `content_view` nested params. Example:

```
"content_view_id"=>3,
 "content_view"=>{"id"=>2, "name"=>"cv2"},
 "environment_id"=>5,
 "environment"=>
  {"library"=>false,
   "registry_name_pattern"=>nil,
   "registry_unauthenticated_pull"=>false,
   "id"=>2,
   "name"=>"dev",
```
(note the nonmatching IDs)

 The API previously compensated for this, until https://github.com/Katello/katello/pull/11135. Now, we compensate for it again.
2. Add a warning banner to the activation key details page: 
![image](https://github.com/user-attachments/assets/2cc6b4af-b8bd-4d88-b52a-41d76fb2ffd6)

3. Ensure that you can make other edits to activation keys without overwriting the AK's content view environments.

#### Considerations taken when implementing this change?

This is somewhat of a stopgap for the UI until we can get true multi-environment display built. The plan is
1. fix what's broken and warn about known issue <-- you are here
2. display multi-env AKs in the web UI <-- future
3. allow you to change CVEs of multi-env AKs in the web UI <-- future

#### What are the testing steps for this pull request?

Create a multi-CV activation key
Make an edit to the description or other AK fields
Ensure that the AK remains a multi-CV AK (you can check by looking for the banner, or looking at the API response `multi_content_view_environment` value
Ensure that you can change an AK's single cv/lce with no errors
Ensure that you can change a multi-env AK's cv/lce in the web UI. This will cause it to become a single-env AK; this is expected (you didn't read that banner, did you? ;)

