### PR TITLE
Fixes #38026 - Remove redundant 'require' calls

### DIFF
--- a/spec/lib/url_matcher_spec.rb
+++ b/spec/lib/url_matcher_spec.rb
@@ -1,5 +1,4 @@
 require 'katello_test_helper'
-require 'katello/util/url_matcher'
 
 module Katello
   describe Util::URLMatcher do

--- a/test/lib/concerns/base_template_scope_extensions_test.rb
+++ b/test/lib/concerns/base_template_scope_extensions_test.rb
@@ -1,6 +1,4 @@
 require 'katello_test_helper'
-require 'foreman/renderer'
-require 'foreman/renderer/source/string'
 
 module Katello
   class BaseTemplateScopeExtensionsTest < ActiveSupport::TestCase

--- a/test/lib/concerns/renderer_extensions_test.rb
+++ b/test/lib/concerns/renderer_extensions_test.rb
@@ -1,5 +1,4 @@
 require 'katello_test_helper'
-require 'foreman/renderer/scope/provisioning'
 
 module Katello
   class RendererExtensionsTest < ActiveSupport::TestCase

--- a/test/lib/resources/candlepin_test.rb
+++ b/test/lib/resources/candlepin_test.rb
@@ -1,5 +1,4 @@
 require 'katello_test_helper'
-require 'katello/resources/candlepin'
 
 module Katello
   module Resources

--- a/test/services/katello/pulp3/repository_integration_test.rb
+++ b/test/services/katello/pulp3/repository_integration_test.rb
@@ -1,6 +1,5 @@
 require 'katello_test_helper'
-require 'support/pulp3_support'
-require 'katello/pulp3/repository'
+require_relative '../../../support/pulp3_support.rb'
 
 types = Katello::RepositoryTypeManager.defined_repository_types
 types.slice!(ENV['TEST_CONTENT_TYPES'].split(',')) unless ENV['CONTENT_TYPES'].blank?


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This is extracted from https://github.com/Katello/katello/pull/11155.

#### Considerations taken when implementing this change?

During Zeitwerk-related changes I've missed some calls that are no longer needed, which are also Rails 7 incompatible.

#### What are the testing steps for this pull request?

Mostly ensuring there are no errors during app loading and the tests are green meaning there are no "undefined constant" errors.

@ekohl 