### PR TITLE
Fixes #38175 - limit errata application to the applicable

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -589,8 +589,8 @@ module Katello
         end
       end
 
-      def advisory_ids(search:, check_installable_for_host: true)
-        errata_scope = check_installable_for_host ? ::Katello::Erratum.installable_for_hosts([self]) : ::Katello::Erratum
+      def advisory_ids(search:)
+        errata_scope = ::Katello::Erratum.installable_for_hosts([self])
         ids = errata_scope.search_for(search).pluck(:errata_id)
         if ids.empty?
           fail _("Cannot install errata: No errata found for search term '%s'") % search

--- a/app/views/foreman/job_templates/install_errata_by_search_query.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query.erb
@@ -15,7 +15,7 @@ foreign_input_sets:
   exclude: action,package
 %>
 
-<% advisory_ids = @host.advisory_ids(search: input("Errata search query"), check_installable_for_host: false) -%>
+<% advisory_ids = @host.advisory_ids(search: input("Errata search query")) -%>
 <% render_error(N_("No errata matching given search query")) if !input("Errata search query").blank? && advisory_ids.blank? -%>
 # RESOLVED_ERRATA_IDS=<%= advisory_ids.join(',') %>
 

--- a/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
@@ -12,7 +12,7 @@ template_inputs:
   required: false
 %>
 
-<% advisory_ids = @host.advisory_ids(search: input("Errata search query"), check_installable_for_host: true) -%>
+<% advisory_ids = @host.advisory_ids(search: input("Errata search query")) -%>
 <% render_error(N_("No errata matching given search query")) if !input("Errata search query").blank? && advisory_ids.blank? -%>
 # RESOLVED_ERRATA_IDS=<%= advisory_ids.join(',') %>
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Only allows installing errata on a host that are applicable to it.

This is to work around the fact that 'select all' in the UI sends an empty search string.

#### Considerations taken when implementing this change?
This means that a host with a stale package profile may show errata and throw Katello errors for errata that are actually applicable. We lose the benefit of having dnf trigger the package profile update.

#### What are the testing steps for this pull request?
1. Sync a repository with errata
2. Register a host with a few installable errata
3. Use 'select all' on the host errata page and apply said errata via REX
4. See that, without this fix, all errata in the system get sent to the dnf command on the host