### PR TITLE
Fixes #38028 - Update smart proxy URI methods for load balancer setups

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -131,9 +131,13 @@ module Katello
         SmartProxy.joins(:smart_proxy_alternate_content_sources).where('katello_smart_proxy_alternate_content_sources.smart_proxy_id' => self.id)
       end
 
-      def registration_host
+      def registration_url
         url = self.setting('Registration', 'registration_url').presence || self.url
-        URI.parse(url).host
+        URI(url)
+      end
+
+      def registration_host
+        registration_url.host
       end
 
       def load_balanced?
@@ -598,12 +602,16 @@ module Katello
         URI(setting(SmartProxy::PULP3_FEATURE, 'content_app_url'))
       end
 
+      def load_balancer_pulp_content_url
+        URI::HTTPS.build(host: registration_url.host, path: pulp_content_url.path)
+      end
+
       def audit_capsule_sync
         write_audit(action: "sync capsule", comment: _('Successfully synced capsule.'), audited_changes: {})
       end
 
       class ::SmartProxy::Jail < ::Safemode::Jail
-        allow :rhsm_url, :pulp_content_url
+        allow :rhsm_url, :pulp_content_url, :load_balancer_pulp_content_url, :registration_url
       end
     end
   end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Goes with https://github.com/theforeman/foreman/pull/10382

Update smart proxy methods so that provisioning can use correct URLs in sub-man config.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Set up a load-balanced smart proxy with `registration_url` set to the fqdn of the load balancer, as outlined in the docs
Provision a host with the load balanced smart proxy set as the content source (?)
The host's "registered through" value should be that of the load balancer, not that of the smart proxy behind the load balancer


