### PR TITLE
Fixes #38152 - Update lifecycle status to allow for empty support

### DIFF
--- a/app/models/katello/rhel_lifecycle_status.rb
+++ b/app/models/katello/rhel_lifecycle_status.rb
@@ -13,6 +13,9 @@ module Katello
     end
 
     RHEL_EOS_SCHEDULE = { # dates that each support category ends
+      'RHEL10' => {
+        'full_support' => nil,
+      },
       'RHEL9' => {
         'full_support' => end_of_day('2027-05-31'),
         'maintenance_support' => end_of_day('2032-05-31'),
@@ -74,6 +77,7 @@ module Katello
 
     def self.lifecycles_expire_soon
       expiring = RHEL_EOS_SCHEDULE.collect do |index, schedules|
+        next if schedules['full_support'].blank?
         expire_soon = schedules.except("full_support").select { |_k, v| (Time.now.utc..Time.now.utc + EOS_WARNING_THRESHOLD).cover?(v) }
         {index => expire_soon} if expire_soon.present?
       end
@@ -98,6 +102,8 @@ module Katello
       extended_support_end_date = RHEL_EOS_SCHEDULE[release]['extended_support']
 
       case
+      when full_support_end_date.blank?
+        return FULL_SUPPORT
       when Date.today <= full_support_end_date
         return FULL_SUPPORT
       when Date.today <= maintenance_support_end_date


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Modified the model to show full support if full_support is blank, this will help when we have to go and add RHEL 11 in the future
* Added a placeholder in for RHEL 10 so we can fill that in once we get the info from the BU
* Wrote a unit test to test the empty value of full support.

#### Considerations taken when implementing this change?
* Since we don't know the lifecycle status currently with RHEL 10 we modified the model to allow for empty values.

#### What are the testing steps for this pull request?

* Checkout PR
* Register a RHEL 10 host and check to see if the lifecycle status shows full support
