### PR TITLE
Fixes #38147 - correctly find org on FakeActivationKey

### DIFF
--- a/app/lib/katello/util/cveak_migrator.rb
+++ b/app/lib/katello/util/cveak_migrator.rb
@@ -27,8 +27,9 @@ module Katello
           Rails.logger.info "You may want to change the content view / lifecycle environment for these activation keys manually."
         end
         (aks_with_no_cve + aks_with_missing_cve).each do |ak|
-          default_content_view = ak.organization.default_content_view
-          library = ak.organization.library
+          ak_organization = ::Organization.find_by(id: ak.organization_id)
+          default_content_view = ak_organization.default_content_view
+          library = ak_organization.library
           Rails.logger.info "Updating activation key #{ak.name} with default content_view_id and lifecycle_environment_id"
           ak&.update_columns(content_view_id: default_content_view&.id, environment_id: library&.id)
         end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

In CVEAKMigrator we create FakeActivationKeys and then try to use the `.organization` method on them, which results in an error

```
2025-01-14 20:23:33 [INFO  ] [configure] /Stage[main]/Foreman::Database/Foreman::Rake[db:migrate]/Exec[foreman-rake-db:migrate]/returns: undefined method `organization' for #<Katello::Util::FakeActivationKey id: 8, name: "Red Hat
Enterprise Linux", description: nil, organization_id: 1, environment_id: 4, created_at: "2023-08-22 21:10:28.552603000 +0000", updated_at: "2023-08-22 21:27:43.731203000 +0000", user_id: 5, max_hosts: nil, content_view_id: nil, cp
```

https://community.theforeman.org/t/issue-when-upgrading-to-3-13-and-the-fix/42026

This should prevent that error.

#### Considerations taken when implementing this change?

I suppose it's possible the organization referenced by the AK could have disappeared, and this won't fix that.

#### What are the testing steps for this pull request?

not really sure. I guess you'd have to down-migrate to before AK MultiCV
Then make sure you have at least one AK with a CV ID and LCE ID that does NOT correspond to a real ContentViewEnvironment (e.g. that content view has not been promoted to that lifecycle environment)

Then try CVEAKMigrator.new.execute! in the console and make sure that codepath runs. 

Alternatively, what I did to reproduce is, in the console

```
class FakeActivationKey < ApplicationRecord
    self.table_name = 'katello_activation_keys'
end

> FakeActivationKey.all.first.organization
NoMethodError: undefined method `organization' for #<FakeActivationKey id: 1, name: "ak1", description: nil, organization_id: 1, created_at: "2025-01-13 14:38:29.042717000 +0000", updated_at: "2025-01-13 14:38:29.309252000 +0000", user_id: 4, max_hosts: nil, cp_id: "4028fae3945ff2a80194601a138b0005", release_version: nil, unlimited_hosts: true, auto_attach: true, purpose_role: nil, purpose_usage: nil>
```

