### PR TITLE
Fixes #37989 - More APIs and remote repository mirroring action

### DIFF
--- a/app/controllers/katello/api/v2/flatpak_remote_repositories_controller.rb
+++ b/app/controllers/katello/api/v2/flatpak_remote_repositories_controller.rb
@@ -1,0 +1,81 @@
+module Katello
+  class Api::V2::FlatpakRemoteRepositoriesController < Katello::Api::V2::ApiController
+    include Katello::Concerns::FilteredAutoCompleteSearch
+
+    before_action :find_remote_repository, :except => [:index, :auto_complete_search]
+    before_action :find_optional_organization, :only => [:index, :auto_complete_search]
+    before_action :find_product, :only => [:mirror]
+
+    resource_description do
+      name 'Flatpak Remote Repositories'
+    end
+
+    def_param_group :flatpak_remote_repositories do
+      param :name, String, :desc => N_("Name of the flatpak remote repository")
+      param :label, String, :desc => N_("Label of the flatpak remote")
+    end
+
+    api :GET, "/organizations/:organization_id/flatpak_remote_repositories", N_("List flatpak remote repositories")
+    api :GET, "/flatpak_remotes/:flatpak_remote_id/flatpak_remote_repositories", N_("List flatpak remote's repositories")
+    param :organization_id, :number, :desc => N_("organization identifier")
+    param :flatpak_remote_id, :number, :desc => N_("ID of flatpak remote to show repositories of"), :required => true
+    param_group :flatpak_remote_repositories
+    param_group :search, Api::V2::ApiController
+    add_scoped_search_description_for(FlatpakRemoteRepository)
+    def index
+      respond(:collection => scoped_search(index_relation, :name, :asc))
+    end
+
+    def index_relation
+      query = FlatpakRemoteRepository.readable
+      query = index_remote_relation(query)
+      query = query.where(name: params[:name]) if params[:name]
+      query = query.where(label: params[:label]) if params[:label]
+      query
+    end
+
+    def index_remote_relation(query)
+      query = query.joins(:flatpak_remote_id => :remote).where("#{FlatpakRemote.table_name}.organization_id" => @organization) if @organization
+      if params[:flatpak_remote_id]
+        query.where(flatpak_remote_id: params[:flatpak_remote_id])
+      else
+        query
+      end
+    end
+
+    api :GET, "/flatpak_remote_repositories/:id", N_("Show a flatpak remote repository")
+    param :id, :number, :desc => N_("Flatpak remote numeric identifier"), :required => true
+    param :manifests, :boolean, :desc => N_("Include manifests"), :required => false
+    def show
+      respond :resource => @flatpak_remote_repository
+    end
+
+    api :POST, "/flatpak_remote_repositories/:id/mirror", N_("Mirror a flatpak remote repository")
+    param :id, :number, :desc => N_("Flatpak remote numeric identifier"), :required => true
+    param :product_id, :number, :desc => N_("Product ID to mirror the repository to"), :required => true
+    def mirror
+      task = async_task(::Actions::Katello::Flatpak::MirrorRemoteRepository, @flatpak_remote_repository, @product)
+      respond_for_async :resource => task
+    end
+
+    def default_sort
+      %w(name asc)
+    end
+
+    def flatpak_remote_repository_params
+      params.require(:flatpak_remote_repository).permit(:name, :label, :flatpak_remote_id)
+    end
+
+    def find_remote_repository
+      @flatpak_remote_repository = FlatpakRemoteRepository.find(params[:id])
+      throw_resource_not_found(name: 'flatpak_remote_repository', id: params[:id]) unless @flatpak_remote_repository
+      @flatpak_remote_repository
+    end
+
+    def find_product
+      @product = Product.editable.find(params[:product_id])
+      throw_resource_not_found(name: 'product', id: params[:product_id]) unless @product
+      @product
+    end
+  end
+end

