### PR TITLE
Fixes #38287 - Pass container registry password on stdin

### DIFF
--- a/app/views/foreman/job_templates/flatpak_login_action.erb
+++ b/app/views/foreman/job_templates/flatpak_login_action.erb
@@ -26,7 +26,7 @@ template_inputs:
   password = input('Password')
 %>
 
-echo <%= password %> | sudo podman login <%= server_url %> --username <%= username %> --password-stdin
+echo <%= shell_escape(password) %> | sudo podman login <%= server_url %> --username <%= username %> --password-stdin
 if test -f "/run/containers/0/auth.json"; then
   sudo cp --update /run/containers/0/auth.json /etc/flatpak/oci-auth.json
 fi

--- a/app/views/foreman/job_templates/flatpak_login_action.erb
+++ b/app/views/foreman/job_templates/flatpak_login_action.erb
@@ -26,7 +26,7 @@ template_inputs:
   password = input('Password')
 %>
 
-sudo podman login <%= server_url %> --username <%= username %> --password <%= password %>
+echo <%= password %> | sudo podman login <%= server_url %> --username <%= username %> --password-stdin
 if test -f "/run/containers/0/auth.json"; then
   sudo cp --update /run/containers/0/auth.json /etc/flatpak/oci-auth.json
 fi

--- a/app/views/foreman/job_templates/flatpak_login_action.erb
+++ b/app/views/foreman/job_templates/flatpak_login_action.erb
@@ -6,7 +6,7 @@ description_format: 'Login to flatpak registry via podman'
 provider_type: script
 template_inputs:
 - name: Flatpak registry URL
-  description: URL of server/capsule
+  description: URL of container registry
   input_type: user
   required: true
 - name: Username

--- a/app/views/foreman/job_templates/flatpak_login_action.erb
+++ b/app/views/foreman/job_templates/flatpak_login_action.erb
@@ -26,7 +26,4 @@ template_inputs:
   password = input('Password')
 %>
 
-echo <%= shell_escape(password) %> | sudo podman login <%= server_url %> --username <%= username %> --password-stdin
-if test -f "/run/containers/0/auth.json"; then
-  sudo cp --update /run/containers/0/auth.json /etc/flatpak/oci-auth.json
-fi
+echo <%= shell_escape(password) %> | sudo podman login <%= server_url %> --username <%= username %> --password-stdin --authfile /etc/flatpak/oci-auth.json


### PR DESCRIPTION
to prevent it from being visible in process listing.

#### What are the testing steps for this pull request?
1) Ensure `podman login` takes a long time to finish, having firewall drop packets could work
2) Run this job template
3) Run `ps -ef | grep 'podman login'`, check that the password doesn't show up there
