### PR TITLE
Fixes #37861 - Update web UI for multi-CV activation key display

### DIFF
--- a/app/views/katello/api/v2/activation_keys/base.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/base.json.rabl
@@ -7,6 +7,30 @@ node :multi_content_view_environment do |ak|
   ak.multi_content_view_environment?
 end
 
+child :content_view_environments => :content_view_environments do
+  node :content_view do |cve|
+    {
+      id: cve.content_view&.id,
+      name: cve.content_view&.name,
+      composite: cve.content_view&.composite,
+      content_view_version: cve.content_view_version&.version,
+      content_view_version_id: cve.content_view_version&.id,
+      content_view_version_latest: cve.content_view_version&.latest?,
+      content_view_default: cve.content_view&.default?
+    }
+  end
+  node :lifecycle_environment do |cve|
+    {
+      id: cve.lifecycle_environment&.id,
+      name: cve.lifecycle_environment&.name,
+      lifecycle_environment_library: cve.lifecycle_environment&.library?
+    }
+  end
+  node :candlepin_name do |cve|
+    cve.candlepin_name
+  end
+end
+
 # single cv/lce for backward compatibility
 node :content_view_id do |ak|
   ak.single_content_view&.id

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-info.html
@@ -8,7 +8,7 @@
 
 <div bst-alert="warning" ng-if="activationKey.multi_content_view_environment">
   <span translate>
-    This activation key has multiple content view environments, which are not yet displayed in the web UI. Changing the content view or lifecycle environment here will overwrite the activation key's multiple environments. To avoid this, update the activation key via Hammer.
+    This activation key has multiple content view environments, which cannot yet be edited in the web UI. To change this key's content view environments, update the activation key via Hammer.
   </span>
 </div>
 
@@ -56,7 +56,6 @@
           </div>
         </div>
       </dd>
-
 
       <div class="divider"></div>
       <h4 translate>System Purpose</h4>
@@ -123,17 +122,18 @@
           on-delete="clearReleaseVersion()"
           on-save="save(activationKey)">
       </dd>
-
+    </dl>
+    <dl class="dl-horizontal dl-horizontal-left" ng-if="!activationKey.multi_content_view_environment">
       <dt bst-feature-flag="lifecycle_environments">
         <span translate>Environment</span>
       </dt>
       <dd bst-feature-flag="lifecycle_environments">
         <div path-selector="environments"
-             ng-model="activationKey.environment"
-             mode="singleSelect"
-             selection-required="selectionRequired"
-             disabled="denied('edit_activation_keys', activationKey)"
-             disable-trigger="disableEnvironmentSelection">
+            ng-model="activationKey.environment"
+            mode="singleSelect"
+            selection-required="selectionRequired"
+            disabled="denied('edit_activation_keys', activationKey)"
+            disable-trigger="disableEnvironmentSelection">
         </div>
       </dd>
 
@@ -142,14 +142,14 @@
       </dt>
       <dd bst-feature-flag="lifecycle_environments">
         <div bst-edit-select="activationKey.content_view.name"
-             readonly="denied('edit_activation_keys', activationKey) || activationKey.environment === undefined || activationKey.environment === null"
-             selector="activationKey.content_view.id"
-             options="contentViews()"
-             on-cancel="cancelContentViewUpdate()"
-             on-save="saveContentView(activationKey)"
-             deletable="activationKey.content_view"
-             on-delete="resetEnvironment(activationKey)"
-             edit-trigger="editContentView">
+            readonly="denied('edit_activation_keys', activationKey) || activationKey.environment === undefined || activationKey.environment === null"
+            selector="activationKey.content_view.id"
+            options="contentViews()"
+            on-cancel="cancelContentViewUpdate()"
+            on-save="saveContentView(activationKey)"
+            deletable="activationKey.content_view"
+            on-delete="resetEnvironment(activationKey)"
+            edit-trigger="editContentView">
         </div>
 
         <div bst-alert="info" ng-show="editEnvironment">
@@ -159,6 +159,14 @@
           <p translate>You must select a new content view before your change of environment can be saved. Use the cancel button on content view selection to revert your environment selection.</p>
         </div>
       </dd>
+    </dl>
+    <dl class="dl-horizontal dl-horizontal-left">
+      <span id="ak-cve-details" data-ak-details="{{ activationKey }}" class="hidden"></span>
+      <foreman-react-component
+          name="CVEDetailsCard"
+          data-props=""
+          ng-if="activationKey.multi_content_view_environment"
+      ></foreman-react-component>
     </dl>
   </div>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/views/activation-keys.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/views/activation-keys.html
