### PR TITLE
Fixes #37886 - CV index page doesn't accurately reflect needs_publish

### DIFF
--- a/app/views/katello/api/v2/content_views/base.json.rabl
+++ b/app/views/katello/api/v2/content_views/base.json.rabl
@@ -13,6 +13,7 @@ attributes :generated_for
 attributes :related_cv_count
 attributes :related_composite_cvs
 attributes :filtered? => :filtered
+attributes :needs_publish? => :needs_publish
 
 node :next_version do |content_view|
   content_view.next_version.to_f.to_s

--- a/app/views/katello/api/v2/content_views/show.json.rabl
+++ b/app/views/katello/api/v2/content_views/show.json.rabl
@@ -3,7 +3,6 @@ object @resource
 extends "katello/api/v2/content_views/base"
 
 attributes :content_host_count
-attributes :needs_publish? => :needs_publish
 
 node :errors do
   unless @resource.valid?


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Move needs_publish attribute to base json rabl so index page has access to it along with details page. 
The CV index page today doesn't have this attribute and hence always assumes it's false and always shows the No updates banner on publish wizard regardless of state of CV.
#### Considerations taken when implementing this change?
There are performance impacts of having the needs_publish attribute on CV index response cause this value is not indexed, rather calculated per CV. So it adds a performance hit when pagination size is big. We need to ensure this is an accepatable hit.

The other fix could be to add a CV details API call when publish wizard is opened from the index page and I am debating whether to go down that route depending on how people feel about it.
#### What are the testing steps for this pull request?
1. Create a CV with some repos and publish a version.
2. Now create a filter or any other change that requires a new version to be published.
3. Go to CV index page and hit publish from the row actions and notice the No Updates warning doesn't show up on publish wizard.
4. Go to CV > details > Publish new version and notice the No updates warning isn't there.