### PR TITLE
don't use evr-enabled PostgreSQL container in tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,6 @@ jobs:
     uses: theforeman/actions/.github/workflows/foreman_plugin.yml@v0
     with:
       plugin: katello
-      postgresql_container: ghcr.io/theforeman/postgresql-evr
       test_existing_database: false
       foreman_version: develop # set to the Foreman release branch after branching :)
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Use the default PostgreSQL container instead of the EVR-enabled one

#### Considerations taken when implementing this change?

Nope

#### What are the testing steps for this pull request?

:green_apple: 