### PR TITLE
Fixes #37921 - Restore purpose_role and purpose_usage to Jail

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -610,7 +610,8 @@ class ::Host::Managed::Jail < Safemode::Jail
         :host_collections, :pools, :hypervisor_host, :installed_debs,
         :installed_packages, :traces_helpers, :advisory_ids, :package_names_for_job_template,
         :filtered_entitlement_quantity_consumed, :bound_repositories,
-        :single_content_view, :single_lifecycle_environment, :release_version
+        :single_content_view, :single_lifecycle_environment, :release_version,
+        :purpose_role, :purpose_usage
 end
 
 class ActiveRecord::Associations::CollectionProxy::Jail < Safemode::Jail


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

:purpose_role and :purpose_usage were inadvertently removed from the Jail, breaking the Host - Installed Products report. This restores them.

#### Considerations taken when implementing this change?

I'm relying on Packit / PRT testing for this

#### What are the testing steps for this pull request?

see above
Try to run Host - Installed Products