### PR TITLE
Fixes #37994 - Populate bootc fields from facts and associate hosts with manifest entities

### DIFF
--- a/app/models/katello/concerns/content_facet_host_extensions.rb
+++ b/app/models/katello/concerns/content_facet_host_extensions.rb
@@ -94,7 +94,8 @@ module Katello
           if state
             hosts = ::Host::Managed.joins(:content_facet).select(:id).where.not("#{::Katello::Host::ContentFacet.table_name}.bootc_booted_image" => nil)
           else
-            hosts = ::Host::Managed.joins(:content_facet).select(:id).where("#{::Katello::Host::ContentFacet.table_name}.bootc_booted_image" => nil)
+            # left_outer_joins will include hosts without a content facet. We assume such hosts are package-mode hosts.
+            hosts = ::Host::Managed.left_outer_joins(:content_facet).select(:id).where("#{::Katello::Host::ContentFacet.table_name}.bootc_booted_image" => nil)
           end
           { :conditions => "#{::Host::Managed.table_name}.id IN (#{hosts.to_sql})" }
         end

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -98,6 +98,9 @@ module Katello
         has_many :content_views, through: :content_view_environments
         has_many :lifecycle_environments, through: :content_view_environments
 
+        has_one :docker_manifest, through: :content_facet, source: :manifest_entity, source_type: 'Katello::DockerManifest'
+        has_one :docker_manifest_list, through: :content_facet, source: :manifest_entity, source_type: 'Katello::DockerManifestList'
+
         has_many :host_installed_packages, :class_name => "::Katello::HostInstalledPackage", :foreign_key => :host_id, :dependent => :delete_all
         has_many :installed_packages, :class_name => "::Katello::InstalledPackage", :through => :host_installed_packages
 

--- a/app/models/katello/docker_manifest.rb
+++ b/app/models/katello/docker_manifest.rb
@@ -5,13 +5,18 @@ module Katello
     has_many :docker_manifest_list_manifests, :class_name => "Katello::DockerManifestListManifest",
              :dependent => :delete_all, :inverse_of => :docker_manifest
     has_many :docker_manifest_lists, :through => :docker_manifest_list_manifests, :inverse_of => :docker_manifests
+    has_many :content_facets, :as => :manifest_entity
+    has_many :hosts, :class_name => "::Host::Managed", :through => :content_facets, :inverse_of => :docker_manifests
 
     CONTENT_TYPE = "docker_manifest".freeze
+
+    scope :bootable, -> { where(:is_bootable => true) }
 
     scoped_search :relation => :docker_tags, :on => :name, :rename => :tag, :complete_value => true
     scoped_search :on => :digest, :rename => :digest, :complete_value => true, :only_explicit => true
     scoped_search :on => :schema_version, :rename => :schema_version, :complete_value => true, :only_explicit => true
     scoped_search :relation => :docker_manifest_lists, :on => :digest, :rename => :manifest_list_digest, :complete_value => true, :only_explicit => true
+    scoped_search :on => :is_bootable, :rename => :bootable, :complete_value => { true => true, false => false }, :only_explicit => true
 
     def self.default_sort
       order(:schema_version)

--- a/app/models/katello/docker_manifest.rb
+++ b/app/models/katello/docker_manifest.rb
@@ -16,7 +16,7 @@ module Katello
     scoped_search :on => :digest, :rename => :digest, :complete_value => true, :only_explicit => true
     scoped_search :on => :schema_version, :rename => :schema_version, :complete_value => true, :only_explicit => true
     scoped_search :relation => :docker_manifest_lists, :on => :digest, :rename => :manifest_list_digest, :complete_value => true, :only_explicit => true
-    scoped_search :on => :is_bootable, :rename => :bootable, :complete_value => { true => true, false => false }, :only_explicit => true
+    scoped_search :on => :is_bootable, :rename => :bootable, :complete_value => true, :only_explicit => true
 
     def self.default_sort
       order(:schema_version)

--- a/app/models/katello/docker_manifest.rb
+++ b/app/models/katello/docker_manifest.rb
@@ -5,7 +5,7 @@ module Katello
     has_many :docker_manifest_list_manifests, :class_name => "Katello::DockerManifestListManifest",
              :dependent => :delete_all, :inverse_of => :docker_manifest
     has_many :docker_manifest_lists, :through => :docker_manifest_list_manifests, :inverse_of => :docker_manifests
