### PR TITLE
Fixes #37887 - Add metadata fields to docker manifest lists

### DIFF
--- a/app/services/katello/pulp3/docker_manifest_list.rb
+++ b/app/services/katello/pulp3/docker_manifest_list.rb
@@ -28,7 +28,11 @@ module Katello
         {
           schema_version: unit['schema_version'],
           digest: unit['digest'],
-          pulp_id: unit[unit_identifier]
+          pulp_id: unit[unit_identifier],
+          annotations: unit['annotations'],
+          labels: unit['labels'],
+          is_bootable: unit['is_bootable'],
+          is_flatpak: unit['is_flatpak']
         }
       end
 

--- a/app/views/katello/api/v2/docker_manifest_lists/show.json.rabl
+++ b/app/views/katello/api/v2/docker_manifest_lists/show.json.rabl
@@ -1,6 +1,7 @@
 object @resource
 
 attributes :id, :schema_version, :digest, :manifest_type
+attributes :annotations, :labels, :is_bootable, :is_flatpak
 
 child :docker_tags => :tags do
   attributes :associated_meta_tag_identifier => :id

--- a/db/migrate/20241007200316_add_fields_to_katello_docker_manifest_list.rb
+++ b/db/migrate/20241007200316_add_fields_to_katello_docker_manifest_list.rb
@@ -1,0 +1,8 @@
+class AddFieldsToKatelloDockerManifestList < ActiveRecord::Migration[6.1]
+  def change
+    add_column :katello_docker_manifest_lists, :annotations, :jsonb, default: {}
+    add_column :katello_docker_manifest_lists, :labels, :jsonb, default: {}
+    add_column :katello_docker_manifest_lists, :is_bootable, :boolean, default: false
+    add_column :katello_docker_manifest_lists, :is_flatpak, :boolean, default: false
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add metadata fields that were added to manifests to manifest labels as these fields are applicable to both.
#### Considerations taken when implementing this change?
This is similar to what we did before for manifests in Katello. https://github.com/Katello/katello/pull/10975
#### What are the testing steps for this pull request?
1. Check out this PR and run bundle exec rails db:migrate
1. Create and sync a bootable or flatpak repo
2. Check that the manifest lists that get created have their own fields set according to information in pulp.

Sync a container repo with labels/anotations.
ex: https://quay.io/repository/centos-bootc/fedora-bootc
tag: sha256-4b336aaec054e57549075517ae025a8c3b8b23703d928437dce6a1db068eae5a

Check the API , replace :ID :

https://centos8-katello-devel-stable.example.com/katello/api/v2/docker_manifest_lists?organization_id=1&page=1&paged=true&per_page=20&repository_id=:ID&search=
