### PR TITLE
Fixes #38025 - Add label option when creating organization

### DIFF
--- a/app/overrides/add_organization_attributes.rb
+++ b/app/overrides/add_organization_attributes.rb
@@ -11,6 +11,12 @@ Deface::Override.new(:virtual_path => "taxonomies/_form",
                      :text => '<% if taxonomy.is_a?(Location) %><%= render_original %><% end %>'
                     )
 
+Deface::Override.new(:virtual_path => "taxonomies/_step1",
+                    :name => "add_organization_attributes_on_create",
+                    :insert_after => 'erb[loud]:contains("text_f"):contains(":name")',
+                    :partial => 'overrides/organizations/step_1_override'
+                    )
+
 # Add organization attributes to org edit
 Deface::Override.new(:virtual_path => "taxonomies/_form",
                      :name => "add_organization_attributes_on_edit",

--- a/app/views/overrides/organizations/_step_1_override.html.erb
+++ b/app/views/overrides/organizations/_step_1_override.html.erb
@@ -1,0 +1,5 @@
+<% if @taxonomy.is_a?(Organization) %>
+
+  <%= text_f f, :label, :class => 'input-xlarge' %>
+
+<% end %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When creating new organization in the UI, the user has the option to input a custom organization label. 

#### Considerations taken when implementing this change?

The label field was removed probably accidentally in #10880.
This action is still doable in API so it should be doable in UI as well.

#### What are the testing steps for this pull request?

1. In the web UI, navigate to **Administer > Organizations**.
2. Click **New Organization**.
3. Input **Name** and custom **Label** and submit.
4. Verify that the inputted label is present by clicking on the organization and displaying its details. 