### PR TITLE
Fixes #38230 - in host edit, unselecting media causes page freeze

### DIFF
--- a/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
+++ b/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
@@ -146,13 +146,13 @@ KT.hosts.onKatelloHostEditLoad = function(){
 
     $.each(prefixes, function(index, prefix) {
         $.each(attributes, function(attrIndex, attribute) {
-            $('body').on('change', '#' + prefix + '_' + attribute, function () {
+            $('body').on('select2:select select2:unselecting', '#' + prefix + '_' + attribute, function () {
                 KT.hosts.toggle_installation_medium();
             });
         });
     });
 
-    $('body').on('change', '#content_source_id', function () {
+    $('body').on('select2:select select2:unselecting', '#content_source_id', function () {
         KT.hosts.contentSourceChanged();
         KT.hosts.toggle_installation_medium();
     });
@@ -266,14 +266,15 @@ KT.hosts.on_synced_content_dropdown_change = function() {
 
 KT.hosts.set_install_media_bindings = function() {
     // reset the host medium id
-    $("#host_medium_id").on("change", KT.hosts.on_install_media_dropdown_change);
-    $("#s2id_host_medium_id").on("change", KT.hosts.on_install_media_dropdown_change);
-    $("#hostgroup_medium_id").on("change", KT.hosts.on_install_media_dropdown_change);
-    $("#s2id_hostgroup_medium_id").on("change", KT.hosts.on_install_media_dropdown_change);
+    $("#host_medium_id").on("select2:select", KT.hosts.on_install_media_dropdown_change);
+    $("#s2id_host_medium_id").on("select2:select", KT.hosts.on_install_media_dropdown_change);
+    $("#hostgroup_medium_id").on("select2:select", KT.hosts.on_install_media_dropdown_change);
+    $("#s2id_hostgroup_medium_id").on("select2:select", KT.hosts.on_install_media_dropdown_change);
 };
-
 KT.hosts.set_synced_content_bindings = function() {
-    KT.hosts.get_synced_content_dropdown().change(KT.hosts.on_synced_content_dropdown_change);
+    KT.hosts
+      .get_synced_content_dropdown()
+      .on('select2:select', KT.hosts.on_synced_content_dropdown_change);
 };
 
 KT.hosts.set_media_selection_bindings = function() {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Similar changes as here: https://github.com/theforeman/foreman/pull/10446 
#### Considerations taken when implementing this change?
usually when changing `on('change` I would also include the unselecting event, but that caused this error:
`Uncaught TypeError: Cannot read property 'query' of null` which might be because of double select2 activation
I'm not sure if we even need to re-activate select2 but keeping it like this seem to work

#### What are the testing steps for this pull request?
Katello must be available to reproduce, 
edit/create host, go to os tab, select architecture, os and media, unselect media -> page doesnt scroll
**Please test that `Synced Content ` still works as expected as I didnt test it** 

The page wont scroll and this error will be in console:
select2.js:5523 Uncaught TypeError: Cannot read properties of null (reading 'current')