-    has_many :content_facets, :as => :manifest_entity
+    has_many :content_facets, :as => :manifest_entity, :dependent => :nullify
     has_many :hosts, :class_name => "::Host::Managed", :through => :content_facets, :inverse_of => :docker_manifests
 
     CONTENT_TYPE = "docker_manifest".freeze

--- a/app/models/katello/docker_manifest.rb
+++ b/app/models/katello/docker_manifest.rb
@@ -5,8 +5,8 @@ module Katello
     has_many :docker_manifest_list_manifests, :class_name => "Katello::DockerManifestListManifest",
              :dependent => :delete_all, :inverse_of => :docker_manifest
     has_many :docker_manifest_lists, :through => :docker_manifest_list_manifests, :inverse_of => :docker_manifests
-    has_many :content_facets, :as => :manifest_entity, :dependent => :nullify
-    has_many :hosts, :class_name => "::Host::Managed", :through => :content_facets, :inverse_of => :docker_manifests
+    has_many :content_facets, :class_name => "::Katello::Host::ContentFacet", :as => :manifest_entity, :dependent => :nullify
+    has_many :hosts, :class_name => "::Host::Managed", :through => :content_facets, :inverse_of => :docker_manifest
 
     CONTENT_TYPE = "docker_manifest".freeze
 

--- a/app/models/katello/docker_manifest_list.rb
+++ b/app/models/katello/docker_manifest_list.rb
@@ -16,7 +16,7 @@ module Katello
     scoped_search :relation => :docker_tags, :on => :name, :rename => :tag, :complete_value => true
     scoped_search :on => :digest, :rename => :digest, :complete_value => true, :only_explicit => true
     scoped_search :on => :schema_version, :rename => :schema_version, :complete_value => true, :only_explicit => true
-    scoped_search :on => :is_bootable, :rename => :bootable, :complete_value => { true => true, false => false }, :only_explicit => true
+    scoped_search :on => :is_bootable, :rename => :bootable, :complete_value => true, :only_explicit => true
 
     def self.default_sort
       order(:schema_version)

--- a/app/models/katello/docker_manifest_list.rb
+++ b/app/models/katello/docker_manifest_list.rb
@@ -6,8 +6,8 @@ module Katello
     has_many :docker_manifest_list_manifests, :class_name => "Katello::DockerManifestListManifest",
              :dependent => :delete_all, :inverse_of => :docker_manifest_list
     has_many :docker_manifests, :through => :docker_manifest_list_manifests, :inverse_of => :docker_manifest_lists
-    has_many :content_facets, :as => :manifest_entity, :dependent => :nullify
-    has_many :hosts, :class_name => "::Host::Managed", :through => :content_facets, :inverse_of => :docker_manifest_lists
+    has_many :content_facets, :class_name => "::Katello::Host::ContentFacet", :as => :manifest_entity, :dependent => :nullify
+    has_many :hosts, :class_name => "::Host::Managed", :through => :content_facets, :inverse_of => :docker_manifest_list
 
     CONTENT_TYPE = "docker_manifest_list".freeze
 

--- a/app/models/katello/docker_manifest_list.rb
+++ b/app/models/katello/docker_manifest_list.rb
@@ -6,12 +6,18 @@ module Katello
     has_many :docker_manifest_list_manifests, :class_name => "Katello::DockerManifestListManifest",
              :dependent => :delete_all, :inverse_of => :docker_manifest_list
     has_many :docker_manifests, :through => :docker_manifest_list_manifests, :inverse_of => :docker_manifest_lists
+    has_many :content_facets, :as => :manifest_entity
+    has_many :hosts, :class_name => "::Host::Managed", :through => :content_facets, :inverse_of => :docker_manifest_lists
+
 
     CONTENT_TYPE = "docker_manifest_list".freeze
+
+    scope :bootable, -> { where(:is_bootable => true) }
 
     scoped_search :relation => :docker_tags, :on => :name, :rename => :tag, :complete_value => true
     scoped_search :on => :digest, :rename => :digest, :complete_value => true, :only_explicit => true
     scoped_search :on => :schema_version, :rename => :schema_version, :complete_value => true, :only_explicit => true
+    scoped_search :on => :is_bootable, :rename => :bootable, :complete_value => { true => true, false => false }, :only_explicit => true
 
     def self.default_sort
       order(:schema_version)

--- a/app/models/katello/docker_manifest_list.rb
+++ b/app/models/katello/docker_manifest_list.rb
@@ -6,9 +6,8 @@ module Katello
     has_many :docker_manifest_list_manifests, :class_name => "Katello::DockerManifestListManifest",
              :dependent => :delete_all, :inverse_of => :docker_manifest_list
     has_many :docker_manifests, :through => :docker_manifest_list_manifests, :inverse_of => :docker_manifest_lists
