### PR TITLE
Fixes #38023 - Stop using deprecated methods for ActiveModel::Errors

### DIFF
--- a/app/lib/katello/validators/alternate_content_source_path_validator.rb
+++ b/app/lib/katello/validators/alternate_content_source_path_validator.rb
@@ -6,11 +6,11 @@ module Katello
           case attribute
           when :base_url
             unless AlternateContentSourcePathValidator.validate_base_url(value)
-              record.errors[attribute] << N_("%s is not a valid path") % value
+              record.errors.add(attribute, N_("%s is not a valid path") % value)
             end
           when :subpaths
             unless AlternateContentSourcePathValidator.validate_subpaths(value)
-              record.errors[attribute] << N_('All subpaths must have a slash at the end and none at the front')
+              record.errors.add(attribute, N_('All subpaths must have a slash at the end and none at the front'))
             end
           end
         end

--- a/app/lib/katello/validators/container_image_name_validator.rb
+++ b/app/lib/katello/validators/container_image_name_validator.rb
@@ -3,7 +3,7 @@ module Katello
     class ContainerImageNameValidator < ActiveModel::EachValidator
       def validate_each(record, attribute, value)
         if value && !ContainerImageNameValidator.validate_name(value)
-          record.errors[attribute] << N_("invalid container image name")
+          record.errors.add(attribute, N_("invalid container image name"))
         end
       end
 

--- a/app/lib/katello/validators/content_validator.rb
+++ b/app/lib/katello/validators/content_validator.rb
@@ -4,7 +4,7 @@ module Katello
       def validate_each(record, attribute, value)
         value.encode("UTF-8", 'binary') unless value.blank?
       rescue Encoding::UndefinedConversionError
-        record.errors[attribute] << (options[:message] || _("cannot be a binary file."))
+        record.errors.add(attribute, (options[:message] || _("cannot be a binary file.")))
       end
     end
   end

--- a/app/lib/katello/validators/content_view_environment_coherent_default_validator.rb
+++ b/app/lib/katello/validators/content_view_environment_coherent_default_validator.rb
@@ -11,8 +11,8 @@ module Katello
             env = KTEnvironment.where(:id => environment_id).first
             return if view.blank? || env.blank?
             if view.default? && !env.library?
-              record.errors[:base] << _("Lifecycle environment '%{env}' cannot be used with content view '%{view}'") %
-                                        {:view => view.name, :env => env.name}
+              record.errors.add(:base, _("Lifecycle environment '%{env}' cannot be used with content view '%{view}'") %
+                                        {:view => view.name, :env => env.name})
             end
           end
         end

--- a/app/lib/katello/validators/content_view_environment_org_validator.rb
+++ b/app/lib/katello/validators/content_view_environment_org_validator.rb
@@ -6,11 +6,11 @@ module Katello
         view = ContentView.where(:id => record.content_view_id).first
         environment = KTEnvironment.where(:id => environment_id).first
         if view.blank? || environment.blank?
-          record.errors[:base] << _("Content view environments must have both a content view and an environment")
+          record.errors.add(:base, _("Content view environments must have both a content view and an environment"))
         end
 
         unless view&.organization == environment&.organization
-          record.errors[:base] << _("%{view_label} could not be promoted to %{environment_label} because the content view and the environment are not in the same organization!") % {:view_label => view&.label, :environment_label => environment&.label}
+          record.errors.add(:base, _("%{view_label} could not be promoted to %{environment_label} because the content view and the environment are not in the same organization!") % {:view_label => view&.label, :environment_label => environment&.label})
         end
       end
     end

--- a/app/lib/katello/validators/content_view_environment_validator.rb
+++ b/app/lib/katello/validators/content_view_environment_validator.rb
@@ -10,12 +10,12 @@ module Katello
           if environment_id
             env = KTEnvironment.where(:id => environment_id).first
             unless view.blank? || env.blank? || view.in_environment?(env)
-              record.errors[:base] << _("Content view '%{view}' is not in environment '%{env}'") %
-                                        {:view => view.name, :env => env.name}
+              record.errors.add(:base, _("Content view '%{view}' is not in environment '%{env}'") %
+                                        {:view => view.name, :env => env.name})
             end
           end
           if view&.generated_for_repository?
