### PR TITLE
Fixes #37911 - Display errata updated as date value

### DIFF
--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
@@ -251,8 +251,7 @@ export default ({ cvId, versionId }) => [
       },
       {
         title: __('Updated'),
-        getProperty: item => item?.updated &&
-          <LongDateTime date={item.updated} showRelativeTimeTooltip />,
+        getProperty: item => item?.updated,
       },
     ],
   },


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Show errata issued and updated as Date strings instead of dates with timezones to match the errata details page. ex: https://access.redhat.com/errata/RHSA-2023:5244
![2023-10-11 16 27 09 access redhat com 60681be49574](https://github.com/Katello/katello/assets/21146741/69f77028-988f-4475-91b8-6bdca31fe56b)

#### Considerations taken when implementing this change?
We made a similar change on other pages earlier but CV > version details> errata tab was missed: https://github.com/Katello/katello/pull/10785
#### What are the testing steps for this pull request?

1. Add a repo with errata into a CV and publish.
2. Go to CV > Version> Details > Errata sub-tab
3. If you are in EST (UTC -4) timezone, you'll see your redhat errata have a day - 1 as the issued/updated date.
4. With this PR, you'll see the same issued/updated as on the https://access.redhat.com/errata/ details page
