### PR TITLE
Fixes #38317 - Create host form - Remember value of content_source_id

### DIFF
--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -161,7 +161,7 @@ module Katello
                                        accessible_content_proxies(host)
                                      end
         accessible_content_objects.each do |content_object|
-          selected = selected_id == content_object.id ? 'selected' : ''
+          selected = "#{selected_id}" == "#{content_object.id}" ? 'selected' : ''
           content_object_options << %(<option value="#{content_object.id}" class="kt-env" #{selected}>#{h(content_object.name)}</option>)
         end
 
@@ -186,10 +186,10 @@ module Katello
       )
     end
 
-    def content_source_options(host, options = {})
+    def content_source_options(host, content_source_id, options = {})
       content_options(
         host,
-        fetch_content_source(host, options).try(:id),
+        content_source_id,
         :content_source,
         options
       )

--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -22,8 +22,14 @@
     <%= select_tag cs_select_id, content_source_options(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path},
                :class => 'form-control',  :name => cs_select_name %>
   <% else %>
-    <%= hidden_field_tag 'host[content_facet_attributes][content_source_id]', fetch_content_source(@host).try(:id) %>
-    <%= select_tag cs_select_id, content_source_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cs_select_name, :disabled => cv_lce_disabled? %>
+    <% content_source_id = fetch_content_source(@host).try(:id) || params.dig("host", "content_facet_attributes", "content_source_id") %>
+    <%= hidden_field_tag 'host[content_facet_attributes][content_source_id]', content_source_id %>
+    <%= select_tag  cs_select_id,
+                    content_source_options(@host, content_source_id, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)),
+                    :data => {"spinner_path" => spinner_path},
+                    :class => 'form-control',
+                    :name => cs_select_name,
+                    :disabled => cv_lce_disabled? %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
### What are the changes introduced in this pull request?
If the host form is not submitted successfully, the content source is reset, and unexpected changes are made in the OS Media Selection.

### Considerations taken when implementing this change?
https://issues.redhat.com/browse/SAT-18646
https://github.com/theforeman/foreman/pull/10495

### What are the testing steps for this pull request?
Preconditions:
* Have an OS with installation media AND synced content for provisioning.
* Do not use a host group for the form.

Steps to reproduce
* Go to Create Host UI from.
* Select Content source, Environment, and content view.
* In the OS tab, select architecture, OS, and Media Selection: Synced content.
* Select Synced Content.
* Submit form.

**Before patch**
Form is going to show errors, and also will reset or change the following fields:
* Content source (reset to empty)
* Root password (fixed in https://github.com/theforeman/foreman/pull/10495)
* Media Selection is changed from Synced content to All Media

**After patch**
* Content source is still selected
* Media selection is unchanged
