### PR TITLE
Fixes #37941 - Handle AK creation params sent by AngularJS

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -345,9 +345,10 @@ module Katello
       end
     end
 
+    # AngularJS sends :environment and :content_view_id
     def single_assignment?
-      (params.key?(:environment_id) && params.key?(:content_view_id)) ||
-      (params.key?(:environment) && params.key?(:content_view))
+      (params.key?(:environment) || params.key?(:environment_id)) &&
+      (params.key?(:content_view) || params.key?(:content_view_id))
     end
 
     def update_cves?

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -227,6 +227,27 @@ module Katello
       assert_template 'katello/api/v2/common/create'
     end
 
+    def test_create_from_angularjs_with_environments_param
+      cve = katello_content_view_environments(:library_default_view_environment)
+      cve.update(organization: @organization)
+      content_view_environments = ['library_default_view_library']
+      ActivationKey.any_instance.expects(:reload)
+      assert_sync_task(::Actions::Katello::ActivationKey::Create) do |activation_key|
+        assert_equal content_view_environments, activation_key.content_view_environments.map(&:label), [cve.label]
+        assert_valid activation_key
+      end
+
+      post :create, params: {
+        :organization_id => @organization.id,
+        :environment => {:id => @library.id},
+        :content_view_id => @acme_view.id,
+        :activation_key => {:name => 'new key'}
+      }
+
+      assert_response :success
+      assert_template 'katello/api/v2/common/create'
+    end
+
     def test_create_with_content_view_environment_ids_param
       cve = katello_content_view_environments(:library_dev_view_library)
       cve.update(organization: @organization)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

During activation key create, the controller assigns content view environments like so:
```
activation_key.content_view_environments = @content_view_environments if update_cves?
```

Due to recent changes, `update_cves?` was always returning false when creating an AK from the AngularJS web UI. This is because (for some reason) the page sends `environment` and `content_view_id` params, a combination that was not previously accounted for. This PR updates `update_cves?` to handle that.

#### Considerations taken when implementing this change?

We sure have a lot of weirdness from AngularJS that we compensate for in the controllers. When the page is removed (someday) I hope we can simplify our code accordingly.

#### What are the testing steps for this pull request?

Create an activation key in the web UI
Select a lifecycle env and content view
Ensure that the AK gets created with the LCE/CV
