### PR TITLE
Refs #38127 - Add sort options to host bootc_images endpoint

### DIFF
--- a/app/controllers/katello/api/v2/host_bootc_images_controller.rb
+++ b/app/controllers/katello/api/v2/host_bootc_images_controller.rb
@@ -23,7 +23,17 @@ module Katello
       bootc_image_map = bootc_host_image_map
       paged_images = bootc_image_map.to_a.paginate(page: page, per_page: per_page)
       results = paged_images.collect { |image| { bootc_booted_image: image[0], digests: image[1] } }
-      render json: { total: bootc_image_map.size, page: page, per_page: per_page, subtotal: bootc_image_map.size, results: results}
+      render json: {
+        total: bootc_image_map.size,
+        page: page,
+        per_page: per_page,
+        subtotal: bootc_image_map.size,
+        sort: {
+          by: params[:sort_by],
+          order: params[:sort_order],
+        },
+        results: results,
+      }
     end
 
     private


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add sort options to host bootc_images endpoint

Related to https://github.com/Katello/hammer-cli-katello/pull/980.

#### Considerations taken when implementing this change?
`sort` options are required [here](https://github.com/theforeman/hammer-cli-foreman/blob/fd288fef6823b3d137ddf641a35992fba7da25ac/lib/hammer_cli_foreman/commands.rb#L47).

#### What are the testing steps for this pull request?
`hammer host bootc images`  should work without any error.