### PR TITLE
Fixes #38109 - As a user, I want to install flatpaks on remote hosts via REX

### DIFF
--- a/app/views/foreman/job_templates/flatpak_install.erb
+++ b/app/views/foreman/job_templates/flatpak_install.erb
@@ -1,0 +1,23 @@
+<%#
+kind: job_template
+name: Install Flatpak application on host
+job_category: Katello
+description_format: 'Install Flatpak application %{Application name} on host'
+provider_type: script
+template_inputs:
+- name: Flatpak remote name
+  description: Name of remote to use on host
+  input_type: user
+  required: false
+- name: Application name
+  description: Name of the application to install
+  input_type: user
+  required: true
+%>
+
+<%
+  remote_name = input('Flatpak remote name')
+  app_name = input('Application name')
+%>
+
+sudo dbus-launch flatpak install <%= remote_name %> <%= app_name %> --assumeyes

--- a/app/views/foreman/job_templates/flatpak_login_action.erb
+++ b/app/views/foreman/job_templates/flatpak_login_action.erb
@@ -1,0 +1,30 @@
+<%#
+kind: job_template
+name: Login to flatpak registry via podman
+job_category: Katello
+description_format: 'Login to flatpak registry via podman'
+provider_type: script
+template_inputs:
+- name: Flatpak registry URL
+  description: URL of server/capsule
+  input_type: user
+  required: true
+- name: Username
+  description: Username for container registry login
+  input_type: user
+  required: true
+- name: Password
+  description: Password/Access token for container registry login
+  input_type: user
+  required: true
+  hidden_value: true
+%>
+
+<%
+  server_url = input('Flatpak registry URL')
+  username = input('Username')
+  password = input('Password')
+%>
+
+sudo podman login <%= server_url %> --username <%= username %> --password <%= password %>
+sudo cp /run/containers/0/auth.json /etc/flatpak/oci-auth.json

--- a/app/views/foreman/job_templates/flatpak_setup.erb
+++ b/app/views/foreman/job_templates/flatpak_setup.erb
@@ -1,0 +1,27 @@
+<%#
+kind: job_template
+name: Set up Flatpak remote on host
+job_category: Katello
+description_format: 'Set up Flatpak remote on host'
+provider_type: script
+template_inputs:
+- name: Remote Name
+  description: Remote name for Flatpak
+  input_type: user
+  required: true
+- name: Flatpak registry URL
+  description: URL of server/capsule
+  input_type: user
+  required: true
+foreign_input_sets:
+- template: Login to flatpak registry via podman
+  exclude: Flatpak registry URL
+%>
+
+<%
+  remote_name = input('Remote Name')
+  registry_url = input('Flatpak registry URL')
+%>
+
+sudo flatpak remote-add --authenticator-name=org.flatpak.Authenticator.Oci <%= remote_name %> oci+<%= registry_url %>/
+<%= render_template('Login to flatpak registry via podman', 'Flatpak registry URL': registry_url) %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds a new job template to setup flatpak remote, authentication and possibly install a flatpak repo on a host
#### Considerations taken when implementing this change?
We are not installing flatpak/podman. Admin/Client will need to do that on their own.
This will need to be run with sudo or as root on the host
#### What are the testing steps for this pull request?
------

To import the new job template:
In Rails console: `ForemanInternal.all.first.delete`
Then run: `bundle exec rails db:seed`

------
1. Run the job template on a host.
2. Monitor the execution output and make sure you are able to see the flatpak installation on the host.