--- a/app/controllers/katello/api/v2/flatpak_remotes_controller.rb
+++ b/app/controllers/katello/api/v2/flatpak_remotes_controller.rb
@@ -1,0 +1,83 @@
+module Katello
+  class Api::V2::FlatpakRemotesController < Katello::Api::V2::ApiController
+    include Katello::Concerns::FilteredAutoCompleteSearch
+
+    before_action :find_authorized_katello_resource, :except => [:index, :create, :scan, :auto_complete_search]
+    before_action :find_optional_organization, :only => [:index, :auto_complete_search]
+
+    resource_description do
+      name 'Flatpak Remotes'
+    end
+
+    def_param_group :flatpak_remote do
+      param :description, String, :desc => N_("Description of the flatpak remote"), :required => false
+      param :username, String, :desc => N_("Username for the flatpak remote"), :required => false
+      param :token, String, :desc => N_("Token/password for the flatpak remote"), :required => false
+    end
+
+    api :GET, "/organizations/:organization_id/flatpak_remotes", N_("List flatpak remotes")
+    api :GET, "/flatpak_remotes", N_("List flatpak remotes")
+    param :organization_id, :number, :desc => N_("organization identifier"), :required => false
+    param :name, String, :desc => N_("Name of the flatpak remote"), :required => false
+    param :label, String, :desc => N_("Label of the flatpak remote"), :required => false
+    param_group :search, Api::V2::ApiController
+    add_scoped_search_description_for(FlatpakRemote)
+    def index
+      respond(:collection => scoped_search(index_relation, :name, :asc))
+    end
+
+    def index_relation
+      remotes = FlatpakRemote.readable
+      remotes = remotes.where(organization_id: @organization.id) if @organization
+      remotes = remotes.where(name: params[:name]) if params[:name]
+      remotes = remotes.where(label: params[:label]) if params[:label]
+      remotes
+    end
+
+    api :GET, "/flatpak_remotes/:id", N_("Show a content view")
+    param :id, :number, :desc => N_("Flatpak remote numeric identifier"), :required => true
+    def show
+      respond :resource => @flatpak_remote
+    end
+
+    api :POST, "/flatpak_remote", N_("Create a flatpak remote")
+    param :name, String, :desc => N_("name"), :required => true
+    param :url, String, :desc => N_("url"), :required => true
+    param :organization_id, :number, :desc => N_("organization identifier"), :required => true
+    param_group :flatpak_remote
+    def create
+      flatpak_remote = FlatpakRemote.new(flatpak_remote_params)
+      respond_for_create(resource: flatpak_remote)
+    end
+
+    api :PUT, "/flatpak_remotes/:id", N_("Update a flatpak remote")
+    param_group :flatpak_remote
+    param :id, :number, :desc => N_("Flatpak remote numeric identifier"), :required => true
+    param :name, String, :desc => N_("name")
+    param :url, String, :desc => N_("url")
+    def update
+      @flatpak_remote.update!(flatpak_remote_params)
+    end
+
+    api :DELETE, "/flatpak_remotes/:id", N_("Delete a flatpak remote")
+    param :id, :number, :desc => N_("Flatpak remote numeric identifier"), :required => true
+    def destroy
+      @flatpak_remote.destroy
+    end
+
+    api :POST, "/flatpak_remote/:id/scan", N_("Scan a flatpak remote")
+    param :id, :number, :desc => N_("Flatpak remote numeric identifier"), :required => true
+    def scan
+      task = async_task(::Actions::Katello::Flatpak::ScanRemote, @flatpak_remote)
+      respond_for_async :resource => task
+    end
+
+    def default_sort
+      %w(name asc)
+    end
+
+    def flatpak_remote_params
+      params.require(:flatpak_remote).permit(:name, :url, :organization_id, :description, :username, :token)
+    end
+  end
+end

--- a/app/controllers/katello/api/v2/flatpak_remotes_controller.rb
+++ b/app/controllers/katello/api/v2/flatpak_remotes_controller.rb
@@ -2,7 +2,7 @@ module Katello
   class Api::V2::FlatpakRemotesController < Katello::Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
 
-    before_action :find_authorized_katello_resource, :except => [:index, :create, :scan, :auto_complete_search]
+    before_action :find_authorized_katello_resource, :except => [:index, :create, :auto_complete_search]
     before_action :find_optional_organization, :only => [:index, :auto_complete_search]
 
     resource_description do
@@ -34,7 +34,7 @@ module Katello
       remotes
     end
 
-    api :GET, "/flatpak_remotes/:id", N_("Show a content view")
+    api :GET, "/flatpak_remotes/:id", N_("Show a flatpak remote")
     param :id, :number, :desc => N_("Flatpak remote numeric identifier"), :required => true
     def show
       respond :resource => @flatpak_remote
@@ -47,6 +47,7 @@ module Katello
     param_group :flatpak_remote
     def create
       flatpak_remote = FlatpakRemote.new(flatpak_remote_params)
+      flatpak_remote.save!
       respond_for_create(resource: flatpak_remote)
     end
 
@@ -57,6 +58,7 @@ module Katello
     param :url, String, :desc => N_("url")
     def update
       @flatpak_remote.update!(flatpak_remote_params)
+      respond_for_show(:resource => @flatpak_remote)
     end
 
     api :DELETE, "/flatpak_remotes/:id", N_("Delete a flatpak remote")

