### PR TITLE
Fixes #38273 - Flatpak remote create no longer logs token

### DIFF
--- a/app/controllers/katello/api/v2/flatpak_remotes_controller.rb
+++ b/app/controllers/katello/api/v2/flatpak_remotes_controller.rb
@@ -1,6 +1,9 @@
 module Katello
   class Api::V2::FlatpakRemotesController < Katello::Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
+    include ::Foreman::Controller::FilterParameters
+
+    filter_parameters :token
 
     before_action :find_authorized_katello_resource, :except => [:index, :create, :auto_complete_search]
     before_action :find_optional_organization, :only => [:index, :auto_complete_search]


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
When creating a Flatpak remote, we no longer log the user's token.

#### Considerations taken when implementing this change?
There are none I am aware of.

#### What are the testing steps for this pull request?
1. Generate Flatpak remote username and token on https://access.redhat.com/terms-based-registry/
2. Create a Satellite Flatpak remote pointing to a Red Hat Flatpak remote:
```
hammer flatpak-remote create --name="test remote" --url="https://flatpaks.redhat.io/rhel" --organization-id=1 --username="<username>" --token="<token>"
```
3. View the log. The token should not be printed:
```
15:35:15 rails.1   | 2025-03-06T15:35:15 [D|app|cc5e8791] With body: {"total":1,"subtotal":1,"selectable":1,"page":1,"per_page":1000,"error":null,"search":null,"sort":{"by":"name","order":"asc"},"results":[{"name":"Redhat flatpak 2","url":"https://flatpaks.redhat.io/rhel","description":null,"username":"5894300|qjames","seeded":false,"registry_url":null,"id":2,"organization_id":1,"organization":{"name":"Default Organization","label":"Default_Organization","id":1}}]}
```
4. Ensure that other Flatpak remote operations still function. For SHOW, the token is not displayed either before or after this PR.