### PR TITLE
Refs #38162 - Fix invalid self-closing tags

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/views/subscription-add-or-remove.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/views/subscription-add-or-remove.html
@@ -40,7 +40,7 @@
        </td>
        <td bst-table-cell><div subscription-type="subscription"></div></td>
        <td bst-table-cell><div subscription-start-date="subscription"></div></td>
-       <td bst-table-cell><date date="subscription.end_date" /></td>
+       <td bst-table-cell><date date="subscription.end_date" ></date></td>
        <td bst-table-cell>{{ subscription.support_level }}</td>
        <td bst-table-cell>{{ subscription.contract_number }}</td>
        <td bst-table-cell>{{ subscription.account_number }}</td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
@@ -102,11 +102,11 @@
               <span ng-switch="newHostDetailsUI">
                 <a ng-switch-when="true" target="_blank" href="{{ '/hosts?search=installable_errata%3D' + erratum.errata_id }}">
                   {{ erratum.affected_hosts_count }}
-                <span class="fa fa-external-link"/>
+                  <span class="fa fa-external-link"></span>
                 </a>
                 <a ng-switch-when="false" target="_blank" href="{{ '/content_hosts?search=installable_errata%3D' + erratum.errata_id }}">
                 {{ erratum.affected_hosts_count }}
-                <span class="fa fa-external-link"/>
+                  <span class="fa fa-external-link"></span>
               </a>
               </span>
              </td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-subscriptions-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-subscriptions-modal.html
@@ -16,7 +16,7 @@
         </p>
 
         <p>
-        <div content-access-mode-banner/>
+        <div content-access-mode-banner></div>
         </p>
 
         <p class="help-text" translate ng-show="table.numSelected > 0 && !simpleContentAccessEnabled">
@@ -106,7 +106,7 @@
               <td bst-table-cell>{{ subscription | subscriptionConsumedFilter }}</td>
               <td bst-table-cell><div subscription-type="subscription"></div></td>
               <td bst-table-cell><div subscription-start-date="subscription"></div></td>
-              <td bst-table-cell><date date="subscription.end_date" /></td>
+              <td bst-table-cell><date date="subscription.end_date" ></date></td>
               <td bst-table-cell>{{ subscription.support_level }}</td>
               <td bst-table-cell>{{ subscription.contract_number }}</td>
               <td bst-table-cell>{{ subscription.account_number }}</td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -136,7 +136,7 @@
               </a>
             </td>
             <td bst-table-cell>{{ erratum.title }}</td>
-            <td bst-table-cell><date date="erratum.updated" /></td>
+            <td bst-table-cell><date date="erratum.updated" ></date></td>
           </tr>
         </tbody>
       </table>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -278,7 +278,7 @@
 
       <dl class="dl-horizontal dl-horizontal-left">
         <dt translate>Registered</dt>
-        <dd><long-date-time date="host.created_at" /></dd>
+        <dd><long-date-time date="host.created_at" ></long-date-time></dd>
 
         <dt translate> Registered By</dt>
         <dd>
@@ -305,7 +305,7 @@
         </dd>
 
         <dt translate>Last Checkin</dt>
-        <dd><long-date-time date="host.subscription_facet_attributes.last_checkin" default="'Never checked in' | translate" /></dd>
+        <dd><long-date-time date="host.subscription_facet_attributes.last_checkin" default="'Never checked in' | translate" ></long-date-time></dd>
       </dl>
 
       <div class="divider"></div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-provisioning-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-provisioning-info.html
@@ -25,7 +25,7 @@
       <dd>{{ host.puppet_environment_name }}</dd>
 
       <dt translate>Last Puppet Report</dt>
-      <dd><short-date-time date="host.last_report" /></dd>
+      <dd><short-date-time date="host.last_report" ></short-date-time></dd>
 
       <dt translate>Model</dt>
       <dd>{{ host.model_name }}</dd>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -139,8 +139,8 @@
           <td bst-table-cell>{{ host.operatingsystem_name }}</td>
           <td bst-table-cell>{{ host.content_facet_attributes.lifecycle_environment.name }}</td>
           <td bst-table-cell>{{ host.content_facet_attributes.content_view.name || "" }}</td>
