### PR TITLE
Fixes #37832 - Don't use cached manifest expiration date after manifest refresh

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -50,6 +50,7 @@ module Katello
     param :id, :number, :desc => N_("organization ID"), :required => true
     def show
       @render_template = 'katello/api/v2/organizations/show'
+      @organization.manifest_expiration_date(cached: false) if params[:force_manifest_expire_cache]
       super
     end
 

--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
@@ -32,7 +32,7 @@ class ManageManifestModal extends Component {
     }
 
     if (prevProps.taskInProgress && !this.props.taskInProgress) {
-      this.props.loadOrganization();
+      this.props.loadOrganization({ force_manifest_expire_cache: true });
       this.props.loadManifestHistory();
     }
 


### PR DESCRIPTION

#### What are the changes introduced in this pull request?

1. Introduce a new undocumented API param, `force_manifest_expire_cache`, in the Organizations API controller. This calls `manifest_expiration_date` with `cached: false`, making sure we make the call to local Candlepin and get the up-to-date manifest expiration date.
2. Pass this param from the Subscriptions page when we're finished refreshing a manifest.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1. Import a BLANK manifest with expiration date < 365 days
2. Refresh the manifest
3. Click Manage Manifest

The expiration date should be extended to one year from today's date, but still shows the old expiration date. Refreshing the browser page resolves the issue.

Now, check out the PR
Delete your manifest
Import the same manifest from the zip file (showing old expiration date)
Now refresh the manifest again.

You should immediately see the new expiration date, with no browser refresh needed.

Important: Make sure you reproduce the issue first. I was only able to reproduce it with a BLANK manifest (with no subscriptions). Manifests with subscriptions don't seem to have the issue.
