### PR TITLE
Fixes #37902 - Add flatpak models and scan action for remote

### DIFF
--- a/app/lib/actions/katello/flatpak/scan_remote.rb
+++ b/app/lib/actions/katello/flatpak/scan_remote.rb
@@ -1,0 +1,63 @@
+require 'cgi'
+require 'uri'
+module Actions
+  module Katello
+    module Flatpak
+      class ScanRemote < Actions::EntryAction
+        def plan(remote, _args = {})
+          url = format_url(remote.url)
+          plan_self({:remote_id => remote.id, :url => url})
+        end
+
+        def run
+          remote = ::Katello::FlatpakRemote.find(input[:remote_id])
+          url = input[:url]
+          request_params = {
+            method: :get,
+            headers: { accept: :json },
+            url: url
+          }
+          results = RestClient::Request.execute(request_params)
+          results = JSON.parse(results)
+          repositories = results['Results']
+          repositories.each do |repository|
+            remote_repository = remote.remote_repositories.find_or_initialize_by(name: repository['Name'])
+            remote_repository.label = remote.name + '-' + repository['Name']
+            remote_repository.flatpak_remote = remote
+            remote_repository.save!
+            repository['Images'].each do |image|
+              remote_repository_manifest = remote_repository.manifests.find_or_initialize_by(digest: image['Digest'])
+              remote_repository_manifest.flatpak_remote_repository_id = remote_repository.id
+              remote_repository_manifest.name = image['Labels']['name']
+              remote_repository_manifest.tags = image['Tags']
+              remote_repository_manifest.application = image['Labels']['org.flatpak.ref'].start_with?('app/')
+              remote_repository_manifest.flatpak_ref = image['Labels']['org.flatpak.ref']
+              remote_repository_manifest.runtime = extract_runtime_from_metadata(image['Labels']['org.flatpak.metadata'])
+              remote_repository_manifest.save!
+            end
+          end
+        end
+
+        private
+
+        def extract_runtime_from_metadata(metadata)
+          match = metadata.match(/^runtime=(.*)$/)
+          match ? "runtime/" + match[1] : nil
+        end
+
+        def format_url(url)
+          unless url.ends_with?('/index/static?')
+            url += '/index/static?'
+          end
+          params = [
+            ['tag', 'latest'],
+            ['label:org.flatpak.ref:exists', '1']
+          ]
+          encoded_params = params.map { |k, v| "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}" }
+          url = "#{url}#{encoded_params.sort.join('&')}"
+          url
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -33,7 +33,7 @@ module Katello
         has_many :product_contents, :through => :products
         has_many :repositories, :through => :products
         has_one :cdn_configuration, :class_name => "Katello::CdnConfiguration", :dependent => :destroy, :inverse_of => :organization
-
+        has_many :flatpak_remotes, :class_name => "Katello::FlatpakRemote", :dependent => :destroy, :inverse_of => :organization
         #older association
         has_many :org_tasks, :dependent => :destroy, :class_name => "Katello::TaskStatus", :inverse_of => :organization
 

--- a/app/models/katello/flatpak_remote.rb
+++ b/app/models/katello/flatpak_remote.rb
@@ -1,0 +1,11 @@
+module Katello
+  class FlatpakRemote < Katello::Model
+    has_many :remote_repositories, dependent: :destroy, class_name: 'Katello::FlatpakRemoteRepository'
+    has_many :remote_repository_manifests, through: :remote_repositories, source: :remote_repository_manifests
+    belongs_to :organization, inverse_of: :flatpak_remotes
+
+    validates :name, presence: true
+    validates :url, presence: true
+    validates :organization_id, presence: true
+  end
+end

--- a/app/models/katello/flatpak_remote_repository.rb
+++ b/app/models/katello/flatpak_remote_repository.rb
@@ -1,0 +1,12 @@
+module Katello
+  class FlatpakRemoteRepository < Katello::Model
+    belongs_to :flatpak_remote, inverse_of: :remote_repositories
+    has_many :remote_repository_manifests, dependent: :destroy, class_name: 'Katello::FlatpakRemoteRepositoryManifest'
+
+    validates :flatpak_remote_id, presence: true
+    validates :name, presence: true
+    validates :label, presence: true
+
+    alias_attribute :manifests, :remote_repository_manifests
+  end
+end

