### PR TITLE
Refs #37865 - Add multi cv env rabl to ak and turn off req for name

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -17,7 +17,6 @@ module Katello
 
     def_param_group :activation_key do
       param :organization_id, :number, :desc => N_("organization identifier"), :required => true
-      param :name, String, :desc => N_("name"), :required => true
       param :description, String, :desc => N_("description")
       param :max_hosts, :number, :desc => N_("maximum number of registered content hosts")
       param :unlimited_hosts, :bool, :desc => N_("can the activation key have unlimited hosts")
@@ -63,6 +62,7 @@ module Katello
     end
 
     api :POST, "/activation_keys", N_("Create an activation key")
+    param :name, String, :desc => N_("name"), :required => true
     param_group :activation_key
     def create
       @activation_key = ActivationKey.new(activation_key_params) do |activation_key|
@@ -79,6 +79,7 @@ module Katello
     api :PUT, "/activation_keys/:id", N_("Update an activation key")
     param_group :activation_key
     param :id, :number, :desc => N_("ID of the activation key"), :required => true
+    param :name, String, :desc => N_("name"), :required => false
     def update
       if @content_view_environments.present? || update_cves?
         if single_assignment? && @content_view_environments.length == 1

--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -189,6 +189,10 @@ module Katello
       releases
     end
 
+    def content_view_environment_labels
+      content_view_environment_names.join(',')
+    end
+
     def available_subscriptions
       all_pools = self.get_pools.map { |pool| pool["id"] }
       added_pools = self.pools.pluck(:cp_id)

--- a/app/views/katello/api/v2/activation_keys/base.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/base.json.rabl
@@ -1,7 +1,7 @@
 extends 'katello/api/v2/common/org_reference'
 extends 'katello/api/v2/common/timestamps'
 
-attributes :id, :name, :description, :unlimited_hosts, :auto_attach
+attributes :id, :name, :description, :unlimited_hosts, :auto_attach, :content_view_environment_labels
 
 node :multi_content_view_environment do |ak|
   ak.multi_content_view_environment?
@@ -16,7 +16,8 @@ child :content_view_environments => :content_view_environments do
       content_view_version: cve.content_view_version&.version,
       content_view_version_id: cve.content_view_version&.id,
       content_view_version_latest: cve.content_view_version&.latest?,
-      content_view_default: cve.content_view&.default?
+      content_view_default: cve.content_view&.default?,
+      content_view_environment_id: cve.id
     }
   end
   node :lifecycle_environment do |cve|
@@ -26,7 +27,7 @@ child :content_view_environments => :content_view_environments do
       lifecycle_environment_library: cve.lifecycle_environment&.library?
     }
   end
-  node :candlepin_name do |cve|
+  node :label do |cve|
     cve.candlepin_name
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Added multiple content view environments into the activation key base rabl, pulled in from Jeremy's WIP branch
* Turned off name as a required param, since that broke host collections since it wanted a name and id
* Moved the name param out of the param_group and put it back to just create/update where it was, Partha said this was an oversight when he worked on the support to add multiple envs to activation keys

#### What are the testing steps for this pull request?

* Create an activation key with multiple environments and content views
* `hammer activation-key create --name=foo --organization-id=1 --content-view-environments='env_label1/cv_label1,env_label2/cv_label2'`
* Check out https://github.com/Katello/hammer-cli-katello/pull/958
* Run the command in the hammer pr and see if you see the multiple environments in the output
