### PR TITLE
Fixes #38191: Skip reassignment for multiCV in remove

### DIFF
--- a/app/lib/actions/katello/content_view/remove.rb
+++ b/app/lib/actions/katello/content_view/remove.rb
@@ -119,13 +119,17 @@ module Actions
           end
           all_cv_envs = combined_cv_envs(cv_envs, versions)
 
-          if all_cv_envs.flat_map(&:hosts).any? && !cve_exists?(options[:system_environment_id],
-                                                                options[:system_content_view_id])
+          single_env_hosts_exist = all_cv_envs.flat_map(&:hosts).any? do |host|
+            !host.content_facet.multi_content_view_environment?
+          end
+          if single_env_hosts_exist && !cve_exists?(options[:system_environment_id], options[:system_content_view_id])
             fail _("Unable to reassign systems. Please check system_content_view_id and system_environment_id.")
           end
 
-          if all_cv_envs.flat_map(&:activation_keys).any? && !cve_exists?(options[:key_environment_id],
-                                                                          options[:key_content_view_id])
+          single_env_keys_exist = all_cv_envs.flat_map(&:activation_keys).any? do |key|
+            !key.multi_content_view_environment?
+          end
+          if single_env_keys_exist && !cve_exists?(options[:key_environment_id], options[:key_content_view_id])
             fail _("Unable to reassign activation_keys. Please check activation_key_content_view_id and activation_key_environment_id.")
           end
         end

--- a/app/views/katello/api/v2/content_view_versions/base.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/base.json.rabl
@@ -73,8 +73,20 @@ child :sorted_organization_readable_environments => :environments do
     ::Host.authorized('view_hosts').in_content_view_environment(:content_view => version.content_view, :lifecycle_environment => env).count
   end
 
+  node :multi_env_host_count do |env|
+    hosts = ::Host.authorized('view_hosts')
+      .in_content_view_environments(content_views: [version.content_view], lifecycle_environments: [env])
+    hosts.count { |host| host.content_facet.multi_content_view_environment? }
+  end
+
   node :activation_key_count do |env|
     Katello::ActivationKey.with_content_views(version.content_view).with_environments(env).count
+  end
+
+  node :multi_env_ak_count do |env|
+    keys = Katello::ActivationKey.with_content_views(version.content_view)
+      .with_environments(env)
+    keys.count { |key| key.multi_content_view_environment? }
   end
 end
 

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVEnvironmentSelectionForm.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVEnvironmentSelectionForm.js
@@ -25,9 +25,15 @@ const CVEnvironmentSelectionForm = () => {
 
   // Based on env selected for removal, decide if we need to reassign hosts and activation keys.
   useDeepCompareEffect(() => {
-    const selectedEnv = versionEnvironments.filter(env => selectedEnvSet.has(env.id));
-    setAffectedActivationKeys(!!(selectedEnv.filter(env => env.activation_key_count > 0).length));
-    setAffectedHosts(!!(selectedEnv.filter(env => env.host_count > 0).length));
+    const selectedEnvironments = versionEnvironments.filter(env => selectedEnvSet.has(env.id));
+
+    const needsHostReassignment = selectedEnvironments.some(env =>
+      (env.host_count || 0) > (env.multi_env_host_count || 0));
+    setAffectedHosts(needsHostReassignment);
+
+    const needsAKReassignment = selectedEnvironments.some(env =>
+      (env.activation_key_count || 0) > (env.multi_env_ak_count || 0));
+    setAffectedActivationKeys(needsAKReassignment);
   }, [setAffectedActivationKeys, setAffectedHosts,
     versionEnvironments, selectedEnvSet, selectedEnvSet.size]);
 

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignActivationKeysForm.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignActivationKeysForm.js
@@ -80,7 +80,7 @@ const CVReassignActivationKeysForm = () => {
     contentViewsInEnvError, selectedEnvForAK, setSelectedCVForAK, setSelectedCVNameForAK,
     cvInEnvLoading, selectedCVForAK, cvId, versionEnvironments, selectedEnvSet]);
 
