### PR TITLE
Fixes #38062 - Fix scoped search for composite key for CVs

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -112,7 +112,7 @@ module Katello
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :organization_id, :complete_value => true, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
     scoped_search :on => :label, :complete_value => true
-    scoped_search :on => :composite, :complete_value => true
+    scoped_search :on => :composite, :complete_value => { :true => true, :false => false }
     scoped_search :on => :generated_for, :complete_value => true
     scoped_search :on => :default # just for ordering
     scoped_search :on => :name, :complete_value => true,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Before:
![image](https://github.com/user-attachments/assets/5dabc126-e447-4801-bd1e-d5d9a30f9143)



After:
![image](https://github.com/user-attachments/assets/31f0d798-1588-4971-9d7f-e434a4e60ac6)


#### What are the testing steps for this pull request?
Go to CV overview page and try to use 'composite' as search filter