### PR TITLE
Fixes #38084 - Add new REX job templates for bootc upgrade/switch/rollback

### DIFF
--- a/app/views/foreman/job_templates/bootc_action.erb
+++ b/app/views/foreman/job_templates/bootc_action.erb
@@ -1,0 +1,26 @@
+<%#
+kind: job_template
+name: Bootc Action - Script Default
+model: JobTemplate
+job_category: Bootc
+description_format: 'bootc %{action} %{options} %{target}'
+provider_type: script
+feature: katello_bootc_action
+template_inputs:
+- name: action
+  description: 'The bootc action: upgrade, switch, rollback or status'
+  input_type: user
+  options: "upgrade\nswitch\nrollback\nstatus"
+  required: true
+- name: options
+  description: Additional options for bootc action
+  input_type: user
+  required: false
+- name: target
+  description: Target for bootc switch action
+  input_type: user
+  required: false
+%>
+
+bootc <%= input('action') %> <%= input('options') %> <%= input('target') %>
+subscription-manager facts --update

--- a/app/views/foreman/job_templates/bootc_rollback.erb
+++ b/app/views/foreman/job_templates/bootc_rollback.erb
@@ -1,0 +1,13 @@
+<%#
+kind: job_template
+name: Bootc Rollback - Script Default
+job_category: Bootc
+description_format: 'bootc rollback'
+feature: katello_bootc_rollback
+provider_type: script
+foreign_input_sets:
+- template: Bootc Action - Script Default
+  exclude: action, options, target
+%>
+
+<%= render_template('Bootc Action - Script Default', :action => 'rollback') %>

--- a/app/views/foreman/job_templates/bootc_status.erb
+++ b/app/views/foreman/job_templates/bootc_status.erb
@@ -1,0 +1,13 @@
+<%#
+kind: job_template
+name: Bootc Status - Script Default
+job_category: Bootc
+description_format: 'bootc status %{options}'
+feature: katello_bootc_status
+provider_type: script
+foreign_input_sets:
+- template: Bootc Action - Script Default
+  exclude: action, target
+%>
+
+<%= render_template('Bootc Action - Script Default', :action => 'status') %>

--- a/app/views/foreman/job_templates/bootc_switch.erb
+++ b/app/views/foreman/job_templates/bootc_switch.erb
@@ -1,0 +1,13 @@
+<%#
+kind: job_template
+name: Bootc Switch - Script Default
+job_category: Bootc
+description_format: 'bootc switch %{options} %{target}'
+feature: katello_bootc_switch
+provider_type: script
+foreign_input_sets:
+- template: Bootc Action - Script Default
+  exclude: action
+%>
+
+<%= render_template('Bootc Action - Script Default', :action => 'switch') %>

--- a/app/views/foreman/job_templates/bootc_upgrade.erb
+++ b/app/views/foreman/job_templates/bootc_upgrade.erb
@@ -1,0 +1,13 @@
+<%#
+kind: job_template
+name: Bootc Upgrade - Script Default
+job_category: Bootc
+description_format: 'bootc upgrade %{options}'
+feature: katello_bootc_upgrade
+provider_type: script
+foreign_input_sets:
+- template: Bootc Action - Script Default
+  exclude: action, target
+%>
+
+<%= render_template('Bootc Action - Script Default', :action => 'upgrade') %>

--- a/db/seeds.d/75-job_templates.rb
+++ b/db/seeds.d/75-job_templates.rb
@@ -1,8 +1,12 @@
 User.as_anonymous_admin do
   JobTemplate.without_auditing do
+    # let's name root template as *_action.erb
+    root_action_files = Dir[File.join("#{Katello::Engine.root}/app/views/foreman/job_templates/**/*_action.erb")]
     template_files = Dir[File.join("#{Katello::Engine.root}/app/views/foreman/job_templates/**/*.erb")]
     template_files.reject! { |file| file.end_with?('_ansible_default.erb') } unless Katello.with_ansible?
-    template_files.each do |template|
+
+    # root templates need to be imported first
+    (root_action_files + (template_files - root_action_files)).each do |template|
       sync = !Rails.env.test? && Setting[:remote_execution_sync_templates]
       template = JobTemplate.import_raw!(File.read(template), :default => true, :lock => true, :update => sync)
 

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -696,6 +696,10 @@ Foreman::Plugin.register :katello do
   RemoteExecutionFeature.register(:katello_module_stream_action, N_("Katello: Module Stream Actions"),
                                   :description => N_("Perform a module stream action via Katello interface"),
                                   :provided_inputs => ['action', 'module_spec', 'options'])
+  RemoteExecutionFeature.register(:katello_bootc_upgrade, N_("Katello: Bootc Upgrade"), :description => N_("Bootc upgrade via Bootc interface"))
+  RemoteExecutionFeature.register(:katello_bootc_switch, N_("Katello: Bootc Switch"), :description => N_("Bootc switch via Bootc interface"))
+  RemoteExecutionFeature.register(:katello_bootc_rollback, N_("Katello: Bootc Rollback"), :description => N_("Bootc rollback via Bootc interface"))
+  RemoteExecutionFeature.register(:katello_bootc_status, N_("Katello: Bootc Status"), :description => N_("Bootc status via Bootc interface"))
   allowed_template_helpers :errata
 
   RemoteExecutionProvider.singleton_class.prepend(Katello::Concerns::RemoteExecutionProviderExtensions)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

1. New REX feature `katello_bootc_upgrade`
2.  New REX feature `katello_bootc_switch`
3.  New REX feature `katello_bootc_rollback`
4. New REX feature `katello_bootc_status`

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
To import the new job template:
```
# in Rails console
ForemanInternal.all.first.delete
```
Then run
```
bundle exec rails db:seed
```
In Hosts > Tempaltes > Job Templates, you'll see new added templates.
Select one of the new bootc job templates and run it.