### PR TITLE
refs #37923 - Bug fixes & improvements for the Default HTTP proxy

### DIFF
--- a/app/controllers/katello/concerns/api/v2/http_proxies_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/http_proxies_controller_extensions.rb
@@ -5,9 +5,9 @@ module Katello
         module HttpProxiesControllerExtensions
           extend ::Apipie::DSL::Concern
 
-          update_api(:create) do
+          update_api(:create, :show) do
             param :http_proxy, Hash do
-              param :default_content_proxy, :bool, :required => false, :desc => N_('Set this HTTP proxy as the default content HTTP proxy')
+              param :content_default_http_proxy, :bool, :required => false, :desc => N_('Set this HTTP proxy as the default content HTTP proxy')
             end
           end
         end

--- a/app/controllers/katello/concerns/http_proxies_controller_extensions.rb
+++ b/app/controllers/katello/concerns/http_proxies_controller_extensions.rb
@@ -11,7 +11,7 @@ module Katello
 
       def update_content_default_http_proxy
         return unless @http_proxy.persisted?
-        return unless ActiveRecord::Type::Boolean.new.deserialize(params.dig('http_proxy', 'default_content'))
+        return unless ActiveRecord::Type::Boolean.new.deserialize(params.dig('http_proxy', 'content_default_http_proxy'))
 
         Setting[:content_default_http_proxy] = @http_proxy.name
       end

--- a/app/models/katello/concerns/http_proxy_extensions.rb
+++ b/app/models/katello/concerns/http_proxy_extensions.rb
@@ -84,6 +84,10 @@ module Katello
         uri.user = nil
         "#{name} (#{uri})"
       end
+
+      def content_default_http_proxy?
+        Setting[:content_default_http_proxy] == name
+      end
     end
   end
 end

--- a/app/views/katello/api/v2/http_proxies/show.json.rabl
+++ b/app/views/katello/api/v2/http_proxies/show.json.rabl
@@ -1,0 +1,1 @@
+node(:content_default_http_proxy) { |sp| sp.content_default_http_proxy? }

--- a/app/views/overrides/http_proxies/_update_setting_input.html.erb
+++ b/app/views/overrides/http_proxies/_update_setting_input.html.erb
@@ -1,16 +1,18 @@
-<% if @http_proxy.new_record? %>
-  <div class="clearfix">
-    <div class="form-group ">
-      <label class="col-md-2 control-label" for="http_proxy_default_content">
-        Default content HTTP proxy
-      </label>
-      <div class="col-md-4">
-        <%= check_box_tag 'http_proxy[default_content]',
-                          '1',
-                          params.dig('http_proxy', 'default_content') == '1',
-                          id: 'http_proxy_default_content' %>
-        Set this proxy as the default for content, updating the 'Default HTTP Proxy' setting.
-      </div>
+<div class="clearfix">
+  <div class="form-group ">
+    <label class="col-md-2 control-label" for="http_proxy_content_default_http_proxy">
+      Default content HTTP proxy
+    </label>
+    <div class="col-md-4">
+    <% if @http_proxy.new_record? %>
+      <%= check_box_tag 'http_proxy[content_default_http_proxy]',
+                        '1',
+                        params.dig('http_proxy', 'content_default_http_proxy') == '1',
+                        id: 'content_default_http_proxy' %>
+      Set this proxy as the default for content, updating the 'Default HTTP Proxy' setting.
+    <% else %>
+      <%= @http_proxy.content_default_http_proxy? ? _('Yes') : _('No') %>
+    <% end %>
     </div>
   </div>
-<% end %>
+</div>

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -300,6 +300,7 @@ Foreman::Plugin.register :katello do
   extend_rabl_template 'api/v2/hosts/show', 'katello/api/v2/hosts/show'
   extend_rabl_template 'api/v2/hosts/show', 'katello/api/v2/hosts/os_attributes'
   extend_rabl_template 'api/v2/hosts/index', 'katello/api/v2/hosts/os_attributes'
+  extend_rabl_template 'api/v2/http_proxies/show', 'katello/api/v2/http_proxies/show'
 
   # Katello variables for Host Registration
   extend_allowed_registration_vars :activation_keys


### PR DESCRIPTION
Follow up on #11183 with

* Unified naming of the parameter ('content_default_http_proxy')
* On edit form showing information if the capsule is default
* Fixed API + extended show with 'content_default_http_proxy'
