### PR TITLE
Fixes #38114 - Document path-id param for environment create

### DIFF
--- a/app/controllers/katello/api/v2/environments_controller.rb
+++ b/app/controllers/katello/api/v2/environments_controller.rb
@@ -84,6 +84,10 @@ module Katello
       ID of an environment that is prior to the new environment in the chain. It has to be
       either the ID of Library or the ID of an environment at the end of a chain.
     DESC
+    param :path_id, Integer, :desc => <<-DESC
+      If you are adding an environment to an existing path after Library, pass the ID of the environment that is the current successor of Library in the path.
+      It has to be the id of the old environment following library in this path.
+    DESC
     def create
       create_params = environment_params
       create_params[:label] = labelize_params(create_params)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Expose path-id as a documented API param for hammer
#### Considerations taken when implementing this change?
Reusing the param that controller provides. Wording can be changed a bit so opening for reviews.
#### What are the testing steps for this pull request?
Start server with this PR and test hammer.

```
Usage:
    hammer lifecycle-environment create [OPTIONS]

Options:
 --description VALUE                            Description of the environment
 --label VALUE                                  Label of the environment
 --name VALUE                                   Name of the environment
 --organization[-id|-title|-label] VALUE/NUMBER Name of organization
 --path-id NUMBER                               If you are adding an environment to an existing path after Library, pass the id
                                                of the environment that is the current successor of Library in the path. It has
                                                to be the id of the old environment following library in this path.
 --prior VALUE                                  Name of the prior environment
 --prior-id NUMBER                              Id of an environment that is prior to the new environment in the chain. It has
                                                to be either the id of Library or the id of an environment at the end of a
                                                chain.
 --registry-name-pattern VALUE                  Pattern for container image names
 --registry-unauthenticated-pull BOOLEAN        Allow unauthenticed pull of container images
 -h, --help                                     Print help
```
You can now create env in a path at the end of library before the other environments in the path. Pass the env-id of the previous successor of Library in the path.
`hammer-cli-katello]$ hammer lifecycle-environment create --label=test12 --name=test12 --prior-id=1 --organization-id=1 --path-id=13`

