### PR TITLE
Fixes #38072 - add host bootc_images endpoint

### DIFF
--- a/app/controllers/katello/api/v2/host_bootc_images_controller.rb
+++ b/app/controllers/katello/api/v2/host_bootc_images_controller.rb
@@ -1,0 +1,32 @@
+module Katello
+  class Api::V2::HostBootcImagesController < Api::V2::ApiController
+    resource_description do
+      api_version 'v2'
+      api_base_url "/api"
+    end
+
+    api :GET, "/hosts/bootc_images", N_("List booted bootc container images for hosts")
+    param :page, :number, :desc => N_("Page number, starting at 1")
+    param :per_page, :number, :desc => N_("Number of results per page to return")
+    def bootc_images
+      bootc_image_map = bootc_host_image_map
+      page = params[:page] || 1
+      per_page = params[:per_page] || Setting[:entries_per_page]
+      paged_results = bootc_image_map.to_a.paginate(page: page, per_page: per_page)
+      render json: { total: bootc_image_map.size, bootc_images: paged_results }
+    end
+
+    private
+
+    def bootc_host_image_map
+      aggregate_bootc_data = ::Katello::Host::ContentFacet.where.not(bootc_booted_image: nil, bootc_booted_digest: nil).
+          select(:bootc_booted_image, :bootc_booted_digest, 'COUNT(hosts.id) as host_count').
+          joins(:host).group(:bootc_booted_image, :bootc_booted_digest).order(:bootc_booted_image)
+      bootc_image_map = Hash.new { |h, k| h[k] = [] }
+      aggregate_bootc_data.each do |host_image|
+        bootc_image_map[host_image.bootc_booted_image] << { bootc_booted_digest: host_image.bootc_booted_digest, host_count: host_image.host_count.to_i }
+      end
+      bootc_image_map
+    end
+  end
+end

--- a/app/controllers/katello/api/v2/host_bootc_images_controller.rb
+++ b/app/controllers/katello/api/v2/host_bootc_images_controller.rb
@@ -8,19 +8,33 @@ module Katello
     end
 
     api :GET, "/hosts/bootc_images", N_("List booted bootc container images for hosts")
-    param :page, :number, :desc => N_("Page number, starting at 1")
-    param :per_page, :number, :desc => N_("Number of results per page to return")
+    param_group :search, Api::V2::ApiController
     def bootc_images
-      bootc_image_map = bootc_host_image_map(params[:search])
-
-      page = params[:page].present? ? params[:page].to_i : 1
+      params[:sort_by] ||= 'bootc_booted_image'
+      params[:sort_order] ||= 'asc'
+      if params[:order]
+        params[:order] = "#{params[:order].split(' ')[0]} #{sanitize_sort_order(params[:order].split(' ')[1])}"
+      else
+        params[:order] = "#{params[:sort_by]} #{sanitize_sort_order(params[:sort_order])}"
+      end
       per_page = params[:per_page].present? ? params[:per_page].to_i : Setting[:entries_per_page]
+      page = params[:page].present? ? params[:page].to_i : 1
+
+      bootc_image_map = bootc_host_image_map
       paged_images = bootc_image_map.to_a.paginate(page: page, per_page: per_page)
-      results = paged_images.collect { |image| { image_name: image[0], digests: image[1] } }
+      results = paged_images.collect { |image| { bootc_booted_image: image[0], digests: image[1] } }
       render json: { total: bootc_image_map.size, page: page, per_page: per_page, subtotal: bootc_image_map.size, results: results}
     end
 
     private
+
+    def sanitize_sort_order(sort_order)
+      if sort_order.present? && ['asc', 'desc'].include?(sort_order.downcase)
+        sort_order.downcase
+      else
+        'asc'
+      end
+    end
 
     def index_relation
       query = resource_class.authorized(:view_hosts).distinct
@@ -32,12 +46,11 @@ module Katello
       ::Host::Managed
     end
 
-    def bootc_host_image_map(host_search)
-      # TODO: can this be optimized such that it doesn't require two queries?
-      content_facets = ::Katello::Host::ContentFacet.where(host_id: ::Host::Managed.joins(:content_facet).search_for(host_search).pluck(:id))
+    def bootc_host_image_map
+      content_facets = ::Katello::Host::ContentFacet.where(host_id: ::Host::Managed.joins(:content_facet).search_for(params[:search]).pluck(:id))
       aggregate_bootc_data = content_facets.where.not(bootc_booted_image: nil, bootc_booted_digest: nil).
           select(:bootc_booted_image, :bootc_booted_digest, 'COUNT(hosts.id) as host_count').
