### PR TITLE
Fixes #38194 - Update UI wording for MultiCV

### DIFF
--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
@@ -130,7 +130,7 @@ const ErrataOverviewCard = ({ hostDetails }) => {
                 <ErrataToggleGroupItem
                   text={__('Installable')}
                   aria-label="Show installable errata chart"
-                  tooltipText={__('Installable errata are applicable errata that are available in the host\'s content view and lifecycle environment.')}
+                  tooltipText={__('Installable errata are applicable errata that are available in the host\'s assigned content view environments.')}
                   isSelected={errataCategory === 'installable'}
                   onChange={selected => selected && setErrataCategory('installable')}
                 />

--- a/webpack/components/extensions/HostDetails/Tabs/DebsTab/DebInstallModal.js
+++ b/webpack/components/extensions/HostDetails/Tabs/DebsTab/DebInstallModal.js
@@ -87,7 +87,7 @@ const DebInstallModal = ({
   isOpen, closeModal, hostId, hostName, triggerPackageInstall,
 }) => {
   const emptyContentTitle = __('No packages available to install');
-  const emptyContentBody = __('No packages available to install on this host. Please check the host\'s content view and lifecycle environment.');
+  const emptyContentBody = __('No packages available to install on this host. Please check the host\'s assigned content view environments.');
   const emptySearchTitle = __('No matching packages found');
   const emptySearchBody = __('Try changing your search settings.');
   const columnHeaders = ['', __('Package'), __('Version')];

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -427,7 +427,7 @@ export const ErrataTab = () => {
             />
             <ErrataToggleGroupItem
               text={__('Installable')}
-              tooltipText={__('Installable errata are applicable errata that are available in the host\'s content view and lifecycle environment.')}
+              tooltipText={__('Installable errata are applicable errata that are available in the host\'s assigned content view environments.')}
               buttonId="installableToggle"
               aria-label="Show installable errata"
               isSelected={toggleGroupState === INSTALLABLE}
@@ -557,7 +557,7 @@ export const ErrataTab = () => {
                         <span>
                           <Tooltip
                             content={
-                              __("This erratum is not installable because it is not in this host's content view and lifecycle environment.")
+                              __("This erratum is not installable because it is not in this host's assigned content view environments.")
                             }
                           >
 

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackageInstallModal.js
@@ -87,7 +87,7 @@ const PackageInstallModal = ({
   isOpen, closeModal, hostId, hostName, triggerPackageInstall,
 }) => {
   const emptyContentTitle = __('No packages available to install');
-  const emptyContentBody = __('No packages available to install on this host. Please check the host\'s content view and lifecycle environment.');
+  const emptyContentBody = __('No packages available to install on this host. Please check the host\'s assigned content view environments.');
   const emptySearchTitle = __('No matching packages found');
   const emptySearchBody = __('Try changing your search settings.');
   const columnHeaders = ['', __('Package'), __('Version')];


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Just some updates to web UI wording for MultiCV. We no longer want to imply that "content view and lifecycle environment" are separate things.

#### Considerations taken when implementing this change?

I left the phrase as-is in a few places where it made sense. I didn't touch Angular pages.

#### What are the testing steps for this pull request?

just read the words
