### PR TITLE
Fixes #37884 - CVE controller to query

### DIFF
--- a/app/controllers/katello/api/v2/content_view_environments_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_environments_controller.rb
@@ -1,0 +1,54 @@
+module Katello
+  class Api::V2::ContentViewEnvironmentsController < Api::V2::ApiController
+    before_action :find_optional_organization, :only => [:index, :auto_complete_search]
+    before_action :find_environment
+    before_action :find_content_view
+    before_action :find_activation_key
+    before_action :find_host
+
+    resource_description do
+      api_version "v2"
+    end
+
+    api :GET, "/content_view_environments", N_("List content view environments")
+    param :organization_id, :number, :desc => N_("organization identifier"), :required => false
+    param :lifecycle_environment_id, :number, :desc => N_("environment identifier"), :required => false
+    param :content_view_id, :number, :desc => N_("Content view identifier"), :required => false
+    param :activation_key_id, :number, :desc => N_("Activation key identifier"), :required => false
+    param :host_id, :number, :desc => N_("Host identifier"), :required => false
+    param_group :search, Api::V2::ApiController
+    def index
+      respond(:collection => scoped_search(index_relation.distinct, :id, :asc, resource_class: ContentViewEnvironment))
+    end
+
+    def index_relation
+      content_view_environments = ContentViewEnvironment.readable.non_generated
+      content_view_environments = content_view_environments.in_organization(@organization) if @organization
+      content_view_environments = content_view_environments.where(environment: @environment) if @environment
+      content_view_environments = content_view_environments.where(content_view: @content_view) if @content_view
+      content_view_environments = content_view_environments.where(id: @activation_key.content_view_environments) if @activation_key
+      content_view_environments = content_view_environments.where(id: @host.content_view_environments) if @host
+      content_view_environments
+    end
+
+    def find_environment
+      return unless params.key?(:lifecycle_environment_id)
+      @environment = KTEnvironment.readable.find(params[:lifecycle_environment_id])
+    end
+
+    def find_content_view
+      return unless params.key?(:content_view_id)
+      @content_view = ContentView.readable.find(params[:content_view_id])
+    end
+
+    def find_activation_key
+      return unless params.key?(:activation_key_id)
+      @activation_key = ActivationKey.readable.find(params[:activation_key_id])
+    end
+
+    def find_host
+      return unless params.key?(:host_id)
+      @host = ::Host::Managed.authorized("view_hosts").find(params[:host_id])
+    end
+  end
+end

--- a/app/models/katello/content_view_environment.rb
+++ b/app/models/katello/content_view_environment.rb
@@ -28,11 +28,20 @@ module Katello
 
     scope :non_default, -> { joins(:content_view).where("katello_content_views.default" => false) }
     scope :default, -> { joins(:content_view).where("katello_content_views.default" => true) }
+    scope :non_generated, -> { where(content_view: ::Katello::ContentView.ignore_generated) }
+
+    scoped_search :on => :id, :complete_value => true
+
     alias :lifecycle_environment :environment
     has_one :organization, :through => :environment
 
+    def self.in_organization(org)
+      where(environment_id: org.kt_environments)
+    end
+
     def self.for_content_facets(content_facets)
-      joins(:content_view_environment_content_facets, :content_facets).where("#{Katello::ContentViewEnvironmentContentFacet.table_name}.content_facet_id" => content_facets).uniq
+      joins(:content_facets).
+        where("#{Katello::ContentViewEnvironmentContentFacet.table_name}.content_facet_id" => content_facets)
     end
 
     def self.with_candlepin_name(cp_name, organization: Organization.current)

--- a/app/views/katello/api/v2/content_view_environments/index.json.rabl
+++ b/app/views/katello/api/v2/content_view_environments/index.json.rabl
@@ -1,0 +1,7 @@
+object false
+
+extends "katello/api/v2/common/metadata"
+
+child @collection[:results] => :results do
+  extends "katello/api/v2/content_view_environments/show"
+end

--- a/app/views/katello/api/v2/content_view_environments/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_environments/show.json.rabl
@@ -1,0 +1,33 @@
+object @resource
+extends 'katello/api/v2/common/identifier'
+
+extends 'katello/api/v2/common/timestamps'
+attributes :default_environment? => :default
+
+child :organization => :organization do
+  attributes :name, :label, :id
+end
+
+node :content_view do |cve|
+  cve.content_view&.slice(:id, :name, :label, :default)
+end
+
+node :lifecycle_environment do |cve|
+  cve.environment&.slice(:id, :name, :label, :library)
+end
+
+node :environment do |cve|
+  cve.environment&.slice(:id, :name, :label, :library)
+end
+
+child :activation_keys => :activation_keys do
+  attributes :id, :name, :label
+end
+
+node :activation_keys_count do |cve|
+  cve.activation_keys.count
+end
+
+node :hosts_count do |cve|
+  cve.hosts.count
+end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -72,6 +72,8 @@ Katello::Engine.routes.draw do
         match '/content_views/:composite_content_view_id/content_view_components/remove' => 'content_view_components#remove_components', :via => :put
         match '/content_views/:composite_content_view_id/content_view_components/:id' => 'content_view_components#update', :via => :put
 
+        api_resources :content_view_environments, :only => [:index]
+
         api_resources :content_views do
           get :auto_complete_search, :on => :collection
           member do

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -83,6 +83,7 @@ module Katello
                    'katello/api/v2/content_view_repositories' => [:show_all],
                    'katello/api/v2/content_view_versions' => [:index, :show, :auto_complete_search],
                    'katello/api/v2/content_view_components' => [:index, :show, :show_all],