-          <td bst-table-cell><long-date-time date="host.subscription_facet_attributes.registered_at" default="'Never registered' | translate" /></td>
-          <td bst-table-cell><long-date-time date="host.subscription_facet_attributes.last_checkin" default="'Never checked in' | translate" /></td>
+          <td bst-table-cell><long-date-time date="host.subscription_facet_attributes.registered_at" default="'Never registered' | translate"></long-date-time></td>
+          <td bst-table-cell><long-date-time date="host.subscription_facet_attributes.last_checkin" default="'Never checked in' | translate"></long-date-time></td>
         </tr>
       </tbody>
     </table>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-content-views.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-content-views.html
@@ -28,7 +28,7 @@
           <span ng-show="contentView.composite" translate>Yes</span>
           <span ng-hide="contentView.composite" translate>No</span>
         </td>
-        <td bst-table-cell><long-date-time date="contentView.last_published" /></td>
+        <td bst-table-cell><long-date-time date="contentView.last_published" ></long-date-time></td>
         <td bst-table-cell class="number-cell">{{ contentView.repositories.length || 0 }}</td>
       </tr>
     </tbody>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-errata.html
@@ -46,7 +46,7 @@
         </td>
         <td bst-table-cell class="number-cell">{{ errata.hosts_available_count || 0 }}</td>
 
-        <td bst-table-cell><date date="errata.updated" /></td>
+        <td bst-table-cell><date date="errata.updated"></date></td>
       </tr>
     </tbody>
   </table>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata-tasks-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata-tasks-list.html
@@ -2,4 +2,5 @@
 <div tasks-table  details-state="errata.tasks.task"
      known-context="errata,organization"
      resource-type="Katello::Erratum"
-     resource-id="{{ errara.id }}"/>
+     resource-id="{{ errara.id }}">
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-info.html
@@ -88,7 +88,7 @@
       <dd>{{ package.buildhost }}</dd>
 
       <dt translate>Build Time</dt>
-      <dd><long-date-time date="package.build_time_utc" /></dd>
+      <dd><long-date-time date="package.build_time_utc"></long-date-time></dd>
     </dl>
   </div>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/views/products-bulk-sync-plan-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/views/products-bulk-sync-plan-modal.html
@@ -68,10 +68,10 @@
             <tr bst-table-row ng-repeat="syncPlan in table.rows" class="clickable-row"
                 ng-click="selectSyncPlan(syncPlan)" ng-class="{'selected-row': syncPlan === selectedSyncPlan }">
               <td bst-table-cell>{{ syncPlan.name }}</td>
-              <td bst-table-cell><long-date-time date="syncPlan.sync_date" /></td>
+              <td bst-table-cell><long-date-time date="syncPlan.sync_date"></long-date-time></td>
               <td bst-table-cell>{{ syncPlan.enabled }}</td>
               <td bst-table-cell>{{ syncPlan.interval | translate | capitalize }}</td>
-              <td bst-table-cell><long-date-time date="syncPlan.next_sync" /></td>
+              <td bst-table-cell><long-date-time date="syncPlan.next_sync"></long-date-time></td>
             </tr>
           </tbody>
         </table>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -400,13 +400,13 @@
         Not Synced
       </dd>
       <dd ng-hide="repository.last_sync == null || repository.last_sync.ended_at == null">
-        <relative-date date="repository.last_sync.ended_at" />
-        (<short-date-time date="repository.last_sync.ended_at" /> <translate>Local Time</translate>)
+        <relative-date date="repository.last_sync.ended_at" ></relative-date>
+        (<short-date-time date="repository.last_sync.ended_at" ></short-date-time> <translate>Local Time</translate>)
       </dd>
 
       <dt translate>Next Sync</dt>
       <dd ng-show="repository.product.sync_plan.next_sync">