@@ -29,6 +29,7 @@
         <th bst-table-column="consumed"><span translate>Host Limit</span></th>
         <th bst-table-column="environment"><span translate>Environment</span></th>
         <th bst-table-column="contentView"><span translate>Content View</span></th>
+        <th bst-table-column="multi-cv"><span translate>Multi Content View Environment</span></th>
       </tr>
       </thead>
 
@@ -48,6 +49,7 @@
         <td bst-table-cell>{{ activationKey | activationKeyConsumedFilter }}</td>
         <td bst-table-cell>{{ activationKey.environment.name || "" }}</td>
         <td bst-table-cell>{{ activationKey.content_view.name || "" }}</td>
+        <td bst-table-cell>{{ activationKey.multi_content_view_environment ? 'Yes' : 'No' }}</td>
       </tr>
       </tbody>
     </table>

--- a/test/models/content_view_environment_test.rb
+++ b/test/models/content_view_environment_test.rb
@@ -54,8 +54,28 @@ module Katello
     def test_fetch_content_view_environments_invalid_ids_does_not_mutate_array
       dev = katello_environments(:dev)
       input_ids = [0, 999]
-      assert_equal [], ContentViewEnvironment.fetch_content_view_environments(ids: input_ids, organization: dev.organization)
+      assert_raises(HttpErrors::UnprocessableEntity) do
+        ContentViewEnvironment.fetch_content_view_environments(ids: input_ids, organization: dev.organization)
+      end
       assert_equal [0, 999], input_ids # should not have a map! which mutates the input array
+    end
+
+    def test_fetch_content_view_environments_mixed_validity_candlepin_names
+      dev = katello_environments(:dev)
+      view = katello_content_views(:library_dev_view)
+      cve = Katello::ContentViewEnvironment.where(:environment_id => dev, :content_view_id => view).first
+      assert_raises(HttpErrors::UnprocessableEntity) do
+        ContentViewEnvironment.fetch_content_view_environments(labels: ['published_dev_view_dev, bogus'], organization: dev.organization)
+      end
+    end
+
+    def test_fetch_content_view_environments_mixed_validity_ids
+      dev = katello_environments(:dev)
+      view = katello_content_views(:library_dev_view)
+      cve = Katello::ContentViewEnvironment.where(:environment_id => dev, :content_view_id => view).first
+      assert_raises(HttpErrors::UnprocessableEntity) do
+        ContentViewEnvironment.fetch_content_view_environments(ids: [cve.id, 9999], organization: dev.organization)
+      end
     end
   end
 end

--- a/test/models/content_view_environment_test.rb
+++ b/test/models/content_view_environment_test.rb
@@ -62,8 +62,6 @@ module Katello
 
     def test_fetch_content_view_environments_mixed_validity_candlepin_names
       dev = katello_environments(:dev)
-      view = katello_content_views(:library_dev_view)
-      cve = Katello::ContentViewEnvironment.where(:environment_id => dev, :content_view_id => view).first
       assert_raises(HttpErrors::UnprocessableEntity) do
         ContentViewEnvironment.fetch_content_view_environments(labels: ['published_dev_view_dev, bogus'], organization: dev.organization)
       end

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -24,6 +24,7 @@ import ContentViewIcon from '../../../../../scenes/ContentViews/components/Conte
 import { hasRequiredPermissions, hostIsRegistered } from '../../hostDetailsHelpers';
 import ChangeHostCVModal from './ChangeHostCVModal';
 import { truncate } from '../../../../../utils/helpers';
