### PR TITLE
Fixes #38076 - Sanitize content_view repository_ids param

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -288,7 +288,10 @@ module Katello
       if (!@content_view || !@content_view.composite?)
         attrs.push({:repository_ids => []}, :repository_ids)
       end
-      params.require(:content_view).permit(*attrs).to_h
+      result = params.require(:content_view).permit(*attrs).to_h
+      # sanitize repository_ids to be a list of integers
+      result[:repository_ids] = result[:repository_ids].compact.map(&:to_i) if result[:repository_ids].present?
+      result
     end
 
     def find_environment

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -243,8 +243,8 @@ module Katello
 
       params = { :repository_ids => [repository.id.to_s] }
       assert_sync_task(::Actions::Katello::ContentView::Update) do |_content_view, content_view_params|
-        assert_equal content_view_params.key?(:repository_ids), true
-        assert_equal content_view_params[:repository_ids], params[:repository_ids]
+        assert content_view_params.key?(:repository_ids)
+        assert_equal [repository.id], content_view_params[:repository_ids]
       end
       put :update, params: { :id => @library_dev_staging_view.id, :content_view => params }
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

For the content_view APIs, the repository_ids param is now cast to a list of integers even if it is supplied as a list of strings before being passed to the backend. This ensures the backend always gets consistent data and can perform list comparisons with data taken from the DB.

#### Considerations taken when implementing this change?

We could of course implement the needed handling within the affected actions instead of the API controller, however, this seems like a less robust design approach, since such special handling can be easily forgotten for the next action that needs it.

#### What are the testing steps for this pull request?

This PR is most easily tested in combination with these PRs:
- https://github.com/Katello/katello/pull/11240
- https://github.com/Katello/hammer-cli-katello/pull/974

Simply create a rolling CV, add a repo to it using Hammer, and then add another repo to it using Hammer. => Everything works.
Now revert this commit and repeat these steps. => Chaos and errors ensue. (Because Hammer sends a list of strings to the API, taking the list difference with the repository_ids already in the rolling CV, will cause Katello to attempt adding the same repo to the rolling CV multiple times in a single task).
