### PR TITLE
Fixes #38314 - Populate counts for partially synced content views on smart proxy

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -602,6 +602,14 @@ module Katello
         repos_in_env_cv(environment, content_view) - repos_in_sync_history
       end
 
+      def up_to_date?(environment = nil, content_view = nil)
+        total_repos = repos_in_env_cv(environment, content_view)&.count
+        pending_sync = repos_pending_sync(environment, content_view)&.count
+        return true if pending_sync&.zero? && total_repos&.positive?
+        return false if total_repos.to_i == pending_sync.to_i
+        return 'partial'
+      end
+
       def rhsm_url
         # Since Foreman 3.1 this setting is set
         if (rhsm_url = setting(SmartProxy::PULP3_FEATURE, 'rhsm_url'))

--- a/app/views/katello/api/v2/capsule_content/sync_status.json.rabl
+++ b/app/views/katello/api/v2/capsule_content/sync_status.json.rabl
@@ -70,7 +70,7 @@ child @lifecycle_environments => :lifecycle_environments do
           :rolling => content_view.rolling,
           :last_published => content_view.versions.empty? ? nil : content_view.versions.in_environment(env).first&.created_at,
           :default => content_view.default,
-          :up_to_date => @capsule.repos_pending_sync(env, content_view).empty?,
+          :up_to_date => @capsule.up_to_date?(env, content_view),
           :counts => {
             :repositories => ::Katello::ContentViewVersion.in_environment(env).find_by(:content_view => content_view)&.archived_repos&.count,
           },

--- a/webpack/scenes/SmartProxy/ExpandableCvDetails.js
+++ b/webpack/scenes/SmartProxy/ExpandableCvDetails.js
@@ -54,7 +54,13 @@ const ExpandableCvDetails = ({
           id, name: cvName, composite, rolling, up_to_date: upToDate,
           cvv_id: versionId, cvv_version: version, repositories,
         } = cv;
-        const upToDateVal = upToDate ? <CheckCircleIcon style={{ color: 'green' }} /> : <TimesCircleIcon style={{ color: 'red' }} />;
+        let upToDateVal;
+        if (upToDate === true) {
+          upToDateVal = <CheckCircleIcon style={{ color: 'green' }} />;
+        } else {
+          upToDateVal = <TimesCircleIcon style={{ color: 'red' }} />;
+        }
+
         const isExpanded = tableRowIsExpanded(versionId);
         return (
           <Tbody key={`${id} + ${versionId}`}isExpanded={isExpanded}>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This pull request introduces a new method to determine the synchronization status of repositories and updates the UI to reflect partial synchronization states. The most important changes include adding the `up_to_date?` method, modifying the API response to use this new method, and updating the frontend components to handle partial synchronization.

Backend changes:

* [`app/models/katello/concerns/smart_proxy_extensions.rb`](diffhunk://#diff-51eeaacd1fa1ccca9a3cdcb8915e74c04a9b5839e7347ee4fe54edf31c30dc4aR605-R612): Added the `up_to_date?` method to determine if repositories are fully synchronized, partially synchronized, or not synchronized.
* [`app/views/katello/api/v2/capsule_content/sync_status.json.rabl`](diffhunk://#diff-a158fb3cb5fb19b1367608ab5666ca8fff0eda8cd9a35234c1d26f71b845e06eL73-R73): Updated the API response to use the new `up_to_date?` method.

Frontend changes:

* [`webpack/scenes/SmartProxy/ExpandableCvDetails.js`](diffhunk://#diff-dfd88b6c9c813de9b41b55a5ff17479c554b2ab53c0b0252e8e76611d9540eeeL57-R63): Modified the `upToDateVal` logic to handle the new partial synchronization state.
* [`webpack/scenes/SmartProxy/ExpandedSmartProxyRepositories.js`](diffhunk://#diff-79b7a170f600fc358d3fa85bc0152df0d08b099ab4ed84c6a9e21754f3649e01R87-R128): Added logic to display unsynced repositories and handle the partial synchronization state in the UI. [[1]](diffhunk://#diff-79b7a170f600fc358d3fa85bc0152df0d08b099ab4ed84c6a9e21754f3649e01R87-R128) [[2]](diffhunk://#diff-79b7a170f600fc358d3fa85bc0152df0d08b099ab4ed84c6a9e21754f3649e01L145-R190)
* [`webpack/scenes/SmartProxy/ExpandedSmartProxyRepositories.js`](diffhunk://#diff-79b7a170f600fc358d3fa85bc0152df0d08b099ab4ed84c6a9e21754f3649e01L43-R43): Updated the repository link to handle cases where `library_id` might be missing.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Prepare a setup with a smart proxy tied to Library environment
Create and sync a repository.
Make sure it synced to smart proxy by visiting the Smart proxy > Content tab
Next, turn the setting: "Sync Smart Proxies after content view promotion" to No
Create and sync another repository

Before PR:
No counts would show up in the Content tab for Default view
After PR:
You should see the counts of the 1st repo that was synced and N/A for the 2nd repo which is not synced.