### PR TITLE
Fixes #38158 - restrict repositories to RHEL 10

### DIFF
--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -39,7 +39,8 @@ module Katello
     RHEL7 = 'rhel-7'.freeze
     RHEL8 = 'rhel-8'.freeze
     RHEL9 = 'rhel-9'.freeze
-    ALLOWED_OS_VERSIONS = [RHEL6, RHEL7, RHEL8, RHEL9].freeze
+    RHEL10 = 'rhel-10'.freeze
+    ALLOWED_OS_VERSIONS = [RHEL6, RHEL7, RHEL8, RHEL9, RHEL10].freeze
 
     MIRRORING_POLICY_ADDITIVE = 'additive'.freeze
     MIRRORING_POLICY_CONTENT = 'mirror_content_only'.freeze

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/os-versions.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/os-versions.service.js
@@ -14,6 +14,7 @@ angular
         this.getOSVersionsOptions = function () {
             return [
                 { name: 'No restriction', id: '' },
+                { name: 'Red Hat Enterprise Linux 10 ', id: 'rhel-10' },
                 { name: 'Red Hat Enterprise Linux 9 ', id: 'rhel-9' },
                 { name: 'Red Hat Enterprise Linux 8 ', id: 'rhel-8' },
                 { name: 'Red Hat Enterprise Linux 7 ', id: 'rhel-7' },

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -51,7 +51,7 @@ module Katello
       assert_not_valid @root
       assert_equal @root.errors.full_messages, [
         "Os versions invalid: Repositories can only require one OS version.",
-        "Os versions must be one of: rhel-6, rhel-7, rhel-8, rhel-9",
+        "Os versions must be one of: rhel-6, rhel-7, rhel-8, rhel-9, rhel-10",
       ]
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds RHEL 10 to the OS restriction list for repos.

#### Considerations taken when implementing this change?
Inspiration: https://github.com/Katello/katello/pull/9786
We need to come up with a way to catch this since it'll be likely forgotten each RHEL release.

#### What are the testing steps for this pull request?
1) Create 3 repositories: 
    - 1 with restrict to RHEL 10
    - 1 with restrict to RHEL 9
    - 1 with no restriction
2) Register a RHEL 10 beta machine
3) See that repo 1 and 3 are available to the host but not repo 2, the RHEL 9 one.