### PR TITLE
Fixes #38143 - Add hint to error message about MultiCV

### DIFF
--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -92,7 +92,7 @@ module Katello
     def content_view_environments=(new_cves)
       if new_cves.length > 1 && !Setting['allow_multiple_content_views']
         fail ::Katello::Errors::MultiEnvironmentNotSupportedError,
-        _("Assigning an activation key to multiple content view environments is not enabled.")
+        _("Assigning an activation key to multiple content view environments is not enabled. To enable, set the allow_multiple_content_views setting.")
       end
       super(new_cves)
       Katello::ContentViewEnvironmentActivationKey.reprioritize_for_activation_key(self, new_cves)

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -136,7 +136,7 @@ module Katello
       def content_view_environments=(new_cves)
         if new_cves.length > 1 && !Setting['allow_multiple_content_views']
           fail ::Katello::Errors::MultiEnvironmentNotSupportedError,
-          _("Assigning a host to multiple content view environments is not enabled.")
+          _("Assigning a host to multiple content view environments is not enabled. To enable, set the allow_multiple_content_views setting.")
         end
         super(new_cves)
         Katello::ContentViewEnvironmentContentFacet.reprioritize_for_content_facet(self, new_cves)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add a hint to the error message we display when you try to assign multiple CVEs to a host or AK

#### Considerations taken when implementing this change?

this was requested by QE and was super easy to add so why not

#### What are the testing steps for this pull request?

Try updating an AK or host with multiple content view environments, with the allow_multiple_content_views Setting turned off.
