### PR TITLE
Fixes #37998 - deb-repos not shown on host repo-set

### DIFF
--- a/app/services/katello/product_content_finder.rb
+++ b/app/services/katello/product_content_finder.rb
@@ -26,7 +26,8 @@ module Katello
       structured_apt_roots = roots.where(:content_id => nil)
       if structured_apt_roots.any?
         deb_repos_query = Katello::Repository.where(root: structured_apt_roots)
-        deb_repos = match_environment ? deb_repos_query.where(content_view_version: versions, environment: consumable.environment) : deb_repos_query.where(:library_instance_id => nil)
+        environment = consumable.respond_to?(:environment) ? consumable.environment : consumable.content_view_environments.select(:environment_id).map(&:environment_id)
+        deb_repos = match_environment ? deb_repos_query.where(content_view_version: versions, environment: environment) : deb_repos_query.where(:library_instance_id => nil)
         content_ids += deb_repos.pluck(:content_id)
       end
 

--- a/test/fixtures/models/katello_content_view_repositories.yml
+++ b/test/fixtures/models/katello_content_view_repositories.yml
@@ -6,6 +6,10 @@ library_view_debian_10_amd64:
   content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_view) %>
   repository_id:   <%= ActiveRecord::FixtureSet.identify(:debian_10_amd64) %>
 
+library_view_acme_debian_10_amd64:
+  content_view_id: <%= ActiveRecord::FixtureSet.identify(:acme_default) %>
+  repository_id:   <%= ActiveRecord::FixtureSet.identify(:debian_10_amd64_dev) %>
+
 library_view_rhel_6_x86_64:
   content_view_id: <%= ActiveRecord::FixtureSet.identify(:acme_default) %>
   repository_id:   <%= ActiveRecord::FixtureSet.identify(:rhel_6_x86_64) %>

--- a/test/fixtures/models/katello_contents.yml
+++ b/test/fixtures/models/katello_contents.yml
@@ -6,6 +6,30 @@ deb_content:
   content_url:  /custom/Debian_12/Debian_12_amd64_main/?comp=main&rel=bookworm
   content_type: "deb"
 
+deb_content_v1:
+  name:         debian
+  label:        debian
+  cp_content_id: 111
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+  content_url:  /custom/Debian_12/Debian_12_amd64_main/?comp=main&rel=bookworm
+  content_type: "deb"
+
+deb_content_v2:
+  name:         debian
+  label:        debian
+  cp_content_id: 112
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+  content_url:  /custom/Debian_12/Debian_12_amd64_main/?comp=main&rel=bookworm
+  content_type: "deb"
+
+deb_content_v3:
+  name:         debian
+  label:        debian
+  cp_content_id: 113
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+  content_url:  /custom/Debian_12/Debian_10_amd64_main/?comp=main&rel=buster
+  content_type: "deb"
+
 some_content:
   name:         Fedora
   cp_content_id: 1

--- a/test/fixtures/models/katello_pool_products.yml
+++ b/test/fixtures/models/katello_pool_products.yml
@@ -6,6 +6,10 @@ basic_redhat:
     pool_id: <%= ActiveRecord::FixtureSet.identify(:pool_one) %>
     product_id: <%= ActiveRecord::FixtureSet.identify(:redhat) %>
 
+basic_debian:
+    pool_id: <%= ActiveRecord::FixtureSet.identify(:pool_one) %>
+    product_id: <%= ActiveRecord::FixtureSet.identify(:debian) %>
+
 other_sub_fedora:
     pool_id: <%= ActiveRecord::FixtureSet.identify(:pool_two) %>
     product_id: <%= ActiveRecord::FixtureSet.identify(:fedora) %>

--- a/test/fixtures/models/katello_product_contents.yml
+++ b/test/fixtures/models/katello_product_contents.yml
@@ -7,3 +7,23 @@ rhel_content:
   content_id: <%= ActiveRecord::FixtureSet.identify(:rhel_content) %>
   product_id: <%= ActiveRecord::FixtureSet.identify(:redhat) %>
   enabled: false
+
+debian_content:
+  content_id: <%= ActiveRecord::FixtureSet.identify(:deb_content) %>
+  product_id: <%= ActiveRecord::FixtureSet.identify(:debian) %>
+  enabled: false
+
+debian_content_v1:
+  content_id: <%= ActiveRecord::FixtureSet.identify(:deb_content_v1) %>
+  product_id: <%= ActiveRecord::FixtureSet.identify(:debian) %>
+  enabled: false
+
+debian_content_v2:
+  content_id: <%= ActiveRecord::FixtureSet.identify(:deb_content_v2) %>
+  product_id: <%= ActiveRecord::FixtureSet.identify(:debian) %>
+  enabled: false
+
+debian_content_v3:
+  content_id: <%= ActiveRecord::FixtureSet.identify(:deb_content_v3) %>
+  product_id: <%= ActiveRecord::FixtureSet.identify(:debian) %>
+  enabled: false

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -15,6 +15,7 @@ debian_9_amd64:
 debian_10_amd64:
   root_id:              <%= ActiveRecord::FixtureSet.identify(:debian_10_amd64_root) %>
   pulp_id:              Debian_10
+  content_id:           110
   relative_path:        'ACME_Corporation/library/debian_10_label'
   environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