-  const multiCVWarning = activationKeysResponse?.results?.some?.(key =>
+  const multiCVInfo = activationKeysResponse?.results?.some?.(key =>
     key.multi_content_view_environment);
 
   const fetchSelectedCVName = (id) => {
@@ -117,12 +117,12 @@ const CVReassignActivationKeysForm = () => {
 
   return (
     <>
-      {!alertDismissed && multiCVWarning && (
+      {!alertDismissed && multiCVInfo && (
         <Alert
-          ouiaId="multi-cv-warning-alert"
-          variant="warning"
+          ouiaId="multi-cv-info-alert"
+          variant="info"
           isInline
-          title={__('Warning')}
+          title={__('Multi-environment activation key(s) affected')}
           actionClose={<AlertActionCloseButton onClose={() => setAlertDismissed(true)} />}
         >
           <p>{multiCVRemovalInfo}</p>

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignHostsForm.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/RemoveSteps/CVReassignHostsForm.js
@@ -30,7 +30,7 @@ const CVReassignHostsForm = () => {
   const [alertDismissed, setAlertDismissed] = useState(false);
   const hostResponse = useSelector(selectCVHosts);
 
-  const multiCVWarning = hostResponse?.results?.some?.(host =>
+  const multiCVInfo = hostResponse?.results?.some?.(host =>
     host.content_facet_attributes?.multi_content_view_environment);
 
   const multiCVRemovalInfo = __('This content view version is used in one or more multi-environment hosts. The version will simply be removed from the multi-environment hosts. The content view and lifecycle environment you select here will only apply to single-environment hosts. See hammer activation-key --help for more details.');
@@ -112,12 +112,12 @@ const CVReassignHostsForm = () => {
 
   return (
     <>
-      {!alertDismissed && multiCVWarning && (
+      {!alertDismissed && multiCVInfo && (
         <Alert
-          ouiaId="multi-cv-warning-alert"
-          variant="warning"
+          ouiaId="multi-cv-info-alert"
+          variant="info"
           isInline
-          title={__('Warning')}
+          title={__('Multi-environment host(s) affected')}
           actionClose={<AlertActionCloseButton onClose={() => setAlertDismissed(true)} />}
         >
           <p>{multiCVRemovalInfo}</p>

--- a/webpack/scenes/ContentViews/Details/Versions/Delete/__tests__/cvVersionRemove.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/Delete/__tests__/cvVersionRemove.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { renderWithRedux, patientlyWaitFor, fireEvent } from 'react-testing-lib-wrapper';
-import { nockInstance, assertNockRequest, mockAutocomplete, mockForemanAutocomplete } from '../../../../../../test-utils/nockWrapper';
+import { nockInstance, assertNockRequest, mockAutocomplete } from '../../../../../../test-utils/nockWrapper';
 import api, { foremanApi } from '../../../../../../services/api';
 import CONTENT_VIEWS_KEY from '../../../../ContentViewsConstants';
 import ContentViewVersions from '../../ContentViewVersions';
@@ -123,7 +123,11 @@ test('Can open Remove wizard and remove version from simple environment', async 
 test('Can open Remove wizard and remove version from environment with hosts', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
   const hostAutocompleteUrl = '/hosts/auto_complete_search';
-  const hostAutocompleteScope = mockForemanAutocomplete(nockInstance, hostAutocompleteUrl);
+  const hostAutocompleteScope = nockInstance
+    .get(foremanApi.getApiUrl(hostAutocompleteUrl))
+    .query(true)
+    .times(2)
+    .reply(200, []);
 
   const scope = nockInstance
     .get(cvVersions)
@@ -138,6 +142,7 @@ test('Can open Remove wizard and remove version from environment with hosts', as
   const hostScope = nockInstance
     .get(hostURL)
     .query(true)
+    .times(2)
     .reply(200, affectedHostData);
 
   const cVDropDownOptionsScope = nockInstance
@@ -211,7 +216,11 @@ test('Can open Remove wizard and remove version from environment with hosts', as
 test('Can open Remove wizard and remove version from environment with activation keys', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
   const akAutocompleteUrl = '/activation_keys/auto_complete_search';
-  const akAutocompleteScope = mockAutocomplete(nockInstance, akAutocompleteUrl);
+  const akAutocompleteScope = nockInstance
+    .get(api.getApiUrl(akAutocompleteUrl))
+    .query(true)
+    .times(2)
+    .reply(200, []);
 
   const scope = nockInstance
     .get(cvVersions)
@@ -226,6 +235,7 @@ test('Can open Remove wizard and remove version from environment with activation
   const activationKeysScope = nockInstance
     .get(activationKeyURL)
     .query(true)
+    .times(2)
     .reply(200, affectedActivationKeysData);
 
   const cVDropDownOptionsScope = nockInstance


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Updated the remove wizard to skip the reassignment selection step in remove version for multiCV. The change streamlines the process by automatically bypassing the unnecessary reassignment of cv/lce, ensuring that the user isn’t prompted to choose a replacement that will ultimately be ignored.

#### Considerations taken when implementing this change?

Ensured that the skipping logic remains intact while improving the user experience by eliminating steps which would be ignored. Special attention was given to maintaining backward compatibility for non-multiCV flows and updating tests to confirm that the wizard behaves as expected. 

#### What are the testing steps for this pull request?

Create a multi-CV activation key

1. Promote a CV Version to multiple environments
2. Using Hammer CLI, update the activation key to use mutli CVE
Example command: hammer activation-key update --organization="Default Organization" --id=1 --content-view-environments="ABC/cv1,XYZ/cv1"
3. Confirm that the activation key uses multi CVEs

Assign and register multiple hosts using the multi-CV activation key

Remove the version from the environment

1. Go to the CV associated with the activation key -> Versions
2. Click on the 3 dots of the respective CV Version and select the option "Remove from environments"
3. If a content view version is used solely by multi-environment hosts, it will simply be removed from those hosts, and the "Reassign affected hosts" step will be skipped.
4. If an environment is used solely by multi-environment activation keys, it will be removed from those keys, and the "Reassign activation keys" step will be skipped.
