### PR TITLE
Fixes #37918 - improve restart services job

### DIFF
--- a/app/views/foreman/job_templates/resolve_traces.erb
+++ b/app/views/foreman/job_templates/resolve_traces.erb
@@ -19,10 +19,17 @@ reboot = commands.delete('reboot')
 <% if reboot -%>
 shutdown -r +1
 <% else -%>
-<%= commands.join("\n") %>
+RETVAL=0
+<% commands.each do |command| -%>
+<%= command %>
+if [ $? -ne 0 ]; then
+  RETVAL=1
+fi
+<% end -%>
 RUN_TRACER_CMD='katello-tracer-upload'
 if [ "$(id -u)" -ne 0 ]; then
   RUN_TRACER_CMD='sudo katello-tracer-upload'
 fi
 $RUN_TRACER_CMD
+exit $RETVAL
 <% end %>

--- a/app/views/foreman/job_templates/resolve_traces_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/resolve_traces_-_katello_ansible_default.erb
@@ -17,10 +17,11 @@ kind: job_template
 commands = @host.traces_helpers(search: input('Traces search query'))
 reboot = commands.delete('reboot')
 -%>
+<% if reboot -%>
+    - reboot:
+<% else -%>
 <%= render_template(
     'Run Command - Ansible Default',
     :command => (commands.push('katello-tracer-upload')).join("\n")
 ) %>
-<% if reboot %>
-    - reboot:
-<% end %>
+<% end -%>

--- a/app/views/foreman/job_templates/restart_services.erb
+++ b/app/views/foreman/job_templates/restart_services.erb
@@ -16,8 +16,16 @@ template_inputs:
 commands = input(:helper).split(',').map { |split| split.strip }
 reboot = commands.delete('reboot')
 -%>
-<%= commands.join("\n") %>
-katello-tracer-upload
 <% if reboot -%>
 <%= render_template('Power Action - Script Default', action: 'restart') %>
-<% end %>
+<% else -%>
+RETVAL=0
+<% commands.each do |command| -%>
+<%= command %>
+if [ $? -ne 0 ]; then
+  RETVAL=1
+fi
+<% end -%>
+katello-tracer-upload
+<% end -%>
+exit $RETVAL

--- a/app/views/foreman/job_templates/restart_services_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/restart_services_-_katello_ansible_default.erb
@@ -18,10 +18,11 @@ kind: job_template
 commands = input(:helper).split(',').map { |split| split.strip }
 reboot = commands.delete('reboot')
 -%>
+<% if reboot -%>
+    - reboot:
+<% else -%>
 <%= render_template(
     'Run Command - Ansible Default',
     :command => (commands.push('katello-tracer-upload')).join("\n")
 ) %>
-<% if reboot %>
-    - reboot:
-<% end %>
+<% end -%>


### PR DESCRIPTION
1. if you do a reboot, you don't need to restart the services first
2. collect the return value of the services start. if one service restart fail, the restart services job fail