--- a/app/lib/actions/katello/flatpak/mirror_remote_repository.rb
+++ b/app/lib/actions/katello/flatpak/mirror_remote_repository.rb
@@ -1,0 +1,30 @@
+module Actions
+  module Katello
+    module Flatpak
+      class MirrorRemoteRepository < Actions::EntryAction
+        def plan(remote_repository, product)
+          repo_params = {
+            name: remote_repository.name,
+            label: remote_repository.label,
+            url: remote_repository.flatpak_remote&.registry_url,
+            description: 'Mirrored from: ' + remote_repository.flatpak_remote.name,
+            product_id: product.id,
+            content_type: 'docker',
+            docker_upstream_name: remote_repository.name,
+            include_tags: ["latest"],
+            upstream_username: remote_repository.flatpak_remote.username,
+            upstream_password: remote_repository.flatpak_remote.token,
+            unprotected: true,
+            mirroring_policy: ::Katello::RootRepository::MIRRORING_POLICY_CONTENT,
+          }
+          root = product.add_repo(repo_params)
+          plan_action(::Actions::Katello::Repository::CreateRoot, root)
+        end
+
+        def humanized_name
+          _("Mirror Remote Repository")
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/authorization/flatpak_remote.rb
+++ b/app/models/katello/authorization/flatpak_remote.rb
@@ -1,0 +1,33 @@
+module Katello
+  module Authorization::FlatpakRemote
+    extend ActiveSupport::Concern
+
+    include Authorizable
+
+    def readable?
+      authorized?(:view_flatpak_remotes)
+    end
+
+    def editable?
+      authorized?(:edit_flatpak_remotes)
+    end
+
+    def deletable?
+      authorized?(:destroy_flatpak_remotes)
+    end
+
+    module ClassMethods
+      def readable
+        authorized(:view_flatpak_remotes)
+      end
+
+      def editable
+        authorized(:edit_flatpak_remotes)
+      end
+
+      def deletable
+        authorized(:destroy_flatpak_remotes)
+      end
+    end
+  end
+end

--- a/app/models/katello/flatpak_remote.rb
+++ b/app/models/katello/flatpak_remote.rb
@@ -1,5 +1,8 @@
 module Katello
   class FlatpakRemote < Katello::Model
+    include Authorization::FlatpakRemote
+    include ForemanTasks::Concerns::ActionSubject
+
     has_many :remote_repositories, dependent: :destroy, class_name: 'Katello::FlatpakRemoteRepository'
     has_many :remote_repository_manifests, through: :remote_repositories, source: :remote_repository_manifests
     belongs_to :organization, inverse_of: :flatpak_remotes
@@ -7,5 +10,12 @@ module Katello
     validates :name, presence: true
     validates :url, presence: true
     validates :organization_id, presence: true
+
+    scope :seeded, -> { where(:seeded => true) }
+
+    scoped_search :on => :name, :complete_value => true
+    scoped_search :on => :organization_id, :complete_value => true, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
+    scoped_search :on => :url, :complete_value => true
+    scoped_search :on => :seeded, :complete_value => true
   end
 end

--- a/app/models/katello/flatpak_remote.rb
+++ b/app/models/katello/flatpak_remote.rb
@@ -17,5 +17,6 @@ module Katello
     scoped_search :on => :organization_id, :complete_value => true, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
     scoped_search :on => :url, :complete_value => true
     scoped_search :on => :seeded, :complete_value => true
+    scoped_search :on => :registry_url, :complete_value => true
   end
 end

--- a/app/models/katello/flatpak_remote_repository.rb
+++ b/app/models/katello/flatpak_remote_repository.rb
@@ -1,5 +1,7 @@
 module Katello
   class FlatpakRemoteRepository < Katello::Model
+    include Ext::LabelFromName
+
     belongs_to :flatpak_remote, inverse_of: :remote_repositories
     has_many :remote_repository_manifests, dependent: :destroy, class_name: 'Katello::FlatpakRemoteRepositoryManifest'
 
@@ -7,6 +9,22 @@ module Katello
     validates :name, presence: true
     validates :label, presence: true
 
+    scoped_search :on => :name, :complete_value => true
+    scoped_search :on => :label, :complete_value => true
+    scoped_search :on => :flatpak_remote_id, :complete_value => true, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
+
     alias_attribute :manifests, :remote_repository_manifests
+
+    def self.readable
+      where(flatpak_remote_id: FlatpakRemote.readable)
+    end
+
+    def manifest_dependencies
+      FlatpakRemoteRepositoryManifest.where(flatpak_ref: self.manifests&.select(:runtime))
+    end
+
+    def repository_dependencies
+      manifest_dependencies&.map(&:remote_repository)
+    end
   end
 end

--- a/app/models/katello/flatpak_remote_repository_manifest.rb
+++ b/app/models/katello/flatpak_remote_repository_manifest.rb
@@ -6,5 +6,9 @@ module Katello
                inverse_of: :remote_repository_manifests
     validates :flatpak_remote_repository_id, presence: true
     validates :name, presence: true
