### PR TITLE
Fixes #38221 - Fix flat APT repo handling

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -1060,7 +1060,8 @@ module Katello
     end
 
     def deb_sanitize_pulp_distribution(distribution)
-      return "flat-repo" if distribution&.end_with?("/")
+      return "flat-repo" if distribution == "/"
+      return distribution.chomp("/") if distribution&.end_with?("/")
       distribution
     end
 


### PR DESCRIPTION
...whith a distribution other than "/".

I really should have gotten this right the first time around, here: https://github.com/Katello/katello/pull/11259