### PR TITLE
Fixes #37933 - Pin pulp_rpm to 3.26.1 to unblock CI

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "pulp_ansible_client", ">= 0.21.3", "< 0.22.0"
   gem.add_dependency "pulp_container_client", ">= 2.20.0", "< 2.21.0"
   gem.add_dependency "pulp_deb_client", ">= 3.2.0", "< 3.3.0"
-  gem.add_dependency "pulp_rpm_client", ">= 3.26.1", "< 3.27.0"
+  gem.add_dependency "pulp_rpm_client", ">= 3.26.1", "< 3.26.2"
   gem.add_dependency "pulp_certguard_client", ">= 3.49.1", "< 3.50.0", "!= 3.49.14"
   gem.add_dependency "pulp_python_client", ">= 3.11.0", "< 3.12.0"
   gem.add_dependency "pulp_ostree_client", ">= 2.3.0", "< 2.4.0"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Pin pulp_rpm_client to 3.26.1 since 3.26.2 causes yum repo creation errors.
#### Considerations taken when implementing this change?
Unblock CI
#### What are the testing steps for this pull request?
Tests green.