### PR TITLE
Fixes #38086 - Slow product last sync audit lookup

### DIFF
--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -50,7 +50,18 @@ module Katello
       end
 
       def last_sync_audit
-        Audited::Audit.where(:auditable_id => self.repositories, :auditable_type => Katello::Repository.name, :action => "sync").order(:created_at).last
+        repository_ids = self.repositories.pluck(:id)
+        return nil if repository_ids.blank?
+
+        Audited::Audit
+         .where(
+          auditable_id: repository_ids,
+          auditable_type: Katello::Repository.name,
+          action: "sync"
+         )
+         .order(created_at: :desc)
+         .limit(1)
+         .first
       end
 
       def last_sync

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -396,8 +396,11 @@
       <span ng-include="'products/details/partials/sync-status.html'"></span>
 
       <dt translate>Last Sync</dt>
-      <dd ng-show="repository.last_sync == null" translate>
+      <dd ng-show="repository.last_sync == null && repository.last_sync_words == null" translate>
         Not Synced
+      </dd>
+      <dd ng-show="repository.last_sync == null && repository.last_sync_words" translate>
+        Completed {{ repository.last_sync_words }} ago
       </dd>
       <dd ng-hide="repository.last_sync == null || repository.last_sync.ended_at == null">
         <relative-date date="repository.last_sync.ended_at" />


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
1. Added an index on action and created datetime for faster filtering and sorting. (https://github.com/theforeman/foreman/pull/10426)
2. Use limit(1) to reduce memory footprint
3. Repository detail page doesn't use audit record today to display last sync if tasks have been cleaned up
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Have a few products with repsositories synced.
2. Cleanup tasks: `bundle exec rails foreman_tasks:cleanup TASK_SEARCH='label = Actions::Katello::Repository::Sync' STATES='stopped'`
3. Go to products index page and confirm the last sync date is displayed using the audit record
4. Go to a repository and make sure you see the same date and not "Not Synced" if an audit record exists.

For performance testing, run this in rails console to create a million audit records for sync action:
```
repo = Katello::Repository.first
audit = repo.audits.last
audits_data = []
million = 1_000_000

audit_data_template = audit.attributes.slice(
  "auditable_id", "auditable_type", "user_id", "username", "action", "audited_changes", 
  "version", "comment", "associated_id", "associated_type", "request_uuid", "auditable_name", "associated_name"
)

million.times do
  audit_data = audit_data_template.dup
  audit_data["created_at"] = Time.current
  audits_data << audit_data
end

audits_data.each_slice(10_000) do |batch|
  Audited::Audit.insert_all(batch)
end

```