### PR TITLE
Fixes #38116 - Handle version removal for multi-CV hosts

### DIFF
--- a/app/lib/actions/katello/content_view_environment/reassign_objects.rb
+++ b/app/lib/actions/katello/content_view_environment/reassign_objects.rb
@@ -5,7 +5,12 @@ module Actions
         def plan(content_view_environment, options)
           concurrence do
             content_view_environment.hosts.each do |host|
-              plan_action(Host::Reassign, host, options[:system_content_view_id], options[:system_environment_id])
+              content_facet_attributes = host.content_facet
+              if content_facet_attributes.multi_content_view_environment?
+                content_facet_attributes.content_view_environments -= [content_view_environment]
+              else
+                plan_action(Host::Reassign, host, options[:system_content_view_id], options[:system_environment_id])
+              end
             end
 
             content_view_environment.activation_keys.each do |key|

--- a/app/views/katello/api/v2/content_view_versions/base.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/base.json.rabl
@@ -46,6 +46,10 @@ node :permissions do |cvv|
   }
 end
 
+child :content_view_environments => :content_view_environments do
+  attributes :label, :environment_id, :environment_name
+end
+
 extends 'katello/api/v2/common/timestamps'
 
 version = @object || @resource

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVVersionRemoveReview.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVVersionRemoveReview.js
@@ -2,27 +2,38 @@ import React, { useContext, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Alert, Flex, FlexItem, Label, AlertActionCloseButton } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { FormattedMessage } from 'react-intl';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { selectCVActivationKeys, selectCVHosts } from '../../../ContentViewDetailSelectors';
+import { selectCVActivationKeys, selectCVHosts, selectCVVersions } from '../../../ContentViewDetailSelectors';
 import DeleteContext from '../DeleteContext';
