### PR TITLE
Fixes #37984 - Add 6.16 Capsule, Maintenance and Utils repos

### DIFF
--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -31,8 +31,6 @@ const recommendedRepositoriesSatTools = [
   'satellite-client-6-for-rhel-8-x86_64-rpms',
   'rhel-7-server-els-satellite-client-6-rpms',
   'rhel-7-server-els-satellite-6-client-2-rpms',
-  'satellite-6-client-2-for-rhel-8-x86_64-rpms',
-  'satellite-6-client-2-for-rhel-9-x86_64-rpms',
 ];
 
 const recommendedRepositoriesMisc = [

--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -37,6 +37,9 @@ const recommendedRepositoriesMisc = [
   'satellite-capsule-6.16-for-rhel-8-x86_64-rpms',
   'satellite-maintenance-6.16-for-rhel-8-x86_64-rpms',
   'satellite-utils-6.16-for-rhel-8-x86_64-rpms',
+  'satellite-utils-6.16-for-rhel-9-x86_64-rpms',
+  'satellite-maintenance-6.16-for-rhel-9-x86_64-rpms',
+  'satellite-capsule-6.16-for-rhel-9-x86_64-rpms',
 ];
 
 const recommendedRepositorySetLables = recommendedRepositoriesRHEL

--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -36,9 +36,9 @@ const recommendedRepositoriesSatTools = [
 ];
 
 const recommendedRepositoriesMisc = [
-  'satellite-capsule-6.15-for-rhel-8-x86_64-rpms',
-  'satellite-maintenance-6.15-for-rhel-8-x86_64-rpms',
-  'satellite-utils-6.15-for-rhel-8-x86_64-rpms',
+  'satellite-capsule-6.16-for-rhel-8-x86_64-rpms',
+  'satellite-maintenance-6.16-for-rhel-8-x86_64-rpms',
+  'satellite-utils-6.16-for-rhel-8-x86_64-rpms',
 ];
 
 const recommendedRepositorySetLables = recommendedRepositoriesRHEL


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

- Need to remove 6.15 repos from the Recommended Repos page
- Add 6.16 Capsule, Maintenance and Utils repos for RHEL 8 and RHEL 9 
- Need to remove Client2 repos from the Recommended Repos page as there is no ETA to push packages in it.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
- Need to verify that RHEL 8 and RHEL 9 based repos for Capsule, Maintenance and Utils can be listed and enabled successfully on the webui 
- Need to confirm that Client2 repos are not listed on the Recommended repos page. 