+
+    def runtime_dependency
+      FlatpakRemoteRepositoryManifest.where(flatpak_ref: self.runtime)
+    end
   end
 end

--- a/app/views/katello/api/v2/flatpak_remote_repositories/base.json.rabl
+++ b/app/views/katello/api/v2/flatpak_remote_repositories/base.json.rabl
@@ -1,0 +1,4 @@
+extends 'katello/api/v2/common/identifier'
+
+attributes :name
+attributes :label, :flatpak_remote_id

--- a/app/views/katello/api/v2/flatpak_remote_repositories/index.json.rabl
+++ b/app/views/katello/api/v2/flatpak_remote_repositories/index.json.rabl
@@ -1,0 +1,7 @@
+object false
+
+extends "katello/api/v2/common/index"
+
+child @collection[:results] => :results do
+  extends "katello/api/v2/flatpak_remote_repositories/base"
+end

--- a/app/views/katello/api/v2/flatpak_remote_repositories/show.json.rabl
+++ b/app/views/katello/api/v2/flatpak_remote_repositories/show.json.rabl
@@ -1,0 +1,13 @@
+object @resource
+
+extends "katello/api/v2/flatpak_remote_repositories/base"
+
+child :flatpak_remote => :flatpak_remote do
+  attributes :id, :name, :url
+end
+
+if ::Foreman::Cast.to_bool params[:manifests]
+  child :manifests => :manifests do
+    attributes :name, :digest, :tags, :application, :runtime, :flatpak_ref
+  end
+end

--- a/app/views/katello/api/v2/flatpak_remotes/base.json.rabl
+++ b/app/views/katello/api/v2/flatpak_remotes/base.json.rabl
@@ -1,0 +1,5 @@
+extends 'katello/api/v2/common/identifier'
+extends 'katello/api/v2/common/org_reference'
+
+attributes :name
+attributes :url, :description, :username, :token, :seeded

--- a/app/views/katello/api/v2/flatpak_remotes/base.json.rabl
+++ b/app/views/katello/api/v2/flatpak_remotes/base.json.rabl
@@ -2,4 +2,4 @@ extends 'katello/api/v2/common/identifier'
 extends 'katello/api/v2/common/org_reference'
 
 attributes :name
-attributes :url, :description, :username, :token, :seeded
+attributes :url, :description, :username, :token, :seeded, :registry_url

--- a/app/views/katello/api/v2/flatpak_remotes/index.json.rabl
+++ b/app/views/katello/api/v2/flatpak_remotes/index.json.rabl
@@ -1,0 +1,8 @@
+object false
+
+extends "katello/api/v2/common/index"
+extends 'katello/api/v2/flatpak_remotes/permissions'
+
+child @collection[:results] => :results do
+  extends "katello/api/v2/flatpak_remotes/base"
+end

--- a/app/views/katello/api/v2/flatpak_remotes/permissions.json.rabl
+++ b/app/views/katello/api/v2/flatpak_remotes/permissions.json.rabl
@@ -1,0 +1,11 @@
+collection @flatpak_remotes
+
+if ::Foreman::Cast.to_bool(params.fetch(:include_permissions, false))
+  user = User.current # current_user is not available here
+  node do
+    node(:can_create) { user.can?("create_flatpak_remotes") }
+    node(:can_edit) { user.can?("edit_flatpak_remotes") }
+    node(:can_delete) { user.can?("destroy_flatpak_remotes") }
+    node(:can_view) { user.can?("view_flatpak_remotes") }
+  end
+end

--- a/app/views/katello/api/v2/flatpak_remotes/show.json.rabl
+++ b/app/views/katello/api/v2/flatpak_remotes/show.json.rabl
@@ -1,0 +1,3 @@
+object @resource
+
+extends "katello/api/v2/flatpak_remotes/base"

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -15,6 +15,13 @@ Katello::Engine.routes.draw do
           get :auto_complete_search, :on => :collection
         end
 
+        api_resources :flatpak_remotes, :only => [:index, :show, :create, :update, :destroy] do
+          get :auto_complete_search, :on => :collection
+          member do
+            post :scan
+          end
+        end
+
         api_resources :capsules, :only => [:index, :show] do
           member do
             resource :content, :only => [], :controller => 'capsule_content' do

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -20,6 +20,14 @@ Katello::Engine.routes.draw do
           member do
             post :scan
           end
+          api_resources :flatpak_remote_repositories, :only => [:index, :show]
+        end
+
+        api_resources :flatpak_remote_repositories, :only => [:index, :show] do
+          get :auto_complete_search, :on => :collection
+          member do
+            post :mirror
+          end
         end
 
         api_resources :capsules, :only => [:index, :show] do

