### PR TITLE
Fixes #38261 - Update Capsule, Maintenance & Utils repos to 6.17

### DIFF
--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -42,12 +42,9 @@ const recommendedRepositoriesSatTools = [
 ];
 
 const recommendedRepositoriesMisc = [
-  'satellite-capsule-6.16-for-rhel-8-x86_64-rpms',
-  'satellite-maintenance-6.16-for-rhel-8-x86_64-rpms',
-  'satellite-utils-6.16-for-rhel-8-x86_64-rpms',
-  'satellite-utils-6.16-for-rhel-9-x86_64-rpms',
-  'satellite-maintenance-6.16-for-rhel-9-x86_64-rpms',
-  'satellite-capsule-6.16-for-rhel-9-x86_64-rpms',
+  'satellite-utils-6.17-for-rhel-9-x86_64-rpms',
+  'satellite-maintenance-6.17-for-rhel-9-x86_64-rpms',
+  'satellite-capsule-6.17-for-rhel-9-x86_64-rpms',
 ];
 
 const recommendedRepositorySetLables = recommendedRepositoriesRHEL


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Updated Recommended Repositories Page to modify Satellite, Capsule and Maintainance repository from 6.16 to 6.17 for RHEL 9

#### Considerations taken when implementing this change?

Care was taken to modify only the relevant repository entries while keeping the structure intact to avoid unintended impacts.

#### What are the testing steps for this pull request?

Need to verify that RHEL 9 based repos for Capsule, Maintenance and Utils can be listed and enabled successfully on the WebUI
