### PR TITLE
Fixes #38297 - Use client certificates for Candlepin events

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -132,9 +132,17 @@ module Katello
 
     config.to_prepare do
       Katello::CandlepinEventListener.client_factory = proc do
+        settings = ActiveRecord::Base.connection_pool.with_connection do
+          SETTINGS[:katello][:candlepin_events].merge(
+            ssl_key_file: Setting[:ssl_priv_key],
+            ssl_cert_file: Setting[:ssl_certificate],
+            ssl_ca_file: Setting[:ssl_ca_file]
+          )
+        end
+
         Katello::Messaging::Connection.create(
           connection_class: Katello::Messaging::StompConnection,
-          settings: SETTINGS[:katello][:candlepin_events]
+          settings: settings
         )
       end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This relies upon first getting in https://github.com/theforeman/puppet-certs/pull/490

The Candlepin events use the Foreman client certificates but the default CA since Candlepin runs using localhost certificates generated by the default CA. This means that it can't use the `/etc/foreman/proxy_ca.pem` certificate in it's current form as it represents the server CA. In the dependent PR, this would move to using a bundle CA combining the default and server CA into the single file allowing it to be used.

In production, the candlepin_events get configured in `katello.yaml` as:

```
  :candlepin_events:
    :ssl_cert_file: /etc/foreman/client_cert.pem
    :ssl_key_file: /etc/foreman/client_key.pem
    :ssl_ca_file: /etc/pki/katello/certs/katello-default-ca.crt
```

If this change goes forward, we would remove this section entirely, and rely upon Foreman core to handle configuration of certificates and reduce the configuration surface area of Katello. It would then follow that we can drop this parameter as well:

```
  :candlepin:
    :ca_cert_file: /etc/pki/katello/certs/katello-default-ca.crt
```

Which the code is already prepared to handle (https://github.com/Katello/katello/blob/master/app/services/cert/certs.rb#L31-L33).

#### What are the testing steps for this pull request?

1. The Packit PR from this change needs to be installed.
2. Install fresh or update install with custom certificates ([this can be helpful](https://github.com/theforeman/forklift/pull/1900)).
3. The installer PR is needed (https://github.com/theforeman/puppet-certs/pull/490)

This can either be installed via Forklift, or wait for it to land in the installer before testing this.