### PR TITLE
Fixes #37876 - add leading slash to /subscriptions/add

### DIFF
--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -204,7 +204,7 @@ class SubscriptionsPage extends Component {
         description: __('Add subscriptions using the Add Subscriptions button.'),
         action: {
           title: __('Add subscriptions'),
-          url: 'subscriptions/add',
+          url: '/subscriptions/add',
         },
       }
       : {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add a leading slash to the "Add Subscriptions" button that shows on the Subscriptions page when your manifest is empty. This will prevent the button from leading to `/subscriptions/add/subscriptions/add` which causes a blank screen.

#### Considerations taken when implementing this change?

Apparently it's been like this since the button was introduced in https://github.com/Katello/katello/pull/10440 and no one noticed.

#### What are the testing steps for this pull request?

Import a manifest with no subscriptions in it
Go to the Subscriptions page
There are two "Add Subscriptions" buttons. We are concerned with the big one in the center (the PF4 one)
Click the button - you should go to the add subscriptions page
Now click Back
and click the button again.

Before - You are directed to `/subscriptions/add/subscriptions/add`, leaving React Router with nothing to render. :cry: 
After - You are correctly directed to `/subscriptions/add` every time, even after navigating back from the Add Subscriptions page.
