### PR TITLE
Fixes #36404 - report content added for modules + container manifests

### DIFF
--- a/lib/katello/repository_types/docker.rb
+++ b/lib/katello/repository_types/docker.rb
@@ -27,10 +27,12 @@ Katello::RepositoryTypeManager.register(::Katello::Repository::DOCKER_TYPE) do
                :priority => 1,
                :pulp3_service_class => ::Katello::Pulp3::DockerManifest,
                :removable => true,
-               :uploadable => true
+               :uploadable => true,
+               :primary_content => true
   content_type Katello::DockerManifestList,
                :priority => 2,
-               :pulp3_service_class => ::Katello::Pulp3::DockerManifestList
+               :pulp3_service_class => ::Katello::Pulp3::DockerManifestList,
+               :primary_content => true
   content_type Katello::DockerTag,
                :priority => 3,
                :pulp3_service_class => ::Katello::Pulp3::DockerTag,

--- a/lib/katello/repository_types/yum.rb
+++ b/lib/katello/repository_types/yum.rb
@@ -27,7 +27,8 @@ Katello::RepositoryTypeManager.register(::Katello::Repository::YUM_TYPE) do
     :uploadable => true
   content_type Katello::ModuleStream,
     :priority => 2,
-    :pulp3_service_class => ::Katello::Pulp3::ModuleStream
+    :pulp3_service_class => ::Katello::Pulp3::ModuleStream,
+    :primary_content => true
   content_type Katello::Erratum, :priority => 3,
     :pulp3_service_class => ::Katello::Pulp3::Erratum,
     :primary_content => true, :mutable => true


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds module streams, container manifests, and container manifest lists as "primary content". This means that new content being synced will stop the "no content added" text from showing up on the repository sync presenter text. It also means the index content output will show how many new units were added of these types.

#### Considerations taken when implementing this change?
The original issue just asked for container manifests to stop doing this. I also included module streams because they're also important and not originally included.

#### What are the testing steps for this pull request?
1) Build a container image and push it to Quay.
2) Sync that repository, **ensuring to use the additive mirroring type**.
3) Make some small change to the Containerfile, rebuild, and repush to Quay.
4) Sync the repository again from the repository details page (so you see the special sync info presenter).
5) Notice how new manifests were added. Without my fix, the sync would still report "no content added".
6) Now, cd into `test/fixtures/test_repos/zoo/` in your dev machine.
7) Delete everything in the repodata folder and run `create.sh`
8) Serve up that repository using `python3.11 -m http.server 33333`
9) Sync that repository, still using additive
10) Close your http server
11) Delete everything in the repodata folder
12) Edit some module stream in modules.yaml. Consider changing a description and **bumping up the version**.
13) Resync the repo. Without my fix, it should add module streams but report no content added.

Now consider -- should any other content types be considered primary?