### PR TITLE
Fixes #38269 - fix container-image-name

### DIFF
--- a/app/lib/katello/validators/container_image_name_validator.rb
+++ b/app/lib/katello/validators/container_image_name_validator.rb
@@ -3,12 +3,13 @@ module Katello
     class ContainerImageNameValidator < ActiveModel::EachValidator
       def validate_each(record, attribute, value)
         if value && !ContainerImageNameValidator.validate_name(value)
-          record.errors.add(attribute, N_("invalid container image name"))
+          record.errors.add(attribute, N_("The generated container repository name is invalid. Please review the lifecycle environment's registry name pattern. It may be caused by special characters in the components that make up the name, like the organization."))
         end
       end
 
       def self.validate_name(name)
-        if name.empty? || name.length > 255 || !/\A([a-z0-9]+[a-z0-9\-_.]*)+(\/[a-z0-9]+[a-z0-9\-_.]*)*\z/.match?(name)
+        # regexp-source: https://specs.opencontainers.org/distribution-spec/?v=v1.0.0#DISTRIBUTION-SPEC-26
+        if name.empty? || name.length > 255 || !/\A[a-z0-9]+([\-_.][a-z0-9]+)*(\/[a-z0-9]+([\-_.][a-z0-9]+)*)*\z/.match?(name)
           return false
         end
         true


### PR DESCRIPTION
**This does not fix the underlying issue, yet!**

The issue being that Organization Labels ending with non-alphanumeric characters will break the container-image-name used for publishing in pulp.
I am hesitant to just strip them, because it may happen that there are two Organizations `ACME Inc.` and `ACME Inc`. Stripping the `_` from the Labels will end in both Orgs having the same container-image base-path.

#### What are the changes introduced in this pull request?
Fixes the Container-Image-Name Validator to detect the same as pulp-container (see https://github.com/pulp/pulp_container/blob/bd2a27e9f581d675bf33232fede2a6466d56aa3d/pulp_container/app/serializers.py#L39).
With this fix it is no longer possible to create docker-type repos in Organizations whose Label ends in `_`. Creation worked before but synchronizing failed, because pulp rejects the container-image-name.

I am open for suggestions on how to fix this thoroughly :thinking: 