### PR TITLE
Fixes #37916 - Add RHEL9 EUS repos to recommended

### DIFF
--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -14,6 +14,8 @@ const recommendedRepositoriesRHEL = [
   'rhel-9-for-x86_64-baseos-kickstart',
   'rhel-9-for-x86_64-appstream-rpms',
   'rhel-9-for-x86_64-appstream-kickstart',
+  'rhel-9-for-x86_64-baseos-eus-rpms',
+  'rhel-9-for-x86_64-appstream-eus-rpms',
   'rhel-8-for-x86_64-baseos-rpms',
   'rhel-8-for-x86_64-baseos-kickstart',
   'rhel-8-for-x86_64-appstream-rpms',


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

- Added RHEL 9 EUS AppStream and BaseOS repos to the Recommended repositories section

#### Considerations taken when implementing this change?

-  Users find it difficult to search and enable RHEL 9 EUS repos

#### What are the testing steps for this pull request?

-  We need to make sure we see RHEL 9 EUS AppStream and BaseOS repos  on the Recommended Repositories page to enable them.