-            record.errors[:base] << _("Generated content views cannot be assigned to hosts or activation keys")
+            record.errors.add(:base, _("Generated content views cannot be assigned to hosts or activation keys"))
           end
         end
       end

--- a/app/lib/katello/validators/content_view_erratum_filter_rule_validator.rb
+++ b/app/lib/katello/validators/content_view_erratum_filter_rule_validator.rb
@@ -5,7 +5,7 @@ module Katello
         if record.errata_id.blank? && record.start_date.blank? && record.end_date.blank? && record.types.blank?
           invalid_parameters = _("Invalid erratum filter rule specified, Must specify at least one of the following:" \
                                      " 'errata_id', 'start_date', 'end_date' or 'types'")
-          record.errors[:base] << invalid_parameters
+          record.errors.add(:base, invalid_parameters)
           return
         end
 
@@ -14,7 +14,7 @@ module Katello
                                         !record.types.blank?)
           invalid_parameters = _("Invalid erratum filter rule specified, 'errata_id' cannot be specified in the" \
                                  " same tuple as 'start_date', 'end_date' or 'types'")
-          record.errors[:base] << invalid_parameters
+          record.errors.add(:base, invalid_parameters)
           return
         end
 
@@ -28,13 +28,13 @@ module Katello
           if !record.filter.erratum_rules.empty? &&
              !record.filter.erratum_rules.any? { |rule| rule.id == record.id }
             invalid_parameters = _("May not add a type or date range rule to a filter that has existing rules.")
-            record.errors[:base] << invalid_parameters
+            record.errors.add(:base, invalid_parameters)
           end
 
         else
           if record.filter_has_date_or_type_rule?
             invalid_parameters = _("May not add an id rule to a filter that has an existing type or date range rule.")
-            record.errors[:base] << invalid_parameters
+            record.errors.add(:base, invalid_parameters)
           end
 
         end
@@ -45,14 +45,14 @@ module Katello
         end_date_int = record.end_date.to_time.to_i unless record.end_date.blank?
 
         if start_date_int && (!start_date_int.is_a?(Integer) || !record.start_date.is_a?(String))
-          record.errors[:base] << _("The erratum filter rule start date is in an invalid format or type.")
+          record.errors.add(:base, _("The erratum filter rule start date is in an invalid format or type."))
         end
         if end_date_int && (!end_date_int.is_a?(Integer) || !record.end_date.is_a?(String))
-          record.errors[:base] << _("The erratum filter rule end date is in an invalid format or type.")
+          record.errors.add(:base, _("The erratum filter rule end date is in an invalid format or type."))
         end
 
         if start_date_int && end_date_int && !(start_date_int <= end_date_int)
-          record.errors[:base] << _("Invalid date range. The erratum filter rule start date must come before the end date")
+          record.errors.add(:base, _("Invalid date range. The erratum filter rule start date must come before the end date"))
         end
       end
 
@@ -60,13 +60,13 @@ module Katello
         if record.types.is_a?(Array)
           invalid_types = record.types.collect(&:to_s) - ContentViewErratumFilter::ERRATA_TYPES.keys
           unless invalid_types.empty?
-            record.errors[:base] <<
+            record.errors.add(:base,
                               _("Invalid erratum types %{invalid_types} provided. Erratum type can be any of %{valid_types}") %
                               { :invalid_types => invalid_types.join(","),
-                                :valid_types => ContentViewErratumFilter::ERRATA_TYPES.keys.join(",")}
+                                :valid_types => ContentViewErratumFilter::ERRATA_TYPES.keys.join(",")})
           end
         else
-          record.errors[:base] << _("The erratum type must be an array. Invalid value provided")
+          record.errors.add(:base, _("The erratum type must be an array. Invalid value provided"))
         end
       end
     end

