### PR TITLE
Fixes #38312 - bind this to repositoryType

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repository-types.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repository-types.service.js
@@ -45,6 +45,9 @@
             return angular.isDefined(this.repositoryType(desiredType));
         };
 
+        this.repositoryType = this.repositoryType.bind(this);
+        this.repositoryTypeEnabled = this.repositoryTypeEnabled.bind(this);
+
         this.pulp3Supported = function(desiredType) {
             var found = _.find(repositoryTypes, function(type) {
                 return type.id === desiredType;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

On the `/lifecycle_environments/{id}` page, several console errors were appearing:

```
this.repositoryType is not a function
```

This (heh) should fix those errors.

#### Considerations taken when implementing this change?

I'm not sure why (or if) this ever worked properly in the past.

It could have also been solved by using arrow functions, but I would want to update that consistently throughout the entire code base, and this isn't the place to do that.

#### What are the testing steps for this pull request?

Create at least one lifecycle environment
Go to its details page
Check the JS console for errors

