### PR TITLE
Fixes #38296 - Show Deb repos for content hosts repo set management page

### DIFF
--- a/app/models/katello/product_content.rb
+++ b/app/models/katello/product_content.rb
@@ -45,7 +45,9 @@ module Katello
     end
 
     def self.enabled(organization)
-      joins(:content).where("#{self.content_table_name}.cp_content_id" => Katello::RootRepository.in_organization(organization).select(:content_id))
+      content_ids = Katello::RootRepository.in_organization(organization).where.not(content_id: nil).pluck(:content_id)
+      structured_apt_content_ids = Katello::Repository.in_organization(organization).library.pluck(:content_id)
+      joins(:content).where("#{self.content_table_name}.cp_content_id" => content_ids + structured_apt_content_ids)
     end
 
     def self.with_valid_subscription(organization)

--- a/test/factories/repository_factory_structured_apt.rb
+++ b/test/factories/repository_factory_structured_apt.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :structured_apt_katello_repository, :class => Katello::Repository do
+    association :root, :factory => :katello_root_repository, :trait => :structured_apt_deb_root, :strategy => :build
+
+    sequence(:pulp_id) { |n| "pulp-#{n}" }
+    sequence(:relative_path) { |n| "/ACME_Corporation/DEV/Repo#{n}" }
+
+    content_id { 'struct-apt-content-id' }
+  end
+end

--- a/test/factories/root_repository_factory.rb
+++ b/test/factories/root_repository_factory.rb
@@ -47,6 +47,15 @@ FactoryBot.define do
       deb_architectures { "x86_64" }
     end
 
+    trait :structured_apt_deb_root do
+      content_type { "deb" }
+      download_policy { "" }
+      deb_releases { "5 6" }
+      deb_components { "best" }
+      deb_architectures { "x86_64" }
+      content_id { nil }
+    end
+
     factory :docker_root_repository, traits: [:docker_root]
   end
 end

--- a/test/models/product_content_test.rb
+++ b/test/models/product_content_test.rb
@@ -52,6 +52,21 @@ module Katello
       assert_includes Katello::ProductContent.enabled(@product.organization), @product_content
     end
 
+    def test_enabled_with_structured_apt_content
+      Setting['deb_enable_structured_apt'] = true
+      assert_includes Katello::ProductContent.all, @product_content
+      refute_includes Katello::ProductContent.enabled(@product.organization), @product_content
+
+      deb_root = FactoryBot.create(:katello_root_repository, :structured_apt_deb_root, :product => @product)
+      deb_repo = FactoryBot.create(:structured_apt_katello_repository, :root => deb_root, :environment_id => @product.organization.library.id, :content_id => @content_id,
+        :content_view_version_id => @product.organization.default_content_view.versions.first.id)
+
+      assert_nil deb_root.content_id
+      assert_equal @content_id, deb_repo.content_id
+      assert_equal deb_root.library_instance.content_id, @content_id
+      assert_includes Katello::ProductContent.enabled(@product.organization), @product_content
+    end
+
     def test_enabled_value_from_candlepin
       ::Katello::Resources::Candlepin::Product.expects(:get).returns(
         [


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Debian repos are not displayed in the Repository Set Management on the Content Hosts page. This is a bug introduced with Debian structured apt and fixed here. 

#### Considerations taken when implementing this change?
For yum repos, the content id is part of the root repository, while for Deb repos with structured apt, it is part of each Katello::Repository. So we need to extract only the content_ids of the Repositories that are library instances to prevent multiple entries. 

#### What are the testing steps for this pull request?
Go to 'Content Hosts' --> Select multiple hosts --> Click 'Select Action' --> Choose 'Manage Repository Sets'

Expected outcome: Repo sets of Deb/Yum repos are shown

Actual outcome: Only Yum repos are shown