--- a/db/migrate/20241107002541_add_registry_url_to_katello_flatpak_remotes.rb
+++ b/db/migrate/20241107002541_add_registry_url_to_katello_flatpak_remotes.rb
@@ -1,0 +1,5 @@
+class AddRegistryURLToKatelloFlatpakRemotes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :katello_flatpak_remotes, :registry_url, :string
+  end
+end

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -306,6 +306,7 @@ module Katello
                            'katello/api/v2/content_uploads' => [:create, :update, :destroy],
                            'katello/api/v2/organizations' => [:repo_discover, :cancel_repo_discover],
                            'katello/api/v2/repository_sets' => [:enable, :disable],
+                           'katello/api/v2/flatpak_remote_repositories' => [:mirror],
                          },
                          :resource_type => 'Katello::Product',
                          :finder_scope => :editable
@@ -454,46 +455,36 @@ module Katello
     def flatpak_remote_permissions
       @plugin.permission :view_flatpak_remotes,
                          {
-                           'katello/api/v2/flatpak_remotes' => [:index, :show, :auto_complete_search]
+                           'katello/api/v2/flatpak_remotes' => [:index, :show, :auto_complete_search],
+                           'katello/api/v2/flatpak_remote_repositories' => [:index, :show, :auto_complete_search],
+                           'katello/api/v2/flatpak_remote_repository_manifests' => [:index, :show, :auto_complete_search],
                          },
                          :resource_type => 'Katello::FlatpakRemote',
                          :finder_scope => :readable
       @plugin.permission :create_flatpak_remotes,
                          {
-                           'katello/api/v2/flatpak_remotes' => [:create]
+                           'katello/api/v2/flatpak_remotes' => [:create],
+                           'katello/api/v2/flatpak_remote_repositories' => [:create],
+                           'katello/api/v2/flatpak_remote_repository_manifests' => [:create],
                          },
                          :resource_type => 'Katello::FlatpakRemote',
                          :finder_scope => :creatable
       @plugin.permission :edit_flatpak_remotes,
                          {
-                           'katello/api/v2/flatpak_remotes' => [:update, :scan]
+                           'katello/api/v2/flatpak_remotes' => [:update, :scan],
+                           'katello/api/v2/flatpak_remote_repositories' => [:update],
+                           'katello/api/v2/flatpak_remote_repository_manifests' => [:update],
                          },
                          :resource_type => 'Katello::FlatpakRemote',
                          :finder_scope => :editable
       @plugin.permission :destroy_flatpak_remotes,
                          {
-                           'katello/api/v2/flatpak_remotes' => [:destroy]
+                           'katello/api/v2/flatpak_remotes' => [:destroy],
+                           'katello/api/v2/flatpak_remote_repositories' => [:destroy],
+                           'katello/api/v2/flatpak_remote_repository_manifests' => [:destroy],
                          },
                          :resource_type => 'Katello::FlatpakRemote',
                          :finder_scope => :deletable
-    end
-
-    def flatpak_remote_repository_permissions
-      @plugin.permission :view_flatpak_remote_repositories,
-                          {
-                            'katello/api/v2/flatpak_remote_repositories' => [:index, :show, :auto_complete_search]
-                          },
-                          :resource_type => 'Katello::FlatpakRemoteRepository',
-                          :finder_scope => :readable
-    end
-
-    def flatpak_remote_repository_manifest_permissions
-      @plugin.permission :view_flatpak_remote_repository_manifests,
-                          {
-                            'katello/api/v2/flatpak_remote_repository_manifests' => [:index, :show, :auto_complete_search]
-                          },
-                          :resource_type => 'Katello::FlatpakRemoteRepositoryManifest',
-                          :finder_scope => :readable
     end
   end
 end

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -16,6 +16,7 @@ module Katello
       subscription_permissions
       sync_plan_permissions
       alternate_content_source_permissions
+      flatpak_remote_permissions
       user_permissions
     end
 
@@ -448,6 +449,51 @@ module Katello
                            'katello/api/v2/content_export_incrementals' => [:library, :version, :repository],
                          },
                          :resource_type => 'Organization'
