### PR TITLE
Fixes #38103 - disallow direct container tar uploads

### DIFF
--- a/app/controllers/katello/api/v2/content_uploads_controller.rb
+++ b/app/controllers/katello/api/v2/content_uploads_controller.rb
@@ -12,9 +12,10 @@ module Katello
     param :repository_id, :number, :required => true, :desc => N_("repository id")
     param :size, :number, :required => true, :desc => N_("Size of file to upload")
     param :checksum, String, :required => false, :desc => N_("Checksum of file to upload")
-    param :content_type, RepositoryTypeManager.uploadable_content_types(false).map(&:label), :required => false, :desc => N_("content type ('deb', 'docker_manifest', 'file', 'ostree_ref', 'rpm', 'srpm')")
+    param :content_type, RepositoryTypeManager.uploadable_content_types(false).map(&:label), :required => false, :desc => N_("content type ('deb', 'file', 'ostree_ref', 'rpm', 'srpm')")
     def create
       fail Katello::Errors::InvalidRepositoryContent, _("Cannot upload Ansible collections.") if @repository.ansible_collection?
+      fail Katello::Errors::InvalidRepositoryContent, _("Cannot upload container content via Hammer/API. Use podman push instead.") if @repository.docker?
       content_type = params[:content_type] || ::Katello::RepositoryTypeManager.find(@repository.content_type)&.default_managed_content_type&.label
       RepositoryTypeManager.check_content_matches_repo_type!(@repository, content_type)
       if ::Katello::RepositoryTypeManager.generic_content_type?(content_type)

--- a/lib/katello/repository_types/docker.rb
+++ b/lib/katello/repository_types/docker.rb
@@ -27,7 +27,6 @@ Katello::RepositoryTypeManager.register(::Katello::Repository::DOCKER_TYPE) do
                :priority => 1,
                :pulp3_service_class => ::Katello::Pulp3::DockerManifest,
                :removable => true,
-               :uploadable => true,
                :primary_content => true
   content_type Katello::DockerManifestList,
                :priority => 2,

--- a/test/controllers/api/v2/content_uploads_controller_test.rb
+++ b/test/controllers/api/v2/content_uploads_controller_test.rb
@@ -46,6 +46,13 @@ module Katello
       assert_response :success
     end
 
+    def test_create_container_upload_request
+      container_repo = katello_repositories(:busybox)
+      post :create, params: { :repository_id => container_repo.id, :size => 100, :checksum => 'test_checksum2' }
+      assert_response :error
+      assert_match 'Cannot upload container content via Hammer/API. Use podman push instead.', @response.body
+    end
+
     def test_create_collection_upload_request
       ansible_collection_repo = katello_repositories(:pulp3_ansible_collection_1)
       post :create, params: { :repository_id => ansible_collection_repo.id, :size => 100, :checksum => 'test_checksum' }

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -929,8 +929,8 @@ module Katello
       post :upload_content, params: { :id => @repository.id, :content_type => 'cheese' }
 
       assert_response 422
-      response =  "{\"displayMessage\":\"Invalid params provided - content_type must be one of deb,docker_manifest,file,ostree_ref,python_package,rpm,srpm\"," \
-        "\"errors\":[\"Invalid params provided - content_type must be one of deb,docker_manifest,file,ostree_ref,python_package,rpm,srpm\"]}"
+      response =  "{\"displayMessage\":\"Invalid params provided - content_type must be one of deb,file,ostree_ref,python_package,rpm,srpm\"," \
+        "\"errors\":[\"Invalid params provided - content_type must be one of deb,file,ostree_ref,python_package,rpm,srpm\"]}"
       assert_match response, @response.body
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Disables uploading container tar files via API/Hammer because podman push is supported now. The workflow was never properly implemented with Pulp 3 Katello and is mostly broken.

#### Considerations taken when implementing this change?
We could technically get the uploads working again, but I don't see a reason why we should support uploading container content outside of the container registry.

#### What are the testing steps for this pull request?
1) Try `hammer repository upload-content` on a container repo.
2) See the failure with a nice message.