### PR TITLE
Fixes #38170 - Explicitly handle content_view params during AK create

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -313,7 +313,7 @@ module Katello
 
     def find_content_view_environments
       @content_view_environments = []
-      if params[:environment_id] || params[:environment]
+      if (params[:environment_id] || params[:environment]) || (params[:content_view_id] || params[:content_view])
         find_cve_for_single
       elsif params_likely_not_from_angularjs? && (params[:content_view_environments] || params[:content_view_environment_ids])
         @content_view_environments = ::Katello::ContentViewEnvironment.fetch_content_view_environments(


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The `find_cve_for_single` method in the activation keys controller handles the logic of finding the content view environment when you've passed in separate `content_view` and `lifecycle_environment` params. However, before this change it did not handle `content_view` param correctly; it ignored it. The effect was a false positive - the activation key would get created, but not with the content view you specified.

With this change, you should correctly get the error 
```
Environment ID and content view ID must be provided together
```

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Test hammer activation-key create
Also test the web UI and make sure nothing breaks there with creating activation keys.