--- a/app/lib/katello/validators/content_view_filter_version_validator.rb
+++ b/app/lib/katello/validators/content_view_filter_version_validator.rb
@@ -5,7 +5,7 @@ module Katello
         if !record.version.blank? && (!record.min_version.blank? || !record.max_version.blank?)
           invalid_parameters = _("Invalid filter rule specified, 'version' cannot be specified in the" \
                                  " same tuple as 'min_version' or 'max_version'")
-          record.errors[:base] << invalid_parameters
+          record.errors.add(:base, invalid_parameters)
         end
       end
     end

--- a/app/lib/katello/validators/generated_content_view_validator.rb
+++ b/app/lib/katello/validators/generated_content_view_validator.rb
@@ -6,7 +6,7 @@ module Katello
           if cve.content_view_id
             view = ContentView.where(:id => cve.content_view_id).first
             if view&.generated_for_repository?
-              record.errors[:base] << _("Content view '%{cv_name}' is a generated content view, which cannot be assigned to hosts or activation keys.") % { :cv_name => view.name }
+              record.errors.add(:base, _("Content view '%{cv_name}' is a generated content view, which cannot be assigned to hosts or activation keys.") % { :cv_name => view.name })
             end
           end
         end

--- a/app/lib/katello/validators/gpg_key_content_type_validator.rb
+++ b/app/lib/katello/validators/gpg_key_content_type_validator.rb
@@ -6,13 +6,13 @@ module Katello
         # ssl_ca_cert, ssl_client_cert, ssl_client_key of GpgKey.content type "cert"
 
         if !record.gpg_key.blank? && record.gpg_key.content_type != "gpg_key"
-          record.errors[:gpg_key] << _("Wrong content type submitted.")
+          record.errors.add(:gpg_key, _("Wrong content type submitted."))
         end
 
         if record.instance_of?(Katello::Product)
           [:ssl_ca_cert, :ssl_client_cert, :ssl_client_key].each do |cert|
             if !record.send(cert).blank? && record.send(cert).content_type != "cert"
-              record.errors[cert] << _("Wrong content type submitted.")
+              record.errors.add(cert, _("Wrong content type submitted."))
             end
           end
         end

--- a/app/lib/katello/validators/gpg_key_content_validator.rb
+++ b/app/lib/katello/validators/gpg_key_content_validator.rb
@@ -15,25 +15,25 @@ module Katello
             gpg_key_line_array.pop
 
             if gpg_key_line_array.empty?
-              record.errors[attribute] << _("must contain valid Public GPG Key")
+              record.errors.add(attribute, _("must contain valid Public GPG Key"))
             else
               unless gpg_key_line_array.drop(1).join.match(/[a-zA-Z0-9+\/=]*/)
-                record.errors[attribute] << _("must contain valid Public GPG Key")
+                record.errors.add(attribute, _("must contain valid Public GPG Key"))
               end
             end
 
           else
-            record.errors[attribute] << _("must contain valid Public GPG Key")
+            record.errors.add(attribute, _("must contain valid Public GPG Key"))
           end
 
         else
-          record.errors[attribute] << _("must contain GPG Key")
+          record.errors.add(attribute, _("must contain GPG Key"))
         end
       end
 
       def self.validate_line_length(record, attribute, value)
         value.each_line do |line|
-          record.errors[attribute] << _("must contain valid  Public GPG Key") if line.length > ContentCredential::MAX_CONTENT_LINE_LENGTH
+          record.errors.add(attribute, _("must contain valid  Public GPG Key")) if line.length > ContentCredential::MAX_CONTENT_LINE_LENGTH
         end
       end
     end

--- a/app/lib/katello/validators/katello_label_format_validator.rb
+++ b/app/lib/katello/validators/katello_label_format_validator.rb
@@ -3,18 +3,18 @@ module Katello
     class KatelloLabelFormatValidator < ActiveModel::EachValidator
       def validate_each(record, attribute, value)
         if value
-          record.errors[attribute] << N_("cannot contain characters other than ascii alpha numerals, '_', '-'. ") unless value =~ /\A[a-zA-Z0-9_\-]+\z/
+          record.errors.add(attribute, N_("cannot contain characters other than ascii alpha numerals, '_', '-'. ")) unless value =~ /\A[a-zA-Z0-9_\-]+\z/
           NoTrailingSpaceValidator.validate_trailing_space(record, attribute, value)
           KatelloLabelFormatValidator.validate_length(record, attribute, value)
         else
