### PR TITLE
Fixes #37946 - Add 'other' option for package type in errata filters

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -40,6 +40,7 @@ module Katello
     param :types, Array, :desc => N_("erratum: types (enhancement, bugfix, security)")
     param :date_type, String, :desc => N_("erratum: search using the 'Issued On' or 'Updated On' column of the errata. Values are 'issued'/'updated'")
     param :module_stream_ids, Array, :desc => N_("module stream ids")
+    param :allow_other_types, :bool, :desc => N_("erratum: allow types not matching a valid errata type")
     def create
       rule_clazz = ContentViewFilter.rule_class_for(@filter)
 
@@ -89,6 +90,7 @@ module Katello
     param :start_date, String, :desc => N_("erratum: start date (YYYY-MM-DD)")
     param :end_date, String, :desc => N_("erratum: end date (YYYY-MM-DD)")
     param :types, Array, :desc => N_("erratum: types (enhancement, bugfix, security)")
+    param :allow_other_types, :bool, :desc => N_("erratum: allow types not matching a valid errata type")
     def update
       update_params = rule_params
       update_params[:name] = update_params[:name].first if update_params[:name]
@@ -136,7 +138,7 @@ module Katello
 
       @rule_params ||= params.fetch(:content_view_filter_rule, {}).
             permit(:uuid, :version, :min_version, :max_version, :architecture,
-                    :errata_id, :start_date, :end_date, :date_type,
+                    :errata_id, :start_date, :end_date, :date_type, :allow_other_types,
                     :types => [], :module_stream_ids => [], :errata_ids => [], name: [])
     end
 

--- a/app/controllers/katello/api/v2/errata_controller.rb
+++ b/app/controllers/katello/api/v2/errata_controller.rb
@@ -59,9 +59,20 @@ module Katello
         fail HttpErrors::UnprocessableEntity, msg
       end
 
+      custom_index_relation_handle_type_and_time(collection)
+    end
+
+    def custom_index_relation_handle_type_and_time(collection)
       collection = collection.where("#{date_type} >= ?", params[:start_date]) if params[:start_date]
       collection = collection.where("#{date_type} <= ?", params[:end_date]) if params[:end_date]
-      collection = collection.of_type(params[:types]) if params[:types]
+      if params[:types]
+        include_other = params[:types]&.include?('other')
+        params[:types]&.delete('other')
+        collection = collection.of_type(
+          params[:types],
+          include_other
+        )
+      end
       collection
     end
 

--- a/app/lib/katello/validators/content_view_erratum_filter_rule_validator.rb
+++ b/app/lib/katello/validators/content_view_erratum_filter_rule_validator.rb
@@ -2,9 +2,9 @@ module Katello
   module Validators
     class ContentViewErratumFilterRuleValidator < ActiveModel::Validator
       def validate(record)
-        if record.errata_id.blank? && record.start_date.blank? && record.end_date.blank? && record.types.blank?
+        if record.errata_id.blank? && record.start_date.blank? && record.end_date.blank? && record.types.blank? && record.allow_other_types == false
           invalid_parameters = _("Invalid erratum filter rule specified, Must specify at least one of the following:" \
-                                     " 'errata_id', 'start_date', 'end_date' or 'types'")
+            " 'errata_id', 'start_date', 'end_date', 'types', or 'allow_other_types'")
           record.errors.add(:base, invalid_parameters)
           return
         end

--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -48,8 +48,14 @@ module Katello
                   :validator => ->(value) { ['true', 'false'].include?(value.downcase) },
                   :operators => ["="]
 
-    def self.of_type(type)
-      where(:errata_type => type)
+    def self.of_type(type, include_other = false)
+      if include_other
+        where.not(
+          :errata_type => [Erratum::SECURITY, Erratum::BUGZILLA, Erratum::ENHANCEMENT].flatten
+          ).or(where(:errata_type => type))
+      else
+        where(:errata_type => type)
+      end
     end
 
     scope :security, -> { of_type(Erratum::SECURITY) }

