### PR TITLE
Fixes #37959 - Allow optimized:false sync for ansible collections

### DIFF
--- a/app/services/katello/pulp3/repository/ansible_collection.rb
+++ b/app/services/katello/pulp3/repository/ansible_collection.rb
@@ -29,6 +29,12 @@ module Katello
           "/pulp_ansible/galaxy/#{repo.relative_path}/api/"
         end
 
+        def sync_url_params(sync_options)
+          params = super
+          params[:optimize] = sync_options[:optimize] if sync_options.key?(:optimize)
+          params
+        end
+
         def mirror_remote_options
           {
           }

--- a/test/services/katello/pulp3/repository/ansible_collection/ansible_collection_repository_mirror_test.rb
+++ b/test/services/katello/pulp3/repository/ansible_collection/ansible_collection_repository_mirror_test.rb
@@ -17,10 +17,10 @@ module Katello
         def test_sync
           @repo_mirror.stubs(:remote_href).returns("remote_href")
           @repo_mirror.stubs(:repository_href).returns("repository_href")
-          sync_url = @repo_service.api.repository_sync_url_class.new(remote: "remote_href", mirror: true)
-          PulpAnsibleClient::AnsibleRepositorySyncURL.expects(:new).with({ remote: "remote_href", mirror: true }).once.returns(sync_url)
+          sync_url = @repo_service.api.repository_sync_url_class.new(remote: "remote_href", mirror: true, optimize: true)
+          PulpAnsibleClient::AnsibleRepositorySyncURL.expects(:new).with({ remote: "remote_href", mirror: true, optimize: true }).once.returns(sync_url)
           PulpAnsibleClient::RepositoriesAnsibleApi.any_instance.expects(:sync).once.with("repository_href", sync_url)
-          @repo_mirror.sync(optimize: "test", skip_types: "another test")
+          @repo_mirror.sync(optimize: true, skip_types: "another test")
         end
 
         def test_refresh_distributions_update_dist


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Ensure Full smart proxy Sync triggers non-optimised pulp sync for ansible collections.
#### Considerations taken when implementing this change?
See: https://github.com/Katello/katello/pull/11168 for more context
Checked the ansible sync API here: https://pulpproject.org/pulp_ansible/restapi/#tag/Repositories:-Ansible/operation/repositories_ansible_ansible_sync
The optimize flag is supported here like yum, apt repos.
#### What are the testing steps for this pull request?
1. Create a collection repo
2. Sync it to a smart proxy
3. Run a complete sync on capsule.
4. Make sure pulp receives optimized:false on the proxy.