### PR TITLE
Fixes #38137 - Do not double-escape * during package update

### DIFF
--- a/app/views/foreman/job_templates/update_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/update_packages_by_search_query_-_katello_ansible_default.erb
@@ -22,7 +22,7 @@ template_inputs:
   versions: input('Selected update versions')
 ) -%>
 <% if package_names.empty? -%>
-<%= render_template('Package Action - Ansible Default', :state => 'latest', :name => '"*"') %>
+<%= render_template('Package Action - Ansible Default', :state => 'latest', :name => '*') %>
 <% else -%>
 ---
 - hosts: all


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Update the "Update packages by search query - Katello Ansible Default" template to pass a simple `*` instead of `"*"` to the upstream "Package Action - Ansible Default" template. This makes it possible to upgrade all packages via Ansible using Katello 4.14 (and other versions). 

The current template is erroring out:

```
fatal: [test-vm-01.example.org]: FAILED! => {"changed": false, "failures": ["No package \"*\" available."], "msg": "Failed to install some of the specified packages", "rc": 1, "results": []}
```

#### Considerations taken when implementing this change?

* I tried to fix this as early as possible in the template call tree, to keep the change as minimal as possible.
* The change has been working well on my production for a while. Most likely other users have heavier customizations to the scripts.

#### What are the testing steps for this pull request?

1. Configure Foreman/Katello to use Ansible for all actions
2. Select all upgradable packages for a host in the UI, and "Upgrade" all the packages through REX
3. It updates all packages and doesn't fail