### PR TITLE
Fixes #38040 - Clear retain_version_count when mirroring policy is not additive

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -403,6 +403,13 @@ Alternatively, use the 'force' parameter to regenerate metadata locally. On the 
         end
       end
 
+      additive_policy = ::Katello::RootRepository::MIRRORING_POLICY_ADDITIVE
+      is_repo_param_additive = repo_params[:mirroring_policy] == additive_policy
+      is_root_additive = @repository.root.mirroring_policy == additive_policy
+
+      if @repository.yum? && !(is_repo_param_additive || is_root_additive)
+        repo_params[:retain_package_versions_count] = nil
+      end
       sync_task(::Actions::Katello::Repository::Update, @repository.root, repo_params)
       respond_for_show(:resource => @repository)
     end

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -337,6 +337,9 @@ module Katello
       unless yum?
         errors.add(:retain_package_versions_count, N_("is only allowed for Yum repositories."))
       end
+      if yum? && self.mirroring_policy != MIRRORING_POLICY_ADDITIVE
+        errors.add(:retain_package_versions_count, N_("cannot be set for repositories without 'Additive' mirroring policy."))
+      end
       if self.retain_package_versions_count.to_i < 0
         errors.add(:retain_package_versions_count, N_("must not be a negative value."))
       end

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -545,6 +545,7 @@ module Katello
     end
 
     def test_update_with_gpg_key
+      @repository.root.update!(mirroring_policy: Katello::RootRepository::MIRRORING_POLICY_ADDITIVE)
       key = ContentCredential.find(katello_gpg_keys('fedora_gpg_key').id)
       assert_sync_task(::Actions::Katello::Repository::Update) do |root, attributes|
         assert_equal root, @repository.root
@@ -557,6 +558,7 @@ module Katello
     end
 
     def test_update_with_cert
+      @repository.root.update!(mirroring_policy: Katello::RootRepository::MIRRORING_POLICY_ADDITIVE)
       cert = ContentCredential.find(katello_gpg_keys('fedora_cert').id)
       assert_sync_task(::Actions::Katello::Repository::Update) do |root, attributes|
         assert_equal root, @repository.root
@@ -657,8 +659,11 @@ module Katello
       repo = katello_repositories(:fedora_17_unpublished)
       assert_sync_task(::Actions::Katello::Repository::Update) do |_, attributes|
         assert_equal attributes[:retain_package_versions_count], retain_package_versions_count
+        assert_equal attributes[:mirroring_policy], ::Katello::RootRepository::MIRRORING_POLICY_ADDITIVE
       end
-      put :update, params: { :id => repo.id, :retain_package_versions_count => retain_package_versions_count }
+      put :update, params: { :id => repo.id,
+                             :retain_package_versions_count => retain_package_versions_count,
+                             :mirroring_policy => ::Katello::RootRepository::MIRRORING_POLICY_ADDITIVE }
     end
 
     def test_update_with_limit_tags
@@ -675,6 +680,7 @@ module Katello
     end
 
     def test_update_non_docker_repo_with_limit_tags
+      @repository.root.update!(mirroring_policy: Katello::RootRepository::MIRRORING_POLICY_ADDITIVE)
       assert_sync_task(::Actions::Katello::Repository::Update) do |root, attributes|
         assert_equal root, @repository.root
         expected = { 'name' => 'new name' }

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -59,6 +59,7 @@ module Katello
       @root.content_type = 'yum'
       @root.url = 'http://inecas.fedorapeople.org/fakerepos/zoo2/'
       @root.retain_package_versions_count = -2
+      @root.mirroring_policy = 'additive'
       assert_not_valid @root
       assert_equal @root.errors[:retain_package_versions_count], ["must not be a negative value."]
     end
@@ -67,6 +68,7 @@ module Katello
       @root.content_type = 'yum'
       @root.url = 'http://inecas.fedorapeople.org/fakerepos/zoo2/'
       @root.retain_package_versions_count = 2
+      @root.mirroring_policy = 'additive'
       assert_valid @root
     end
 
@@ -582,7 +584,12 @@ module Katello
       assert @root.valid?
 
       @root.retain_package_versions_count = 2
+      @root.mirroring_policy = 'additive'
       assert @root.valid?
+
+      @root.mirroring_policy = 'mirror_content_only'
+      refute @root.valid?
+      assert_equal @root.errors[:retain_package_versions_count], ["cannot be set for repositories without 'Additive' mirroring policy."]
     end
 
     def test_sha1_checksum_removed


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
1. On the API, clear out retain_package_versions_count when mirroring policy is anything other than additive
2. Add a validation on root model to make sure retain_package_versions_count is only set when mirroring policy is additive.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a yum repo with some retain_package_versions_count and mirroring policy as Additive
2. Sync
3. Now update mirroring policy to Content only/Complete and sync again.
4. You'll see an error.
5. In console if you check `repo.root.retain_package_versions_count` it will still have the value from step 1

With this change,
In step 4 you'll not see the sync error
In console if you check repo.root.retain_package_versions_count you'll see nil

We can also test the validation by doing so in console:
```
repo.root.mirroring_policy = "mirror_complete"
repo.root.retain_package_versions_count = 3
repo.root.valid? # false
repo.root.errors.messages # {:retain_package_versions_count=>["cannot be set for repos without 'Additive' mirroring policy."]}
```
