### PR TITLE
Fixes #38104 - Hide Media when Synced Content is selected

### DIFF
--- a/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
@@ -23,9 +23,15 @@
              :class => 'form-control',  :name => ks_repo_select_name, :disabled => kickstart_options.empty? %>
 <% end %>
 
-<% content_for(:javascripts) do -%>
-  <script>
+<script>
+  if(window.allJsLoaded){
     KT.hosts.set_media_selection_bindings();
     KT.hosts.update_media_enablement();
-  </script>
-<% end -%>
+  }
+  else {
+  $(document).on('ContentLoad', function(){
+    KT.hosts.set_media_selection_bindings();
+    KT.hosts.update_media_enablement();
+  }); 
+  } 
+</script>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Instead of loading the script inside content_for(:javascripts) , load it in the file, but add the checks to make sure it runs after KT.hosts exists.

#### Considerations taken when implementing this change?
Didn't find another <script> that could be effected by it.
The issue is when os is selected (os_selected request) it returns part of the page, and the selectors and eventlisteners need to bind again. after getting only part of the page content_for is not loaded again

#### What are the testing steps for this pull request?
to reproduce have a kickstarter repo and create a hostgroup, select the matching Content Source, Lifecycle Environment, Content View, go to the os tab, select Architecture and the OS that was created from the kickstart repo, when selecting the Synced Content radio, media should disappear but it does not
