### PR TITLE
Fixes #37831 - Don't filter job template install content by bound repos

### DIFF
--- a/app/views/foreman/job_templates/install_errata_by_search_query.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query.erb
@@ -15,7 +15,7 @@ foreign_input_sets:
   exclude: action,package
 %>
 
-<% advisory_ids = @host.advisory_ids(search: input("Errata search query")) -%>
+<% advisory_ids = @host.advisory_ids(search: input("Errata search query"), check_installable_for_host: false) -%>
 <% render_error(N_("No errata matching given search query")) if !input("Errata search query").blank? && advisory_ids.blank? -%>
 # RESOLVED_ERRATA_IDS=<%= advisory_ids.join(',') %>
 

--- a/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
@@ -12,7 +12,7 @@ template_inputs:
   required: false
 %>
 
-<% advisory_ids = @host.advisory_ids(search: input("Errata search query")) -%>
+<% advisory_ids = @host.advisory_ids(search: input("Errata search query"), check_installable_for_host: false) -%>
 <% render_error(N_("No errata matching given search query")) if !input("Errata search query").blank? && advisory_ids.blank? -%>
 # RESOLVED_ERRATA_IDS=<%= advisory_ids.join(',') %>
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Stops RPM, Deb, and Errata installation jobs from limiting content searches to what Katello thinks is applicable to a host. If a user made changes to reposets, the applicability data could be out of date. This change lets `dnf` rather than Katello be the final determination of whether or not some content is installable.

There's a bonus too -- if the dnf run completes, the package profile will get uploaded, which will in turn update applicability.

#### Considerations taken when implementing this change?
I couldn't think of any reason why Katello needs to block content installation attempts when `dnf` can do it itself.

I considered just updating the error message to tell the user that the package profile may need updating. However, I think it's a bit of a technical thing to have users worry about.

#### What are the testing steps for this pull request?
1) Enable a repository set on a host but don't do anything to get the package profile re-uploaded
  -> We want the package profile to be stale so that packages are installable but Katello doesn't know that
2) Try to install **both** packages and errata that should be installable even though Katello doesn't think so
3) Without the patch, the job will fail on Katello not being able to find the packages / errata. With the patch, the job should succeed (or at least `dnf` will be the one to report any issues).
4) Try other package actions, like updating them and removing them with and without stale package profiles
5) Think -- are there any other scenarios that this change might break?