### PR TITLE
Fixes #38083 - Add repository filter to Debian packages page

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/debs.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/debs.controller.js
@@ -1,37 +1,51 @@
-(function () {
-    'use strict';
-
-    /**
-     * @ngdoc controller
-     * @name  Bastion.debs.controller:DebsController
-     *
-     * @description
-     *   Handles fetching deb packages and populating Nutupane based on the current
-     *   ui-router state.
-     *
-     * @requires translate
-     *
-     */
-    function DebsController($scope, $location, translate, Nutupane, Deb, CurrentOrganization) {
+/**
+ * @ngdoc controller
+ * @name  Bastion.debs.controller:DebsController
+ *
+ * @description
+ *   Handles fetching deb packages and populating Nutupane based on the current
+ *   ui-router state.
+ *
+ * @requires translate
+ *
+ */
+angular.module('Bastion.debs').controller('DebsController',
+    ['$scope', '$location', 'translate', 'Nutupane', 'Deb', 'Repository', 'CurrentOrganization',
+    function DebsController($scope, $location, translate, Nutupane, Deb, Repository, CurrentOrganization) {
         var nutupane;
 
         var params = {
             'organization_id': CurrentOrganization,
             'search': $location.search().search || "",
+            'repository_id': $location.search().repositoryId || null,
             'paged': true,
             'sort_by': 'name',
             'sort_order': 'ASC'
         };
 
-        nutupane = new Nutupane(Deb, params);
+        nutupane = $scope.nutupane = new Nutupane(Deb, params);
         nutupane.primaryOnly = true;
 
         $scope.table = nutupane.table;
 
         // Labels so breadcrumb strings can be translated
         $scope.label = translate('Debs');
+        $scope.repositoriesLabel = translate('Repositories');
 
         $scope.controllerName = 'katello_debs';
+
+        $scope.repository = {name: translate('All Repositories'), id: 'all'};
+
+        Repository.queryUnpaged({'organization_id': CurrentOrganization, 'content_type': 'deb', 'with_content': 'deb'}, function (response) {
+            $scope.repositories = [$scope.repository];
+            $scope.repositories = $scope.repositories.concat(response.results);
+
+            if ($location.search().repositoryId) {
+                $scope.repository = _.find($scope.repositories, function (repository) {
+                    return repository.id === parseInt($location.search().repositoryId, 10);
+                });
+            }
+        });
 
         Deb.queryPaged({'organization_id': CurrentOrganization}, function (result) {
             $scope.packageCount = result.total;
@@ -50,12 +64,22 @@
             nutupane.refresh();
         };
 
-    }
+        $scope.$watch('repository', function (repository) {
+            var nutupaneParams = nutupane.getParams();
 
-    angular
-        .module('Bastion.debs')
-        .controller('DebsController', DebsController);
+            if (repository.id === 'all') {
+                nutupaneParams['repository_id'] = null;
+                nutupane.setParams(nutupaneParams);
+            } else {
+                $location.search('repositoryId', repository.id);
+                nutupaneParams['repository_id'] = repository.id;
+                nutupane.setParams(nutupaneParams);
+            }
 
-    DebsController.$inject = ['$scope', '$location', 'translate', 'Nutupane', 'Deb', 'CurrentOrganization'];
+            if (!nutupane.table.initialLoad) {
+                nutupane.refresh();
+            }
+        });
 
-})();
+    }]
+);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/views/debs.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/debs/views/debs.html
@@ -6,6 +6,10 @@
     <h2 translate>Deb Packages</h2>
   </header>
 
+  <div data-block="search-filter">
+    <select class="form-control" ng-model="repository" ng-options="repository.name for (id, repository) in repositories"></select>
+  </div>
+
   <div data-block="filters">
     <label class="checkbox-inline" title="{{ 'Only show Packages that are Applicable to one or more Content Hosts' | translate }}">
       <input type="checkbox" ng-model="showApplicable" ng-disabled="showUpgradable" ng-change="toggleFilters()"/>

--- a/engines/bastion_katello/test/debs/debs.controller.test.js
+++ b/engines/bastion_katello/test/debs/debs.controller.test.js
@@ -4,6 +4,7 @@ describe('Controller: DebsController', function() {
         $controller,
         dependencies,
         Deb,
+        Repository,
         Nutupane;
 
     beforeEach(module('Bastion.debs', 'Bastion.test-mocks'));
@@ -25,7 +26,7 @@ describe('Controller: DebsController', function() {
 
     beforeEach(inject(function(_$controller_, $rootScope, _$location_, MockResource, translateMock) {
         Deb = MockResource.$new();
-        //Repository = MockResource.$new();
+        Repository = MockResource.$new();
         $scope = $rootScope.$new();
         $location = _$location_;
 
@@ -36,7 +37,7 @@ describe('Controller: DebsController', function() {
             Nutupane: Nutupane,
             Deb: Deb,
             //Task: Task,
-            //Repository: Repository,
+            Repository: Repository,
             CurrentOrganization: 'CurrentOrganization',
             translate: translateMock
         };
@@ -63,4 +64,24 @@ describe('Controller: DebsController', function() {
         expect($scope.table.params['packages_restrict_applicable']).toBe(true)
         expect($scope.table.params['packages_restrict_upgradable']).toBe(true)
     });
+
+    it('should set the repository_id param on Nutupane when a repository is chosen', function () {
+        spyOn($scope.nutupane, 'setParams');
+        spyOn($scope.nutupane, 'refresh');
+
+        $scope.repository = {id: 1};
+        $scope.$apply();
+
+        expect($scope.nutupane.setParams).toHaveBeenCalledWith({'repository_id': 1});
+        expect($scope.nutupane.refresh).toHaveBeenCalled();
+    });
+
+    it('allows the setting of the repositoryId via a query string parameter', function () {
+        $location.search('repositoryId', '1');
+
+        $controller('DebsController', dependencies);
+
+        expect($scope.repository.id).toBe(1);
+    });
+
 });


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adding repository filter for Deb Packages page: 
![image](https://github.com/user-attachments/assets/30a1f8c2-3ec9-426a-8487-1029b5572b14)

#### Considerations taken when implementing this change?
In Content --> Content Type --> Packages we have a repository filter. We want the same for Deb packages. 

#### What are the testing steps for this pull request?
1) You need Debian Repositories with packages.
2) Go Content --> Content Type --> Deb Packages 
3) Select repository from 'All repositories' selection drop down