### PR TITLE
Fixes #37845 - Errata modal breaks header css

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-modal-helper.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-modal-helper.service.js
@@ -39,7 +39,6 @@ angular.module('Bastion.content-hosts').service('ContentHostsModalHelper', ['$ui
             $uibModal.open({
                 templateUrl: 'content-hosts/bulk/views/content-hosts-bulk-errata-modal.html',
                 controller: 'ContentHostsBulkErrataModalController',
-                openedClass: 'bastion',
                 size: 'lg',
                 resolve: {
                     hostIds: this.resolveFunc()


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
remove bastion classname from the body tag

#### Considerations taken when implementing this change?
The class name does not look to change anything in the modal, and is breaking the header css since its added to the body and not the modal

#### What are the testing steps for this pull request?
Test that the errata modal in content hosts still works as expected 