### PR TITLE
Fixes #38236 - copy /run/containers/0/auth.json only if it exists

### DIFF
--- a/app/views/foreman/job_templates/flatpak_login_action.erb
+++ b/app/views/foreman/job_templates/flatpak_login_action.erb
@@ -27,4 +27,6 @@ template_inputs:
 %>
 
 sudo podman login <%= server_url %> --username <%= username %> --password <%= password %>
-sudo cp /run/containers/0/auth.json /etc/flatpak/oci-auth.json
+if test -f "/run/containers/0/auth.json"; then
+  sudo cp --update /run/containers/0/auth.json /etc/flatpak/oci-auth.json
+fi


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Don't fail on copy `/run/containers/0/auth.json` to `/etc/flatpak/oci-auth.json` if the source file does not exist - its presence is optional.

#### Considerations taken when implementing this change?
There are a few options how to fix this, i.e. redirect stderr to `/dev/null`. I chose this `cp` option:

       -u, --update
              copy only when the SOURCE file is newer than the destination file or when the destination file is missing

for its positive side-effect: dont overwrite `oci-auth.json` if it has a newer content (at least I see this as a feature and not a bug of the chosen fix - let me see if you think otherwise).

#### What are the testing steps for this pull request?
Ensure no `/run/containers/0/auth.json` is present on a Host with podman and flatpak (this is default), and apply the job template to the Host.
