### PR TITLE
Fixes #38107 - Booted container images page

### DIFF
--- a/app/lib/katello/concerns/bookmark_controller_validator_extensions.rb
+++ b/app/lib/katello/concerns/bookmark_controller_validator_extensions.rb
@@ -1,0 +1,13 @@
+module Katello
+  module Concerns
+    module BookmarkControllerValidatorExtensions
+      extend ActiveSupport::Concern
+
+      def valid_controllers_list
+        @valid_controllers_list ||= (["dashboard", "common_parameters", "/katello/api/v2/host_bootc_images"] +
+          ActiveRecord::Base.connection.tables.map(&:to_s) +
+          Permission.resources.map(&:tableize)).uniq
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,8 @@ Katello::Engine.routes.draw do
   match '/alternate_content_sources' => 'react#index', :via => [:get]
   match '/alternate_content_sources/*page' => 'react#index', :via => [:get]
 
+  match '/booted_container_images' => 'react#index', :via => [:get]
+
   Katello::RepositoryTypeManager.generic_ui_content_types(false).each do |type|
     get "/#{type.pluralize}", to: redirect("/content/#{type.pluralize}")
     get "/#{type.pluralize}/:page", to: redirect("/content/#{type.pluralize}/%{page}")

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -156,6 +156,9 @@ module Katello
       ::HttpProxy.include Katello::Concerns::HttpProxyExtensions
       ForemanTasks::RecurringLogic.include Katello::Concerns::RecurringLogicExtensions
 
+      # Validator extensions
+      ::BookmarkControllerValidator.singleton_class.send :prepend, Katello::Concerns::BookmarkControllerValidatorExtensions
+
       #Controller extensions
       ::HostsController.include Katello::Concerns::HostsControllerExtensions
       ::SmartProxiesController.include Katello::Concerns::SmartProxiesControllerExtensions

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -70,6 +70,15 @@ Foreman::Plugin.register :katello do
          :engine => Katello::Engine,
          :turbolinks => false
 
+    menu :top_menu,
+         :booted_container_images,
+         :caption => N_('Booted container images'),
+         :url_hash => {:controller => 'katello/api/v2/host_bootc_images',
+                       :action => 'bootc_images'},
+         :url => '/booted_container_images',
+         :engine => Katello::Engine,
+         :turbolinks => false
+
     divider :top_menu, :caption => N_('Lifecycle'), :parent => :content_menu
 
     menu :top_menu,

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -72,7 +72,7 @@ Foreman::Plugin.register :katello do
 
     menu :top_menu,
          :booted_container_images,
-         :caption => N_('Booted container images'),
+         :caption => N_('Booted Container Images'),
          :url_hash => {:controller => 'katello/api/v2/host_bootc_images',
                        :action => 'bootc_images'},
          :url => '/booted_container_images',

--- a/webpack/__mocks__/foremanReact/Root/Context/ForemanContext.js
+++ b/webpack/__mocks__/foremanReact/Root/Context/ForemanContext.js
@@ -1,3 +1,4 @@
 // eslint-disable-next-line import/prefer-default-export
 export const useForemanSettings = () => ({ perPage: 20 });
 export const useForemanVersion = () => 'nightly';
+export const useForemanHostsPageUrl = () => '/new/hosts';

--- a/webpack/containers/Application/config.js
+++ b/webpack/containers/Application/config.js
@@ -15,6 +15,7 @@ import ContentDetails from '../../scenes/Content/Details';
 import withHeader from './withHeaders';
 import ChangeContentSource from '../../scenes/Hosts/ChangeContentSource';
 import AlternateContentSource from '../../scenes/AlternateContentSources';
+import BootedContainerImages from '../../scenes/BootedContainerImages';
 
 // eslint-disable-next-line import/prefer-default-export
 export const links = [
@@ -84,5 +85,9 @@ export const links = [
     path: 'alternate_content_sources/:id([0-9]+)',
     component: WithOrganization(withHeader(AlternateContentSource, { title: __('Alternate Content Sources') })),
     exact: false,
+  },
+  {
+    path: 'booted_container_images',
+    component: WithOrganization(withHeader(BootedContainerImages, { title: __('Booted container images') })),
   },
 ];

--- a/webpack/scenes/BootedContainerImages/BootedContainerImagesConstants.js
+++ b/webpack/scenes/BootedContainerImages/BootedContainerImagesConstants.js
@@ -1,0 +1,6 @@
+import { translate as __ } from 'foremanReact/common/I18n';
+import { foremanApi } from '../../services/api';
+
+const BOOTED_CONTAINER_IMAGES_KEY = 'BOOTED_CONTAINER_IMAGES';
+export const BOOTED_CONTAINER_IMAGES_API_PATH = foremanApi.getApiUrl('/hosts/bootc_images');
+export default BOOTED_CONTAINER_IMAGES_KEY;

--- a/webpack/scenes/BootedContainerImages/BootedContainerImagesConstants.js
+++ b/webpack/scenes/BootedContainerImages/BootedContainerImagesConstants.js
@@ -1,4 +1,3 @@
-import { translate as __ } from 'foremanReact/common/I18n';
 import { foremanApi } from '../../services/api';
 
 const BOOTED_CONTAINER_IMAGES_KEY = 'BOOTED_CONTAINER_IMAGES';

