### PR TITLE
Fixes #38047 - Do not tranlsate links in toasts

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-traces-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-traces-modal.controller.js
@@ -34,7 +34,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkTracesContro
                 Notification.setSuccessMessage(message, {
                     link: {
                         children: translate("View job invocations."),
-                        href: translate("/job_invocations")
+                        href: "/job_invocations"
                     }});
                 $scope.ok();
             };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/products-bulk-advanced-sync-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/products-bulk-advanced-sync-modal.controller.js
@@ -25,7 +25,7 @@ angular.module('Bastion.products').controller('ProductsBulkAdvancedSyncModalCont
                 Notification.setSuccessMessage(message, {
                 link: {
                     children: translate("Click to view task"),
-                    href: translate("/foreman_tasks/tasks/%taskId").replace('%taskId', task.id)
+                    href: "/foreman_tasks/tasks/%taskId".replace('%taskId', task.id)
                 }});
             };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
@@ -68,7 +68,7 @@ angular.module('Bastion.products').controller('ProductsController',
             Notification.setSuccessMessage(message, {
                 link: {
                     children: translate("Click to view task"),
-                    href: translate("/foreman_tasks/tasks/%taskId").replace('%taskId', taskId)
+                    href: "/foreman_tasks/tasks/%taskId".replace('%taskId', taskId)
                 }});
         });
 
@@ -98,7 +98,7 @@ angular.module('Bastion.products').controller('ProductsController',
                 Notification.setSuccessMessage(message, {
                     link: {
                         children: translate("Click to monitor task progress."),
-                        href: translate("/foreman_tasks/tasks/%taskId").replace('%taskId', task.id)
+                        href: "/foreman_tasks/tasks/%taskId".replace('%taskId', task.id)
                     }});
             };
 
@@ -113,7 +113,7 @@ angular.module('Bastion.products').controller('ProductsController',
                 Notification.setSuccessMessage(message, {
                     link: {
                         children: translate("Click to monitor task progress."),
-                        href: translate("/foreman_tasks/tasks/%taskId").replace('%taskId', task.id)
+                        href: "/foreman_tasks/tasks/%taskId".replace('%taskId', task.id)
                     }});
             };
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Links are no longer translated for toast notifications 

#### Considerations taken when implementing this change?
Searched for `translate\(.*/` in the code, and removed the translation around links 

#### What are the testing steps for this pull request?
have mark for translations on, sync a product and click the link, the link will work as its not surrounded by X