### PR TITLE
Fixes #37881 - Update global reg form for multi-env AKs and clean up loose ends

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -323,7 +323,7 @@ module Katello
           ids: params[:content_view_environment_ids],
           organization: @organization || @activation_key&.organization)
         if @content_view_environments.blank?
-          handle_errors(candlepin_names: params[:content_view_environments],
+          handle_errors(labels: params[:content_view_environments],
           ids: params[:content_view_environment_ids])
         end
       end

--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -30,7 +30,7 @@ module Katello
       param :environment, Hash, :desc => N_("Hash containing the Id of the single lifecycle environment to be associated with the activation key."), deprecated: true
       param :content_view_id, Integer, :desc => N_("Id of the single content view to be associated with the activation key.")
       param :environment_id, Integer, :desc => N_("Id of the single lifecycle environment to be associated with the activation key.")
-      param :content_view_environments, Array, :desc => N_("Comma-separated list of Candlepin environment names to be associated with the activation key,"\
+      param :content_view_environments, Array, :desc => N_("Comma-separated list of content view environment labels to be associated with the activation key,"\
                                               " in the format of 'lifecycle_environment_label/content_view_label'."\
                                               " Ignored if content_view_environment_ids is specified, or if content_view_id and lifecycle_environment_id are specified."\
                                               " Requires allow_multiple_content_views setting to be on.")
@@ -46,7 +46,7 @@ module Katello
     param :environment_id, :number, :desc => N_("environment identifier")
     param :content_view_id, :number, :desc => N_("content view identifier")
     param :name, String, :desc => N_("activation key name to filter by")
-    param :content_view_environments, Array, :desc => N_("Comma-separated list of Candlepin environment names associated with the activation key,"\
+    param :content_view_environments, Array, :desc => N_("Comma-separated list of content view environment labels associated with the activation key,"\
                                             " in the format of 'lifecycle_environment_label/content_view_label'."\
                                             " Ignored if content_view_environment_ids is specified, or if content_view_id and lifecycle_environment_id are specified."\
                                             " Requires allow_multiple_content_views setting to be on.")
@@ -304,7 +304,7 @@ module Katello
     def params_likely_not_from_angularjs?
       # AngularJS sends back the activation key's existing API response values.
       # A side effect of this is that when it sends params[:content_view_environments] or params[:content_view_environment_ids],
-      # it incorrectly sends the nested objects from the rabl response, instead of the required single comma-separated string of Candlepin names.
+      # it incorrectly sends the nested objects from the rabl response, instead of the required single comma-separated string of CVE labels.
       # This would cause fetch_content_view_environments to fail.
       # Therefore, we need a way to (a) detect if the request is from AngularJS, and (b) avoid trying to handle the nested objects as if they were strings.
       # So we look at params[:multi_content_view_environment]. This is a computed value, not meant to be submitted as part of an update request.

--- a/app/controllers/katello/api/v2/host_contents_controller.rb
+++ b/app/controllers/katello/api/v2/host_contents_controller.rb
@@ -3,7 +3,7 @@ module Katello
     def_param_group :content_facet_attributes do
       param :content_view_id, Integer, :desc => N_("Id of the single content view to be associated with the host.")
       param :lifecycle_environment_id, Integer, :desc => N_("Id of the single lifecycle environment to be associated with the host.")
-      param :content_view_environments, Array, :desc => N_("Comma-separated list of Candlepin environment names to be associated with the host,"\
+      param :content_view_environments, Array, :desc => N_("Comma-separated list of content view environment labels to be associated with the host,"\
                                               " in the format of 'lifecycle_environment_label/content_view_label'."\
                                               " Ignored if content_view_environment_ids is specified, or if content_view_id and lifecycle_environment_id are specified."\
                                               " Requires allow_multiple_content_views setting to be on.")

--- a/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
@@ -53,7 +53,7 @@ module Katello
           if cves.present?
             @host.content_facet.content_view_environments = cves
           else
-            handle_errors(candlepin_names: cve_params[:content_view_environments],
+            handle_errors(labels: cve_params[:content_view_environments],
               ids: cve_params[:content_view_environment_ids])
           end
         end

--- a/app/controllers/katello/concerns/api/v2/multi_cv_params_handling.rb
+++ b/app/controllers/katello/concerns/api/v2/multi_cv_params_handling.rb
@@ -4,9 +4,9 @@ module Katello
       extend ActiveSupport::Concern
       include ::Katello::Api::V2::ErrorHandling
 
-      def handle_errors(candlepin_names: [], ids: [])
-        if candlepin_names.present?
-          fail HttpErrors::UnprocessableEntity, "No content view environments found with names: #{candlepin_names.join(',')}"
+      def handle_errors(labels: [], ids: [])
+        if labels.present?
+          fail HttpErrors::UnprocessableEntity, "No content view environments found with names: #{labels.join(',')}"
         elsif ids.present?
           fail HttpErrors::UnprocessableEntity, "No content view environments found with ids: #{ids}"
         end

--- a/app/controllers/katello/concerns/registration_commands_controller_extensions.rb
+++ b/app/controllers/katello/concerns/registration_commands_controller_extensions.rb
@@ -7,7 +7,7 @@ module Katello
         aks = ActivationKey.authorized(:view_activation_keys)
                            .where(organization_id: registration_params[:organization_id])
                            .order(:name)
-                           .map { |ak| { name: ak.name, lce: ak.environment&.name } }
+                           .map { |ak| { name: ak.name, cves: ak.content_view_environments.map(&:label).join(', ') } }
 
         lces = KTEnvironment.readable
                             .where(organization_id: registration_params[:organization_id])

--- a/app/models/katello/content_view_environment.rb
+++ b/app/models/katello/content_view_environment.rb
@@ -44,8 +44,8 @@ module Katello
         where("#{Katello::ContentViewEnvironmentContentFacet.table_name}.content_facet_id" => content_facets)
     end
 
-    def self.with_candlepin_name(cp_name, organization: Organization.current)
-      joins(:environment, :content_view).where("#{Katello::KTEnvironment.table_name}.organization_id" => organization, label: cp_name).first
+    def self.with_label_and_org(label, organization: Organization.current)
+      joins(:environment, :content_view).where("#{Katello::KTEnvironment.table_name}.organization_id" => organization, label: label).first
     end
 
     # retrieve the owning environment for this content view environment.
@@ -63,10 +63,6 @@ module Katello
 
     def default_environment?
       content_view.default? && environment.library?
-    end
-
-    def candlepin_name
-      label
     end
 
     def priority(content_object)
@@ -95,7 +91,7 @@ module Katello
       elsif labels.present?
         environment_names = labels.map(&:strip)
         environment_names.each do |name|
-          cve = with_candlepin_name(name, organization: organization)
+          cve = with_label_and_org(name, organization: organization)
           if cve.blank?
             label_errors << name
           else

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -359,11 +359,6 @@ module Katello
         host.refresh_global_status!
       end
 
-      # TODO: uncomment when we need to display multiple CVE names in the UI
-      # def content_view_environment_names
-      #   content_view_environments.map(&:candlepin_name).join(', ')
-      # end
-
       def self.joins_installable_relation(content_model, facet_join_model)
         facet_repository = Katello::ContentFacetRepository.table_name
         content_table = content_model.table_name

--- a/app/views/katello/api/v2/activation_keys/base.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/base.json.rabl
@@ -28,7 +28,7 @@ child :content_view_environments => :content_view_environments do
     }
   end
   node :label do |cve|
-    cve.candlepin_name
+    cve.label
   end
 end
 

--- a/app/views/katello/api/v2/content_facet/base.json.rabl
+++ b/app/views/katello/api/v2/content_facet/base.json.rabl
@@ -27,8 +27,8 @@ child :content_view_environments => :content_view_environments do
       lifecycle_environment_library: cve.lifecycle_environment&.library?
     }
   end
-  node :candlepin_name do |cve|
-    cve.candlepin_name
+  node :label do |cve|
+    cve.label
   end
 end
 

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -362,7 +362,7 @@ Foreman::Plugin.register :katello do
         type: :boolean,
         default: false,
         full_name: N_('Allow multiple content views'),
-        description: N_("Allow a host to be assigned to multiple content view environments with 'subscription-manager register --environments' or 'subscription-manager environments --set'.") # TODO: update this description when AKs support this setting as well
+        description: N_("Allow hosts or activation keys to be associated with multiple content view environments")
 
       setting 'content_default_http_proxy',
         type: :string,

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -213,7 +213,7 @@ module Katello
       content_view_environments = ['published_dev_view_library']
       ActivationKey.any_instance.expects(:reload)
       assert_sync_task(::Actions::Katello::ActivationKey::Create) do |activation_key|
-        assert_equal content_view_environments, activation_key.content_view_environments.map(&:candlepin_name), [cve.candlepin_name]
+        assert_equal content_view_environments, activation_key.content_view_environments.map(&:label), [cve.label]
         assert_valid activation_key
       end
 

--- a/test/models/content_view_environment_test.rb
+++ b/test/models/content_view_environment_test.rb
@@ -30,14 +30,14 @@ module Katello
       assert_includes cve.hosts, host
     end
 
-    def test_with_candlepin_name
+    def test_with_label_and_org
       dev = katello_environments(:dev)
       view = katello_content_views(:library_dev_view)
       cve = Katello::ContentViewEnvironment.where(:environment_id => dev, :content_view_id => view).first
-      assert_equal cve, ContentViewEnvironment.with_candlepin_name('published_dev_view_dev', organization: dev.organization)
+      assert_equal cve, ContentViewEnvironment.with_label_and_org('published_dev_view_dev', organization: dev.organization)
     end
 
-    def test_fetch_content_view_environments_candlepin_names
+    def test_fetch_content_view_environments_labels
       dev = katello_environments(:dev)
       view = katello_content_views(:library_dev_view)
       cve = Katello::ContentViewEnvironment.where(:environment_id => dev, :content_view_id => view).first
@@ -60,7 +60,7 @@ module Katello
       assert_equal [0, 999], input_ids # should not have a map! which mutates the input array
     end
 
-    def test_fetch_content_view_environments_mixed_validity_candlepin_names
+    def test_fetch_content_view_environments_mixed_validity_labels
       dev = katello_environments(:dev)
       assert_raises(HttpErrors::UnprocessableEntity) do
         ContentViewEnvironment.fetch_content_view_environments(labels: ['published_dev_view_dev, bogus'], organization: dev.organization)

--- a/webpack/ForemanColumnExtensions/index.js
+++ b/webpack/ForemanColumnExtensions/index.js
@@ -131,7 +131,7 @@ const hostsIndexColumnExtensions = [
             }
           >
             <FlexItem>
-              {truncate(contentViewEnvironments.map(cve => cve.candlepin_name).join(', '), 35)}
+              {truncate(contentViewEnvironments.map(cve => cve.label).join(', '), 35)}
             </FlexItem>
           </Popover>
         </Flex>

--- a/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/RepositorySetsTab/RepositorySetsTab.js
@@ -194,7 +194,7 @@ const RepositorySetsTab = () => {
   const { name: lifecycleEnvironmentName } = lifecycleEnvironment ?? {};
   const multiEnvHost = contentViewEnvironments.length > 1;
   const contentViewEnvironmentNames =
-    contentViewEnvironments.map(({ candlepin_name: candlepinName }) => candlepinName).join(', ');
+    contentViewEnvironments.map(({ label }) => label).join(', ');
   const nonLibraryHost = contentViewDefault === false ||
     lifecycleEnvironmentLibrary === false;
   const [isBulkActionOpen, setIsBulkActionOpen] = useState(false);

--- a/webpack/components/extensions/RegistrationCommands/fields/ActivationKeys.js
+++ b/webpack/components/extensions/RegistrationCommands/fields/ActivationKeys.js
@@ -125,7 +125,7 @@ const ActivationKeys = ({
             <SelectOption
               key={ack.name}
               value={ack.name}
-              description={ack?.lce ? ack.lce : __('No environment')}
+              description={ack?.cves ? ack.cves : __('No content view environments')}
             />
           ))}
       </Select>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

![image](https://github.com/user-attachments/assets/1fbf33bb-1d11-46a8-8782-eb12ae138112)


1. Update the global registration form to display content view environment labels, including for multi-env AKs, and not just lifecycle environments.
2. Rename `candlepin_name` and `candlepin_names` methods and method arguments to `labels` throughout the Ruby codebase.
3. Update the description of the allow_multiple_content_views Setting

#### Considerations taken when implementing this change?

This resolves the outstanding issues mentioned in https://github.com/Katello/katello/pull/11161#issuecomment-2393770414

It also cleans up the loose end with the setting description, and eliminates a TODO comment.

#### What are the testing steps for this pull request?

This should affect these places in the UI - make sure everything works ok:

1. Global Registration form - Activation Keys dropdown
2. Host details Repository Sets tab - banner text when your host is multi-environment

also, the method name changes affect multi-env hosts and AKs, so test some updates and make sure everything still works.