--- a/webpack/scenes/BootedContainerImages/BootedContainerImagesPage.js
+++ b/webpack/scenes/BootedContainerImages/BootedContainerImagesPage.js
@@ -22,7 +22,7 @@ import BOOTED_CONTAINER_IMAGES_KEY, { BOOTED_CONTAINER_IMAGES_API_PATH } from '.
 
 const BootedContainerImagesPage = () => {
   const columns = {
-    image_name: {
+    bootc_booted_image: {
       title: __('Image name'),
       isSorted: true,
     },
@@ -32,8 +32,8 @@ const BootedContainerImagesPage = () => {
     },
     hosts: {
       title: __('Hosts'),
-      wrapper: ({image_name, digests}) => (
-        <a href={`/hosts?search=bootc_booted_image%20=%20${image_name}`}>{digests.reduce((total, digest) => total + digest.host_count, 0)}</a>
+      wrapper: ({bootc_booted_image, digests}) => (
+        <a href={`/hosts?search=bootc_booted_image%20=%20${bootc_booted_image}`}>{digests.reduce((total, digest) => total + digest.host_count, 0)}</a>
       ),
     },
   };
@@ -59,13 +59,19 @@ const BootedContainerImagesPage = () => {
       columnsToSortParams[columns[key].title] = key;
     }
   });
+  const onSort = (_event, index, direction) => {
+    setParamsAndAPI({
+      ...params,
+      order: `${Object.keys(columns)[index]} ${direction}`,
+    });
+  };
   const { pfSortParams } = useTableSort({
     allColumns: Object.keys(columns).map(k => columns[k].title),
     columnsToSortParams,
     onSort,
   });
   const expandedImages = useSet([]);
-  const imageIsExpanded = image_name => expandedImages.has(image_name);
+  const imageIsExpanded = bootc_booted_image => expandedImages.has(bootc_booted_image);
   const STATUS = {
     PENDING: 'PENDING',
     RESOLVED: 'RESOLVED',
@@ -91,12 +97,6 @@ const BootedContainerImagesPage = () => {
   });
 
   const [columnNamesKeys, keysToColumnNames] = getColumnHelpers(columns);
-  const onSort = (_event, index, direction) => {
-    setParamsAndAPI({
-      ...params,
-      order: `${Object.keys(columns)[index]} ${direction}`,
-    });
-  };
   const onPagination = newPagination => {
     setParamsAndAPI({ ...params, ...newPagination });
   };
@@ -175,17 +175,17 @@ const BootedContainerImagesPage = () => {
             )}
           </Tbody>
           {results?.map((result, rowIndex) => {
-            const { image_name, digests } = result;
-            const isExpanded = imageIsExpanded(image_name);
+            const { bootc_booted_image, digests } = result;
+            const isExpanded = imageIsExpanded(bootc_booted_image);
             return (
               <Tbody key={`bootable-container-images-body-${rowIndex}`} isExpanded={isExpanded}>
-                <Tr key={image_name} ouiaId={`table-row-${rowIndex}`}>
+                <Tr key={bootc_booted_image} ouiaId={`table-row-${rowIndex}`}>
                   <>
                     <Td
                       expand={digests.length > 0 && {
                         rowIndex,
                         isExpanded,
-                        onToggle: (_event, _rInx, isOpen,) => expandedImages.onToggle(isOpen, image_name),
+                        onToggle: (_event, _rInx, isOpen,) => expandedImages.onToggle(isOpen, bootc_booted_image),
                         expandId: 'booted-containers-expander'
                       }}
                     />

--- a/webpack/scenes/BootedContainerImages/BootedContainerImagesPage.js
+++ b/webpack/scenes/BootedContainerImages/BootedContainerImagesPage.js
@@ -96,17 +96,6 @@ const BootedContainerImagesPage = () => {
   const onPagination = (newPagination) => {
     setParamsAndAPI({ ...params, ...newPagination });
   };
-  const bottomPagination = (
-    <Pagination
-      key="table-bottom-pagination"
-      page={params.page}
-      perPage={params.perPage}
-      itemCount={subtotal}
-      onChange={onPagination}
-      updateParamsByUrl
-    />
-  );
-
   const getColumnWidth = (key) => {
     if (key === 'bootc_booted_image') return 40;
     if (key === 'digest') return 15;
@@ -178,10 +167,10 @@ const BootedContainerImagesPage = () => {
             )}
           </Tbody>
           {results?.map((result, rowIndex) => {
-            const { bootcBootedImage, digests } = result;
+            const { bootc_booted_image: bootcBootedImage, digests } = result;
             const isExpanded = imageIsExpanded(bootcBootedImage);
             return (
-              <Tbody key="bootable-container-images-body" isExpanded={isExpanded}>
+              <Tbody key={`bootable-container-images-body-${bootcBootedImage}`} isExpanded={isExpanded}>
                 <Tr key={bootcBootedImage} ouiaId={`table-row-${rowIndex}`}>
                   <>
                     <Td
@@ -190,12 +179,12 @@ const BootedContainerImagesPage = () => {
                         isExpanded,
                         onToggle: (_event, _rInx, isOpen) =>
                           expandedImages.onToggle(isOpen, bootcBootedImage),
-                        expandId: 'booted-containers-expander',
+                        expandId: `booted-containers-expander-${bootcBootedImage}`,
                       }}
                     />
                     {columnNamesKeys.map(k => (
                       <Td
-                        key={k}
+                        key={`${bootcBootedImage}-${keysToColumnNames[k]}`}
                         dataLabel={keysToColumnNames[k]}
                       >
                         {columns[k].wrapper ? columns[k].wrapper(result) : result[k]}
@@ -217,7 +206,7 @@ const BootedContainerImagesPage = () => {
                           </Thead>
                           <Tbody>
                             {digests.map((digest, index) => (
-                              <Tr key={digest} ouiaId={`table-row-expandable-content-${index}`}>
+                              <Tr key={digest.bootc_booted_digest} ouiaId={`table-row-expandable-content-${index}`}>
                                 <Td>{digest.bootc_booted_digest}</Td>
                                 <Td>
                                   <a href={`/hosts?search=bootc_booted_digest%20=%20${digest.bootc_booted_digest}`}>{digest.host_count}</a>
@@ -233,7 +222,16 @@ const BootedContainerImagesPage = () => {
             );
           })}
         </TableComposable>
-        {results.length > 0 && !errorMessage && bottomPagination}
+        {results.length > 0 && !errorMessage &&
+          <Pagination
+            key="table-bottom-pagination"
+            page={params.page}
+            perPage={params.perPage}
+            itemCount={subtotal}
+            onChange={onPagination}
+            updateParamsByUrl
+          />
+        }
       </>
     </TableIndexPage>
   );

--- a/webpack/scenes/BootedContainerImages/BootedContainerImagesPage.js
+++ b/webpack/scenes/BootedContainerImages/BootedContainerImagesPage.js
@@ -15,6 +15,17 @@ const BootedContainerImagesPage = () => {
   const columns = {
     image_name: {
       title: __('Image name'),
+      isSorted: true,
+    },
+    digest: {
+      title: __('Image digests'),
+      wrapper: ({digests}) => digests.length,
+    },
+    hosts: {
+      title: __('Hosts'),
+      wrapper: ({image_name, digests}) => (
+        <a href={`/hosts?search=bootc_booted_image%20=%20${image_name}`}>{digests.reduce((total, digest) => total + digest.host_count, 0)}</a>
+      ),
     },
   };
 

--- a/webpack/scenes/BootedContainerImages/BootedContainerImagesPage.js
+++ b/webpack/scenes/BootedContainerImages/BootedContainerImagesPage.js
@@ -1,13 +1,22 @@
 import React from 'react';
+import { TableComposable, Thead, Th, Tbody, Tr, Td, ExpandableRowContent } from '@patternfly/react-table';
 import TableIndexPage from 'foremanReact/components/PF4/TableIndexPage/TableIndexPage';
-import { Table } from 'foremanReact/components/PF4/TableIndexPage/Table/Table';
 import {
   useSetParamsAndApiAndSearch,
   useTableIndexAPIResponse,
 } from 'foremanReact/components/PF4/TableIndexPage/Table/TableIndexHooks';
 import {
   useUrlParams,
+  useSet,
 } from 'foremanReact/components/PF4/TableIndexPage/Table/TableHooks';
+import {
+  getColumnHelpers,
+} from 'foremanReact/components/PF4/TableIndexPage/Table/helpers';
+import {
+  useTableSort,
+} from 'foremanReact/components/PF4/Helpers/useTableSort';
+import Pagination from 'foremanReact/components/Pagination';
+import EmptyPage from 'foremanReact/routes/common/EmptyPage';
 import { translate as __ } from 'foremanReact/common/I18n';
 import BOOTED_CONTAINER_IMAGES_KEY, { BOOTED_CONTAINER_IMAGES_API_PATH } from './BootedContainerImagesConstants';
 
@@ -29,12 +38,6 @@ const BootedContainerImagesPage = () => {
     },
   };
 
-  const STATUS = {
-    PENDING: 'PENDING',
-    RESOLVED: 'RESOLVED',
-    ERROR: 'ERROR',
-  };
-
   const {
     searchParam: urlSearchQuery = '',
     page: urlPage,
@@ -44,15 +47,34 @@ const BootedContainerImagesPage = () => {
   if (urlPage) defaultParams.page = Number(urlPage);
   if (urlPerPage) defaultParams.per_page = Number(urlPerPage);
   const apiOptions = { key: BOOTED_CONTAINER_IMAGES_KEY };
+
   const response = useTableIndexAPIResponse({
     apiUrl: BOOTED_CONTAINER_IMAGES_API_PATH,
     apiOptions,
     defaultParams,
   });
+  const columnsToSortParams = {};
+  Object.keys(columns).forEach(key => {
+    if (columns[key].isSorted) {
+      columnsToSortParams[columns[key].title] = key;
+    }
+  });
+  const { pfSortParams } = useTableSort({
+    allColumns: Object.keys(columns).map(k => columns[k].title),
+    columnsToSortParams,
+    onSort,
+  });
+  const expandedImages = useSet([]);
+  const imageIsExpanded = image_name => expandedImages.has(image_name);
+  const STATUS = {
+    PENDING: 'PENDING',
+    RESOLVED: 'RESOLVED',
+    ERROR: 'ERROR',
+  };
 
   const {
     response: {
-      results,
+      results = [],
       per_page: perPage,
       page,
       subtotal,
@@ -68,40 +90,145 @@ const BootedContainerImagesPage = () => {
     setAPIOptions: response.setAPIOptions,
   });
 
+  const [columnNamesKeys, keysToColumnNames] = getColumnHelpers(columns);
+  const onSort = (_event, index, direction) => {
+    setParamsAndAPI({
+      ...params,
+      order: `${Object.keys(columns)[index]} ${direction}`,
+    });
+  };
+  const onPagination = newPagination => {
+    setParamsAndAPI({ ...params, ...newPagination });
+  };
+  const bottomPagination = (
+    <Pagination
+      key="table-bottom-pagination"
+      page={params.page}
+      perPage={params.perPage}
+      itemCount={subtotal}
+      onChange={onPagination}
+      updateParamsByUrl={true}
+    />
+  );
+
   return (
     <TableIndexPage
       apiUrl={BOOTED_CONTAINER_IMAGES_API_PATH}
-      apiOptions={{ key: BOOTED_CONTAINER_IMAGES_KEY }}
+      apiOptions={apiOptions}
       header={__('Booted container images')}
       createable={false}
       isDeleteable={false}
       controller="/katello/api/v2/host_bootc_images"
     >
-      <Table
-        ouiaId="booted-container-images-table"
-        isEmbedded={false}
-        params={{
-          ...params,
-          page,
-          perPage,
-        }}
-        setParams={setParamsAndAPI}
-        itemCount={subtotal}
-        results={results}
-        url={BOOTED_CONTAINER_IMAGES_API_PATH}
-        isDeleteable={false}
-        refreshData={() =>
-          setAPIOptions({
-            ...apiOptions,
-            params: { urlSearchQuery },
-          })
-        }
-        columns={columns}
-        errorMessage={
-          status === STATUS.ERROR && errorMessage ? errorMessage : null
-        }
-        isPending={status === STATUS.PENDING}
-      />
+      <>
+        <TableComposable variant="compact" ouiaId="booted-containers-table" isStriped>
+          <Thead>
+            <Tr ouiaId="table-header">
+              <>
+                <Th />
+                {columnNamesKeys.map(k => (
+                  <Th
+                    key={k}
+                    sort={
+                      Object.values(columnsToSortParams).includes(k) &&
+                      pfSortParams(keysToColumnNames[k])
+                    }
+                  >
+                    {keysToColumnNames[k]}
+                  </Th>
+                ))}
+              </>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {status === STATUS.PENDING && results.length === 0 && (
+              <Tr ouiaId="table-loading">
+                <Td colSpan={100}>
+                  <EmptyPage
+                    message={{
+                      type: 'loading',
+                      text: __('Loading...'),
+                    }}
+                  />
+                </Td>
+              </Tr>
+            )}
+            {!status === STATUS.PENDING &&
+              results.length === 0 &&
+              !errorMessage && (
+                <Tr ouiaId="table-empty">
+                  <Td colSpan={100}>
+                    <EmptyPage
+                      message={{
+                        type: 'empty',
+                      }}
+                    />
+                  </Td>
+                </Tr>
+              )}
+            {errorMessage && (
+              <Tr ouiaId="table-error">
+                <Td colSpan={100}>
+                  <EmptyPage message={{ type: 'error', text: errorMessage }} />
+                </Td>
+              </Tr>
+            )}
+          </Tbody>
+          {results?.map((result, rowIndex) => {
+            const { image_name, digests } = result;
+            const isExpanded = imageIsExpanded(image_name);
+            return (
+              <Tbody key={`bootable-container-images-body-${rowIndex}`} isExpanded={isExpanded}>
+                <Tr key={image_name} ouiaId={`table-row-${rowIndex}`}>
+                  <>
+                    <Td
+                      expand={digests.length > 0 && {
+                        rowIndex,
+                        isExpanded,
+                        onToggle: (_event, _rInx, isOpen,) => expandedImages.onToggle(isOpen, image_name),
+                        expandId: 'booted-containers-expander'
+                      }}
+                    />
+                    {columnNamesKeys.map(k => (
+                      <Td
+                        key={k}
+                        dataLabel={keysToColumnNames[k]}
+                      >
+                        {columns[k].wrapper ? columns[k].wrapper(result) : result[k]}
+                      </Td>
+                    ))}
+                  </>
+                </Tr>
+                {digests ? <Tr isExpanded={isExpanded}>
+                  <Td colSpan={3}>
+                    <ExpandableRowContent>
+                      <TableComposable variant="compact" isStriped>
+                        <Thead>
+                          <Tr>
+                            <Th>{__('Image digest')}</Th>
+                            <Th>{__('Hosts')}</Th>
+                          </Tr>
+                        </Thead>
+                        <Tbody>
+                          {digests.map((digest, index) => (
+                            <Tr key={index}>
+                              <Td>{digest.bootc_booted_digest}</Td>
+                              <Td>
+                                <a href={`/hosts?search=bootc_booted_digest%20=%20${digest.bootc_booted_digest}`}>{digest.host_count}</a>
+                              </Td>
+                            </Tr>
+                          ))}
+                        </Tbody>
+                      </TableComposable>
+                    </ExpandableRowContent>
+                  </Td>
+                </Tr> : null}
+              </Tbody>
+            );
+          })}
+        </TableComposable>
+        {results.length > 0 && !errorMessage && bottomPagination}
+      </>
     </TableIndexPage>
   );
 };

--- a/webpack/scenes/BootedContainerImages/BootedContainerImagesPage.js
+++ b/webpack/scenes/BootedContainerImages/BootedContainerImagesPage.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import TableIndexPage from 'foremanReact/components/PF4/TableIndexPage/TableIndexPage';
+import { translate as __ } from 'foremanReact/common/I18n';
+import BOOTED_CONTAINER_IMAGES_KEY, { BOOTED_CONTAINER_IMAGES_API_PATH } from './BootedContainerImagesConstants';
+
+const BootedContainerImagesPage = () => {
+  const columns = {
+    image_name: {
+      title: __('Image name'),
+    },
+  };
+  return (
+    <TableIndexPage
+      apiUrl={BOOTED_CONTAINER_IMAGES_API_PATH}
+      apiOptions={{ key: BOOTED_CONTAINER_IMAGES_KEY }}
+      header={__('Booted container images')}
+      createable={false}
+      isDeleteable={false}
+      controller="/katello/api/v2/host_bootc_images"
+      columns={columns}
+    />
+  );
+};
+
+export default BootedContainerImagesPage;

--- a/webpack/scenes/BootedContainerImages/BootedContainerImagesPage.js
+++ b/webpack/scenes/BootedContainerImages/BootedContainerImagesPage.js
@@ -18,9 +18,11 @@ import {
 import Pagination from 'foremanReact/components/Pagination';
 import EmptyPage from 'foremanReact/routes/common/EmptyPage';
 import { translate as __ } from 'foremanReact/common/I18n';
+import { useForemanHostsPageUrl } from 'foremanReact/Root/Context/ForemanContext';
 import BOOTED_CONTAINER_IMAGES_KEY, { BOOTED_CONTAINER_IMAGES_API_PATH } from './BootedContainerImagesConstants';
 
 const BootedContainerImagesPage = () => {
+  const foremanHostsPageUrl = useForemanHostsPageUrl();
   const columns = {
     bootc_booted_image: {
       title: __('Image name'),
@@ -33,7 +35,7 @@ const BootedContainerImagesPage = () => {
     hosts: {
       title: __('Hosts'),
       wrapper: ({ bootc_booted_image: bootcBootedImage, digests }) => (
-        <a href={`/hosts?search=bootc_booted_image%20=%20${bootcBootedImage}`}>{digests.reduce((total, digest) => total + digest.host_count, 0)}</a>
+        <a href={`${foremanHostsPageUrl}?search=bootc_booted_image%20=%20${bootcBootedImage}`}>{digests.reduce((total, digest) => total + digest.host_count, 0)}</a>
       ),
     },
   };
@@ -145,7 +147,7 @@ const BootedContainerImagesPage = () => {
                 </Td>
               </Tr>
             )}
-            {!status === STATUS.PENDING &&
+            {!(status === STATUS.PENDING) &&
               results.length === 0 &&
               !errorMessage && (
                 <Tr ouiaId="table-empty">
@@ -200,8 +202,8 @@ const BootedContainerImagesPage = () => {
                         <TableComposable variant="compact" isStriped ouiaId={`table-composable-expanded-${rowIndex}`}>
                           <Thead>
                             <Tr ouiaId={`table-row-inner-expandable-${rowIndex}`}>
-                              <Th width={50}>{__('Image digest')}</Th>
-                              <Th width={50}>{__('Hosts')}</Th>
+                              <Th width={55}>{__('Image digest')}</Th>
+                              <Th width={45}>{__('Hosts')}</Th>
                             </Tr>
                           </Thead>
                           <Tbody>
@@ -209,7 +211,7 @@ const BootedContainerImagesPage = () => {
                               <Tr key={digest.bootc_booted_digest} ouiaId={`table-row-expandable-content-${index}`}>
                                 <Td>{digest.bootc_booted_digest}</Td>
                                 <Td>
-                                  <a href={`/hosts?search=bootc_booted_digest%20=%20${digest.bootc_booted_digest}`}>{digest.host_count}</a>
+                                  <a href={`${foremanHostsPageUrl}?search=bootc_booted_digest%20=%20${digest.bootc_booted_digest}`}>{digest.host_count}</a>
                                 </Td>
                               </Tr>
                             ))}

--- a/webpack/scenes/BootedContainerImages/BootedContainerImagesPage.js
+++ b/webpack/scenes/BootedContainerImages/BootedContainerImagesPage.js
@@ -1,5 +1,13 @@
 import React from 'react';
 import TableIndexPage from 'foremanReact/components/PF4/TableIndexPage/TableIndexPage';
+import { Table } from 'foremanReact/components/PF4/TableIndexPage/Table/Table';
+import {
+  useSetParamsAndApiAndSearch,
+  useTableIndexAPIResponse,
+} from 'foremanReact/components/PF4/TableIndexPage/Table/TableIndexHooks';
+import {
+  useUrlParams,
+} from 'foremanReact/components/PF4/TableIndexPage/Table/TableHooks';
 import { translate as __ } from 'foremanReact/common/I18n';
 import BOOTED_CONTAINER_IMAGES_KEY, { BOOTED_CONTAINER_IMAGES_API_PATH } from './BootedContainerImagesConstants';
 
@@ -9,6 +17,46 @@ const BootedContainerImagesPage = () => {
       title: __('Image name'),
     },
   };
+
+  const STATUS = {
+    PENDING: 'PENDING',
+    RESOLVED: 'RESOLVED',
+    ERROR: 'ERROR',
+  };
+
+  const {
+    searchParam: urlSearchQuery = '',
+    page: urlPage,
+    per_page: urlPerPage,
+  } = useUrlParams();
+  const defaultParams = { search: urlSearchQuery };
+  if (urlPage) defaultParams.page = Number(urlPage);
+  if (urlPerPage) defaultParams.per_page = Number(urlPerPage);
+  const apiOptions = { key: BOOTED_CONTAINER_IMAGES_KEY };
+  const response = useTableIndexAPIResponse({
+    apiUrl: BOOTED_CONTAINER_IMAGES_API_PATH,
+    apiOptions,
+    defaultParams,
+  });
+
+  const {
+    response: {
+      results,
+      per_page: perPage,
+      page,
+      subtotal,
+      message: errorMessage,
+    },
+    status = STATUS.PENDING,
+    setAPIOptions,
+  } = response;
+
+  const { setParamsAndAPI, params } = useSetParamsAndApiAndSearch({
+    defaultParams,
+    apiOptions,
+    setAPIOptions: response.setAPIOptions,
+  });
+
   return (
     <TableIndexPage
       apiUrl={BOOTED_CONTAINER_IMAGES_API_PATH}
@@ -17,8 +65,33 @@ const BootedContainerImagesPage = () => {
       createable={false}
       isDeleteable={false}
       controller="/katello/api/v2/host_bootc_images"
-      columns={columns}
-    />
+    >
+      <Table
+        ouiaId="booted-container-images-table"
+        isEmbedded={false}
+        params={{
+          ...params,
+          page,
+          perPage,
+        }}
+        setParams={setParamsAndAPI}
+        itemCount={subtotal}
+        results={results}
+        url={BOOTED_CONTAINER_IMAGES_API_PATH}
+        isDeleteable={false}
+        refreshData={() =>
+          setAPIOptions({
+            ...apiOptions,
+            params: { urlSearchQuery },
+          })
+        }
+        columns={columns}
+        errorMessage={
+          status === STATUS.ERROR && errorMessage ? errorMessage : null
+        }
+        isPending={status === STATUS.PENDING}
+      />
+    </TableIndexPage>
   );
 };
 

--- a/webpack/scenes/BootedContainerImages/__tests__/bootedContainerImages.fixtures.js
+++ b/webpack/scenes/BootedContainerImages/__tests__/bootedContainerImages.fixtures.js
@@ -1,0 +1,42 @@
+import Immutable from 'seamless-immutable';
+
+const bootedContainerImagesResponse = Immutable({
+  total: 2,
+  page: 1,
+  per_page: 20,
+  subtotal: 2,
+  results: [
+    {
+      bootc_booted_image: 'quay.io/centos-bootc/centos-bootc:stream10',
+      digests: [
+        {
+          bootc_booted_digest: 'sha256:54256a998f0c62e16f3927c82b570f90bd8449a52e03daabd5fd16d6419fd572',
+          host_count: 1,
+        },
+        {
+          bootc_booted_digest: 'sha256:54256a998f0c62e16f3927c82b570f90bd8449a52e03daabd5fd16d6419fd573',
+          host_count: 1,
+        },
+        {
+          bootc_booted_digest: 'sha256:54256a998f0c62e16f3927c82b570f90bd8449a52e03daabd5fd16d6419fd574',
+          host_count: 1,
+        },
+        {
+          bootc_booted_digest: 'sha256:54256a998f0c62e16f3927c82b570f90bd8449a52e03daabd5fd16d6419fd575',
+          host_count: 1,
+        },
+      ],
+    },
+    {
+      bootc_booted_image: 'quay.io/centos-bootc/centos-bootc:stream9',
+      digests: [
+        {
+          bootc_booted_digest: 'sha256:54256a998f0c62e16f3927c82b570f90bd8449a52e03daabd5fd16d6419fd576',
+          host_count: 1,
+        },
+      ],
+    },
+  ],
+});
+
+export default bootedContainerImagesResponse;

--- a/webpack/scenes/BootedContainerImages/__tests__/bootedContainerImages.fixtures.js
+++ b/webpack/scenes/BootedContainerImages/__tests__/bootedContainerImages.fixtures.js
@@ -15,15 +15,15 @@ const bootedContainerImagesResponse = Immutable({
         },
         {
           bootc_booted_digest: 'sha256:54256a998f0c62e16f3927c82b570f90bd8449a52e03daabd5fd16d6419fd573',
-          host_count: 1,
+          host_count: 2,
         },
         {
           bootc_booted_digest: 'sha256:54256a998f0c62e16f3927c82b570f90bd8449a52e03daabd5fd16d6419fd574',
-          host_count: 1,
+          host_count: 3,
         },
         {
           bootc_booted_digest: 'sha256:54256a998f0c62e16f3927c82b570f90bd8449a52e03daabd5fd16d6419fd575',
-          host_count: 1,
+          host_count: 4,
         },
       ],
     },
@@ -32,7 +32,7 @@ const bootedContainerImagesResponse = Immutable({
       digests: [
         {
           bootc_booted_digest: 'sha256:54256a998f0c62e16f3927c82b570f90bd8449a52e03daabd5fd16d6419fd576',
-          host_count: 1,
+          host_count: 6,
         },
       ],
     },

--- a/webpack/scenes/BootedContainerImages/__tests__/bootedContainerImagesPage.test.js
+++ b/webpack/scenes/BootedContainerImages/__tests__/bootedContainerImagesPage.test.js
@@ -1,27 +1,61 @@
 import React from 'react';
 import { renderWithRedux, patientlyWaitFor, act } from 'react-testing-lib-wrapper';
 import { nockInstance, assertNockRequest, mockAutocomplete } from '../../../test-utils/nockWrapper';
-import api from '../../../services/api';
-import BOOTED_CONTAINER_IMAGES_KEY from '../BootedContainerImagesConstants';
 import BootedContainerImagesPage from '../BootedContainerImagesPage';
 import bootcImagesData from './bootedContainerImages.fixtures';
 
-// const bootedContainerImagesIndexPath = api.getApiUrl('/booted_container_images');
-// const renderOptions = { apiNamespace: BOOTED_CONTAINER_IMAGES_KEY };
 const bootcImagesUrl = '/api/v2/hosts/bootc_images';
 const autocompleteUrl = '/host_bootc_images/auto_complete_search';
 const autocompleteQuery = {
   search: '',
 };
 
-let firstImage;
-let secondImage;
-beforeEach(() => {
-  const { results } = bootcImagesData;
-  [firstImage, secondImage] = results;
+const buildBootedImage = id => ({
+  bootc_booted_image: `quay.io/centos-bootc/centos-bootc:stream${id}`,
+  digests: [
+    {
+      bootc_booted_digest: `sha256:54256a998f0c62e16f3927c82b570f90bd8449a52e03daabd5fd16d6419fd57${id}`,
+      host_count: 1,
+    },
+  ],
 });
 
-test('BootedContainerImagesPage renders correctly', async (done) => {
+const createBootedImages = (amount) => {
+  const response = {
+    total: amount,
+    subtotal: amount,
+    page: 1,
+    per_page: 20,
+    error: null,
+    search: null,
+    sort: {
+      by: 'bootc_booted_image',
+      order: 'asc',
+    },
+    results: [],
+  };
+
+  [...Array(amount).keys()].forEach((_, i) => response.results.push(buildBootedImage(i + 1)));
+
+  return response;
+};
+
+let centos10Image;
+let centos9Image;
+let stream10Digest1;
+let stream10Digest2;
+let stream10Digest3;
+let stream10Digest4;
+let stream9Digest;
+beforeEach(() => {
+  const { results } = bootcImagesData;
+  [centos10Image, centos9Image] = results;
+  [stream10Digest1, stream10Digest2, stream10Digest3, stream10Digest4] =
+    centos10Image.digests.map(digest => digest.bootc_booted_digest);
+  stream9Digest = centos9Image.digests[0].bootc_booted_digest;
+});
+
+test('BootedContainerImagesPage renders correctly expanded', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl, autocompleteQuery);
   const scope = nockInstance
     .get(bootcImagesUrl)
@@ -30,14 +64,170 @@ test('BootedContainerImagesPage renders correctly', async (done) => {
     .times(2)
     .reply(200, bootcImagesData);
 
-  const { queryByText, queryAllByText } = renderWithRedux(<BootedContainerImagesPage />);
-  expect(queryByText(firstImage.bootc_booted_image)).toBeNull();
+  const {
+    queryByText, queryAllByText, queryAllByRole,
+  } = renderWithRedux(<BootedContainerImagesPage />);
+
+  expect(queryByText(centos10Image.bootc_booted_image)).toBeNull();
 
   await patientlyWaitFor(() => {
-    expect(queryByText(firstImage.bootc_booted_image)).toBeInTheDocument();
+    // Expand the rows
+    queryAllByRole('button').find(btn => btn.getAttribute('aria-labelledby') ===
+      'simple-node1 booted-containers-expander-quay.io/centos-bootc/centos-bootc:stream91').click();
+    queryAllByRole('button').find(btn => btn.getAttribute('aria-labelledby') ===
+      'simple-node0 booted-containers-expander-quay.io/centos-bootc/centos-bootc:stream100').click();
+
+    // Check that the digest host count links appear
+    expect(queryAllByText('1').find(link => String(link.getAttribute('href')).includes(stream10Digest1))).toBeVisible();
+    expect(queryAllByText('2').find(link => String(link.getAttribute('href')).includes(stream10Digest2))).toBeVisible();
+    expect(queryAllByText('3').find(link => String(link.getAttribute('href')).includes(stream10Digest3))).toBeVisible();
+    expect(queryAllByText('4').find(link => String(link.getAttribute('href')).includes(stream10Digest4))).toBeVisible();
+    expect(queryAllByText('6').find(link => String(link.getAttribute('href')).includes(stream9Digest))).toBeVisible();
+
+    // Check that the image host count links appear
+    const links = queryAllByRole('link');
+    const stream10Link = links.find(link => link.getAttribute('href') === `/new/hosts?search=bootc_booted_image%20=%20${centos10Image.bootc_booted_image}`);
+    const stream9Link = links.find(link => link.getAttribute('href') === `/new/hosts?search=bootc_booted_image%20=%20${centos9Image.bootc_booted_image}`);
+    expect(stream10Link).toBeVisible();
+    expect(stream9Link).toBeVisible();
+
+    // Check that the image names appear
+    expect(queryByText(centos10Image.bootc_booted_image)).toBeVisible();
+    expect(queryByText(centos9Image.bootc_booted_image)).toBeVisible();
+
+    // Check that the digest counts appear
+    // console.log(queryAllByText('4')[0].closest('td'));
+    expect(queryAllByText('4')[0].closest('td')).toBeVisible();
+    expect(queryAllByText('1')[1].closest('td')).toBeVisible();
+
+    // Check that the digest names appear
+    expect(queryByText(stream10Digest1).closest('td')).toBeVisible();
+    expect(queryByText(stream10Digest2).closest('td')).toBeVisible();
+    expect(queryByText(stream10Digest3).closest('td')).toBeVisible();
+    expect(queryByText(stream10Digest4).closest('td')).toBeVisible();
+    expect(queryByText(stream9Digest).closest('td')).toBeVisible();
   });
 
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope, done);
+  act(done);
+});
+
+test('BootedContainerImagesPage renders correctly unexpanded', async (done) => {
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl, autocompleteQuery);
+  const scope = nockInstance
+    .get(bootcImagesUrl)
+    .query(true)
+    // Why does the page load twice?
+    .times(2)
+    .reply(200, bootcImagesData);
+
+  const {
+    queryByText, queryAllByText, queryAllByRole,
+  } = renderWithRedux(<BootedContainerImagesPage />);
+
+  expect(queryByText(centos10Image.bootc_booted_image)).toBeNull();
+
+  await patientlyWaitFor(() => {
+    // Check that the digest host count links don't appear
+    expect(queryAllByText('1').find(link => String(link.getAttribute('href')).includes(stream10Digest1))).not.toBeVisible();
+    expect(queryAllByText('2').find(link => String(link.getAttribute('href')).includes(stream10Digest2))).not.toBeVisible();
+    expect(queryAllByText('3').find(link => String(link.getAttribute('href')).includes(stream10Digest3))).not.toBeVisible();
+    expect(queryAllByText('4').find(link => String(link.getAttribute('href')).includes(stream10Digest4))).not.toBeVisible();
+    expect(queryAllByText('6').find(link => String(link.getAttribute('href')).includes(stream9Digest))).not.toBeVisible();
+
+    // Check that the image host count links appear
+    const links = queryAllByRole('link');
+    const stream10Link = links.find(link => link.getAttribute('href') === `/new/hosts?search=bootc_booted_image%20=%20${centos10Image.bootc_booted_image}`);
+    const stream9Link = links.find(link => link.getAttribute('href') === `/new/hosts?search=bootc_booted_image%20=%20${centos9Image.bootc_booted_image}`);
+    expect(stream10Link).toBeVisible();
+    expect(stream9Link).toBeVisible();
+
+    // Check that the image names appear
+    expect(queryByText(centos10Image.bootc_booted_image)).toBeVisible();
+    expect(queryByText(centos9Image.bootc_booted_image)).toBeVisible();
+
+    // Check that the digest counts appear
+    expect(queryAllByText('4')[0].closest('td')).toBeVisible();
+    expect(queryAllByText('1')[1].closest('td')).toBeVisible();
+
+    // Check that the digest names don't appear
+    expect(queryByText(stream10Digest1).closest('td')).not.toBeVisible();
+    expect(queryByText(stream10Digest2).closest('td')).not.toBeVisible();
+    expect(queryByText(stream10Digest3).closest('td')).not.toBeVisible();
+    expect(queryByText(stream10Digest4).closest('td')).not.toBeVisible();
+    expect(queryByText(stream9Digest).closest('td')).not.toBeVisible();
+  });
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(scope, done);
+  act(done);
+});
+
+test('Can handle no booted images being present', async (done) => {
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl, autocompleteQuery);
+  const noResults = {
+    total: 0,
+    subtotal: 0,
+    page: 1,
+    per_page: 20,
+    results: [],
+  };
+  const scope = nockInstance
+    .get(bootcImagesUrl)
+    .query(true)
+    // Why does the page load twice?
+    .times(2)
+    .reply(200, noResults);
+  const { queryByText } = renderWithRedux(<BootedContainerImagesPage />);
+
+  expect(queryByText(centos10Image.bootc_booted_image)).toBeNull();
+  await patientlyWaitFor(() => expect(queryByText('No Results')).toBeInTheDocument());
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(scope, done);
+});
+
+test('Can handle pagination', async (done) => {
+  const largeBootcData = createBootedImages(100);
+  const { results } = largeBootcData;
+  const bootcFirstPage = { ...largeBootcData, ...{ results: results.slice(0, 20) } };
+  const bootcSecondPage = { ...largeBootcData, page: 2, results: results.slice(20, 40) };
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl, autocompleteQuery);
+
+  // Match first page API request
+  const firstPageScope = nockInstance
+    .get(bootcImagesUrl)
+    .query(true)
+    .times(2)
+    .reply(200, bootcFirstPage);
+
+  // Match second page API request
+  const secondPageScope = nockInstance
+    .get(bootcImagesUrl)
+    // Using a custom query params matcher because parameters can be strings
+    .query(actualQueryObject => (parseInt(actualQueryObject.page, 10) === 2))
+    .reply(200, bootcSecondPage);
+  const { queryByText, getAllByLabelText } = renderWithRedux(<BootedContainerImagesPage />);
+  // Wait for first paginated page to load and assert only the first page of results are present
+  await patientlyWaitFor(() => {
+    expect(queryByText(results[0].bootc_booted_image)).toBeInTheDocument();
+    expect(queryByText(results[19].bootc_booted_image)).toBeInTheDocument();
+    expect(queryByText(results[21].bootc_booted_image)).not.toBeInTheDocument();
+  });
+
+  // Label comes from patternfly, if this test fails, check if patternfly updated the label.
+  const [top, bottom] = getAllByLabelText('Go to next page');
+  expect(top).toBeInTheDocument();
+  expect(bottom).toBeInTheDocument();
+  bottom.click();
+  // Wait for second paginated page to load and assert only the second page of results are present
+  await patientlyWaitFor(() => {
+    expect(queryByText(results[20].bootc_booted_image)).toBeInTheDocument();
+    expect(queryByText(results[39].bootc_booted_image)).toBeInTheDocument();
+    expect(queryByText(results[41].bootc_booted_image)).not.toBeInTheDocument();
+  });
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(firstPageScope);
+  assertNockRequest(secondPageScope, done);
   act(done);
 });

--- a/webpack/scenes/BootedContainerImages/__tests__/bootedContainerImagesPage.test.js
+++ b/webpack/scenes/BootedContainerImages/__tests__/bootedContainerImagesPage.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { renderWithRedux, patientlyWaitFor, act } from 'react-testing-lib-wrapper';
+import { nockInstance, assertNockRequest, mockAutocomplete } from '../../../test-utils/nockWrapper';
+import api from '../../../services/api';
+import BOOTED_CONTAINER_IMAGES_KEY from '../BootedContainerImagesConstants';
+import BootedContainerImagesPage from '../BootedContainerImagesPage';
+import bootcImagesData from './bootedContainerImages.fixtures';
+
+// const bootedContainerImagesIndexPath = api.getApiUrl('/booted_container_images');
+// const renderOptions = { apiNamespace: BOOTED_CONTAINER_IMAGES_KEY };
+const bootcImagesUrl = '/api/v2/hosts/bootc_images';
+const autocompleteUrl = '/host_bootc_images/auto_complete_search';
+const autocompleteQuery = {
+  search: '',
+};
+
+let firstImage;
+let secondImage;
+beforeEach(() => {
+  const { results } = bootcImagesData;
+  [firstImage, secondImage] = results;
+});
+
+test('BootedContainerImagesPage renders correctly', async (done) => {
+  const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl, autocompleteQuery);
+  const scope = nockInstance
+    .get(bootcImagesUrl)
+    .query(true)
+    // Why does the page load twice?
+    .times(2)
+    .reply(200, bootcImagesData);
+
+  const { queryByText, queryAllByText } = renderWithRedux(<BootedContainerImagesPage />);
+  expect(queryByText(firstImage.bootc_booted_image)).toBeNull();
+
+  await patientlyWaitFor(() => {
+    expect(queryByText(firstImage.bootc_booted_image)).toBeInTheDocument();
+  });
+
+  assertNockRequest(autocompleteScope);
+  assertNockRequest(scope, done);
+  act(done);
+});

--- a/webpack/scenes/BootedContainerImages/index.js
+++ b/webpack/scenes/BootedContainerImages/index.js
@@ -1,0 +1,4 @@
+import { withRouter } from 'react-router-dom';
+import BootedContainerImagesPage from './BootedContainerImagesPage';
+
+export default withRouter(BootedContainerImagesPage);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds the "Booted container images" page. In the future it'll likely change to be the "Containers" page and merge with the new container images UI.

Within the page, there is a table that shows an overview of booted container images used by bootc hosts. The table shows the image name, number of digests within, and the number of hosts using that container image:

![image](https://github.com/user-attachments/assets/e1a6ec2e-6374-4624-8d47-6350832a01b4)

The last functionality-TODO is to make the rows expand and show the actual digests within. I also need to write tests.

#### Considerations taken when implementing this change?
I decided to use the newer TableIndexPage from Foreman since it's the new goodness.

This PR is built on top of https://github.com/Katello/katello/pull/11257.

#### What are the testing steps for this pull request?
1) Create hosts that have bootc attributes, ideally enough to test the counting and pagination
2) Try everything the new page has to offer, including the hyperlinks