### PR TITLE
Fixes #38264 - prevent duplicate entries

### DIFF
--- a/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
+++ b/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
@@ -49,7 +49,7 @@ KT.hosts.fetchEnvironments = function () {
         });
     $.get(url, function (content_source) {
         $.each(content_source.lifecycle_environments, function(index, env) {
-            // Don't show environments that aren't in the selected org. See jQuery.each() docs    
+            // Don't show environments that aren't in the selected org. See jQuery.each() docs
             if (!orgIds.includes(env.organization_id)) return true;
             option = $("<option />").val(env.id).text(env.name);
             select.append(option);
@@ -150,15 +150,17 @@ KT.hosts.onKatelloHostEditLoad = function(){
     var prefixes = ['host', 'hostgroup'],
         attributes = ['content_view_id', 'environment_id', 'architecture_id'];
 
+    $('body').off('.hostsContentSourceNS');
+
     $.each(prefixes, function(index, prefix) {
         $.each(attributes, function(attrIndex, attribute) {
-            $('body').on('select2:select select2:unselecting', '#' + prefix + '_' + attribute, function () {
+            $('body').on('select2:select.hostsContentSourceNS select2:unselecting.hostsContentSourceNS', '#' + prefix + '_' + attribute, function () {
                 KT.hosts.toggle_installation_medium();
             });
         });
     });
 
-    $('body').on('select2:select select2:unselecting', '#content_source_id', function () {
+    $('body').on('select2:select.hostsContentSourceNS select2:unselecting.hostsContentSourceNS', '#content_source_id', function() {
         KT.hosts.contentSourceChanged();
         KT.hosts.toggle_installation_medium();
     });


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Prevent to bind to the on ContentLoad multiple times which would lead to duplicate entries in the Lifecycle Environment Selection on the CreateHost page.

#### Considerations taken when implementing this change?
Unbind to the event and then bind new to prevent duplicate entries. 

#### What are the testing steps for this pull request?
- Use the create host page
- Select the Hostgroup which uses ContentSource and all Katello related stuff
- Unselect (x) the Content Source
- Select the same Content Source
- Try to pick another Hostgroup and Unselect/Select the Content Source for another test
At all stages, the Lifcecycle Environment Selection should not have duplicate entries. 