### PR TITLE
Fixes #38015 - Handle empty content counts on Proxy UI

### DIFF
--- a/webpack/scenes/SmartProxy/ExpandableCvDetails.js
+++ b/webpack/scenes/SmartProxy/ExpandableCvDetails.js
@@ -88,7 +88,7 @@ const ExpandableCvDetails = ({
             <Tr key="child_row" ouiaId={`ContentViewTableRowChild-${id}`} isExpanded={isExpanded}>
               <Td colSpan={12}>
                 <ExpandedSmartProxyRepositories
-                  contentCounts={contentCounts?.content_view_versions[versionId]?.repositories}
+                  contentCounts={contentCounts?.content_view_versions?.[versionId]?.repositories}
                   repositories={repositories}
                   syncedToCapsule={upToDate}
                   envId={envId}

--- a/webpack/scenes/SmartProxy/__tests__/SmartProxyContentTest.js
+++ b/webpack/scenes/SmartProxy/__tests__/SmartProxyContentTest.js
@@ -50,6 +50,43 @@ test('Can display Smart proxy content table and expand env and cv details', asyn
   assertNockRequest(detailsScope, done);
 });
 
+test('Handles empty content_counts and displays N/A for Packages and Additional content', async (done) => {
+  const emptyContentCountsData = {
+    ...smartProxyContent,
+    content_counts: {},
+  };
+
+  const detailsScope = nockInstance
+    .get(smartProxyContentPath)
+    .query(true)
+    .reply(200, emptyContentCountsData);
+
+  const { getByText, getAllByText, getByLabelText } = renderWithRedux(contentTable);
+
+  await patientlyWaitFor(() => expect(getByText('Environment')).toBeInTheDocument());
+
+  const tdEnvExpand = getByLabelText('expand-env-1');
+  const envExpansion = within(tdEnvExpand).getByLabelText('Details');
+  envExpansion.click();
+
+  await patientlyWaitFor(() => expect(getAllByText('Content view')[0]).toBeInTheDocument());
+  expect(getAllByText('Last published')[0]).toBeInTheDocument();
+  expect(getAllByText('Repository')[0]).toBeInTheDocument();
+  expect(getAllByText('Synced')[0]).toBeInTheDocument();
+
+  const tdCvExpand = getByLabelText('expand-cv-1');
+  const cvExpansion = within(tdCvExpand).getByLabelText('Details');
+  expect(cvExpansion).toHaveAttribute('aria-expanded', 'false');
+  cvExpansion.click();
+
+  await patientlyWaitFor(() => expect(cvExpansion).toHaveAttribute('aria-expanded', 'true'));
+
+  expect(getAllByText('N/A')[0]).toBeInTheDocument();
+  expect(getAllByText('N/A')[1]).toBeInTheDocument();
+
+  assertNockRequest(detailsScope, done);
+});
+
 test('Can call content count refresh for environment', async (done) => {
   const detailsScope = nockInstance
     .get(smartProxyContentPath)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Updated the SmartProxyExpandableTable component to use optional chaining for safer property access and added a test case to validate correct behavior and UI rendering.

#### Considerations taken when implementing this change?

Ensured the component handles content_counts as an empty object {} without errors, maintains backward compatibility, and preserves UI consistency with appropriate placeholders for missing data.

#### What are the testing steps for this pull request?

Set content_counts = {}:

1. Got to Rails Console:
        bundle exec rails console
2. Assign Empty Object {} to the respective SmartProxy's content_counts attribute: 
        sp = SmartProxy.find(smartproxy_id)
        sp.content_counts = {}
3. Save the changes:
        sp.save

Check the UI

1. Go to Infrastructure -> Smart Proxies -> Any Proxy -> Content
2. Expand Env -> Expand Content View
3. It should not give console error and able to view the fields with the value "N/A" for Packages and Additional Content