### PR TITLE
Refs #38180 - Properly reference updated flatpak template in render

### DIFF
--- a/app/views/foreman/job_templates/flatpak_setup.erb
+++ b/app/views/foreman/job_templates/flatpak_setup.erb
@@ -24,4 +24,4 @@ foreign_input_sets:
 %>
 
 sudo flatpak remote-add --authenticator-name=org.flatpak.Authenticator.Oci <%= remote_name %> oci+<%= registry_url %>/
-<%= render_template('Login to flatpak registry via podman', 'Flatpak registry URL': registry_url) %>
+<%= render_template('Flatpak - Login to registry via podman', 'Flatpak registry URL': registry_url) %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Use updated flatpak template name in render. The names were changed in https://github.com/Katello/katello/pull/11297/ but there is still one reference to the old template name. 
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Run the template **Flatpak - Set up remote on host** against a host and make sure the job succeeds.