### PR TITLE
Fixes #37945 - UI: Granular content count actions

### DIFF
--- a/webpack/scenes/SmartProxy/ExpandableCvDetails.js
+++ b/webpack/scenes/SmartProxy/ExpandableCvDetails.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
@@ -8,17 +9,26 @@ import { urlBuilder } from 'foremanReact/common/urlHelpers';
 import { useSet } from 'foremanReact/components/PF4/TableIndexPage/Table/TableHooks';
 import ContentViewIcon from '../ContentViews/components/ContentViewIcon';
 import ExpandedSmartProxyRepositories from './ExpandedSmartProxyRepositories';
+import { updateSmartProxyContentCounts } from './SmartProxyContentActions';
 
-const ExpandableCvDetails = ({ contentViews, contentCounts, envId }) => {
+const ExpandableCvDetails = ({
+  smartProxyId, contentViews, contentCounts, envId,
+}) => {
   const columnHeaders = [
     __('Content view'),
     __('Version'),
     __('Last published'),
     __('Synced'),
   ];
-  // const { content_counts: contentCounts } = counts;
+  const dispatch = useDispatch();
   const expandedTableRows = useSet([]);
   const tableRowIsExpanded = id => expandedTableRows.has(id);
+  const refreshCountAction = cvId => ({
+    title: __('Refresh counts'),
+    onClick: () => {
+      dispatch(updateSmartProxyContentCounts(smartProxyId, { content_view_id: cvId }));
+    },
+  });
 
   return (
     <TableComposable
@@ -68,6 +78,12 @@ const ExpandableCvDetails = ({ contentViews, contentCounts, envId }) => {
               </Td>
               <Td><LongDateTime date={cv.last_published} showRelativeTimeTooltip /></Td>
               <Td>{upToDateVal}</Td>
+              <Td
+                key={`rowActions-${id}`}
+                actions={{
+                  items: [refreshCountAction(id)],
+                }}
+              />
             </Tr>
             <Tr key="child_row" ouiaId={`ContentViewTableRowChild-${id}`} isExpanded={isExpanded}>
               <Td colSpan={12}>
@@ -89,6 +105,10 @@ const ExpandableCvDetails = ({ contentViews, contentCounts, envId }) => {
 };
 
 ExpandableCvDetails.propTypes = {
+  smartProxyId: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]).isRequired,
   contentViews: PropTypes.arrayOf(PropTypes.shape({})),
   contentCounts: PropTypes.shape({
     content_view_versions: PropTypes.shape({}),

--- a/webpack/scenes/SmartProxy/SmartProxyContentActions.js
+++ b/webpack/scenes/SmartProxy/SmartProxyContentActions.js
@@ -18,10 +18,11 @@ export const getSmartProxies = () => get({
   params: { organization_id: orgId(), per_page: 'all' },
 });
 
-export const updateSmartProxyContentCounts = smartProxyId => post({
+export const updateSmartProxyContentCounts = (smartProxyId, params) => post({
   type: API_OPERATIONS.POST,
   key: SMART_PROXY_COUNTS_UPDATE_KEY,
   url: api.getApiUrl(`/capsules/${smartProxyId}/content/update_counts`),
+  params,
   handleSuccess: (response) => {
     renderTaskStartedToast(response?.data, __('Smart proxy content count refresh has started in the background'));
   },

--- a/webpack/scenes/SmartProxy/SmartProxyExpandableTable.js
+++ b/webpack/scenes/SmartProxy/SmartProxyExpandableTable.js
@@ -35,12 +35,13 @@ const SmartProxyExpandableTable = ({ smartProxyId, organizationId }) => {
     __('Last sync'),
   ];
 
-  const refreshCountAction = {
+  const refreshCountAction = envId => ({
     title: __('Refresh counts'),
     onClick: () => {
-      dispatch(updateSmartProxyContentCounts(smartProxyId));
+      dispatch(updateSmartProxyContentCounts(smartProxyId, { environment_id: envId }));
     },
-  };
+  });
+
   const fetchItems = useCallback(
     () => getSmartProxyContent({ smartProxyId, organizationId }),
     [smartProxyId, organizationId],
@@ -109,7 +110,7 @@ const SmartProxyExpandableTable = ({ smartProxyId, organizationId }) => {
                   <Td
                     key={`rowActions-${id}`}
                     actions={{
-                      items: [refreshCountAction],
+                      items: [refreshCountAction(id)],
                     }}
                   />
                 </Tr>
@@ -117,6 +118,7 @@ const SmartProxyExpandableTable = ({ smartProxyId, organizationId }) => {
                   <Td colSpan={4}>
                     {isExpanded ?
                       <ExpandableCvDetails
+                        smartProxyId={smartProxyId}
                         contentViews={contentViews}
                         contentCounts={contentCounts}
                         envId={id}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
On the smart proxy content page:
1. Update refresh action next to environment row to pass environment as param to API
2. Add row action to CVs in env on the page and add the CV refresh count action.

![Screenshot from 2024-10-23 14-17-03](https://github.com/user-attachments/assets/1b37c7d6-0ff3-4d2f-9509-256304e572c2)


#### Considerations taken when implementing this change?

1. Decided against adding actions per repo inside CV. Too granular. 
2. Only way to run global content counting now is with capsule sync.

#### What are the testing steps for this pull request?
Test the following changes:
1. Updated refresh action next to environment row to pass environment as param to API
2. Added row action to CVs in env on the page and add the CV refresh count action.

For the 2 UI actions, make sure API calls are correct and if you pull this commit on top of https://github.com/Katello/katello/pull/11176, you can test that PR, the API and end-to-end tasks for content counting.