-          record.errors[attribute] << N_("can't be blank")
+          record.errors.add(attribute, N_("can't be blank"))
         end
       end
 
       def self.validate_length(record, attribute, value, max_length = 128, min_length = 1)
         if value
-          record.errors[attribute] << N_("cannot contain more than %s characters") % max_length unless value.length <= max_length
-          record.errors[attribute] << N_("must contain at least %s character") % min_length unless value.length >= min_length
+          record.errors.add(attribute, N_("cannot contain more than %s characters") % max_length) unless value.length <= max_length
+          record.errors.add(attribute, N_("must contain at least %s character") % min_length) unless value.length >= min_length
         end
       end
     end

--- a/app/lib/katello/validators/katello_name_format_validator.rb
+++ b/app/lib/katello/validators/katello_name_format_validator.rb
@@ -8,13 +8,13 @@ module Katello
           NoTrailingSpaceValidator.validate_trailing_space(record, attribute, value)
           KatelloNameFormatValidator.validate_length(record, attribute, value)
         else
-          record.errors[attribute] << N_("cannot be blank")
+          record.errors.add(attribute, N_("cannot be blank"))
         end
       end
 
       def self.validate_length(record, attribute, value, min_length = 1)
         if value && !(value.length >= min_length)
-          record.errors[attribute] << _("must contain at least %s character") % min_length
+          record.errors.add(attribute, _("must contain at least %s character") % min_length)
         end
       end
     end

--- a/app/lib/katello/validators/katello_url_format_validator.rb
+++ b/app/lib/katello/validators/katello_url_format_validator.rb
@@ -13,7 +13,7 @@ module Katello
         end
 
         attribute_name = options[:field_name] || attribute
-        record.errors[attribute_name] << N_("is invalid") unless kurl_valid?(value)
+        record.errors.add(attribute_name, N_("is invalid")) unless kurl_valid?(value)
       end
     end
   end

--- a/app/lib/katello/validators/library_presence_validator.rb
+++ b/app/lib/katello/validators/library_presence_validator.rb
@@ -2,7 +2,7 @@ module Katello
   module Validators
     class LibraryPresenceValidator < ActiveModel::EachValidator
       def validate_each(record, attribute, value)
-        record.errors[attribute] << N_("must contain '%s'") % "Library" if value.select { |e| e.library }.empty?
+        record.errors.add(attribute, N_("must contain '%s'") % "Library") if value.select { |e| e.library }.empty?
       end
     end
   end

--- a/app/lib/katello/validators/no_trailing_space_validator.rb
+++ b/app/lib/katello/validators/no_trailing_space_validator.rb
@@ -7,7 +7,7 @@ module Katello
 
       def self.validate_trailing_space(record, attribute, value)
         if value && !(value.strip == value)
-          record.errors[attribute] << _("must not contain leading or trailing white spaces.")
+          record.errors.add(attribute, _("must not contain leading or trailing white spaces."))
         end
       end
     end

--- a/app/lib/katello/validators/non_library_environment_validator.rb
+++ b/app/lib/katello/validators/non_library_environment_validator.rb
@@ -3,7 +3,7 @@ module Katello
     class NonLibraryEnvironmentValidator < ActiveModel::EachValidator
       def validate_each(record, attribute, value)
         return unless value
-        record.errors[attribute] << N_("Cannot register a system to the '%s' environment") % "Library" if !record.environment.nil? && record.environment.library?
+        record.errors.add(attribute, N_("Cannot register a system to the '%s' environment") % "Library") if !record.environment.nil? && record.environment.library?
       end
     end
   end

--- a/app/lib/katello/validators/not_in_library_validator.rb
+++ b/app/lib/katello/validators/not_in_library_validator.rb
@@ -2,7 +2,7 @@ module Katello
   module Validators
     class NotInLibraryValidator < ActiveModel::Validator
       def validate(record)
