### PR TITLE
Fixes #38196 - Remove use of $.removeAttr from Katello

### DIFF
--- a/app/assets/javascripts/katello/common/katello_object.js
+++ b/app/assets/javascripts/katello/common/katello_object.js
@@ -77,10 +77,10 @@ KT.object.label = (function(){
     enable_inputs = function(current_name_input) {
         if (current_name_input === undefined) {
             // enable all label inputs
-            $(".label_input").removeAttr("disabled");
+            $(".label_input").prop("disabled", false);
         } else {
             // enable the label input associated with the current name
-            current_name_input.closest('fieldset').next('fieldset').find('input.label_input').removeAttr("disabled");
+            current_name_input.closest('fieldset').next('fieldset').find('input.label_input').prop("disabled", false);
         }
     };
 

--- a/app/assets/javascripts/katello/sync_management/sync_management.js
+++ b/app/assets/javascripts/katello/sync_management/sync_management.js
@@ -124,7 +124,7 @@ KT.content = (function () {
       KT.content.select_repo();
     },
     select_none = function () {
-      $("#products_table").find("input[type=checkbox]").removeAttr("checked");
+      $("#products_table").find("input[type=checkbox]").prop("checked", false);
       KT.content.select_repo();
     },
     select_repo = function () {
@@ -185,7 +185,7 @@ KT.content = (function () {
     expand_all = function () {
       var sync_toggle = $("#sync_toggle");
       if ($(sync_toggle).is(":checked")) {
-        $(sync_toggle).removeAttr("checked");
+        $(sync_toggle).prop("checked", false);
         KT.content.showAll();
       }
       $("#products_table")

--- a/engines/bastion/vendor/assets/javascripts/bastion/angular-bootstrap/ui-bootstrap-tpls.js
+++ b/engines/bastion/vendor/assets/javascripts/bastion/angular-bootstrap/ui-bootstrap-tpls.js
@@ -6083,7 +6083,7 @@ angular.module('ui.bootstrap.timepicker', [])
     padHours = angular.isDefined($attrs.padHours) ? $scope.$parent.$eval($attrs.padHours) : true;
 
   $scope.tabindex = angular.isDefined($attrs.tabindex) ? $attrs.tabindex : 0;
-  $element.removeAttr('tabindex');
+  $element.prop('tabIndex', false);
 
   this.init = function(ngModelCtrl_, inputs) {
     ngModelCtrl = ngModelCtrl_;
@@ -6806,7 +6806,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.debounce', 'ui.bootstrap
       });
 
       if (hintInputElem.attr('id')) {
-        hintInputElem.removeAttr('id'); // remove duplicate id if present.
+        hintInputElem.prop('id', false); // remove duplicate id if present.
       }
       inputsContainer.append(hintInputElem);
       hintInputElem.after(element);
@@ -6855,7 +6855,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.debounce', 'ui.bootstrap
     // This attribute is added or removed automatically when the `activeIdx` changes.
     scope.$watch('activeIdx', function(index) {
       if (index < 0) {
-        element.removeAttr('aria-activedescendant');
+        element.prop('aria-activedescendant', false);
       } else {
         element.attr('aria-activedescendant', getMatchId(index));
       }

--- a/engines/bastion/vendor/assets/javascripts/bastion/angular-bootstrap/ui-bootstrap.js
+++ b/engines/bastion/vendor/assets/javascripts/bastion/angular-bootstrap/ui-bootstrap.js
@@ -6082,7 +6082,7 @@ angular.module('ui.bootstrap.timepicker', [])
     padHours = angular.isDefined($attrs.padHours) ? $scope.$parent.$eval($attrs.padHours) : true;
 
   $scope.tabindex = angular.isDefined($attrs.tabindex) ? $attrs.tabindex : 0;
-  $element.removeAttr('tabindex');
+  $element.prop('tabindex', false);
 
   this.init = function(ngModelCtrl_, inputs) {
     ngModelCtrl = ngModelCtrl_;
@@ -6805,7 +6805,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.debounce', 'ui.bootstrap
       });
 
       if (hintInputElem.attr('id')) {
-        hintInputElem.removeAttr('id'); // remove duplicate id if present.
+        hintInputElem.prop('id', false); // remove duplicate id if present.
       }
       inputsContainer.append(hintInputElem);
       hintInputElem.after(element);
@@ -6854,7 +6854,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.debounce', 'ui.bootstrap
     // This attribute is added or removed automatically when the `activeIdx` changes.
     scope.$watch('activeIdx', function(index) {
       if (index < 0) {
-        element.removeAttr('aria-activedescendant');
+        element.prop('aria-activedescendant', '');
       } else {
         element.attr('aria-activedescendant', getMatchId(index));
       }

--- a/engines/bastion/vendor/assets/javascripts/bastion/angular/angular.js
+++ b/engines/bastion/vendor/assets/javascripts/bastion/angular/angular.js
@@ -9593,7 +9593,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
 
         if (writeAttr !== false) {
           if (value === null || isUndefined(value)) {
-            this.$$element.removeAttr(attrName);
+            this.$$element.prop(attrName, false);
           } else {
             if (SIMPLE_ATTR_NAME.test(attrName)) {
               // jQuery skips special boolean attrs treatment in XML nodes for
@@ -9602,7 +9602,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               // in XHTML, call `removeAttr` in such cases instead.
               // See https://github.com/jquery/jquery/issues/4249
               if (booleanKey && value === false) {
-                this.$$element.removeAttr(attrName);
+                this.$$element.prop(attrName, false);
               } else {
                 this.$$element.attr(attrName, value);
               }


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Because of [this breaking change](https://jquery.com/upgrade-guide/3.0/#breaking-change-removeattr-no-longer-sets-properties-to-false) in jQuery 3.0, the 'Select None' button on the Sync Status page had stopped working. This change should make it work again.

#### Considerations taken when implementing this change?

The solution is to replace `removeAttr()` with `.prop(attrName, value)`. I found several other instances of its use, which I also updated. There were a few where I'm not sure `false` is the correct value, but I don't know if that will matter..

#### What are the testing steps for this pull request?

Reproduce the issue:
Make sure your Foreman is up to date with latest develop and Katello is latest master
Run npm i 

Fix the issue:
Check out this PR
check Sync Status page Select None button, make sure it works
Check other Angular pages and make sure I didn't break anything
