### PR TITLE
Fixes #36874 - Drop migrated_pulp3_href from content tables

### DIFF
--- a/db/migrate/20241025151105_remove_pulp3_migrated_hrefs_from_content_tables.rb
+++ b/db/migrate/20241025151105_remove_pulp3_migrated_hrefs_from_content_tables.rb
@@ -1,0 +1,10 @@
+class RemovePulp3MigratedHrefsFromContentTables < ActiveRecord::Migration[6.1]
+  def change
+    content_models = [Katello::Rpm, Katello::ModuleStream, Katello::Erratum, Katello::PackageGroup, Katello::YumMetadataFile,
+                      Katello::Srpm, Katello::FileUnit, Katello::DockerManifestList, Katello::DockerManifest, Katello::DockerTag]
+
+    content_models.each do |model|
+      remove_column model.table_name, :migrated_pulp3_href, :string
+    end
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Drop migrated_pulp3_href from content tables.
#### Considerations taken when implementing this change?
Did a grep for migrated_pulp3_href and didn't find any usages so it should be safe to just drop these.
#### What are the testing steps for this pull request?
Run db:migrate against this branch.
Run db:rollback to confirm we don't break rollbacks.