+    end
+
+    def flatpak_remote_permissions
+      @plugin.permission :view_flatpak_remotes,
+                         {
+                           'katello/api/v2/flatpak_remotes' => [:index, :show, :auto_complete_search]
+                         },
+                         :resource_type => 'Katello::FlatpakRemote',
+                         :finder_scope => :readable
+      @plugin.permission :create_flatpak_remotes,
+                         {
+                           'katello/api/v2/flatpak_remotes' => [:create]
+                         },
+                         :resource_type => 'Katello::FlatpakRemote',
+                         :finder_scope => :creatable
+      @plugin.permission :edit_flatpak_remotes,
+                         {
+                           'katello/api/v2/flatpak_remotes' => [:update, :scan]
+                         },
+                         :resource_type => 'Katello::FlatpakRemote',
+                         :finder_scope => :editable
+      @plugin.permission :destroy_flatpak_remotes,
+                         {
+                           'katello/api/v2/flatpak_remotes' => [:destroy]
+                         },
+                         :resource_type => 'Katello::FlatpakRemote',
+                         :finder_scope => :deletable
+    end
+
+    def flatpak_remote_repository_permissions
+      @plugin.permission :view_flatpak_remote_repositories,
+                          {
+                            'katello/api/v2/flatpak_remote_repositories' => [:index, :show, :auto_complete_search]
+                          },
+                          :resource_type => 'Katello::FlatpakRemoteRepository',
+                          :finder_scope => :readable
+    end
+
+    def flatpak_remote_repository_manifest_permissions
+      @plugin.permission :view_flatpak_remote_repository_manifests,
+                          {
+                            'katello/api/v2/flatpak_remote_repository_manifests' => [:index, :show, :auto_complete_search]
+                          },
+                          :resource_type => 'Katello::FlatpakRemoteRepositoryManifest',
+                          :finder_scope => :readable
     end
   end
 end

--- a/test/actions/katello/flatpak/mirror_remote_repository_test.rb
+++ b/test/actions/katello/flatpak/mirror_remote_repository_test.rb
@@ -1,0 +1,42 @@
+require 'katello_test_helper'
+
+module ::Actions::Katello::Flatpak
+  class MirrorRemoteRepositoryTest < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+
+    let(:action) { create_action action_class }
+    let(:remote_repository) { katello_flatpak_remote_repositories(:rhel9_flatpak_runtime) }
+    let(:product) { katello_products(:empty_product) }
+    let(:random_root) { katello_root_repositories(:busybox_root) }
+
+    class MirrorRemoteRepositoryTest < MirrorRemoteRepositoryTest
+      let(:action_class) { ::Actions::Katello::Flatpak::MirrorRemoteRepository }
+      let(:input) do
+        {
+          remote_repository: remote_repository,
+          product: product,
+        }
+      end
+
+      it 'plans' do
+        product.expects(:add_repo).with({
+                                          name: remote_repository.name,
+                                          label: remote_repository.label,
+                                          url: remote_repository.flatpak_remote&.registry_url,
+                                          description: 'Mirrored from: ' + remote_repository.flatpak_remote.name,
+                                          product_id: product.id,
+                                          content_type: 'docker',
+                                          docker_upstream_name: "rhel9/flatpak-runtime",
+                                          include_tags: ["latest"],
+                                          upstream_username: nil,
+                                          upstream_password: nil,
+                                          unprotected: true,
+                                          mirroring_policy: ::Katello::RootRepository::MIRRORING_POLICY_CONTENT,
+                                        }).returns(random_root)
+        plan_action action, remote_repository, product
+        assert_action_planned_with(action, ::Actions::Katello::Repository::CreateRoot, random_root)
+      end
+    end
+  end
+end

--- a/test/controllers/api/v2/flatpak_remote_repositories_controller_test.rb
+++ b/test/controllers/api/v2/flatpak_remote_repositories_controller_test.rb
@@ -1,0 +1,98 @@
+require 'katello_test_helper'
+
+module Katello
+  class Api::V2::FlatpakRemoteRepositoriesControllerTest < ActionController::TestCase
+    include Support::ForemanTasks::Task
+    def models
+      @organization = get_organization
+      @product = katello_products(:empty_product)
+      @remote = katello_flatpak_remotes(:redhat_flatpak_remote)
+      @redhat_remote_runtime_repository = katello_flatpak_remote_repositories(:rhel9_flatpak_runtime)
+      @redhat_remote_firefox_repository = katello_flatpak_remote_repositories(:rhel9_firefox_flatpak)
+    end
+
+    def permissions
+      @view_permission = :view_flatpak_remotes
+      @create_permission = :create_flatpak_remotes
+      @update_permission = :edit_flatpak_remotes
+      @destroy_permission = :destroy_flatpak_remotes
+      @product_edit_permission = :edit_products
+    end
+
+    def setup
+      setup_controller_defaults_api
+      models
+      permissions
+    end
+
+    def test_index
+      get :index
+      assert_response :success
+      assert_template 'api/v2/flatpak_remote_repositories/index'
+    end
+
+    def test_index_with_name
+      response = get :index, params: { name: @redhat_remote_runtime_repository.name }
+
+      assert_response :success
+      assert_template 'api/v2/flatpak_remote_repositories/index'
+      assert_response_ids response, [@redhat_remote_runtime_repository.id]
+    end
+
+    def test_index_with_remote
+      response = get :index, params: { flatpak_remote_id: @remote.id }
+
+      assert_response :success
+      assert_template 'api/v2/flatpak_remote_repositories/index'
+      assert_response_ids response, [@redhat_remote_runtime_repository.id, @redhat_remote_firefox_repository.id]
+    end
+
+    def test_index_protected
+      allowed_perms = [@view_permission]
+      denied_perms = [@create_permission, @update_permission, @destroy_permission]
+
+      assert_protected_action(:index, allowed_perms, denied_perms, [@organization]) do
+        get :index, params: { :organization_id => @organization.id }
+      end
+    end
+
+    def test_show
+      get :show, params: { :id => @redhat_remote_runtime_repository.id }
+
+      assert_response :success
+      assert_template 'api/v2/flatpak_remote_repositories/show'
+    end
+
+    def test_show_with_manifest
+      get :show, params: { :id => @redhat_remote_runtime_repository.id, :manifests => true }
+
+      assert_response :success
+      assert_template 'api/v2/flatpak_remote_repositories/show'
+    end
+
+    def test_show_protected
+      allowed_perms = [@view_permission]
+      denied_perms = [@create_permission, @update_permission, @destroy_permission]
+
+      assert_protected_action(:show, allowed_perms, denied_perms) do
+        get :show, params: { :id => @redhat_remote_runtime_repository.id }
+      end
+    end
+
+    def test_mirror
+      post :mirror, params: { :id => @redhat_remote_runtime_repository.id, :product_id => @product.id }
+
+      assert_response :success
+      assert_template 'api/v2/common/async'
+    end
+
+    def test_mirror_protected
+      allowed_perms = [@product_edit_permission]
+      denied_perms = [@create_permission, @view_permission, @update_permission, @destroy_permission]
+
+      assert_protected_action(:mirror, allowed_perms, denied_perms) do
+        post :mirror, params: { :id => @redhat_remote_runtime_repository.id, :product_id => @product.id }
+      end
+    end
+  end
+end