@@ -36,6 +37,7 @@ debian_10_dev_library_view:
   library_instance:     debian_10_amd64
   root_id:              <%= ActiveRecord::FixtureSet.identify(:debian_10_amd64_root) %>
   pulp_id:              debian_10_dev_library_view
+  content_id:           112
   relative_path:        'ACME_Corporation/dev/debian_10_library_library_view_label'
   environment_id:       <%= ActiveRecord::FixtureSet.identify(:dev) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_view_version_2) %>
@@ -44,6 +46,7 @@ debian_10_amd64_dev:
   library_instance:     debian_10_amd64
   root_id:              <%= ActiveRecord::FixtureSet.identify(:debian_10_amd64_root) %>
   pulp_id:              12
+  content_id:           111
   relative_path:        'ACME_Corporation/dev/debian_10_dev_label'
   environment_id:       <%= ActiveRecord::FixtureSet.identify(:dev) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_dev_view_version) %>
@@ -309,6 +312,15 @@ busybox_view2:
   relative_path:        'ACME_Corporation/library/busybox'
   environment_id:
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_view_version_2) %>
+
+debian_10_amd64_composite_view_version_1:
+  library_instance:     debian_10_amd64
+  root_id:              <%= ActiveRecord::FixtureSet.identify(:debian_10_amd64_root) %>
+  pulp_id:              8_deb_composite_version1
+  content_id:           113
+  relative_path:        'ACME_Corporation/library/composite/debian_10_label'
+  environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:composite_view_version_1) %>
 
 rhel_6_x86_64_composite_view_version_1:
   library_instance:     rhel_6_x86_64

--- a/test/services/product_content_finder_test.rb
+++ b/test/services/product_content_finder_test.rb
@@ -5,10 +5,13 @@ module Katello
     def setup
       @product1 = katello_products(:fedora)
       @product2 = katello_products(:redhat)
+      @product3 = katello_products(:debian)
 
       @repo1 = katello_repositories(:fedora_17_x86_64)
       @repo2 = katello_repositories(:rhel_7_x86_64)
       @repo2_cv = katello_repositories(:rhel_6_x86_64_composite_view_version_1)
+      @repo3 = katello_repositories(:debian_10_amd64)
+      @repo4 = katello_repositories(:debian_10_amd64_dev)
 
       #@repo1's content is already in fixtures
       [@repo2].each do |repo|
@@ -31,16 +34,20 @@ module Katello
 
       assert product_content.any? { |pc| pc.content.cp_content_id == @repo1.content_id }
       assert product_content.any? { |pc| pc.content.cp_content_id == @repo2.content_id }
+      assert product_content.any? { |pc| pc.content.cp_content_id == @repo3.content_id }
+      refute product_content.any? { |pc| pc.content.cp_content_id == @repo4.content_id }
     end
 
     def test_match_subs
-      @key.expects(:products).returns([@product1])
+      @key.expects(:products).returns([@product1, @product3])
 
       pcf = Katello::ProductContentFinder.new(:consumable => @key, :match_subscription => true)
       product_content = pcf.product_content
 
       assert product_content.any? { |pc| pc.content.cp_content_id == @repo1.content_id }
       refute product_content.any? { |pc| pc.content.cp_content_id == @repo2.content_id }
+      assert product_content.any? { |pc| pc.content.cp_content_id == @repo3.content_id }
+      refute product_content.any? { |pc| pc.content.cp_content_id == @repo4.content_id }
     end
 
     def test_match_environments
@@ -57,6 +64,33 @@ module Katello
 
       refute product_content.any? { |pc| pc.content.cp_content_id == @repo1.content_id }
       assert product_content.any? { |pc| pc.content.cp_content_id == @repo2.content_id }
+    end
+  end
+
+  class ProductContentFinderHostSubscriptionTest < ProductContentFinderActivationKeyTest
+    def setup
+      super
+      @key = katello_subscription_facets(:one)
+    end
+
+    def test_match_environments
+      repo5 = katello_repositories(:debian_10_amd64_composite_view_version_1)
+      cves = ::Katello::ContentViewEnvironment.where(environment_id: @repo2_cv.environment,
+                                                      content_view_id: @repo2_cv.content_view)
+
+      @key.stubs(:content_view_environments).returns(cves)
+
+      #Katello::Repository.where(:root => Katello::RootRepository.where(:content_id => @repo1.content_id),
+      #                          :content_view_version_id => @key.content_view.version(@key.environment)).destroy_all
+
+      pcf = Katello::ProductContentFinder.new(:consumable => @key, :match_environment => true)
+      product_content = pcf.product_content
+
+      refute product_content.any? { |pc| pc.content.cp_content_id == @repo1.content_id }
+      assert product_content.any? { |pc| pc.content.cp_content_id == @repo2.content_id }
+      refute product_content.any? { |pc| pc.content.cp_content_id == @repo3.content_id }
+      refute product_content.any? { |pc| pc.content.cp_content_id == @repo4.content_id }
+      assert product_content.any? { |pc| pc.content.cp_content_id == repo5.content_id }
     end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Host did not show any debian repositories on Content->RepositorySet tab.
Error-toast is shown.

Todo:

- [x] test coverage

#### Considerations taken when implementing this change?
We have to make sure that we do not show duplicate repo-entries in case structured-apt feature is enabled.
That is the reason to also check the environment.

#### What are the testing steps for this pull request?

1. create ActivationKey with deb-repositories
2. register a (deb-)host
3. go to RepositorySet on new HostDetails' Content-tab
4. deb-repos are displayed