-        record.errors[:environment] << _("The '%s' environment cannot contain a changeset!") % "Library" if record.environment.library?
+        record.errors.add(:environment, _("The '%s' environment cannot contain a changeset!") % "Library") if record.environment.library?
       end
     end
   end

--- a/app/lib/katello/validators/path_descendents_validator.rb
+++ b/app/lib/katello/validators/path_descendents_validator.rb
@@ -6,7 +6,7 @@ module Katello
         #environment is not duplicated in its path
         # We do not want circular dependencies
         return if record.prior.nil?
-        record.errors[:prior] << _(" environment cannot be set to an environment already on its path") if duplicate? record.prior
+        record.errors.add(:prior, _(" environment cannot be set to an environment already on its path")) if duplicate? record.prior
       end
 
       def duplicate?(record)

--- a/app/lib/katello/validators/prior_validator.rb
+++ b/app/lib/katello/validators/prior_validator.rb
@@ -8,7 +8,7 @@ module Katello
         # prior to have only one child (unless its the Library)
         ancestor = record.prior
         if ancestor && !ancestor.library? && (ancestor.successors.count == 1 && !ancestor.successors.include?(record))
-          record.errors[:prior] << _("prior environment can only have one child")
+          record.errors.add(:prior, _("prior environment can only have one child"))
         end
       end
     end

--- a/app/lib/katello/validators/product_unique_attribute_validator.rb
+++ b/app/lib/katello/validators/product_unique_attribute_validator.rb
@@ -5,7 +5,7 @@ module Katello
         unique = self.unique_attribute?(record, attribute, value)
 
         unless unique
-          record.errors[attribute] << _("has already been taken for a product in this organization.")
+          record.errors.add(attribute, _("has already been taken for a product in this organization."))
         end
       end
 

--- a/app/lib/katello/validators/repo_disablement_validator.rb
+++ b/app/lib/katello/validators/repo_disablement_validator.rb
@@ -3,9 +3,9 @@ module Katello
     class RepoDisablementValidator < ActiveModel::Validator
       def validate(record)
         if record.redhat? && record.enabled_changed? && !record.enabled? && record.promoted?
-          record.errors[:base] << N_("Repository cannot be disabled since it has already been promoted.")
+          record.errors.add(:base, N_("Repository cannot be disabled since it has already been promoted."))
         elsif !record.redhat? && !record.enabled?
-          record.errors[:base] << N_("Custom repositories cannot be disabled.")
+          record.errors.add(:base, N_("Custom repositories cannot be disabled."))
         end
       end
     end

--- a/app/lib/katello/validators/root_repository_unique_attribute_validator.rb
+++ b/app/lib/katello/validators/root_repository_unique_attribute_validator.rb
@@ -5,7 +5,7 @@ module Katello
         exists = RootRepository.where(:product_id => record.product_id, attribute => value).where("id != ?", record.id || -1).exists?
 
         if record.send("#{attribute}_changed?") && record.custom? && exists
-          record.errors[attribute] << _("has already been taken for this product.")
+          record.errors.add(attribute, _("has already been taken for this product."))
         end
       end
     end

--- a/app/lib/katello/validators/self_reference_environment_validator.rb
+++ b/app/lib/katello/validators/self_reference_environment_validator.rb
@@ -2,7 +2,7 @@ module Katello
   module Validators
     class SelfReferenceEnvironmentValidator < ActiveModel::Validator
       def validate(record)
-        record.errors[:base] << _("Environment cannot be in its own promotion path") if record.priors.select(:id).include? record.id
+        record.errors.add(:base, _("Environment cannot be in its own promotion path")) if record.priors.select(:id).include? record.id
       end
     end
   end

--- a/app/lib/katello/validators/unique_field_in_org.rb
+++ b/app/lib/katello/validators/unique_field_in_org.rb
@@ -7,7 +7,7 @@ module Katello
         if value
           others = record.class.where(attribute => value).joins(:environment).where("#{Katello::KTEnvironment.table_name}.organization_id" => record.environment.organization_id)
           others = others.where("#{record.class.table_name}.id != ?", record.id) if record.persisted?
-          record.errors[attribute] << N_("already taken") if others.any?
+          record.errors.add(attribute, N_("already taken")) if others.any?
         end
       end
     end