--- a/test/controllers/api/v2/flatpak_remotes_controller_test.rb
+++ b/test/controllers/api/v2/flatpak_remotes_controller_test.rb
@@ -1,0 +1,109 @@
+require 'katello_test_helper'
+
+module Katello
+  class Api::V2::FlatpakRemotesControllerTest < ActionController::TestCase
+    include Support::ForemanTasks::Task
+    def models
+      @organization = get_organization
+      @remote = katello_flatpak_remotes(:redhat_flatpak_remote)
+    end
+
+    def permissions
+      @view_permission = :view_flatpak_remotes
+      @create_permission = :create_flatpak_remotes
+      @update_permission = :edit_flatpak_remotes
+      @destroy_permission = :destroy_flatpak_remotes
+    end
+
+    def setup
+      setup_controller_defaults_api
+      models
+      permissions
+    end
+
+    def test_index
+      get :index
+
+      assert_response :success
+      assert_template 'api/v2/flatpak_remotes/index'
+    end
+
+    def test_index_with_name
+      response = get :index, params: { name: @remote.name }
+
+      assert_response :success
+      assert_template 'api/v2/flatpak_remotes/index'
+      assert_response_ids response, [@remote.id]
+    end
+
+    def test_index_protected
+      allowed_perms = [@view_permission]
+      denied_perms = [@create_permission, @update_permission, @destroy_permission]
+
+      assert_protected_action(:index, allowed_perms, denied_perms, [@organization]) do
+        get :index, params: { :organization_id => @organization.id }
+      end
+    end
+
+    def test_show
+      get :show, params: { :id => @remote.id }
+
+      assert_response :success
+      assert_template 'api/v2/flatpak_remotes/show'
+    end
+
+    def test_show_protected
+      allowed_perms = [@view_permission]
+      denied_perms = [@create_permission, @update_permission, @destroy_permission]
+
+      assert_protected_action(:show, allowed_perms, denied_perms) do
+        get :show, params: { :id => @remote.id }
+      end
+    end
+
+    def test_create
+      post :create, params: { name: 'test', url: 'https://test.com', organization_id: @organization.id }
+
+      assert_response :success
+      assert_template 'api/v2/common/create'
+    end
+
+    def test_create_protected
+      allowed_perms = [@create_permission]
+      denied_perms = [@view_permission, @update_permission, @destroy_permission]
+
+      assert_protected_action(:create, allowed_perms, denied_perms, [@organization]) do
+        post :create, params: { name: 'test', url: 'https://test.com', organization_id: @organization.id }
+      end
+    end
+
+    def test_update
+      put :update, params: { id: @remote.id, name: 'test' }
+
+      assert_response :success
+      assert_template 'api/v2/flatpak_remotes/show'
+    end
+
+    def test_destroy
+      delete :destroy, params: { id: @remote.id }
+
+      assert_response :success
+    end
+
+    def test_scan
+      post :scan, params: { id: @remote.id }
+
+      assert_response :success
+      assert_template 'api/v2/common/async'
+    end
+
+    def test_scan_protected
+      allowed_perms = [@update_permission]
+      denied_perms = [@create_permission, @view_permission, @destroy_permission]
+
+      assert_protected_action(:scan, allowed_perms, denied_perms) do
+        post :scan, params: { id: @remote.id }
+      end
+    end
+  end
+end