--- a/app/models/katello/flatpak_remote_repository_manifest.rb
+++ b/app/models/katello/flatpak_remote_repository_manifest.rb
@@ -1,0 +1,10 @@
+module Katello
+  class FlatpakRemoteRepositoryManifest < Katello::Model
+    belongs_to :remote_repository,
+               class_name: 'Katello::FlatpakRemoteRepository',
+               foreign_key: 'flatpak_remote_repository_id',
+               inverse_of: :remote_repository_manifests
+    validates :flatpak_remote_repository_id, presence: true
+    validates :name, presence: true
+  end
+end

--- a/db/migrate/20241030181402_create_katello_flatpak_tables.rb
+++ b/db/migrate/20241030181402_create_katello_flatpak_tables.rb
@@ -1,0 +1,41 @@
+class CreateKatelloFlatpakTables < ActiveRecord::Migration[6.1]
+  #rubocop:disable Metrics/MethodLength
+  def change
+    create_table :katello_flatpak_remotes do |t|
+      t.string :name, null: false
+      t.string :url, null: false
+      t.integer :organization_id, null: false
+      t.text :description
+      t.boolean :seeded, default: false, null: false
+      t.string :username
+      t.text :token
+      t.timestamps
+    end
+
+    add_foreign_key :katello_flatpak_remotes, :taxonomies, name: 'katello_flatpak_remotes_organization_id', column: :organization_id
+
+    create_table :katello_flatpak_remote_repositories do |t|
+      t.string :name, null: false
+      t.string :label, null: false
+      t.integer :flatpak_remote_id, null: false
+      t.timestamps
+    end
+
+    create_table :katello_flatpak_remote_repository_manifests do |t|
+      t.integer :flatpak_remote_repository_id, null: false
+      t.string :digest, null: false
+      t.string :tags, array: true, default: []
+      t.string :name, null: false
+      t.boolean :application, default: true, null: false
+      t.text :runtime
+      t.string :flatpak_ref, null: false
+      t.timestamps
+    end
+
+    add_index :katello_flatpak_remote_repository_manifests, :flatpak_ref, name: 'index_remote_repository_manifests_on_flatpak_ref'
+    add_index :katello_flatpak_remote_repository_manifests, [:flatpak_remote_repository_id, :digest], unique: true, name: 'index_remote_repository_manifests_on_repo_id_and_digest'
+    add_foreign_key :katello_flatpak_remote_repository_manifests, :katello_flatpak_remote_repositories, column: :flatpak_remote_repository_id
+    add_foreign_key :katello_flatpak_remote_repositories, :katello_flatpak_remotes, column: :flatpak_remote_id
+  end
+  #rubocop:enable Metrics/MethodLength
+end

--- a/test/actions/katello/flatpak/scan_remote_test.rb
+++ b/test/actions/katello/flatpak/scan_remote_test.rb
@@ -1,0 +1,26 @@
+require 'katello_test_helper'
+
+module ::Actions::Katello::Flatpak
+  class TestScanRemoteBase < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+
+    let(:action) { create_action action_class }
+    let(:remote) { katello_flatpak_remotes(:redhat_flatpak_remote) }
+  end
+
+  class ScanRemoteTest < TestScanRemoteBase
+    let(:action_class) { ::Actions::Katello::Flatpak::ScanRemote }
+    let(:input) do
+      {
+        remote_id: remote.id,
+        url: 'https://flatpaks.redhat.io/rhel//index/static?label%3Aorg.flatpak.ref%3Aexists=1&tag=latest'
+      }
+    end
+
+    it 'plans_self' do
+      action.expects(:plan_self).with(input)
+      plan_action action, remote
+    end
+  end
+end

