### PR TITLE
Fixes #38226 - image mode column title should be Type

### DIFF
--- a/webpack/ForemanColumnExtensions/index.js
+++ b/webpack/ForemanColumnExtensions/index.js
@@ -31,9 +31,7 @@ const hostsIndexColumnExtensions = [
   {
     columnName: 'bootc_booted_image',
     title: (
-      <span id="image-mode-column-title-icon">
-        <FontAwesomeImageModeIcon title={__('Image mode / package mode')} />
-      </span>
+      <Text title={__('Image mode / package mode')} ouiaId="image-mode-column-title" className="pf-c-table__text">{__('Type')}</Text>
     ),
     wrapper: (hostDetails) => {
       const imageMode = hostDetails?.content_facet_attributes?.bootc_booted_image;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Changes the column title for host type to be "Type" instead of the image mode icon.

#### Considerations taken when implementing this change?
...

#### What are the testing steps for this pull request?
Enable the Type column, make sure it looks like:
![image](https://github.com/user-attachments/assets/7665704a-affb-4a2f-a258-b86fe1a3de81)

Make sure the popover says "Image mode / package mode".