### PR TITLE
Fixes #38056 - Refresh content count action fails when count is set to {}

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -171,10 +171,10 @@ module Katello
       end
 
       def initialize_content_counts(reset: false)
-        if reset
+        if reset || content_counts.empty?
           { content_view_versions: {} }.with_indifferent_access
         else
-          (content_counts&.deep_dup || { content_view_versions: {} }).with_indifferent_access
+          content_counts.deep_dup.with_indifferent_access
         end
       end
 
@@ -182,7 +182,9 @@ module Katello
         repo_mirror_service = repo.backend_service(self).with_mirror_adapter
         repo_content_counts = repo_mirror_service.latest_content_counts
         translated_counts = translate_counts(repo, repo_mirror_service, repo_content_counts)
-        content_counts[:content_view_versions][repo.content_view_version_id.to_s] ||= { repositories: {}}
+        if content_counts[:content_view_versions][repo.content_view_version_id.to_s].empty?
+          content_counts[:content_view_versions][repo.content_view_version_id.to_s] = { repositories: {}}.with_indifferent_access
+        end
         content_counts[:content_view_versions][repo.content_view_version_id.to_s][:repositories][repo.id.to_s] = translated_counts
       end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add check for smart proxy content_count being {}
#### Considerations taken when implementing this change?
We were handling the nil case but not empty? case, i.e {}
Added empty checks for content_counts in 2 places. 
One for content_counts where we reinitialize it to { content_view_versions: {} } and for repositories where we need to handle content_counts[:content_view_versions][repo.content_view_version_id.to_s].empty?
#### What are the testing steps for this pull request?
In the console, 
```
sp = SmartProxy.find("id")
sp.content_counts = {}
sp.save!
```
Try refresh counts action against any env/cv or global and the content count task will fail.

If you have some content_counts populated, pick any cv_version_id,
You can also try to test the empty hash case for cv version id keys. 
Example:
`sp.content_counts["content_view_versions"]["8"] = {}`

Run refresh action for that cv_version from UI and see that it passes for this PR but fails without the PR.
