### PR TITLE
Fixes #37863 - delete container push repos properly on org delete

### DIFF
--- a/app/lib/actions/pulp3/content_view/delete_repository_references.rb
+++ b/app/lib/actions/pulp3/content_view/delete_repository_references.rb
@@ -14,7 +14,11 @@ module Actions
           to_delete = content_view.repository_references.select do |repository_reference|
             repo = repository_reference.root_repository.library_instance
             if delete_href?(repository_reference.repository_href, content_view)
-              tasks << repo.backend_service(smart_proxy).delete_repository(repository_reference)
+              if repo.root.is_container_push?
+                tasks << repo.backend_service(smart_proxy).delete_distributions
+              else
+                tasks << repo.backend_service(smart_proxy).delete_repository(repository_reference)
+              end
               true
             else
               false
@@ -22,7 +26,7 @@ module Actions
           end
           to_delete.each(&:destroy)
 
-          output[:pulp_tasks] = tasks
+          output[:pulp_tasks] = tasks.compact
         end
 
         #migrated composites may have the same RepositoryReference as their component


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Switches delete_repository_references to delete container push library instance repos by distribution rather than  by repository href. Pulp container push repos must be deleted by distribution.

#### Considerations taken when implementing this change?
Testing -- the test workflow for simulating deletion of a container push repo is complicated. I think it would be best left to BATS (which is where this issue was caught in the first place).

#### What are the testing steps for this pull request?
1) Create an organization
2) Push some container repos into a product in that new organization
3) Create some content views and composite content views with those repos for good measure
4) Delete the organization
5) Ensure the deletion is complete