### PR TITLE
Fixes #38097 - Add packages count to new All Hosts page

### DIFF
--- a/app/views/katello/api/v2/hosts/base.json.rabl
+++ b/app/views/katello/api/v2/hosts/base.json.rabl
@@ -5,14 +5,6 @@ object @resource
 
 attributes :id, :name, :description
 
-node :operatingsystem_family do |resource|
-  resource.operatingsystem&.family
-end
-
-node :operatingsystem_major do |resource|
-  resource.operatingsystem&.major
-end
-
 if @facet
   node :content_view do
     content_view = @facet&.single_content_view

--- a/app/views/katello/api/v2/hosts/os_attributes.json.rabl
+++ b/app/views/katello/api/v2/hosts/os_attributes.json.rabl
@@ -1,0 +1,13 @@
+object @resource
+
+@resource ||= @object
+
+attributes :id, :name, :description
+
+node :operatingsystem_family do |resource|
+  resource.operatingsystem&.family
+end
+
+node :operatingsystem_major do |resource|
+  resource.operatingsystem&.major
+end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -298,6 +298,8 @@ Foreman::Plugin.register :katello do
   extend_rabl_template 'api/v2/smart_proxies/main', 'katello/api/v2/smart_proxies/pulp_info'
   extend_rabl_template 'api/v2/hosts/show', 'katello/api/v2/hosts/host_collections'
   extend_rabl_template 'api/v2/hosts/show', 'katello/api/v2/hosts/show'
+  extend_rabl_template 'api/v2/hosts/show', 'katello/api/v2/hosts/os_attributes'
+  extend_rabl_template 'api/v2/hosts/index', 'katello/api/v2/hosts/os_attributes'
 
   # Katello variables for Host Registration
   extend_allowed_registration_vars :activation_keys

--- a/test/views/api/v2/hosts_test.rb
+++ b/test/views/api/v2/hosts_test.rb
@@ -1,0 +1,18 @@
+require 'katello_test_helper'
+
+module Katello
+  class HostsViewTest < ActiveSupport::TestCase
+    def setup
+      @host = FactoryBot.build(:host, :with_operatingsystem,
+                               :compute_resource_id => compute_resources(:one).id)
+    end
+
+    def test_base
+      render_rabl('katello/api/v2/hosts/base.json', @host)
+    end
+
+    def test_show
+      render_rabl('katello/api/v2/hosts/show.json', @host)
+    end
+  end
+end

--- a/webpack/ForemanColumnExtensions/index.js
+++ b/webpack/ForemanColumnExtensions/index.js
@@ -97,6 +97,7 @@ const hostsIndexColumnExtensions = [
       const registered = !!hostDetails?.subscription_facet_attributes?.uuid;
       const { security, bugfix, enhancement } = errataCounts ?? {};
       const upgradableRpmCount = hostDetails?.content_facet_attributes?.upgradable_package_count;
+      const upgradableDebCount = hostDetails?.content_facet_attributes?.upgradable_deb_count;
       if (!registered) return '—';
       const hostErrataUrl = type => `hosts/${hostDetails?.name}#/Content/errata?type=${type}&show=installable`;
       return (
@@ -119,10 +120,14 @@ const hostsIndexColumnExtensions = [
               <Link to={hostErrataUrl('enhancement')}>{enhancement}</Link>
             </FlexItem>
           }
-          {upgradableRpmCount !== undefined &&
+          {(upgradableRpmCount !== undefined || upgradableDebCount !== undefined) &&
             <FlexItem>
               <PackageIcon />
-              <Link to={`hosts/${hostDetails?.name}#/Content/Packages?status=Upgradable`}>{upgradableRpmCount}</Link>
+              { hostDetails?.operatingsystem_family === 'Debian' ?
+                <Link to={`hosts/${hostDetails?.name}#/Content/Debs?status=Upgradable`}>{upgradableDebCount}</Link>
+                :
+                <Link to={`hosts/${hostDetails?.name}#/Content/Packages?status=Upgradable`}>{upgradableRpmCount}</Link>
+              }
             </FlexItem>
           }
         </Flex>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
The package count on the new All hosts page does not work. This PR aims to fix this.

#### Considerations taken when implementing this change?
Errata is not available for Debian, so it is okay for those fields to show 0. 

#### What are the testing steps for this pull request?
You need a Debain package on a host that can is upgradable. 