### PR TITLE
Fixes #37966 - Rescue Candlepin error during force registration

### DIFF
--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -279,6 +279,16 @@ module Katello
         ::Katello::RegistrationManager.register_host(@host, rhsm_params, [@content_view_environment])
       end
 
+      def test_force_registration_existing_host
+        ::Host::Managed.any_instance.expects(:update_candlepin_associations).times(1)
+        ::Katello::RegistrationManager.expects(:unregister_host).raises(RestClient::Gone)
+        ::Katello::RegistrationManager.expects(:create_in_candlepin)
+        ::Katello::RegistrationManager.expects(:finalize_registration)
+        Rails.logger.expects(:debug).with("Host #{@host.name} has been removed in preparation for reregistration")
+        Rails.logger.expects(:debug).with("ContentFacet: Marking CVEs changed for host #{@host.name}").times(1)
+        ::Katello::RegistrationManager.register_host(@host, rhsm_params, [@content_view_environment])
+      end
+
       def test_unregister_host
         ::Host::Managed.any_instance.stubs(:update_candlepin_associations)
         @host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @content_view,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Rescue Candlepin error during force registration
after deleting certs from host. In this situation
Katello tries to update the consumer it just deleted.

Also added a test.

#### Considerations taken when implementing this change?

This same thing was fixed in https://github.com/Katello/katello/pull/10694 but has since popped up again. I figure a rescue will be more foolproof for next time.

#### What are the testing steps for this pull request?

See the Redmine issue https://projects.theforeman.org/issues/37966