-          joins(:host).group(:bootc_booted_image, :bootc_booted_digest).order(:bootc_booted_image)
+          joins(:host).group(:bootc_booted_image, :bootc_booted_digest).order(params[:order])
       bootc_image_map = Hash.new { |h, k| h[k] = [] }
       aggregate_bootc_data.each do |host_image|
         bootc_image_map[host_image.bootc_booted_image] << { bootc_booted_digest: host_image.bootc_booted_digest, host_count: host_image.host_count.to_i }

--- a/app/controllers/katello/api/v2/host_bootc_images_controller.rb
+++ b/app/controllers/katello/api/v2/host_bootc_images_controller.rb
@@ -13,8 +13,8 @@ module Katello
     def bootc_images
       bootc_image_map = bootc_host_image_map(params[:search])
 
-      page = params[:page].to_i || 1
-      per_page = params[:per_page].to_i || Setting[:entries_per_page]
+      page = params[:page].present? ? params[:page].to_i : 1
+      per_page = params[:per_page].present? ? params[:per_page].to_i : Setting[:entries_per_page]
       paged_images = bootc_image_map.to_a.paginate(page: page, per_page: per_page)
       results = paged_images.collect { |image| { image_name: image[0], digests: image[1] } }
       render json: { total: bootc_image_map.size, page: page, per_page: per_page, subtotal: bootc_image_map.size, results: results}

--- a/app/controllers/katello/api/v2/host_bootc_images_controller.rb
+++ b/app/controllers/katello/api/v2/host_bootc_images_controller.rb
@@ -10,10 +10,11 @@ module Katello
     param :per_page, :number, :desc => N_("Number of results per page to return")
     def bootc_images
       bootc_image_map = bootc_host_image_map
-      page = params[:page] || 1
-      per_page = params[:per_page] || Setting[:entries_per_page]
-      paged_results = bootc_image_map.to_a.paginate(page: page, per_page: per_page)
-      render json: { total: bootc_image_map.size, bootc_images: paged_results }
+      page = params[:page].to_i || 1
+      per_page = params[:per_page].to_i || Setting[:entries_per_page]
+      paged_images = bootc_image_map.to_a.paginate(page: page, per_page: per_page)
+      results = paged_images.collect { |image| { image_name: image[0], digests: image[1] } }
+      render json: { total: bootc_image_map.size, page: page, per_page: per_page, subtotal: bootc_image_map.size, results: results}
     end
 
     private

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -30,6 +30,10 @@ Katello::Engine.routes.draw do
           end
         end
 
+        api_resources :host_bootc_images, :only => [:bootc_images] do
+          get :auto_complete_search, :on => :collection
+        end
+
         api_resources :capsules, :only => [:index, :show] do
           member do
             resource :content, :only => [], :controller => 'capsule_content' do

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -30,7 +30,7 @@ Katello::Engine.routes.draw do
           end
         end
 
-        api_resources :host_bootc_images, :only => [:bootc_images] do
+        api_resources :host_bootc_images, :only => [:auto_complete_search] do
           get :auto_complete_search, :on => :collection
         end
 

--- a/config/routes/overrides.rb
+++ b/config/routes/overrides.rb
@@ -59,6 +59,7 @@ Foreman::Application.routes.draw do
 
           collection do
             match '/auto_complete_search' => 'host_autocomplete#auto_complete_search', :via => :get
+            match '/bootc_images' => 'host_bootc_images#bootc_images', :via => :get
             match '/bulk/add_host_collections' => 'hosts_bulk_actions#bulk_add_host_collections', :via => :put
             match '/bulk/remove_host_collections' => 'hosts_bulk_actions#bulk_remove_host_collections', :via => :put
             match '/bulk/remove_host_collections' => 'hosts_bulk_actions#bulk_remove_host_collections', :via => :put

