### PR TITLE
Fixes #37072 - Made package update choose the correct version

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -534,10 +534,16 @@ module Katello
           versions_by_name_arch = {}
           if versions.present?
             JSON.parse(versions).each do |nvra|
-              nvra =~ /([^.]*)-[-.\w]*\.(\w+)/
-              versions_by_name_arch[[Regexp.last_match(1), Regexp.last_match(2)]] = nvra
+              package_info = ::Katello::Util::Package.parse_nvrea(nvra)
+              versions_by_name_arch[[package_info[:name], package_info[:arch]]] = nvra
             end
           end
+
+          # > versions_by_name_arch
+          # =>
+          # {["glibc-langpack-en", "x86_64"]=>"glibc-langpack-en-2.34-100.el9_4.2.x86_64",
+          #  ["crypto-policies", "noarch"]=>"crypto-policies-20221215-1.git9a18988.el9_2.1.noarch"}
+
           pkg_name_archs = installed_packages.search_for(search).distinct.pluck(:name, :arch)
           if pkg_name_archs.empty?
             fail _("Cannot upgrade packages: No installed packages found for search term '%s'.") % search


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Package Update now correctly picks the package to update when you chose from a drop down on the host packages tab.

#### Considerations taken when implementing this change?

When we choose a specific version of package a to update on the host -  we try to infer the name and arch of the package to be upgraded. This information is then used to determine how the update command should look. The changes here use the pre-existing `Katello::Util::Package.parse_nvrea` to figure out the package provided in the template instead of the magical potentially fault regex

#### What are the testing steps for this pull request?
1) Create a RHEL 9.2 machine with `crypto-policies-20221215-1.git9a18988.el9.noarch`
2) Sync RHEL 9 appstream + baseos
3) Try to upgrade to `crypto-policies-scripts-20221215-1.git9a18988.el9_2.1.noarch` via the dropdown on the right side of the upgradable RPM

Check the template preview of the job created


#### Before PR
```
#!/bin/bash
.......

# Action
  yum -y  update crypto-policies-scripts
RETVAL=$?
[ $RETVAL -eq 0 ] || exit_with_message "Package action failed" $RETVAL
```

#### After PR
```
#!/bin/bash
....
# Action
  yum -y  update crypto-policies-scripts-20221215-1.git9a18988.el9_2.1.noarch
RETVAL=$?
[ $RETVAL -eq 0 ] || exit_with_message "Package action failed" $RETVAL
```


Feel free to try other rpms to upgrade.