### PR TITLE
Fixes #37957 - Add CVE labels to host rabl

### DIFF
--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -190,7 +190,7 @@ module Katello
     end
 
     def content_view_environment_labels
-      content_view_environment_names.join(',')
+      content_view_environments.map(&:label).join(',')
     end
 
     def available_subscriptions

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -127,6 +127,10 @@ module Katello
         self.host&.update_candlepin_associations unless self.host&.new_record?
       end
 
+      def content_view_environment_labels
+        content_view_environments.map(&:label).join(',')
+      end
+
       # rubocop:disable Metrics/CyclomaticComplexity
       def assign_single_environment(
         content_view_id: nil, lifecycle_environment_id: nil, environment_id: nil,

--- a/app/views/katello/api/v2/content_facet/base.json.rabl
+++ b/app/views/katello/api/v2/content_facet/base.json.rabl
@@ -32,6 +32,8 @@ child :content_view_environments => :content_view_environments do
   end
 end
 
+attributes :content_view_environment_labels
+
 node :multi_content_view_environment do |content_facet|
   content_facet.multi_content_view_environment?
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Goes with https://github.com/Katello/hammer-cli-katello/pull/964

1. Add content view environment labels to host_managed_extensions rabl, so that hammer has consistent output between hosts/AKs.
2. Update the incorrect logic of `content_view_environment_labels`. This always should have been based on labels, not names.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Test with [the hammer-cli-katello pr.](https://github.com/Katello/hammer-cli-katello/pull/964)

