### PR TITLE
Fixes #38265 - Use jquery data for nested hostgroups

### DIFF
--- a/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
+++ b/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
@@ -36,11 +36,17 @@ KT.hosts.fetchEnvironments = function () {
   select.find('option').remove();
   if (content_source_id) {
     var url = tfm.tools.foremanUrl('/katello/api/capsules/' + content_source_id);
-    var orgIds = $("#hostgroup_organization_ids").val();
-    if(orgIds === undefined || orgIds === null || orgIds.length === 0) {
+    var orgIdsElem = $("#hostgroup_organization_ids");
+    var orgIds = orgIdsElem.val();
+    if (orgIds === undefined || orgIds === null || orgIds.length === 0) {
+        orgIds = orgIdsElem.data('useds');
+    }
+    if (orgIds === undefined || orgIds === null || orgIds.length === 0) {
         orgIds = [$("#host_organization_id").val()];
     };
-    orgIds = orgIds.map(id => Number(id));
+    orgIds = orgIds.map(function (id) {
+            return Number(id);
+        });
     $.get(url, function (content_source) {
         $.each(content_source.lifecycle_environments, function(index, env) {
             // Don't show environments that aren't in the selected org. See jQuery.each() docs    


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

In the host_and_hostgroup_edit form, there is a hidden select element created with the ID `#hostgroup_organization_ids`. 

![image](https://github.com/user-attachments/assets/5200c40f-b5ba-4815-8197-614f732065dc)

Its value is an array of organization IDs. When a user changes the content source using the dropdown, this hidden element is used to get organization IDs to query. This is done in order to populate the Lifecycle Environment and Content View fields.

Previously (I'm assuming before jQuery 3?) this was accessed via
```
$("#hostgroup_organization_ids").val()
```

Problem is, when creating a nested hostgroup, that jQuery call seems to return `[]` -- even though the vanilla JS call `document.querySelector("#hostgroup_organization_ids")` confirms the element is there, and has the required data (`[1]` in my case).

I fixed the issue by using `.data('useds')` instead of `.val()`. This fixed the nested hostgroup issue, but broke hostgroup edit.
So I altered the logic to only use `.data('useds')` in the specific case of nested hostgroups.

#### Considerations taken when implementing this change?

I am not sure why my solution works, or why it breaks the other flow, or if my solution is at all correct.

#### What are the testing steps for this pull request?

Steps to Reproduce:

1. Set up a Foreman server with a Smart Proxy with Content and have multiple LCE

2. Create a hostgroup HG1 with Foreman server as content source and choose any set of LCE and CV

3. Now create a nested hostgroup HG2 from HG1
and
Change the content source to Smart Proxy
Now try to select other cv or lce

Before patch:
It wont populate any and says "No matches found"

Expected behavior:
It should populate other cv and lce
