### PR TITLE
Fixes #38018 - Rails 7 compatible angular-rails-templates

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -63,7 +63,7 @@ Gem::Specification.new do |gem|
 
   # UI
   gem.add_dependency "deface", '>= 1.0.2', '< 2.0.0'
-  gem.add_dependency "angular-rails-templates", "~> 1.1.0"
+  gem.add_dependency "angular-rails-templates", "~> 1.1"
 
   gem.add_development_dependency "theforeman-rubocop", '~> 0.1.0'
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

By pinning to 1.x instead of 1.1.x version 1.2 is allowed. That version only updates the gem dependencies to allow Rails 7 compatible versions.

#### Considerations taken when implementing this change?

It is currently part of https://github.com/Katello/katello/pull/11155 but by separating this and already merging it we can start updating packaging, which makes testing easier.

#### What are the testing steps for this pull request?

Verify no regressions show up.