### PR TITLE
Fixes #37951 - Appropriate generic default value for the UI

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
@@ -160,6 +160,8 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
                     $scope.genericRemoteOptions.forEach(function(option) {
                         if (option.type === "Array" && option.value !== "") {
                             repository[option.name] = option.value.split(option.delimiter);
+                        } else if (option.type === "number" && option.value === "") {
+                            repository[option.name] = option.default;
                         } else {
                             repository[option.name] = option.value;
                         }

--- a/lib/katello/repository_types/ostree.rb
+++ b/lib/katello/repository_types/ostree.rb
@@ -24,7 +24,7 @@ Katello::RepositoryTypeManager.register('ostree') do
   generic_remote_option :exclude_refs, title: N_("Exclude Refs"), type: Array, input_type: "text", delimiter: ",", default: [],
                          description: N_("A comma-separated list of tags to exclude during an ostree sync. The wildcards *, ? are recognized. 'exclude_refs' is evaluated after 'include_refs'.")
 
-  generic_remote_option :depth, title: N_("Depth"), type: :number, input_type: "number", delimiter: "", default: 0, description: N_("An option to specify how many ostree commits to traverse.")
+  generic_remote_option :depth, title: N_("Depth"), type: :number, input_type: "number", default: 0, description: N_("An option to specify how many ostree commits to traverse.")
 
   url_description N_("URL of an OSTree repository.")
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Updated the code to use the default value of the generic content type in the new repository creation form.

#### Considerations taken when implementing this change?

This change is not limited to the depth field. All generic repository options will now be set to its respective default value.

#### What are the testing steps for this pull request?

1. Go to Products -> Any Product ->New Repository
2. Select OSTree as Content Type and fill only the required fields
3. Notice that the default value of the Depth field is set to 0
4. Able to save and create a New Repository