### PR TITLE
Fixes #37888 - add host bootc information to API

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -89,7 +89,7 @@ module Katello
         prepend Overrides
 
         delegate :content_source_id, :single_content_view, :single_lifecycle_environment, :default_environment?, :single_content_view_environment?, :multi_content_view_environment?, :kickstart_repository_id, :bound_repositories,
-          :installable_errata, :installable_rpms, to: :content_facet, allow_nil: true
+          :installable_errata, :installable_rpms, :image_mode_host?, to: :content_facet, allow_nil: true
 
         delegate :release_version, :purpose_role, :purpose_usage, to: :subscription_facet, allow_nil: true
 
@@ -127,6 +127,10 @@ module Katello
         register_rebuild(:queue_refresh_content_host_status, N_("Refresh_Content_Host_Status"))
 
         scope :with_pools_expiring_in_days, ->(days) { joins(:pools).merge(Katello::Pool.expiring_in_days(days)).distinct }
+
+        scope :image_mode, -> do
+          joins(:content_facet).where.not("#{::Katello::Host::ContentFacet.table_name}.bootc_booted_image" => nil)
+        end
 
         scoped_search :relation => :host_collections, :on => :id, :complete_value => false, :rename => :host_collection_id, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
         scoped_search :relation => :host_collections, :on => :name, :complete_value => true, :rename => :host_collection

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -47,6 +47,8 @@ module Katello
       validates_with Katello::Validators::GeneratedContentViewValidator
       validates_associated :content_view_environment_content_facets, :message => _("invalid: The content source must sync the lifecycle environment assigned to the host. See the logs for more information.")
       validates :host, :presence => true, :allow_blank => false
+      validates :bootc_booted_digest, :bootc_available_digest, :bootc_staged_digest, :bootc_rollback_digest,
+                format: { with: /\Asha256:[A-Fa-f0-9]{64}\z/, message: "must be a valid sha256 digest", allow_nil: true }
 
       scope :with_environments, ->(lifecycle_environments) do
         joins(:content_view_environment_content_facets => :content_view_environment).
@@ -86,6 +88,10 @@ module Katello
 
       def mark_cves_unchanged
         self.cves_changed = false
+      end
+
+      def image_mode_host?
+        bootc_booted_image.present?
       end
 
       def cves_changed?

--- a/app/views/katello/api/v2/content_facet/base.json.rabl
+++ b/app/views/katello/api/v2/content_facet/base.json.rabl
@@ -67,3 +67,6 @@ end
 child :kickstart_repository => :kickstart_repository do
   attributes :id, :name
 end
+
+attributes :bootc_booted_image, :bootc_booted_digest, :bootc_available_image, :bootc_available_digest,
+           :bootc_staged_image, :bootc_staged_digest, :bootc_rollback_image, :bootc_rollback_digest

--- a/db/migrate/20241007212705_add_bootc_facts_to_content_facet.rb
+++ b/db/migrate/20241007212705_add_bootc_facts_to_content_facet.rb
@@ -1,0 +1,27 @@
+class AddBootcFactsToContentFacet < ActiveRecord::Migration[6.1]
+  def change
+    add_column :katello_content_facets, :bootc_booted_image, :string
+    add_column :katello_content_facets, :bootc_booted_digest, :string
+
+    add_column :katello_content_facets, :bootc_available_image, :string
+    add_column :katello_content_facets, :bootc_available_digest, :string
+
+    add_column :katello_content_facets, :bootc_staged_image, :string
+    add_column :katello_content_facets, :bootc_staged_digest, :string
+
+    add_column :katello_content_facets, :bootc_rollback_image, :string
+    add_column :katello_content_facets, :bootc_rollback_digest, :string
+
+    add_index :katello_content_facets, :bootc_booted_image
+    add_index :katello_content_facets, :bootc_booted_digest
+
+    add_index :katello_content_facets, :bootc_available_image
+    add_index :katello_content_facets, :bootc_available_digest
+
+    add_index :katello_content_facets, :bootc_staged_image
+    add_index :katello_content_facets, :bootc_staged_digest
+
+    add_index :katello_content_facets, :bootc_rollback_image
+    add_index :katello_content_facets, :bootc_rollback_digest
+  end
+end

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -27,6 +27,58 @@ module Katello
       assert_equal view.version(library), host.content_facet.content_view_environments.reload.first.content_view_version
     end
 
