### PR TITLE
Fixes #38243 - Find a newly registered host correctly in the DB

### DIFF
--- a/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
@@ -5,7 +5,8 @@ module Katello
 
       def prepare_host
         if params['uuid']
-          @host = Katello::Host::SubscriptionFacet.find_by(uuid: params['uuid'])&.host
+          host_id = Katello::Host::SubscriptionFacet.find_by(uuid: params['uuid'])&.host_id
+          @host = ::Host::Managed.unscoped.find_by(id: host_id)
           if @host.nil?
             msg = _("Host was not found by the subscription UUID: '%s', this can happen if the host is registered already, but not to this instance") % params['uuid']
             fail ActiveRecord::RecordNotFound, msg


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Find the newly registered host in the DB correctly to set it into specified organization and location.

#### Considerations taken when implementing this change?
Host registration is a multiple steps process.
1 It's first stored into DB by [registration_manager](https://github.com/Katello/katello/blob/ebfaf9bb78bf8ac663584f647ae220b3ac928c6f/app/services/katello/registration_manager.rb#L29) with default location from setting [default_location_subscribed_hosts](https://github.com/Katello/katello/blob/83498c4f1e027faf730f6d40d27dcdf309d0af1e/app/models/katello/concerns/location_extensions.rb#L56).
2 Host gets updated by [host_fact_importer](https://github.com/theforeman/foreman/blob/84a54dc883f61907a9d9312720d1c0c61147958c/app/services/host_fact_importer.rb#L43) with default location from setting [default_location](https://github.com/theforeman/foreman/blob/84a54dc883f61907a9d9312720d1c0c61147958c/app/services/host_fact_importer.rb#L71).
3 Finally [Katello prepare_host](https://github.com/Katello/katello/blob/83498c4f1e027faf730f6d40d27dcdf309d0af1e/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb#L6) updates the host with the specified organization and location in the `Register Host` form.

When a non-admin user registers a host, the host's organization is retrieved from ActivationKey and set correctly.
Its location is set to the value of those two location settings in the first 2 steps and is supposed to be updated to the specified location in step 3.
But `Katello::Host::SubscriptionFacet.find_by(uuid: params['uuid'])&.host` in step 3 fails to find the newly registered host as it does a scoped search and looks for the host in the specified location from the `Register Host` form.

The change is this PR would search the host in the whole DB since `host id` is unique. 

#### What are the testing steps for this pull request?
1. Create a organization and location, create AK and create a non-admin user with "Register hosts" role
2. Login with the user and navigate to Hosts -> Register Host, and generate a registration command with created organization and location 
3. Run the registration command on host, and check the host in Satellite webUI in specified organization and location 

**Before**
Host is not present in specified location, instead present in "Default location"

**After**
Host is present in specified location, instead of "Default location"