### PR TITLE
Fixes #38260 - Unregister duplicate event listeners for select2

### DIFF
--- a/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
+++ b/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
@@ -43,7 +43,7 @@ KT.hosts.fetchEnvironments = function () {
     orgIds = orgIds.map(id => Number(id));
     $.get(url, function (content_source) {
         $.each(content_source.lifecycle_environments, function(index, env) {
-            // Don't show environments that aren't in the selected org. See jQuery.each() docs    
+            // Don't show environments that aren't in the selected org. See jQuery.each() docs
             if (!orgIds.includes(env.organization_id)) return true;
             option = $("<option />").val(env.id).text(env.name);
             select.append(option);
@@ -151,7 +151,7 @@ KT.hosts.onKatelloHostEditLoad = function(){
             });
         });
     });
-
+    $('body').off('select2:select select2:unselecting', '#content_source_id');
     $('body').on('select2:select select2:unselecting', '#content_source_id', function () {
         KT.hosts.contentSourceChanged();
         KT.hosts.toggle_installation_medium();


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Some event listeners get registered multiple times, causing unnecessary calls. This change tries to make sure one of the event listeners gets registered once.

#### Considerations taken when implementing this change?

Easiest solution?.. Probably fixes only described issue.

#### What are the testing steps for this pull request?

1. Have two organizations
2. Go to Hosts > Create Host
3. Change organization to the other org and back a couple of times
4. Select content source
5. Open the lifecycle environment select

Actual behavior:
The lifecycle environment select offers the same environments many times, depending on how many times the organization was changed in step 3.

Expected behavior:
Each environment is offered only once

@MariaAga, you might want to check this.