+                   'katello/api/v2/content_view_environments' => [:index],
                    'katello/api/v2/debs' => [:index],
                    'katello/api/v2/packages' => [:index],
                    'katello/api/v2/package_groups' => [:index, :show, :auto_complete_search, :compare],
@@ -215,7 +216,8 @@ module Katello
       @plugin.permission :view_lifecycle_environments,
                          {
                            'katello/api/v2/environments' => [:index, :show, :paths, :repositories, :auto_complete_search],
-                           'katello/api/rhsm/candlepin_proxies' => [:rhsm_index]
+                           'katello/api/rhsm/candlepin_proxies' => [:rhsm_index],
+                           'katello/api/v2/content_view_environments' => [:index]
                          },
                          :resource_type => 'Katello::KTEnvironment',
                          :finder_scope => :readable

--- a/test/controllers/api/v2/content_view_environments_controller_test.rb
+++ b/test/controllers/api/v2/content_view_environments_controller_test.rb
@@ -1,0 +1,80 @@
+require "katello_test_helper"
+module Katello
+  class Api::V2::ContentViewEnvironmentsControllerTest < ActionController::TestCase
+    include Support::ForemanTasks::Task
+
+    def models
+      @organization = get_organization
+      @library_dev_staging_view = katello_content_views(:library_dev_staging_view)
+      @staging = KTEnvironment.find(katello_environments(:staging).id)
+      @library_dev_staging_ak = katello_activation_keys(:library_dev_staging_view_key)
+    end
+
+    def permissions
+      @view_cv_permission = :view_content_views
+      @view_lce_permission = :view_lifecycle_environments
+      @denied_perms = [:create_content_views]
+    end
+
+    def setup
+      setup_controller_defaults_api
+      models
+      permissions
+    end
+
+    def resp
+      @resp ||= JSON.parse(response.body, object_class: OpenStruct)
+    end
+
+    def test_index
+      get :index, params: { }
+
+      assert_response :success
+      assert resp.total > 0
+      assert_template 'api/v2/content_view_environments/index'
+    end
+
+    def test_index_org
+      get :index, params: { :organization_id => @organization.id }
+
+      assert_response :success
+      assert resp.total > 0
+      assert resp.results.all? { |result| result.organization.id == @organization.id }
+      assert_template 'api/v2/content_view_environments/index'
+    end
+
+    def test_index_in_environment
+      get :index, params: { :lifecycle_environment_id => @staging.id }
+
+      assert_response :success
+      assert resp.total > 0
+      assert resp.results.all? { |result| result.lifecycle_environment.id == @staging.id }
+      assert_template 'api/v2/content_view_environments/index'
+    end
+
+    def test_index_in_content_view
+      get :index, params: { :content_view_id => @library_dev_staging_view.id }
+
+      assert_response :success
+      assert resp.total > 0
+      assert resp.results.all? { |result| result.content_view.id == @library_dev_staging_view.id }
+      assert_template 'api/v2/content_view_environments/index'
+    end
+
+    def test_index_for_activation_key
+      get :index, params: { :activation_key_id => @library_dev_staging_ak.id }
+
+      assert_response :success
+      assert resp.total > 0
+      assert resp.results.all? { |result| result.activation_keys.map(&:id).include? @library_dev_staging_ak.id }
+      assert_template 'api/v2/content_view_environments/index'
+    end
+
+    def test_index_protected
+      allowed_perms = [@view_cv_permission, @view_lce_permission]
+      assert_protected_action(:index, allowed_perms, @denied_perms, [@organization]) do
+        get :index, params: {}
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This PR adds a content view environments controller with an index method 
You can query cve based on cv, lce, org, ak and host
```
$ curl -k -u admin:changeme http://localhost:3000/katello/api/v2/content_view_environments/?host_id=26|jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   706  100   706    0     0    500      0  0:00:01  0:00:01 --:--:--   500
{
  "total": 1,
  "subtotal": 1,
  "selectable": 1,
  "page": 1,
  "per_page": 20,
  "error": null,
  "search": null,
  "sort": {
    "by": "id",
    "order": "asc"
  },
  "results": [
    {
      "default": true,
      "id": 1,
      "name": "Library",
      "label": "Library",
      "created_at": "2024-08-12 21:07:07 UTC",
      "updated_at": "2024-08-12 21:07:07 UTC",
      "organization": {
        "name": "Default Organization",
        "label": "Default_Organization",
        "id": 1
      },
      "activation_keys": [
        {
          "id": 1,
          "name": "ak"
        },
        {
          "id": 2,
          "name": "default"
        }
      ],
      "content_view": {
        "id": 1,
        "name": "Default Organization View",
        "label": "Default_Organization_View",
        "default": true
      },
      "lifecyle_environment": {
        "id": 1,
        "name": "Library",
        "label": "Library",
        "library": true
      },
      "environment": {
        "id": 1,
        "name": "Library",
        "label": "Library",
        "library": true
      },
      "hosts_count": 24
    }
  ]
}
```

#### What are the testing steps for this pull request?

- Create a bunch of content view environments by promoting content views to environments
- Have some of em associated to an AK
- Have some of em associated to a Host
- Query the api  with org_id, env_id, cv_id, host_id and ak_id and you should get the right results.
```
$ curl -k -u admin:changeme http://localhost:3000/katello/api/v2/content_view_environments/?host_id=26

```

