### PR TITLE
Fixes #37923 - Set HTTP proxy as default after creating

### DIFF
--- a/app/controllers/katello/concerns/api/v2/http_proxies_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/http_proxies_controller_extensions.rb
@@ -1,0 +1,17 @@
+module Katello
+  module Concerns
+    module Api
+      module V2
+        module HttpProxiesControllerExtensions
+          extend ::Apipie::DSL::Concern
+
+          update_api(:create) do
+            param :http_proxy, Hash do
+              param :default_content_proxy, :bool, :required => false, :desc => N_('Set this HTTP proxy as the default content HTTP proxy')
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/katello/concerns/http_proxies_controller_extensions.rb
+++ b/app/controllers/katello/concerns/http_proxies_controller_extensions.rb
@@ -1,0 +1,20 @@
+module Katello
+  module Concerns
+    module HttpProxiesControllerExtensions
+      extend ActiveSupport::Concern
+
+      included do
+        after_action :update_content_default_http_proxy, only: :create
+      end
+
+      private
+
+      def update_content_default_http_proxy
+        return unless @http_proxy.persisted?
+        return unless ActiveRecord::Type::Boolean.new.deserialize(params.dig('http_proxy', 'default_content'))
+
+        Setting[:content_default_http_proxy] = @http_proxy.name
+      end
+    end
+  end
+end

--- a/app/views/overrides/http_proxies/_update_setting_input.html.erb
+++ b/app/views/overrides/http_proxies/_update_setting_input.html.erb
@@ -1,0 +1,16 @@
+<% if @http_proxy.new_record? %>
+  <div class="clearfix">
+    <div class="form-group ">
+      <label class="col-md-2 control-label" for="http_proxy_default_content">
+        Default content HTTP proxy
+      </label>
+      <div class="col-md-4">
+        <%= check_box_tag 'http_proxy[default_content]',
+                          '1',
+                          params.dig('http_proxy', 'default_content') == '1',
+                          id: 'http_proxy_default_content' %>
+        Set this proxy as the default for content, updating the 'Default HTTP Proxy' setting.
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/initializers/pagelets.rb
+++ b/config/initializers/pagelets.rb
@@ -4,3 +4,9 @@ Pagelets::Manager.with_key "hosts/_form" do |mgr|
     :partial => "overrides/activation_keys/host_environment_select",
     :priority => 80
 end
+
+Pagelets::Manager.with_key "http_proxies/_form" do |mgr|
+  mgr.add_pagelet :main_tab_fields,
+    :partial => "overrides/http_proxies/update_setting_input",
+    :priority => 80
+end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -159,6 +159,7 @@ module Katello
       #Controller extensions
       ::HostsController.include Katello::Concerns::HostsControllerExtensions
       ::SmartProxiesController.include Katello::Concerns::SmartProxiesControllerExtensions
+      ::HttpProxiesController.include Katello::Concerns::HttpProxiesControllerExtensions
       ::RegistrationCommandsController.prepend Katello::Concerns::RegistrationCommandsControllerExtensions
 
       #Helper Extensions
@@ -198,6 +199,8 @@ module Katello
       ::Api::V2::HostsBulkActionsController.include Katello::Concerns::Api::V2::HostsBulkActionsControllerExtensions
       ::Api::V2::HostgroupsController.include Katello::Concerns::Api::V2::HostgroupsControllerExtensions
       ::Api::V2::SmartProxiesController.include Katello::Concerns::Api::V2::SmartProxiesControllerExtensions
+      ::Api::V2::HttpProxiesController.include Katello::Concerns::HttpProxiesControllerExtensions
+      ::Api::V2::HttpProxiesController.include Katello::Concerns::Api::V2::HttpProxiesControllerExtensions
       ::Api::V2::RegistrationController.include ::Foreman::Controller::SmartProxyAuth
       ::Api::V2::RegistrationController.prepend Katello::Concerns::Api::V2::RegistrationControllerExtensions
       ::Api::V2::RegistrationCommandsController.include Katello::Concerns::Api::V2::RegistrationCommandsControllerExtensions


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
An option for making  HTTP proxy the default content proxy after creation.

#### Considerations taken when implementing this change?
https://issues.redhat.com/browse/SAT-28860

#### What are the testing steps for this pull request?
* Pull https://github.com/theforeman/foreman/pull/10372
* Create a new HTTP proxy (API/UI) with `default content = true`
* Check the value of the `content_default_http_proxy` setting