### PR TITLE
Fixes #38102 - Auth token of flatpak-remote shouldn't be returned by API

### DIFF
--- a/app/views/katello/api/v2/flatpak_remotes/base.json.rabl
+++ b/app/views/katello/api/v2/flatpak_remotes/base.json.rabl
@@ -2,4 +2,4 @@ extends 'katello/api/v2/common/identifier'
 extends 'katello/api/v2/common/org_reference'
 
 attributes :name
-attributes :url, :description, :username, :token, :seeded, :registry_url
+attributes :url, :description, :username, :seeded, :registry_url


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Don't return token of flatpak remote on the API
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Go to katello/api/v2/flatpak_remotes/ and make sure you don't see the authentication token.