### PR TITLE
Fixes #38071 - Add content_type field to container manifests

### DIFF
--- a/app/models/katello/docker_manifest.rb
+++ b/app/models/katello/docker_manifest.rb
@@ -11,12 +11,15 @@ module Katello
     CONTENT_TYPE = "docker_manifest".freeze
 
     scope :bootable, -> { where(:is_bootable => true) }
+    scope :flatpak, -> { where(:is_flatpak => true) }
 
     scoped_search :relation => :docker_tags, :on => :name, :rename => :tag, :complete_value => true
     scoped_search :on => :digest, :rename => :digest, :complete_value => true, :only_explicit => true
     scoped_search :on => :schema_version, :rename => :schema_version, :complete_value => true, :only_explicit => true
     scoped_search :relation => :docker_manifest_lists, :on => :digest, :rename => :manifest_list_digest, :complete_value => true, :only_explicit => true
     scoped_search :on => :is_bootable, :rename => :bootable, :complete_value => true, :only_explicit => true
+    scoped_search :on => :is_flatpak, :rename => :flatpak, :complete_value => true, :only_explicit => true
+    scoped_search :on => :content_type, :complete_value => true, :only_explicit => true
 
     def self.default_sort
       order(:schema_version)

--- a/app/models/katello/docker_manifest_list.rb
+++ b/app/models/katello/docker_manifest_list.rb
@@ -12,11 +12,14 @@ module Katello
     CONTENT_TYPE = "docker_manifest_list".freeze
 
     scope :bootable, -> { where(:is_bootable => true) }
+    scope :flatpak, -> { where(:is_flatpak => true) }
 
     scoped_search :relation => :docker_tags, :on => :name, :rename => :tag, :complete_value => true
     scoped_search :on => :digest, :rename => :digest, :complete_value => true, :only_explicit => true
     scoped_search :on => :schema_version, :rename => :schema_version, :complete_value => true, :only_explicit => true
     scoped_search :on => :is_bootable, :rename => :bootable, :complete_value => true, :only_explicit => true
+    scoped_search :on => :is_flatpak, :rename => :flatpak, :complete_value => true, :only_explicit => true
+    scoped_search :on => :content_type, :complete_value => true, :only_explicit => true
 
     def self.default_sort
       order(:schema_version)

--- a/app/services/katello/pulp3/docker_manifest.rb
+++ b/app/services/katello/pulp3/docker_manifest.rb
@@ -29,8 +29,9 @@ module Katello
           pulp_id: unit[unit_identifier],
           annotations: unit['annotations'],
           labels: unit['labels'],
-          is_bootable: unit['is_bootable'],
-          is_flatpak: unit['is_flatpak'],
+          is_bootable: unit['is_bootable'] || unit['type'] == 'bootable',
+          is_flatpak: unit['is_flatpak'] || unit['type'] == 'flatpak',
+          content_type: unit['type'],
         }
       end
     end

--- a/app/services/katello/pulp3/docker_manifest_list.rb
+++ b/app/services/katello/pulp3/docker_manifest_list.rb
@@ -31,8 +31,9 @@ module Katello
           pulp_id: unit[unit_identifier],
           annotations: unit['annotations'],
           labels: unit['labels'],
-          is_bootable: unit['is_bootable'],
-          is_flatpak: unit['is_flatpak'],
+          is_bootable: unit['is_bootable'] || unit['type'] == 'bootable',
+          is_flatpak: unit['is_flatpak'] || unit['type'] == 'flatpak',
+          content_type: unit['type'],
         }
       end
 

--- a/app/views/katello/api/v2/docker_manifest_lists/show.json.rabl
+++ b/app/views/katello/api/v2/docker_manifest_lists/show.json.rabl
@@ -1,6 +1,6 @@
 object @resource
 
-attributes :id, :schema_version, :digest, :manifest_type
+attributes :id, :schema_version, :digest, :manifest_type, :content_type
 attributes :annotations, :labels, :is_bootable, :is_flatpak
 
 child :docker_tags => :tags do

--- a/app/views/katello/api/v2/docker_manifests/show.json.rabl
+++ b/app/views/katello/api/v2/docker_manifests/show.json.rabl
@@ -1,6 +1,6 @@
 object @resource
 
-attributes :id, :schema_version, :digest, :manifest_type
+attributes :id, :schema_version, :digest, :manifest_type, :content_type
 attributes :annotations, :labels, :is_bootable, :is_flatpak
 
 child :docker_tags => :tags do

--- a/db/migrate/20241206183052_add_content_type_to_container_manifests_and_lists.rb
+++ b/db/migrate/20241206183052_add_content_type_to_container_manifests_and_lists.rb
@@ -1,0 +1,9 @@
+class AddContentTypeToContainerManifestsAndLists < ActiveRecord::Migration[6.1]
+  def change
+    add_column :katello_docker_manifests, :content_type, :string, :limit => 255
+    add_column :katello_docker_manifest_lists, :content_type, :string, :limit => 255
+
+    add_index :katello_docker_manifests, :content_type
+    add_index :katello_docker_manifest_lists, :content_type
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds a type -> content_type field on container manifest and manifest lists and add these to rabls and indexing
#### Considerations taken when implementing this change?
We can't name fields `type` since it's reserved. Going with content_type after some offline discussions with Ian.
#### What are the testing steps for this pull request?
1. Create a bootable/flatpak repository and sync
2. Check the API request for repository > manifests page and make sure the content_type field is correctly set.