### PR TITLE
Fixes #37981 - generic content units api docs fixes

### DIFF
--- a/app/controllers/katello/api/v2/generic_content_units_controller.rb
+++ b/app/controllers/katello/api/v2/generic_content_units_controller.rb
@@ -2,7 +2,8 @@ module Katello
   class Api::V2::GenericContentUnitsController < Api::V2::ApiController
     resource_description do
       name 'Content Units'
-      param :content_type, String, desc: N_("Possible values: #{Katello::RepositoryTypeManager.generic_content_types.join(", ")}"), required: true
+      param :content_type, lambda { |val| Katello::RepositoryTypeManager.generic_content_types.include?(val) },
+            desc: N_("Possible values: %s") % Katello::RepositoryTypeManager.generic_content_types.join(", "), required: true
     end
     apipie_concern_subst(:a_resource => N_("a content unit"), :resource_id => "content_units")
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fixes translations and also adds validation for the content type param

#### Considerations taken when implementing this change?
Found when discussing https://projects.theforeman.org/issues/37977?issue_count=56&issue_position=1&next_issue_id=37976

#### What are the testing steps for this pull request?
Ensure /apidoc/v2/generic_content_units/default_sort.en.html looks fine

Try using the APIs within and make sure they work