--- a/test/fixtures/models/katello_flatpak_remote_repositories.yml
+++ b/test/fixtures/models/katello_flatpak_remote_repositories.yml
@@ -1,0 +1,28 @@
+rhel9_flatpak_runtime:
+  name: "rhel9/flatpak-runtime"
+  label: "Redhat flatpak-rhel9/flatpak-runtime"
+  flatpak_remote_id: <%= ActiveRecord::FixtureSet.identify(:redhat_flatpak_remote) %>
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+f41_flatpak_runtime:
+  name: "f41/flatpak-runtime"
+  label: "Fedora flatpak-f41/flatpak-runtime"
+  flatpak_remote_id: <%= ActiveRecord::FixtureSet.identify(:fedora_flatpak_remote) %>
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+rhel9_firefox_flatpak:
+  name: "rhel9/firefox-flatpak"
+  label: "Redhat flatpak-rhel9/firefox-flatpak"
+  flatpak_remote_id: <%= ActiveRecord::FixtureSet.identify(:redhat_flatpak_remote) %>
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+firefox:
+  name: firefox
+  label: "Fedora flatpak-firefox"
+  flatpak_remote_id: <%= ActiveRecord::FixtureSet.identify(:fedora_flatpak_remote) %>
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+

--- a/test/fixtures/models/katello_flatpak_remote_repository_manifests.yml
+++ b/test/fixtures/models/katello_flatpak_remote_repository_manifests.yml
@@ -1,0 +1,35 @@
+rhel9_runtime_manifest:
+  name: runtime
+  flatpak_remote_repository_id: <%= ActiveRecord::FixtureSet.identify(:rhel9_flatpak_runtime) %>
+  digest: "sha256:661b328e7e3b8108948b8712f81fc9ee496c0bf3998a8d68c8a3ca25becb3844"
+  tags:
+    - "latest"
+    - "el9-9040020240312160503.1726696165"
+    - "el9"
+  application: false
+  runtime: runtime/com.redhat.Platform/x86_64/el9
+  flatpak_ref: runtime/com.redhat.Platform/x86_64/el9
+
+rhel9_firefox_manifest_x86_84:
+  name: firefox
+  flatpak_remote_repository_id: <%= ActiveRecord::FixtureSet.identify(:rhel9_firefox_flatpak) %>
+  digest: "sha256:1a9e49a6360bf87c3aaa5efb7b8479ddc220e5e963f8c625556cd359d3396560"
+  tags:
+    - "flatpak"
+    - "latest"
+    - "flatpak-9040020240611093110.1728578272"
+  application: true
+  runtime: runtime/com.redhat.Platform/x86_64/el9
+  flatpak_ref: app/org.mozilla.Firefox/x86_64/stable
+
+rhel9_firefox_manifest_s390x:
+  name: firefox
+  flatpak_remote_repository_id: <%= ActiveRecord::FixtureSet.identify(:rhel9_firefox_flatpak) %>
+  digest: "sha256:5ad3e3aaab201f1b6e684a638d931459b1e911c11596eeea86aac5edb24c58e7"
+  tags:
+    - "flatpak"
+    - "latest"
+    - "flatpak-9000020220822143207.1"
+  application: true
+  runtime: runtime/com.redhat.Platform/s390x/el9
+  flatpak_ref: app/org.mozilla.Firefox/s390x/stable

--- a/test/fixtures/models/katello_flatpak_remotes.yml
+++ b/test/fixtures/models/katello_flatpak_remotes.yml
@@ -1,0 +1,16 @@
+redhat_flatpak_remote:
+  name: Red Hat Flatpak Remote
+  url: "https://flatpaks.redhat.io/rhel/"
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+  seeded: true
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
+fedora_flatpak_remote:
+  name: Fedora Flatpak Remote
+  url: "https://flatpaks.fedoraproject.org/"
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+  seeded: true
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -74,8 +74,6 @@ module FixtureTestCase
       taxonomy['label'] = taxonomy['name'].tr(' ', '_')
     end
     File.write(taxonomies_file, taxonomies.to_yaml)
-
-    set_fixture_class katello_generic_content_units: Katello::GenericContentUnit
     fixtures(:all)
 
     load_permissions

