### PR TITLE
Fixes #38096 - Fix flat APT repo handling

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -1059,10 +1059,15 @@ module Katello
       pulp_api.list({:repository_version => version_href}).results.map { |x| x.component }.uniq
     end
 
+    def deb_sanitize_pulp_distribution(distribution)
+      return "flat-repo" if distribution&.end_with?("/")
+      distribution
+    end
+
     def deb_pulp_distributions(version_href = self.version_href)
       return [] if version_href.blank?
       pulp_api = Katello::Pulp3::Repository.instance_for_type(self, SmartProxy.pulp_primary).api.content_release_components_api
-      pulp_api.list({:repository_version => version_href}).results.map { |x| x.distribution }.uniq
+      pulp_api.list({:repository_version => version_href}).results.map { |x| deb_sanitize_pulp_distribution(x.distribution) }.uniq
     end
 
     def sync_status


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Special handling for APT repos using the flat repository format in order to compensate odd pulp_deb behaviour for such repos.

#### Considerations taken when implementing this change?

Eventually we want to fix the underlying cause on the pulp_deb side, at which point we can revert this PR. However, the underlying pulp_deb behaviour is much harder to fix and might be some time away. The Katello side fix is pretty simple, and will not have any adverse effects even if pulp_deb behaviour changes.

#### What are the testing steps for this pull request?

See the reproducer steps in the ticket: https://projects.theforeman.org/issues/38096