-import { pluralize } from '../../../../../../utils/helpers';
 import WizardHeader from '../../../../components/WizardHeader';
 
 const CVVersionRemoveReview = () => {
   const [alertDismissed, setAlertDismissed] = useState(false);
   const {
-    cvId, versionNameToRemove, versionEnvironments, selectedEnvSet,
+    cvId, versionIdToRemove, versionNameToRemove, selectedEnvSet,
     selectedEnvForAK, selectedCVNameForAK, selectedCVNameForHosts,
     selectedEnvForHost, affectedActivationKeys, affectedHosts, deleteFlow, removeDeletionFlow,
   } = useContext(DeleteContext);
   const activationKeysResponse = useSelector(state => selectCVActivationKeys(state, cvId));
   const hostsResponse = useSelector(state => selectCVHosts(state, cvId));
-  const { results: hostResponse } = hostsResponse;
+  const { results: hostResponse = [] } = hostsResponse || {};
   const { results: akResponse = [] } = activationKeysResponse || {};
-  const selectedEnv = versionEnvironments.filter(env => selectedEnvSet.has(env.id));
+  const cvVersions = useSelector(state => selectCVVersions(state, cvId));
   const versionDeleteInfo = __(`Version ${versionNameToRemove} will be deleted from all environments. It will no longer be available for promotion.`);
   const removalNotice = __(`Version ${versionNameToRemove} will be removed from the environments listed below, and will remain available for later promotion. ` +
     'Changes listed below will be effective after clicking Remove.');
+
+  const matchedCVResults = cvVersions?.results?.filter(cv => cv.id === versionIdToRemove) || [];
+  const selectedCVE = matchedCVResults
+    .flatMap(cv => cv.content_view_environments || [])
+    .filter(env => selectedEnvSet.has(env.environment_id));
+
+  const multiCVHosts = hostResponse?.filter(host =>
+    host.content_facet_attributes?.multi_content_view_environment) || [];
+  const multiCVHostsCount = multiCVHosts.length;
+
+  const singleCVHostsCount = (hostResponse?.length || 0) - multiCVHostsCount;
 
   const multiCVActivationKeys = akResponse.filter(key => key.multi_content_view_environment);
   const multiCVActivationKeysCount = multiCVActivationKeys.length;
@@ -43,7 +54,7 @@ const CVVersionRemoveReview = () => {
           <p style={{ marginBottom: '0.5em' }}>{versionDeleteInfo}</p>
         </Alert>}
       {!(deleteFlow || removeDeletionFlow) && <WizardHeader description={removalNotice} />}
-      {(selectedEnv.length !== 0) &&
+      {(selectedCVE?.length !== 0) &&
         <>
           <h3>{__('Environments')}</h3>
           <Flex>
@@ -51,18 +62,65 @@ const CVVersionRemoveReview = () => {
             <FlexItem style={{ marginBottom: '0.5em' }}>{__('This version will be removed from:')}</FlexItem>
           </Flex>
           <Flex>
-            {selectedEnv?.map(({ name, id }) =>
+            {selectedCVE?.map(({ environment_name: name, environment_id: id }) =>
               <FlexItem key={name}><Label isTruncated color="purple" href={`/lifecycle_environments/${id}`}>{name}</Label></FlexItem>)}
           </Flex>
         </>}
       {affectedHosts &&
         <>
           <h3>{__('Content hosts')}</h3>
-          <Flex>
-            <FlexItem><ExclamationTriangleIcon /></FlexItem>
-            <FlexItem><p>{__(`${pluralize(hostResponse.length, 'host')} will be moved to content view ${selectedCVNameForHosts} in `)}</p></FlexItem>
-            <FlexItem><Label isTruncated color="purple" href={`/lifecycle_environments/${selectedEnvForHost[0].id}`}>{selectedEnvForHost[0].name}</Label></FlexItem>
-          </Flex>
+          {singleCVHostsCount > 0 && (
+            <Flex>
+              <FlexItem><ExclamationTriangleIcon /></FlexItem>
+              <FlexItem data-testid="single-cv-hosts-remove">
+                <FormattedMessage
+                  id="single-cv-hosts-remove"
+                  defaultMessage="{count, plural, one {# {singular}} other {# {plural}}} will be moved to content view {cvName} in {envName}."
+                  values={{
+                    count: singleCVHostsCount,
+                    singular: __('host'),
+                    plural: __('hosts'),
+                    cvName: selectedCVNameForHosts,
+                    envName: selectedEnvForHost[0] && (
+                      <Label isTruncated color="purple" href={`/lifecycle_environments/${selectedEnvForHost[0].id}`}>
+                        {selectedEnvForHost[0].name}
+                      </Label>
+                    ),
+                  }}
+                />
+              </FlexItem>
+            </Flex>
+          )}
+          {multiCVHostsCount > 0 && (
+            <Flex>
+              <FlexItem><ExclamationTriangleIcon /></FlexItem>
+              <FlexItem>
+                <FormattedMessage
+                  id="multi-cv-hosts-remove"
+                  defaultMessage="{envSingularOrPlural} {envCV} will be removed from {hostCount, plural, one {# {hostSingular}} other {# {hostPlural}}}."
+                  values={{
+                    envSingularOrPlural: (
+                      <FormattedMessage
+                        id="environment.plural"
+                        defaultMessage="{count, plural, one {{envSingular}} other {{envPlural}}}"
+                        values={{
+                          count: selectedCVE?.length,
+                          envSingular: __('Content view environment'),
+                          envPlural: __('Content view environments'),
+                        }}
+                      />
+                    ),
+                    envCV: selectedCVE
+                      ?.map(cve => cve.label)
+                      .join(', '),
+                    hostCount: multiCVHostsCount,
+                    hostSingular: __('multi-environment host'),
+                    hostPlural: __('multi-environment hosts'),
+                  }}
+                />
+              </FlexItem>
+            </Flex>
+          )}
         </>}
       {affectedActivationKeys &&
         <>
@@ -70,17 +128,52 @@ const CVVersionRemoveReview = () => {
           {singleCVActivationKeysCount > 0 && (
             <Flex>
               <FlexItem><ExclamationTriangleIcon /></FlexItem>
-              <FlexItem><p>{__(`${pluralize(singleCVActivationKeysCount, 'activation key')} will be moved to content view ${selectedCVNameForAK} in `)}</p></FlexItem>
-              <FlexItem><Label isTruncated color="purple" href={`/lifecycle_environments/${selectedEnvForAK[0].id}`}>{selectedEnvForAK[0].name}</Label></FlexItem>
+              <FlexItem data-testid="single-cv-activation-keys-remove">
+                <FormattedMessage
+                  id="single-cv-activation-keys-remove"
+                  defaultMessage="{count, plural, one {# {singular}} other {# {plural}}} will be moved to content view {cvName} in {envName}."
+                  values={{
+                    count: singleCVActivationKeysCount,
+                    singular: __('activation key'),
+                    plural: __('activation keys'),
+                    cvName: selectedCVNameForAK,
+                    envName: selectedEnvForAK[0] && (
+                      <Label isTruncated color="purple" href={`/lifecycle_environments/${selectedEnvForAK[0].id}`}>
+                        {selectedEnvForAK[0].name}
+                      </Label>
+                    ),
+                  }}
+                />
+              </FlexItem>
             </Flex>
           )}
           {multiCVActivationKeysCount > 0 && (
             <Flex>
               <FlexItem><ExclamationTriangleIcon /></FlexItem>
               <FlexItem>
-                <p>
-                  {__(`Content view environment will be removed from ${pluralize(multiCVActivationKeysCount, 'multi-environment activation key')}.`)}
-                </p>
+                <FormattedMessage
+                  id="multi-cv-activation-keys-remove"
+                  defaultMessage="{envSingularOrPlural} {envCV} will be removed from {akCount, plural, one {# {keySingular}} other {# {keyPlural}}}."
+                  values={{
+                    envSingularOrPlural: (
+                      <FormattedMessage
+                        id="environment.plural"
+                        defaultMessage="{count, plural, one {{envSingular}} other {{envPlural}}}"
+                        values={{
+                          count: selectedCVE?.length,
+                          envSingular: __('Content view environment'),
+                          envPlural: __('Content view environments'),
+                        }}
+                      />
+                    ),
+                    envCV: selectedCVE
+                      ?.map(cve => cve.label)
+                      .join(', '),
+                    akCount: multiCVActivationKeysCount,
+                    keySingular: __('multi-environment activation key'),
+                    keyPlural: __('multi-environment activation keys'),
+                  }}
+                />
               </FlexItem>
             </Flex>
           )}

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/__tests__/cvVersionRemove.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/__tests__/cvVersionRemove.test.js
@@ -152,7 +152,8 @@ test('Can open Remove wizard and remove version from environment with hosts', as
 
 
   const {
-    getByText, getAllByText, getByLabelText, getAllByLabelText, queryByText, getByPlaceholderText,
+    getByText, getAllByText, getByLabelText, getAllByLabelText, queryByText,
+    getByPlaceholderText, getByTestId,
   } = renderWithRedux(
     <ContentViewVersions cvId={2} details={cvDetailData} />,
     renderOptions,
@@ -192,7 +193,7 @@ test('Can open Remove wizard and remove version from environment with hosts', as
   fireEvent.click(getByText('Next'));
   await patientlyWaitFor(() => {
     expect(getByText('Review details')).toBeInTheDocument();
-    expect(getByText('1 host will be moved to content view cv2 in')).toBeInTheDocument();
+    expect(getByTestId('single-cv-hosts-remove')).toBeInTheDocument();
   });
   fireEvent.click(getAllByText('Remove')[0]);
   assertNockRequest(scope);
@@ -238,7 +239,8 @@ test('Can open Remove wizard and remove version from environment with activation
 
 
   const {
-    getByText, getAllByText, getByLabelText, getAllByLabelText, queryByText, getByPlaceholderText,
+    getByText, getAllByText, getByLabelText, getAllByLabelText, queryByText,
+    getByPlaceholderText, getByTestId,
   } = renderWithRedux(
     <ContentViewVersions cvId={2} details={cvDetailData} />,
     renderOptions,
@@ -278,7 +280,7 @@ test('Can open Remove wizard and remove version from environment with activation
   fireEvent.click(getByText('Next'));
   await patientlyWaitFor(() => {
     expect(getByText('Review details')).toBeInTheDocument();
-    expect(getByText('1 activation key will be moved to content view cv2 in')).toBeInTheDocument();
+    expect(getByTestId('single-cv-activation-keys-remove')).toBeInTheDocument();
   });
   fireEvent.click(getAllByText('Remove')[0]);
 

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/affectedHosts.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/affectedHosts.js
@@ -30,6 +30,7 @@ const AffectedHosts = ({
   const columnHeaders = [
     __('Name'),
     __('Environment'),
+    __('Multi Content View Environment'),
   ];
   const emptyContentTitle = __('No matching hosts found.');
   const emptyContentBody = __("Given criteria doesn't match any hosts. Try changing your rule.");
@@ -63,13 +64,17 @@ const AffectedHosts = ({
         {results?.map(({
           name,
           id,
-          content_facet_attributes: { lifecycle_environment: environment },
+          content_facet_attributes: {
+            lifecycle_environment: environment,
+            multi_content_view_environment: multiContentViewEnvironment,
+          },
         }) => (
           <Tr ouiaId={id} key={id}>
             <Td>
               <a rel="noreferrer" target="_blank" href={urlBuilder(`new/hosts/${id}`, '')}>{name}</a>
             </Td>
             <Td><EnvironmentLabels environments={environment} /></Td>
+            <Td>{ multiContentViewEnvironment ? __('Yes') : __('No') }</Td>
           </Tr>
         ))
         }


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Added checks for multi-CV host associations and helper methods to handle version removal from the environment, ensuring that relevant content facets and environment links are cleaned up. This ensures that only the targeted version is removed without affecting unrelated associations or environments.

#### Considerations taken when implementing this change?

Ensured selective removal of associations for multi-CV hosts to avoid reassigning hosts linked to single CVEs or impacting unrelated environments, while preserving existing associations and removing only the targeted version from the hosts' content facets. Existing methods were reused for consistency and to minimize duplication, and checks were added to handle edge cases, such as multiple hosts linked to the same environment, to prevent unintended side effects.

#### What are the testing steps for this pull request?

Create a multi-CV activation key

1. Promote a CV Version to multiple environments
2. Using Hammer CLI, update the activation key to use mutli CVE
Example command: hammer activation-key update --organization="Default Organization" --id=1 --content-view-environments="ABC/cv1,XYZ/cv1"
3. Confirm that the activation key uses multi CVEs

Assign and register multiple hosts using the multi-CV activation key

Remove the version from the environment

1. Go to the CV associated with the activation key -> Versions
2. Click on the 3 dots of the respective CV Version and select the option "Remove from environments"
3. Follow the steps to remove the CV Version from the environment
4. A task will be created which should successfully remove the version from the environment when the CVE is in use by a multi-CV host