--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -42,16 +42,16 @@ module Katello
     validates_each :max_hosts do |record, attr, value|
       if record.unlimited_hosts
         unless value.nil?
-          record.errors[attr] << _("cannot be set because unlimited hosts is set")
+          record.errors.add(attr, _("cannot be set because unlimited hosts is set"))
         end
       else
         if value.nil?
-          record.errors[attr] << _("cannot be nil")
+          record.errors.add(attr, _("cannot be nil"))
         elsif value <= 0
-          record.errors[attr] << _("cannot be less than one")
+          record.errors.add(attr, _("cannot be less than one"))
         elsif value < record.subscription_facets.length
           # we don't let users to set usage limit lower than current in-use
-          record.errors[attr] << _("cannot be lower than current usage count (%s)" % record.subscription_facets.length)
+          record.errors.add(attr, _("cannot be lower than current usage count (%s)" % record.subscription_facets.length))
         end
       end
     end

--- a/test/lib/validators/gpg_key_content_validator_test.rb
+++ b/test/lib/validators/gpg_key_content_validator_test.rb
@@ -14,7 +14,7 @@ module Katello
 
     test "test gpg_key file validation" do
       response = @validator.validate_each(@gpg_key, :content, @gpg_key.content)
-      assert_equal 'must contain valid Public GPG Key', response[0]
+      assert_equal 'must contain valid Public GPG Key', response.message
     end
   end
 end

--- a/test/lib/validators/hostgroup_kickstart_repository_validator_test.rb
+++ b/test/lib/validators/hostgroup_kickstart_repository_validator_test.rb
@@ -63,7 +63,7 @@ module Katello
 
       @validator.validate(@content_facet)
 
-      assert_empty @content_facet.errors.values
+      assert_empty @content_facet.errors.map(&:message)
     end
 
     test 'it invalidates missing content source on a hostgroup' do

--- a/test/lib/validators/katello_label_format_validator_test.rb
+++ b/test/lib/validators/katello_label_format_validator_test.rb
@@ -1,10 +1,21 @@
 require 'katello_test_helper'
 
 module Katello
+  class KatelloLabelFormatValidatorMockModel < Hash
+    def initialize
+      super
+      self[:name] = []
+    end
+
+    def add(attribute, message)
+      self[attribute] << message
+    end
+  end
+
   class KatelloLabelFormatValidatorTest < ActiveSupport::TestCase
     def setup
       @validator = Validators::KatelloLabelFormatValidator.new(:attributes => [:name])
-      @model = OpenStruct.new(:errors => {:name => []})
+      @model = OpenStruct.new(:errors => KatelloLabelFormatValidatorMockModel.new)
     end
 
     def test_validate_each

--- a/test/lib/validators/katello_name_format_validator_test.rb
+++ b/test/lib/validators/katello_name_format_validator_test.rb
@@ -3,10 +3,21 @@
 require 'katello_test_helper'
 
 module Katello
+  class KatelloNameFormatValidatorMockModel < Hash
+    def initialize
+      super
+      self[:name] = []
+    end
+
+    def add(attribute, message)
+      self[attribute] << message
+    end
+  end
+
   class KatelloNameFormatValidatorTest < ActiveSupport::TestCase
     def setup
       @validator = Validators::KatelloNameFormatValidator.new(:attributes => [:name])
-      @model = OpenStruct.new(:errors => {:name => []})
+      @model = OpenStruct.new(:errors => KatelloNameFormatValidatorMockModel.new)
     end
 
     def test_validate_each

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -37,7 +37,7 @@ module Katello
       ak = ActivationKey.create!(name: 'new_key', organization: org2)
       ak.content_view_environments << library_dev_staging_cve
       refute ak.save
-      refute_empty ak.errors.keys
+      refute_empty ak.errors.attribute_names
       assert_raises(ActiveRecord::RecordInvalid) do
         ak.save!
       end

