### PR TITLE
Fixes #38204 - refresh repos should fix pulp primary repos

### DIFF
--- a/app/lib/actions/katello/capsule_content/refresh_repos.rb
+++ b/app/lib/actions/katello/capsule_content/refresh_repos.rb
@@ -45,9 +45,15 @@ module Actions
 
             pulp_repo = repo.backend_service(smart_proxy)
             if !current_repos_on_capsule_ids.include?(repo.id)
+              # create_mirror_entities does not apply to the primary smart proxy
               pulp_repo.create_mirror_entities
             else
-              tasks += pulp_repo.refresh_mirror_entities
+              if smart_proxy.pulp_primary?
+                # The primary smart proxy has extra remote options, like proxy_url
+                tasks += pulp_repo.refresh_entities
+              else
+                tasks += pulp_repo.refresh_mirror_entities
+              end
             end
           end
           tasks

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -136,6 +136,10 @@ module Katello
         RepositoryMirror.new(self).refresh_entities
       end
 
+      def refresh_entities
+        [update_remote].flatten.compact
+      end
+
       def refresh_if_needed
         tasks = []
         tasks << update_remote #always update remote


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Stops `RefreshRepos` from using the `RepositoryMirror` service class instead of the `Repository` service class for repositories on the primary smart proxy. This caused the `refresh_repos` rake task to fail to fix broken remotes. 

#### Considerations taken when implementing this change?
There shouldn't be any side effects on normal repositories since the new code is using existing remote update methods.

#### What are the testing steps for this pull request?
1) Use pulp-cli to update the `proxy_url` for some remote
2) Run `katello:refresh_repos`
3) See that the pulp remote now matches the config in Katello