### PR TITLE
Fixes #38283 - Hide deb_enable_structured_apt setting in satellite

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -686,7 +686,8 @@ Foreman::Plugin.register :katello do
         default: false,
         full_name: N_('Enable structured APT for deb content'),
         description: N_("If set, newly created APT repos in Katello will use the same repo structure as the remote repos they are synchronized from. " \
-                        "You may migrate existing APT repos to match the setting, by running 'foreman-rake katello:migrate_structure_content_for_deb'.")
+                        "You may migrate existing APT repos to match the setting, by running 'foreman-rake katello:migrate_structure_content_for_deb'."),
+        :if => lambda { ::Katello::RepositoryTypeManager.enabled?(::Katello::Repository::DEB_TYPE) }
     end
   end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Hides the deb_enable_structured_apt setting in Satellite if Debian content management is not enabled or supported.

#### Considerations taken when implementing this change?

Ensures that the setting is only visible when Debian content management is enabled and supported, preventing unnecessary configuration options from being displayed.

#### What are the testing steps for this pull request?

1. Install a Satellite 6.17 snap 1.1
2. Check in Administer --> Settings --> Content tab and scroll at the very end
3. Alternatively check via hammer for "deb_enable_structured_apt" 
4. You should not see any deb\apt relevant settings in Satellite if deb content management is not enabled. 
