### PR TITLE
Fixes #38015 - Enable org and CVE scoping for flatpak content

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -5,7 +5,7 @@ module Katello
     before_action :confirm_settings
     skip_before_action :authorize
     before_action :optional_authorize, only: [:token, :catalog]
-    before_action :registry_authorize, except: [:token, :v1_search, :catalog]
+    before_action :registry_authorize, except: [:token, :v1_search, :catalog, :static_index]
     before_action :authorize_repository_read, only: [:pull_manifest, :tags_list, :check_blob, :pull_blob]
     before_action :container_push_prop_validation, only: [:start_upload_blob, :upload_blob, :finish_upload_blob, :push_manifest]
     before_action :create_container_repo_if_needed, only: [:start_upload_blob, :upload_blob, :finish_upload_blob, :push_manifest]
@@ -805,6 +805,26 @@ module Katello
 
     def item_not_found(item)
       render_podman_error("NAME_UNKNOWN", _("%s was not found!") % item, :not_found)
+    end
+
+    def static_index
+      host_ip = request.remote_ip
+      host = ::Host.joins(:primary_interface).where("nics.ip = :host_ip OR nics.ip6 = :host_ip", host_ip: host_ip)&.first
+      flatpak_index = (redirect_client { Resources::Registry::Proxy.get(@_request.fullpath, headers) })
+      flatpak_index_json = JSON.parse(flatpak_index)
+      # Filter out repositories if it's a registered host
+      if host&.content_view_environments&.any?
+        # host.update(flatpak_index: flatpak_index) Will this help??
+        repos = host.content_view_environments.flat_map do |cve|
+          cve.content_view_version.repositories
+        end
+        available_container_repo_names = repos.map(&:container_repository_name)
+        flatpak_index_json['Results'] = flatpak_index_json['Results'].select do |result|
+          available_container_repo_names.include?(result['Name'])
+        end
+      end
+      # Otherwise just return unfiltered pulp flatpak index
+      render json: flatpak_index_json
     end
   end
 end

--- a/config/routes/api/registry.rb
+++ b/config/routes/api/registry.rb
@@ -19,6 +19,7 @@ Katello::Engine.routes.draw do
       match '/v2' => 'registry_proxies#ping', :via => :get
       match '/v1/_ping' => 'registry_proxies#v1_ping', :via => :get
       match '/v1/search' => 'registry_proxies#v1_search', :via => :get
+      match '/index/static' => 'registry_proxies#static_index', :via => :get
     end
   end
 end

--- a/lib/katello/permissions/registry_permissions.rb
+++ b/lib/katello/permissions/registry_permissions.rb
@@ -14,4 +14,5 @@ Foreman::AccessControl.permission(:create_personal_access_tokens).actions.concat
   'katello/api/registry/registry_proxies/start_upload_blob',
   'katello/api/registry/registry_proxies/upload_blob',
   'katello/api/registry/registry_proxies/finish_upload_blob',
+  'katello/api/registry/registry_proxies/static_index',
 ]


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?
1. Use host's IP address to identify and then filter content based on host's repositories.
2. If host is not identified, send the unfiltered flatpak index and allow normal flatpak operations. We could switch this tonot showing anything in the future once users are more accustomed to the flow?
#### What are the testing steps for this pull request?
Sync a few flatpak repos in different orgs and add them to some content view.
Create activation keys for those CVEs and then register a host using the key.
Setup a host to consume flatpak content from the katello server. Use server/index/static url instead of server/pulpcore_registry/ endpoint..
Try flatpak remote-ls and ensure you only see repos the host has access to.