--- a/test/fixtures/models/katello_flatpak_remote_repositories.yml
+++ b/test/fixtures/models/katello_flatpak_remote_repositories.yml
@@ -1,27 +1,27 @@
 rhel9_flatpak_runtime:
   name: "rhel9/flatpak-runtime"
-  label: "Redhat flatpak-rhel9/flatpak-runtime"
+  label: "Redhat_flatpak-rhel9_flatpak-runtime"
   flatpak_remote_id: <%= ActiveRecord::FixtureSet.identify(:redhat_flatpak_remote) %>
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
 
 f41_flatpak_runtime:
   name: "f41/flatpak-runtime"
-  label: "Fedora flatpak-f41/flatpak-runtime"
+  label: "Fedora_flatpak-f41_flatpak-runtime"
   flatpak_remote_id: <%= ActiveRecord::FixtureSet.identify(:fedora_flatpak_remote) %>
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
 
 rhel9_firefox_flatpak:
   name: "rhel9/firefox-flatpak"
-  label: "Redhat flatpak-rhel9/firefox-flatpak"
+  label: "Redhat_flatpak-rhel9-firefox-flatpak"
   flatpak_remote_id: <%= ActiveRecord::FixtureSet.identify(:redhat_flatpak_remote) %>
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
 
 firefox:
   name: firefox
-  label: "Fedora flatpak-firefox"
+  label: "Fedora_flatpak-firefox"
   flatpak_remote_id: <%= ActiveRecord::FixtureSet.identify(:fedora_flatpak_remote) %>
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add API endpoints for remote repositories, manifests and introduce the remote repository mirroring action which mirrors the remote repository into a katello repository.
#### Considerations taken when implementing this change?
Added a registry_url on remote object cause remote url != registry URL.
#### What are the testing steps for this pull request?
Run bundle exec rails db:migrate to migrate db
Run following to create 2 remotes, one pointing to redhat flatpak index and another at fedora flatpak index:


```
remote1 = Katello::FlatpakRemote.new(name: "Redhat flatpak", 
url: "https://flatpaks.redhat.io/rhel",
organization_id: 1,
seeded: true,
username: get from [token.redhat.com ](https://access.redhat.com/terms-based-registry/token/)
token: get from [token.redhat.com ](https://access.redhat.com/terms-based-registry/token/)
)
remote1.save!

remote2 = Katello::FlatpakRemote.new(name: "Fedora flatpak", url: "https://registry.fedoraproject.org/",organization_id: 1,seeded: true)
remote2.save!

```
Run the below actions to scan the 2 indexes and you should have 2 successful actions in your foreman tasks.


#Sync redhat flatpak:
redhat_remote =  Katello::FlatpakRemote.find_by(name: "Redhat flatpak")
ForemanTasks.sync_task(::Actions::Katello::Flatpak::ScanRemote, redhat_remote)

#Sync fedora flatpak:
fedora_remote =  Katello::FlatpakRemote.find_by(name: "Fedora flatpak")
ForemanTasks.sync_task(::Actions::Katello::Flatpak::ScanRemote, fedora_remote)

API:
Remotes:
[https://centos9-katello-devel.sajha.example.com/katello/api/v2/flatpak_remotes/](https://centos9-katello-devel.sajha.example.com/katello/api/v2/flatpak_remotes/5/flatpak_remote_repositories/1059?manifests=true)

Remote repository:
https://centos9-katello-devel.sajha.example.com/katello/api/v2/flatpak_remotes/5/flatpak_remote_repositories/

Remote repository with manifests:
https://centos9-katello-devel.sajha.example.com/katello/api/v2/flatpak_remotes/5/flatpak_remote_repositories/1059?manifests=true

Now you can mirror the repo into Katello by providing remote repo id and a product id:
To mirror a remote repository:
Console:

product = Katello::Product.custom.last
firefox_repository = Katello::FlatpakRemoteRepository.find_by(name: "rhel9/firefox-flatpak")
ForemanTasks.sync_task(::Actions::Katello::Flatpak::MirrorRemoteRepository, firefox_repository, product)

Now sync the new repo and verify that everything looks sane.

Testing permissions:
All of the above steps should work for the admin user and the console admin.
If you create a new user role, they'll need flatpak_remote_permissions : view_flatpak_remotes, create_flatpak_remotes and edit_flatpak_remotes to do actions on remotes.
To mirror remote repos, i.e, create katello repos from remote repo, you need to have the edit_product permission.