### PR TITLE
Fixes #38128 - allow blank image mode digests

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -59,7 +59,7 @@ module Katello
       validates_associated :content_view_environment_content_facets, :message => _("invalid: The content source must sync the lifecycle environment assigned to the host. See the logs for more information.")
       validates :host, :presence => true, :allow_blank => false
       validates :bootc_booted_digest, :bootc_available_digest, :bootc_staged_digest, :bootc_rollback_digest,
-                format: { with: /\Asha256:[A-Fa-f0-9]{64}\z/, message: "must be a valid sha256 digest", allow_nil: true }
+                format: { with: /\Asha256:[A-Fa-f0-9]{64}\z/, message: "must be a valid sha256 digest", allow_blank: true }
 
       scope :with_environments, ->(lifecycle_environments) do
         joins(:content_view_environment_content_facets => :content_view_environment).

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -70,6 +70,13 @@ module Katello
       assert_includes ::Host.search_for('pools_expiring_in_days = 30'), host_with_pool
     end
 
+    def test_bootc_allow_blank
+      Support::HostSupport.attach_content_facet(@foreman_host, @view, @library)
+      @foreman_host.content_facet.update(bootc_booted_image: 'quay.io/salami/soup')
+      @foreman_host.content_facet.update(bootc_booted_digest: '')
+      assert @foreman_host.content_facet.image_mode_host?
+    end
+
     def test_image_mode_search
       host_no_image = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @library_view, :lifecycle_environment => @library)
       Support::HostSupport.attach_content_facet(@foreman_host, @view, @library)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Allows blank digests to support the format of `bootc internals publish-rhsm-facts`:

```
{
  "bootc.booted.image": "quay.io/centos-bootc/centos-bootc:stream10",
  "bootc.booted.version": "stream10.20241230.0",
  "bootc.booted.digest": "sha256:48884b0220bb075ce50ae31d8e6739f3e9b3870e746a4b3c87ea2fe3353b7208",
  "bootc.staged.image": "",
  "bootc.staged.version": "",
  "bootc.staged.digest": "",
  "bootc.rollback.image": "quay.io/centos-bootc/centos-bootc:stream10",
  "bootc.rollback.version": "stream10.20241216.0",
  "bootc.rollback.digest": "sha256:e168d2f013ed4cc89771d2c5d1b15951ae09792ed3d647226f48e5b62316d7fb",
  "bootc.available.image": "",
  "bootc.available.version": "",
  "bootc.available.digest": ""
}
```

#### Considerations taken when implementing this change?
Our UI appears to be checking for empty string properly as opposed to null.

#### What are the testing steps for this pull request?
Register a bootc host with a /etc/rhsm/facts/bootc.facts file  that looks like what's above.