### PR TITLE
Fixes #37827 - Bring back sync status progress bars on initial page load

### DIFF
--- a/app/assets/javascripts/katello/sync_management/sync_management.js
+++ b/app/assets/javascripts/katello/sync_management/sync_management.js
@@ -205,10 +205,22 @@ KT.content = (function () {
           $(this).collapse();
         });
     };
+    populate_repo_status = function () {
+      var ids = [];
+      $.each(KT.repo_status, function (repo_id, status) {
+        if (status.is_running) {
+          ids.push(repo_id);
+          KT.content.draw_syncing(repo_id, status.progress.progress, status.sync_id);
+        }
+      });
+      KT.content.reset_products(KT.repo_status);
+      KT.content_actions.addSyncing(ids);
+    }
 
   return {
     updateProduct: updateProduct,
     updateRepo: updateRepo,
+    populateRepoStatus: populate_repo_status,
     finishRepo: finishRepo,
     select_all: select_all,
     select_none: select_none,
@@ -346,15 +358,7 @@ KT.content_actions = (function () {
   };
 })();
 
-var ids = [];
-$.each(KT.repo_status, function (repo_id, status) {
-  if (status.is_running) {
-    ids.push(repo_id);
-    KT.content.draw_syncing(repo_id, status.progress.progress, status.sync_id);
-  }
-});
-KT.content.reset_products(KT.repo_status);
-KT.content_actions.addSyncing(ids);
+KT.content.populateRepoStatus();
 
 $("#select_all").on("click", KT.content.select_all);
 $("#select_none").on("click", KT.content.select_none);

--- a/app/views/katello/sync_management/index.html.erb
+++ b/app/views/katello/sync_management/index.html.erb
@@ -8,9 +8,9 @@
       "complete": "<%= escape_javascript(_('Sync complete.')) %>",
       "no_start_time": "<%= escape_javascript(_('No start time currently available.')) %>"
     });
-
       KT.repo_status = JSON.parse('<%= escape_javascript(@repo_status.to_json.html_safe) %>');
       KT.permissions = { "syncable" : <%= any_syncable? %> };
+      KT.content.populateRepoStatus();
   </script>
 <% end -%>
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Seems the code in `app/assets/javascripts/katello/sync_management/sync_management.js` to populate the sync status progress bars was running prematurely, before `app/views/katello/sync_management/index.html.erb` had a chance to populate the data. I moved it into a function and now run it right when we need it. The effect should be that the progress bars return to the page, even on initial page load. The second effect is that the "Active only" checkbox becomes useful again, because its function is to show you only the rows that have those progress bars.

#### Considerations taken when implementing this change?

I barely understand any of this ancient code so please tell me if I did something wrong lol

#### What are the testing steps for this pull request?

Get some really big, slow-syncing repos
Go to the sync_management page
Hit Select All (and optionally Expand All, if you want to see what you've selected)
Click Synchronize Now and immediately refresh the browser page

On page load, you should now see the progress bars (before you'd just see the task status - "Running" etc.)
Also, the "Active only" checkbox should work.
