### PR TITLE
Fixes #38215 - Add unset option to bulk content host set rel version

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-release-version-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-release-version-modal.controller.js
@@ -27,12 +27,14 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkReleaseVersi
         }
 
         $scope.selected = {
-            release: undefined
+            release: ""
         };
         $scope.fetchingReleases = true;
 
         Organization.releaseVersions({id: CurrentOrganization}, function (response) {
             $scope.releases = response.results;
+            // Add empty string to unset the release version
+            $scope.releases.unshift("");
             $scope.fetchingReleases = false;
         });
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-release-version-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-release-version-modal.html
@@ -27,7 +27,7 @@
         <i ng-show="fetchingReleases" class="fa fa-spinner inline-icon fa-spin"></i>
         <select ng-hide="fetchingReleases || releases.length === 0"
                 type="select"
-                ng-options="release for release in releases"
+                ng-options="release === '' ? '(unset)' : release for release in releases"
                 ng-model="selected.release">
         </select>
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Add an unset option in the content host bulk actions for set release version

#### Considerations taken when implementing this change?
* I know we are doing the new all hosts page for 6.18 but right now customers still need an option and it's a small change

#### What are the testing steps for this pull request?
* Check out PR
* Assign a release version to your content host and check and see if it got set
* Unset the release version and see if it got removed