### PR TITLE
Fixes #38112 - Order LCEs by LCE path in Content View GUI and Hammer

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -342,7 +342,9 @@ module Katello
     end
 
     def latest_version_env
-      latest_version_object.try(:environments) || []
+      environments = organization.readable_promotion_paths.flatten
+      environments.insert(0, organization.library)
+      environments.intersection(latest_version_object.try(:environments) || [])
     end
 
     def last_task

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -108,6 +108,12 @@ module Katello
       name
     end
 
+    def sorted_organization_readable_environments
+      organization_readable_environments = organization.readable_promotion_paths.flatten
+      organization_readable_environments.insert(0, organization.library)
+      organization_readable_environments.intersection(environments)
+    end
+
     def self.contains_file(file_unit_id)
       where(id: Katello::Repository.where(id: Katello::RepositoryFileUnit.where(file_unit_id: file_unit_id).select(:repository_id)).select(:content_view_version_id))
     end

--- a/app/views/katello/api/v2/content_view_versions/base.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/base.json.rabl
@@ -49,7 +49,7 @@ end
 extends 'katello/api/v2/common/timestamps'
 
 version = @object || @resource
-child :environments => :environments do
+child :sorted_organization_readable_environments => :environments do
   attributes :id, :name, :label
 
   node :publish_date do |env|


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Updated the ContentView and ContentViewVersion models to order LCEs based on their promotion paths  in both the GUI Content View page and the Hammer CLI. The API response was updated to reflect the new ordering, providing consistency across interfaces.

#### Considerations taken when implementing this change?

Optimized the changes to minimize performance impact while maintaining backward compatibility to ensure existing functionality remains unaffected. Ensured consistency across the GUI and Hammer CLI with thorough testing to validate correct behavior. Designed the implementation to be modular and maintainable for future updates.

#### What are the testing steps for this pull request?

1. Publish and promote a content view, after selecting multiple LCE 
2. Go to Content -> Lifecycle -> Content Views and verify that the content view GUI displays the LCEs in the correct order as per the LCE path
3. Use the Hammer CLI command (hammer content-view version list --content-view-id <content_view_id>) to verify that the LCEs are listed in the correct order as per the LCE path
