### PR TITLE
Fixes #38253 - Send error via json so it is propagated to Hammer

### DIFF
--- a/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
@@ -48,6 +48,8 @@ module Katello
             handle_errors(labels: cve_params[:content_view_environments],
               ids: cve_params[:content_view_environment_ids])
           end
+        rescue Katello::Errors::MultiEnvironmentNotSupportedError => e
+          handle_multicv_not_enabled(e)
         end
 
         def cve_params

--- a/app/controllers/katello/concerns/api/v2/multi_cv_params_handling.rb
+++ b/app/controllers/katello/concerns/api/v2/multi_cv_params_handling.rb
@@ -19,6 +19,10 @@ module Katello
           :with_logging => true
         )
       end
+
+      def handle_multicv_not_enabled(e)
+        render :json => { :error => { :message => e.message }}, :status => :bad_request
+      end
     end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Send error via json so it's properly propagated to hammer. See the [redmine](https://projects.theforeman.org/issues/38253) for more details

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
