### PR TITLE
Fixes #38080 - Added lab navigation menu for flatpak UI

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -204,6 +204,15 @@ Foreman::Plugin.register :katello do
        :after => :content_hosts,
        :turbolinks => false
 
+  menu :labs_menu,
+       :flatpak,
+       :url => '/labs/flatpak_remotes',
+       :url_hash => {:controller => 'katello/api/v2/flatpak_remotes_controller',
+                     :action => 'index'},
+       :caption => N_('Flatpak Remotes'),
+       :parent => :lab_features_menu,
+       :turbolinks => false
+
   extend_template_helpers Katello::KatelloUrlsHelper
   extend_template_helpers Katello::Concerns::BaseTemplateScopeExtensions
 

--- a/webpack/containers/Application/config.js
+++ b/webpack/containers/Application/config.js
@@ -15,6 +15,7 @@ import ContentDetails from '../../scenes/Content/Details';
 import withHeader from './withHeaders';
 import ChangeContentSource from '../../scenes/Hosts/ChangeContentSource';
 import AlternateContentSource from '../../scenes/AlternateContentSources';
+import Flatpak from '../../scenes/Flatpak';
 
 // eslint-disable-next-line import/prefer-default-export
 export const links = [
@@ -84,5 +85,9 @@ export const links = [
     path: 'alternate_content_sources/:id([0-9]+)',
     component: WithOrganization(withHeader(AlternateContentSource, { title: __('Alternate Content Sources') })),
     exact: false,
+  },
+  {
+    path: 'labs/flatpak_remotes',
+    component: WithOrganization(withHeader(Flatpak, { title: __('Flatpak Remotes') })),
   },
 ];

--- a/webpack/scenes/Flatpak/index.js
+++ b/webpack/scenes/Flatpak/index.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default () => <h1>Flatpak Remotes UI</h1>;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Added a new "Flatpak Remotes" menu item under the "Lab Features" section. It introduces a React-based placeholder UI component and prepares the foundation for future development.

#### Considerations taken when implementing this change?

Ensured alignment with existing navigation patterns to maintain consistency and integrated the menu under "Lab Features" to preserve hierarchical organization.

#### What are the testing steps for this pull request?

Enable Lab Features:

1. Go to Administer -> Settings
2. Set Show Experimental Labs to Yes

Check Flatpak Navigation

1. Go to Lab Features -> Flatpak Remotes
2. You should be able to navigate to Flatpak Remotes 
