### PR TITLE
Fixes #37899 - Send proper EnvironmentDTO from hypervisors

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -158,7 +158,7 @@ module Katello
             { :id => cve.content_view.cp_environment_id(cve.lifecycle_environment) }
           end
         else
-          self.host.organization.default_content_view.cp_environment_id(self.host.organization.library)
+          [{ :id => self.host.organization.default_content_view.cp_environment_id(self.host.organization.library) }]
         end
       end
 

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -187,7 +187,7 @@ module Katello
 
     def test_candlepin_environment_id_no_content
       subscription_facet.host.content_facet.destroy!
-      assert_equal subscription_facet.reload.candlepin_environments.first, ContentViewEnvironment.where(:content_view_id => org.default_content_view,
+      assert_equal subscription_facet.reload.candlepin_environments.first[:id], ContentViewEnvironment.where(:content_view_id => org.default_content_view,
                                                                                                :environment_id => org.library).first.cp_id
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Send Candlepin properly-formatted environment lists on consumer update, even for hosts with no content facet. Apparently hypervisors can hit this.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Set up a virt-who hypervisor
(To fake it, I think you could also just take a regular host and delete its content facet but leave its subscription facet.)

Go to All Hosts > your hypervisor > Overview tab > System Purpose card
Attempt to set any syspurpose attribute. 

You should no longer get an error.

