### PR TITLE
Fixes #38251 - Make content view field ng-required on AK create

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/new/views/activation-key-new.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/new/views/activation-key-new.html
@@ -56,6 +56,7 @@
           <select ng-hide="contentViews.length === 0 || activationKey.environment === undefined "
                   id="content_view_id"
                   name="content_view_id"
+                  ng-required="activationKey.environment"
                   ng-model="activationKey.content_view_id"
                   ng-options="contentView.id as contentView.name for contentView in contentViews"
                   autofocus>
@@ -64,7 +65,7 @@
             The selected environment contains no Content Views, please select a different environment.
           </span>
           <span class="help-block" ng-show="activationKey.environment === undefined" translate>
-            Please select an environment.
+            Please select a lifecycle environment. Lifecycle environment and content view must be provided together.
           </span>
         </div>
       </span>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

On the Activation Key create form, make the Content View field `ng-required` if you've selected a lifecycle environment.
This disables the 'Save' button until you select both a LCE and CV.

#### Considerations taken when implementing this change?

Often required fields include a `*` next to them, but other `ng-required` fields on our Angular pages don't seem to have them. So I didn't add one here. Disabling Save should be enough for consistent behavior at least.

I tried to add the same improvement to the AK edit page, but it didn't work due to some Angular intricacies. However, the error message you get in that case when you save is very clear so I think that should be ok.

#### What are the testing steps for this pull request?

Create a new activation key
Select LCE but no content view
Try to save --> Observe that the Save button is disabled
Select a content view --> The Save button should now be enabled and work as normal
