### PR TITLE
Fixes #38163 - Pass installable advisories only to install command

### DIFF
--- a/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
@@ -12,7 +12,7 @@ template_inputs:
   required: false
 %>
 
-<% advisory_ids = @host.advisory_ids(search: input("Errata search query"), check_installable_for_host: false) -%>
+<% advisory_ids = @host.advisory_ids(search: input("Errata search query"), check_installable_for_host: true) -%>
 <% render_error(N_("No errata matching given search query")) if !input("Errata search query").blank? && advisory_ids.blank? -%>
 # RESOLVED_ERRATA_IDS=<%= advisory_ids.join(',') %>
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Filter Errata via `check_installable_for_host` before passing them to the install command.

Prevents generating a command with all the errata that will result in "Argument list too long".

* [Redmine Bug](https://projects.theforeman.org/issues/38163)

#### Considerations taken when implementing this change?

The arg was just added in Sept 2024 in ec14209530cc385397bc1dfaa845603676482f37, I'm only changing it for Ansible because puppet probably works as intended.

#### What are the testing steps for this pull request?

* Configure Foreman/Katello to use Ansible for all actions
* Wait for a host to be affected by more than one Errata
* Apply several Errata at once via Errata tab in the content UI
* The resulting job applies all installable errata