-        <long-date-time date="repository.product.sync_plan.next_sync" /> (<translate>Server Time</translate>)
+        <long-date-time date="repository.product.sync_plan.next_sync" ></long-date-time> (<translate>Server Time</translate>)
       </dd>
       <dd ng-hide="repository.product.sync_plan.next_sync" translate>
         Synced manually, no interval set.
@@ -537,7 +537,7 @@
         </tbody>
       </table>
 
-      <div class="divider" ng-if="repository.content_type === 'ostree'"/>
+      <div class="divider" ng-if="repository.content_type === 'ostree'"></div>
     </section>
 
     <span ng-hide="(repository.content_type === 'deb' && repository.url)">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-tasks.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-tasks.html
@@ -1,4 +1,5 @@
 <div tasks-table  details-state="product.repository.tasks.details"
      known-context="repository,organization"
      resource-type="Katello::Repository"
-     resource-id="{{ repository.id }}"/>
+     resource-id="{{ repository.id }}">
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-info.html
@@ -88,13 +88,13 @@
 
       <dt translate>Last Sync</dt>
       <dd>
-        <relative-date date="product.last_sync" />
-        (<long-date-time date="product.last_sync" /> <translate>Local Time</translate>)
+        <relative-date date="product.last_sync" ></relative-date>
+        (<long-date-time date="product.last_sync" ></long-date-time> <translate>Local Time</translate>)
       </dd>
 
       <dt translate>Next Sync</dt>
       <dd ng-show="product.sync_plan.next_sync">
-        <long-date-time date="product.sync_plan.next_sync" /> (<translate>Server Time</translate>)
+        <long-date-time date="product.sync_plan.next_sync" ></long-date-time> (<translate>Server Time</translate>)
       </dd>
       <dd ng-hide="product.sync_plan.next_sync" translate>
         Synced manually, no interval set.

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-tasks.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-tasks.html
@@ -1,4 +1,5 @@
 <div tasks-table  details-state="product.tasks.details"
               known-context="product,organization"
               resource-type="Katello::Product"
-              resource-id="{{ product.id }}"/>
+              resource-id="{{ product.id }}">
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery-create.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery-create.html
@@ -16,7 +16,8 @@
       <select class="form-control" ng-disabled="creating()"
               ng-model="createRepoChoices.existingProductId"
               ng-options="product.id as product.name for product in products"
-              ng-required="createRepoChoices.newProduct === 'false'"/>
+              ng-required="createRepoChoices.newProduct === 'false'">
+      </select>
     </div>
 
     <div bst-form-group ng-show="createRepoChoices.newProduct === 'true'"
@@ -45,7 +46,8 @@
     <div bst-form-group ng-show="createRepoChoices.newProduct === 'true' && contentCredentials.length !== 0"
          label="{{ 'GPG Key' | translate }}">
       <select class="form-control" ng-model="createRepoChoices.product.gpg_key_id"
-              ng-options="content_credential.id as content_credential.name for content_credential in contentCredentials"/>
+              ng-options="content_credential.id as content_credential.name for content_credential in contentCredentials">
+      </select>
     </div>
 
     <h4 translate>Repository Options</h4>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
@@ -4,7 +4,8 @@
   <form ng-submit="discover()" name="discoveryForm" class="col-sm-5" role="form">
     <div bst-form-group label="{{ 'Repository Type' | translate }}">
       <select ng-model="discovery.contentType"
-              ng-options="contentType.id as contentType.name for contentType in contentTypes"/>
+              ng-options="contentType.id as contentType.name for contentType in contentTypes">
+      </select>
     </div>
 
     <div bst-form-group ng-if="discovery.contentType === 'yum'"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/partials/product-table-sync-status.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/partials/product-table-sync-status.html
@@ -1,7 +1,7 @@
 <div class="list-unstyled" ng-show="product.last_sync">
   <div>
     <span translate>Last synced </span>
