### PR TITLE
Refs #37989 - Pluralize api docs endpoint and other changes

### DIFF
--- a/app/controllers/katello/api/v2/flatpak_remote_repositories_controller.rb
+++ b/app/controllers/katello/api/v2/flatpak_remote_repositories_controller.rb
@@ -35,7 +35,7 @@ module Katello
     end
 
     def index_remote_relation(query)
-      query = query.joins(:flatpak_remote_id => :remote).where("#{FlatpakRemote.table_name}.organization_id" => @organization) if @organization
+      query = query.joins(:flatpak_remote).where("#{FlatpakRemote.table_name}.organization_id" => @organization) if @organization
       if params[:flatpak_remote_id]
         query.where(flatpak_remote_id: params[:flatpak_remote_id])
       else
@@ -44,15 +44,15 @@ module Katello
     end
 
     api :GET, "/flatpak_remote_repositories/:id", N_("Show a flatpak remote repository")
-    param :id, :number, :desc => N_("Flatpak remote numeric identifier"), :required => true
+    param :id, :number, :desc => N_("Flatpak remote repository numeric identifier"), :required => true
     param :manifests, :boolean, :desc => N_("Include manifests"), :required => false
     def show
       respond :resource => @flatpak_remote_repository
     end
 
     api :POST, "/flatpak_remote_repositories/:id/mirror", N_("Mirror a flatpak remote repository")
-    param :id, :number, :desc => N_("Flatpak remote numeric identifier"), :required => true
-    param :product_id, :number, :desc => N_("Product ID to mirror the repository to"), :required => true
+    param :id, :number, :desc => N_("Flatpak remote repository numeric identifier"), :required => true
+    param :product_id, :number, :desc => N_("Product ID to mirror the remote repository to"), :required => true
     def mirror
       task = async_task(::Actions::Katello::Flatpak::MirrorRemoteRepository, @flatpak_remote_repository, @product)
       respond_for_async :resource => task

--- a/app/controllers/katello/api/v2/flatpak_remotes_controller.rb
+++ b/app/controllers/katello/api/v2/flatpak_remotes_controller.rb
@@ -19,7 +19,6 @@ module Katello
     api :GET, "/flatpak_remotes", N_("List flatpak remotes")
     param :organization_id, :number, :desc => N_("organization identifier"), :required => false
     param :name, String, :desc => N_("Name of the flatpak remote"), :required => false
-    param :label, String, :desc => N_("Label of the flatpak remote"), :required => false
     param_group :search, Api::V2::ApiController
     add_scoped_search_description_for(FlatpakRemote)
     def index
@@ -35,14 +34,16 @@ module Katello
     end
 
     api :GET, "/flatpak_remotes/:id", N_("Show a flatpak remote")
+    api :GET, "/organizations/:organization_id/flatpak_remotes/:id", N_("Show a flatpak remote")
     param :id, :number, :desc => N_("Flatpak remote numeric identifier"), :required => true
+    param :organization_id, :number, :desc => N_("organization identifier")
     def show
       respond :resource => @flatpak_remote
     end
 
-    api :POST, "/flatpak_remote", N_("Create a flatpak remote")
+    api :POST, "/flatpak_remotes", N_("Create a flatpak remote")
     param :name, String, :desc => N_("name"), :required => true
-    param :url, String, :desc => N_("url"), :required => true
+    param :url, String, :desc => N_("Base URL of the flatpak registry index, ex: https://flatpaks.redhat.io/rhel/ , https://registry.fedoraproject.org/."), :required => true
     param :organization_id, :number, :desc => N_("organization identifier"), :required => true
     param_group :flatpak_remote
     def create
@@ -55,7 +56,7 @@ module Katello
     param_group :flatpak_remote
     param :id, :number, :desc => N_("Flatpak remote numeric identifier"), :required => true
     param :name, String, :desc => N_("name")
-    param :url, String, :desc => N_("url")
+    param :url, String, :desc => N_("Base URL of the flatpak registry index, ex: https://flatpaks.redhat.io/rhel/ , https://registry.fedoraproject.org/.")
     def update
       @flatpak_remote.update!(flatpak_remote_params)
       respond_for_show(:resource => @flatpak_remote)
@@ -67,7 +68,7 @@ module Katello
       @flatpak_remote.destroy
     end
 
-    api :POST, "/flatpak_remote/:id/scan", N_("Scan a flatpak remote")
+    api :POST, "/flatpak_remotes/:id/scan", N_("Scan a flatpak remote")
     param :id, :number, :desc => N_("Flatpak remote numeric identifier"), :required => true
     def scan
       task = async_task(::Actions::Katello::Flatpak::ScanRemote, @flatpak_remote)
@@ -79,7 +80,7 @@ module Katello
     end
 
     def flatpak_remote_params
-      params.require(:flatpak_remote).permit(:name, :url, :organization_id, :description, :username, :token)
+      params.require(:flatpak_remote).permit(:name, :url, :description, :organization_id, :username, :token)
     end
   end
 end

--- a/app/models/katello/flatpak_remote.rb
+++ b/app/models/katello/flatpak_remote.rb
@@ -10,6 +10,7 @@ module Katello
     validates :name, presence: true
     validates :url, presence: true
     validates :organization_id, presence: true
+    validates :name, :uniqueness => {:scope => :organization_id}
 
     scope :seeded, -> { where(:seeded => true) }
 

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -278,6 +278,8 @@ Katello::Engine.routes.draw do
               get :manifest_history
             end
           end
+          api_resources :flatpak_remotes, :only => [:index, :show]
+          api_resources :flatpak_remote_repositories, :only => [:index, :show]
         end
 
         match "/packages/thindex" => "packages#thindex", :via => :get


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Pluralize a couple of API endpoint docs so hammer and apidocs can correctly point to them.
Add label to remote index rabl
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Go to the remote index and show endpoints and check if you see label field.
Check if the apidocs point correctly to the create/scan endpoints.