--- a/test/models/host_collection_test.rb
+++ b/test/models/host_collection_test.rb
@@ -143,7 +143,7 @@ module Katello
       invalid_name_list.each do |name|
         host_collection = HostCollection.new(:name => name, :organization => @organization)
         refute host_collection.valid?, "Validation succeed for create with invalid name: '#{name}' length: #{name.length})"
-        assert host_collection.errors.key?(:name)
+        assert_includes host_collection.errors.attribute_names, :name
       end
     end
 

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -76,7 +76,7 @@ module Katello
             :name => name
         )
         refute product.valid?, "Validation succeeded for create with invalid name: '#{name}' length: #{name.length})"
-        assert_includes product.errors.keys, :name
+        assert_includes product.errors.attribute_names, :name
       end
     end
 
@@ -89,7 +89,7 @@ module Katello
           :label => RFauxFactory.gen_utf8
       )
       refute_valid product
-      assert_includes product.errors.keys, :label
+      assert_includes product.errors.attribute_names, :label
     end
 
     test_attributes :pid => '1a9f6e0d-43fb-42e2-9dbd-e880f03b0297'
@@ -124,7 +124,7 @@ module Katello
       invalid_name_list.each do |name|
         @product.name = name
         refute @product.valid?, "Validation succeeded for update with invalid name: '#{name}' length: #{name.length})"
-        assert_includes @product.errors.keys, :name
+        assert_includes @product.errors.attribute_names, :name
       end
     end
 
@@ -134,7 +134,7 @@ module Katello
       @product.save!
       @product.label = RFauxFactory.gen_alpha
       refute_valid @product
-      assert_includes @product.errors.keys, :label
+      assert_includes @product.errors.attribute_names, :label
       assert_equal 'cannot be changed.', @product.errors['label'][0]
     end
 

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -156,7 +156,7 @@ module Katello
       %w[sha256 sha384 sha512].each do |checksum_type|
         @root.checksum_type = checksum_type
         refute @root.valid?, "Validation failed for create with valid checksum_type: '#{checksum_type}'"
-        assert @root.errors.key?(:checksum_type)
+        assert_includes @root.errors.attribute_names, :checksum_type
       end
     end
 
@@ -174,7 +174,7 @@ module Katello
       invalid_name_list.each do |invalid_name|
         @root.name = invalid_name
         refute @root.valid?, "Validation passed for create with invalid name: '#{invalid_name}' length: #{invalid_name.length}"
-        assert @root.errors.key?(:name)
+        assert_includes @root.errors.attribute_names, :name
       end
     end
 
@@ -188,7 +188,7 @@ module Katello
                       )
 
       refute_valid new_repo
-      assert new_repo.errors.key?(:name)
+      assert_includes new_repo.errors.attribute_names, :name
       assert_match 'has already been taken for this product.', new_repo.errors[:name][0]
     end
 
@@ -196,7 +196,7 @@ module Katello
     def test_create_with_invalid_label
       @root.label = RFauxFactory.gen_utf8
       refute_valid @root
-      assert @root.errors.key?(:label)
+      assert_includes @root.errors.attribute_names, :label
       assert_match 'cannot contain characters other than ascii alpha numerals, \'_\', \'-\'.', @root.errors[:label][0]
     end
 
@@ -212,7 +212,7 @@ module Katello
             @root.valid?
           end
         end
-        assert @root.errors.key?(:url)
+        assert_includes @root.errors.attribute_names, :url
         assert_match 'is invalid', @root.errors[:url][0]
       end
     end
@@ -228,7 +228,7 @@ module Katello
         assert_raise URI::InvalidURIError do
           @root.valid?
         end
-        assert @root.errors.key?(:url)
+        assert_includes @root.errors.attribute_names, :url
         assert_match 'is invalid', @root.errors[:url][0]
       end
     end
@@ -246,7 +246,7 @@ module Katello
             @root.valid?
           end
         end
-        assert @root.errors.key?(:url)
+        assert_includes @root.errors.attribute_names, :url
         assert_match 'is too long (maximum is 1024 characters)', @root.errors[:url][0]
       end
     end
@@ -257,7 +257,7 @@ module Katello
       assert @root.save
       @root.download_policy = 'invalid_download_policy'
       refute_valid @root
