### PR TITLE
Fixes #38011 - Apply environment filter for content override

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -184,7 +184,7 @@ module Katello
         validate_content_overrides_enabled(override_params)
       end
       sync_task(::Actions::Katello::Host::UpdateContentOverrides, @host, content_override_values, false)
-      fetch_product_content
+      fetch_product_content(!params.dig(:content_overrides_search, :search).nil? && Foreman::Cast.to_bool(params.dig(:content_overrides_search, :limit_to_env)))
     end
 
     api :GET, "/hosts/:host_id/subscriptions/available_release_versions", N_("Show releases available for the content host")
@@ -203,8 +203,8 @@ module Katello
 
     private
 
-    def fetch_product_content
-      content_finder = ProductContentFinder.new(:consumable => @host.subscription_facet)
+    def fetch_product_content(limit_to_env = false)
+      content_finder = ProductContentFinder.new(:match_environment => limit_to_env, :consumable => @host.subscription_facet)
       content = content_finder.presenter_with_overrides(@host.subscription_facet.candlepin_consumer.content_overrides)
       respond_with_template_collection("index", 'repository_sets', :collection => full_result_response(content))
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
When overriding the status on the repository sets page, the state was internally changed. However, it did not show but instead an empty error toast was shown. 

#### Considerations taken when implementing this change?
In structured-apt feature, we use a specific environment to show the correct repo entry, otherwise we would show multiple entries for one repository. We need to apply this environment filter when the override is evaluated. 

#### What are the testing steps for this pull request?
1. Enable structured-apt feature
2. Create ActivationKey with deb-repositories
3. Roll out a Debian host
4. Go to Host --> HostDetails --> Content --> Repository Sets
5. Try to change any override setting in the repo's kebab menu 