### PR TITLE
Fixes #37858 - Send events on angular translation load

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/i18n/i18n.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/i18n/i18n.module.js
@@ -5,6 +5,10 @@
  * @description
  *   Module for internationalization.
  */
+var loadAngularJSi18n = new Event('loadAngularJSi18n');
+
 angular.module('Bastion.i18n', [
     'gettext'
 ]);
+
+document.dispatchEvent(loadAngularJSi18n);

--- a/engines/bastion/vendor/assets/javascripts/bastion/angular-gettext/angular-gettext.js
+++ b/engines/bastion/vendor/assets/javascripts/bastion/angular-gettext/angular-gettext.js
@@ -1,3 +1,5 @@
+var loadAngularJSgettext = new Event('loadAngularJSgettext');
+
 angular.module('gettext', []);
 angular.module('gettext').constant('gettext', function (str) {
   /*
@@ -343,3 +345,5 @@ angular.module('gettext').factory('gettextPlurals', function () {
     }
   };
 });
+
+document.dispatchEvent(loadAngularJSgettext);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Sending events after loading i18n and gettext in angular

#### Considerations taken when implementing this change?
Could not know when they are loaded otherwise. 
Tried using MutationObserver to see when the script to load them was called, but that happens just before they are loaded.

The deface for branding needs to happen (from `engines/bastion/app/views/bastion/layouts/assets.html.erb`):
* after angular and i18n, gettext are created: ` <%= javascript_include_tag('bastion/bastion', {type: 'module'})%>`
* and before the first translation is used with `translate(...`, I think its in: `<%= javascript_include_tag('bastion_katello/bastion_katello',  {type: 'module'}) %>`

#### What are the testing steps for this pull request?
I dont see how it could break anything
