### PR TITLE
Fixes #38161 - Humanize flatpak remote resource name

### DIFF
--- a/app/models/katello/flatpak_remote.rb
+++ b/app/models/katello/flatpak_remote.rb
@@ -19,5 +19,9 @@ module Katello
     scoped_search :on => :url, :complete_value => true
     scoped_search :on => :seeded, :complete_value => true
     scoped_search :on => :registry_url, :complete_value => true
+
+    def self.humanize_class_name(_name = nil)
+      _("Flatpak Remotes")
+    end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Humanize flatpak remote class name.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a new role under Adminster> Roles
2. For the new role> Add Filters
3. Check flatpak remote Resource name in the Resource type dropdown
4. It should read Flatpak Remotes with this PR. Without this, it translates to Katello/flatpak remote