--- a/lib/katello/permissions/host_permissions.rb
+++ b/lib/katello/permissions/host_permissions.rb
@@ -43,6 +43,8 @@ Foreman::AccessControl.permission(:edit_hosts).actions.concat [
 
 Foreman::AccessControl.permission(:view_hosts).actions.concat [
   'hosts/content_hosts',
+  'katello/api/v2/host_bootc_images/bootc_images',
+  'katello/api/v2/host_bootc_images/auto_complete_search',
   'katello/api/v2/host_autocomplete/auto_complete_search',
   'katello/api/v2/host_errata/index',
   'katello/api/v2/host_errata/show',

--- a/test/controllers/api/v2/host_bootc_images_controller_test.rb
+++ b/test/controllers/api/v2/host_bootc_images_controller_test.rb
@@ -26,9 +26,9 @@ module Katello
     def test_bootc_images_counts_properly_no_paging
       get :bootc_images
       assert_response :success
-      results = JSON.parse(@response.body)['bootc_images']
-      assert_includes results, ["image1", [{"bootc_booted_digest" => "sha256:dcfb2965cda67bd3731408ace23dd07ff3116168c2b832e16bba8234525724a3", "host_count" => 2}]]
-      assert_includes results, ["image2", [{"bootc_booted_digest" => "sha256:dcfb2965cda67bc3731408aae23dd07ff3116168c2b832e16bba8234525724a5", "host_count" => 1}]]
+      results = JSON.parse(@response.body)['results']
+      assert_includes results, {"bootc_booted_image" => "image1", "digests" => [{"bootc_booted_digest" => "sha256:dcfb2965cda67bd3731408ace23dd07ff3116168c2b832e16bba8234525724a3", "host_count" => 2}]}
+      assert_includes results, {"bootc_booted_image" => "image2", "digests" => [{"bootc_booted_digest" => "sha256:dcfb2965cda67bc3731408aae23dd07ff3116168c2b832e16bba8234525724a5", "host_count" => 1}]}
     end
 
     def test_bootc_images_pages
@@ -43,10 +43,10 @@ module Katello
       get :bootc_images, params: { page: 4, per_page: 1 }
       page4 = @response.body
 
-      assert_equal [["image1", [{"bootc_booted_digest" => "sha256:dcfb2965cda67bd3731408ace23dd07ff3116168c2b832e16bba8234525724a3", "host_count" => 1}]]], JSON.parse(page1)['bootc_images']
-      assert_equal [["image2", [{"bootc_booted_digest" => "sha256:dcfb2965cda67bc3731408aae23dd07ff3116168c2b832e16bba8234525724a5", "host_count" => 1}]]], JSON.parse(page2)['bootc_images']
-      assert_equal [["image3", [{"bootc_booted_digest" => "sha256:dcfb2965cda67bd3731408ace93dd07ff3116168c2b832e16bba8234525724c9", "host_count" => 1}]]], JSON.parse(page3)['bootc_images']
-      assert_empty JSON.parse(page4)['bootc_images']
+      assert_equal [{"bootc_booted_image" => "image1", "digests" => [{"bootc_booted_digest" => "sha256:dcfb2965cda67bd3731408ace23dd07ff3116168c2b832e16bba8234525724a3", "host_count" => 1}]}], JSON.parse(page1)['results']
+      assert_equal [{"bootc_booted_image" => "image2", "digests" => [{"bootc_booted_digest" => "sha256:dcfb2965cda67bc3731408aae23dd07ff3116168c2b832e16bba8234525724a5", "host_count" => 1}]}], JSON.parse(page2)['results']
+      assert_equal [{"bootc_booted_image" => "image3", "digests" => [{"bootc_booted_digest" => "sha256:dcfb2965cda67bd3731408ace93dd07ff3116168c2b832e16bba8234525724c9", "host_count" => 1}]}], JSON.parse(page3)['results']
+      assert_empty JSON.parse(page4)['results']
     end
   end
 end

--- a/test/controllers/api/v2/host_bootc_images_controller_test.rb
+++ b/test/controllers/api/v2/host_bootc_images_controller_test.rb
@@ -1,0 +1,52 @@
+# encoding: utf-8
+
+require "katello_test_helper"
+
+module Katello
+  class Api::V2::HostBootcImagesControllerTest < ActionController::TestCase
+    tests ::Katello::Api::V2::HostBootcImagesController
+
+    def setup
+      setup_controller_defaults_api
+      setup_foreman_routes
+      @host1 = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => katello_content_views(:library_dev_view),
+                                :lifecycle_environment => katello_environments(:library))
+      @host2 = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => katello_content_views(:library_dev_view),
+                                :lifecycle_environment => katello_environments(:library))
+      @host3 = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => katello_content_views(:library_dev_view),
+                                :lifecycle_environment => katello_environments(:library))
+      @host1.content_facet.update!(bootc_booted_image: 'image1')
+      @host1.content_facet.update!(bootc_booted_digest: 'sha256:dcfb2965cda67bd3731408ace23dd07ff3116168c2b832e16bba8234525724a3')
+      @host2.content_facet.update!(bootc_booted_image: 'image1')
+      @host2.content_facet.update!(bootc_booted_digest: 'sha256:dcfb2965cda67bd3731408ace23dd07ff3116168c2b832e16bba8234525724a3')
+      @host3.content_facet.update!(bootc_booted_image: 'image2')
+      @host3.content_facet.update!(bootc_booted_digest: 'sha256:dcfb2965cda67bc3731408aae23dd07ff3116168c2b832e16bba8234525724a5')
+    end
+
+    def test_bootc_images_counts_properly_no_paging
+      get :bootc_images
+      assert_response :success
+      results = JSON.parse(@response.body)['bootc_images']
+      assert_includes results, ["image1", [{"bootc_booted_digest" => "sha256:dcfb2965cda67bd3731408ace23dd07ff3116168c2b832e16bba8234525724a3", "host_count" => 2}]]
+      assert_includes results, ["image2", [{"bootc_booted_digest" => "sha256:dcfb2965cda67bc3731408aae23dd07ff3116168c2b832e16bba8234525724a5", "host_count" => 1}]]
+    end
+
+    def test_bootc_images_pages
+      @host2.content_facet.update!(bootc_booted_image: 'image3')
+      @host2.content_facet.update!(bootc_booted_digest: 'sha256:dcfb2965cda67bd3731408ace93dd07ff3116168c2b832e16bba8234525724c9')
+      get :bootc_images, params: { page: 1, per_page: 1 }
+      page1 = @response.body
+      get :bootc_images, params: { page: 2, per_page: 1 }
+      page2 = @response.body
+      get :bootc_images, params: { page: 3, per_page: 1 }
+      page3 = @response.body
+      get :bootc_images, params: { page: 4, per_page: 1 }
+      page4 = @response.body
+
+      assert_equal [["image1", [{"bootc_booted_digest" => "sha256:dcfb2965cda67bd3731408ace23dd07ff3116168c2b832e16bba8234525724a3", "host_count" => 1}]]], JSON.parse(page1)['bootc_images']
+      assert_equal [["image2", [{"bootc_booted_digest" => "sha256:dcfb2965cda67bc3731408aae23dd07ff3116168c2b832e16bba8234525724a5", "host_count" => 1}]]], JSON.parse(page2)['bootc_images']
+      assert_equal [["image3", [{"bootc_booted_digest" => "sha256:dcfb2965cda67bd3731408ace93dd07ff3116168c2b832e16bba8234525724c9", "host_count" => 1}]]], JSON.parse(page3)['bootc_images']
+      assert_empty JSON.parse(page4)['bootc_images']
+    end
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds a new `/hosts/bootc_images` endpoint that returns an overview of all bootc images that hosts are using.

