### PR TITLE
Bump nightly devel version to 4.17

### DIFF
--- a/lib/katello/version.rb
+++ b/lib/katello/version.rb
@@ -1,3 +1,3 @@
 module Katello
-  VERSION = "4.16.0-master".freeze
+  VERSION = "4.17.0-master".freeze
 end


### PR DESCRIPTION
Katello 4.16 branching requires updating the Katello version in master. Bumping to 4.17.