--- a/app/views/katello/api/v2/content_view_filter_rules/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_filter_rules/show.json.rabl
@@ -13,6 +13,7 @@ attributes :start_date, :if => lambda { |rule| rule.respond_to?(:start_date) && 
 attributes :end_date, :if => lambda { |rule| rule.respond_to?(:end_date) && !rule.end_date.blank? }
 attributes :architecture, :if => lambda { |rule| rule.respond_to?(:architecture) && !rule.architecture.blank? }
 attributes :types, :if => lambda { |rule| rule.respond_to?(:types) && !rule.types.blank? }
+attributes :allow_other_types, :if => lambda { |rule| rule.respond_to?(:allow_other_types) }
 attributes :date_type, :if => lambda { |rule| rule.respond_to?(:date_type) }
 attributes :module_stream_id, :if => lambda { |rule| rule.respond_to?(:module_stream_id) && !rule.module_stream_id.blank? }
 if @resource&.try(:module_stream)

--- a/db/migrate/20241120213713_add_allow_other_types_to_content_view_erratum_filter_rules.rb
+++ b/db/migrate/20241120213713_add_allow_other_types_to_content_view_erratum_filter_rules.rb
@@ -1,0 +1,6 @@
+class AddAllowOtherTypesToContentViewErratumFilterRules < ActiveRecord::Migration[6.1]
+  def change
+    add_column :katello_content_view_erratum_filter_rules, :allow_other_types, :boolean,
+      :default => false, :null => false
+  end
+end

--- a/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVErrataIDFilterContent.js
@@ -60,7 +60,7 @@ const CVErrataIDFilterContent = ({
   const hasNotAddedSelected = rows.some(({ selected, added }) => selected && !added);
   const [statusSelected, setStatusSelected] = useState(ALL_STATUSES);
   const [typeSelectOpen, setTypeSelectOpen] = useState(false);
-  const [selectedTypes, setSelectedTypes] = useState(ERRATA_TYPES);
+  const [selectedTypes, setSelectedTypes] = useState([...ERRATA_TYPES, 'other']);
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
   const activeFilters = [statusSelected, selectedTypes, startDate, endDate];
@@ -198,9 +198,15 @@ const CVErrataIDFilterContent = ({
 
   const onTypeSelect = (selection) => {
     if (selectedTypes.includes(selection)) {
+      // If the selection is the only selection remaining, do not allow it to be removed
       if (selectedTypes.length === 1) return;
+
+      // Filter out the current selection to deselect it
       setSelectedTypes(selectedTypes.filter(e => e !== selection));
-    } else setSelectedTypes([...selectedTypes, selection]);
+    } else {
+      // Add the current selection to the selected types
+      setSelectedTypes([...selectedTypes, selection]);
+    }
     setTypeSelectOpen(false);
   };
 
@@ -324,6 +330,11 @@ const CVErrataIDFilterContent = ({
                       <SelectOption isDisabled={singleSelection('bugfix')} key="bugfix" value="bugfix">
                         <p style={{ marginTop: '4px' }}>
                           {__('Bugfix')}
+                        </p>
+                      </SelectOption>
+                      <SelectOption isDisabled={singleSelection('bugfix')} key="other" value="other">
+                        <p style={{ marginTop: '4px' }}>
+                          {__('Other')}
                         </p>
                       </SelectOption>
                     </Select>

--- a/webpack/scenes/ContentViews/Details/Filters/CVFilterDetailType.js
+++ b/webpack/scenes/ContentViews/Details/Filters/CVFilterDetailType.js
@@ -47,7 +47,7 @@ const CVFilterDetailType = ({
       details={details}
     />);
   case 'erratum':
-    if (head(rules)?.types) {
+    if (head(rules)?.types || head(rules)?.allow_other_types) {
       return (<CVErrataDateFilterContent
         cvId={cvId}
         filterId={filterId}

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataDateFilterContent.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/cvErrataDateFilterContent.test.js
@@ -23,6 +23,7 @@ test('Can display errata-date filter rule and edit', async (done) => {
     end_date: '2020-08-15T12:00:00.000Z',
     types: ['enhancement', 'security'],
     date_type: 'issued',
+    allow_other_types: false,
   };
 
   const ruleEditScope = nockInstance


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Added "other" option for package type in errata filters by date. This allows users to include the "newpackage" type (and others) when filtering by date and/or type. Apologies for how messy this is, more changes are to come.

#### Considerations taken when implementing this change?
There are a few places in the source where I wasn't quite sure if the 'other' category made sense to add. There are a lot of UI files where this functionality will be added in a future PR, but I'd like input on whether these areas (or any other) would benefit from the addition of the 'other' option:
```
app/mailers/katello/errata_mailer.rb
app/models/katello/host_collection.rb
app/models/katello/host/content_facet.rb
```

#### What are the testing steps for this pull request?
Run these steps before pulling this PR:
1. Install EPEL 8 on your foreman server:
    - Create a content credential GPG key from this URL: `https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8`.
    - Create a product 'EPEL8' using the GPG key.
    - 'New Repository' named 'EPEL8 x86_64' or something similar of type 'yum'. Restrict to x86_64 and set the upstream URL to `https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/`. Set the download policy to 'On Demand'. You may have to set the GPG key here as well.
    - Run a sync on the repo.
2. Create a test content view and add EPEL8 to the repositories list. Publish a new version.
3. Add a filter to the CV, 'Errata by Date Range', include. Set the end date of the filter to today, leaving everything else blank / the same as default.
4. Add another filter, 'RPM', and check 'Include all RPMs not associated with any errata'.
5. Publish a new CV version (this will take a while).
6. Go to the content view version overview page and take note of the number of packages and errata. Both the package and errata count will have dropped substantially, even though nothing should be filtered.

Run these steps after pulling the PR:
1. Publish a new CV version. The counts should not change.
2. Edit the 'Errata by Date Range' filter and check the 'Other' field to allow for non-standard errata to be added to the filter. Save and publish a new CV version.
3. Go to the content view version overview page. The package and errata count should match the initial counts for V1.