### PR TITLE
run Angular tests on Ubuntu 24.04

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,7 +31,7 @@ jobs:
 
   angular:
     name: Angular ${{ matrix.engine }} - NodeJS ${{ matrix.node }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Using Ubuntu 24.04 instead of 22.04 for Angular tests.

While 22.04 is still supported for some while, let's use the latest available environment if we can.

#### Considerations taken when implementing this change?

None

#### What are the testing steps for this pull request?

CI green, everyone happy
