### PR TITLE
Fixes #37895 - Handle version removal for multi-CV activation key

### DIFF
--- a/app/lib/actions/katello/content_view_environment/reassign_objects.rb
+++ b/app/lib/actions/katello/content_view_environment/reassign_objects.rb
@@ -9,7 +9,11 @@ module Actions
             end
 
             content_view_environment.activation_keys.each do |key|
-              plan_action(ActivationKey::Reassign, key, options[:key_content_view_id], options[:key_environment_id])
+              if key.multi_content_view_environment?
+                key.content_view_environments = key.content_view_environments - [content_view_environment]
+              else
+                plan_action(ActivationKey::Reassign, key, options[:key_content_view_id], options[:key_environment_id])
+              end
             end
           end
         end

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVVersionRemoveReview.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVVersionRemoveReview.js
@@ -18,11 +18,16 @@ const CVVersionRemoveReview = () => {
   const activationKeysResponse = useSelector(state => selectCVActivationKeys(state, cvId));
   const hostsResponse = useSelector(state => selectCVHosts(state, cvId));
   const { results: hostResponse } = hostsResponse;
-  const { results: akResponse } = activationKeysResponse;
+  const { results: akResponse = [] } = activationKeysResponse || {};
   const selectedEnv = versionEnvironments.filter(env => selectedEnvSet.has(env.id));
   const versionDeleteInfo = __(`Version ${versionNameToRemove} will be deleted from all environments. It will no longer be available for promotion.`);
   const removalNotice = __(`Version ${versionNameToRemove} will be removed from the environments listed below, and will remain available for later promotion. ` +
     'Changes listed below will be effective after clicking Remove.');
+
+  const multiCVActivationKeys = akResponse.filter(key => key.multi_content_view_environment);
+  const multiCVActivationKeysCount = multiCVActivationKeys.length;
+
+  const singleCVActivationKeysCount = akResponse.length - multiCVActivationKeysCount;
 
   return (
     <>
@@ -62,11 +67,23 @@ const CVVersionRemoveReview = () => {
       {affectedActivationKeys &&
         <>
           <h3>{__('Activation keys')}</h3>
-          <Flex>
-            <FlexItem><ExclamationTriangleIcon /></FlexItem>
-            <FlexItem><p>{__(`${pluralize(akResponse.length, 'activation key')} will be moved to content view ${selectedCVNameForAK} in `)}</p></FlexItem>
-            <FlexItem><Label isTruncated color="purple" href={`/lifecycle_environments/${selectedEnvForAK[0].id}`}>{selectedEnvForAK[0].name}</Label></FlexItem>
-          </Flex>
+          {singleCVActivationKeysCount > 0 && (
+            <Flex>
+              <FlexItem><ExclamationTriangleIcon /></FlexItem>
+              <FlexItem><p>{__(`${pluralize(singleCVActivationKeysCount, 'activation key')} will be moved to content view ${selectedCVNameForAK} in `)}</p></FlexItem>
+              <FlexItem><Label isTruncated color="purple" href={`/lifecycle_environments/${selectedEnvForAK[0].id}`}>{selectedEnvForAK[0].name}</Label></FlexItem>
+            </Flex>
+          )}
+          {multiCVActivationKeysCount > 0 && (
+            <Flex>
+              <FlexItem><ExclamationTriangleIcon /></FlexItem>
+              <FlexItem>
+                <p>
+                  {__(`Content view environment will be removed from ${pluralize(multiCVActivationKeysCount, 'multi-environment activation key')}.`)}
+                </p>
+              </FlexItem>
+            </Flex>
+          )}
         </>}
     </>
   );

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/affectedActivationKeys.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/affectedActivationKeys.js
@@ -35,6 +35,7 @@ const AffectedActivationKeys = ({
   const columnHeaders = [
     __('Name'),
     __('Environment'),
+    __('Multi Content View Environment'),
   ];
   const emptyContentTitle = __('No matching activation keys found.');
   const emptyContentBody = __("Given criteria doesn't match any activation keys. Try changing your rule.");
@@ -65,12 +66,15 @@ const AffectedActivationKeys = ({
         </Tr>
       </Thead>
       <Tbody>
-        {results?.map(({ name, id, environment }) => (
+        {results?.map(({
+          name, id, environment, multi_content_view_environment: multiContentViewEnvironment,
+        }) => (
           <Tr ouiaId={id} key={id}>
             <Td>
               <a rel="noreferrer" target="_blank" href={urlBuilder(`activation_keys/${id}`, '')}>{name}</a>
             </Td>
             <Td><EnvironmentLabels environments={environment} /></Td>
+            <Td>{ multiContentViewEnvironment ? 'Yes' : 'No' }</Td>
           </Tr>
         ))
         }


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Added checks for multi-CV associations and helper methods to handle version removal from the environment, cleaning up relevant activation key and environment links to ensure only the targeted version is removed without affecting unrelated associations.

#### Considerations taken when implementing this change?

Ensured selective removal of associations to avoid reassigning multi-CV AK to single CVE and impacting unrelated environments or activation keys, preserved existing associations while removing the targeted version, reused existing methods for consistency, and added checks for edge cases like multiple activation keys linked to the same environment.

#### What are the testing steps for this pull request?

Create a multi-CV activation key

1. Promote a CV Version to multiple environments
2. Using Hammer CLI, update the  activation key to use mutli CVE
     Example command: hammer activation-key update --organization="Default Organization" --id=1 --content-view-environments="ABC/cv1,XYZ/cv1"
3. Confirm that the activation key uses multi CVEs

Remove the version from the environment

1. Go to the CV associated with the activation key -> Versions
2. Click on the 3 dots of the respective CV Version and select the option "Remove from environments"
3. Follow the steps to remove the CV Version from the environment
4. A task will be created which should successfully remove the version from the environment when the CVE is in use by a multi-CV activation key