-    has_many :content_facets, :as => :manifest_entity
+    has_many :content_facets, :as => :manifest_entity, :dependent => :nullify
     has_many :hosts, :class_name => "::Host::Managed", :through => :content_facets, :inverse_of => :docker_manifest_lists
-
 
     CONTENT_TYPE = "docker_manifest_list".freeze
 

--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -302,10 +302,11 @@ module Katello
         return unless host.subscription_facet || has_convert2rhel
         # Add in custom convert2rhel fact if system was converted using convert2rhel through Katello
         # We want the value nil unless the custom fact is present otherwise we get a 0 in the database which if debugging
-        # might make you think it was converted2rhel but not with satellite, that is why I have the tenary below.
+        # might make you think it was converted2rhel but not with satellite, that is why I have the ternary below.
         facet = host.subscription_facet || host.build_subscription_facet
         facet.attributes = {
           convert2rhel_through_foreman: has_convert2rhel ? ::Foreman::Cast.to_bool(parser.facts['conversions.env.CONVERT2RHEL_THROUGH_FOREMAN']) : nil,
+
         }.compact
         facet.save unless facet.new_record?
       end

--- a/db/migrate/20241112145802_add_manifest_entity_to_content_facets.rb
+++ b/db/migrate/20241112145802_add_manifest_entity_to_content_facets.rb
@@ -1,0 +1,7 @@
+class AddManifestEntityToContentFacets < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :katello_content_facets, :manifest_entity, polymorphic: true, index: true
+    change_column_null :katello_content_facets, :manifest_entity_type, true
+    change_column_null :katello_content_facets, :manifest_entity_id, true
+  end
+end

--- a/webpack/ForemanColumnExtensions/index.js
+++ b/webpack/ForemanColumnExtensions/index.js
@@ -5,9 +5,19 @@ import {
   SecurityIcon,
   EnhancementIcon,
   PackageIcon,
+  CheckIcon,
 } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
-import { Flex, FlexItem, Popover, Badge } from '@patternfly/react-core';
+import {
+  Flex,
+  FlexItem,
+  Popover,
+  Badge,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListDescription as Dd,
+  DescriptionListTerm as Dt,
+} from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import RelativeDateTime from 'foremanReact/components/common/dates/RelativeDateTime';
 import { ContentViewEnvironmentDisplay } from '../components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard';
@@ -22,6 +32,47 @@ const hostsIndexColumnExtensions = [
       return rhelLifecycle || '—';
     },
     weight: 2000,
