### PR TITLE
Fixes #38214 - Hide Change content source task when permissions are missing

### DIFF
--- a/app/views/katello/api/v2/content_facet/show.json.rabl
+++ b/app/views/katello/api/v2/content_facet/show.json.rabl
@@ -39,6 +39,8 @@ child :content_facet => :content_facet_attributes do
     node(:view_activation_keys) { user.can?("view_activation_keys") }
     node(:view_products) { user.can?("view_products") }
     node(:create_bookmarks) { user.can?("create_bookmarks") }
+    node(:view_smart_proxies) { user.can?("view_smart_proxies") }
+    node(:view_capsule_content) { user.can?("view_capsule_content") }
   end
 end
 

--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -5,8 +5,9 @@
     option.kt-cv  { margin-left: 1em; }
 </style>
 <% spinner_path = asset_path('spinner.gif') %>
+<% can_change_content_source = User.current.can?("view_smart_proxies") && User.current.can?("view_capsule_content") %>
 
-<% if edit_action? && !using_hostgroups_page? && !using_discovered_hosts_page? %>
+<% if edit_action? && !using_hostgroups_page? && !using_discovered_hosts_page? && can_change_content_source %>
   <div style="margin-left: 270px">
     <%= link_to _("Change content source"), "/change_host_content_source?fromPage=hostEdit&host_id=#{@host.id}&initialContentSourceId=#{@host.content_source_id}" %>
   </div>

--- a/webpack/components/extensions/HostDetails/ActionsBar/index.js
+++ b/webpack/components/extensions/HostDetails/ActionsBar/index.js
@@ -22,6 +22,9 @@ const HostActionsBar = () => {
   const recalculateApplicability = ['edit_hosts', 'create_job_invocations'];
   const showRecalculate =
     can(recalculateApplicability, userPermissionsFromHostDetails({ hostDetails }));
+  const changeContentSource = ['view_smart_proxies', 'view_capsule_content'];
+  const showChangeContentSource =
+    can(changeContentSource, userPermissionsFromHostDetails({ hostDetails }));
 
   const refreshHostDetails = () => dispatch({
     type: 'API_GET',
@@ -62,14 +65,17 @@ const HostActionsBar = () => {
         </DropdownItem>
       )
       }
-      <DropdownItem
-        ouiaId="katello-change-host-content-source"
-        key="katello-change-host-content-source"
-        href={foremanUrl(`/change_host_content_source?host_id=${hostDetails?.id}&initialContentSourceId=${hostDetails?.content_facet_attributes?.content_source_id}`)}
-        icon={<CubeIcon />}
-      >
-        {__('Change content source')}
-      </DropdownItem>
+      {showChangeContentSource && (
+        <DropdownItem
+          ouiaId="katello-change-host-content-source"
+          key="katello-change-host-content-source"
+          href={foremanUrl(`/change_host_content_source?host_id=${hostDetails?.id}&initialContentSourceId=${hostDetails?.content_facet_attributes?.content_source_id}`)}
+          icon={<CubeIcon />}
+        >
+          {__('Change content source')}
+        </DropdownItem>
+      )
+      }
     </>
   );
 };


### PR DESCRIPTION
 #### What are the changes introduced in this pull request?
Check for permissions `view_smart_proxies` and `view_capsule_content` when displaying `Change content source` task.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

- Create  a limited user with permissions:

  ![roles](https://github.com/user-attachments/assets/bf3e3e7d-ea14-4619-9b58-17776faac2f2)

- Log in as limited user
- Hosts - select a host
     1. Permissions for smart proxy are set
         Change content source task in kebab menu is listed and works
     2.  Permissions for smart proxy are NOT set
          Change content source is not listed in the menu.