### PR TITLE
Fixes #37840 - Update RHEL 7 recommended repos and add client 2 repos

### DIFF
--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -20,17 +20,17 @@ const recommendedRepositoriesRHEL = [
   'rhel-8-for-x86_64-appstream-kickstart',
   'rhel-8-for-x86_64-baseos-eus-rpms',
   'rhel-8-for-x86_64-appstream-eus-rpms',
-  'rhel-7-server-rpms',
-  'rhel-7-server-optional-rpms',
-  'rhel-7-server-extras-rpms',
-  'rhel-7-server-kickstart',
+  'rhel-7-server-els-rpms',
+  'rhel-7-server-els-optional-rpms',
 ];
 
 const recommendedRepositoriesSatTools = [
   'satellite-client-6-for-rhel-9-x86_64-rpms',
   'satellite-client-6-for-rhel-8-x86_64-rpms',
-  'rhel-7-server-satellite-client-6-rpms',
-  'rhel-6-server-els-satellite-client-6-rpms',
+  'rhel-7-server-els-satellite-client-6-rpms',
+  'rhel-7-server-els-satellite-6-client-2-rpms',
+  'satellite-6-client-2-for-rhel-8-x86_64-rpms',
+  'satellite-6-client-2-for-rhel-9-x86_64-rpms',
 ];
 
 const recommendedRepositoriesMisc = [


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Swapped the RHEL 7 repos for the extended update support ones, since it's in EOL
* Removed the RHEL 7 kickstart and extras repo from the recommended page
* Added the new client tools repo for RHEL 7 EUS/8/9

#### Considerations taken when implementing this change?
* Removed the RHEL 7 extra repo since RHEL 7 is in extended support, no need to show it anymore on the recommended page and there is not an ELS repo for it, see `Red Hat Enterprise Linux 7 Extended Lifecycle Support Exclusions` in https://access.redhat.com/support/policy/updates/rhel7-els-support-maintenance-policy

#### What are the testing steps for this pull request?
* Checkout PR
* Make sure you see ELS repos for EL7 and the client tools repo, need an ELS sub to enable it but should still show up.
* Not sure if the client tools one will show up since it's not on the CDN yet, but pulled that from here given to me by the delivery team: https://docs.google.com/spreadsheets/d/1Fa__6ruFdswDRylaHsSNShP4TjqRtQb0bhWHiT1kQLg/edit?gid=398726148#gid=398726148
