### PR TITLE
Fixes #38160 - Update hosts link to new hosts URL

### DIFF
--- a/webpack/__mocks__/foremanReact/Root/Context/ForemanContext.js
+++ b/webpack/__mocks__/foremanReact/Root/Context/ForemanContext.js
@@ -1,3 +1,4 @@
 // eslint-disable-next-line import/prefer-default-export
 export const useForemanSettings = () => ({ perPage: 20 });
 export const useForemanVersion = () => 'nightly';
+export const useForemanHostsPageUrl = () => '/new/hosts';

--- a/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
+++ b/webpack/scenes/ContentViews/__tests__/contentViewPage.test.js
@@ -132,7 +132,7 @@ test('Can expand cv and show activation keys and hosts', async (done) => {
     expect(queryByLabelText('activation_keys_link_2').textContent).toEqual('1');
 
     // Displays hosts link with count
-    expect(queryByLabelText('host_link_2')).toHaveAttribute('href', '/hosts?search=content_view_id+%3D+2');
+    expect(queryByLabelText('host_link_2')).toHaveAttribute('href', '/new/hosts?search=content_view_id%3D2');
     expect(queryByLabelText('host_link_2').textContent).toEqual('1');
   });
 

--- a/webpack/scenes/ContentViews/expansions/DetailsExpansion.js
+++ b/webpack/scenes/ContentViews/expansions/DetailsExpansion.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
+import { useForemanHostsPageUrl } from 'foremanReact/Root/Context/ForemanContext';
 import RelatedCompositeContentViewsModal from './RelatedCompositeContentViewsModal';
 import RelatedContentViewComponentsModal from './RelatedContentViewComponentsModal';
 
@@ -9,6 +10,9 @@ const DetailsExpansion = ({
 }) => {
   const activationKeyCount = activationKeys.length;
   const hostCount = hosts.length;
+
+  const baseHostsPageUrl = useForemanHostsPageUrl();
+  const hostsPageUrl = `${baseHostsPageUrl}?search=${encodeURIComponent(`content_view_id=${cvId}`)}`;
 
   const relatedContentViewModal = () => {
     if (cvComposite) {
@@ -36,7 +40,7 @@ const DetailsExpansion = ({
     <div id={`cv-details-expansion-${cvId}`}>
       {__('Activation keys: ')}<a aria-label={`activation_keys_link_${cvId}`} href={`/activation_keys?search=content_view_id+%3D+${cvId}`}>{activationKeyCount}</a>
       <br />
-      {__('Hosts: ')}<a aria-label={`host_link_${cvId}`} href={`/hosts?search=content_view_id+%3D+${cvId}`}>{hostCount}</a>
+      {__('Hosts: ')}<a aria-label={`host_link_${cvId}`} href={hostsPageUrl}>{hostCount}</a>
       <br />
       {relatedContentViewModal()}
     </div>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Updated the hosts link to use the new hosts URL instead of the old hardcoded UI link to dynamically determine the correct hosts page URL, improving maintainability and consistency.

#### Considerations taken when implementing this change?

The new hosts page URL was used to ensure consistency. Care was taken to maintain existing functionality while improving accuracy and maintainability.

#### What are the testing steps for this pull request?

1. Go to Lifecycle -> Content Views
2. Expand any of the cv details
3. Click on the hosts count
4. You should be redirected to the hosts page 