-    <relative-date date="product.last_sync" />.
+      <relative-date date="product.last_sync" ></relative-date>.
   </div>
   <div ng-show="mostImportantSyncState(product) == 'pending'"
         translate

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscription-start-date.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscription-start-date.html
@@ -1,2 +1,2 @@
 
-<date date="subscription.start_date" />{{ checkFutureDate(subscription.start_date) }}
+<date date="subscription.start_date" ></date>{{ checkFutureDate(subscription.start_date) }}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-info.html
@@ -42,7 +42,7 @@
       </dd>
 
       <dt translate>Next Sync</dt>
-      <dd><long-date-time date="syncPlan.next_sync" /></dd>
+      <dd><long-date-time date="syncPlan.next_sync"></long-date-time></dd>
 
       <dt translate>Recurring Logic</dt>
       <dd>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/views/sync-plans.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/views/sync-plans.html
@@ -43,10 +43,10 @@
             </a>
           </td>
           <td bst-table-cell>{{ syncPlan.description }}</td>
-          <td bst-table-cell><long-date-time date="syncPlan.sync_date" /></td>
+          <td bst-table-cell><long-date-time date="syncPlan.sync_date"></long-date-time></td>
           <td bst-table-cell>{{ syncPlan.enabled }}</td>
           <td bst-table-cell>{{ syncPlan.interval | translate | capitalize }}</td>
-          <td bst-table-cell><long-date-time date="syncPlan.next_sync" /></td>
+          <td bst-table-cell><long-date-time date="syncPlan.next_sync"></long-date-time></td>
         </tr>
       </tbody>
     </table>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks-table.directive.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks-table.directive.js
@@ -26,7 +26,8 @@
         <div tasks-table  details-state="product.tasks.details"
                           known-context="product,organization"
                           resource-type="Katello::Product"
-                          resource-id="{{ product.id }}"/>
+                          resource-id="{{ product.id }}">
+        </dev>
      </pre>
  */
 angular.module('Bastion.tasks').directive('tasksTable',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/views/task-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/views/task-details.html
@@ -8,10 +8,10 @@
   <dd>{{ task.username }}</dd>
 
   <dt translate>Started At</dt>
-  <dd><short-date-time date="task.started_at" /></dd>
+  <dd><short-date-time date="task.started_at"></short-date-time></dd>
 
   <dt translate>Finished At</dt>
-  <dd><short-date-time date="task.ended_at" /></dd>
+  <dd><short-date-time date="task.ended_at"></short-date-time></dd>
 
   <dt translate>Parameters</dt>
   <dd ng-switch="isArray(task.humanized.input)">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/views/tasks-index.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/views/tasks-index.html
@@ -1,1 +1,1 @@
-<div tasks-table details-state="tasks.details" all/>
+<div tasks-table details-state="tasks.details" all></div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/views/tasks-table.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/views/tasks-table.html
@@ -32,7 +32,7 @@
             </a>
           </td>
           <td bst-table-cell>{{ task.username }}</td>
-          <td bst-table-cell><short-date-time date="task.started_at" /></td>
+          <td bst-table-cell><short-date-time date="task.started_at"></short-date-time></td>
         </tr>
       </tbody>
     </table>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/views/user-tasks-table.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/views/user-tasks-table.html
@@ -22,7 +22,7 @@
               {{ task.humanized.input | taskInputShort | taskInputCompile }}
             </a>
           </td>
-          <td bst-table-cell><short-date-time date="task.started_at" /></td>
+          <td bst-table-cell><short-date-time date="task.started_at"></short-date-time></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add closing tag for `<select>, <div>, <span>` and some bastion `<date>` tags 

#### Considerations taken when implementing this change?
Some browsers are smart and display invalid HTML correctly. Not all invalid self closing tags were causing issues for me on the UI in chrome. Others like select and textarea were.
 
#### What are the testing steps for this pull request?

1. Go to Products > Repo discovery and make sure the form renders correctly.
2. Scan a URL for repos, ex: https://jlsherrill.fedorapeople.org/fake-repos/
3. Create a repository out of a discovered repo and make sure the form looks ok in the create page.