### PR TITLE
Fixes #38225 - Prevent empty tbody inside booted containers

### DIFF
--- a/webpack/scenes/BootedContainerImages/BootedContainerImagesPage.js
+++ b/webpack/scenes/BootedContainerImages/BootedContainerImagesPage.js
@@ -134,40 +134,42 @@ const BootedContainerImagesPage = () => {
               </>
             </Tr>
           </Thead>
-          <Tbody>
-            {status === STATUS.PENDING && results.length === 0 && (
-              <Tr ouiaId="table-loading">
-                <Td colSpan={100}>
-                  <EmptyPage
-                    message={{
-                      type: 'loading',
-                      text: __('Loading...'),
-                    }}
-                  />
-                </Td>
-              </Tr>
-            )}
-            {!(status === STATUS.PENDING) &&
-              results.length === 0 &&
-              !errorMessage && (
-                <Tr ouiaId="table-empty">
+          {(results.length === 0 || errorMessage) && (
+            <Tbody>
+              {status === STATUS.PENDING && results.length === 0 && (
+                <Tr ouiaId="table-loading">
                   <Td colSpan={100}>
                     <EmptyPage
                       message={{
-                        type: 'empty',
+                        type: 'loading',
+                        text: __('Loading...'),
                       }}
                     />
                   </Td>
                 </Tr>
-            )}
-            {errorMessage && (
-              <Tr ouiaId="table-error">
-                <Td colSpan={100}>
-                  <EmptyPage message={{ type: 'error', text: errorMessage }} />
-                </Td>
-              </Tr>
-            )}
-          </Tbody>
+              )}
+              {!(status === STATUS.PENDING) &&
+                results.length === 0 &&
+                !errorMessage && (
+                  <Tr ouiaId="table-empty">
+                    <Td colSpan={100}>
+                      <EmptyPage
+                        message={{
+                          type: 'empty',
+                        }}
+                      />
+                    </Td>
+                  </Tr>
+              )}
+              {errorMessage && (
+                <Tr ouiaId="table-error">
+                  <Td colSpan={100}>
+                    <EmptyPage message={{ type: 'error', text: errorMessage }} />
+                  </Td>
+                </Tr>
+              )}
+            </Tbody>
+          )}
           {results?.map((result, rowIndex) => {
             const { bootc_booted_image: bootcBootedImage, digests } = result;
             const isExpanded = imageIsExpanded(bootcBootedImage);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Resolves empty <tbody> elements in the booted container images table by consolidating state checks (loading/empty/error) into a single <tbody>, ensuring valid HTML structure and preventing automation test failures caused by empty DOM nodes.

#### Considerations taken when implementing this change?

Empty <tbody> elements violated HTML specifications and led to flaky automation tests due to invalid DOM structure. The fix ensures the table always renders valid content while maintaining testability and accessibility compliance.

#### What are the testing steps for this pull request?

1. Register a bootc host
2. Go to Content -> Booted Container Images
3. Expand and view the table
4. This code snippet (Dev Console - Elements) shouldn't leave behind this empty tag if the conditions don't evaluate properly.
