### PR TITLE
Fixes #37839 - bold skip dependency solving checkbox text

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
@@ -119,7 +119,7 @@
     <div class="checkbox" ng-show="updates.length > 0">
       <label>
         <input name="noDepSolve" ng-model="noDepSolve" type="checkbox"/>
-        <span translate>Skip dependency solving for a significant speed increase. If the update cannot be applied to the host, delete the incremental content view version and retry the application with dependency solving turned on.</span>
+        <b><span translate>Skip dependency solving for a significant speed increase. If the update cannot be applied to the host, delete the incremental content view version and retry the application with dependency solving turned on.</span></b>
       </label>
     </div>
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Bolds "Skip dependency solving for a significant speed increase" text when performing an incremental update via the UI.

#### Considerations taken when implementing this change?
Should all or some of the text be bold?

#### What are the testing steps for this pull request?
Try to apply some errata to a host that is applicable but not installable. Decide which looks better:

![image](https://github.com/user-attachments/assets/f5d9553d-41ac-4760-8fc0-3de811503e11)

or

![image](https://github.com/user-attachments/assets/36b95726-439a-4b9a-99f5-3e9b634d405a)
