### PR TITLE
Fixes #38142 - Add MultiCV methods to jail for hosts and activation keys reporting

### DIFF
--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -290,7 +290,7 @@ module Katello
       property :name, String, desc: 'Returns the name of the Activation Key.'
     end
     class Jail < ::Safemode::Jail
-      allow :name
+      allow :name, :content_view_environment_labels, :multi_content_view_environment?
     end
   end
 end

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -89,7 +89,7 @@ module Katello
         prepend Overrides
 
         delegate :content_source_id, :single_content_view, :single_lifecycle_environment, :default_environment?, :single_content_view_environment?, :multi_content_view_environment?, :kickstart_repository_id, :bound_repositories,
-          :installable_errata, :installable_rpms, :image_mode_host?, to: :content_facet, allow_nil: true
+          :content_view_environment_labels, :installable_errata, :installable_rpms, :image_mode_host?, to: :content_facet, allow_nil: true
 
         delegate :release_version, :purpose_role, :purpose_usage, to: :subscription_facet, allow_nil: true
 
@@ -623,8 +623,8 @@ class ::Host::Managed::Jail < Safemode::Jail
         :host_collections, :pools, :hypervisor_host, :installed_debs,
         :installed_packages, :traces_helpers, :advisory_ids, :package_names_for_job_template,
         :filtered_entitlement_quantity_consumed, :bound_repositories,
-        :single_content_view, :single_lifecycle_environment, :release_version,
-        :purpose_role, :purpose_usage
+        :single_content_view, :single_lifecycle_environment, :content_view_environment_labels, :multi_content_view_environment?,
+        :release_version, :purpose_role, :purpose_usage
 end
 
 class ActiveRecord::Associations::CollectionProxy::Jail < Safemode::Jail

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -453,7 +453,7 @@ module Katello
               :errata_counts, :id, :kickstart_repository, :kickstart_repository_id, :kickstart_repository_name,
               :upgradable_deb_count, :upgradable_module_stream_count, :upgradable_rpm_count, :uuid,
               :installable_security_errata_count, :installable_bugfix_errata_count, :installable_enhancement_errata_count,
-              :single_content_view, :single_lifecycle_environment
+              :single_content_view, :single_lifecycle_environment, :content_view_environment_labels
       end
     end
   end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

With the MultiCV feature now available, the Host - Installed Products report now must handle multiple content view environments instead of just a single content view and lifecycle environment. This makes that possible, and also adds a few more methods to Jail that may be of use.

Goes with https://github.com/theforeman/foreman/pull/10417

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Test together with the Foreman PR; see instructions there
