### PR TITLE
Refs #37785 - Race condition during container push

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -354,7 +354,7 @@ module Katello
           container_push_name: @container_path_input,
           container_push_name_format: @container_push_name_format
         )
-        sync_task(::Actions::Katello::Repository::CreateRoot, root, @container_path_input)
+        sync_task(::Actions::Katello::Repository::CreateContainerPushRoot, root, @container_path_input)
       end
     end
 

--- a/app/lib/actions/katello/repository/create_container_push_root.rb
+++ b/app/lib/actions/katello/repository/create_container_push_root.rb
@@ -1,0 +1,44 @@
+module Actions
+  module Katello
+    module Repository
+      class CreateContainerPushRoot < Actions::EntryAction
+        def plan(root, relative_path = nil)
+          repository = ::Katello::Repository.new(:environment => root.organization.library, :content_view_version => root.organization.library.default_content_view_version, :root => root)
+          #Container push may concurrently call root add several times before the db can update.
+          # If the root already exists, we can skip the creation of the root and repository.
+          # We acquire a lock on the product to ensure that the root is not created multiple times by different workers.
+
+          root.product.with_lock do
+            begin
+              root.save!
+            rescue ActiveRecord::RecordInvalid => e
+              if root.is_container_push && e.message.include?("Name has already been taken for this product")
+                Rails.logger.debug("Skipping root repository creation as container push root repository already exists: #{root.container_push_name}")
+                return
+              end
+              raise e
+            end
+            repository.container_repository_name = relative_path if root.docker? && root.is_container_push
+            repository.relative_path = relative_path || repository.custom_repo_path
+            begin
+              repository.save!
+            rescue ActiveRecord::RecordInvalid => e
+              if root.is_container_push && e.message.include?("Container Repository Name") && e.message.include?("conflicts with an existing repository")
+                Rails.logger.debug("Skipping repository creation as container push repository already exists: #{root.container_push_name}")
+                return
+              end
+              raise e
+            end
+          end
+
+          action_subject(repository)
+          plan_action(::Actions::Katello::Repository::Create, repository)
+        end
+
+        def humanized_name
+          _("Create Container Push Repository Root")
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/create_root.rb
+++ b/app/lib/actions/katello/repository/create_root.rb
@@ -2,23 +2,13 @@ module Actions
   module Katello
     module Repository
       class CreateRoot < Actions::EntryAction
-        def plan(root, relative_path = nil)
-          begin
-            root.save!
-          rescue ActiveRecord::RecordInvalid => e
-            if root.is_container_push && e.message.include?("Container Repository Name") && e.message.include?("conflicts with an existing repository")
-              logger.warn("Skipping repository creation as container push repository already exists: #{root.container_push_name}")
-              return
-            end
-            raise e
-          end
+        def plan(root)
+          root.save!
           repository = ::Katello::Repository.new(:environment => root.organization.library,
-                                      :content_view_version => root.organization.library.default_content_view_version,
-                                      :root => root)
-          repository.container_repository_name = relative_path if root.docker? && root.is_container_push
-          repository.relative_path = relative_path || repository.custom_repo_path
+                                                 :content_view_version => root.organization.library.default_content_view_version,
+                                                 :root => root)
+          repository.relative_path = repository.custom_repo_path
           repository.save!
-
           action_subject(repository)
           plan_action(::Actions::Katello::Repository::Create, repository)
         end

--- a/test/controllers/api/registry/registry_proxies_controller_test.rb
+++ b/test/controllers/api/registry/registry_proxies_controller_test.rb
@@ -993,7 +993,7 @@ module Katello
         @controller.instance_variable_set(:@container_path_input, container_push_name)
         @controller.instance_variable_set(:@container_push_name_format, container_push_name_format)
         @controller.expects(:sync_task).with(
-          ::Actions::Katello::Repository::CreateRoot,
+          ::Actions::Katello::Repository::CreateContainerPushRoot,
           mock_root_repo,
           container_push_name
         ).returns(true)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Updates:
Refactor container push root creation into it's own action.
Acquire lock on product when saving container push root and repository.
#### Considerations taken when implementing this change?
Acquiring lock on product before saving root and repo makes sure only one worker can run the save! at a time even if we have multiple workers starting the create_root task at the exact same time.
#### What are the testing steps for this pull request?
What are the testing steps for this pull request?

Push a container image to katello.
```
podman pull quay.io/prometheus/busybox
podman login `hostname`
podman image list
podman push <img_id> `hostname`/default_organization/<product_label>/<container_name>
```
Try multiple times till you see the race condition happen. It might take a few attempts to reproduce this.
On this branch, you shouldn't see the race condition causing a container push failure. You may see a logger statement when the race condition happens and the push should proceed as normal afterwards.