### PR TITLE
Fixes #38290 - set image mode details card ouiaId

### DIFF
--- a/webpack/components/extensions/HostDetails/DetailsTabCards/ImageModeCard.js
+++ b/webpack/components/extensions/HostDetails/DetailsTabCards/ImageModeCard.js
@@ -33,6 +33,7 @@ const ImageModeCard = ({ isExpandedGlobal, hostDetails }) => {
       expandable
       masonryLayout
       isExpandedGlobal={isExpandedGlobal}
+      ouiaId="image-mode"
     >
       <a href={actionUrl(hostDetails.name)}>{__('Modify via remote execution')}</a>
       <DescriptionList isHorizontal>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Sets the ouiaId of the Image Mode card properly.

#### Considerations taken when implementing this change?
If Foreman wasn't also edited in https://github.com/theforeman/foreman/pull/10480 , including the nice icon would not be possible while also maintaining a sane ouiaId

#### What are the testing steps for this pull request?
Check the image mode card's ouiaId in a web dev console:

![image](https://github.com/user-attachments/assets/09f3a2f8-7115-4dde-a218-e00d34fab10a)