+import InactiveText from '../../../../../scenes/ContentViews/components/InactiveText';
 
 const requiredPermissions = [
   'view_lifecycle_environments', 'view_content_views',
@@ -144,6 +145,9 @@ export const CVEDetailsBareCard = ({
       </CardHeader>
       <CardBody>
         <Flex direction={{ default: 'column' }}>
+          {contentViewEnvironments.length === 0 && (
+            <InactiveText text={__('N/A')} />
+          )}
           {contentViewEnvironments.map(env => (
             <ContentViewEnvironmentDisplay
               key={`${env.lifecycle_environment.name}-${env.content_view.name}`}

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -135,7 +135,7 @@ export const CVEDetailsBareCard = ({
                 toggle={<KebabToggle aria-label="change_content_view_hamburger" onToggle={toggleHamburger} />}
                 isOpen={isDropdownOpen}
                 isPlain
-                ouiaId="change-host-content-view-kebab"
+                ouiaId="change-content-view-environments-card-kebab"
                 position="right"
                 dropdownItems={dropdownItems}
               />

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -95,7 +95,103 @@ ContentViewEnvironmentDisplay.propTypes = {
   }).isRequired,
 };
 
-const HostContentViewDetails = ({
+export const CVEDetailsBareCard = ({
+  contentViewEnvironments, hostPermissions, permissions, dropdownItems,
+  isDropdownOpen, toggleHamburger,
+}) => {
+  const userPermissions = { ...hostPermissions, ...permissions };
+  const showKebab = hasRequiredPermissions(requiredPermissions, userPermissions);
+
+  return (
+    <Card ouiaId="content-view-details-card">
+      <CardHeader>
+        <Flex
+          alignItems={{ default: 'alignItemsCenter' }}
+          justifyContent={{ default: 'justifyContentSpaceBetween' }}
+          style={{ width: '100%' }}
+        >
+          <FlexItem>
+            <Flex
+              alignItems={{ default: 'alignItemsCenter' }}
+              justifyContent={{ default: 'justifyContentSpaceBetween' }}
+            >
+              <FlexItem>
+                <CardTitle>
+                  <FormattedMessage
+                    id="cv-card-title"
+                    defaultMessage="{count, plural, =0 {Content view environments} one {Content view environment} other {Content view environments}}"
+                    values={{
+                      count: contentViewEnvironments.length,
+                    }}
+                  />
+                </CardTitle>
+              </FlexItem>
+            </Flex>
+          </FlexItem>
+          {showKebab && dropdownItems && (
+            <FlexItem>
+              <Dropdown
+                toggle={<KebabToggle aria-label="change_content_view_hamburger" onToggle={toggleHamburger} />}
+                isOpen={isDropdownOpen}
+                isPlain
+                ouiaId="change-host-content-view-kebab"
+                position="right"
+                dropdownItems={dropdownItems}
+              />
+            </FlexItem>
+          )}
+        </Flex>
+      </CardHeader>
+      <CardBody>
+        <Flex direction={{ default: 'column' }}>
+          {contentViewEnvironments.map(env => (
+            <ContentViewEnvironmentDisplay
+              key={`${env.lifecycle_environment.name}-${env.content_view.name}`}
+              contentView={env.content_view}
+              lifecycleEnvironment={env.lifecycle_environment}
+            />
+          ))}
+        </Flex>
+      </CardBody>
+    </Card>
+  );
+};
+
+CVEDetailsBareCard.propTypes = {
+  contentViewEnvironments: PropTypes.arrayOf(PropTypes.shape({
+    content_view: PropTypes.shape({
+      name: PropTypes.string,
+      id: PropTypes.number,
+      composite: PropTypes.bool,
+    }),
+    lifecycle_environment: PropTypes.shape({
+      name: PropTypes.string,
+      id: PropTypes.number,
+    }),
+  })),
+  hostPermissions: PropTypes.shape({
+    edit_hosts: PropTypes.bool,
+  }),
+  permissions: PropTypes.shape({
+    view_content_views: PropTypes.bool,
+    view_lifecycle_environments: PropTypes.bool,
+    promote_or_remove_content_views_to_environments: PropTypes.bool,
+  }),
+  dropdownItems: PropTypes.arrayOf(PropTypes.node),
+  isDropdownOpen: PropTypes.bool,
+  toggleHamburger: PropTypes.func,
+};
+
+CVEDetailsBareCard.defaultProps = {
+  contentViewEnvironments: [],
+  hostPermissions: {},
+  permissions: {},
+  dropdownItems: [],
+  isDropdownOpen: false,
+  toggleHamburger: () => {},
+};
+
+export const ContentViewEnvironmentDetails = ({
   contentViewEnvironments, hostId, hostName, orgId, hostEnvId,
   hostPermissions, permissions, contentSourceId,
 }) => {
@@ -126,57 +222,14 @@ const HostContentViewDetails = ({
 
   return (
     <GridItem rowSpan={1} md={6} lg={4} xl2={3} >
-      <Card ouiaId="content-view-details-card">
-        <CardHeader>
-          <Flex
-            alignItems={{ default: 'alignItemsCenter' }}
-            justifyContent={{ default: 'justifyContentSpaceBetween' }}
-            style={{ width: '100%' }}
-          >
-            <FlexItem>
-              <Flex
-                alignItems={{ default: 'alignItemsCenter' }}
-                justifyContent={{ default: 'justifyContentSpaceBetween' }}
-              >
-                <FlexItem>
-                  <CardTitle>
-                    <FormattedMessage
-                      id="cv-card-title"
-                      defaultMessage="{count, plural, =0 {Content view environments} one {Content view environment} other {Content view environments}}"
-                      values={{
-                        count: contentViewEnvironments.length,
-                      }}
-                    />
-                  </CardTitle>
-                </FlexItem>
-              </Flex>
-            </FlexItem>
-            {showKebab && (
-              <FlexItem>
-                <Dropdown
-                  toggle={<KebabToggle aria-label="change_content_view_hamburger" onToggle={toggleHamburger} />}
-                  isOpen={isDropdownOpen}
-                  isPlain
-                  ouiaId="change-host-content-view-kebab"
-                  position="right"
-                  dropdownItems={dropdownItems}
-                />
-              </FlexItem>
-            )}
-          </Flex>
-        </CardHeader>
-        <CardBody>
-          <Flex direction={{ default: 'column' }}>
-            {contentViewEnvironments.map(env => (
-              <ContentViewEnvironmentDisplay
-                key={`${env.lifecycle_environment.name}-${env.content_view.name}`}
-                contentView={env.content_view}
-                lifecycleEnvironment={env.lifecycle_environment}
-              />
-            ))}
-          </Flex>
-        </CardBody>
-      </Card>
+      <CVEDetailsBareCard
+        isDropdownOpen={isDropdownOpen}
+        toggleHamburger={toggleHamburger}
+        contentViewEnvironments={contentViewEnvironments}
+        hostPermissions={hostPermissions}
+        permissions={permissions}
+        dropdownItems={showKebab ? dropdownItems : []}
+      />
       {hostId &&
         <ChangeHostCVModal
           isOpen={isModalOpen}
@@ -194,7 +247,7 @@ const HostContentViewDetails = ({
   );
 };
 
-HostContentViewDetails.propTypes = {
+ContentViewEnvironmentDetails.propTypes = {
   contentViewEnvironments: PropTypes.arrayOf(PropTypes.shape({
     content_view: PropTypes.shape({
       name: PropTypes.string,
@@ -221,7 +274,7 @@ HostContentViewDetails.propTypes = {
   contentSourceId: PropTypes.number,
 };
 
-HostContentViewDetails.defaultProps = {
+ContentViewEnvironmentDetails.defaultProps = {
   contentViewEnvironments: [],
   hostId: null,
   hostName: '',
@@ -232,10 +285,11 @@ HostContentViewDetails.defaultProps = {
   contentSourceId: null,
 };
 
+
 const ContentViewDetailsCard = ({ hostDetails }) => {
   if (hostIsRegistered({ hostDetails })
     && hostDetails.content_facet_attributes && hostDetails.organization_id) {
-    return (<HostContentViewDetails
+    return (<ContentViewEnvironmentDetails
       hostId={hostDetails.id}
       hostName={hostDetails.name}
       contentSourceId={hostDetails.content_facet_attributes.content_source?.id}
@@ -246,37 +300,6 @@ const ContentViewDetailsCard = ({ hostDetails }) => {
     />);
   }
   return null;
-};
-
-HostContentViewDetails.propTypes = {
-  contentView: PropTypes.shape({
-    name: PropTypes.string,
-    id: PropTypes.number,
-    composite: PropTypes.bool,
-  }).isRequired,
-  hostId: PropTypes.number,
-  hostName: PropTypes.string,
-  contentSourceId: PropTypes.number,
-  orgId: PropTypes.number,
-  hostEnvId: PropTypes.number,
-  hostPermissions: PropTypes.shape({
-    edit_hosts: PropTypes.bool,
-  }),
-  permissions: PropTypes.shape({
-    view_content_views: PropTypes.bool,
-    view_lifecycle_environments: PropTypes.bool,
-    promote_or_remove_content_views_to_environments: PropTypes.bool,
-  }),
-};
-
-HostContentViewDetails.defaultProps = {
-  hostEnvId: null,
-  hostId: null,
-  hostName: '',
-  orgId: null,
-  contentSourceId: null,
-  hostPermissions: {},
-  permissions: {},
 };
 
 ContentViewDetailsCard.propTypes = {

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -38,6 +38,7 @@ import BulkChangeHostCVModal from './components/extensions/Hosts/BulkActions/Bul
 import BulkPackagesWizardModal from './components/extensions/Hosts/BulkActions/BulkPackagesWizard/index.js';
 import BulkErrataWizardModal from './components/extensions/Hosts/BulkActions/BulkErrataWizard/index.js';
 import ActivationKeysSearch from './components/ActivationKeysSearch';
+import { CVEDetailsCard } from './scenes/ActivationKeys/Details/components/CVEDetailsCard.js';
 
 registerReducer('katelloExtends', extendReducer);
 registerReducer('katello', rootReducer);
@@ -102,8 +103,14 @@ registerGetActions({
   tableName: 'hosts',
 });
 
-componentRegistry.register({
-  name: 'ActivationKeysSearch',
-  type: ActivationKeysSearch,
-});
+componentRegistry.registerMultiple([
+  {
+    name: 'ActivationKeysSearch',
+    type: ActivationKeysSearch,
+  },
+  {
+    name: 'CVEDetailsCard',
+    type: CVEDetailsCard,
+  },
+]);
 

--- a/webpack/scenes/ActivationKeys/Details/ActivationKeyDetails.js
+++ b/webpack/scenes/ActivationKeys/Details/ActivationKeyDetails.js
@@ -34,6 +34,7 @@ import { getActivationKey } from './ActivationKeyActions';
 import DeleteModal from './components/DeleteModal';
 import InactiveText from '../../ContentViews/components/InactiveText';
 import SystemPurposeCard from '../../../components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeCard';
+import { CVEDetailsBareCard } from '../../../components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard';
 
 const ActivationKeyDetails = ({ match }) => {
   const dispatch = useDispatch();
@@ -112,6 +113,9 @@ const ActivationKeyDetails = ({ match }) => {
         <Grid className="ak-details-tab-page" hasGutter>
           <GridItem span={6}>
             <SystemPurposeCard akDetails={akDetails} />
+          </GridItem>
+          <GridItem span={6}>
+            <CVEDetailsBareCard contentViewEnvironments={akDetails.contentViewEnvironments} />
           </GridItem>
         </Grid>
       </PageSection>

--- a/webpack/scenes/ActivationKeys/Details/components/CVEDetailsCard.js
+++ b/webpack/scenes/ActivationKeys/Details/components/CVEDetailsCard.js
@@ -1,0 +1,37 @@
+import React, { useRef, useState } from 'react';
+import { propsToCamelCase } from 'foremanReact/common/helpers';
+import { CVEDetailsBareCard } from '../../../../components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard';
+
+const getAKDetailsFromDOM = (node) => {
+  try {
+    return propsToCamelCase(JSON.parse(node.dataset.akDetails));
+  } catch (e) {
+    return null;
+  }
+};
+export const CVEDetailsCard = () => { // used as foreman-react-component, takes no props
+  const akDetailsNode = useRef(document.getElementById('ak-cve-details')).current;
+  const [akDetails, setAkDetails] = useState(getAKDetailsFromDOM(akDetailsNode));
+
+  const observer = new MutationObserver((mutationsList) => {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const mutation of mutationsList) {
+      if (mutation.type === 'attributes' && mutation.attributeName.startsWith('data-')) {
+        akDetailsNode.current = document.getElementById('ak-cve-details');
+        setAkDetails(getAKDetailsFromDOM(akDetailsNode));
+      }
+    }
+  });
+
+  // Start observing akDetailsNode for attribute changes
+  if (akDetailsNode) observer.observe(akDetailsNode, { attributes: true });
+
+  if (!akDetails || !akDetails.contentViewEnvironments) return null;
+  return (
+    <CVEDetailsBareCard
+      contentViewEnvironments={akDetails.contentViewEnvironments}
+    />
+  );
+};
+
+export default CVEDetailsCard;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Display multiCV activation key details in the web UI. Does __not__ include changing multiCV activation keys' content view environments.

1. Extract the `ContentViewEnvironmentDetails` card into a `CVEDetailsBareCard` so we can reuse it. This was necessary because the `ContentViewEnvironmentDetails` was coupled to a `useUrlParams` which made it not reusable enough.
2. Add `content_view_environments` nodes to activation key rabl
3. Display the new content view environments details on the Angular activation key details page.
4. Display the new content view environments details on the new experimental activation key details page.

![image](https://github.com/user-attachments/assets/47ab6a38-2c0f-4079-89d7-56aa41627fe3)


#### Considerations taken when implementing this change?

I'm using `foreman-react-component` (its first use in Katello) to render a React component on an AngularJS page. It's a bit hacky but it works!

When an activation key is single-environment, we fall back to displaying what we always have, rather than displaying the new card. This should help with existing web UI automation tests.

#### What are the testing steps for this pull request?

Create one or more multiCV activation keys
Test both pages 
make sure edits to other fields still work
display should work fine as well
