### PR TITLE
Fixes #38270 - Don't create content view environment when CV is not published to LCE

### DIFF
--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -14,6 +14,8 @@ module Katello
 
     class MultiEnvironmentNotSupportedError < StandardError; end
 
+    class ContentViewEnvironmentError < StandardError; end
+
     # unauthorized access
     class SecurityViolation < StandardError; end
 

--- a/app/models/katello/content_view_environment.rb
+++ b/app/models/katello/content_view_environment.rb
@@ -21,6 +21,7 @@ module Katello
     validates_lengths_from_database
     validates :environment_id, uniqueness: {scope: :content_view_id}, presence: true
     validates :content_view_id, presence: true
+    validates :content_view_version_id, presence: true
     validates_with Validators::ContentViewEnvironmentOrgValidator
     validates_with Validators::ContentViewEnvironmentCoherentDefaultValidator
 

--- a/spec/helpers/organization_helper_methods.rb
+++ b/spec/helpers/organization_helper_methods.rb
@@ -30,7 +30,7 @@ module Katello
         view = ContentView.create!(:name => "test view #{count}", :label => "test_view_#{count}",
                                    :organization => env.organization)
 
-        version = ContentViewVersion.new(:content_view => view,
+        version = ContentViewVersion.first_or_create(:content_view => view,
                                          :major => 1)
         view.add_environment(env, version)
         version.save!

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -61,13 +61,13 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     put :update, params: {
       :id => host.id,
       :content_facet_attributes => {
-        :content_view_id => @cv2.id,
+        :content_view_id => @cv3.id,
         :lifecycle_environment_id => @dev.id,
       },
     }, session: set_session_user
     assert_response :success
     host.content_facet.reload
-    target_cve = ::Katello::ContentViewEnvironment.where(:content_view_id => @cv2.id,
+    target_cve = ::Katello::ContentViewEnvironment.where(:content_view_id => @cv3.id,
       :environment_id => @dev.id).first
     assert_equal 1, host.content_facet.content_view_environment_ids.count
     refute_equal orig_cves, host.content_facet.content_view_environment_ids

--- a/test/factories/content_view_environment_factory.rb
+++ b/test/factories/content_view_environment_factory.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :katello_content_view_environment, :class => Katello::ContentViewEnvironment do
     sequence(:name) { |n| "name#{n}" }
     sequence(:label) { |n| "label#{n}" }
+    association :content_view_version, :factory => :katello_content_view_version
   end
 end

--- a/test/helpers/hosts_and_hostgroups_helper_test.rb
+++ b/test/helpers/hosts_and_hostgroups_helper_test.rb
@@ -75,6 +75,7 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
     @arch = architectures(:x86_64)
     @cv = @repo_with_distro.content_view
     @env = @repo_with_distro.environment
+    @cv2 = katello_content_views(:library_view)
   end
 
   test "kickstart repository options should handle os - selected call with no params" do
@@ -192,8 +193,8 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
     host = ::Host.new
     host.content_facet = ::Katello::Host::ContentFacet.new(:content_source_id => 999)
     host.content_facet.assign_single_environment(
-      lifecycle_environment_id: 997,
-      content_view_id: 998
+      lifecycle_environment_id: @env.id,
+      content_view_id: @cv2.id
     )
     host.content_facet.content_view_environments.first.stubs(:generate_info)
     hostgroup = ::Hostgroup.new(

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -148,7 +148,7 @@ module Katello
 
     def test_update_with_invalid_cv_env_combo
       host = FactoryBot.create(:host, :with_content, :content_view => @library_view, :lifecycle_environment => @library)
-      assert_raises(ActiveRecord::RecordInvalid) do
+      assert_raises(Katello::Errors::ContentViewEnvironmentError) do
         host.content_facet.assign_single_environment(
           content_view: @library_view,
           lifecycle_environment: @organization1_library # env is not in the same org as @library_view


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Previously Katello would create a `Katello::ContentViewEnvironment` when creating a host, if none existed with that combination of cv/lce. The problem is that creating one without the corresponding Pulp content being hosted (e.g. publishing/promoting the content view to the LCE) will break things.

#### Considerations taken when implementing this change?

The UI already guards against this, so I think this fix is mainly for Robottelo.

#### What are the testing steps for this pull request?

Try `hammer host create` with `--lifecycle-environment-id` and `--content-view-id` options

With a valid combination (published/promoted CV), it should work.
With an invalid combination, you should get one of the new error messages (see the code).

