### PR TITLE
Fixes #38020 - Add RHEL 10 recommended repositories

### DIFF
--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -10,6 +10,14 @@ const repoTypeSearchQueryMap = {
 };
 
 const recommendedRepositoriesRHEL = [
+  'rhel-10-for-x86_64-baseos-rpms',
+  'rhel-10-for-x86_64-baseos-kickstart',
+  'rhel-10-for-x86_64-baseos-rpms',
+  'rhel-10-for-x86_64-baseos-kickstart',
+  'rhel-10-for-x86_64-appstream-rpms',
+  'rhel-10-for-x86_64-appstream-kickstart',
+  'rhel-10-for-x86_64-baseos-eus-rpms',
+  'rhel-10-for-x86_64-appstream-eus-rpms',
   'rhel-9-for-x86_64-baseos-rpms',
   'rhel-9-for-x86_64-baseos-kickstart',
   'rhel-9-for-x86_64-appstream-rpms',
@@ -27,6 +35,7 @@ const recommendedRepositoriesRHEL = [
 ];
 
 const recommendedRepositoriesSatTools = [
+  'satellite-client-6-for-rhel-10-x86_64-rpms',
   'satellite-client-6-for-rhel-9-x86_64-rpms',
   'satellite-client-6-for-rhel-8-x86_64-rpms',
   'rhel-7-server-els-satellite-client-6-rpms',


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds RHEL 10 in the recommended repos list.

#### Considerations taken when implementing this change?
Should the RHEL 10 Satellite client repo be added proactively? We'd need to make sure the name is correct.

#### What are the testing steps for this pull request?
Check that all of the recommended repositories added here show up on the Red Hat repos page. You won't be able to enable them, but you should see them.