-      assert @root.errors.key?(:download_policy)
+      assert_includes @root.errors.attribute_names, :download_policy
       assert_match 'must be one of the following: immediate, on_demand', @root.errors[:download_policy][0]
     end
 
@@ -266,7 +266,7 @@ module Katello
       @root.download_policy = ::Katello::RootRepository::DOWNLOAD_ON_DEMAND
       @root.content_type = 'ansible_collection'
       refute @root.valid?, "Validation succeed for create with download_policy and non-yum repository: ansible_collection"
-      assert @root.errors.key?(:download_policy)
+      assert_includes @root.errors.attribute_names, :download_policy
       assert_match(/Cannot set attribute.*ansible_collection.*/, @root.errors[:download_policy][0])
     end
 
@@ -275,7 +275,7 @@ module Katello
       @root.checksum_type = 'invalid checksum_type'
       @root.download_policy = ::Katello::RootRepository::DOWNLOAD_IMMEDIATE
       refute_valid @root
-      assert @root.errors.key?(:checksum_type)
+      assert_includes @root.errors.attribute_names, :checksum_type
       assert_match 'is not included in the list', @root.errors[:checksum_type][0]
     end
 
@@ -396,7 +396,7 @@ module Katello
       invalid_name_list.each do |invalid_name|
         @fedora_root.name = invalid_name
         refute @fedora_root.valid?, "Validation succeed for update with invalid name: #{invalid_name} length: #{invalid_name.length}"
-        assert @fedora_root.errors.key?(:name)
+        assert_includes @fedora_root.errors.attribute_names, :name
       end
     end
 
@@ -405,7 +405,7 @@ module Katello
       repo = @fedora_root
       repo.label = 'new_label'
       refute repo.valid?
-      assert repo.errors.key?(:label)
+      assert_includes repo.errors.attribute_names, :label
       assert_match 'cannot be changed.', repo.errors[:label][0]
     end
 
@@ -421,7 +421,7 @@ module Katello
           repo.valid?
         end
 
-        assert repo.errors.key?(:url)
+        assert_includes repo.errors.attribute_names, :url
         assert_match 'is invalid', repo.errors[:url][0]
       end
     end
@@ -439,7 +439,7 @@ module Katello
             repo.valid?
           end
         end
-        assert repo.errors.key?(:url)
+        assert_includes repo.errors.attribute_names, :url
         assert_match 'is too long (maximum is 1024 characters)', repo.errors[:url][0]
       end
     end

--- a/test/models/sync_plan_test.rb
+++ b/test/models/sync_plan_test.rb
@@ -84,7 +84,7 @@ module Katello
       invalid_name_list.each do |name|
         sync_plan = SyncPlan.new(valid_attributes.merge(:name => name))
         refute sync_plan.valid?, "Validation succeed for create with invalid name: '#{name}' length: #{name.length})"
-        assert sync_plan.errors.key?(:name)
+        assert_includes sync_plan.errors.attribute_names, :name
       end
     end
 
@@ -93,7 +93,7 @@ module Katello
       invalid_name_list.each do |interval|
         sync_plan = SyncPlan.new(valid_attributes.merge(:interval => interval))
         refute sync_plan.valid?, "Validation succeed for create with invalid interval: '#{interval}'"
-        assert sync_plan.errors.key?(:interval)
+        assert_includes sync_plan.errors.attribute_names, :interval
       end
     end
 
@@ -183,7 +183,7 @@ module Katello
       invalid_name_list.each do |name|
         @plan.name = name
         refute @plan.valid?, "Validation succeed for update with invalid name: '#{name}' length: #{name.length})"
-        assert @plan.errors.key?(:name)
+        assert_includes @plan.errors.attribute_names, :name
       end
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Deprecation fixes:
 - Changing #<< to #add for ActiveModel::Errors objects
 - Changing #keys to #attribute_names for ActiveModel::Errors objects

#### Considerations taken when implementing this change?

Extracted from https://github.com/Katello/katello/pull/11155 for easier review/merge.

#### What are the testing steps for this pull request?

 - Hope tests are green
 - Hope I didn't overlook anything
 
 @ekohl 