### PR TITLE
Fixes #38140 - Defer rebooting to "Power Action - Ansible Default" job

### DIFF
--- a/app/views/foreman/job_templates/resolve_traces_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/resolve_traces_-_katello_ansible_default.erb
@@ -18,7 +18,7 @@ commands = @host.traces_helpers(search: input('Traces search query'))
 reboot = commands.delete('reboot')
 -%>
 <% if reboot -%>
-    - reboot:
+<%= render_template('Power Action - Ansible Default', action: 'restart') %>
 <% else -%>
 <%= render_template(
     'Run Command - Ansible Default',


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This defers the implementation of the reboot action to the "Power Action - Ansible Default" job template.

The current implementation exhibits the following bug on EL9:

```
ERROR! 'reboot' is not a valid attribute for a Play
The error appears to be in '/tmp/d20250115-157201-nu0y9u/project/playbook.yml': line 1, column 7, but may
be elsewhere in the file depending on the exact syntax problem.
The offending line appears to be:
- reboot:
^ here
```

#### Considerations taken when implementing this change?

* I chose to use a `render_template` call so the code aligns with the rest of the existing template
* The other template used in the job is "Run Command - Ansible Default", i picked "Power Action - Ansible Default" because it seems to match
 
#### What are the testing steps for this pull request?

* Configure Foreman/Katello to use Ansible for all actions
* Install  tracer on a host, apply an Errata that needs a reboot
* Schedule the reboot with the "Reboot host" button and watch the host reboot