+    isSorted: true,
+  },
+  {
+    columnName: 'bootc_booted_image',
+    title: __('Image mode'),
+    wrapper: (hostDetails) => {
+      const imageMode = hostDetails?.content_facet_attributes?.bootc_booted_image;
+      const digest = hostDetails?.content_facet_attributes?.bootc_booted_digest;
+      return (
+        <Flex>
+          {imageMode ?
+            <Popover
+              id="image-mode-tooltip"
+              className="image-mode-tooltip"
+              maxWidth="74rem"
+              headerContent={hostDetails.display_name}
+              bodyContent={
+                <Flex direction={{ default: 'column' }}>
+                  <DescriptionList isHorizontal>
+                    <DescriptionListGroup>
+                      <Dt>{__('Booted image')}</Dt>
+                      <Dd>{hostDetails.content_facet_attributes.bootc_booted_image}</Dd>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <Dt>{__('Digest')}</Dt>
+                      <Dd>{digest}</Dd>
+                    </DescriptionListGroup>
+                  </DescriptionList>
+                </Flex>
+              }
+            >
+              <FlexItem>
+                <CheckIcon />
+              </FlexItem>
+            </Popover>
+            : '—'
+          }
+        </Flex>
+      );
+    },
+    weight: 2050,
     isSorted: true,
   },
   {

--- a/webpack/ForemanColumnExtensions/index.js
+++ b/webpack/ForemanColumnExtensions/index.js
@@ -5,7 +5,6 @@ import {
   SecurityIcon,
   EnhancementIcon,
   PackageIcon,
-  CheckIcon,
 } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 import {
@@ -22,21 +21,12 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import RelativeDateTime from 'foremanReact/components/common/dates/RelativeDateTime';
 import { ContentViewEnvironmentDisplay } from '../components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard';
 import { truncate } from '../utils/helpers';
+import RepoIcon from '../scenes/ContentViews/Details/Repositories/RepoIcon';
 
 const hostsIndexColumnExtensions = [
   {
-    columnName: 'rhel_lifecycle_status',
-    title: __('RHEL Lifecycle status'),
-    wrapper: (hostDetails) => {
-      const rhelLifecycle = hostDetails?.rhel_lifecycle_status_label;
-      return rhelLifecycle || '—';
-    },
-    weight: 2000,
-    isSorted: true,
-  },
-  {
     columnName: 'bootc_booted_image',
-    title: __('Image mode'),
+    title: <RepoIcon type="docker" customTooltip={__('Image mode / package mode')} />,
     wrapper: (hostDetails) => {
       const imageMode = hostDetails?.content_facet_attributes?.bootc_booted_image;
       const digest = hostDetails?.content_facet_attributes?.bootc_booted_digest;
@@ -64,15 +54,25 @@ const hostsIndexColumnExtensions = [
               }
             >
               <FlexItem>
-                <CheckIcon />
+                <RepoIcon type="docker" customTooltip={__('Image mode')} />
               </FlexItem>
             </Popover>
-            : '—'
+            : <span style={{ color: 'gray' }}><RepoIcon type="yum" customTooltip={__('Package mode')} /></span>
           }
         </Flex>
       );
     },
-    weight: 2050,
+    weight: 35, // between power status (0) and name (50)
+    isSorted: true,
+  },
+  {
+    columnName: 'rhel_lifecycle_status',
+    title: __('RHEL Lifecycle status'),
+    wrapper: (hostDetails) => {
+      const rhelLifecycle = hostDetails?.rhel_lifecycle_status_label;
+      return rhelLifecycle || '—';
+    },
+    weight: 2000,
     isSorted: true,
   },
   {

--- a/webpack/ForemanColumnExtensions/index.js
+++ b/webpack/ForemanColumnExtensions/index.js
@@ -16,22 +16,30 @@ import {
   DescriptionListGroup,
   DescriptionListDescription as Dd,
   DescriptionListTerm as Dt,
+  Text,
+  TextVariants,
 } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import RelativeDateTime from 'foremanReact/components/common/dates/RelativeDateTime';
 import { ContentViewEnvironmentDisplay } from '../components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard';
 import { truncate } from '../utils/helpers';
 import RepoIcon from '../scenes/ContentViews/Details/Repositories/RepoIcon';
+import FontAwesomeImageModeIcon from '../components/extensions/Hosts/FontAwesomeImageModeIcon';
+import './index.scss';
 
 const hostsIndexColumnExtensions = [
   {
     columnName: 'bootc_booted_image',
-    title: <RepoIcon type="docker" customTooltip={__('Image mode / package mode')} />,
+    title: (
+      <span id="image-mode-column-title-icon">
+        <FontAwesomeImageModeIcon title={__('Image mode / package mode')} />
+      </span>
+    ),
     wrapper: (hostDetails) => {
       const imageMode = hostDetails?.content_facet_attributes?.bootc_booted_image;
       const digest = hostDetails?.content_facet_attributes?.bootc_booted_digest;
       return (
-        <Flex>
+        <span className={imageMode ? 'image-mode-column-td-icon' : 'package-mode-column-td-icon'}>
           {imageMode ?
             <Popover
               id="image-mode-tooltip"
@@ -40,9 +48,17 @@ const hostsIndexColumnExtensions = [
               headerContent={hostDetails.display_name}
               bodyContent={
                 <Flex direction={{ default: 'column' }}>
-                  <DescriptionList isHorizontal>
+                  <FlexItem>
+                    <Flex direction={{ default: 'row' }} alignItems={{ default: 'alignItemsCenter' }}>
+                      <FlexItem>
+                        <FontAwesomeImageModeIcon />
+                      </FlexItem>
+                      <Text ouiaId="image-mode-popover-h4" component={TextVariants.h4}>{__('Image-mode host')}</Text>
+                    </Flex>
+                  </FlexItem>
+                  <DescriptionList isCompact isHorizontal>
                     <DescriptionListGroup>
-                      <Dt>{__('Booted image')}</Dt>
+                      <Dt>{__('Running image')}</Dt>
                       <Dd>{hostDetails.content_facet_attributes.bootc_booted_image}</Dd>
                     </DescriptionListGroup>
                     <DescriptionListGroup>
@@ -53,13 +69,11 @@ const hostsIndexColumnExtensions = [
                 </Flex>
               }
             >
-              <FlexItem>
-                <RepoIcon type="docker" customTooltip={__('Image mode')} />
-              </FlexItem>
+              <FontAwesomeImageModeIcon title={__('Image mode')} />
             </Popover>
-            : <span style={{ color: 'gray' }}><RepoIcon type="yum" customTooltip={__('Package mode')} /></span>
+            : <span style={{ color: 'var(--pf-global--palette--black-600)' }}><RepoIcon type="yum" customTooltip={__('Package mode')} /></span>
           }
-        </Flex>
+        </span>
       );
     },
     weight: 35, // between power status (0) and name (50)

--- a/webpack/ForemanColumnExtensions/index.scss
+++ b/webpack/ForemanColumnExtensions/index.scss
@@ -1,0 +1,9 @@
+#image-mode-column-title-icon {
+  padding: 5px;
+}
+.image-mode-column-td-icon {
+  padding: 6px;
+}
+.package-mode-column-td-icon {
+  padding: 4px;
+}

--- a/webpack/components/extensions/Hosts/FontAwesomeImageModeIcon.js
+++ b/webpack/components/extensions/Hosts/FontAwesomeImageModeIcon.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { Tooltip } from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+const FontAwesomeImageModeIcon = ({ fill, margin, title }) => (
+  <Tooltip content={title}>
+    <svg
+      id="Layer_2"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 221.37 221.44"
+      width="14px"
+      height="14px"
+      version="1.1"
+      xmlSpace="preserve"
+      style={{
+        fillRule: 'evenodd',
+        clipRule: 'evenodd',
+        strokeLinejoin: 'round',
+        strokeMiterlimit: 2,
+        margin: margin || '-2px',
+      }}
+    >
+      <g id="Layer_1-2">
+        <circle
+          fill={fill}
+          className="cls-1"
+          cx="77.01"
+          cy="87"
+          r="20.41"
+          transform="translate(-39.07 79) rotate(-45)"
+        />
+        <path
+          className="cls-1"
+          fill={fill}
+          d="M205.48,40.09L120.07,1.72c-5.84-2.28-12.28-2.29-18.13-.02L15.93,40.09h0C6.25,43.85,0,52.98,0,63.37v91.2c0,9.48,5.5,18.28,14.02,22.44l85.84,41.91c3.45,1.68,7.2,2.52,10.95,2.52,4.03,0,8.05-.97,11.69-2.89l85.58-45.31c8.2-4.34,13.29-12.8,13.29-22.07V63.35c0-10.36-6.24-19.49-15.88-23.26ZM110.97,28.55l82.09,37.07v60.44l-39.44-37.64c-2.09-2.09-5.48-2.09-7.57,0l-60.43,60.43-24.76-24.76c-2.09-2.09-5.48-2.09-7.57,0l-25,26.93v-85.39L110.97,28.55Z"
+        />
+      </g>
+    </svg>
+  </Tooltip>
+);
+
+FontAwesomeImageModeIcon.propTypes = {
+  fill: propTypes.string,
+  margin: propTypes.string,
+  title: propTypes.string,
+};
+
+FontAwesomeImageModeIcon.defaultProps = {
+  fill: 'var(--pf-global--palette--black-600)',
+  margin: '-2px',
+  title: __('Image mode'),
+};
+
+export default FontAwesomeImageModeIcon;

--- a/webpack/scenes/ContentViews/Details/Repositories/RepoIcon.js
+++ b/webpack/scenes/ContentViews/Details/Repositories/RepoIcon.js
@@ -3,7 +3,7 @@ import { Tooltip } from '@patternfly/react-core';
 import { BundleIcon, MiddlewareIcon, BoxIcon, CodeBranchIcon, FanIcon, TenantIcon, AnsibleTowerIcon } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
 
-const RepoIcon = ({ type }) => {
+const RepoIcon = ({ type, customTooltip }) => {
   const iconMap = {
     yum: BundleIcon,
     docker: MiddlewareIcon,
@@ -14,15 +14,17 @@ const RepoIcon = ({ type }) => {
   };
   const Icon = iconMap[type] || BoxIcon;
 
-  return <Tooltip content={<div>{type}</div>}><Icon aria-label={`${type}_type_icon`} /></Tooltip>;
+  return <Tooltip content={<div>{customTooltip ?? type}</div>}><Icon aria-label={`${type}_type_icon`} /></Tooltip>;
 };
 
 RepoIcon.propTypes = {
   type: PropTypes.string,
+  customTooltip: PropTypes.string,
 };
 
 RepoIcon.defaultProps = {
   type: '', // prevent errors if data isn't loaded yet
+  customTooltip: null,
 };
 
 export default RepoIcon;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

1. Ingest bootc-related facts and populate values in the host's content facet.
2. Based on the bootc_booted_digest, associate host content facets with either a DockerManifest or DockerManifestList.
3. Display this information on the new All Hosts UI.

#### Considerations taken when implementing this change?

* ~~I didn't use the correct image mode / package mode icons in the table column. This is because it would require Font Awesome icons which we don't have set up.For now I'm using the BundleIcon for package mode, and the MiddlewareIcon for image mode.~~
* The table cell has a popover showing the booted image and digest. I didn't link to anything because apparently the appropriate pages don't exist yet.

#### What are the testing steps for this pull request?

#### Setup

1. Run the migrations
2. Sync a repo containing DockerManifests and DockerManifestLists - https://quay.io/repository/centos-bootc/centos-bootc. Use a tag in include list on docker repo creation page so it doesn't sync everything.. "stream9" tag has a manifest list and some bootable manifests.
3. Register a host
4. Create a file on the host, `/etc/rhsm/facts/bootc.facts`

```bash
# cat bootc.facts
{
"bootc.booted.image": "quay.io/centos-bootc/centos-bootc:42",
"bootc.booted.version": "42.20241104.1",
"bootc.booted.digest": "sha256:18ec8a272258b22bf9707b1963d72b8987110c8965c3d08b496fac0b1fb22159",
"bootc.staged.image": "quay.io/fedora/fedora-bootc:40",
"bootc.staged.version": "40.20241023.0",
"bootc.staged.digest": "sha256:b2b888aa0a05f3278e4957cb658fd088e3579e214140dc88ca138f47144d6a05",
"bootc.rollback.image": "quay.io/centos-bootc/centos-bootc:stream9",
"bootc.rollback.version": "stream9.20241101.0",
"bootc.rollback.digest": "sha256:893b636bbc5725378ce602f222f26c29f51334f93243ae8657d31391634eb024",
"bootc.available.image": null,
"bootc.available.version": null,
"bootc.available.digest": null
}
```

6. Make sure the bootc.booted.digest matches the digest of one of the DockerManifests or DockerManifestLists you have synced
7. On the host, run `subscription-manager facts --update`

#### Testing

1. The facts update should complete without errors
3. The host content facet should show the same data as the facts file:
```rb
pry(main)> rhel9b.content_facet
=> #<Katello::Host::ContentFacet:0x00007fac3c807fb0
 id: 4,
 host_id: 5,
 uuid: "45d3d61a-b76e-404d-98ed-3475a06c7611",
 kickstart_repository_id: nil,
 content_source_id: 1,
 installable_security_errata_count: 94,
 installable_enhancement_errata_count: 14,
 installable_bugfix_errata_count: 177,
 applicable_rpm_count: 693,
 upgradable_rpm_count: 693,
 applicable_module_stream_count: 0,
 upgradable_module_stream_count: 0,
 applicable_deb_count: 0,
 upgradable_deb_count: 0,
 bootc_booted_image: "quay.io/centos-bootc/centos-bootc:42",
 bootc_booted_digest: "sha256:18ec8a272258b22bf9707b1963d72b8987110c8965c3d08b496fac0b1fb22159",
 bootc_available_image: nil,
 bootc_available_digest: nil,
 bootc_staged_image: "quay.io/fedora/fedora-bootc:40",
 bootc_staged_digest: "sha256:b2b888aa0a05f3278e4957cb658fd088e3579e214140dc88ca138f47144d6a05",
 bootc_rollback_image: "quay.io/centos-bootc/centos-bootc:stream9",
 bootc_rollback_digest: "sha256:893b636bbc5725378ce602f222f26c29f51334f93243ae8657d31391634eb024",
 manifest_entity_type: "Katello::DockerManifest",
 manifest_entity_id: 8>
```
3. Add the new "Image mode / package mode" column to All Hosts and verify it works. Click on an image mode icon to see the popover with details.
4. These new Active Record queries should work as expected:

```rb
my_docker_manifest.hosts
my_docker_manifest.content_facets
my_content_facet.manifest_entity # can be either a DockerManifest or DockerManifestList

# one of the following two will be nil
my_host.docker_manifest
my_host.docker_manifest_list
```

5. When you remove the facts from the host and do another facts update:
* the content facet values should get cleared out
* the associations will be removed