The return data looks like the following:

```json
{
  "total": 499,
  "bootc_images": [
    [
      "quay.io/centos-bootc/centos-bootc:stream10",
      [
        {
          "bootc_booted_digest": "sha256:54256a998f0c62e16f3927c82b570f90bd8449a52e03daabd5fd16d6419fd572",
          "host_count": 1
        }
      ]
    ]
  ]
}
```

This data will power a page that shows a list of image paths and each image mode host that is using that image path. Since each host could use the same image but a different digest, each image path holds any number of digests with the count of hosts that are using that digest. More digests per image path means more drift from the latest container content under that container tag.

#### Considerations taken when implementing this change?
Choosing where this goes was difficult -- it's related to hosts so I decided to stick it under the hosts endpoint. I use facts as a similar paradigm: host facts and bootc images are both aggregate information from hosts that are available at a single API endpoint.

#### What are the testing steps for this pull request?
1) Make a bunch of different bootc hosts. You can use the following script to create one clone:
```bash
#!/bin/bash

uuid=$(uuidgen)
short=$(hostname -s)
domain=manicotto.example.com
echo "{\"dmi.system.uuid\": \"${uuid}\"}" > /etc/rhsm/facts/uuid.facts
hostnamectl set-hostname ${short}.${uuid%%-*}.${domain}
subscription-manager clean
subscription-manager register --activationkey "Default Library Key" --org "Default_Organization"
```
2) Query the endpoint, test with and without paging
```bash
curl "https://`hostname`/api/hosts/bootc_images?per_page=5&page=7" -uadmin:pass
```

3) Ensure that empty conditions work, check page sizes that don't make sense, etc.