+    def test_bootc_booted_digest_validation
+      error = assert_raises(ActiveRecord::RecordInvalid) do
+        host.content_facet.update!(bootc_booted_digest: "blah")
+      end
+      assert_includes error.message, "Bootc booted digest must be a valid sha256 digest"
+    end
+
+    def test_bootc_available_digest_validation
+      error = assert_raises(ActiveRecord::RecordInvalid) do
+        host.content_facet.update!(bootc_available_digest: "blah")
+      end
+      assert_includes error.message, "Bootc available digest must be a valid sha256 digest"
+    end
+
+    def test_bootc_staged_digest_validation
+      error = assert_raises(ActiveRecord::RecordInvalid) do
+        host.content_facet.update!(bootc_staged_digest: "blah")
+      end
+      assert_includes error.message, "Bootc staged digest must be a valid sha256 digest"
+    end
+
+    def test_bootc_rollback_digest_validation
+      error = assert_raises(ActiveRecord::RecordInvalid) do
+        host.content_facet.update!(bootc_rollback_digest: "blah")
+      end
+      assert_includes error.message, "Bootc rollback digest must be a valid sha256 digest"
+    end
+
+    def test_bootc_booted_digest_valid
+      valid_digest = "sha256:dcfb2965cda67bd3731408ace23dd07ff3116168c2b832e16bba8234525724a3"
+      host.content_facet.update!(bootc_booted_digest: valid_digest)
+      assert_equal valid_digest, host.content_facet.bootc_booted_digest
+    end
+
+    def test_bootc_available_digest_valid
+      valid_digest = "sha256:dcfb2965cda67bd3731408ace23dd07ff3116168c2b832e16bba8234525724a3"
+      host.content_facet.update!(bootc_available_digest: valid_digest)
+      assert_equal valid_digest, host.content_facet.bootc_available_digest
+    end
+
+    def test_bootc_staged_digest_valid
+      valid_digest = "sha256:dcfb2965cda67bd3731408ace23dd07ff3116168c2b832e16bba8234525724a3"
+      host.content_facet.update!(bootc_staged_digest: valid_digest)
+      assert_equal valid_digest, host.content_facet.bootc_staged_digest
+    end
+
+    def test_bootc_rollback_digest_valid
+      valid_digest = "sha256:dcfb2965cda67bd3731408ace23dd07ff3116168c2b832e16bba8234525724a3"
+      host.content_facet.update!(bootc_rollback_digest: valid_digest)
+      assert_equal valid_digest, host.content_facet.bootc_rollback_digest
+    end
+
     def test_tracer_installed?
       refute host.content_facet.tracer_installed?
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
- Adds bootc image + digest  string fields for booted, available, staged, and rollback images.
- Adds this information to the hosts API under content_facet_attributes
- Also adds a shortcut to check if a host is an image mode host.

#### Considerations taken when implementing this change?
- The naming -- this is the first time "image mode" and "bootc" will appear in our code, so let's make sure we're happy with that.
- I don't think we need to get into the business of validating that the image looks like a container image path, it would be a complicated check:
  - chatgpt says `^(?:[a-zA-Z0-9.-]+(?::[0-9]+)?/)?([a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*(?::[a-zA-Z0-9._-]+)?(?:@[A-Fa-f0-9]+:[A-Fa-f0-9]{64})?$`
  - This is due to the number of optional add-ons that a tag can have, like a full digest, tag, etc.
  - However, we can at least check that the digest looks like a digest.

#### What are the testing steps for this pull request?

- Run the migrations
- Register a host
- Check that the API values make sense
- Add some dummy data to the new records
- Check that the values still make sense.
- Test that scoped searching works and is autocompleted for the bootc facts and "image_mode" (boolean).