### PR TITLE
Fixes #35676 - Handle whitespace issue in Python package types

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -307,6 +307,10 @@ Pass [] to make repo available for clients regardless of OS version. Maximum len
       repo_params[:ssl_client_cert] = ssl_client_cert
       repo_params[:ssl_client_key] = ssl_client_key
 
+      if repo_params[:package_types]
+        repo_params[:package_types] = repo_params[:package_types].map(& :strip)
+      end
+
       root = construct_repo_from_params(repo_params)
       sync_task(::Actions::Katello::Repository::CreateRoot, root)
       @repository = root.reload.library_instance
@@ -393,6 +397,10 @@ Alternatively, use the 'force' parameter to regenerate metadata locally. On the 
       repo_params = repository_params
       if !repo_params[:url].nil? && URI(repo_params[:url]).userinfo
         fail "Do not include the username/password in the URL. Use the username/password settings instead."
+      end
+
+      if repo_params[:package_types]
+        repo_params[:package_types] = repo_params[:package_types].map(& :strip)
       end
 
       if @repository.generic?

--- a/lib/katello/repository_types/python.rb
+++ b/lib/katello/repository_types/python.rb
@@ -26,7 +26,7 @@ Katello::RepositoryTypeManager.register('python') do
                         description: N_("Python packages to exclude from the upstream URL, names separated by newline. You may also specify versions, for example: django~=2.0.")
 
   generic_remote_option :package_types, title: N_("Package Types"), type: Array, input_type: "text", delimiter: ",", default: [],
-                        description: N_("Package types to sync for Python content, separated by comma. Leave empty to get every package type. Package types are: bdist_dmg, bdist_dumb, bdist_egg, bdist_msi, bdist_rpm, bdist_wheel, bdist_wininst, sdist.")
+                        description: N_("Package types to sync for Python content, separated by comma. Leave empty to get every package type. Package types are: bdist_dmg,bdist_dumb,bdist_egg,bdist_msi,bdist_rpm,bdist_wheel,bdist_wininst,sdist.")
 
   generic_remote_option :keep_latest_packages, title: N_("Keep latest packages"), type: :number, input_type: "number", default: 0,
                         description: N_("The amount of latest versions of a package to keep on sync, includes pre-releases if synced. Default 0 keeps all versions.")


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Added handling to ensure that whitespace is removed from Python package types to prevent issues when creating a new repo.

#### Considerations taken when implementing this change?

Ensures consistency in handling Python package types while maintaining compatibility with the existing repo creation flow.

#### What are the testing steps for this pull request?

1. Go to Products -> Create a new product
2. Go to Repositories
3. Click on New Repository
4. Add all the required details by selecting the type as Python
5. Select Save -> You should be able to create a new repository without any errors
6. For verification: After creation, Select action -> Sync now - The sync task should be completed successfully and you should be able to see the synced data.