--- a/test/models/flatpak_model_tests.rb
+++ b/test/models/flatpak_model_tests.rb
@@ -1,0 +1,71 @@
+require 'katello_test_helper'
+
+module Katello
+  class FlatpakRemoteTest < ActiveSupport::TestCase
+    def setup
+      @redhat_remote = katello_flatpak_remotes(:redhat_flatpak_remote)
+      @fedora_remote = katello_flatpak_remotes(:fedora_flatpak_remote)
+    end
+
+    should validate_presence_of(:name)
+    should validate_presence_of(:url)
+    should validate_presence_of(:organization_id)
+    should have_many(:remote_repositories).dependent(:destroy).class_name('Katello::FlatpakRemoteRepository')
+    should have_many(:remote_repository_manifests).through(:remote_repositories).source(:remote_repository_manifests)
+    should belong_to(:organization).inverse_of(:flatpak_remotes)
+
+    test 'flatpak remote fixtures are valid and creatable' do
+      assert @redhat_remote.valid?
+      assert @fedora_remote.valid?
+      assert @redhat_remote.save!
+      assert @fedora_remote.save!
+    end
+  end
+
+  class FlatpakRemoteRepositoryTest < ActiveSupport::TestCase
+    def setup
+      @redhat_remote_runtime_repository = katello_flatpak_remote_repositories(:rhel9_flatpak_runtime)
+      @fedora_remote_runtime_repository = katello_flatpak_remote_repositories(:f41_flatpak_runtime)
+      @redhat_remote_firefox_repository = katello_flatpak_remote_repositories(:rhel9_firefox_flatpak)
+      @fedora_remote_firefox_repository = katello_flatpak_remote_repositories(:firefox)
+    end
+
+    should validate_presence_of(:name)
+    should validate_presence_of(:flatpak_remote_id)
+    should have_many(:remote_repository_manifests).dependent(:destroy).class_name('Katello::FlatpakRemoteRepositoryManifest')
+    should belong_to(:flatpak_remote).inverse_of(:remote_repositories)
+
+    test 'flatpak remote repository fixtures are valid and creatable' do
+      assert @redhat_remote_runtime_repository.valid?
+      assert @fedora_remote_runtime_repository.valid?
+      assert @redhat_remote_firefox_repository.valid?
+      assert @fedora_remote_firefox_repository.valid?
+      assert @redhat_remote_runtime_repository.save!
+      assert @fedora_remote_runtime_repository.save!
+      assert @redhat_remote_firefox_repository.save!
+      assert @fedora_remote_firefox_repository.save!
+    end
+  end
+
+  class FlatpakRemoteRepositoryManifestTest < ActiveSupport::TestCase
+    def setup
+      @redhat_runtime_manifest = katello_flatpak_remote_repository_manifests(:rhel9_runtime_manifest)
+      @rhel9_firefox_manifest_x_86_84 = katello_flatpak_remote_repository_manifests(:rhel9_firefox_manifest_x86_84)
+      @rhel9_firefox_manifest_s390x = katello_flatpak_remote_repository_manifests(:rhel9_firefox_manifest_s390x)
+    end
+
+    should validate_presence_of(:name)
+    should validate_presence_of(:flatpak_remote_repository_id)
+    should belong_to(:remote_repository).class_name('Katello::FlatpakRemoteRepository').inverse_of(:remote_repository_manifests)
+
+    test 'flatpak remote repository manifest fixtures are valid and creatable' do
+      assert @redhat_runtime_manifest.valid?
+      assert @rhel9_firefox_manifest_x_86_84.valid?
+      assert @rhel9_firefox_manifest_s390x.valid?
+
+      assert @redhat_runtime_manifest.save!
+      assert @rhel9_firefox_manifest_x_86_84.save!
+      assert @rhel9_firefox_manifest_s390x.save!
+    end
+  end
+end

--- a/test/support/fixtures_support.rb
+++ b/test/support/fixtures_support.rb
@@ -66,7 +66,11 @@ module Katello
       :katello_repository_ansible_collections => Katello::RepositoryAnsibleCollection,
       :katello_smart_proxies => SmartProxy,
       :katello_smart_proxy_features => SmartProxyFeature,
-      :katello_features => Feature
+      :katello_features => Feature,
+      :katello_generic_content_units => Katello::GenericContentUnit,
+      :katello_flatpak_remotes => Katello::FlatpakRemote,
+      :katello_flatpak_remote_repositories => Katello::FlatpakRemoteRepository,
+      :katello_flatpak_remote_repository_manifests => Katello::FlatpakRemoteRepositoryManifest
     }.freeze
 
     # rubocop:disable Naming/AccessorMethodName


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This pull request introduces a new feature to support scanning Flatpak remotes in the Katello. 
More details here: https://community.theforeman.org/t/rfc-flatpak-support-in-katello/39768
The changes include adding new models, creating database tables, and implementing the core logic for scanning and processing Flatpak repositories and their manifests.

### Scanning flatpak remotes:

* [`app/lib/actions/katello/flatpak/scan_remote.rb`](diffhunk://#diff-cd4c85f1e98edaf2dfc5d845ca3e2391152d3e45ab82148ad6f87d9ce4d24554R1-R65): Added the `ScanRemote` action to handle the scanning of Flatpak remotes, including formatting the URL, executing the request, and processing the results.
1. Note the `find_or_initialize_by` used for repository and manifest by name and digest respectively. The assumption is that name will be unique for repositories in the index and inside a repositroy, manifest digests will be unique.
As a result, if the action doesn't find these, it will create the records. If it finds these records, the action will update the record with latest data from the remote.

2. Also note that there is no deletion logic. So if a repository is deleted on the remote, we don't delete it automatically from the DB. Nor do we delete manifests inside a repository if they have disappeared in index for now but we'll possibly need to do that.

### Model Additions:

* [`app/models/katello/flatpak_remote.rb`](diffhunk://#diff-d8960094c20d50a66a34a818a6337158e717c3c5e97c15cc002bb7a9503d6b25R1-R13): Added the `FlatpakRemote` model to represent a Flatpak remote, including associations and validations.
* [`app/models/katello/flatpak_remote_repository.rb`](diffhunk://#diff-257addf250f03a1c9bac91a6c41ed6994b45e223b4408aae20396fc82c98aeadR1-R12): Added the `FlatpakRemoteRepository` model to represent repositories within a Flatpak remote, including associations and validations.
* [`app/models/katello/flatpak_remote_repository_manifest.rb`](diffhunk://#diff-cc03a0c2edca81d617213b438405537ad69961ca954458a4b11669e0c534f1eeR1-R10): Added the `FlatpakRemoteRepositoryManifest` model to represent manifests within a Flatpak repository, including associations and validations.

### Database Migrations:

* [`db/migrate/20241030181402_create_katello_flatpak_tables.rb`](diffhunk://#diff-7745b3674a7a6033779b1f906577164ac59b869987d574f39099e0c0bd6e7f19R1-R42): Created database tables for `katello_flatpak_remotes`, `katello_flatpak_remote_repositories`, and `katello_flatpak_remote_repository_manifests`, including necessary indexes and foreign keys.
#### Considerations taken when implementing this change?
The flatpak indexes seem to be cached at static endpoint. What that means is the flatpak index might have a different image under latest tag whereas registry might be another: https://catalog.redhat.com/software/containers/rhel9/flatpak-runtime/61482b687c13a3cb0655413f

Matching by digest might not be the best approach as a result. Will need to check to see what field makes most sense.
#### What are the testing steps for this pull request?
1. Run `bundle exec rails db:migrate` to migrate db
2. Run following to create 2 remotes, one pointing to redhat flatpak index and another at fedora flatpak index: 
      ```
      remote1 = Katello::FlatpakRemote.new(name: "Redhat flatpak", url: "https://flatpaks.redhat.io/rhel",organization_id: 1,seeded: true)
      remote1.save!
      
      remote2 = Katello::FlatpakRemote.new(name: "Fedora flatpak", url: "https://registry.fedoraproject.org/",organization_id: 1,seeded: true)
      remote2.save!
      ```
3. Run the below actions to scan the 2 indexes and you should have 2 successful actions in your foreman tasks.
```
#Sync redhat flatpak:
redhat_remote =  Katello::FlatpakRemote.find_by(name: "Redhat flatpak")
ForemanTasks.sync_task(::Actions::Katello::Flatpak::ScanRemote, redhat_remote)

#Sync fedora flatpak:
fedora_remote =  Katello::FlatpakRemote.find_by(name: "Fedora flatpak")
ForemanTasks.sync_task(::Actions::Katello::Flatpak::ScanRemote, fedora_remote)
```

4. Upon completion of the actions above, you should be able to see several remote repositories and child manifests.
```
redhat_remote =  Katello::FlatpakRemote.find_by(name: "Redhat flatpak")
redhat_remote.repositories
redhat.repositories.first.manifests
```
5. Make sure everything looks sane. 😸 

## Open questions:

1. Because we are using the static endpoint for fedora and redhat, there's a possibility that flatpak index isn't up to date with the actual registry repo. I saw this on rhel9-runtime repo where flatpak index had an older manifest digest and when the repo was synced from registry, it pulled in manifest with newer digest.
