### PR TITLE
Fixes #38180 - Better names for flatpak rex templates

### DIFF
--- a/app/views/foreman/job_templates/flatpak_install.erb
+++ b/app/views/foreman/job_templates/flatpak_install.erb
@@ -1,6 +1,6 @@
 <%#
 kind: job_template
-name: Install Flatpak application on host
+name: Flatpak - Install application on host
 job_category: Katello
 description_format: 'Install Flatpak application %{Application name} on host'
 provider_type: script

--- a/app/views/foreman/job_templates/flatpak_login_action.erb
+++ b/app/views/foreman/job_templates/flatpak_login_action.erb
@@ -1,6 +1,6 @@
 <%#
 kind: job_template
-name: Login to flatpak registry via podman
+name: Flatpak - Login to registry via podman
 job_category: Katello
 description_format: 'Login to flatpak registry via podman'
 provider_type: script

--- a/app/views/foreman/job_templates/flatpak_setup.erb
+++ b/app/views/foreman/job_templates/flatpak_setup.erb
@@ -1,6 +1,6 @@
 <%#
 kind: job_template
-name: Set up Flatpak remote on host
+name: Flatpak - Set up remote on host
 job_category: Katello
 description_format: 'Set up Flatpak remote on host'
 provider_type: script
@@ -14,7 +14,7 @@ template_inputs:
   input_type: user
   required: true
 foreign_input_sets:
-- template: Login to flatpak registry via podman
+- template: Flatpak - Login to registry via podman
   exclude: Flatpak registry URL
 %>
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Better names for flatpak templates to group them together.
#### Considerations taken when implementing this change?
As with other templates of similar grouping, use "Flatpak - " to create the grouping.
#### What are the testing steps for this pull request?
In rails console:
n Rails console: ForemanInternal.all.first.delete
Then run: bundle exec rails db:seed

In Jobs template list, check if the template names are updated and appear in order.