### PR TITLE
Fixes #38284 - Fix capsule sync-status rolling CV

### DIFF
--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -186,7 +186,7 @@ module Katello
     end
 
     def archived_repos
-      self.default? ? self.repositories : self.repos(nil)
+      (self.default? || self.rolling?) ? self.repositories : self.repos(nil)
     end
 
     def non_archive_repos


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fix SmartProxy Content sync-status not showing repository names for Rolling CVs

see also https://github.com/Katello/katello/pull/11240#issuecomment-2698939650
