### PR TITLE
Fixes #38205 - avoid orphan cleanup distributed repo version error

### DIFF
--- a/app/lib/actions/pulp3/orchestration/orphan_cleanup/remove_orphans.rb
+++ b/app/lib/actions/pulp3/orchestration/orphan_cleanup/remove_orphans.rb
@@ -6,13 +6,14 @@ module Actions
           def plan(proxy)
             if proxy.pulp3_enabled?
               sequence do
-                plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanDistributions, proxy)
-                plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanRepositoryVersions, proxy)
                 if proxy.pulp_mirror?
                   plan_action(Actions::Pulp3::OrphanCleanup::RemoveUnneededRepos, proxy)
                   plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanAlternateContentSources, proxy)
                   plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanRemotes, proxy)
                 end
+                # Deleting repos causes orphaned distributions, so delete them before the distributions.
+                plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanDistributions, proxy)
+                plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanRepositoryVersions, proxy)
                 plan_action(Actions::Pulp3::OrphanCleanup::RemoveOrphans, proxy)
                 plan_action(Actions::Pulp3::OrphanCleanup::PurgeCompletedTasks, proxy)
               end

--- a/app/lib/actions/pulp3/orchestration/orphan_cleanup/remove_orphans.rb
+++ b/app/lib/actions/pulp3/orchestration/orphan_cleanup/remove_orphans.rb
@@ -6,10 +6,10 @@ module Actions
           def plan(proxy)
             if proxy.pulp3_enabled?
               sequence do
+                plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanDistributions, proxy)
                 plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanRepositoryVersions, proxy)
                 if proxy.pulp_mirror?
                   plan_action(Actions::Pulp3::OrphanCleanup::RemoveUnneededRepos, proxy)
-                  plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanDistributions, proxy)
                   plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanAlternateContentSources, proxy)
                   plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanRemotes, proxy)
                 end

--- a/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_repository_versions.rb
+++ b/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_repository_versions.rb
@@ -7,7 +7,9 @@ module Actions
         end
 
         def run
-          output[:pulp_tasks] = ::Katello::Pulp3::SmartProxyRepository.instance_for_type(smart_proxy).delete_orphan_repository_versions
+          cleanup_outputs = ::Katello::Pulp3::SmartProxyRepository.instance_for_type(smart_proxy).delete_orphan_repository_versions
+          output[:pulp_tasks] = cleanup_outputs[:pulp_tasks]
+          output[:errors] = cleanup_outputs[:errors]
         end
       end
     end

--- a/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_repository_versions.rb
+++ b/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_repository_versions.rb
@@ -6,10 +6,15 @@ module Actions
           plan_self(:smart_proxy_id => smart_proxy.id)
         end
 
+        def rescue_strategy
+          Dynflow::Action::Rescue::Skip
+        end
+
         def run
           cleanup_outputs = ::Katello::Pulp3::SmartProxyRepository.instance_for_type(smart_proxy).delete_orphan_repository_versions
           output[:pulp_tasks] = cleanup_outputs[:pulp_tasks]
           output[:errors] = cleanup_outputs[:errors]
+          fail ::Katello::Errors::OrphanCleanupRepoVersionDeleteError if output[:errors].any?
         end
       end
     end

--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -172,5 +172,11 @@ module Katello
         _("This Organization's subscription manifest has expired. Please import a new manifest.")
       end
     end
+
+    class OrphanCleanupRepoVersionDeleteError < StandardError
+      def message
+        _('Orphan cleanup failed to delete some Pulp repository versions. Check the logs for more details.')
+      end
+    end
   end
 end

--- a/app/services/katello/pulp3/api/core.rb
+++ b/app/services/katello/pulp3/api/core.rb
@@ -211,6 +211,12 @@ module Katello
           self.class.fetch_from_list { |page_opts| repository_versions_api.list(repository_href, page_opts.merge(options)) }
         end
 
+        def publications_list_all(args = {})
+          self.class.fetch_from_list do |page_opts|
+            publications_api.list(page_opts.merge(args))
+          end
+        end
+
         def distributions_list_all(args = {})
           self.class.fetch_from_list do |page_opts|
             distributions_api.list(page_opts.merge(args))

--- a/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
+++ b/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
@@ -22,6 +22,9 @@ module Katello
       def orphan_repository_versions
         repo_version_map = {}
 
+        # TODO: if there is an error, check if the related distribution is deletable.
+        # If it is (no expected path), then delete the distribution and then the version.
+        # If it is not, skip deleting the version and log an error.
         pulp3_enabled_repo_types.each do |repo_type|
           api = repo_type.pulp3_api(smart_proxy)
           version_hrefs = api.repository_versions

--- a/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
+++ b/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
@@ -23,8 +23,14 @@ module Katello
         repo_version_map = {}
 
         # TODO: if there is an error, check if the related distribution is deletable.
-        # If it is (no expected path), then delete the distribution and then the version.
-        # If it is not, skip deleting the version and log an error.
+        # If it is orphaned in Katello, then delete the distribution and then the version.
+        # If it is not:
+        #   For content on the main Katello server, distribute the version saved on the Repository record.
+        #   For content on a smart proxy, redistribute the content using the latest version of the Pulp repository.
+        # Question: should we just throw an error telling users to
+        #   resync the smart proxy / regenerate metadata on the main server?
+        # Question: will putting orphaned distribution deletion first help fix things?
+
         pulp3_enabled_repo_types.each do |repo_type|
           api = repo_type.pulp3_api(smart_proxy)
           version_hrefs = api.repository_versions

--- a/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
+++ b/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
@@ -48,6 +48,9 @@ module Katello
         # 4. Pulp content was modified outside of Katello
         #    - Fix: find repositories outside of Katello and delete them. Deleting the entire repo works and leaves an orphaned distribution.
         #        - If RemoveUnneededRepos goes first, this should be taken care of.
+        # 5. An older repository version has a distribution, but the repository is not an orphan
+        #    - Fix: delete the orphan distribution
+        errors = []
         related_distributions = if api.repository_type.publications_api_class.present?
                                   publication_hrefs = api.publications_list_all(repository_version: href).map(&:pulp_href)
                                   # Searching distributions by publication isn't supported
@@ -57,16 +60,19 @@ module Katello
                                   api.distributions_list_all.select { |dist| dist.repository_version == href }
                                 end
         repositories_to_redistribute = ::Katello::Repository.where(pulp_id: related_distributions.map(&:name))
-        warning = "Completely resync (skip metadata check) repositories with the following paths to the smart proxy with ID #{smart_proxy.id}: " \
-                  "#{repositories_to_redistribute.map(&:relative_path).join(', ')}. " \
-                  "Orphan cleanup is skipped for these repositories until they are fixed on smart proxy with ID #{smart_proxy.id}. " \
-                  "Try `hammer capsule content synchronize --id #{smart_proxy.id} --skip-metadata-check 1 ...` using " \
-                  "--repository-id with #{repositories_to_redistribute.map(&:id).join(', ')}"
-        errors << warning
-        Rails.logger.warn(warning)
+        if repositories_to_redistribute.present?
+          warning = "Completely resync (skip metadata check) repositories with the following paths to the smart proxy with ID #{smart_proxy.id}: " \
+                    "#{repositories_to_redistribute.map(&:relative_path).join(', ')}. " \
+                    "Orphan cleanup is skipped for these repositories until they are fixed on smart proxy with ID #{smart_proxy.id}. " \
+                    "Try `hammer capsule content synchronize --id #{smart_proxy.id} --skip-metadata-check 1 ...` using " \
+                    "--repository-id with #{repositories_to_redistribute.map(&:id).join(', ')}."
+          errors << warning
+          Rails.logger.warn(warning)
+        end
         Rails.logger.debug("Orphan cleanup error: investigate the version_href #{href} on the smart proxy with ID #{smart_proxy.id} " \
                             "and the related distributions #{related_distributions.map(&:pulp_href)}")
         Rails.logger.debug('It is likely that the related distributions are distributing an older version of the repository.')
+        errors
       end
 
       # See app/services/katello/pulp3/smart_proxy_repository.rb#delete_orphan_repository_versions for foreman orphan cleanup
@@ -78,7 +84,7 @@ module Katello
             tasks << api.repository_versions_api.delete(href)
           rescue => e
             if e.message.include?('Please update the necessary distributions first.')
-              report_misconfigured_repository_version(api, href)
+              errors << report_misconfigured_repository_version(api, href)
             else
               raise e
             end

--- a/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
+++ b/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
@@ -126,7 +126,7 @@ module Katello
       def self.orphan_distribution?(distribution)
         distribution.try(:publication).nil? &&
             distribution.try(:repository).nil? &&
-            distribution.try(:repository_version).nil? &&
+            distribution.try(:repository_version).nil? ||
             ::Katello::Repository.pluck(:pulp_id).exclude?(distribution.name)
       end
 

--- a/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
+++ b/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
@@ -126,7 +126,8 @@ module Katello
       def self.orphan_distribution?(distribution)
         distribution.try(:publication).nil? &&
             distribution.try(:repository).nil? &&
-            distribution.try(:repository_version).nil?
+            distribution.try(:repository_version).nil? &&
+            ::Katello::Repository.pluck(:pulp_id).exclude?(distribution.name)
       end
 
       def delete_orphan_alternate_content_sources

--- a/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
+++ b/app/services/katello/pulp3/smart_proxy_mirror_repository.rb
@@ -37,45 +37,48 @@ module Katello
         repo_version_map
       end
 
+      def report_misconfigured_repository_version(api, href)
+        # Reasons for distributions distributing orphaned repository versions:
+        # 1. The sync succeeded but Pulp did not update the publication (yum content)
+        #    - Fix: completely resync the repository to the smart proxy (need to verify)
+        # 2. The sync suceeded but metadata was not generated (non-yum content)
+        #    - Fix: completely resync the repository on the smart proxy (need to verify)
+        # 3. A repository, distribution, and publication was lost track of
+        #    - Fix: same as 4
+        # 4. Pulp content was modified outside of Katello
+        #    - Fix: find repositories outside of Katello and delete them. Deleting the entire repo works and leaves an orphaned distribution.
+        #        - If RemoveUnneededRepos goes first, this should be taken care of.
+        related_distributions = if api.repository_type.publications_api_class.present?
+                                  publication_hrefs = api.publications_list_all(repository_version: href).map(&:pulp_href)
+                                  # Searching distributions by publication isn't supported
+                                  api.distributions_list_all.select { |dist| publication_hrefs.include? dist.publication }
+                                else
+                                  # Searching distributions by repository version isn't supported
+                                  api.distributions_list_all.select { |dist| dist.repository_version == href }
+                                end
+        repositories_to_redistribute = ::Katello::Repository.where(pulp_id: related_distributions.map(&:name))
+        warning = "Completely resync (skip metadata check) repositories with the following paths to the smart proxy with ID #{smart_proxy.id}: " \
+                  "#{repositories_to_redistribute.map(&:relative_path).join(', ')}. " \
+                  "Orphan cleanup is skipped for these repositories until they are fixed on smart proxy with ID #{smart_proxy.id}. " \
+                  "Try `hammer capsule content synchronize --id #{smart_proxy.id} --skip-metadata-check 1 ...` using " \
+                  "--repository-id with #{repositories_to_redistribute.map(&:id).join(', ')}"
+        errors << warning
+        Rails.logger.warn(warning)
+        Rails.logger.debug("Orphan cleanup error: investigate the version_href #{href} on the smart proxy with ID #{smart_proxy.id} " \
+                            "and the related distributions #{related_distributions.map(&:pulp_href)}")
+        Rails.logger.debug('It is likely that the related distributions are distributing an older version of the repository.')
+      end
+
       # See app/services/katello/pulp3/smart_proxy_repository.rb#delete_orphan_repository_versions for foreman orphan cleanup
       def delete_orphan_repository_versions
         tasks = []
         errors = []
         orphan_repository_versions.each do |api, version_hrefs|
-          tasks << version_hrefs.collect do |href|
-            api.repository_versions_api.delete(href)
+          version_hrefs.each do |href|
+            tasks << api.repository_versions_api.delete(href)
           rescue => e
             if e.message.include?('Please update the necessary distributions first.')
-              # Reasons for distributions distributing orphaned repository versions:
-              # 1. The sync succeeded but Pulp did not update the publication (yum content)
-              #    - Fix: completely resync the repository to the smart proxy (need to verify)
-              # 2. The sync suceeded but metadata was not generated (non-yum content)
-              #    - Fix: completely resync the repository on the smart proxy (need to verify)
-              # 3. A repository, distribution, and publication was lost track of
-              #    - Fix: same as 4
-              # 4. Pulp content was modified outside of Katello
-              #    - Fix: find repositories outside of Katello and delete them. Deleting the entire repo works and leaves an orphaned distribution.
-              #        - If RemoveUnneededRepos goes first, this should be taken care of.
-
-              related_distributions = if api.repository_type.publications_api_class.present?
-                                        publication_hrefs = api.publications_list_all(repository_version: href).map(&:pulp_href)
-                                        # Searching distributions by publication isn't supported
-                                        api.distributions_list_all.select { |dist| publication_hrefs.include? dist.publication }
-                                      else
-                                        # Searching distributions by repository version isn't supported
-                                        api.distributions_list_all.select { |dist| dist.repository_version == href }
-                                      end
-              repositories_to_redistribute = ::Katello::Repository.where(pulp_id: related_distributions.map(&:name))
-              warning = "Completely resync (skip metadata check) repositories with the following paths to the smart proxy with ID #{smart_proxy.id}: " \
-                        "#{repositories_to_redistribute.map(&:relative_path).join(', ')}. " \
-                        "Orphan cleanup is skipped for these repositories until they are fixed on smart proxy with ID #{smart_proxy.id}. " \
-                        "Try `hammer capsule content synchronize --id #{smart_proxy.id} --skip-metadata-check 1 ...` using " \
-                        "--repository-id with #{repositories_to_redistribute.map(&:id).join(', ')}"
-              errors << warning
-              Rails.logger.warn(warning)
-              Rails.logger.debug("Orphan cleanup error: investigate the version_href #{href} on the smart proxy with ID #{smart_proxy.id} " \
-                                 "and the related distributions #{related_distributions.map(&:pulp_href)}")
-              Rails.logger.debug('It is likely that the related distributions are distributing an older version of the repository.')
+              report_misconfigured_repository_version(api, href)
             else
               raise e
             end

--- a/app/services/katello/pulp3/smart_proxy_repository.rb
+++ b/app/services/katello/pulp3/smart_proxy_repository.rb
@@ -33,11 +33,35 @@ module Katello
         katello_repos.select { |repo| repo_ids.include? repo.pulp_id }
       end
 
+      # See app/services/katello/pulp3/smart_proxy_mirror_repository.rb#delete_orphan_repository_versions for content proxy orphan cleanup
       def delete_orphan_repository_versions
         tasks = []
         orphan_repository_versions.each do |api, version_hrefs|
           tasks << version_hrefs.collect do |href|
             api.repository_versions_api.delete(href)
+          rescue => e
+            if e.message.include?('Please update the necessary distributions first.')
+              related_distributions = if api.repository_type.publications_api_class.present?
+                                        publication_hrefs = api.publications_list_all(repository_version: href).map(&:pulp_href)
+                                        # Searching distributions by publication isn't supported
+                                        api.distributions_list_all.select { |dist| publication_hrefs.include? dist.publication }
+                                      else
+                                        # Searching distributions by repository version isn't supported
+                                        api.distributions_list_all.select { |dist| dist.repository_version == href }
+                                      end
+              repositories_to_redistribute = ::Katello::Repository.joins(:distribution_references)
+                .where(:distribution_references => { :href => related_distributions.map(&:pulp_href) })
+              warning = 'Completely resync (skip metadata check) or regenerate metadata for repositories with the following paths: ' \
+                        "#{repositories_to_redistribute.map(&:relative_path).join(', ')}. " \
+                        "Orphan cleanup is skipped for these repositories until they are fixed on smart proxy with ID #{smart_proxy.id}. " \
+                        "Try `hammer repository synchronize --skip-metadata-check 1 ...` using --id with #{repositories_to_redistribute.map(&:id).join(', ')}."
+              Rails.logger.warn(warning)
+              Rails.logger.debug("Orphan cleanup error: investigate the version_href #{href} " \
+                                 "and the related distributions #{related_distributions.map(&:pulp_href)}")
+              Rails.logger.debug('It is likely that the related distributions are distributing an older version of the repository.')
+            else
+              raise e
+            end
           end
         end
         tasks.flatten

--- a/app/services/katello/pulp3/smart_proxy_repository.rb
+++ b/app/services/katello/pulp3/smart_proxy_repository.rb
@@ -34,6 +34,7 @@ module Katello
       end
 
       def report_misconfigured_repository_version(api, href)
+        errors = []
         related_distributions = if api.repository_type.publications_api_class.present?
                                   publication_hrefs = api.publications_list_all(repository_version: href).map(&:pulp_href)
                                   # Searching distributions by publication isn't supported
@@ -44,20 +45,23 @@ module Katello
                                 end
         repositories_to_redistribute = ::Katello::Repository.joins(:distribution_references)
           .where(:distribution_references => { :href => related_distributions.map(&:pulp_href) })
-        warning = 'Completely resync (skip metadata check) or regenerate metadata for repositories with the following paths: ' \
-                  "#{repositories_to_redistribute.map(&:relative_path).join(', ')}. " \
-                  "Orphan cleanup is skipped for these repositories until they are fixed on smart proxy with ID #{smart_proxy.id}. "
-        if repositories_to_redistribute.in_default_view.any?
-          warning += "Try `hammer repository synchronize --skip-metadata-check 1 ...` using --id with #{repositories_to_redistribute.in_default_view.map(&:id).join(', ')}. " \
+        if repositories_to_redistribute.present?
+          warning = 'Completely resync (skip metadata check) or regenerate metadata for repositories with the following paths: ' \
+                    "#{repositories_to_redistribute.map(&:relative_path).join(', ')}. " \
+                    "Orphan cleanup is skipped for these repositories until they are fixed on smart proxy with ID #{smart_proxy.id}. "
+          if repositories_to_redistribute.in_default_view.any?
+            warning += "Try `hammer repository synchronize --skip-metadata-check 1 ...` using --id with #{repositories_to_redistribute.in_default_view.map(&:id).join(', ')}. " \
+          end
+          if repositories_to_redistribute.in_non_default_view.any?
+            warning += "Try `hammer content-view version republish-repositories ...` using --id with #{repositories_to_redistribute.in_non_default_view.pluck(:content_view_version_id).uniq.join(', ')}." \
+          end
+          errors << warning
+          Rails.logger.warn(warning)
         end
-        if repositories_to_redistribute.in_non_default_view.any?
-          warning += "Try `hammer content-view version republish-repositories ...` using --id with #{repositories_to_redistribute.in_non_default_view.pluck(:content_view_version_id).uniq}." \
-        end
-        errors << warning
-        Rails.logger.warn(warning)
         Rails.logger.debug("Orphan cleanup error: investigate the version_href #{href} " \
                           "and the related distributions #{related_distributions.map(&:pulp_href)}")
         Rails.logger.debug('It is likely that the related distributions are distributing an older version of the repository.')
+        errors
       end
 
       # See app/services/katello/pulp3/smart_proxy_mirror_repository.rb#delete_orphan_repository_versions for content proxy orphan cleanup
@@ -69,7 +73,7 @@ module Katello
             tasks << api.repository_versions_api.delete(href)
           rescue => e
             if e.message.include?('Please update the necessary distributions first.')
-              report_misconfigured_repository_version(api, href)
+              errors << report_misconfigured_repository_version(api, href)
             else
               raise e
             end

--- a/app/services/katello/pulp3/smart_proxy_repository.rb
+++ b/app/services/katello/pulp3/smart_proxy_repository.rb
@@ -53,8 +53,13 @@ module Katello
                 .where(:distribution_references => { :href => related_distributions.map(&:pulp_href) })
               warning = 'Completely resync (skip metadata check) or regenerate metadata for repositories with the following paths: ' \
                         "#{repositories_to_redistribute.map(&:relative_path).join(', ')}. " \
-                        "Orphan cleanup is skipped for these repositories until they are fixed on smart proxy with ID #{smart_proxy.id}. " \
-                        "Try `hammer repository synchronize --skip-metadata-check 1 ...` using --id with #{repositories_to_redistribute.map(&:id).join(', ')}."
+                        "Orphan cleanup is skipped for these repositories until they are fixed on smart proxy with ID #{smart_proxy.id}. "
+              if repositories_to_redistribute.in_default_view.any?
+                warning += "Try `hammer repository synchronize --skip-metadata-check 1 ...` using --id with #{repositories_to_redistribute.in_default_view.map(&:id).join(', ')}. " \
+              end
+              if repositories_to_redistribute.in_non_default_view.any?
+                warning += "Try `hammer content-view version republish-repositories ...` using --id with #{repositories_to_redistribute.in_non_default_view.pluck(:content_view_version_id).uniq}." \
+              end
               Rails.logger.warn(warning)
               Rails.logger.debug("Orphan cleanup error: investigate the version_href #{href} " \
                                  "and the related distributions #{related_distributions.map(&:pulp_href)}")

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,13 +23,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:45 GMT
+      - Mon, 31 Mar 2025 22:09:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -43,20 +43,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 34227a6d69424eada78c92537767fab5
+      - b75f2b6e89154fda8ceca89ac7555ef6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:45 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:18 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,13 +77,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:45 GMT
+      - Mon, 31 Mar 2025 22:09:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -97,20 +97,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 982580907bf248b19c979462e6fa872a
+      - e1bed4281d424c3ebb40ff8ce3bfa6e8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:45 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:18 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -118,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,13 +131,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:45 GMT
+      - Mon, 31 Mar 2025 22:09:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -151,20 +151,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9e8e48931f8d4a24bfadbc0aefe4e3a5
+      - 7760bc4c994c46b79e6276148f31fba1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:45 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:19 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -172,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,13 +185,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:45 GMT
+      - Mon, 31 Mar 2025 22:09:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -205,20 +205,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 36713f74f12a4d0c9d43f3009825b0ee
+      - f8abadc0ba5a4e9086d31bd92f399f61
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:45 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:19 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -235,7 +235,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -248,15 +248,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:45 GMT
+      - Mon, 31 Mar 2025 22:09:20 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/01932529-52f5-74e3-b815-d8ecc4d53432/"
+      - "/pulp/api/v3/remotes/file/file/0195ee40-83fd-75a3-b348-e80b99455a90/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -270,20 +270,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 72168ce25bec426aa1ee82b17e0cbe8f
+      - f4ee2c54de144db1a2a4294ead899238
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE5MzI1MjktNTJmNS03NGUzLWI4MTUtZDhlY2M0ZDUzNDMyLyIsInBybiI6
-        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5MzI1MjktNTJmNS03NGUzLWI4MTUt
-        ZDhlY2M0ZDUzNDMyIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1
-        NDo0NS40OTM1OTJaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEz
-        VDEwOjU0OjQ1LjQ5MzYwM1oiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        MDE5NWVlNDAtODNmZC03NWEzLWIzNDgtZTgwYjk5NDU1YTkwLyIsInBybiI6
+        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NWVlNDAtODNmZC03NWEzLWIzNDgt
+        ZTgwYjk5NDU1YTkwIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjow
+        OToyMC4zODQyMDlaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMx
+        VDIyOjA5OjIwLjM4NDIzNVoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
         b24tQ2FiaW5ldC1NeV9GaWxlcyIsInVybCI6Imh0dHA6Ly90ZXN0L3Rlc3Qv
         L1BVTFBfTUFOSUZFU1QiLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6
         bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwi
@@ -297,10 +297,10 @@ http_interactions:
         ZSI6InByb3h5X3Bhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoi
         dXNlcm5hbWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwYXNzd29yZCIs
         ImlzX3NldCI6ZmFsc2V9XX0=
-  recorded_at: Wed, 13 Nov 2024 10:54:45 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:20 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -310,7 +310,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -323,15 +323,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:45 GMT
+      - Mon, 31 Mar 2025 22:09:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/01932529-538a-7c20-a79b-8bfe1023099e/"
+      - "/pulp/api/v3/repositories/file/file/0195ee40-8797-7f54-8041-efd411ea08de/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -345,33 +345,33 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '08266f9aabd948db8723ba70a98c9452'
+      - ba0ccaff1f754742870ef6f5386f6570
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMTkzMjUyOS01MzhhLTdjMjAtYTc5Yi04YmZlMTAyMzA5OWUvIiwi
-        cHJuIjoicHJuOmZpbGUuZmlsZXJlcG9zaXRvcnk6MDE5MzI1MjktNTM4YS03
-        YzIwLWE3OWItOGJmZTEwMjMwOTllIiwicHVscF9jcmVhdGVkIjoiMjAyNC0x
-        MS0xM1QxMDo1NDo0NS42NDI0ODdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIy
-        MDI0LTExLTEzVDEwOjU0OjQ1LjY0NzEyNVoiLCJ2ZXJzaW9uc19ocmVmIjoi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1Mjkt
-        NTM4YS03YzIwLWE3OWItOGJmZTEwMjMwOTllL3ZlcnNpb25zLyIsInB1bHBf
+        ZmlsZS8wMTk1ZWU0MC04Nzk3LTdmNTQtODA0MS1lZmQ0MTFlYTA4ZGUvIiwi
+        cHJuIjoicHJuOmZpbGUuZmlsZXJlcG9zaXRvcnk6MDE5NWVlNDAtODc5Ny03
+        ZjU0LTgwNDEtZWZkNDExZWEwOGRlIiwicHVscF9jcmVhdGVkIjoiMjAyNS0w
+        My0zMVQyMjowOToyMS4zMDc1OTFaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIy
+        MDI1LTAzLTMxVDIyOjA5OjIxLjMxNDYyOFoiLCJ2ZXJzaW9uc19ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NWVlNDAt
+        ODc5Ny03ZjU0LTgwNDEtZWZkNDExZWEwOGRlL3ZlcnNpb25zLyIsInB1bHBf
         bGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTMyNTI5LTUzOGEtN2MyMC1h
-        NzliLThiZmUxMDIzMDk5ZS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTVlZTQwLTg3OTctN2Y1NC04
+        MDQxLWVmZDQxMWVhMDhkZS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0
         X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwiZGVzY3JpcHRpb24i
         Om51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51
         bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWFuaWZlc3QiOiJQVUxQX01BTklG
         RVNUIn0=
-  recorded_at: Wed, 13 Nov 2024 10:54:45 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:21 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/01932529-538a-7c20-a79b-8bfe1023099e/versions/2/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/0195ee40-8797-7f54-8041-efd411ea08de/versions/2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -379,7 +379,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -392,13 +392,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:47 GMT
+      - Mon, 31 Mar 2025 22:09:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -412,36 +412,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9e42c55d51f0435cb269c9d310a219b5
+      - 27c236b38d154e939e7066e6b1234ce7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMTkzMjUyOS01MzhhLTdjMjAtYTc5Yi04YmZlMTAyMzA5OWUvdmVy
+        ZmlsZS8wMTk1ZWU0MC04Nzk3LTdmNTQtODA0MS1lZmQ0MTFlYTA4ZGUvdmVy
         c2lvbnMvMi8iLCJwcm4iOiJwcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjow
-        MTkzMjUyOS01NzkzLTdiMTQtOTgyYy0zNDg1ZTFkNGVhZGIiLCJwdWxwX2Ny
-        ZWF0ZWQiOiIyMDI0LTExLTEzVDEwOjU0OjQ2LjY3NTYwNFoiLCJwdWxwX2xh
-        c3RfdXBkYXRlZCI6IjIwMjQtMTEtMTNUMTA6NTQ6NDYuNzI0OTA5WiIsIm51
+        MTk1ZWU0MC1hNGQ0LTc5YjUtYTdhNC00NGQ2Mjc1OGFhZmUiLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI1LTAzLTMxVDIyOjA5OjI4Ljc5MDk0NFoiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjUtMDMtMzFUMjI6MDk6MjguOTAwMDE1WiIsIm51
         bWJlciI6MiwicmVwb3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
-        ZXMvZmlsZS9maWxlLzAxOTMyNTI5LTUzOGEtN2MyMC1hNzliLThiZmUxMDIz
-        MDk5ZS8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6
+        ZXMvZmlsZS9maWxlLzAxOTVlZTQwLTg3OTctN2Y1NC04MDQxLWVmZDQxMWVh
+        MDhkZS8iLCJiYXNlX3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6
         eyJhZGRlZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjEsImhyZWYiOiIvcHVs
         cC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNp
         b25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUv
-        MDE5MzI1MjktNTM4YS03YzIwLWE3OWItOGJmZTEwMjMwOTllL3ZlcnNpb25z
+        MDE5NWVlNDAtODc5Ny03ZjU0LTgwNDEtZWZkNDExZWEwOGRlL3ZlcnNpb25z
         LzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJmaWxlLmZpbGUiOnsi
         Y291bnQiOjIsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2Zp
         bGVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9maWxlL2ZpbGUvMDE5MzI1MjktNTM4YS03YzIwLWE3OWItOGJmZTEw
-        MjMwOTllL3ZlcnNpb25zLzIvIn19fX0=
-  recorded_at: Wed, 13 Nov 2024 10:54:47 GMT
+        cmllcy9maWxlL2ZpbGUvMDE5NWVlNDAtODc5Ny03ZjU0LTgwNDEtZWZkNDEx
+        ZWEwOGRlL3ZlcnNpb25zLzIvIn19fX0=
+  recorded_at: Mon, 31 Mar 2025 22:09:29 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/01932529-52f5-74e3-b815-d8ecc4d53432/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/0195ee40-83fd-75a3-b348-e80b99455a90/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -449,7 +449,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -462,13 +462,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:47 GMT
+      - Mon, 31 Mar 2025 22:09:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -482,20 +482,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d77245a45133441d8858137915eb840e
+      - 161adc52d5b14ea38c2375684c1b0587
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTI5LTU5YTktN2Fj
-        Ni1hZjQ3LWE4NWQ2ZmY2Y2RiYi8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:47 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQwLWFhNzMtNzY2
+        Ny1hNzNjLTk2ZmY5MmNkYTdiMy8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:30 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/01932529-59a9-7ac6-af47-a85d6ff6cdbb/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee40-aa73-7667-a73c-96ff92cda7b3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -503,7 +503,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -516,19 +516,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:47 GMT
+      - Mon, 31 Mar 2025 22:09:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '845'
+      - '826'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -536,37 +536,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 03ef1164e26446c9bfd933c621739a4a
+      - 6d3e386aa90149b7864be7c4143b089a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MjktNTlh
-        OS03YWM2LWFmNDctYTg1ZDZmZjZjZGJiLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MjktNTlhOS03YWM2LWFmNDctYTg1ZDZmZjZjZGJiIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NDo0Ny4yMTA1NzhaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU0OjQ3LjIxMDU4OVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDAtYWE3
+        My03NjY3LWE3M2MtOTZmZjkyY2RhN2IzLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDAtYWE3My03NjY3LWE3M2MtOTZmZjkyY2RhN2IzIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjowOTozMC4yMjkwMTJaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjA5OjMwLjIyOTAzNVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiZDc3MjQ1
-        YTQ1MTMzNDQxZDg4NTgxMzc5MTVlYjg0MGUiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMDo1NDo0Ny4yMjQwNjRaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTA6NTQ6NDcuMjU5MzU0WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MDo1NDo0Ny4yOTQ0ODdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTMyNTIzLTkwMWUtN2ZiMC05ZTA3LTljZGY0
-        ZDJiMWNhMC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpmaWxlLmZpbGVyZW1vdGU6MDE5MzI1MjktNTJmNS03NGUzLWI4
-        MTUtZDhlY2M0ZDUzNDMyIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTky
-        YzU3ZC1mYjk1LTc5MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 10:54:47 GMT
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiMTYxYWRj
+        NTJkNWIxNGVhMzhjMjM3NTY4NGMxYjA1ODciLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjMwLjI1OTg5MVoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjowOTozMC4zMzQ1NDRaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjMwLjQyMjcxNVoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmI5Mi03YzNiLTlmNTEtZTk4YTllZTI4YmE0LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10s
+        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOmZpbGUuZmlsZXJl
+        bW90ZTowMTk1ZWU0MC04M2ZkLTc1YTMtYjM0OC1lODBiOTk0NTVhOTAiLCJz
+        aGFyZWQ6cHJuOmNvcmUuZG9tYWluOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0
+        LTUyOGMyOTEyOWExMyJdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:30 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/01932529-538a-7c20-a79b-8bfe1023099e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/0195ee40-8797-7f54-8041-efd411ea08de/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -574,7 +574,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -587,13 +587,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:47 GMT
+      - Mon, 31 Mar 2025 22:09:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -607,20 +607,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1abfa93fe1454d5b8789bc77dc08a4d5
+      - df4a7abe653342419d4ee2a760435dcc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTI5LTVhYjAtNzAw
-        Zi04MzkzLWU5ZTUyMGQ3NGQzNi8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:47 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQwLWFjZDUtNzIx
+        NC05YjUwLTYzZjRkNWYyOGI2OC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:30 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/01932529-5ab0-700f-8393-e9e520d74d36/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee40-acd5-7214-9b50-63f4d5f28b68/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -628,7 +628,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -641,19 +641,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:47 GMT
+      - Mon, 31 Mar 2025 22:09:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '849'
+      - '830'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -661,37 +661,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 33b42952467748bda9a09e11e9900529
+      - b3634c751f4c4845a8fcbf4240b26a19
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MjktNWFi
-        MC03MDBmLTgzOTMtZTllNTIwZDc0ZDM2LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MjktNWFiMC03MDBmLTgzOTMtZTllNTIwZDc0ZDM2IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NDo0Ny40NzI5NjhaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU0OjQ3LjQ3Mjk3OVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDAtYWNk
+        NS03MjE0LTliNTAtNjNmNGQ1ZjI4YjY4LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDAtYWNkNS03MjE0LTliNTAtNjNmNGQ1ZjI4YjY4IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjowOTozMC44Mzg4MDBaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjA5OjMwLjgzODgyMloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiMWFiZmE5
-        M2ZlMTQ1NGQ1Yjg3ODliYzc3ZGMwOGE0ZDUiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMDo1NDo0Ny40ODQ5MDNaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTA6NTQ6NDcuNTIyOTk3WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MDo1NDo0Ny41Njk3NDRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTMyNTIzLTkwMWUtN2ZiMC05ZTA3LTljZGY0
-        ZDJiMWNhMC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpmaWxlLmZpbGVyZXBvc2l0b3J5OjAxOTMyNTI5LTUzOGEtN2My
-        MC1hNzliLThiZmUxMDIzMDk5ZSIsInNoYXJlZDpwcm46Y29yZS5kb21haW46
-        MDE5MmM1N2QtZmI5NS03OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 10:54:47 GMT
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiZGY0YTdh
+        YmU2NTMzNDI0MTlkNGVlMmE3NjA0MzVkY2MiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjMwLjg4NTc2M1oi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjowOTozMC45NjU4MzlaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjMxLjA5NzA2MloiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmI5Mi03YzNiLTlmNTEtZTk4YTllZTI4YmE0LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10s
+        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOmZpbGUuZmlsZXJl
+        cG9zaXRvcnk6MDE5NWVlNDAtODc5Ny03ZjU0LTgwNDEtZWZkNDExZWEwOGRl
+        Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo2ZDNjNjAxZi1mZWFmLTRiOTMt
+        ODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:09:31 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -699,7 +699,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.22.3/ruby
+      - OpenAPI-Generator/0.22.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -712,13 +712,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:47 GMT
+      - Mon, 31 Mar 2025 22:09:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -732,20 +732,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7749238974f543faaab1fc6f852636ea
+      - 0ec088e3438647cf8e0fc68a4bb60842
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:47 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:31 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -766,13 +766,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:47 GMT
+      - Mon, 31 Mar 2025 22:09:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -786,20 +786,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b9c806632e52402494f5bf18a7e7b52a
+      - c86405d6a30441baa48c889113457960
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:47 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:31 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -807,7 +807,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.22.0/ruby
+      - OpenAPI-Generator/2.22.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -820,13 +820,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:47 GMT
+      - Mon, 31 Mar 2025 22:09:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -840,20 +840,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 423e1a535a9a4c26bed8389351b502bd
+      - 370144d487604bb7ae77bc87368d019f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:47 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:31 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -861,7 +861,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -874,13 +874,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:47 GMT
+      - Mon, 31 Mar 2025 22:09:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -894,20 +894,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1a4638683dde4e94b5599b2da421ea4d
+      - 8c2becda62ef459c84eddc14c16a9bf1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:47 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:31 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -915,7 +915,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.4.4/ruby
+      - OpenAPI-Generator/2.4.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -928,13 +928,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:47 GMT
+      - Mon, 31 Mar 2025 22:09:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -948,20 +948,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f8a24fac5d4047e38f954f62d64b1599
+      - f5ef5040c113446d8a57a426788d4dcb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:47 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:32 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -969,7 +969,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.12.5/ruby
+      - OpenAPI-Generator/3.12.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -982,13 +982,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:47 GMT
+      - Mon, 31 Mar 2025 22:09:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1002,20 +1002,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 36a2d9f4fb2b48888efab243e9e43b46
+      - b890ff2e61d945b3ad28c3165a58167b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:47 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:32 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1036,13 +1036,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:48 GMT
+      - Mon, 31 Mar 2025 22:09:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1056,76 +1056,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1ddb0534b49a4fb890ce4f5fba2351fe
+      - 37c17a3311864e9594b48d96584726c9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:48 GMT
-- request:
-    method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/orphans/cleanup/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJvcnBoYW5fcHJvdGVjdGlvbl90aW1lIjoxNDQwfQ==
-
-        '
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 13 Nov 2024 10:54:48 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - POST, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 2f79070e55ae4ba19b1ab7143afa1317
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTI5LTVkMTAtNzlk
-        OS05MGExLTllMTBiMjAyNmE3NC8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:48 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:32 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/01932529-5d10-79d9-90a1-9e10b2026a74/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1133,7 +1077,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/0.22.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1146,19 +1090,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:48 GMT
+      - Mon, 31 Mar 2025 22:09:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1077'
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1166,52 +1110,354 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6e634d9b2c804bddbf88957f9612a1cd
+      - 181d396afb1b4e5cb2a7b06f5c561098
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MjktNWQx
-        MC03OWQ5LTkwYTEtOWUxMGIyMDI2YTc0LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MjktNWQxMC03OWQ5LTkwYTEtOWUxMGIyMDI2YTc0IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NDo0OC4wODEyNDJaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU0OjQ4LjA4MTI1Mloi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiIyZjc5
-        MDcwZTU1YWU0YmExOWIxYWI3MTQzYWZhMTMxNyIsImNyZWF0ZWRfYnkiOiIv
-        cHVscC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTEx
-        LTEzVDEwOjU0OjQ4LjA5MzAwM1oiLCJzdGFydGVkX2F0IjoiMjAyNC0xMS0x
-        M1QxMDo1NDo0OC4xMzQxMTlaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTExLTEz
-        VDEwOjU0OjQ4LjI1NDk0MFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1
-        bHAvYXBpL3YzL3dvcmtlcnMvMDE5MzI1MjMtOTAxZS03ZmIwLTllMDctOWNk
-        ZjRkMmIxY2EwLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6
-        W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1l
-        c3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQ29udGVudCIsImNvZGUiOiJjbGVh
-        bi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwi
-        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJDbGVhbiB1cCBv
-        cnBoYW4gQXJ0aWZhY3RzIiwiY29kZSI6ImNsZWFuLXVwLmFydGlmYWN0cyIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jl
-        c291cmNlc19yZWNvcmQiOlsicGRybjowMTkyYzU3ZC1mYjk1LTc5MTgtODdl
-        NC05ZGU1YjE1YWI1MzY6b3JwaGFucyIsInNoYXJlZDpwcm46Y29yZS5kb21h
-        aW46MDE5MmM1N2QtZmI5NS03OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 10:54:48 GMT
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:32 GMT
 - request:
-    method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/purge/
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
-      encoding: UTF-8
-      base64_string: |
-        eyJmaW5pc2hlZF9iZWZvcmUiOiIzMDAwLTAxLTAxVDAwOjAwOjAwLjAwMCsw
-        MDowMCJ9
+      encoding: US-ASCII
+      base64_string: ''
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.3.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4188b7267f184ed89900845b2b86b677
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:32 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.22.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - ecc551e57d6341b992e38f5dd118e363
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:32 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0e7b3f2c4a34443ba0801e99a1d4f7d3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:32 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.4.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - a5b9aea75d8e446a913733633f1d4fb3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:33 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.12.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 15a8641c87a346f0b458e256546e5781
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:33 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.27.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:33 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0b3db479e48246bba1ae479ddf2cb2f6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:33 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/orphans/cleanup/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJvcnBoYW5fcHJvdGVjdGlvbl90aW1lIjoxNDQwfQ==
+
+        '
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1224,13 +1470,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:48 GMT
+      - Mon, 31 Mar 2025 22:09:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - POST, OPTIONS
       X-Frame-Options:
@@ -1244,15 +1490,147 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 015d3d6c681240ce83a42cd93f831ef9
+      - 75f32820654b4256a8c203c1431b7a6f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTI5LTVlMTQtN2E3
-        Ni05MTA4LTVhMzlkMTdlMmMxYy8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:48 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQwLWI2ZmMtNzgw
+        MC1iNDhiLTgxZjkzMjgzMTIyYi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:33 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee40-b6fc-7800-b48b-81f93283122b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '1062'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - bbe65e467faf4c3b8ae1a57a9a10ef7b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDAtYjZm
+        Yy03ODAwLWI0OGItODFmOTMyODMxMjJiLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDAtYjZmYy03ODAwLWI0OGItODFmOTMyODMxMjJiIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjowOTozMy40MzgxNzNaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjA5OjMzLjQzODE5Nloi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiI3NWYz
+        MjgyMDY1NGI0MjU2YThjMjAzYzE0MzFiN2E2ZiIsImNyZWF0ZWRfYnkiOm51
+        bGwsInVuYmxvY2tlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MDk6MzMuNDc2MjM1
+        WiIsInN0YXJ0ZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjMzLjU2NTkzOVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MDk6MzUuNTA2Nzc1WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8w
+        MTk1ZDJlZS1iYjkyLTdjM2ItOWY1MS1lOThhOWVlMjhiYTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkNsZWFuIHVwIG9y
+        cGhhbiBDb250ZW50IiwiY29kZSI6ImNsZWFuLXVwLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjo0MiwiZG9uZSI6NDIsInN1ZmZpeCI6
+        bnVsbH0seyJtZXNzYWdlIjoiQ2xlYW4gdXAgb3JwaGFuIEFydGlmYWN0cyIs
+        ImNvZGUiOiJjbGVhbi11cC5hcnRpZmFjdHMiLCJzdGF0ZSI6ImNvbXBsZXRl
+        ZCIsInRvdGFsIjo2MSwiZG9uZSI6NjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVh
+        dGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQi
+        OlsicGRybjo2ZDNjNjAxZi1mZWFmLTRiOTMtODI2NC01MjhjMjkxMjlhMTM6
+        b3JwaGFucyIsInNoYXJlZDpwcm46Y29yZS5kb21haW46NmQzYzYwMWYtZmVh
+        Zi00YjkzLTgyNjQtNTI4YzI5MTI5YTEzIl19
+  recorded_at: Mon, 31 Mar 2025 22:09:35 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/purge/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJmaW5pc2hlZF9iZWZvcmUiOiIzMDAwLTAxLTAxVDAwOjAwOjAwLjAwMCsw
+        MDowMCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:35 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4210c38d442a40dab0de580658663ed9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQwLWMwNWItN2Jl
+        My04MjM2LTVmYjM3MWRhYjVhMS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:35 GMT
 recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary.yml
@@ -12193,122 +12193,6 @@ http_interactions:
         bjowMTkyYzU3ZC1mYjk1LTc5MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
   recorded_at: Wed, 13 Nov 2024 10:24:16 GMT
 - request:
-    method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 13 Nov 2024 10:50:12 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 21ecc6bcf9524631a615da7de5ed2a56
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:50:12 GMT
-- request:
-    method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjo3NDB9
-
-        '
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 13 Nov 2024 10:50:13 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/uploads/01932525-2a9d-7f8a-8b61-e061c3d9a12e/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '241'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 31b54e994f204e17bce420b28c3dcece
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMTkzMjUyNS0y
-        YTlkLTdmOGEtOGI2MS1lMDYxYzNkOWExMmUvIiwicHJuIjoicHJuOmNvcmUu
-        dXBsb2FkOjAxOTMyNTI1LTJhOWQtN2Y4YS04YjYxLWUwNjFjM2Q5YTEyZSIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjQtMTEtMTNUMTA6NTA6MTMuMDIxOTEyWiIs
-        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0xMS0xM1QxMDo1MDoxMy4wMjE5
-        MjNaIiwic2l6ZSI6NzQwfQ==
-  recorded_at: Wed, 13 Nov 2024 10:50:13 GMT
-- request:
     method: put
     uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/uploads/01932525-2a9d-7f8a-8b61-e061c3d9a12e/
     body:
@@ -12393,60 +12277,6 @@ http_interactions:
         InB1bHBfY3JlYXRlZCI6IjIwMjQtMTEtMTNUMTA6NTA6MTMuMDIxOTEyWiIs
         InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0xMS0xM1QxMDo1MDoxMy4wMjE5
         MjNaIiwic2l6ZSI6NzQwfQ==
-  recorded_at: Wed, 13 Nov 2024 10:50:13 GMT
-- request:
-    method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 13 Nov 2024 10:50:13 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - f5878391ef2e4291b4e3e730c0897d4d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
   recorded_at: Wed, 13 Nov 2024 10:50:13 GMT
 - request:
     method: post
@@ -12575,196 +12405,6 @@ http_interactions:
         cmNlc19yZWNvcmQiOlsicHJuOmNvcmUudXBsb2FkOjAxOTMyNTI1LTJhOWQt
         N2Y4YS04YjYxLWUwNjFjM2Q5YTEyZSIsInNoYXJlZDpwcm46Y29yZS5kb21h
         aW46MDE5MmM1N2QtZmI5NS03OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 10:50:13 GMT
-- request:
-    method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 13 Nov 2024 10:50:13 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '834'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - ebdf1bed2ebd40e09a4a96d4da28f950
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE5
-        MzI1MjUtMmI1Mi03M2IzLWEzOTQtNWZiZWRkYmVhMmNmLyIsInBybiI6InBy
-        bjpjb3JlLmFydGlmYWN0OjAxOTMyNTI1LTJiNTItNzNiMy1hMzk0LTVmYmVk
-        ZGJlYTJjZiIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMTEtMTNUMTA6NTA6MTMu
-        MjAyOTA2WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0xMS0xM1QxMDo1
-        MDoxMy4yMDI5MThaIiwiZmlsZSI6ImFydGlmYWN0L2VmLzBjOTk4MzEwNmI4
-        MjRmOTQzODUwZGY5NDQyMGU3ZjE4YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2
-        MGE3NzkxIiwic2l6ZSI6NzQwLCJtZDUiOm51bGwsInNoYTEiOiI2MDk4ODU3
-        MTVmZDhkNmE3MDdmMThmYzU1OWQ2MWI4YmRlZTcxODBlIiwic2hhMjI0Ijoi
-        ZTI5MzFmMDM2NjU2YmE2ZDAxN2I1MDZiOGZlYzU3Yjg3ZTU3ZWVjMjdhZWFk
-        MGRmN2FkOGVkM2MiLCJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUw
-        ZGY5NDQyMGU3ZjE4YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwi
-        c2hhMzg0IjoiZDNjNTI4ZDIxMTBkODA2Njc1OWJlZDBjZGRjMDk5MTM5MWQ0
-        NzcyN2Q3YmIwMDM4NjRlYTkzNjIxM2E4ZWM0NGEzZGY1MmRkMWIyN2M3ODVj
-        N2U2N2IxMDMyMmU5OWZkIiwic2hhNTEyIjoiY2ZiODUyM2U4N2M3YmY5MWU4
-        MjMwZjVjZTE2OGJlMWQ4NTI3YWI3NjdmNTU3MTRlZTQ1ZGJjZDUwNWY3N2U4
-        NDFhNTQxNzgyMjQ4N2ZkZTIyNWU2MjJmZDRmOWNkZjMzMzg0NWQ5MDE0MDA3
-        ODYzYTk5YTE5YTdmNDkwMmVlMjgifV19
-  recorded_at: Wed, 13 Nov 2024 10:50:13 GMT
-- request:
-    method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 13 Nov 2024 10:50:13 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 34291a8a65034391918b83cba6af2875
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:50:13 GMT
-- request:
-    method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/content/file/files/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTdlMGQ3NTUwODM0ZmJl
-        ZmIwZWI5NDkyYmY5ZWY4Y2QzDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bS5q
-        c29uDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtN2UwZDc1NTA4
-        MzRmYmVmYjBlYjk0OTJiZjllZjhjZDMNCkNvbnRlbnQtRGlzcG9zaXRpb246
-        IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2FwaS92My9h
-        cnRpZmFjdHMvMDE5MzI1MjUtMmI1Mi03M2IzLWEzOTQtNWZiZWRkYmVhMmNm
-        Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTdlMGQ3NTUwODM0
-        ZmJlZmIwZWI5NDkyYmY5ZWY4Y2QzLS0NCg==
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-7e0d7550834fbefb0eb9492bf9ef8cd3
-      User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '385'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 13 Nov 2024 10:50:13 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - dc62eccd19fa415489386ded876cc084
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTI1LTJjMWYtN2Q4
-        MS1hYTRiLTQyYmQ0ZmIzMGUwOC8ifQ==
   recorded_at: Wed, 13 Nov 2024 10:50:13 GMT
 - request:
     method: get
@@ -12969,78 +12609,6 @@ http_interactions:
         bjowMTkyYzU3ZC1mYjk1LTc5MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
   recorded_at: Wed, 13 Nov 2024 10:50:13 GMT
 - request:
-    method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 13 Nov 2024 10:54:45 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '861'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 64caa7440323432f9fefdcbabff211a3
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
-        ZmlsZXMvMDE5MzI1MjUtMmNhOS03MTVhLWE4ZjYtM2Q5M2U4OWExMWM3LyIs
-        InBybiI6InBybjpmaWxlLmZpbGVjb250ZW50OjAxOTMyNTI1LTJjYTktNzE1
-        YS1hOGY2LTNkOTNlODlhMTFjNyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMTEt
-        MTNUMTA6NTA6MTMuNTQ2NzQzWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        NC0xMS0xM1QxMDo1MDoxMy41NDY3NTRaIiwiYXJ0aWZhY3QiOiIvcHVscC9h
-        cGkvdjMvYXJ0aWZhY3RzLzAxOTMyNTI1LTJiNTItNzNiMy1hMzk0LTVmYmVk
-        ZGJlYTJjZi8iLCJyZWxhdGl2ZV9wYXRoIjoidGVzdF9lcnJhdHVtLmpzb24i
-        LCJtZDUiOm51bGwsInNoYTEiOiI2MDk4ODU3MTVmZDhkNmE3MDdmMThmYzU1
-        OWQ2MWI4YmRlZTcxODBlIiwic2hhMjI0IjoiZTI5MzFmMDM2NjU2YmE2ZDAx
-        N2I1MDZiOGZlYzU3Yjg3ZTU3ZWVjMjdhZWFkMGRmN2FkOGVkM2MiLCJzaGEy
-        NTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4YWQzODFh
-        Y2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwic2hhMzg0IjoiZDNjNTI4ZDIx
-        MTBkODA2Njc1OWJlZDBjZGRjMDk5MTM5MWQ0NzcyN2Q3YmIwMDM4NjRlYTkz
-        NjIxM2E4ZWM0NGEzZGY1MmRkMWIyN2M3ODVjN2U2N2IxMDMyMmU5OWZkIiwi
-        c2hhNTEyIjoiY2ZiODUyM2U4N2M3YmY5MWU4MjMwZjVjZTE2OGJlMWQ4NTI3
-        YWI3NjdmNTU3MTRlZTQ1ZGJjZDUwNWY3N2U4NDFhNTQxNzgyMjQ4N2ZkZTIy
-        NWU2MjJmZDRmOWNkZjMzMzg0NWQ5MDE0MDA3ODYzYTk5YTE5YTdmNDkwMmVl
-        MjgifV19
-  recorded_at: Wed, 13 Nov 2024 10:54:45 GMT
-- request:
     method: post
     uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/01932529-538a-7c20-a79b-8bfe1023099e/modify/
     body:
@@ -13170,4 +12738,833 @@ http_interactions:
         YzIwLWE3OWItOGJmZTEwMjMwOTllIiwic2hhcmVkOnBybjpjb3JlLmRvbWFp
         bjowMTkyYzU3ZC1mYjk1LTc5MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
   recorded_at: Wed, 13 Nov 2024 10:54:46 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:21 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1e99a34efe9346f8ba6897eefff4e49b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:21 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:21 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2603b475f1e841e78f71fa35ac87bac4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:21 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjo3NDB9
+
+        '
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/0195ee40-8ab7-7522-ab9d-ad8dc22f6246/"
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '241'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 90809017653949689c3edc4865edca0b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMTk1ZWU0MC04
+        YWI3LTc1MjItYWI5ZC1hZDhkYzIyZjYyNDYvIiwicHJuIjoicHJuOmNvcmUu
+        dXBsb2FkOjAxOTVlZTQwLThhYjctNzUyMi1hYjlkLWFkOGRjMjJmNjI0NiIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjUtMDMtMzFUMjI6MDk6MjIuMTA0OTk2WiIs
+        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wMy0zMVQyMjowOToyMi4xMDUw
+        MThaIiwic2l6ZSI6NzQwfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:22 GMT
+- request:
+    method: put
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/uploads/0195ee40-8ab7-7522-ab9d-ad8dc22f6246/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTU5YmYyZWQ4NmJlMmQ3
+        NDUwYTM3MDEwNjk1NDNiM2U0DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyNTAz
+        MzEtMjI3MzY5LXVxd201cyINCkNvbnRlbnQtTGVuZ3RoOiA3NDANCkNvbnRl
+        bnQtVHlwZTogYXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtDQpDb250ZW50LVRy
+        YW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KeyJ1bml0X2tleSI6IHsiaWQi
+        OiAidGVzdCJ9LCAidW5pdF9tZXRhZGF0YSI6IHsic3RhdHVzIjogImZpbmFs
+        IiwgInVwZGF0ZWQiOiAiMjAxMi03LTI1IDAwOjAwOjAwIiwgImRlc2NyaXB0
+        aW9uIjogbnVsbCwgImlzc3VlZCI6ICIyMDEwLTExLTcgMDA6MDA6MDAiLCAi
+        cHVzaGNvdW50IjogIiIsICJyZWZlcmVuY2VzIjogW10sICJmcm9tIjogInB1
+        bHAtbGlzdEByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6
+        ICJUZXN0IEVycmF0YSByZWZlcnJpbmcgdG8gdGVzdC1wYWNrYWdlLTAuMiIs
+        ICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIs
+        ICJ2ZXJzaW9uIjogIjEiLCAicmVsZWFzZSI6ICIiLCAicmVib290X3N1Z2dl
+        c3RlZCI6IGZhbHNlLCAidHlwZSI6ICJlbmhhbmNlbWVudHMiLCAicGtnbGlz
+        dCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogInRlc3QtcGFja2FnZS0wLjIt
+        MS5lbDYuc3JjLnJwbSIsICJuYW1lIjogInRlc3QtcGFja2FnZSIsICJzdW0i
+        OiBbIm1kNSIsICI1YjU5MGNjOTVmZGZmMTQ1NjAwMzRhMWYzMzRhNDc1MyJd
+        LCAiZmlsZW5hbWUiOiAidGVzdC1wYWNrYWdlLTAuMi0xLmVsNi5ub2FyY2gu
+        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAicmVsZWFz
+        ZSI6ICIxLmVsNiIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiUHVs
+        cCBUZXN0IFBhY2thZ2VzIiwgInNob3J0IjogIlRlc3RDb2xsZWN0aW9uIn1d
+        fX0NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC01OWJmMmVkODZi
+        ZTJkNzQ1MGEzNzAxMDY5NTQzYjNlNC0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-59bf2ed86be2d7450a3701069543b3e4
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-739/740
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '1061'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '241'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4caf6af972dd42b280b2983b71c8a8cd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMTk1ZWU0MC04
+        YWI3LTc1MjItYWI5ZC1hZDhkYzIyZjYyNDYvIiwicHJuIjoicHJuOmNvcmUu
+        dXBsb2FkOjAxOTVlZTQwLThhYjctNzUyMi1hYjlkLWFkOGRjMjJmNjI0NiIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjUtMDMtMzFUMjI6MDk6MjIuMTA0OTk2WiIs
+        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wMy0zMVQyMjowOToyMi4xMDUw
+        MThaIiwic2l6ZSI6NzQwfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:22 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - f5f4039599064c53ae5e1340e0052132
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:22 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/uploads/0195ee40-8ab7-7522-ab9d-ad8dc22f6246/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4
+        YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - POST
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 346a2923078b450abc50cf4ecbf29ee1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQwLThlNmUtN2E5
+        MS04NmU1LWZlM2YxNmFiYmMxYy8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:23 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee40-8e6e-7a91-86e5-fe3f16abbc1c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '878'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8b9714ea3180426d8c1435d52fca78ef
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDAtOGU2
+        ZS03YTkxLTg2ZTUtZmUzZjE2YWJiYzFjLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDAtOGU2ZS03YTkxLTg2ZTUtZmUzZjE2YWJiYzFjIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjowOToyMy4wNTY1OTlaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjA5OjIzLjA1NjYyM1oi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3MudXBsb2FkLmNvbW1pdCIsImxvZ2dpbmdfY2lkIjoiMzQ2YTI5MjMwNzhi
+        NDUwYWJjNTBjZjRlY2JmMjllZTEiLCJjcmVhdGVkX2J5IjpudWxsLCJ1bmJs
+        b2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjIzLjEwMjk4OVoiLCJzdGFy
+        dGVkX2F0IjoiMjAyNS0wMy0zMVQyMjowOToyMy4yMTc1MThaIiwiZmluaXNo
+        ZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjIzLjMyNTAxN1oiLCJlcnJvciI6
+        bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5NWQyZWUt
+        YmFlYi03ZTdlLTk0NWQtZmRlYzk2MzEzZDkwLyIsInBhcmVudF90YXNrIjpu
+        dWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dy
+        ZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9h
+        cGkvdjMvYXJ0aWZhY3RzLzAxOTVlZTQwLThmNDAtNzk0OS04YTNjLWYzYjNm
+        ZjlhNjdiMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46
+        Y29yZS51cGxvYWQ6MDE5NWVlNDAtOGFiNy03NTIyLWFiOWQtYWQ4ZGMyMmY2
+        MjQ2Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo2ZDNjNjAxZi1mZWFmLTRi
+        OTMtODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:09:24 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '834'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1039e5bae6c1458399f2f73d46a7e692
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE5
+        NWVlNDAtOGY0MC03OTQ5LThhM2MtZjNiM2ZmOWE2N2IxLyIsInBybiI6InBy
+        bjpjb3JlLmFydGlmYWN0OjAxOTVlZTQwLThmNDAtNzk0OS04YTNjLWYzYjNm
+        ZjlhNjdiMSIsInB1bHBfY3JlYXRlZCI6IjIwMjUtMDMtMzFUMjI6MDk6MjMu
+        MjY4OTM0WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wMy0zMVQyMjow
+        OToyMy4yNjg5NThaIiwiZmlsZSI6ImFydGlmYWN0L2VmLzBjOTk4MzEwNmI4
+        MjRmOTQzODUwZGY5NDQyMGU3ZjE4YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2
+        MGE3NzkxIiwic2l6ZSI6NzQwLCJtZDUiOm51bGwsInNoYTEiOiI2MDk4ODU3
+        MTVmZDhkNmE3MDdmMThmYzU1OWQ2MWI4YmRlZTcxODBlIiwic2hhMjI0Ijoi
+        ZTI5MzFmMDM2NjU2YmE2ZDAxN2I1MDZiOGZlYzU3Yjg3ZTU3ZWVjMjdhZWFk
+        MGRmN2FkOGVkM2MiLCJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUw
+        ZGY5NDQyMGU3ZjE4YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwi
+        c2hhMzg0IjoiZDNjNTI4ZDIxMTBkODA2Njc1OWJlZDBjZGRjMDk5MTM5MWQ0
+        NzcyN2Q3YmIwMDM4NjRlYTkzNjIxM2E4ZWM0NGEzZGY1MmRkMWIyN2M3ODVj
+        N2U2N2IxMDMyMmU5OWZkIiwic2hhNTEyIjoiY2ZiODUyM2U4N2M3YmY5MWU4
+        MjMwZjVjZTE2OGJlMWQ4NTI3YWI3NjdmNTU3MTRlZTQ1ZGJjZDUwNWY3N2U4
+        NDFhNTQxNzgyMjQ4N2ZkZTIyNWU2MjJmZDRmOWNkZjMzMzg0NWQ5MDE0MDA3
+        ODYzYTk5YTE5YTdmNDkwMmVlMjgifV19
+  recorded_at: Mon, 31 Mar 2025 22:09:24 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2a72463e4936456982531719a9526a37
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:24 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/file/files/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWUxOTBjNDY3OWMwZTlm
+        ZGM2NWIyZDBmMDNhMTdiZTRkDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bS5q
+        c29uDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtZTE5MGM0Njc5
+        YzBlOWZkYzY1YjJkMGYwM2ExN2JlNGQNCkNvbnRlbnQtRGlzcG9zaXRpb246
+        IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2FwaS92My9h
+        cnRpZmFjdHMvMDE5NWVlNDAtOGY0MC03OTQ5LThhM2MtZjNiM2ZmOWE2N2Ix
+        Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWUxOTBjNDY3OWMw
+        ZTlmZGM2NWIyZDBmMDNhMTdiZTRkLS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-e190c4679c0e9fdc65b2d0f03a17be4d
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '385'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 41937bc7d8d44d8891a53ea5f91598b1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQwLTk0MmMtN2Uy
+        ZC1hMmI4LWYzZmE4NTZjYTBjZC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:24 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee40-942c-7e2d-a2b8-f3fa856ca0cd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:25 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '838'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - ecc06cdeac214d848aa5dc39b77a6988
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDAtOTQy
+        Yy03ZTJkLWEyYjgtZjNmYTg1NmNhMGNkLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDAtOTQyYy03ZTJkLWEyYjgtZjNmYTg1NmNhMGNkIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjowOToyNC41MjU3NDFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjA5OjI0LjUyNTc1OFoi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiNDE5Mzdi
+        YzdkOGQ0NGQ4ODkxYTUzZWE1ZjkxNTk4YjEiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjI0LjU0NzE0NVoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjowOToyNC42NDk5NjNaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjI1LjAzMjYwOVoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmFlYi03ZTdlLTk0NWQtZmRlYzk2MzEzZDkwLyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIv
+        cHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLzAxOTVlZTQwLTk2MTMt
+        NzFkYi1iZDFmLTM4YTRkMjRiNTA5Ni8iXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
+        X3JlY29yZCI6WyJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjZkM2M2MDFmLWZl
+        YWYtNGI5My04MjY0LTUyOGMyOTEyOWExMyJdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:25 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/0195ee40-8797-7f54-8041-efd411ea08de/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzAxOTVlZTQwLTk2MTMtNzFkYi1iZDFmLTM4YTRkMjRiNTA5
+        Ni8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:25 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - f53a219b2a72460592e41188340f8910
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQwLTk3MzAtN2Qy
+        Ni04YjI4LTE5ZWMwYjBhNDJkMS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:25 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee40-9730-7d26-8b28-19ec0b0a42d1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:26 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '922'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 250082601bec439cb5273dd86c2fb944
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDAtOTcz
+        MC03ZDI2LThiMjgtMTllYzBiMGE0MmQxLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDAtOTczMC03ZDI2LThiMjgtMTllYzBiMGE0MmQxIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjowOToyNS4yOTkxODNaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjA5OjI1LjI5OTIwNFoi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92ZSIsImxvZ2dpbmdfY2lkIjoi
+        ZjUzYTIxOWIyYTcyNDYwNTkyZTQxMTg4MzQwZjg5MTAiLCJjcmVhdGVkX2J5
+        IjpudWxsLCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjI1LjMz
+        NjQzMFoiLCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjowOToyNS40MTYx
+        OTZaIiwiZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjI1LjU3MDA4
+        OVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMDE5NWQyZWUtYmNmMC03ZjU5LWFhZmEtYzAyYzY0YmU5Nzk2LyIsInBh
+        cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
+        Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk1
+        ZWU0MC04Nzk3LTdmNTQtODA0MS1lZmQ0MTFlYTA4ZGUvdmVyc2lvbnMvMS8i
+        XSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46ZmlsZS5maWxl
+        cmVwb3NpdG9yeTowMTk1ZWU0MC04Nzk3LTdmNTQtODA0MS1lZmQ0MTFlYTA4
+        ZGUiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjZkM2M2MDFmLWZlYWYtNGI5
+        My04MjY0LTUyOGMyOTEyOWExMyJdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:26 GMT
 recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary_duplicate.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/duplicate_upload_binary_duplicate.yml
@@ -8652,196 +8652,6 @@ http_interactions:
   recorded_at: Wed, 13 Nov 2024 10:24:17 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 13 Nov 2024 10:50:14 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '834'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - ed1e9d5f40654cb7ab023dd1ad0964ef
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE5
-        MzI1MjUtMmI1Mi03M2IzLWEzOTQtNWZiZWRkYmVhMmNmLyIsInBybiI6InBy
-        bjpjb3JlLmFydGlmYWN0OjAxOTMyNTI1LTJiNTItNzNiMy1hMzk0LTVmYmVk
-        ZGJlYTJjZiIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMTEtMTNUMTA6NTA6MTMu
-        MjAyOTA2WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0xMS0xM1QxMDo1
-        MDoxMy4yMDI5MThaIiwiZmlsZSI6ImFydGlmYWN0L2VmLzBjOTk4MzEwNmI4
-        MjRmOTQzODUwZGY5NDQyMGU3ZjE4YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2
-        MGE3NzkxIiwic2l6ZSI6NzQwLCJtZDUiOm51bGwsInNoYTEiOiI2MDk4ODU3
-        MTVmZDhkNmE3MDdmMThmYzU1OWQ2MWI4YmRlZTcxODBlIiwic2hhMjI0Ijoi
-        ZTI5MzFmMDM2NjU2YmE2ZDAxN2I1MDZiOGZlYzU3Yjg3ZTU3ZWVjMjdhZWFk
-        MGRmN2FkOGVkM2MiLCJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUw
-        ZGY5NDQyMGU3ZjE4YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwi
-        c2hhMzg0IjoiZDNjNTI4ZDIxMTBkODA2Njc1OWJlZDBjZGRjMDk5MTM5MWQ0
-        NzcyN2Q3YmIwMDM4NjRlYTkzNjIxM2E4ZWM0NGEzZGY1MmRkMWIyN2M3ODVj
-        N2U2N2IxMDMyMmU5OWZkIiwic2hhNTEyIjoiY2ZiODUyM2U4N2M3YmY5MWU4
-        MjMwZjVjZTE2OGJlMWQ4NTI3YWI3NjdmNTU3MTRlZTQ1ZGJjZDUwNWY3N2U4
-        NDFhNTQxNzgyMjQ4N2ZkZTIyNWU2MjJmZDRmOWNkZjMzMzg0NWQ5MDE0MDA3
-        ODYzYTk5YTE5YTdmNDkwMmVlMjgifV19
-  recorded_at: Wed, 13 Nov 2024 10:50:14 GMT
-- request:
-    method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum1.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 13 Nov 2024 10:50:14 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - c10c4f6d1b00428085c6be4757541bbf
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:50:14 GMT
-- request:
-    method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/content/file/files/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTM3MTJkNzFkMWI2NDMy
-        ZDRkNTI5Njg4YTZlODEyOTg4DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bTEu
-        anNvbg0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTM3MTJkNzFk
-        MWI2NDMyZDRkNTI5Njg4YTZlODEyOTg4DQpDb250ZW50LURpc3Bvc2l0aW9u
-        OiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0KDQovcHVscC9hcGkvdjMv
-        YXJ0aWZhY3RzLzAxOTMyNTI1LTJiNTItNzNiMy1hMzk0LTVmYmVkZGJlYTJj
-        Zi8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC0zNzEyZDcxZDFi
-        NjQzMmQ0ZDUyOTY4OGE2ZTgxMjk4OC0tDQo=
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-3712d71d1b6432d4d529688a6e812988
-      User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '386'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 13 Nov 2024 10:50:14 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - e112b97346214cb6a521c9838b2f6468
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTI1LTJmYWUtN2I4
-        Ni04MTI5LTMwY2NkOGJmNzViZC8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:50:14 GMT
-- request:
-    method: get
     uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/01932525-2fae-7b86-8129-30ccd8bf75bd/
     body:
       encoding: US-ASCII
@@ -9043,78 +8853,6 @@ http_interactions:
         bjowMTkyYzU3ZC1mYjk1LTc5MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
   recorded_at: Wed, 13 Nov 2024 10:50:14 GMT
 - request:
-    method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum1.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 13 Nov 2024 10:54:46 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '862'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 319ae288f5e14cb79c530a140400cc1a
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
-        ZmlsZXMvMDE5MzI1MjUtMzA1OS03MmE2LWFmMWMtNjk3NTI3MmE0MmJiLyIs
-        InBybiI6InBybjpmaWxlLmZpbGVjb250ZW50OjAxOTMyNTI1LTMwNTktNzJh
-        Ni1hZjFjLTY5NzUyNzJhNDJiYiIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMTEt
-        MTNUMTA6NTA6MTQuNDkwOTYyWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        NC0xMS0xM1QxMDo1MDoxNC40OTA5NzVaIiwiYXJ0aWZhY3QiOiIvcHVscC9h
-        cGkvdjMvYXJ0aWZhY3RzLzAxOTMyNTI1LTJiNTItNzNiMy1hMzk0LTVmYmVk
-        ZGJlYTJjZi8iLCJyZWxhdGl2ZV9wYXRoIjoidGVzdF9lcnJhdHVtMS5qc29u
-        IiwibWQ1IjpudWxsLCJzaGExIjoiNjA5ODg1NzE1ZmQ4ZDZhNzA3ZjE4ZmM1
-        NTlkNjFiOGJkZWU3MTgwZSIsInNoYTIyNCI6ImUyOTMxZjAzNjY1NmJhNmQw
-        MTdiNTA2YjhmZWM1N2I4N2U1N2VlYzI3YWVhZDBkZjdhZDhlZDNjIiwic2hh
-        MjU2IjoiZWYwYzk5ODMxMDZiODI0Zjk0Mzg1MGRmOTQ0MjBlN2YxOGFkMzgx
-        YWNjNmJkNWEyMWVhMDVkY2Y2NjBhNzc5MSIsInNoYTM4NCI6ImQzYzUyOGQy
-        MTEwZDgwNjY3NTliZWQwY2RkYzA5OTEzOTFkNDc3MjdkN2JiMDAzODY0ZWE5
-        MzYyMTNhOGVjNDRhM2RmNTJkZDFiMjdjNzg1YzdlNjdiMTAzMjJlOTlmZCIs
-        InNoYTUxMiI6ImNmYjg1MjNlODdjN2JmOTFlODIzMGY1Y2UxNjhiZTFkODUy
-        N2FiNzY3ZjU1NzE0ZWU0NWRiY2Q1MDVmNzdlODQxYTU0MTc4MjI0ODdmZGUy
-        MjVlNjIyZmQ0ZjljZGYzMzM4NDVkOTAxNDAwNzg2M2E5OWExOWE3ZjQ5MDJl
-        ZTI4In1dfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:46 GMT
-- request:
     method: post
     uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/01932529-538a-7c20-a79b-8bfe1023099e/modify/
     body:
@@ -9244,4 +8982,449 @@ http_interactions:
         YzIwLWE3OWItOGJmZTEwMjMwOTllIiwic2hhcmVkOnBybjpjb3JlLmRvbWFp
         bjowMTkyYzU3ZC1mYjk1LTc5MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
   recorded_at: Wed, 13 Nov 2024 10:54:46 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum1.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2420a728183247b79ebfbeeedb0ade9a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:27 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/artifacts/?sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '834'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - ea42c89dc0b741138beda4815b1f7a81
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE5
+        NWVlNDAtOGY0MC03OTQ5LThhM2MtZjNiM2ZmOWE2N2IxLyIsInBybiI6InBy
+        bjpjb3JlLmFydGlmYWN0OjAxOTVlZTQwLThmNDAtNzk0OS04YTNjLWYzYjNm
+        ZjlhNjdiMSIsInB1bHBfY3JlYXRlZCI6IjIwMjUtMDMtMzFUMjI6MDk6MjMu
+        MjY4OTM0WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wMy0zMVQyMjow
+        OToyMy4yNjg5NThaIiwiZmlsZSI6ImFydGlmYWN0L2VmLzBjOTk4MzEwNmI4
+        MjRmOTQzODUwZGY5NDQyMGU3ZjE4YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2
+        MGE3NzkxIiwic2l6ZSI6NzQwLCJtZDUiOm51bGwsInNoYTEiOiI2MDk4ODU3
+        MTVmZDhkNmE3MDdmMThmYzU1OWQ2MWI4YmRlZTcxODBlIiwic2hhMjI0Ijoi
+        ZTI5MzFmMDM2NjU2YmE2ZDAxN2I1MDZiOGZlYzU3Yjg3ZTU3ZWVjMjdhZWFk
+        MGRmN2FkOGVkM2MiLCJzaGEyNTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUw
+        ZGY5NDQyMGU3ZjE4YWQzODFhY2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwi
+        c2hhMzg0IjoiZDNjNTI4ZDIxMTBkODA2Njc1OWJlZDBjZGRjMDk5MTM5MWQ0
+        NzcyN2Q3YmIwMDM4NjRlYTkzNjIxM2E4ZWM0NGEzZGY1MmRkMWIyN2M3ODVj
+        N2U2N2IxMDMyMmU5OWZkIiwic2hhNTEyIjoiY2ZiODUyM2U4N2M3YmY5MWU4
+        MjMwZjVjZTE2OGJlMWQ4NTI3YWI3NjdmNTU3MTRlZTQ1ZGJjZDUwNWY3N2U4
+        NDFhNTQxNzgyMjQ4N2ZkZTIyNWU2MjJmZDRmOWNkZjMzMzg0NWQ5MDE0MDA3
+        ODYzYTk5YTE5YTdmNDkwMmVlMjgifV19
+  recorded_at: Mon, 31 Mar 2025 22:09:27 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum1.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - fd88190f2802437697b7ed14f8c5b521
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:27 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/file/files/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTExYTI5ODVlMzkyNjkw
+        ODMwOWJiYzgxOWJhYTg0Y2IzDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlbGF0aXZlX3BhdGgiDQoNCnRlc3RfZXJyYXR1bTEu
+        anNvbg0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTExYTI5ODVl
+        MzkyNjkwODMwOWJiYzgxOWJhYTg0Y2IzDQpDb250ZW50LURpc3Bvc2l0aW9u
+        OiBmb3JtLWRhdGE7IG5hbWU9ImFydGlmYWN0Ig0KDQovcHVscC9hcGkvdjMv
+        YXJ0aWZhY3RzLzAxOTVlZTQwLThmNDAtNzk0OS04YTNjLWYzYjNmZjlhNjdi
+        MS8NCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9zdC0xMWEyOTg1ZTM5
+        MjY5MDgzMDliYmM4MTliYWE4NGNiMy0tDQo=
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-11a2985e3926908309bbc819baa84cb3
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '386'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 906fd75b08ee4421afff71ef8dbcea99
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQwLWExMTgtNzJm
+        Ny05MDQ5LTkyNWI1MTA1YjU1OC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:27 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee40-a118-72f7-9049-925b5105b558/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '838'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - c81b470150e44335a4db2bf6c5991bb8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDAtYTEx
+        OC03MmY3LTkwNDktOTI1YjUxMDViNTU4LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDAtYTExOC03MmY3LTkwNDktOTI1YjUxMDViNTU4IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjowOToyNy44MzMwNjVaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjA5OjI3LjgzMzA4MVoi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiOTA2ZmQ3
+        NWIwOGVlNDQyMWFmZmY3MWVmOGRiY2VhOTkiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjI3Ljg2NTk1OVoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjowOToyNy45NjI1MzBaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjI4LjM2NjU3OVoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmI5Mi03YzNiLTlmNTEtZTk4YTllZTI4YmE0LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIv
+        cHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLzAxOTVlZTQwLWEzMTMt
+        NzY4YS1iODBmLTgyM2Q1ZGRlYzRiNi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
+        X3JlY29yZCI6WyJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjZkM2M2MDFmLWZl
+        YWYtNGI5My04MjY0LTUyOGMyOTEyOWExMyJdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:28 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/0195ee40-8797-7f54-8041-efd411ea08de/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzAxOTVlZTQwLWEzMTMtNzY4YS1iODBmLTgyM2Q1ZGRlYzRi
+        Ni8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 07f4755e95de473192d36c946ce609a0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQwLWE0MjMtN2Qw
+        MS1iYjIzLTY2ZDNlYWYzZWYzOC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:28 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee40-a423-7d01-bb23-66d3eaf3ef38/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '922'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - dd08428627f34a8c8aeb751fd1012fd9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDAtYTQy
+        My03ZDAxLWJiMjMtNjZkM2VhZjNlZjM4LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDAtYTQyMy03ZDAxLWJiMjMtNjZkM2VhZjNlZjM4IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjowOToyOC42MTI0MDZaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjA5OjI4LjYxMjQyNVoi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92ZSIsImxvZ2dpbmdfY2lkIjoi
+        MDdmNDc1NWU5NWRlNDczMTkyZDM2Yzk0NmNlNjA5YTAiLCJjcmVhdGVkX2J5
+        IjpudWxsLCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjI4LjYz
+        MjI1OVoiLCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjowOToyOC43NDYx
+        NTVaIiwiZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjI4LjkyMzI4
+        M1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMDE5NWQyZWUtYmFlYi03ZTdlLTk0NWQtZmRlYzk2MzEzZDkwLyIsInBh
+        cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
+        Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk1
+        ZWU0MC04Nzk3LTdmNTQtODA0MS1lZmQ0MTFlYTA4ZGUvdmVyc2lvbnMvMi8i
+        XSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46ZmlsZS5maWxl
+        cmVwb3NpdG9yeTowMTk1ZWU0MC04Nzk3LTdmNTQtODA0MS1lZmQ0MTFlYTA4
+        ZGUiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjZkM2M2MDFmLWZlYWYtNGI5
+        My04MjY0LTUyOGMyOTEyOWExMyJdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:29 GMT
 recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,13 +23,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:42 GMT
+      - Mon, 31 Mar 2025 22:09:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -43,20 +43,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 06e1efd33ac74372b5057c156e773a05
+      - e562087de22f4a6f85252e14ef422b19
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:42 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:37 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,13 +77,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:42 GMT
+      - Mon, 31 Mar 2025 22:09:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -97,20 +97,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8f7fce98adfe467d87aa9ced903db852
+      - e214b75cc2b941da8bbb517f961bc0a2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:42 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:37 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -118,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,13 +131,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:42 GMT
+      - Mon, 31 Mar 2025 22:09:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -151,20 +151,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c5cb809770c1453890bee6e03186914d
+      - 8c1c84eacaa44d08b5ae21a0d4197303
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:42 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:37 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/My_Files
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -172,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,13 +185,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:42 GMT
+      - Mon, 31 Mar 2025 22:09:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -205,20 +205,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ddaea36ce5334ca5b5ee52d207268cf5
+      - 89809b41d9924a74ae5cb6f33578cd66
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:42 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:37 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -235,7 +235,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -248,15 +248,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:42 GMT
+      - Mon, 31 Mar 2025 22:09:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/01932529-4614-71ff-bf9b-cf1d1f87d6c0/"
+      - "/pulp/api/v3/remotes/file/file/0195ee40-c72f-7346-93ba-fcf68d8096e3/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -270,20 +270,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 63a10afa3b6e478b881530c51daa5bd1
+      - 9c0699015dec47d4b957ba7db1d7e158
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE5MzI1MjktNDYxNC03MWZmLWJmOWItY2YxZDFmODdkNmMwLyIsInBybiI6
-        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5MzI1MjktNDYxNC03MWZmLWJmOWIt
-        Y2YxZDFmODdkNmMwIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1
-        NDo0Mi4xOTYzNThaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEz
-        VDEwOjU0OjQyLjE5NjM2N1oiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        MDE5NWVlNDAtYzcyZi03MzQ2LTkzYmEtZmNmNjhkODA5NmUzLyIsInBybiI6
+        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NWVlNDAtYzcyZi03MzQ2LTkzYmEt
+        ZmNmNjhkODA5NmUzIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjow
+        OTozNy41ODU5MzBaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMx
+        VDIyOjA5OjM3LjU4NTk1NloiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
         b24tQ2FiaW5ldC1NeV9GaWxlcyIsInVybCI6Imh0dHA6Ly90ZXN0L3Rlc3Qv
         L1BVTFBfTUFOSUZFU1QiLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6
         bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwi
@@ -297,10 +297,10 @@ http_interactions:
         ZSI6InByb3h5X3Bhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoi
         dXNlcm5hbWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwYXNzd29yZCIs
         ImlzX3NldCI6ZmFsc2V9XX0=
-  recorded_at: Wed, 13 Nov 2024 10:54:42 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:37 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -310,7 +310,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -323,15 +323,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:42 GMT
+      - Mon, 31 Mar 2025 22:09:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/01932529-4680-7867-a1ff-c25b8e83a9f3/"
+      - "/pulp/api/v3/repositories/file/file/0195ee40-c863-7ceb-a6a7-060f15bfd273/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -345,33 +345,33 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 42bd7968639b411fa2ecb65ec5eb63e2
+      - 6073404e5118480ab94ba4d8d99ecd3a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMTkzMjUyOS00NjgwLTc4NjctYTFmZi1jMjViOGU4M2E5ZjMvIiwi
-        cHJuIjoicHJuOmZpbGUuZmlsZXJlcG9zaXRvcnk6MDE5MzI1MjktNDY4MC03
-        ODY3LWExZmYtYzI1YjhlODNhOWYzIiwicHVscF9jcmVhdGVkIjoiMjAyNC0x
-        MS0xM1QxMDo1NDo0Mi4zMDUwMTVaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIy
-        MDI0LTExLTEzVDEwOjU0OjQyLjMwOTU1MloiLCJ2ZXJzaW9uc19ocmVmIjoi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1Mjkt
-        NDY4MC03ODY3LWExZmYtYzI1YjhlODNhOWYzL3ZlcnNpb25zLyIsInB1bHBf
+        ZmlsZS8wMTk1ZWU0MC1jODYzLTdjZWItYTZhNy0wNjBmMTViZmQyNzMvIiwi
+        cHJuIjoicHJuOmZpbGUuZmlsZXJlcG9zaXRvcnk6MDE5NWVlNDAtYzg2My03
+        Y2ViLWE2YTctMDYwZjE1YmZkMjczIiwicHVscF9jcmVhdGVkIjoiMjAyNS0w
+        My0zMVQyMjowOTozNy44OTMxMDRaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIy
+        MDI1LTAzLTMxVDIyOjA5OjM3Ljg5Nzg0OFoiLCJ2ZXJzaW9uc19ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NWVlNDAt
+        Yzg2My03Y2ViLWE2YTctMDYwZjE1YmZkMjczL3ZlcnNpb25zLyIsInB1bHBf
         bGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTMyNTI5LTQ2ODAtNzg2Ny1h
-        MWZmLWMyNWI4ZTgzYTlmMy92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTVlZTQwLWM4NjMtN2NlYi1h
+        NmE3LTA2MGYxNWJmZDI3My92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0
         X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwiZGVzY3JpcHRpb24i
         Om51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJyZW1vdGUiOm51
         bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWFuaWZlc3QiOiJQVUxQX01BTklG
         RVNUIn0=
-  recorded_at: Wed, 13 Nov 2024 10:54:42 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:37 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/01932529-4614-71ff-bf9b-cf1d1f87d6c0/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/file/file/0195ee40-c72f-7346-93ba-fcf68d8096e3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -379,7 +379,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -392,13 +392,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:43 GMT
+      - Mon, 31 Mar 2025 22:09:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -412,20 +412,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 170a8362309d4e59b0a4cbb472f3e142
+      - c85e7cd93b3f4e19badccdc964fe3e4d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTI5LTRhMjctNzA4
-        ZC1hZmU3LTUzNGEyZWUyMDJhYS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:43 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQwLWQwNGItNzI2
+        Yi05ZTIzLTA5NjMyNDViZjk1Ny8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:39 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/01932529-4a27-708d-afe7-534a2ee202aa/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee40-d04b-726b-9e23-0963245bf957/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -433,7 +433,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -446,19 +446,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:43 GMT
+      - Mon, 31 Mar 2025 22:09:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '845'
+      - '826'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -466,37 +466,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c46b0a4012ba4c4e91d16ed609458ec5
+      - 5ec630f4b65245d0be90922a9dc15164
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MjktNGEy
-        Ny03MDhkLWFmZTctNTM0YTJlZTIwMmFhLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MjktNGEyNy03MDhkLWFmZTctNTM0YTJlZTIwMmFhIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NDo0My4yNDAwNzNaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU0OjQzLjI0MDA5MFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDAtZDA0
+        Yi03MjZiLTllMjMtMDk2MzI0NWJmOTU3LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDAtZDA0Yi03MjZiLTllMjMtMDk2MzI0NWJmOTU3IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjowOTozOS45MTYwODJaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjA5OjM5LjkxNjEwNFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiMTcwYTgz
-        NjIzMDlkNGU1OWIwYTRjYmI0NzJmM2UxNDIiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMDo1NDo0My4yNTcxOTZaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTA6NTQ6NDMuMzExOTg2WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MDo1NDo0My4zNDQ2MzFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTMyNTIzLTkwMWUtN2ZiMC05ZTA3LTljZGY0
-        ZDJiMWNhMC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpmaWxlLmZpbGVyZW1vdGU6MDE5MzI1MjktNDYxNC03MWZmLWJm
-        OWItY2YxZDFmODdkNmMwIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTky
-        YzU3ZC1mYjk1LTc5MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 10:54:43 GMT
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiYzg1ZTdj
+        ZDkzYjNmNGUxOWJhZGNjZGM5NjRmZTNlNGQiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjM5LjkzNzUwMloi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjowOTo0MC4wMTE0MDZaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjQwLjA4OTE5NloiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmNmMC03ZjU5LWFhZmEtYzAyYzY0YmU5Nzk2LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10s
+        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOmZpbGUuZmlsZXJl
+        bW90ZTowMTk1ZWU0MC1jNzJmLTczNDYtOTNiYS1mY2Y2OGQ4MDk2ZTMiLCJz
+        aGFyZWQ6cHJuOmNvcmUuZG9tYWluOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0
+        LTUyOGMyOTEyOWExMyJdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:40 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/01932529-4680-7867-a1ff-c25b8e83a9f3/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/0195ee40-c863-7ceb-a6a7-060f15bfd273/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -504,7 +504,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -517,13 +517,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:43 GMT
+      - Mon, 31 Mar 2025 22:09:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -537,20 +537,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6588e3a171694c10bd0571af23af4b20
+      - bcf1fabae0494b70b1ed237db52d32b4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTI5LTRiNmUtNzVl
-        NS05Yzc5LThkZmYxODFlMDk0MC8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:43 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQwLWQyOTYtN2Jl
+        MS1iODgyLTJjYjBhMTZjNWYzYi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:40 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/01932529-4b6e-75e5-9c79-8dff181e0940/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee40-d296-7be1-b882-2cb0a16c5f3b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -558,7 +558,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -571,19 +571,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:43 GMT
+      - Mon, 31 Mar 2025 22:09:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '849'
+      - '830'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -591,37 +591,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 90d2fa3979684e83a024dcd6bdb0daf1
+      - 52d080b55d4c4c8fb557a1a85d8105c5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MjktNGI2
-        ZS03NWU1LTljNzktOGRmZjE4MWUwOTQwLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MjktNGI2ZS03NWU1LTljNzktOGRmZjE4MWUwOTQwIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NDo0My41NjY1MTVaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU0OjQzLjU2NjUyOFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDAtZDI5
+        Ni03YmUxLWI4ODItMmNiMGExNmM1ZjNiLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDAtZDI5Ni03YmUxLWI4ODItMmNiMGExNmM1ZjNiIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjowOTo0MC41MDM0MjBaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjA5OjQwLjUwMzQ3NVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiNjU4OGUz
-        YTE3MTY5NGMxMGJkMDU3MWFmMjNhZjRiMjAiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMDo1NDo0My41ODAwMjBaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTA6NTQ6NDMuNjIzMDMzWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MDo1NDo0My42ODY3NjFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTMyNTIzLTkwMWUtN2ZiMC05ZTA3LTljZGY0
-        ZDJiMWNhMC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpmaWxlLmZpbGVyZXBvc2l0b3J5OjAxOTMyNTI5LTQ2ODAtNzg2
-        Ny1hMWZmLWMyNWI4ZTgzYTlmMyIsInNoYXJlZDpwcm46Y29yZS5kb21haW46
-        MDE5MmM1N2QtZmI5NS03OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 10:54:43 GMT
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiYmNmMWZh
+        YmFlMDQ5NGI3MGIxZWQyMzdkYjUyZDMyYjQiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjQwLjUyNTkxN1oi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjowOTo0MC42MTM4NDlaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjQwLjc0MzA2MloiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmNmMC03ZjU5LWFhZmEtYzAyYzY0YmU5Nzk2LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10s
+        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOmZpbGUuZmlsZXJl
+        cG9zaXRvcnk6MDE5NWVlNDAtYzg2My03Y2ViLWE2YTctMDYwZjE1YmZkMjcz
+        Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo2ZDNjNjAxZi1mZWFmLTRiOTMt
+        ODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:09:40 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -629,7 +629,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.22.3/ruby
+      - OpenAPI-Generator/0.22.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -642,13 +642,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:43 GMT
+      - Mon, 31 Mar 2025 22:09:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -662,20 +662,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ad54645af7974666bad194423c9bcc48
+      - 431834ecf2e94b8290dfa6e6e735977e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:43 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:41 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -696,13 +696,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:44 GMT
+      - Mon, 31 Mar 2025 22:09:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -716,20 +716,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 35a945ae642845de8cc2cbfe671251f3
+      - fda2e7732f7b41a6bae3bcbb343be751
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:44 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:41 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -737,7 +737,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.22.0/ruby
+      - OpenAPI-Generator/2.22.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -750,13 +750,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:44 GMT
+      - Mon, 31 Mar 2025 22:09:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -770,20 +770,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fadf6e109847436890f767a9952f2abd
+      - 1edcd1f91dc74a169f26000d1fb2ffbc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:44 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:41 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -791,7 +791,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -804,13 +804,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:44 GMT
+      - Mon, 31 Mar 2025 22:09:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -824,20 +824,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cb6939f83a864f7297f0780093400c19
+      - 461b81002e2a49309a46691811f5cce9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:44 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:41 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -845,7 +845,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.4.4/ruby
+      - OpenAPI-Generator/2.4.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -858,13 +858,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:44 GMT
+      - Mon, 31 Mar 2025 22:09:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -878,20 +878,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 07a3f2ef810b44fc8604e2f9283fcdf2
+      - 2d010d398185433191c0ab440d6ef2b3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:44 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:41 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -899,7 +899,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.12.5/ruby
+      - OpenAPI-Generator/3.12.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -912,13 +912,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:44 GMT
+      - Mon, 31 Mar 2025 22:09:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -932,20 +932,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 930f39b897ae4210892fa5c2ce323c64
+      - d49d17f5a78845ad988c9420d28a051a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:44 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:41 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -966,13 +966,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:44 GMT
+      - Mon, 31 Mar 2025 22:09:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -986,76 +986,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2e574a2ddbbe4ddfbed0a1fc53c2a1dd
+      - 91ff46b055da4cecb4bcc7a31d4543e5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:44 GMT
-- request:
-    method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/orphans/cleanup/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJvcnBoYW5fcHJvdGVjdGlvbl90aW1lIjoxNDQwfQ==
-
-        '
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 13 Nov 2024 10:54:44 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - POST, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 6912582a6bd946a386dd2dd097bd020c
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTI5LTRlODItN2Qy
-        Yy1iZjQyLThlZjZkM2QxNDA4OC8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:44 GMT
+  recorded_at: Mon, 31 Mar 2025 22:09:41 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/01932529-4e82-7d2c-bf42-8ef6d3d14088/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1063,7 +1007,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/0.22.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1076,19 +1020,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:44 GMT
+      - Mon, 31 Mar 2025 22:09:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
+      - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1077'
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1096,52 +1040,354 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6ba27652d84c4a23b6e39eebbe3449dd
+      - 77ea2c61efdb44fb80926f01cfd0d08a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MjktNGU4
-        Mi03ZDJjLWJmNDItOGVmNmQzZDE0MDg4LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MjktNGU4Mi03ZDJjLWJmNDItOGVmNmQzZDE0MDg4IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NDo0NC4zNTUyOTZaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU0OjQ0LjM1NTMxNFoi
-        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiI2OTEy
-        NTgyYTZiZDk0NmEzODZkZDJkZDA5N2JkMDIwYyIsImNyZWF0ZWRfYnkiOiIv
-        cHVscC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTEx
-        LTEzVDEwOjU0OjQ0LjM3NTczMFoiLCJzdGFydGVkX2F0IjoiMjAyNC0xMS0x
-        M1QxMDo1NDo0NC40MTM4NDZaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTExLTEz
-        VDEwOjU0OjQ0LjU4NTM3MVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1
-        bHAvYXBpL3YzL3dvcmtlcnMvMDE5MzI1MjMtOTAxZS03ZmIwLTllMDctOWNk
-        ZjRkMmIxY2EwLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6
-        W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1l
-        c3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQ29udGVudCIsImNvZGUiOiJjbGVh
-        bi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwi
-        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJDbGVhbiB1cCBv
-        cnBoYW4gQXJ0aWZhY3RzIiwiY29kZSI6ImNsZWFuLXVwLmFydGlmYWN0cyIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jl
-        c291cmNlc19yZWNvcmQiOlsicGRybjowMTkyYzU3ZC1mYjk1LTc5MTgtODdl
-        NC05ZGU1YjE1YWI1MzY6b3JwaGFucyIsInNoYXJlZDpwcm46Y29yZS5kb21h
-        aW46MDE5MmM1N2QtZmI5NS03OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 10:54:44 GMT
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:42 GMT
 - request:
-    method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/purge/
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
-      encoding: UTF-8
-      base64_string: |
-        eyJmaW5pc2hlZF9iZWZvcmUiOiIzMDAwLTAxLTAxVDAwOjAwOjAwLjAwMCsw
-        MDowMCJ9
+      encoding: US-ASCII
+      base64_string: ''
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.3.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - d29bb133d0d9463c83d449e3afe19247
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:42 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.22.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5dbce3d8d8984ac0ac656f5f53891a6e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:42 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 56c73cddf123471a8f952b8a2a23bee4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:42 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.4.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 520b6e27a8d9427b8732016631bc2b4a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:42 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.12.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - c905cfad47ac414a93a814873d6b6803
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:42 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.27.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:42 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - fa100ec4899d44f59e5f36f542c33dce
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:42 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/orphans/cleanup/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJvcnBoYW5fcHJvdGVjdGlvbl90aW1lIjoxNDQwfQ==
+
+        '
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1154,13 +1400,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:54:44 GMT
+      - Mon, 31 Mar 2025 22:09:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - POST, OPTIONS
       X-Frame-Options:
@@ -1174,15 +1420,147 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d9454cc94b9944c18b85a3f37dd71910
+      - 528cb2225b894786b3df5bb32b26a65a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTI5LTRmZDEtNzUw
-        OC04ZGZkLTU3YjBiMDBkYzU0Ni8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:54:44 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQwLWRjNWItN2Jk
+        MS04NWUwLTAzMGIwYTY5MTUwZS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:43 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee40-dc5b-7bd1-85e0-030b0a69150e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '1058'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8dbb1e83f62948268e49a23e7be1d89e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDAtZGM1
+        Yi03YmQxLTg1ZTAtMDMwYjBhNjkxNTBlLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDAtZGM1Yi03YmQxLTg1ZTAtMDMwYjBhNjkxNTBlIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjowOTo0My4wMDQ5NzVaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjA5OjQzLjAwNDk5Nloi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiI1Mjhj
+        YjIyMjViODk0Nzg2YjNkZjViYjMyYjI2YTY1YSIsImNyZWF0ZWRfYnkiOm51
+        bGwsInVuYmxvY2tlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MDk6NDMuMDI1OTk5
+        WiIsInN0YXJ0ZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjQzLjEyNzE2MFoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MDk6NDMuNDYyMjAxWiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8w
+        MTk1ZDJlZS1iYTNhLTc0NjMtYTE1NS05ODdjY2M5ZTVhNzQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkNsZWFuIHVwIG9y
+        cGhhbiBDb250ZW50IiwiY29kZSI6ImNsZWFuLXVwLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51
+        bGx9LHsibWVzc2FnZSI6IkNsZWFuIHVwIG9ycGhhbiBBcnRpZmFjdHMiLCJj
+        b2RlIjoiY2xlYW4tdXAuYXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJw
+        ZHJuOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUyOGMyOTEyOWExMzpvcnBo
+        YW5zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo2ZDNjNjAxZi1mZWFmLTRi
+        OTMtODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:09:43 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/purge/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJmaW5pc2hlZF9iZWZvcmUiOiIzMDAwLTAxLTAxVDAwOjAwOjAwLjAwMCsw
+        MDowMCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - fe4022e9c4e646578ea39873bfaa5568
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQwLWRmMjYtNzU0
+        ZC1hMTg2LWJiMDBmNDBiM2YzMi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:43 GMT
 recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/file_upload/upload_binary.yml
@@ -10084,78 +10084,6 @@ http_interactions:
         bjowMTkyYzU3ZC1mYjk1LTc5MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
   recorded_at: Wed, 13 Nov 2024 10:24:20 GMT
 - request:
-    method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 13 Nov 2024 10:50:17 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '861'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - dc85a81562bd4fdba6fedab49ac9ef49
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
-        ZmlsZXMvMDE5MzI1MjUtMmNhOS03MTVhLWE4ZjYtM2Q5M2U4OWExMWM3LyIs
-        InBybiI6InBybjpmaWxlLmZpbGVjb250ZW50OjAxOTMyNTI1LTJjYTktNzE1
-        YS1hOGY2LTNkOTNlODlhMTFjNyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMTEt
-        MTNUMTA6NTA6MTMuNTQ2NzQzWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        NC0xMS0xM1QxMDo1MDoxMy41NDY3NTRaIiwiYXJ0aWZhY3QiOiIvcHVscC9h
-        cGkvdjMvYXJ0aWZhY3RzLzAxOTMyNTI1LTJiNTItNzNiMy1hMzk0LTVmYmVk
-        ZGJlYTJjZi8iLCJyZWxhdGl2ZV9wYXRoIjoidGVzdF9lcnJhdHVtLmpzb24i
-        LCJtZDUiOm51bGwsInNoYTEiOiI2MDk4ODU3MTVmZDhkNmE3MDdmMThmYzU1
-        OWQ2MWI4YmRlZTcxODBlIiwic2hhMjI0IjoiZTI5MzFmMDM2NjU2YmE2ZDAx
-        N2I1MDZiOGZlYzU3Yjg3ZTU3ZWVjMjdhZWFkMGRmN2FkOGVkM2MiLCJzaGEy
-        NTYiOiJlZjBjOTk4MzEwNmI4MjRmOTQzODUwZGY5NDQyMGU3ZjE4YWQzODFh
-        Y2M2YmQ1YTIxZWEwNWRjZjY2MGE3NzkxIiwic2hhMzg0IjoiZDNjNTI4ZDIx
-        MTBkODA2Njc1OWJlZDBjZGRjMDk5MTM5MWQ0NzcyN2Q3YmIwMDM4NjRlYTkz
-        NjIxM2E4ZWM0NGEzZGY1MmRkMWIyN2M3ODVjN2U2N2IxMDMyMmU5OWZkIiwi
-        c2hhNTEyIjoiY2ZiODUyM2U4N2M3YmY5MWU4MjMwZjVjZTE2OGJlMWQ4NTI3
-        YWI3NjdmNTU3MTRlZTQ1ZGJjZDUwNWY3N2U4NDFhNTQxNzgyMjQ4N2ZkZTIy
-        NWU2MjJmZDRmOWNkZjMzMzg0NWQ5MDE0MDA3ODYzYTk5YTE5YTdmNDkwMmVl
-        MjgifV19
-  recorded_at: Wed, 13 Nov 2024 10:50:17 GMT
-- request:
     method: post
     uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/01932525-3b09-79a0-a8c1-9fb18f4ec16f/modify/
     body:
@@ -10487,4 +10415,206 @@ http_interactions:
         ODY3LWExZmYtYzI1YjhlODNhOWYzIiwic2hhcmVkOnBybjpjb3JlLmRvbWFp
         bjowMTkyYzU3ZC1mYjk1LTc5MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
   recorded_at: Wed, 13 Nov 2024 10:54:42 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/file/files/?relative_path=test_erratum.json&sha256=ef0c9983106b824f943850df94420e7f18ad381acc6bd5a21ea05dcf660a7791
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '878'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - e408c115235c403da59ed1e70df97f33
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
+        ZmlsZXMvMDE5NWVlNDAtOTYxMy03MWRiLWJkMWYtMzhhNGQyNGI1MDk2LyIs
+        InBybiI6InBybjpmaWxlLmZpbGVjb250ZW50OjAxOTVlZTQwLTk2MTMtNzFk
+        Yi1iZDFmLTM4YTRkMjRiNTA5NiIsInB1bHBfY3JlYXRlZCI6IjIwMjUtMDMt
+        MzFUMjI6MDk6MjUuMDE0OTE4WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
+        NS0wMy0zMVQyMjowOToyNS4wMTQ5MzhaIiwicHVscF9sYWJlbHMiOnt9LCJh
+        cnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE5NWVlNDAtOGY0
+        MC03OTQ5LThhM2MtZjNiM2ZmOWE2N2IxLyIsInJlbGF0aXZlX3BhdGgiOiJ0
+        ZXN0X2VycmF0dW0uanNvbiIsIm1kNSI6bnVsbCwic2hhMSI6IjYwOTg4NTcx
+        NWZkOGQ2YTcwN2YxOGZjNTU5ZDYxYjhiZGVlNzE4MGUiLCJzaGEyMjQiOiJl
+        MjkzMWYwMzY2NTZiYTZkMDE3YjUwNmI4ZmVjNTdiODdlNTdlZWMyN2FlYWQw
+        ZGY3YWQ4ZWQzYyIsInNoYTI1NiI6ImVmMGM5OTgzMTA2YjgyNGY5NDM4NTBk
+        Zjk0NDIwZTdmMThhZDM4MWFjYzZiZDVhMjFlYTA1ZGNmNjYwYTc3OTEiLCJz
+        aGEzODQiOiJkM2M1MjhkMjExMGQ4MDY2NzU5YmVkMGNkZGMwOTkxMzkxZDQ3
+        NzI3ZDdiYjAwMzg2NGVhOTM2MjEzYThlYzQ0YTNkZjUyZGQxYjI3Yzc4NWM3
+        ZTY3YjEwMzIyZTk5ZmQiLCJzaGE1MTIiOiJjZmI4NTIzZTg3YzdiZjkxZTgy
+        MzBmNWNlMTY4YmUxZDg1MjdhYjc2N2Y1NTcxNGVlNDVkYmNkNTA1Zjc3ZTg0
+        MWE1NDE3ODIyNDg3ZmRlMjI1ZTYyMmZkNGY5Y2RmMzMzODQ1ZDkwMTQwMDc4
+        NjNhOTlhMTlhN2Y0OTAyZWUyOCJ9XX0=
+  recorded_at: Mon, 31 Mar 2025 22:09:38 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/0195ee40-c863-7ceb-a6a7-060f15bfd273/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJhZGRfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9m
+        aWxlL2ZpbGVzLzAxOTVlZTQwLTk2MTMtNzFkYi1iZDFmLTM4YTRkMjRiNTA5
+        Ni8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - d7b81704f14c4e01ba16a7cf8ea44cbf
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQwLWNhZmEtNzQx
+        MC1iODc5LTkzZDQ5OGNiZDk1YS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:38 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee40-cafa-7410-b879-93d498cbd95a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:09:38 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '922'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - e809ab4d6a674e208ad3617a6eb24ade
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDAtY2Fm
+        YS03NDEwLWI4NzktOTNkNDk4Y2JkOTVhLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDAtY2FmYS03NDEwLWI4NzktOTNkNDk4Y2JkOTVhIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjowOTozOC41NTYwNTJaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjA5OjM4LjU1NjA3NFoi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92ZSIsImxvZ2dpbmdfY2lkIjoi
+        ZDdiODE3MDRmMTRjNGUwMWJhMTZhN2NmOGVhNDRjYmYiLCJjcmVhdGVkX2J5
+        IjpudWxsLCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjM4LjU4
+        Njc4M1oiLCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjowOTozOC42Nzcw
+        ODZaIiwiZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjA5OjM4Ljg1MjUw
+        NVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtl
+        cnMvMDE5NWQyZWUtYmFlYi03ZTdlLTk0NWQtZmRlYzk2MzEzZDkwLyIsInBh
+        cmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAi
+        Om51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNl
+        cyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk1
+        ZWU0MC1jODYzLTdjZWItYTZhNy0wNjBmMTViZmQyNzMvdmVyc2lvbnMvMS8i
+        XSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46ZmlsZS5maWxl
+        cmVwb3NpdG9yeTowMTk1ZWU0MC1jODYzLTdjZWItYTZhNy0wNjBmMTViZmQy
+        NzMiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjZkM2M2MDFmLWZlYWYtNGI5
+        My04MjY0LTUyOGMyOTEyOWExMyJdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:09:38 GMT
 recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/actions/pulp3/remove_orphans/orphans_are_removed.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/remove_orphans/orphans_are_removed.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:40 GMT
+      - Thu, 03 Apr 2025 21:18:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,20 +43,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b433ebfd1b964c469092a59a0b3b3bcb
+      - c5012e24c87447979402a3acbdb78475
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:40 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:36 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:40 GMT
+      - Thu, 03 Apr 2025 21:18:36 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,20 +97,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b0437d715b2d480ea859c0c04298a4d1
+      - 4483d22b82ad48acbf58d0a6aca92fed
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:40 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:36 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -118,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:40 GMT
+      - Thu, 03 Apr 2025 21:18:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,20 +151,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 479cb6362f844005bf0a619ee1278192
+      - 16a4a66236444993adf91c6088dc7ea3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:40 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:37 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -172,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:40 GMT
+      - Thu, 03 Apr 2025 21:18:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,20 +205,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 35a9435e943d455db5fffdc12242ea2a
+      - 31fa84154d944312a25f2fbbccdea781
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:40 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:37 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -226,7 +226,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -239,7 +239,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:41 GMT
+      - Thu, 03 Apr 2025 21:18:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -259,20 +259,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1a27135c3b874cb089233a80a2f62207
+      - 2bec3995a9e64183afc1b978a40c4fef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:41 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:37 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -280,7 +280,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -293,7 +293,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:41 GMT
+      - Thu, 03 Apr 2025 21:18:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -313,20 +313,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 026a67c1c52c4b0195e8554e3116d077
+      - 8230f2148fc846edbde4d76ac46b9531
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:41 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:37 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -334,7 +334,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -347,7 +347,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:41 GMT
+      - Thu, 03 Apr 2025 21:18:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -367,20 +367,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0fb1165920364c34886b0a015333257e
+      - 349e0fe34bc64b0eab8aa1186aeefd7c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:41 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:37 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -388,7 +388,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -401,7 +401,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:41 GMT
+      - Thu, 03 Apr 2025 21:18:37 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -421,20 +421,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ab716620a0554b94b05884092186e962
+      - 7582ca001a024b20b5471f69070e064f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:41 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:37 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -452,7 +452,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -465,13 +465,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:41 GMT
+      - Thu, 03 Apr 2025 21:18:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/0193252a-2ce9-711f-b971-a8379cd6a8ab/"
+      - "/pulp/api/v3/remotes/file/file/0195fd85-2b92-76e8-8ff6-2770c8ac18d0/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -487,20 +487,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a303832f6a2041a6bd7940ec2e878d63
+      - '08cb313764f8497685324ecb8ad5091c'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE5MzI1MmEtMmNlOS03MTFmLWI5NzEtYTgzNzljZDZhOGFiLyIsInBybiI6
-        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5MzI1MmEtMmNlOS03MTFmLWI5NzEt
-        YTgzNzljZDZhOGFiIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1
-        NTo0MS4yODkzMDVaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEz
-        VDEwOjU1OjQxLjI4OTMxNloiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        MDE5NWZkODUtMmI5Mi03NmU4LThmZjYtMjc3MGM4YWMxOGQwLyIsInBybiI6
+        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NWZkODUtMmI5Mi03NmU4LThmZjYt
+        Mjc3MGM4YWMxOGQwIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMTox
+        ODozNy45NzEyNzlaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAz
+        VDIxOjE4OjM3Ljk3MTI5NloiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
         b24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJ1cmwiOiJodHRwczovL2ZpeHR1
         cmVzLnB1bHBwcm9qZWN0Lm9yZy9maWxlMi8vUFVMUF9NQU5JRkVTVCIsImNh
         X2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlv
@@ -514,10 +514,10 @@ http_interactions:
         YW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicHJveHlfcGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJ1c2VybmFtZSIsImlzX3NldCI6
         ZmFsc2V9LHsibmFtZSI6InBhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX1dfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:41 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:38 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -527,7 +527,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -540,13 +540,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:41 GMT
+      - Thu, 03 Apr 2025 21:18:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/0193252a-2d67-7d98-902e-ee04e755364c/"
+      - "/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -562,33 +562,33 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d5bcad0eff744a90870193504bf8379e
+      - ff559e4be7484ab091d9b4e60beafc7e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMTkzMjUyYS0yZDY3LTdkOTgtOTAyZS1lZTA0ZTc1NTM2NGMvIiwi
-        cHJuIjoicHJuOmZpbGUuZmlsZXJlcG9zaXRvcnk6MDE5MzI1MmEtMmQ2Ny03
-        ZDk4LTkwMmUtZWUwNGU3NTUzNjRjIiwicHVscF9jcmVhdGVkIjoiMjAyNC0x
-        MS0xM1QxMDo1NTo0MS40MTYxNjdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIy
-        MDI0LTExLTEzVDEwOjU1OjQxLjQyMDY5NFoiLCJ2ZXJzaW9uc19ocmVmIjoi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1MmEt
-        MmQ2Ny03ZDk4LTkwMmUtZWUwNGU3NTUzNjRjL3ZlcnNpb25zLyIsInB1bHBf
+        ZmlsZS8wMTk1ZmQ4NS0yY2FlLTdhNjYtOWY2NC0zNjU2ZTUwZDFiMmQvIiwi
+        cHJuIjoicHJuOmZpbGUuZmlsZXJlcG9zaXRvcnk6MDE5NWZkODUtMmNhZS03
+        YTY2LTlmNjQtMzY1NmU1MGQxYjJkIiwicHVscF9jcmVhdGVkIjoiMjAyNS0w
+        NC0wM1QyMToxODozOC4yNTU1NTZaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIy
+        MDI1LTA0LTAzVDIxOjE4OjM4LjI2NjQ1MVoiLCJ2ZXJzaW9uc19ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NWZkODUt
+        MmNhZS03YTY2LTlmNjQtMzY1NmU1MGQxYjJkL3ZlcnNpb25zLyIsInB1bHBf
         bGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTMyNTJhLTJkNjctN2Q5OC05
-        MDJlLWVlMDRlNzU1MzY0Yy92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTVmZDg1LTJjYWUtN2E2Ni05
+        ZjY0LTM2NTZlNTBkMWIyZC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0
         X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIsImRlc2NyaXB0
         aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3Rl
         IjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1hbmlmZXN0IjoiUFVMUF9N
         QU5JRkVTVCJ9
-  recorded_at: Wed, 13 Nov 2024 10:55:41 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:38 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -605,7 +605,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -618,13 +618,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:41 GMT
+      - Thu, 03 Apr 2025 21:18:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/0193252a-2dff-7c9f-bf4a-66bd7fc531ae/"
+      - "/pulp/api/v3/remotes/file/file/0195fd85-2e04-7ae7-aeba-b82234b9a198/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -640,20 +640,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 212738a8f9594bf79f8661de50d92ed8
+      - 332986a03add47ea86bdcf9b9bc02309
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE5MzI1MmEtMmRmZi03YzlmLWJmNGEtNjZiZDdmYzUzMWFlLyIsInBybiI6
-        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5MzI1MmEtMmRmZi03YzlmLWJmNGEt
-        NjZiZDdmYzUzMWFlIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1
-        NTo0MS41Njc1MzZaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEz
-        VDEwOjU1OjQxLjU2NzU0NloiLCJuYW1lIjoidGVzdF9yZW1vdGVfbmFtZSIs
+        MDE5NWZkODUtMmUwNC03YWU3LWFlYmEtYjgyMjM0YjlhMTk4LyIsInBybiI6
+        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NWZkODUtMmUwNC03YWU3LWFlYmEt
+        YjgyMjM0YjlhMTk4IiwicHVscF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMTox
+        ODozOC41OTY3OTlaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAz
+        VDIxOjE4OjM4LjU5NjgxNFoiLCJuYW1lIjoidGVzdF9yZW1vdGVfbmFtZSIs
         InVybCI6Imh0dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL2ZpbGUy
         Ly9QVUxQX01BTklGRVNUIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQi
         Om51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGws
@@ -667,10 +667,10 @@ http_interactions:
         bWUiOiJwcm94eV9wYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6
         InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfV19
-  recorded_at: Wed, 13 Nov 2024 10:55:41 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:38 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193252a-2dff-7c9f-bf4a-66bd7fc531ae/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/0195fd85-2e04-7ae7-aeba-b82234b9a198/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -678,7 +678,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -691,7 +691,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:41 GMT
+      - Thu, 03 Apr 2025 21:18:38 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -711,20 +711,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7a52cef0bd6447e192cb4405327fd765
+      - 241d8882b6644421b6565ffa47c17e8a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTJlMmUtNzAx
-        Ni04NTE4LWU3ZGNhOTE5ODk5Mi8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:41 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTJlNDYtN2E0
+        Yi1iYzhmLWYxYjgyNDg4ODY2Mi8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:38 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193252a-2d67-7d98-902e-ee04e755364c/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/
     body:
       encoding: UTF-8
       base64_string: |
@@ -734,7 +734,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -747,7 +747,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:41 GMT
+      - Thu, 03 Apr 2025 21:18:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -767,20 +767,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 40dad64bbfae4975a3cfc742d59b48c7
+      - 982fc3b0137f478c841f39aeb997e368
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTJlYmMtN2U0
-        Zi04YzhjLWUzNzlmZDU2ODI2Yy8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:41 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTJmODMtNzRh
+        YS05NzM5LWI3YWVmYTczNzVlNC8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:39 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193252a-2ce9-711f-b971-a8379cd6a8ab/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/0195fd85-2b92-76e8-8ff6-2770c8ac18d0/
     body:
       encoding: UTF-8
       base64_string: |
@@ -798,7 +798,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -811,7 +811,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:41 GMT
+      - Thu, 03 Apr 2025 21:18:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -831,20 +831,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bd280dfc83c94a6aa9a3779a18f91e86
+      - bdb692320ca84277881f8363b259b105
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTJmMTMtNzEx
-        NC05NDQ1LTdhZDMwYmE4N2E4ZS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:41 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTMwODMtNzVi
+        YS05NjNjLTNiMDY1NzI1MjdiMi8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:39 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193252a-2f13-7114-9445-7ad30ba87a8e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-3083-75ba-963c-3b06572527b2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -852,7 +852,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -865,7 +865,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:41 GMT
+      - Thu, 03 Apr 2025 21:18:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -885,36 +885,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a23e0a82558c4cff80f0e43a3db83344
+      - 71828f8d418a43c5a3a531153c784f75
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MmEtMmYx
-        My03MTE0LTk0NDUtN2FkMzBiYTg3YThlLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MmEtMmYxMy03MTE0LTk0NDUtN2FkMzBiYTg3YThlIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NTo0MS44NDQwNjhaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU1OjQxLjg0NDA3OFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtMzA4
+        My03NWJhLTk2M2MtM2IwNjU3MjUyN2IyLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWZkODUtMzA4My03NWJhLTk2M2MtM2IwNjU3MjUyN2IyIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODozOS4yMzY5MzFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjM5LjIzNjk1OFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYmQyODBk
-        ZmM4M2M5NGE2YWE5YTM3NzlhMThmOTFlODYiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMDo1NTo0MS44NTM4ODBaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTA6NTU6NDEuODU2OTgyWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MDo1NTo0MS44NjY5NTlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYmRiNjky
+        MzIwY2E4NDI3Nzg4MWY4MzYzYjI1OWIxMDUiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        M1QyMToxODozOS4yNTY3NDFaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
+        MjE6MTg6MzkuMjU5NTI4WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
+        MToxODozOS4yNzIxNTBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46Zmls
-        ZS5maWxlcmVtb3RlOjAxOTMyNTJhLTJjZTktNzExZi1iOTcxLWE4Mzc5Y2Q2
-        YThhYiIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmM1N2QtZmI5NS03
-        OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 10:55:41 GMT
+        ZS5maWxlcmVtb3RlOjAxOTVmZDg1LTJiOTItNzZlOC04ZmY2LTI3NzBjOGFj
+        MThkMCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5NTYyMTctZmM5ZS03
+        NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Thu, 03 Apr 2025 21:18:39 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -922,7 +922,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -935,7 +935,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:41 GMT
+      - Thu, 03 Apr 2025 21:18:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -955,20 +955,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9d3b1723a6be4b578975074ffff41e6c
+      - 3c6abce47ed74c3b91ad1813512c14de
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:41 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:39 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -980,7 +980,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -993,7 +993,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:42 GMT
+      - Thu, 03 Apr 2025 21:18:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1013,20 +1013,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 88eb937062a2402e8db950fe3d184a38
+      - 40a47a14f5704f5da873a7bb9e465faf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTJmYzEtN2Q4
-        My05NzliLTEzYWFlYTc4ODdlYi8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:42 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTMxYWQtN2Mz
+        YS1hNTNiLTQ0NWFkMzYzMDNkNi8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:39 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193252a-2fc1-7d83-979b-13aaea7887eb/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-31ad-7c3a-a53b-445ad36303d6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1034,7 +1034,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1047,7 +1047,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:42 GMT
+      - Thu, 03 Apr 2025 21:18:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1067,39 +1067,39 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6c285b6151bd427882740dfa606d1502
+      - bba40c8636724e339ad99edac139d0ca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MmEtMmZj
-        MS03ZDgzLTk3OWItMTNhYWVhNzg4N2ViLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MmEtMmZjMS03ZDgzLTk3OWItMTNhYWVhNzg4N2ViIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NTo0Mi4wMTc4NjhaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU1OjQyLjAxNzg3OFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtMzFh
+        ZC03YzNhLWE1M2ItNDQ1YWQzNjMwM2Q2LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWZkODUtMzFhZC03YzNhLWE1M2ItNDQ1YWQzNjMwM2Q2IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODozOS41MzM2MjVaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjM5LjUzMzYzOFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiODhlYjkz
-        NzA2MmEyNDAyZThkYjk1MGZlM2QxODRhMzgiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMDo1NTo0Mi4wMjg2NTRaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTA6NTU6NDIuMDU1MTgzWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MDo1NTo0Mi4xMTg1MThaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTMyNTIzLTkwMWUtN2ZiMC05ZTA3LTljZGY0
-        ZDJiMWNhMC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiNDBhNDdh
+        MTRmNTcwNGY1ZGE4NzNhN2JiOWU0NjVmYWYiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        M1QyMToxODozOS41NDk3NDlaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
+        MjE6MTg6MzkuNjAyMTQ5WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
+        MToxODozOS43Mjc4OTZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOTVmZDg0LTc2M2EtN2Y1Ny05M2RlLTVjZjlm
+        ZmJjNTc3Ny8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
-        ZmlsZS9maWxlLzAxOTMyNTJhLTMwMTMtNzViOC1iOGVhLTYxMTMyYzkyZjM2
-        YS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAxOTJj
-        NTdkLWZiOTUtNzkxOC04N2U0LTlkZTViMTVhYjUzNjpkaXN0cmlidXRpb25z
-        Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyYzU3ZC1mYjk1LTc5MTgt
-        ODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 10:55:42 GMT
+        ZmlsZS9maWxlLzAxOTVmZDg1LTMyMzAtNzVjNi1hMWViLWI1NzdhY2EzYmMz
+        Ny8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAxOTU2
+        MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRpb25z
+        Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0Y2Yt
+        OTAyNC1lODAzNDY3ZmU0ZDAiXX0=
+  recorded_at: Thu, 03 Apr 2025 21:18:39 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193252a-3013-75b8-b8ea-61132c92f36a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/0195fd85-3230-75c6-a1eb-b577aca3bc37/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1107,7 +1107,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1120,7 +1120,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:42 GMT
+      - Thu, 03 Apr 2025 21:18:39 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1132,7 +1132,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '607'
+      - '605'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1140,32 +1140,32 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c1420046897543cc8669939c99deea13
+      - 8c25c330b26841a39788dc0d2ca33cbc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
-        L2ZpbGUvMDE5MzI1MmEtMzAxMy03NWI4LWI4ZWEtNjExMzJjOTJmMzZhLyIs
-        InBybiI6InBybjpmaWxlLmZpbGVkaXN0cmlidXRpb246MDE5MzI1MmEtMzAx
-        My03NWI4LWI4ZWEtNjExMzJjOTJmMzZhIiwicHVscF9jcmVhdGVkIjoiMjAy
-        NC0xMS0xM1QxMDo1NTo0Mi4xMDEwNjhaIiwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDI0LTExLTEzVDEwOjU1OjQyLjEwMTA4MloiLCJiYXNlX3BhdGgiOiJE
+        L2ZpbGUvMDE5NWZkODUtMzIzMC03NWM2LWExZWItYjU3N2FjYTNiYzM3LyIs
+        InBybiI6InBybjpmaWxlLmZpbGVkaXN0cmlidXRpb246MDE5NWZkODUtMzIz
+        MC03NWM2LWExZWItYjU3N2FjYTNiYzM3IiwicHVscF9jcmVhdGVkIjoiMjAy
+        NS0wNC0wM1QyMToxODozOS42NjcxNDVaIiwicHVscF9sYXN0X3VwZGF0ZWQi
+        OiIyMDI1LTA0LTAzVDIxOjE4OjM5LjY2NzE2NVoiLCJiYXNlX3BhdGgiOiJE
         ZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsImJh
-        c2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwuZGljZXJv
-        czIwMjMuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5p
-        emF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3VhcmQi
-        Om51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjpudWxsLCJoaWRkZW4i
-        OmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
-        aXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnkiOm51
-        bGwsInB1YmxpY2F0aW9uIjpudWxsfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:42 GMT
+        c2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwubWFuaWNv
+        dHRvLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2FuaXph
+        dGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMS8iLCJjb250ZW50X2d1YXJkIjpu
+        dWxsLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6bnVsbCwiaGlkZGVuIjpm
+        YWxzZSwicHVscF9sYWJlbHMiOnt9LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJyZXBvc2l0b3J5IjpudWxs
+        LCJwdWJsaWNhdGlvbiI6bnVsbH0=
+  recorded_at: Thu, 03 Apr 2025 21:18:39 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193252a-2ce9-711f-b971-a8379cd6a8ab/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/0195fd85-2b92-76e8-8ff6-2770c8ac18d0/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1183,7 +1183,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1196,7 +1196,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:42 GMT
+      - Thu, 03 Apr 2025 21:18:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1216,20 +1216,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f82deff52791448ab61aabd43ab64f14
+      - 3cb702779ec74f69bf4f5ad8d93d4992
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTMxOGItN2Nl
-        My05Yjc2LTk1NmI5MDA4N2ZjOS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:42 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTM0NDItN2U2
+        Yi1hZjQwLTJhNTBkZjI5ZDgzOC8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:40 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193252a-318b-7ce3-9b76-956b90087fc9/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-3442-7e6b-af40-2a50df29d838/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1237,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1250,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:42 GMT
+      - Thu, 03 Apr 2025 21:18:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1270,47 +1270,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b5632e4b5c844115bd4857410114e67d
+      - d285476132d6417b8d1e4b4c604b0a40
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MmEtMzE4
-        Yi03Y2UzLTliNzYtOTU2YjkwMDg3ZmM5LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MmEtMzE4Yi03Y2UzLTliNzYtOTU2YjkwMDg3ZmM5IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NTo0Mi40NzU1MzlaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU1OjQyLjQ3NTU0OVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtMzQ0
+        Mi03ZTZiLWFmNDAtMmE1MGRmMjlkODM4LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWZkODUtMzQ0Mi03ZTZiLWFmNDAtMmE1MGRmMjlkODM4IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0MC4xOTQ5MjdaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQwLjE5NDk1MVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiZjgyZGVm
-        ZjUyNzkxNDQ4YWI2MWFhYmQ0M2FiNjRmMTQiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMDo1NTo0Mi40ODUyMTBaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTA6NTU6NDIuNDg3NTExWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MDo1NTo0Mi40OTUwODFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiM2NiNzAy
+        Nzc5ZWM3NGY2OWJmNGY1YWQ4ZDkzZDQ5OTIiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        M1QyMToxODo0MC4yMTU0NThaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
+        MjE6MTg6NDAuMjE4Mjk3WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
+        MToxODo0MC4yMzE3MTBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46Zmls
-        ZS5maWxlcmVtb3RlOjAxOTMyNTJhLTJjZTktNzExZi1iOTcxLWE4Mzc5Y2Q2
-        YThhYiIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmM1N2QtZmI5NS03
-        OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 10:55:42 GMT
+        ZS5maWxlcmVtb3RlOjAxOTVmZDg1LTJiOTItNzZlOC04ZmY2LTI3NzBjOGFj
+        MThkMCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5NTYyMTctZmM5ZS03
+        NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Thu, 03 Apr 2025 21:18:40 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193252a-2d67-7d98-902e-ee04e755364c/sync/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE5
-        MzI1MmEtMmNlOS03MTFmLWI5NzEtYTgzNzljZDZhOGFiLyIsIm1pcnJvciI6
+        NWZkODUtMmI5Mi03NmU4LThmZjYtMjc3MGM4YWMxOGQwLyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1323,7 +1323,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:42 GMT
+      - Thu, 03 Apr 2025 21:18:40 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1343,20 +1343,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f60b2b4b361e4f52800b52351e125e33
+      - 53318a8ce91d415e92a6c757b20f999b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTMyMGQtNzNh
-        Ny1hNDhhLWEyMzA2MTQxZTQ1OS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:42 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTM1MWUtNzNj
+        MS04ZDRmLWQ5ZDYwMTE1ZWY0OS8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:40 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193252a-320d-73a7-a48a-a2306141e459/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-351e-73c1-8d4f-d9d60115ef49/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1364,7 +1364,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1377,7 +1377,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:43 GMT
+      - Thu, 03 Apr 2025 21:18:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1397,56 +1397,56 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1c1e90e3be3d4640bdfa1293cf411a3f
+      - 8dde3ce47f014ffab8b605ea2aa7e81d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MmEtMzIw
-        ZC03M2E3LWE0OGEtYTIzMDYxNDFlNDU5LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MmEtMzIwZC03M2E3LWE0OGEtYTIzMDYxNDFlNDU5IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NTo0Mi42MDUzNzhaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU1OjQyLjYwNTM4N1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtMzUx
+        ZS03M2MxLThkNGYtZDlkNjAxMTVlZjQ5LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWZkODUtMzUxZS03M2MxLThkNGYtZDlkNjAxMTVlZjQ5IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0MC40MTU4ODFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQwLjQxNTg5Nloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX2ZpbGUuYXBwLnRh
         c2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25pemUiLCJsb2dnaW5nX2NpZCI6
-        ImY2MGIyYjRiMzYxZTRmNTI4MDBiNTIzNTFlMTI1ZTMzIiwiY3JlYXRlZF9i
+        IjUzMzE4YThjZTkxZDQxNWU5MmE2Yzc1N2IyMGY5OTliIiwiY3JlYXRlZF9i
         eSI6Ii9wdWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIw
-        MjQtMTEtMTNUMTA6NTU6NDIuNjE0OTA2WiIsInN0YXJ0ZWRfYXQiOiIyMDI0
-        LTExLTEzVDEwOjU1OjQyLjY0MTMwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjQt
-        MTEtMTNUMTA6NTU6NDMuNDIzNzAyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
-        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTkzMjUyMy04ZmVhLTc0MTYtYjkx
-        Ny1hMmQwYTJhYjNkZjcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
+        MjUtMDQtMDNUMjE6MTg6NDAuNDM2NDA5WiIsInN0YXJ0ZWRfYXQiOiIyMDI1
+        LTA0LTAzVDIxOjE4OjQwLjQ4MjQ4OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjUt
+        MDQtMDNUMjE6MTg6NDEuMDY0MDY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTk1ZmQ4NC03NWVkLTc1NDEtODFh
+        My1hNzc1ZjU1ZGUzNjgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
         c2tzIjpbXSwidGFza19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6
         W3sibWVzc2FnZSI6IkRvd25sb2FkaW5nIE1ldGFkYXRhIiwiY29kZSI6InN5
         bmMuZG93bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
         InRvdGFsIjpudWxsLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IlBhcnNpbmcgTWV0YWRhdGEgTGluZXMiLCJjb2RlIjoic3luYy5wYXJz
-        aW5nLm1ldGFkYXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6Mywi
-        ZG9uZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGlu
-        ZyBBcnRpZmFjdHMiLCJjb2RlIjoic3luYy5kb3dubG9hZGluZy5hcnRpZmFj
-        dHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjow
-        LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENv
-        bnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUi
-        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4Ijpu
-        dWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6
-        ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
-        dGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9y
+        ZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25s
+        b2FkaW5nLmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
+        Om51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNz
+        b2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50
+        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6Mywi
+        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1ldGFkYXRhIExp
+        bmVzIiwiY29kZSI6InN5bmMucGFyc2luZy5tZXRhZGF0YSIsInN0YXRlIjoi
+        Y29tcGxldGVkIiwidG90YWwiOjMsImRvbmUiOjMsInN1ZmZpeCI6bnVsbH0s
+        eyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1
+        bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9y
         ZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2Zp
-        bGUvMDE5MzI1MmEtMmQ2Ny03ZDk4LTkwMmUtZWUwNGU3NTUzNjRjL3ZlcnNp
+        bGUvMDE5NWZkODUtMmNhZS03YTY2LTlmNjQtMzY1NmU1MGQxYjJkL3ZlcnNp
         b25zLzEvIiwiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUv
-        MDE5MzI1MmEtMzUxNC03ZWMwLWI1ZDktNWRiNTE5M2VmMjJlLyJdLCJyZXNl
+        MDE5NWZkODUtMzc0Ny03YzI3LWFkMjQtNjY2NmU1YzRlNDI5LyJdLCJyZXNl
         cnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpmaWxlLmZpbGVyZXBvc2l0
-        b3J5OjAxOTMyNTJhLTJkNjctN2Q5OC05MDJlLWVlMDRlNzU1MzY0YyIsInNo
-        YXJlZDpwcm46ZmlsZS5maWxlcmVtb3RlOjAxOTMyNTJhLTJjZTktNzExZi1i
-        OTcxLWE4Mzc5Y2Q2YThhYiIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5
-        MmM1N2QtZmI5NS03OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 10:55:43 GMT
+        b3J5OjAxOTVmZDg1LTJjYWUtN2E2Ni05ZjY0LTM2NTZlNTBkMWIyZCIsInNo
+        YXJlZDpwcm46ZmlsZS5maWxlcmVtb3RlOjAxOTVmZDg1LTJiOTItNzZlOC04
+        ZmY2LTI3NzBjOGFjMThkMCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5
+        NTYyMTctZmM5ZS03NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Thu, 03 Apr 2025 21:18:41 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1454,7 +1454,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1467,7 +1467,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:43 GMT
+      - Thu, 03 Apr 2025 21:18:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1479,7 +1479,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '659'
+      - '657'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1487,45 +1487,45 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 91ee915ff5034393b189402f52729986
+      - 5035aa73f1524b4f9176631eaf7c4e99
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMTkzMjUyYS0zMDEzLTc1YjgtYjhlYS02MTEzMmM5MmYz
-        NmEvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTkzMjUy
-        YS0zMDEzLTc1YjgtYjhlYS02MTEzMmM5MmYzNmEiLCJwdWxwX2NyZWF0ZWQi
-        OiIyMDI0LTExLTEzVDEwOjU1OjQyLjEwMTA2OFoiLCJwdWxwX2xhc3RfdXBk
-        YXRlZCI6IjIwMjQtMTEtMTNUMTA6NTU6NDIuMTAxMDgyWiIsImJhc2VfcGF0
+        L2ZpbGUvZmlsZS8wMTk1ZmQ4NS0zMjMwLTc1YzYtYTFlYi1iNTc3YWNhM2Jj
+        MzcvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk1ZmQ4
+        NS0zMjMwLTc1YzYtYTFlYi1iNTc3YWNhM2JjMzciLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDI1LTA0LTAzVDIxOjE4OjM5LjY2NzE0NVoiLCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjUtMDQtMDNUMjE6MTg6MzkuNjY3MTY1WiIsImJhc2VfcGF0
         aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8x
-        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5k
-        aWNlcm9zMjAyMy5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9P
-        cmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19GaWxlXzEvIiwiY29udGVudF9n
-        dWFyZCI6bnVsbCwibm9fY29udGVudF9jaGFuZ2Vfc2luY2UiOm51bGwsImhp
-        ZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IkRlZmF1bHRf
-        T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwicmVwb3NpdG9y
-        eSI6bnVsbCwicHVibGljYXRpb24iOm51bGx9XX0=
-  recorded_at: Wed, 13 Nov 2024 10:55:43 GMT
+        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5t
+        YW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3Vh
+        cmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjpudWxsLCJoaWRk
+        ZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09y
+        Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnki
+        Om51bGwsInB1YmxpY2F0aW9uIjpudWxsfV19
+  recorded_at: Thu, 03 Apr 2025 21:18:41 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193252a-3013-75b8-b8ea-61132c92f36a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/0195fd85-3230-75c6-a1eb-b577aca3bc37/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        MmEtMzUxNC03ZWMwLWI1ZDktNWRiNTE5M2VmMjJlLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NWZk
+        ODUtMzc0Ny03YzI3LWFkMjQtNjY2NmU1YzRlNDI5LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1538,7 +1538,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:43 GMT
+      - Thu, 03 Apr 2025 21:18:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1558,20 +1558,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 11f0f836490049c3bca22ecfe946d71c
+      - 9a17208c65644eefad32ab076509d051
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTM2MDUtNzg2
-        My1iODIwLTZiMDNjMTM1NDc2My8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:43 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTM5OTEtNzFi
+        NC05MDA1LTljMDQ5ZDE1ZThjYS8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:41 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193252a-3605-7863-b820-6b03c1354763/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-3991-71b4-9005-9c049d15e8ca/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1579,7 +1579,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1592,7 +1592,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:43 GMT
+      - Thu, 03 Apr 2025 21:18:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1612,48 +1612,48 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 550acf793a7d4212a7f438d2e16bf562
+      - ee9f70512eb44b7da00572c3697f08c7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MmEtMzYw
-        NS03ODYzLWI4MjAtNmIwM2MxMzU0NzYzLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MmEtMzYwNS03ODYzLWI4MjAtNmIwM2MxMzU0NzYzIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NTo0My42MjE5NDdaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU1OjQzLjYyMTk1N1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtMzk5
+        MS03MWI0LTkwMDUtOWMwNDlkMTVlOGNhLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWZkODUtMzk5MS03MWI0LTkwMDUtOWMwNDlkMTVlOGNhIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0MS41NTM3MDFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQxLjU1MzcxNVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiMTFmMGY4
-        MzY0OTAwNDljM2JjYTIyZWNmZTk0NmQ3MWMiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMDo1NTo0My42MzM5ODJaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTA6NTU6NDMuNjM2MjMyWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MDo1NTo0My42NDkyMTlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiOWExNzIw
+        OGM2NTY0NGVlZmFkMzJhYjA3NjUwOWQwNTEiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        M1QyMToxODo0MS41NzAxNjhaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
+        MjE6MTg6NDEuNTc2NjY3WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
+        MToxODo0MS42MDExMTVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJjNTdkLWZiOTUtNzkxOC04N2U0LTlkZTViMTVhYjUzNjpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyYzU3ZC1mYjk1LTc5
-        MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 10:55:43 GMT
+        OTU2MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRp
+        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0
+        Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
+  recorded_at: Thu, 03 Apr 2025 21:18:41 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193252a-3013-75b8-b8ea-61132c92f36a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/0195fd85-3230-75c6-a1eb-b577aca3bc37/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        MmEtMzUxNC03ZWMwLWI1ZDktNWRiNTE5M2VmMjJlLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NWZk
+        ODUtMzc0Ny03YzI3LWFkMjQtNjY2NmU1YzRlNDI5LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1666,7 +1666,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:43 GMT
+      - Thu, 03 Apr 2025 21:18:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1686,20 +1686,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fee551aaa2f14d358bc3de5128fceade
+      - 23bf9273a4f045dfbc62c730261d0431
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTM2OWUtN2Jj
-        YS04MDYwLWI4MjJhYTE0ZWM4OC8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:43 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTNhNzQtNzRk
+        MS04ZjQyLTU0ZThmNjM2Y2M1NS8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:41 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1716,7 +1716,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1729,13 +1729,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:43 GMT
+      - Thu, 03 Apr 2025 21:18:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/0193252a-3741-7a98-9322-fa0ad7c37331/"
+      - "/pulp/api/v3/remotes/file/file/0195fd85-3b6d-7db7-b2e0-53434765367e/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1751,20 +1751,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c73b068d98124820844a98edf6d97087
+      - 26efc2c75657411bafea203d2b1177f9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE5MzI1MmEtMzc0MS03YTk4LTkzMjItZmEwYWQ3YzM3MzMxLyIsInBybiI6
-        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5MzI1MmEtMzc0MS03YTk4LTkzMjIt
-        ZmEwYWQ3YzM3MzMxIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1
-        NTo0My45Mzc0NTZaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEz
-        VDEwOjU1OjQzLjkzNzQ2NloiLCJuYW1lIjoidGVzdF9yZW1vdGVfbmFtZSIs
+        MDE5NWZkODUtM2I2ZC03ZGI3LWIyZTAtNTM0MzQ3NjUzNjdlLyIsInBybiI6
+        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NWZkODUtM2I2ZC03ZGI3LWIyZTAt
+        NTM0MzQ3NjUzNjdlIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMTox
+        ODo0Mi4wMzAyNDRaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAz
+        VDIxOjE4OjQyLjAzMDI1OVoiLCJuYW1lIjoidGVzdF9yZW1vdGVfbmFtZSIs
         InVybCI6Imh0dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL2ZpbGUv
         L1BVTFBfTUFOSUZFU1QiLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6
         bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwi
@@ -1778,10 +1778,10 @@ http_interactions:
         ZSI6InByb3h5X3Bhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoi
         dXNlcm5hbWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwYXNzd29yZCIs
         ImlzX3NldCI6ZmFsc2V9XX0=
-  recorded_at: Wed, 13 Nov 2024 10:55:43 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193252a-3741-7a98-9322-fa0ad7c37331/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/0195fd85-3b6d-7db7-b2e0-53434765367e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1789,7 +1789,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1802,7 +1802,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:43 GMT
+      - Thu, 03 Apr 2025 21:18:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1822,20 +1822,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a85d5ee1ede440f9a7eb75f78b5ae5f6
+      - 2438c35a476b49619647a1125d60e46f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTM3NzAtN2Q3
-        My1iZWFkLTM3ZWFkOTNiNjQwNi8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:43 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTNiYjItN2M1
+        Ni1hYTc0LTRhNTdkZThiMTM3ZS8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193252a-2d67-7d98-902e-ee04e755364c/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1845,7 +1845,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1858,7 +1858,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:44 GMT
+      - Thu, 03 Apr 2025 21:18:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1878,20 +1878,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ef5516531b27431abf879d1911d4892a
+      - d3451d1e6dcc4e5bb01e3d48ba9d7964
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTM3ZmUtNzRh
-        ZS1iYTgxLTM5ZTk0NGUyODczMi8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:44 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTNjNzYtNzcz
+        MS05YWQxLTY1NjQxNjJjMGE5Ny8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193252a-2ce9-711f-b971-a8379cd6a8ab/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/0195fd85-2b92-76e8-8ff6-2770c8ac18d0/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1909,7 +1909,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1922,7 +1922,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:44 GMT
+      - Thu, 03 Apr 2025 21:18:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1942,20 +1942,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c8b7f87d51cc4cd998ffae5cf596b24d
+      - 58a95542e76f4efb8e2816e623edd634
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTM4NTQtNzU3
-        Yy1iMDEzLWY2Y2QwNWJlMzBiZS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:44 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTNjZjUtNzBm
+        Ny05ZDRkLWUyOWE2MDk5NGQ4NS8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193252a-3854-757c-b013-f6cd05be30be/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-3cf5-70f7-9d4d-e29a60994d85/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1963,7 +1963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1976,7 +1976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:44 GMT
+      - Thu, 03 Apr 2025 21:18:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1996,36 +1996,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0a98276fa39241878dac59a5f5d3591d
+      - 7f578d92fdb74c4695d52baab0aa0f5f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MmEtMzg1
-        NC03NTdjLWIwMTMtZjZjZDA1YmUzMGJlLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MmEtMzg1NC03NTdjLWIwMTMtZjZjZDA1YmUzMGJlIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NTo0NC4yMTMwMTNaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU1OjQ0LjIxMzAyNFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtM2Nm
+        NS03MGY3LTlkNGQtZTI5YTYwOTk0ZDg1LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWZkODUtM2NmNS03MGY3LTlkNGQtZTI5YTYwOTk0ZDg1IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0Mi40MjIyMDVaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQyLjQyMjIxOFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYzhiN2Y4
-        N2Q1MWNjNGNkOTk4ZmZhZTVjZjU5NmIyNGQiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMDo1NTo0NC4yMjM5ODlaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTA6NTU6NDQuMjI3NzQ5WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MDo1NTo0NC4yMzYyMzlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiNThhOTU1
+        NDJlNzZmNGVmYjhlMjgxNmU2MjNlZGQ2MzQiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        M1QyMToxODo0Mi40Mzg0MzFaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
+        MjE6MTg6NDIuNDQxNDQ3WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
+        MToxODo0Mi40NTQwMTJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46Zmls
-        ZS5maWxlcmVtb3RlOjAxOTMyNTJhLTJjZTktNzExZi1iOTcxLWE4Mzc5Y2Q2
-        YThhYiIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmM1N2QtZmI5NS03
-        OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 10:55:44 GMT
+        ZS5maWxlcmVtb3RlOjAxOTVmZDg1LTJiOTItNzZlOC04ZmY2LTI3NzBjOGFj
+        MThkMCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5NTYyMTctZmM5ZS03
+        NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2033,7 +2033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2046,7 +2046,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:44 GMT
+      - Thu, 03 Apr 2025 21:18:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2058,7 +2058,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '755'
+      - '753'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2066,47 +2066,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d6d0f65ffb5546a7a50368f2653a2051
+      - b0fdf6810d26489680ee05fe5d66eb30
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMTkzMjUyYS0zMDEzLTc1YjgtYjhlYS02MTEzMmM5MmYz
-        NmEvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTkzMjUy
-        YS0zMDEzLTc1YjgtYjhlYS02MTEzMmM5MmYzNmEiLCJwdWxwX2NyZWF0ZWQi
-        OiIyMDI0LTExLTEzVDEwOjU1OjQyLjEwMTA2OFoiLCJwdWxwX2xhc3RfdXBk
-        YXRlZCI6IjIwMjQtMTEtMTNUMTA6NTU6NDMuNzk3MTU4WiIsImJhc2VfcGF0
+        L2ZpbGUvZmlsZS8wMTk1ZmQ4NS0zMjMwLTc1YzYtYTFlYi1iNTc3YWNhM2Jj
+        MzcvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk1ZmQ4
+        NS0zMjMwLTc1YzYtYTFlYi1iNTc3YWNhM2JjMzciLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDI1LTA0LTAzVDIxOjE4OjM5LjY2NzE0NVoiLCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjUtMDQtMDNUMjE6MTg6NDEuODEwNDYyWiIsImJhc2VfcGF0
         aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8x
-        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5k
-        aWNlcm9zMjAyMy5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9P
-        cmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19GaWxlXzEvIiwiY29udGVudF9n
-        dWFyZCI6bnVsbCwibm9fY29udGVudF9jaGFuZ2Vfc2luY2UiOiIyMDI0LTEx
-        LTEzVDEwOjU1OjQzLjc5NzE1OFoiLCJoaWRkZW4iOmZhbHNlLCJwdWxwX2xh
-        YmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0
-        LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        MmEtMzUxNC03ZWMwLWI1ZDktNWRiNTE5M2VmMjJlLyJ9XX0=
-  recorded_at: Wed, 13 Nov 2024 10:55:44 GMT
+        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5t
+        YW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3Vh
+        cmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNS0wNC0w
+        M1QyMToxODo0MS44MTA0NjJaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9sYWJl
+        bHMiOnt9LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1w
+        dWxwM19GaWxlXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6
+        Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOTVmZDg1
+        LTM3NDctN2MyNy1hZDI0LTY2NjZlNWM0ZTQyOS8ifV19
+  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193252a-3013-75b8-b8ea-61132c92f36a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/0195fd85-3230-75c6-a1eb-b577aca3bc37/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        MmEtMzUxNC03ZWMwLWI1ZDktNWRiNTE5M2VmMjJlLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NWZk
+        ODUtMzc0Ny03YzI3LWFkMjQtNjY2NmU1YzRlNDI5LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2119,7 +2119,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:44 GMT
+      - Thu, 03 Apr 2025 21:18:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2139,20 +2139,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e9076214f59f4e39957e06dcb01559bc
+      - e479cf8eb4ae45d4855b23a27f265a4d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTM5MDgtNzQw
-        Zi1iNTBlLTU0MDc0YTg0NDY0ZS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:44 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTNlMjAtNzc5
+        Zi1hOTBkLTA2MWNlNGEyMTBjZi8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193252a-3908-740f-b50e-54074a84464e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-3e20-779f-a90d-061ce4a210cf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2160,7 +2160,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2173,7 +2173,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:44 GMT
+      - Thu, 03 Apr 2025 21:18:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2193,48 +2193,48 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6c8585b1469c466faf05c1921c3e9684
+      - f63e87e066794cb082238290bc81c9ef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MmEtMzkw
-        OC03NDBmLWI1MGUtNTQwNzRhODQ0NjRlLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MmEtMzkwOC03NDBmLWI1MGUtNTQwNzRhODQ0NjRlIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NTo0NC4zOTMwMzNaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU1OjQ0LjM5MzA0M1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtM2Uy
+        MC03NzlmLWE5MGQtMDYxY2U0YTIxMGNmLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWZkODUtM2UyMC03NzlmLWE5MGQtMDYxY2U0YTIxMGNmIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0Mi43MjA1ODBaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQyLjcyMDU5NFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiZTkwNzYy
-        MTRmNTlmNGUzOTk1N2UwNmRjYjAxNTU5YmMiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMDo1NTo0NC40MDIxNzlaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTA6NTU6NDQuNDA1MTE0WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MDo1NTo0NC40MTcxMzhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiZTQ3OWNm
+        OGViNGFlNDVkNDg1NWIyM2EyN2YyNjVhNGQiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        M1QyMToxODo0Mi43MzQyNjhaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
+        MjE6MTg6NDIuNzM3MTcwWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
+        MToxODo0Mi43NTQzMzVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJjNTdkLWZiOTUtNzkxOC04N2U0LTlkZTViMTVhYjUzNjpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyYzU3ZC1mYjk1LTc5
-        MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 10:55:44 GMT
+        OTU2MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRp
+        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0
+        Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
+  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193252a-3013-75b8-b8ea-61132c92f36a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/0195fd85-3230-75c6-a1eb-b577aca3bc37/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        MmEtMzUxNC03ZWMwLWI1ZDktNWRiNTE5M2VmMjJlLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NWZk
+        ODUtMzc0Ny03YzI3LWFkMjQtNjY2NmU1YzRlNDI5LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2247,7 +2247,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:44 GMT
+      - Thu, 03 Apr 2025 21:18:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2267,20 +2267,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d1e8f362dd5944548b8c749170a6ca64
+      - d50737fca3774fc49264c1a5f1c5c133
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTM5OTMtNzY5
-        OS1iOTEzLWZiMzA2ODQwMzFiMy8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:44 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTNlZTYtNzZi
+        ZC05ODcyLWI4MzIxODUyOGYzNi8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193252a-2ce9-711f-b971-a8379cd6a8ab/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/0195fd85-2b92-76e8-8ff6-2770c8ac18d0/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2298,7 +2298,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2311,7 +2311,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:44 GMT
+      - Thu, 03 Apr 2025 21:18:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2331,20 +2331,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 17e03f26ceb14ce68010151acdf29005
+      - b1fce24bfcdd48619b7dfdc932311807
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTNhYjAtNzlh
-        OS04ZjJhLWQ4NzExZmFhOTNhOS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:44 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTQwZDQtNzRk
+        OC1hOTI5LWI1MzVkN2NiZjZiMC8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:43 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193252a-3ab0-79a9-8f2a-d8711faa93a9/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-40d4-74d8-a929-b535d7cbf6b0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2352,7 +2352,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2365,7 +2365,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:44 GMT
+      - Thu, 03 Apr 2025 21:18:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2385,47 +2385,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6c9ff6a32080415a98b173392ad78a0e
+      - fb1a406ae4b542c9b23ef8d1de76fff2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MmEtM2Fi
-        MC03OWE5LThmMmEtZDg3MTFmYWE5M2E5LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MmEtM2FiMC03OWE5LThmMmEtZDg3MTFmYWE5M2E5IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NTo0NC44MTY4MTZaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU1OjQ0LjgxNjgyNVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtNDBk
+        NC03NGQ4LWE5MjktYjUzNWQ3Y2JmNmIwLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWZkODUtNDBkNC03NGQ4LWE5MjktYjUzNWQ3Y2JmNmIwIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0My40MTI4MThaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQzLjQxMjg0OFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiMTdlMDNm
-        MjZjZWIxNGNlNjgwMTAxNTFhY2RmMjkwMDUiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMDo1NTo0NC44MjYwNzhaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTA6NTU6NDQuODI4MTM3WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MDo1NTo0NC44MzYxMjdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYjFmY2Uy
+        NGJmY2RkNDg2MTliN2RmZGM5MzIzMTE4MDciLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        M1QyMToxODo0My40Mjg5ODlaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
+        MjE6MTg6NDMuNDMyMDU3WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
+        MToxODo0My40NDI4NjhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46Zmls
-        ZS5maWxlcmVtb3RlOjAxOTMyNTJhLTJjZTktNzExZi1iOTcxLWE4Mzc5Y2Q2
-        YThhYiIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmM1N2QtZmI5NS03
-        OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 10:55:44 GMT
+        ZS5maWxlcmVtb3RlOjAxOTVmZDg1LTJiOTItNzZlOC04ZmY2LTI3NzBjOGFj
+        MThkMCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5NTYyMTctZmM5ZS03
+        NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Thu, 03 Apr 2025 21:18:43 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193252a-2d67-7d98-902e-ee04e755364c/sync/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE5
-        MzI1MmEtMmNlOS03MTFmLWI5NzEtYTgzNzljZDZhOGFiLyIsIm1pcnJvciI6
+        NWZkODUtMmI5Mi03NmU4LThmZjYtMjc3MGM4YWMxOGQwLyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2438,7 +2438,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:44 GMT
+      - Thu, 03 Apr 2025 21:18:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2458,20 +2458,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a3a0113b34f2459fa34b094e669cc98c
+      - 75308e5a39504f23972207999d624e78
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTNiMmYtN2Ni
-        MS1hMDE1LTg1NzkzNzBlYWIwYi8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:44 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTQxOWMtNzU2
+        Mi1iNmRiLWMxYzI4YjcxZjA0MS8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:43 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193252a-3b2f-7cb1-a015-8579370eab0b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-419c-7562-b6db-c1c28b71f041/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2479,7 +2479,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2492,7 +2492,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:45 GMT
+      - Thu, 03 Apr 2025 21:18:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2512,56 +2512,56 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7045e0f220b14dcbb82957ce9f177d03
+      - c101047ad4a849bc9f2c00588064dae9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MmEtM2Iy
-        Zi03Y2IxLWEwMTUtODU3OTM3MGVhYjBiLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MmEtM2IyZi03Y2IxLWEwMTUtODU3OTM3MGVhYjBiIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NTo0NC45NDQwOTFaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU1OjQ0Ljk0NDEwMVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtNDE5
+        Yy03NTYyLWI2ZGItYzFjMjhiNzFmMDQxLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWZkODUtNDE5Yy03NTYyLWI2ZGItYzFjMjhiNzFmMDQxIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0My42MTMzMDdaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQzLjYxMzMyMloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX2ZpbGUuYXBwLnRh
         c2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25pemUiLCJsb2dnaW5nX2NpZCI6
-        ImEzYTAxMTNiMzRmMjQ1OWZhMzRiMDk0ZTY2OWNjOThjIiwiY3JlYXRlZF9i
+        Ijc1MzA4ZTVhMzk1MDRmMjM5NzIyMDc5OTlkNjI0ZTc4IiwiY3JlYXRlZF9i
         eSI6Ii9wdWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIw
-        MjQtMTEtMTNUMTA6NTU6NDQuOTUzMjAzWiIsInN0YXJ0ZWRfYXQiOiIyMDI0
-        LTExLTEzVDEwOjU1OjQ0Ljk4NDc3OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQt
-        MTEtMTNUMTA6NTU6NDUuNzc4NTE2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
-        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTkzMjUyMy05MDFlLTdmYjAtOWUw
-        Ny05Y2RmNGQyYjFjYTAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
+        MjUtMDQtMDNUMjE6MTg6NDMuNjI4OTk4WiIsInN0YXJ0ZWRfYXQiOiIyMDI1
+        LTA0LTAzVDIxOjE4OjQzLjY4OTMxNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjUt
+        MDQtMDNUMjE6MTg6NDQuMTkyMzQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTk1ZmQ4NC03NWI1LTcxYTMtYTNk
+        Yi0xYWQxZTI5NzJjMDcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
         c2tzIjpbXSwidGFza19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6
-        W3sibWVzc2FnZSI6IlBhcnNpbmcgTWV0YWRhdGEgTGluZXMiLCJjb2RlIjoi
-        c3luYy5wYXJzaW5nLm1ldGFkYXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
-        b3RhbCI6MywiZG9uZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJV
-        bi1Bc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6InVuYXNzb2NpYXRpbmcu
-        Y29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRv
-        bmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcg
-        TWV0YWRhdGEiLCJjb2RlIjoic3luYy5kb3dubG9hZGluZy5tZXRhZGF0YSIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUiOjEsInN1
-        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3Rz
-        IiwiY29kZSI6InN5bmMuZG93bmxvYWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUi
-        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4Ijpu
-        dWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6
-        ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        W3sibWVzc2FnZSI6IkRvd25sb2FkaW5nIE1ldGFkYXRhIiwiY29kZSI6InN5
+        bmMuZG93bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjpudWxsLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
+        ZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25s
+        b2FkaW5nLmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
+        Om51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNz
+        b2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50
+        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6Mywi
+        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1ldGFkYXRhIExp
+        bmVzIiwiY29kZSI6InN5bmMucGFyc2luZy5tZXRhZGF0YSIsInN0YXRlIjoi
+        Y29tcGxldGVkIiwidG90YWwiOjMsImRvbmUiOjMsInN1ZmZpeCI6bnVsbH0s
+        eyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1
+        bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9y
         ZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2Zp
-        bGUvMDE5MzI1MmEtMmQ2Ny03ZDk4LTkwMmUtZWUwNGU3NTUzNjRjL3ZlcnNp
+        bGUvMDE5NWZkODUtMmNhZS03YTY2LTlmNjQtMzY1NmU1MGQxYjJkL3ZlcnNp
         b25zLzIvIiwiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUv
-        MDE5MzI1MmEtM2UzZC03YmQyLTg2MTAtYzM3OTYzMTBhNmYwLyJdLCJyZXNl
+        MDE5NWZkODUtNDNhNy03OWFhLWE0MjItYTJhMjhiMzc0NDU1LyJdLCJyZXNl
         cnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpmaWxlLmZpbGVyZXBvc2l0
-        b3J5OjAxOTMyNTJhLTJkNjctN2Q5OC05MDJlLWVlMDRlNzU1MzY0YyIsInNo
-        YXJlZDpwcm46ZmlsZS5maWxlcmVtb3RlOjAxOTMyNTJhLTJjZTktNzExZi1i
-        OTcxLWE4Mzc5Y2Q2YThhYiIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5
-        MmM1N2QtZmI5NS03OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 10:55:45 GMT
+        b3J5OjAxOTVmZDg1LTJjYWUtN2E2Ni05ZjY0LTM2NTZlNTBkMWIyZCIsInNo
+        YXJlZDpwcm46ZmlsZS5maWxlcmVtb3RlOjAxOTVmZDg1LTJiOTItNzZlOC04
+        ZmY2LTI3NzBjOGFjMThkMCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5
+        NTYyMTctZmM5ZS03NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Thu, 03 Apr 2025 21:18:44 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2569,7 +2569,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2582,7 +2582,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:45 GMT
+      - Thu, 03 Apr 2025 21:18:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2594,7 +2594,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '755'
+      - '753'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2602,47 +2602,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4c9cb618fbd841edb16da826c59777f3
+      - f38b3b36083e45cfa308ebd707de1dd9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMTkzMjUyYS0zMDEzLTc1YjgtYjhlYS02MTEzMmM5MmYz
-        NmEvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTkzMjUy
-        YS0zMDEzLTc1YjgtYjhlYS02MTEzMmM5MmYzNmEiLCJwdWxwX2NyZWF0ZWQi
-        OiIyMDI0LTExLTEzVDEwOjU1OjQyLjEwMTA2OFoiLCJwdWxwX2xhc3RfdXBk
-        YXRlZCI6IjIwMjQtMTEtMTNUMTA6NTU6NDQuNTU0MTcyWiIsImJhc2VfcGF0
+        L2ZpbGUvZmlsZS8wMTk1ZmQ4NS0zMjMwLTc1YzYtYTFlYi1iNTc3YWNhM2Jj
+        MzcvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk1ZmQ4
+        NS0zMjMwLTc1YzYtYTFlYi1iNTc3YWNhM2JjMzciLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDI1LTA0LTAzVDIxOjE4OjM5LjY2NzE0NVoiLCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjUtMDQtMDNUMjE6MTg6NDIuOTQ4NDU4WiIsImJhc2VfcGF0
         aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8x
-        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5k
-        aWNlcm9zMjAyMy5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9P
-        cmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19GaWxlXzEvIiwiY29udGVudF9n
-        dWFyZCI6bnVsbCwibm9fY29udGVudF9jaGFuZ2Vfc2luY2UiOiIyMDI0LTEx
-        LTEzVDEwOjU1OjQ0LjU1NDE3MloiLCJoaWRkZW4iOmZhbHNlLCJwdWxwX2xh
-        YmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0
-        LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        MmEtMzUxNC03ZWMwLWI1ZDktNWRiNTE5M2VmMjJlLyJ9XX0=
-  recorded_at: Wed, 13 Nov 2024 10:55:45 GMT
+        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5t
+        YW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3Vh
+        cmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNS0wNC0w
+        M1QyMToxODo0Mi45NDg0NThaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9sYWJl
+        bHMiOnt9LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1w
+        dWxwM19GaWxlXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6
+        Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOTVmZDg1
+        LTM3NDctN2MyNy1hZDI0LTY2NjZlNWM0ZTQyOS8ifV19
+  recorded_at: Thu, 03 Apr 2025 21:18:44 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193252a-3013-75b8-b8ea-61132c92f36a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/0195fd85-3230-75c6-a1eb-b577aca3bc37/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        MmEtM2UzZC03YmQyLTg2MTAtYzM3OTYzMTBhNmYwLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NWZk
+        ODUtNDNhNy03OWFhLWE0MjItYTJhMjhiMzc0NDU1LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2655,7 +2655,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:45 GMT
+      - Thu, 03 Apr 2025 21:18:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,20 +2675,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d3dea0a33b09459296e15e693bfb4173
+      - 7e521e8b6bad4c45854498cda9119f9a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTNmMjktN2Yz
-        MC04MzU2LTlhOTMzNGM5MTJiYS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:45 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTQ1MzItN2Y0
+        OS1iMjIwLWM4MzJmNWE1YjJhYy8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:44 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193252a-3f29-7f30-8356-9a9334c912ba/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-4532-7f49-b220-c832f5a5b2ac/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2696,7 +2696,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2709,7 +2709,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:46 GMT
+      - Thu, 03 Apr 2025 21:18:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2729,48 +2729,48 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 62d95a600f62404488b5df40344a9cc8
+      - 28fe1720341b412c8b22e354ca430bf8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MmEtM2Yy
-        OS03ZjMwLTgzNTYtOWE5MzM0YzkxMmJhLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MmEtM2YyOS03ZjMwLTgzNTYtOWE5MzM0YzkxMmJhIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NTo0NS45NjE1NzNaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU1OjQ1Ljk2MTU4NFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtNDUz
+        Mi03ZjQ5LWIyMjAtYzgzMmY1YTViMmFjLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWZkODUtNDUzMi03ZjQ5LWIyMjAtYzgzMmY1YTViMmFjIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0NC41MzA0OTVaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQ0LjUzMDUwOVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiZDNkZWEw
-        YTMzYjA5NDU5Mjk2ZTE1ZTY5M2JmYjQxNzMiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMDo1NTo0NS45NzIxNDlaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTA6NTU6NDUuOTc0ODEzWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MDo1NTo0NS45ODc2NDRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiN2U1MjFl
+        OGI2YmFkNGM0NTg1NDQ5OGNkYTkxMTlmOWEiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        M1QyMToxODo0NC41NDM1MjZaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
+        MjE6MTg6NDQuNTQ3NTk0WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
+        MToxODo0NC41NjQwNjBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJjNTdkLWZiOTUtNzkxOC04N2U0LTlkZTViMTVhYjUzNjpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyYzU3ZC1mYjk1LTc5
-        MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 10:55:46 GMT
+        OTU2MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRp
+        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0
+        Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
+  recorded_at: Thu, 03 Apr 2025 21:18:44 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193252a-3013-75b8-b8ea-61132c92f36a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/0195fd85-3230-75c6-a1eb-b577aca3bc37/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        MmEtM2UzZC03YmQyLTg2MTAtYzM3OTYzMTBhNmYwLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NWZk
+        ODUtNDNhNy03OWFhLWE0MjItYTJhMjhiMzc0NDU1LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2783,7 +2783,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:46 GMT
+      - Thu, 03 Apr 2025 21:18:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2803,20 +2803,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2c0a61e9d93e4b34b416151ccd09041d
+      - ce07c281409b47d58a6c194cb8bbd795
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTNmYzctNzlh
-        OC05NGU1LTUwMDZhZTg5MmM0NS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:46 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTQ2MjMtN2Ri
+        Yi1hMmIyLTkwODg3NmEyMDdkOC8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:44 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2824,7 +2824,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.22.3/ruby
+      - OpenAPI-Generator/0.22.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2837,7 +2837,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:46 GMT
+      - Thu, 03 Apr 2025 21:18:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2857,20 +2857,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f8cc797106484fdba38729de14b9b635
+      - ce8418ec12364d74ba37478ac6f26779
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:46 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2891,7 +2891,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:46 GMT
+      - Thu, 03 Apr 2025 21:18:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2911,20 +2911,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3b67e766d0a645a78a15eb9f2469d75b
+      - 67e73b953c3a48dba3ed16e57aac88a6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:46 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2932,7 +2932,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.22.0/ruby
+      - OpenAPI-Generator/2.22.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -2945,7 +2945,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:46 GMT
+      - Thu, 03 Apr 2025 21:18:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2965,20 +2965,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7f9ccac6abf24c3ab4313419d46064df
+      - ef4c80b400ca48979daf737799829104
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:46 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2986,7 +2986,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2999,7 +2999,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:46 GMT
+      - Thu, 03 Apr 2025 21:18:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3011,7 +3011,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '691'
+      - '753'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -3019,34 +3019,35 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 412dab61b4814914b07da3d6d94882a8
+      - ae79ce794a9946eb8ebec7f6bea7629d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTMyNTJhLTJkNjctN2Q5OC05MDJlLWVlMDRlNzU1MzY0
-        Yy8iLCJwcm4iOiJwcm46ZmlsZS5maWxlcmVwb3NpdG9yeTowMTkzMjUyYS0y
-        ZDY3LTdkOTgtOTAyZS1lZTA0ZTc1NTM2NGMiLCJwdWxwX2NyZWF0ZWQiOiIy
-        MDI0LTExLTEzVDEwOjU1OjQxLjQxNjE2N1oiLCJwdWxwX2xhc3RfdXBkYXRl
-        ZCI6IjIwMjQtMTEtMTNUMTA6NTU6NDUuNzE1Mzg1WiIsInZlcnNpb25zX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTkz
-        MjUyYS0yZDY3LTdkOTgtOTAyZS1lZTA0ZTc1NTM2NGMvdmVyc2lvbnMvIiwi
-        cHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1MmEtMmQ2Ny03
-        ZDk4LTkwMmUtZWUwNGU3NTUzNjRjL3ZlcnNpb25zLzIvIiwibmFtZSI6IkRl
-        ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwiZGVz
-        Y3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJy
-        ZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWFuaWZlc3QiOiJQ
-        VUxQX01BTklGRVNUIn1dfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:46 GMT
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L2ZpbGUvZmlsZS8wMTk1ZmQ4NS0zMjMwLTc1YzYtYTFlYi1iNTc3YWNhM2Jj
+        MzcvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk1ZmQ4
+        NS0zMjMwLTc1YzYtYTFlYi1iNTc3YWNhM2JjMzciLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDI1LTA0LTAzVDIxOjE4OjM5LjY2NzE0NVoiLCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjUtMDQtMDNUMjE6MTg6NDQuODAwODcwWiIsImJhc2VfcGF0
+        aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8x
+        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5t
+        YW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3Vh
+        cmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNS0wNC0w
+        M1QyMToxODo0NC44MDA4NzBaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9sYWJl
+        bHMiOnt9LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1w
+        dWxwM19GaWxlXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6
+        Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOTVmZDg1
+        LTQzYTctNzlhYS1hNDIyLWEyYTI4YjM3NDQ1NS8ifV19
+  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193252a-2d67-7d98-902e-ee04e755364c/versions/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3054,7 +3055,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/2.4.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -3067,110 +3068,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:46 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '2251'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - d3d6ad285be54141a8861fd1d5e12995
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTMyNTJhLTJkNjctN2Q5OC05MDJlLWVlMDRlNzU1MzY0
-        Yy92ZXJzaW9ucy8yLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
-        aW9uOjAxOTMyNTJhLTNiNjctN2FjMi04YWYwLWQxOWM1ZWMxMWM4NiIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMTEtMTNUMTA6NTU6NDQuOTk5OTIxWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NTo0NS43MTcwMTBa
-        IiwibnVtYmVyIjoyLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1MmEtMmQ2Ny03ZDk4LTkwMmUtZWUw
-        NGU3NTUzNjRjLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
-        YXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6
-        Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlf
-        dmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMTkzMjUyYS0yZDY3LTdkOTgtOTAyZS1lZTA0ZTc1NTM2NGMvdmVy
-        c2lvbnMvMi8ifX0sInJlbW92ZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50Ijoz
-        LCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVw
-        b3NpdG9yeV92ZXJzaW9uX3JlbW92ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9maWxlL2ZpbGUvMDE5MzI1MmEtMmQ2Ny03ZDk4LTkwMmUtZWUwNGU3
-        NTUzNjRjL3ZlcnNpb25zLzIvIn19LCJwcmVzZW50Ijp7ImZpbGUuZmlsZSI6
-        eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
-        ZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2ZpbGUvZmlsZS8wMTkzMjUyYS0yZDY3LTdkOTgtOTAyZS1lZTA0
-        ZTc1NTM2NGMvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTMyNTJhLTJkNjct
-        N2Q5OC05MDJlLWVlMDRlNzU1MzY0Yy92ZXJzaW9ucy8xLyIsInBybiI6InBy
-        bjpjb3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOTMyNTJhLTMyNDEtNzE1My1h
-        NmM0LWZkNWUxZDRmZmVkZiIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMTEtMTNU
-        MTA6NTU6NDIuNjU3ODY0WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0x
-        MS0xM1QxMDo1NTo0My4zNjU2NzlaIiwibnVtYmVyIjoxLCJyZXBvc2l0b3J5
-        IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1
-        MmEtMmQ2Ny03ZDk4LTkwMmUtZWUwNGU3NTUzNjRjLyIsImJhc2VfdmVyc2lv
-        biI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmls
-        ZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Zp
-        bGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTkzMjUyYS0yZDY3LTdkOTgt
-        OTAyZS1lZTA0ZTc1NTM2NGMvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9
-        LCJwcmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9w
-        dWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVy
-        c2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTkz
-        MjUyYS0yZDY3LTdkOTgtOTAyZS1lZTA0ZTc1NTM2NGMvdmVyc2lvbnMvMS8i
-        fX19fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTMyNTJhLTJkNjctN2Q5OC05MDJlLWVlMDRlNzU1MzY0
-        Yy92ZXJzaW9ucy8wLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
-        aW9uOjAxOTMyNTJhLTJkNmMtNzk3ZC1iZjI0LWFlZGYxNTFiZWNkNSIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMTEtMTNUMTA6NTU6NDEuNDIyMDQ1WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NTo0MS40MjIwNTFa
-        IiwibnVtYmVyIjowLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1MmEtMmQ2Ny03ZDk4LTkwMmUtZWUw
-        NGU3NTUzNjRjLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
-        YXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1d
-        fQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:46 GMT
-- request:
-    method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/2.4.4/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 13 Nov 2024 10:55:46 GMT
+      - Thu, 03 Apr 2025 21:18:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3190,20 +3088,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8a1192de650e4858b174c98c4bacf4f5
+      - 672a1489f25e4e13b8857a7833244c42
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:46 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3211,7 +3109,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.12.5/ruby
+      - OpenAPI-Generator/3.12.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -3224,7 +3122,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:46 GMT
+      - Thu, 03 Apr 2025 21:18:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3244,20 +3142,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fcec5bced24b4c589ee8fbbecfc5769e
+      - 6f4d1151e0f04a5eadba5525cd422be8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:46 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3278,7 +3176,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:46 GMT
+      - Thu, 03 Apr 2025 21:18:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3298,20 +3196,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d126739e7bdc4eb1b93270730d38fe10
+      - 6246b10832c14ddb8b4e4295bdb87249
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:46 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
 - request:
-    method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193252a-2d67-7d98-902e-ee04e755364c/versions/1/
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3319,7 +3217,502 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/0.22.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 03 Apr 2025 21:18:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 325a1be45f6e46cbaee079482515d7ff
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.3.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 03 Apr 2025 21:18:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 506a5346248846f7ad2e7a8bf32f8f1f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.22.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 03 Apr 2025 21:18:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - c02bfcd01b5142c3820757ed55bdc6d6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.13/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 03 Apr 2025 21:18:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '691'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 939e2d263ff649e3a08d20f8a7f78cd4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ZmlsZS9maWxlLzAxOTVmZDg1LTJjYWUtN2E2Ni05ZjY0LTM2NTZlNTBkMWIy
+        ZC8iLCJwcm4iOiJwcm46ZmlsZS5maWxlcmVwb3NpdG9yeTowMTk1ZmQ4NS0y
+        Y2FlLTdhNjYtOWY2NC0zNjU2ZTUwZDFiMmQiLCJwdWxwX2NyZWF0ZWQiOiIy
+        MDI1LTA0LTAzVDIxOjE4OjM4LjI1NTU1NloiLCJwdWxwX2xhc3RfdXBkYXRl
+        ZCI6IjIwMjUtMDQtMDNUMjE6MTg6NDQuMTIyNjcyWiIsInZlcnNpb25zX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk1
+        ZmQ4NS0yY2FlLTdhNjYtOWY2NC0zNjU2ZTUwZDFiMmQvdmVyc2lvbnMvIiwi
+        cHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NWZkODUtMmNhZS03
+        YTY2LTlmNjQtMzY1NmU1MGQxYjJkL3ZlcnNpb25zLzIvIiwibmFtZSI6IkRl
+        ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwiZGVz
+        Y3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJy
+        ZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWFuaWZlc3QiOiJQ
+        VUxQX01BTklGRVNUIn1dfQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.13/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 03 Apr 2025 21:18:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '2251'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4d5c6539149d4afeaebdf5758bb6b46b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ZmlsZS9maWxlLzAxOTVmZDg1LTJjYWUtN2E2Ni05ZjY0LTM2NTZlNTBkMWIy
+        ZC92ZXJzaW9ucy8yLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
+        aW9uOjAxOTVmZDg1LTQxZjYtNzJkZi04MDYxLTM2MDhiZjg3MGIwYSIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjUtMDQtMDNUMjE6MTg6NDMuNzAzMDQ1WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0NC4xMjQ3MDJa
+        IiwibnVtYmVyIjoyLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9maWxlL2ZpbGUvMDE5NWZkODUtMmNhZS03YTY2LTlmNjQtMzY1
+        NmU1MGQxYjJkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
+        YXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlf
+        dmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
+        ZmlsZS8wMTk1ZmQ4NS0yY2FlLTdhNjYtOWY2NC0zNjU2ZTUwZDFiMmQvdmVy
+        c2lvbnMvMi8ifX0sInJlbW92ZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50Ijoz
+        LCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX3JlbW92ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9maWxlL2ZpbGUvMDE5NWZkODUtMmNhZS03YTY2LTlmNjQtMzY1NmU1
+        MGQxYjJkL3ZlcnNpb25zLzIvIn19LCJwcmVzZW50Ijp7ImZpbGUuZmlsZSI6
+        eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
+        ZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzL2ZpbGUvZmlsZS8wMTk1ZmQ4NS0yY2FlLTdhNjYtOWY2NC0zNjU2
+        ZTUwZDFiMmQvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTVmZDg1LTJjYWUt
+        N2E2Ni05ZjY0LTM2NTZlNTBkMWIyZC92ZXJzaW9ucy8xLyIsInBybiI6InBy
+        bjpjb3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOTVmZDg1LTM1NzMtN2Y4Yi04
+        YjM0LWE4MDBjYjc4M2Y1YiIsInB1bHBfY3JlYXRlZCI6IjIwMjUtMDQtMDNU
+        MjE6MTg6NDAuNTAwNDQzWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0w
+        NC0wM1QyMToxODo0MC45NDM3NzJaIiwibnVtYmVyIjoxLCJyZXBvc2l0b3J5
+        IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NWZk
+        ODUtMmNhZS03YTY2LTlmNjQtMzY1NmU1MGQxYjJkLyIsImJhc2VfdmVyc2lv
+        biI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmls
+        ZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Zp
+        bGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkv
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk1ZmQ4NS0yY2FlLTdhNjYt
+        OWY2NC0zNjU2ZTUwZDFiMmQvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9
+        LCJwcmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVy
+        c2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk1
+        ZmQ4NS0yY2FlLTdhNjYtOWY2NC0zNjU2ZTUwZDFiMmQvdmVyc2lvbnMvMS8i
+        fX19fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ZmlsZS9maWxlLzAxOTVmZDg1LTJjYWUtN2E2Ni05ZjY0LTM2NTZlNTBkMWIy
+        ZC92ZXJzaW9ucy8wLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
+        aW9uOjAxOTVmZDg1LTJjYjktNzUwZi04YzFkLTUxZmJmZGU4ZGM2MCIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjUtMDQtMDNUMjE6MTg6MzguMjY5NDU2WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wNC0wM1QyMToxODozOC4yNjk0Njha
+        IiwibnVtYmVyIjowLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy9maWxlL2ZpbGUvMDE5NWZkODUtMmNhZS03YTY2LTlmNjQtMzY1
+        NmU1MGQxYjJkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
+        YXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1d
+        fQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.4.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 03 Apr 2025 21:18:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - f41e063b29ff4f609eb0bfc4258c0253
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.12.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 03 Apr 2025 21:18:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 42cdd9ac63f54d45b850bcd5a5402bbf
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.27.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 03 Apr 2025 21:18:45 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 84e9ff0d1ab549b38792084999e8e740
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel.manicotto.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+- request:
+    method: delete
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3332,7 +3725,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:46 GMT
+      - Thu, 03 Apr 2025 21:18:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3352,20 +3745,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f8242271d7da43da8eda60d62cb1e151
+      - 18f3d4b8655c4b32ab4663e8c1022b24
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTQyNTMtN2Iw
-        Mi04MzFmLTZlYWEzNGI5ODc0My8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:46 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTRhZWEtNzg5
+        My05NDYwLTE0ZDViMDE1ZDc4Ni8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:46 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/orphans/cleanup/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
     body:
       encoding: UTF-8
       base64_string: 'eyJvcnBoYW5fcHJvdGVjdGlvbl90aW1lIjoxNDQwfQ==
@@ -3375,7 +3768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3388,7 +3781,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:46 GMT
+      - Thu, 03 Apr 2025 21:18:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3408,20 +3801,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 76ea64a771d344b5a9a3f72a32778d51
+      - f0ea3e863a264f9a976b2d5b3fe10ac8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTQyYTUtNzhj
-        Zi1hMDc3LTVhYjIxNDYzMWY5ZC8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:46 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTRiNWUtNzlk
+        ZS04YjUxLTc4Zjk0YjVmYjQ4MC8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:46 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193252a-42a5-78cf-a077-5ab214631f9d/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-4b5e-79de-8b51-78f94b5fb480/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3429,7 +3822,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3442,7 +3835,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:47 GMT
+      - Thu, 03 Apr 2025 21:18:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3462,28 +3855,28 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b28780d4e741499daeff8862094cc788
+      - 4b88922785884d17aece0a5d2232bf80
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MmEtNDJh
-        NS03OGNmLWEwNzctNWFiMjE0NjMxZjlkLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MmEtNDJhNS03OGNmLWEwNzctNWFiMjE0NjMxZjlkIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NTo0Ni44NTM0NzdaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU1OjQ2Ljg1MzQ4Nloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtNGI1
+        ZS03OWRlLThiNTEtNzhmOTRiNWZiNDgwLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWZkODUtNGI1ZS03OWRlLThiNTEtNzhmOTRiNWZiNDgwIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0Ni4xMTExNDZaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQ2LjExMTE2OFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiI3NmVh
-        NjRhNzcxZDM0NGI1YTlhM2Y3MmEzMjc3OGQ1MSIsImNyZWF0ZWRfYnkiOiIv
-        cHVscC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTEx
-        LTEzVDEwOjU1OjQ2Ljg2ODAwOVoiLCJzdGFydGVkX2F0IjoiMjAyNC0xMS0x
-        M1QxMDo1NTo0Ni45MDk0MzZaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTExLTEz
-        VDEwOjU1OjQ3LjA2MDkxNFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1
-        bHAvYXBpL3YzL3dvcmtlcnMvMDE5MzI1MjMtOGZlYS03NDE2LWI5MTctYTJk
-        MGEyYWIzZGY3LyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6
+        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiJmMGVh
+        M2U4NjNhMjY0ZjlhOTc2YjJkNWIzZmUxMGFjOCIsImNyZWF0ZWRfYnkiOiIv
+        cHVscC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTA0
+        LTAzVDIxOjE4OjQ2LjEyNzI4M1oiLCJzdGFydGVkX2F0IjoiMjAyNS0wNC0w
+        M1QyMToxODo0Ni4xOTU2MThaIiwiZmluaXNoZWRfYXQiOiIyMDI1LTA0LTAz
+        VDIxOjE4OjQ2LjM2MzMyMFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1
+        bHAvYXBpL3YzL3dvcmtlcnMvMDE5NWZkODQtNzVkNC03ZjQ2LWI3OWYtNzEw
+        M2MxYjJjZTYwLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6
         W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1l
         c3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQ29udGVudCIsImNvZGUiOiJjbGVh
         bi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwi
@@ -3491,13 +3884,13 @@ http_interactions:
         cnBoYW4gQXJ0aWZhY3RzIiwiY29kZSI6ImNsZWFuLXVwLmFydGlmYWN0cyIs
         InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZp
         eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jl
-        c291cmNlc19yZWNvcmQiOlsicGRybjowMTkyYzU3ZC1mYjk1LTc5MTgtODdl
-        NC05ZGU1YjE1YWI1MzY6b3JwaGFucyIsInNoYXJlZDpwcm46Y29yZS5kb21h
-        aW46MDE5MmM1N2QtZmI5NS03OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 10:55:47 GMT
+        c291cmNlc19yZWNvcmQiOlsicGRybjowMTk1NjIxNy1mYzllLTc0Y2YtOTAy
+        NC1lODAzNDY3ZmU0ZDA6b3JwaGFucyIsInNoYXJlZDpwcm46Y29yZS5kb21h
+        aW46MDE5NTYyMTctZmM5ZS03NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Thu, 03 Apr 2025 21:18:46 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/purge/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/purge/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3507,7 +3900,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3520,7 +3913,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:47 GMT
+      - Thu, 03 Apr 2025 21:18:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3540,20 +3933,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a10664c71f8e4aef89d505a9ab0e5c5b
+      - '01427092f0b94586b4d3120b64126052'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTQzZjQtN2U3
-        Yy04NGUwLWRkZWYwNWFlYjU2My8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:47 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTRjZGMtNzA1
+        My04ZDljLWUzMjMwZjIyYmJkNC8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:46 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193252a-2d67-7d98-902e-ee04e755364c/versions/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/versions/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3561,7 +3954,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3574,7 +3967,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:47 GMT
+      - Thu, 03 Apr 2025 21:18:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3594,47 +3987,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1f2f016714944d4f8de7095768c4ce17
+      - 2cbfb457db4b4efeaebba099c80372e4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTMyNTJhLTJkNjctN2Q5OC05MDJlLWVlMDRlNzU1MzY0
-        Yy92ZXJzaW9ucy8yLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
-        aW9uOjAxOTMyNTJhLTNiNjctN2FjMi04YWYwLWQxOWM1ZWMxMWM4NiIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMTEtMTNUMTA6NTU6NDQuOTk5OTIxWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NTo0NS43MTcwMTBa
+        ZmlsZS9maWxlLzAxOTVmZDg1LTJjYWUtN2E2Ni05ZjY0LTM2NTZlNTBkMWIy
+        ZC92ZXJzaW9ucy8yLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
+        aW9uOjAxOTVmZDg1LTQxZjYtNzJkZi04MDYxLTM2MDhiZjg3MGIwYSIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjUtMDQtMDNUMjE6MTg6NDMuNzAzMDQ1WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0NC4xMjQ3MDJa
         IiwibnVtYmVyIjoyLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1MmEtMmQ2Ny03ZDk4LTkwMmUtZWUw
-        NGU3NTUzNjRjLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
+        aXRvcmllcy9maWxlL2ZpbGUvMDE5NWZkODUtMmNhZS03YTY2LTlmNjQtMzY1
+        NmU1MGQxYjJkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
         YXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6
         Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlf
         dmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMTkzMjUyYS0yZDY3LTdkOTgtOTAyZS1lZTA0ZTc1NTM2NGMvdmVy
+        ZmlsZS8wMTk1ZmQ4NS0yY2FlLTdhNjYtOWY2NC0zNjU2ZTUwZDFiMmQvdmVy
         c2lvbnMvMi8ifX0sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7ImZpbGUuZmls
         ZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Zp
         bGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTkzMjUyYS0yZDY3LTdkOTgtOTAyZS1l
-        ZTA0ZTc1NTM2NGMvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTMyNTJhLTJk
-        NjctN2Q5OC05MDJlLWVlMDRlNzU1MzY0Yy92ZXJzaW9ucy8wLyIsInBybiI6
-        InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOTMyNTJhLTJkNmMtNzk3
-        ZC1iZjI0LWFlZGYxNTFiZWNkNSIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMTEt
-        MTNUMTA6NTU6NDEuNDIyMDQ1WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        NC0xMS0xM1QxMDo1NTo0MS40MjIwNTFaIiwibnVtYmVyIjowLCJyZXBvc2l0
+        b3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk1ZmQ4NS0yY2FlLTdhNjYtOWY2NC0z
+        NjU2ZTUwZDFiMmQvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTVmZDg1LTJj
+        YWUtN2E2Ni05ZjY0LTM2NTZlNTBkMWIyZC92ZXJzaW9ucy8wLyIsInBybiI6
+        InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOTVmZDg1LTJjYjktNzUw
+        Zi04YzFkLTUxZmJmZGU4ZGM2MCIsInB1bHBfY3JlYXRlZCI6IjIwMjUtMDQt
+        MDNUMjE6MTg6MzguMjY5NDU2WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
+        NS0wNC0wM1QyMToxODozOC4yNjk0NjhaIiwibnVtYmVyIjowLCJyZXBvc2l0
         b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5
-        MzI1MmEtMmQ2Ny03ZDk4LTkwMmUtZWUwNGU3NTUzNjRjLyIsImJhc2VfdmVy
+        NWZkODUtMmNhZS03YTY2LTlmNjQtMzY1NmU1MGQxYjJkLyIsImJhc2VfdmVy
         c2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVt
         b3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:47 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:46 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/?state__in=completed
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/?state__in=completed
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3642,7 +4035,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3655,7 +4048,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:47 GMT
+      - Thu, 03 Apr 2025 21:18:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3675,20 +4068,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8267188b3ac043b38863712bd04719e5
+      - d6ee649e4e064f4da1663949501e1a61
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:47 GMT
+  recorded_at: Thu, 03 Apr 2025 21:18:46 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193252a-2ce9-711f-b971-a8379cd6a8ab/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/0195fd85-2b92-76e8-8ff6-2770c8ac18d0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3696,7 +4089,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3709,7 +4102,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:47 GMT
+      - Thu, 03 Apr 2025 21:18:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3729,20 +4122,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5ebb33bdd29c4223b2170b3126851a9e
+      - 4ee644f0d4604421a34e84c84d004baf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTQ1MWItNzE5
-        OC1iYmRkLTA5Y2FkNTk0OTZmYy8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:47 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTRlN2MtN2Ni
+        My04OTdjLTJjZjZlZDNhZmQwYS8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:46 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193252a-451b-7198-bbdd-09cad59496fc/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-4e7c-7cb3-897c-2cf6ed3afd0a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3750,7 +4143,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3763,7 +4156,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:47 GMT
+      - Thu, 03 Apr 2025 21:18:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3783,37 +4176,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7c3c9cf027fb4401921bfc02a5c1b1bc
+      - 1ce17192af09421cababd31b14fc3395
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MmEtNDUx
-        Yi03MTk4LWJiZGQtMDljYWQ1OTQ5NmZjLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MmEtNDUxYi03MTk4LWJiZGQtMDljYWQ1OTQ5NmZjIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NTo0Ny40ODM5MzJaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU1OjQ3LjQ4Mzk0Mloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtNGU3
+        Yy03Y2IzLTg5N2MtMmNmNmVkM2FmZDBhLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWZkODUtNGU3Yy03Y2IzLTg5N2MtMmNmNmVkM2FmZDBhIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0Ni45MDg5OTFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQ2LjkwOTAwN1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiNWViYjMz
-        YmRkMjljNDIyM2IyMTcwYjMxMjY4NTFhOWUiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMDo1NTo0Ny40OTU3MTFaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTA6NTU6NDcuNTI3NjMwWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MDo1NTo0Ny41Njc2MThaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTMyNTIzLThmZWEtNzQxNi1iOTE3LWEyZDBh
-        MmFiM2RmNy8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiNGVlNjQ0
+        ZjBkNDYwNDQyMWEzNGU4NGM4NGQwMDRiYWYiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        M1QyMToxODo0Ni45MzQ1MDVaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
+        MjE6MTg6NDcuMDQyODM4WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
+        MToxODo0Ny4xMDk3NzJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOTVmZDg0LTc1ZDQtN2Y0Ni1iNzlmLTcxMDNj
+        MWIyY2U2MC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpmaWxlLmZpbGVyZW1vdGU6MDE5MzI1MmEtMmNlOS03MTFmLWI5
-        NzEtYTgzNzljZDZhOGFiIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTky
-        YzU3ZC1mYjk1LTc5MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 10:55:47 GMT
+        IjpbInBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NWZkODUtMmI5Mi03NmU4LThm
+        ZjYtMjc3MGM4YWMxOGQwIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1
+        NjIxNy1mYzllLTc0Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
+  recorded_at: Thu, 03 Apr 2025 21:18:47 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193252a-3013-75b8-b8ea-61132c92f36a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/0195fd85-3230-75c6-a1eb-b577aca3bc37/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3821,7 +4214,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3834,7 +4227,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:47 GMT
+      - Thu, 03 Apr 2025 21:18:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3854,20 +4247,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 47f7ff7cba48491dadabb75e24255260
+      - be31186a5e8f4a69a72d1ca918eaa3bd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTQ1ZGItNzNl
-        ZS1hNTgyLWE3NWIwYmI0Mzg1ZS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:47 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTRmZTMtN2Uz
+        OC1hNmFiLWZhZWJjNmQ4NzYyYS8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:47 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193252a-2d67-7d98-902e-ee04e755364c/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3875,7 +4268,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3888,7 +4281,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:47 GMT
+      - Thu, 03 Apr 2025 21:18:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3908,20 +4301,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9e55e7b3d84a4d03b8bb76eae59f6d11
+      - 434a316d2a764821a258dceb5a89b921
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTJhLTQ2MzUtNzNi
-        Ni1iMzIyLTg0NmY2MjBjZTk0Ny8ifQ==
-  recorded_at: Wed, 13 Nov 2024 10:55:47 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTUwNmEtN2U2
+        MC1iYTA3LWE4ZjhmODVlZjBjOC8ifQ==
+  recorded_at: Thu, 03 Apr 2025 21:18:47 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193252a-4635-73b6-b322-846f620ce947/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-506a-7e60-ba07-a8f8f85ef0c8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3929,7 +4322,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3942,7 +4335,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 10:55:47 GMT
+      - Thu, 03 Apr 2025 21:18:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3962,32 +4355,32 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5f5929e5a9164e2a866f5eda1249a751
+      - 6415bf458beb48bc8afe89c15f557cbb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1MmEtNDYz
-        NS03M2I2LWIzMjItODQ2ZjYyMGNlOTQ3LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1MmEtNDYzNS03M2I2LWIzMjItODQ2ZjYyMGNlOTQ3IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMDo1NTo0Ny43NjU5NjhaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDEwOjU1OjQ3Ljc2NTk3OFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtNTA2
+        YS03ZTYwLWJhMDctYThmOGY4NWVmMGM4LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWZkODUtNTA2YS03ZTYwLWJhMDctYThmOGY4NWVmMGM4IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0Ny40MDM1NTNaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQ3LjQwMzU2N1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiOWU1NWU3
-        YjNkODRhNGQwM2I4YmI3NmVhZTU5ZjZkMTEiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMDo1NTo0Ny43Nzc3NzZaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTA6NTU6NDcuODA3MDc4WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MDo1NTo0Ny45MTAwOTJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTMyNTIzLThmZWEtNzQxNi1iOTE3LWEyZDBh
-        MmFiM2RmNy8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiNDM0YTMx
+        NmQyYTc2NDgyMWEyNThkY2ViNWE4OWI5MjEiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        M1QyMToxODo0Ny40MTc2NTRaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
+        MjE6MTg6NDcuNDc0ODQwWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
+        MToxODo0Ny42MDM0MzlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOTVmZDg0LTc1ZDQtN2Y0Ni1iNzlmLTcxMDNj
+        MWIyY2U2MC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpmaWxlLmZpbGVyZXBvc2l0b3J5OjAxOTMyNTJhLTJkNjctN2Q5
-        OC05MDJlLWVlMDRlNzU1MzY0YyIsInNoYXJlZDpwcm46Y29yZS5kb21haW46
-        MDE5MmM1N2QtZmI5NS03OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 10:55:47 GMT
+        IjpbInBybjpmaWxlLmZpbGVyZXBvc2l0b3J5OjAxOTVmZDg1LTJjYWUtN2E2
+        Ni05ZjY0LTM2NTZlNTBkMWIyZCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46
+        MDE5NTYyMTctZmM5ZS03NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Thu, 03 Apr 2025 21:18:47 GMT
 recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_http_proxy_with_no_url.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_http_proxy_with_no_url.yml
@@ -23,13 +23,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:48 GMT
+      - Mon, 31 Mar 2025 22:12:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9f174cd675c149e9ab5166d6e991163f
+      - 5b57e963240a4667846f050d1420dae4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:48 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:46 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -77,13 +77,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:48 GMT
+      - Mon, 31 Mar 2025 22:12:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0db0c9a87e894be4be33a8d37650c2c7
+      - 113dc6bfb98342a989e821ae1a2ff2e5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:48 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:46 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -131,13 +131,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:48 GMT
+      - Mon, 31 Mar 2025 22:12:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e5ee0baf01c641319a53383f8e3f7169
+      - 21e89e08cd5c4099a37a9c14e1c51321
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:48 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:47 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -185,13 +185,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:48 GMT
+      - Mon, 31 Mar 2025 22:12:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 344b3f5dd12b46d3813baec1ef431ed9
+      - 49e67a17030c4c669624c2152a189569
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:48 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:47 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -247,15 +247,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:48 GMT
+      - Mon, 31 Mar 2025 22:12:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/0192df20-98b0-7120-8258-2d52cd7333b0/"
+      - "/pulp/api/v3/remotes/rpm/rpm/0195ee43-ac51-7394-8bde-0eb35089a5f2/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -269,7 +269,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b9cddc9c3a58473e996b18856ff4765b
+      - dce107e83ba541008f4436de30bfba3b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -278,11 +278,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OTJkZjIwLTk4YjAtNzEyMC04MjU4LTJkNTJjZDczMzNiMC8iLCJwcm4iOiJw
-        cm46cnBtLnJwbXJlbW90ZTowMTkyZGYyMC05OGIwLTcxMjAtODI1OC0yZDUy
-        Y2Q3MzMzYjAiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjQ4
-        LjQwMDY2MFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMTAtMzBUMjA6
-        MzE6NDguNDAwNjg2WiIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0
+        OTVlZTQzLWFjNTEtNzM5NC04YmRlLTBlYjM1MDg5YTVmMi8iLCJwcm4iOiJw
+        cm46cnBtLnJwbXJlbW90ZTowMTk1ZWU0My1hYzUxLTczOTQtOGJkZS0wZWIz
+        NTA4OWE1ZjIiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjQ3
+        LjMxNDI4MloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUtMDMtMzFUMjI6
+        MTI6NDcuMzE0MzA1WiIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0
         dHA6Ly9teXJlcG8uY29tIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQi
         Om51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGws
         InB1bHBfbGFiZWxzIjp7fSwiZG93bmxvYWRfY29uY3VycmVuY3kiOm51bGws
@@ -295,7 +295,7 @@ http_interactions:
         bWUiOiJwcm94eV9wYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6
         InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfV0sInNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
-  recorded_at: Wed, 30 Oct 2024 20:31:48 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:47 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -321,21 +321,21 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:48 GMT
+      - Mon, 31 Mar 2025 22:12:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/0192df20-998c-71fd-9c17-69d841f09b93/"
+      - "/pulp/api/v3/repositories/rpm/rpm/0195ee43-ad94-758c-a6b2-25a070b5bac2/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '880'
+      - '894'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -343,7 +343,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5932a6b1b867493f99fcebccb74b3796
+      - bc55c0b3e20c4ee187b9dadccdb220ff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -352,16 +352,16 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMDE5MmRmMjAtOTk4Yy03MWZkLTljMTctNjlkODQxZjA5YjkzLyIsInBy
-        biI6InBybjpycG0ucnBtcmVwb3NpdG9yeTowMTkyZGYyMC05OThjLTcxZmQt
-        OWMxNy02OWQ4NDFmMDliOTMiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMw
-        VDIwOjMxOjQ4LjYyMTY5NFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQt
-        MTAtMzBUMjA6MzE6NDguNjM0NzM3WiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAtOTk4Yy03
-        MWZkLTljMTctNjlkODQxZjA5YjkzL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
+        cG0vMDE5NWVlNDMtYWQ5NC03NThjLWE2YjItMjVhMDcwYjViYWMyLyIsInBy
+        biI6InBybjpycG0ucnBtcmVwb3NpdG9yeTowMTk1ZWU0My1hZDk0LTc1OGMt
+        YTZiMi0yNWEwNzBiNWJhYzIiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMx
+        VDIyOjEyOjQ3LjYzOTc5NFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUt
+        MDMtMzFUMjI6MTI6NDcuNjQ2NjMxWiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDMtYWQ5NC03
+        NThjLWE2YjItMjVhMDcwYjViYWMyL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
         Ijp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcnBtL3JwbS8wMTkyZGYyMC05OThjLTcxZmQtOWMxNy02OWQ4
-        NDFmMDliOTMvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJk
+        c2l0b3JpZXMvcnBtL3JwbS8wMTk1ZWU0My1hZDk0LTc1OGMtYTZiMi0yNWEw
+        NzBiNWJhYzIvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJk
         ZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGws
         InJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9z
         aWduaW5nX3NlcnZpY2UiOm51bGwsInBhY2thZ2Vfc2lnbmluZ19zZXJ2aWNl
@@ -370,8 +370,8 @@ http_interactions:
         bWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjpudWxsLCJncGdjaGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6
         bnVsbCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9
-        LCJjb21wcmVzc2lvbl90eXBlIjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:48 GMT
+        LCJjb21wcmVzc2lvbl90eXBlIjpudWxsLCJsYXlvdXQiOm51bGx9
+  recorded_at: Mon, 31 Mar 2025 22:12:47 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -379,8 +379,8 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE5MmRmMjAtOTk4Yy03MWZkLTljMTctNjlkODQxZjA5
-        YjkzL3ZlcnNpb25zLzAvIiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiJ9
+        aWVzL3JwbS9ycG0vMDE5NWVlNDMtYWQ5NC03NThjLWE2YjItMjVhMDcwYjVi
+        YWMyL3ZlcnNpb25zLzAvIiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiJ9
     headers:
       Content-Type:
       - application/json
@@ -398,13 +398,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:49 GMT
+      - Mon, 31 Mar 2025 22:12:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -418,7 +418,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 216dc7f5841c4d3ca79c039fec4f1df9
+      - 76268a27009a483382376e238b196421
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -426,12 +426,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLTliYWQtN2Q5
-        OS1hNzA1LWQ4NmI0YTIyMzljZS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:49 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWIwNTUtNzg1
+        NS05ZjhjLTU0ZGRjN2NiZDU2Zi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:48 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-9bad-7d99-a705-d86b4a2239ce/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-b055-7855-9f8c-54ddc7cbd56f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -439,7 +439,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -452,19 +452,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:49 GMT
+      - Mon, 31 Mar 2025 22:12:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1060'
+      - '1041'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -472,7 +472,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cbfb58ec27af4f148dd1892b7d71b885
+      - 6d0fa3ded5cd49c9b12fa887b656ed41
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -480,31 +480,31 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtOWJh
-        ZC03ZDk5LWE3MDUtZDg2YjRhMjIzOWNlLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtOWJhZC03ZDk5LWE3MDUtZDg2YjRhMjIzOWNlIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMTo0OS4xNjYwNDNaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjQ5LjE2NjA2MFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtYjA1
+        NS03ODU1LTlmOGMtNTRkZGM3Y2JkNTZmLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtYjA1NS03ODU1LTlmOGMtNTRkZGM3Y2JkNTZmIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjo0OC4zNDMyMTRaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjQ4LjM0MzIzOFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFz
-        a3MucHVibGlzaGluZy5wdWJsaXNoIiwibG9nZ2luZ19jaWQiOiIyMTZkYzdm
-        NTg0MWM0ZDNjYTc5YzAzOWZlYzRmMWRmOSIsImNyZWF0ZWRfYnkiOiIvcHVs
-        cC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTEwLTMw
-        VDIwOjMxOjQ5LjE4NDExN1oiLCJzdGFydGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMTo0OS4yNDE1OTZaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTEwLTMwVDIw
-        OjMxOjQ5LjQyMTM2MloiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
-        YXBpL3YzL3dvcmtlcnMvMDE5MmRlYWMtMzk1OS03ZTA2LTkyZjgtZmQ5YjUx
-        ODFiN2VlLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10s
-        InRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3Nh
-        Z2UiOiJHZW5lcmF0aW5nIHJlcG9zaXRvcnkgbWV0YWRhdGEiLCJjb2RlIjoi
-        cHVibGlzaC5nZW5lcmF0aW5nX21ldGFkYXRhIiwic3RhdGUiOiJjb21wbGV0
-        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
-        ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBt
-        L3JwbS8wMTkyZGYyMC05YzBiLTdlOTYtOWM4YS00NWZhYTEzNzM4OGUvIl0s
-        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsic2hhcmVkOnBybjpycG0u
-        cnBtcmVwb3NpdG9yeTowMTkyZGYyMC05OThjLTcxZmQtOWMxNy02OWQ4NDFm
-        MDliOTMiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAxOTJkZWFiLTE2NDct
-        NzY1NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:49 GMT
+        a3MucHVibGlzaGluZy5wdWJsaXNoIiwibG9nZ2luZ19jaWQiOiI3NjI2OGEy
+        NzAwOWE0ODMzODIzNzZlMjM4YjE5NjQyMSIsImNyZWF0ZWRfYnkiOm51bGws
+        InVuYmxvY2tlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6NDguMzg5NjA2WiIs
+        InN0YXJ0ZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjQ4LjQ4MDkxMloiLCJm
+        aW5pc2hlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6NDguODA3MjkwWiIsImVy
+        cm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTk1
+        ZDJlZS1iYWViLTdlN2UtOTQ1ZC1mZGVjOTYzMTNkOTAvIiwicGFyZW50X3Rh
+        c2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVsbCwi
+        cHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkdlbmVyYXRpbmcgcmVw
+        b3NpdG9yeSBtZXRhZGF0YSIsImNvZGUiOiJwdWJsaXNoLmdlbmVyYXRpbmdf
+        bWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25l
+        IjoxLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1
+        bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBtLzAxOTVlZTQzLWIwZmEt
+        N2VkMy05MjFkLTdjODFmMzc2MDNmMi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
+        X3JlY29yZCI6WyJzaGFyZWQ6cHJuOnJwbS5ycG1yZXBvc2l0b3J5OjAxOTVl
+        ZTQzLWFkOTQtNzU4Yy1hNmIyLTI1YTA3MGI1YmFjMiIsInNoYXJlZDpwcm46
+        Y29yZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgyNjQtNTI4YzI5MTI5
+        YTEzIl19
+  recorded_at: Mon, 31 Mar 2025 22:12:48 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -528,13 +528,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:49 GMT
+      - Mon, 31 Mar 2025 22:12:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -548,7 +548,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 50ffa6fe813145a9ab2adbd4bd0860f6
+      - 28b270d580cb418192059d7b2d449d8f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -558,10 +558,10 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:49 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:49 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df20-9c0b-7e96-9c8a-45faa137388e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee43-b0fa-7ed3-921d-7c81f37603f2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -582,19 +582,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:49 GMT
+      - Mon, 31 Mar 2025 22:12:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -602,7 +602,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5784d52c264647b0b2bb4feef049cfa3
+      - 25f033c757804094b474b9f9a410f388
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -611,21 +611,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtOWMwYi03ZTk2LTljOGEtNDVmYWExMzczODhlLyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjAtOWMwYi03ZTk2
-        LTljOGEtNDVmYWExMzczODhlIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMTo0OS4yNjIwOTFaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMxOjQ5LjQxNTc5NVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAt
-        OTk4Yy03MWZkLTljMTctNjlkODQxZjA5YjkzL3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDMtYjBmYS03ZWQzLTkyMWQtN2M4MWYzNzYwM2YyLyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDMtYjBmYS03ZWQz
+        LTkyMWQtN2M4MWYzNzYwM2YyIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMjo0OC41MDk3NDZaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjEyOjQ4Ljc5ODYxMVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDMt
+        YWQ5NC03NThjLWE2YjItMjVhMDcwYjViYWMyL3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMC05OThjLTcxZmQtOWMxNy02OWQ4NDFmMDliOTMvIiwiY2hlY2tz
+        MTk1ZWU0My1hZDk0LTc1OGMtYTZiMi0yNWEwNzBiNWJhYzIvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:49 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:49 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/
@@ -635,8 +635,8 @@ http_interactions:
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vMDE5MmRmMjAtOWMwYi03ZTk2LTljOGEtNDVm
-        YWExMzczODhlLyJ9
+        bGljYXRpb25zL3JwbS9ycG0vMDE5NWVlNDMtYjBmYS03ZWQzLTkyMWQtN2M4
+        MWYzNzYwM2YyLyJ9
     headers:
       Content-Type:
       - application/json
@@ -654,13 +654,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:49 GMT
+      - Mon, 31 Mar 2025 22:12:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -674,7 +674,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 12105286d7f648c9b89ac797dd5a6b5f
+      - e56824a6a54143e7991883862d2c3ace
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -682,12 +682,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLTlkZjktNzQ1
-        Ni1hZGMyLWU2NjcwMDRiNzE5NC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:49 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWI0OTAtN2Fl
+        Ny1hNmVjLTMxNzFmM2UxMWNiYS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:49 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-9df9-7456-adc2-e667004b7194/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-b490-7ae7-a6ec-3171f3e11cba/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -695,7 +695,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -708,19 +708,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:50 GMT
+      - Mon, 31 Mar 2025 22:12:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '918'
+      - '899'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -728,7 +728,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a61bd0c7b05843b2afd4a10cd7ec5caf
+      - 111de2372455400eac8e907673db97d3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -736,31 +736,30 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtOWRm
-        OS03NDU2LWFkYzItZTY2NzAwNGI3MTk0LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtOWRmOS03NDU2LWFkYzItZTY2NzAwNGI3MTk0IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMTo0OS43NTM1MjlaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjQ5Ljc1MzU2Nloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtYjQ5
+        MC03YWU3LWE2ZWMtMzE3MWYzZTExY2JhLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtYjQ5MC03YWU3LWE2ZWMtMzE3MWYzZTExY2JhIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjo0OS40MjUyMjdaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjQ5LjQyNTI1MFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiMTIxMDUy
-        ODZkN2Y2NDhjOWI4OWFjNzk3ZGQ1YTZiNWYiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMTo0OS43NzI3NjVaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzE6NDkuODM4ODE2WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMTo1MC4wNzI5ODdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTNhNDItN2QyNC1hYjVmLTg4ZGNj
-        YzI4YjNiZC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
-        cnBtL3JwbS8wMTkyZGYyMC05ZjI5LTczMmItODBhNy03N2FjODQwNzY4NjMv
-        Il0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicGRybjowMTkyZGVh
-        Yi0xNjQ3LTc2NTQtOGJmMS1iNWRmYmI3MzQ1OTE6ZGlzdHJpYnV0aW9ucyIs
-        InNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmRlYWItMTY0Ny03NjU0LThi
-        ZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:31:50 GMT
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiZTU2ODI0
+        YTZhNTQxNDNlNzk5MTg4Mzg2MmQyYzNhY2UiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjQ5LjQ1MTI2M1oi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjo0OS41Mzk4ODRaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjUwLjEwODc4OFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmFlYi03ZTdlLTk0NWQtZmRlYzk2MzEzZDkwLyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIv
+        cHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0vcnBtLzAxOTVlZTQzLWI3
+        MWUtN2IxMy04YjAwLTM4NDgxZTAzNWUyMC8iXSwicmVzZXJ2ZWRfcmVzb3Vy
+        Y2VzX3JlY29yZCI6WyJwZHJuOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUy
+        OGMyOTEyOWExMzpkaXN0cmlidXRpb25zIiwic2hhcmVkOnBybjpjb3JlLmRv
+        bWFpbjo2ZDNjNjAxZi1mZWFmLTRiOTMtODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:12:50 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-9f29-732b-80a7-77ac84076863/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-b71e-7b13-8b00-38481e035e20/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -781,13 +780,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:50 GMT
+      - Mon, 31 Mar 2025 22:12:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -801,7 +800,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2918f2c8067440f098bde036a9c1b27f
+      - 5b56f18078154768b1abce068b1d8cba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -810,25 +809,25 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzAxOTJkZjIwLTlmMjktNzMyYi04MGE3LTc3YWM4NDA3Njg2My8iLCJw
-        cm4iOiJwcm46cnBtLnJwbWRpc3RyaWJ1dGlvbjowMTkyZGYyMC05ZjI5LTcz
-        MmItODBhNy03N2FjODQwNzY4NjMiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEw
-        LTMwVDIwOjMxOjUwLjA1OTA0NloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
-        MjQtMTAtMzBUMjA6MzE6NTAuMDU5MDY2WiIsImJhc2VfcGF0aCI6IkFDTUVf
+        cnBtLzAxOTVlZTQzLWI3MWUtN2IxMy04YjAwLTM4NDgxZTAzNWUyMC8iLCJw
+        cm4iOiJwcm46cnBtLnJwbWRpc3RyaWJ1dGlvbjowMTk1ZWU0My1iNzFlLTdi
+        MTMtOGIwMC0zODQ4MWUwMzVlMjAiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAz
+        LTMxVDIyOjEyOjUwLjA4MTEzMFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
+        MjUtMDMtMzFUMjI6MTI6NTAuMDgxMTUzWiIsImJhc2VfcGF0aCI6IkFDTUVf
         Q29ycG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJi
         YXNlX3VybCI6Imh0dHBzOi8vY2VudG9zOS1rYXRlbGxvLWRldmVsLXN0YWJs
         ZS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9k
         ZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJk
-        IjpudWxsLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6IjIwMjQtMTAtMzBU
-        MjA6MzE6NTAuMDU5MDY2WiIsImhpZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxz
+        IjpudWxsLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6IjIwMjUtMDMtMzFU
+        MjI6MTI6NTAuMDgxMTUzWiIsImhpZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxz
         Ijp7fSwibmFtZSI6IjJfZHVwbGljYXRlIiwicmVwb3NpdG9yeSI6bnVsbCwi
         cHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtOWMwYi03ZTk2LTljOGEtNDVmYWExMzczODhlLyIsImdl
+        cG0vMDE5NWVlNDMtYjBmYS03ZWQzLTkyMWQtN2M4MWYzNzYwM2YyLyIsImdl
         bmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX0=
-  recorded_at: Wed, 30 Oct 2024 20:31:50 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:50 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0192df20-998c-71fd-9c17-69d841f09b93/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0195ee43-ad94-758c-a6b2-25a070b5bac2/
     body:
       encoding: UTF-8
       base64_string: |
@@ -851,13 +850,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:50 GMT
+      - Mon, 31 Mar 2025 22:12:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -871,7 +870,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 42704b1a93f743179aee7710e106695f
+      - 4312cacaf6f44c29bf27e4f4b3c8db72
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -879,9 +878,9 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWExMWEtN2Ni
-        OS05YWJkLTViY2QxOGJmMTgwYi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:50 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWJhNDctNzA0
+        MS05ZjUyLWMwZWU4ZWE1MTVmMi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:50 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -905,13 +904,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:50 GMT
+      - Mon, 31 Mar 2025 22:12:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -925,7 +924,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 00bbc902dd9841c881624fec95e35c7a
+      - f82e0028950944fc8ce4e196f2e56e93
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -935,25 +934,25 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMDE5MmRmMjAtOWYyOS03MzJiLTgwYTctNzdhYzg0MDc2ODYz
-        LyIsInBybiI6InBybjpycG0ucnBtZGlzdHJpYnV0aW9uOjAxOTJkZjIwLTlm
-        MjktNzMyYi04MGE3LTc3YWM4NDA3Njg2MyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMTAtMzBUMjA6MzE6NTAuMDU5MDQ2WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0xMC0zMFQyMDozMTo1MC4wNTkwNjZaIiwiYmFzZV9wYXRoIjoi
+        L3JwbS9ycG0vMDE5NWVlNDMtYjcxZS03YjEzLThiMDAtMzg0ODFlMDM1ZTIw
+        LyIsInBybiI6InBybjpycG0ucnBtZGlzdHJpYnV0aW9uOjAxOTVlZTQzLWI3
+        MWUtN2IxMy04YjAwLTM4NDgxZTAzNWUyMCIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjUtMDMtMzFUMjI6MTI6NTAuMDgxMTMwWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNS0wMy0zMVQyMjoxMjo1MC4wODExNTNaIiwiYmFzZV9wYXRoIjoi
         QUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJl
         bCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwt
         c3RhYmxlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01FX0NvcnBvcmF0
         aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIsImNvbnRlbnRf
-        Z3VhcmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNC0x
-        MC0zMFQyMDozMTo1MC4wNTkwNjZaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9s
+        Z3VhcmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNS0w
+        My0zMVQyMjoxMjo1MC4wODExNTNaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9s
         YWJlbHMiOnt9LCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJyZXBvc2l0b3J5Ijpu
         dWxsLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
-        cnBtL3JwbS8wMTkyZGYyMC05YzBiLTdlOTYtOWM4YS00NWZhYTEzNzM4OGUv
+        cnBtL3JwbS8wMTk1ZWU0My1iMGZhLTdlZDMtOTIxZC03YzgxZjM3NjAzZjIv
         IiwiZ2VuZXJhdGVfcmVwb19jb25maWciOmZhbHNlfV19
-  recorded_at: Wed, 30 Oct 2024 20:31:50 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df20-9c0b-7e96-9c8a-45faa137388e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee43-b0fa-7ed3-921d-7c81f37603f2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -974,19 +973,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:50 GMT
+      - Mon, 31 Mar 2025 22:12:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -994,7 +993,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cf150aaf546a41e18547694556866c27
+      - bd25b19178cc45e8a3ce0f3ab05b4d77
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1003,31 +1002,31 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtOWMwYi03ZTk2LTljOGEtNDVmYWExMzczODhlLyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjAtOWMwYi03ZTk2
-        LTljOGEtNDVmYWExMzczODhlIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMTo0OS4yNjIwOTFaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMxOjQ5LjQxNTc5NVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAt
-        OTk4Yy03MWZkLTljMTctNjlkODQxZjA5YjkzL3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDMtYjBmYS03ZWQzLTkyMWQtN2M4MWYzNzYwM2YyLyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDMtYjBmYS03ZWQz
+        LTkyMWQtN2M4MWYzNzYwM2YyIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMjo0OC41MDk3NDZaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjEyOjQ4Ljc5ODYxMVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDMt
+        YWQ5NC03NThjLWE2YjItMjVhMDcwYjViYWMyL3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMC05OThjLTcxZmQtOWMxNy02OWQ4NDFmMDliOTMvIiwiY2hlY2tz
+        MTk1ZWU0My1hZDk0LTc1OGMtYTZiMi0yNWEwNzBiNWJhYzIvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:50 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:51 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-9f29-732b-80a7-77ac84076863/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-b71e-7b13-8b00-38481e035e20/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE5
-        MmRmMjAtOWMwYi03ZTk2LTljOGEtNDVmYWExMzczODhlLyJ9
+        NWVlNDMtYjBmYS03ZWQzLTkyMWQtN2M4MWYzNzYwM2YyLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1045,13 +1044,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:50 GMT
+      - Mon, 31 Mar 2025 22:12:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1065,7 +1064,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 853c653d41f644e795ec3a4a99855f6f
+      - d694f022d8fc44029d85765739d40b7b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1073,12 +1072,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWEyMjUtN2Q1
-        NC1hY2JhLWQ0MGIyODM5OWFhNC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:50 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWJjMzYtN2Qz
+        Yi1hY2RlLTZmZGFkZGIxZWZhZC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-a225-7d54-acba-d40b28399aa4/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-bc36-7d3b-acde-6fdaddb1efad/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1086,7 +1085,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1099,19 +1098,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:50 GMT
+      - Mon, 31 Mar 2025 22:12:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '788'
+      - '769'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1119,7 +1118,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8f6cf577ffd344d190eeb3eb9a4bfeac
+      - 7c8febfa75ab4afd86d0b95bcb1a2bd5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1127,28 +1126,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtYTIy
-        NS03ZDU0LWFjYmEtZDQwYjI4Mzk5YWE0LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtYTIyNS03ZDU0LWFjYmEtZDQwYjI4Mzk5YWE0IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMTo1MC44MjE4MTFaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjUwLjgyMTgyOFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtYmMz
+        Ni03ZDNiLWFjZGUtNmZkYWRkYjFlZmFkLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtYmMzNi03ZDNiLWFjZGUtNmZkYWRkYjFlZmFkIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjo1MS4zODMzMTZaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjUxLjM4MzM0MFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiODUzYzY1
-        M2Q0MWY2NDRlNzk1ZWMzYTRhOTk4NTVmNmYiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMTo1MC44Mzc2MTJaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzE6NTAuODQwNTAxWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMTo1MC44NTcxMDNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJkZWFiLTE2NDctNzY1NC04YmYxLWI1ZGZiYjczNDU5MTpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyZGVhYi0xNjQ3LTc2
-        NTQtOGJmMS1iNWRmYmI3MzQ1OTEiXX0=
-  recorded_at: Wed, 30 Oct 2024 20:31:50 GMT
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiZDY5NGYw
+        MjJkOGZjNDQwMjlkODU3NjU3MzlkNDBiN2IiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjUxLjQwMzcwMloi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjo1MS40MDY4MDlaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjUxLjQzMzYyN1oiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjpudWxsLCJwYXJlbnRfdGFzayI6bnVsbCwi
+        Y2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19y
+        ZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbInBkcm46NmQzYzYwMWYtZmVhZi00YjkzLTgy
+        NjQtNTI4YzI5MTI5YTEzOmRpc3RyaWJ1dGlvbnMiLCJzaGFyZWQ6cHJuOmNv
+        cmUuZG9tYWluOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUyOGMyOTEyOWEx
+        MyJdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df20-9c0b-7e96-9c8a-45faa137388e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee43-b0fa-7ed3-921d-7c81f37603f2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1169,19 +1168,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:51 GMT
+      - Mon, 31 Mar 2025 22:12:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1189,7 +1188,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 787563ddf1284a3bb48b4b3ef796654e
+      - d2437d98f4ec4296a44976f4681625a5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1198,31 +1197,31 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtOWMwYi03ZTk2LTljOGEtNDVmYWExMzczODhlLyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjAtOWMwYi03ZTk2
-        LTljOGEtNDVmYWExMzczODhlIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMTo0OS4yNjIwOTFaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMxOjQ5LjQxNTc5NVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAt
-        OTk4Yy03MWZkLTljMTctNjlkODQxZjA5YjkzL3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDMtYjBmYS03ZWQzLTkyMWQtN2M4MWYzNzYwM2YyLyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDMtYjBmYS03ZWQz
+        LTkyMWQtN2M4MWYzNzYwM2YyIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMjo0OC41MDk3NDZaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjEyOjQ4Ljc5ODYxMVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDMt
+        YWQ5NC03NThjLWE2YjItMjVhMDcwYjViYWMyL3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMC05OThjLTcxZmQtOWMxNy02OWQ4NDFmMDliOTMvIiwiY2hlY2tz
+        MTk1ZWU0My1hZDk0LTc1OGMtYTZiMi0yNWEwNzBiNWJhYzIvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:51 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:51 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-9f29-732b-80a7-77ac84076863/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-b71e-7b13-8b00-38481e035e20/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE5
-        MmRmMjAtOWMwYi03ZTk2LTljOGEtNDVmYWExMzczODhlLyJ9
+        NWVlNDMtYjBmYS03ZWQzLTkyMWQtN2M4MWYzNzYwM2YyLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1240,13 +1239,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:51 GMT
+      - Mon, 31 Mar 2025 22:12:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1260,7 +1259,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 13d578a99d0a4302930977dae3857c29
+      - ccfc77db99e448978c8c048f8e3e7a95
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1268,12 +1267,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWEzNDYtNzdh
-        Yi04OGM5LTQ1ZDFkMTYyNDIzNS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:51 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWJlMzYtNzI3
+        My05OWZmLTQwNWQ5MGEzMTk3Yi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:51 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-9f29-732b-80a7-77ac84076863/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-b71e-7b13-8b00-38481e035e20/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1294,13 +1293,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:51 GMT
+      - Mon, 31 Mar 2025 22:12:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1314,7 +1313,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 81f62fbb2eb44fa492acbabd84c1b578
+      - 365cb31d53ba423b9e2054d49f5d7995
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1322,12 +1321,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWEzZTgtNzcz
-        ZS1hNmI2LWRiMjMyZTA4ZGJkZi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:51 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWJmMWItN2Nl
+        OC04OWYzLTE3OTkzNDRmZmQ1My8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:52 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df20-98b0-7120-8258-2d52cd7333b0/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee43-ac51-7394-8bde-0eb35089a5f2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1348,13 +1347,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:51 GMT
+      - Mon, 31 Mar 2025 22:12:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1368,7 +1367,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8b3b23e14b8a4c079a1d785057108425
+      - 2349f2442dca4ece8deaf4ffcdb5c87e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1376,12 +1375,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWE0ZTUtNzRi
-        Ny04NWEyLTUxYzAzMzU5ZDZkYi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:51 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWMwYWUtN2Qx
+        Zi04YTdlLWFhN2Q3ZDBmZTM2MC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:52 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-a4e5-74b7-85a2-51c03359d6db/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-c0ae-7d1f-8a7e-aa7d7d0fe360/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1389,7 +1388,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1402,19 +1401,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:51 GMT
+      - Mon, 31 Mar 2025 22:12:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '843'
+      - '824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1422,7 +1421,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ceabcbe725ad418abd784a842bdc20d5
+      - c85268d352b34118ae6104ee8df871ea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1430,29 +1429,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtYTRl
-        NS03NGI3LTg1YTItNTFjMDMzNTlkNmRiLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtYTRlNS03NGI3LTg1YTItNTFjMDMzNTlkNmRiIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMTo1MS41MjYyMjhaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjUxLjUyNjI0NVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtYzBh
+        ZS03ZDFmLThhN2UtYWE3ZDdkMGZlMzYwLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtYzBhZS03ZDFmLThhN2UtYWE3ZDdkMGZlMzYwIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjo1Mi41Mjc5NDhaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjUyLjUyNzk3MFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiOGIzYjIz
-        ZTE0YjhhNGMwNzlhMWQ3ODUwNTcxMDg0MjUiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMTo1MS41NDEwOTFaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzE6NTEuNTkxMzQ5WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMTo1MS42NDU5NTFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTM5Y2YtNzZkNS05ODQ5LWY1MGRm
-        NjYxZWZiNC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpycG0ucnBtcmVtb3RlOjAxOTJkZjIwLTk4YjAtNzEyMC04MjU4
-        LTJkNTJjZDczMzNiMCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmRl
-        YWItMTY0Ny03NjU0LThiZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:31:51 GMT
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiMjM0OWYy
+        NDQyZGNhNGVjZThkZWFmNGZmY2RiNWM4N2UiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjUyLjU0ODMxMloi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjo1Mi42MzE5NTVaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjUyLjcxMzIxMFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmFlYi03ZTdlLTk0NWQtZmRlYzk2MzEzZDkwLyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10s
+        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOnJwbS5ycG1yZW1v
+        dGU6MDE5NWVlNDMtYWM1MS03Mzk0LThiZGUtMGViMzUwODlhNWYyIiwic2hh
+        cmVkOnBybjpjb3JlLmRvbWFpbjo2ZDNjNjAxZi1mZWFmLTRiOTMtODI2NC01
+        MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:12:52 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0192df20-998c-71fd-9c17-69d841f09b93/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0195ee43-ad94-758c-a6b2-25a070b5bac2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1473,13 +1472,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:51 GMT
+      - Mon, 31 Mar 2025 22:12:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1493,7 +1492,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a7ad70e6a52c40fb9328160fc7f253cc
+      - 980078a21ad94729a3f7b1e7d41d3e4d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1501,12 +1500,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWE2MTQtNzk4
-        MS1hY2Y4LWVhYmY5ZDE2NTc2OC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:51 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWMzMGUtNzEx
+        Ny1hZTg3LTg4ZWE2MDM1NjZiNy8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:53 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-a614-7981-acf8-eabf9d165768/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-c30e-7117-ae87-88ea603566b7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1514,7 +1513,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1527,19 +1526,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:52 GMT
+      - Mon, 31 Mar 2025 22:12:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '847'
+      - '828'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1547,7 +1546,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 58aeb892969b4503bf03d8d61d0fb2e6
+      - 87ff62967a5e40749ad3053abbfd078d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1555,29 +1554,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtYTYx
-        NC03OTgxLWFjZjgtZWFiZjlkMTY1NzY4LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtYTYxNC03OTgxLWFjZjgtZWFiZjlkMTY1NzY4IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMTo1MS44Mjg4MTRaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjUxLjgyODgzMloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtYzMw
+        ZS03MTE3LWFlODctODhlYTYwMzU2NmI3LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtYzMwZS03MTE3LWFlODctODhlYTYwMzU2NmI3IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjo1My4xMzU3OTZaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjUzLjEzNTgyMFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiYTdhZDcw
-        ZTZhNTJjNDBmYjkzMjgxNjBmYzdmMjUzY2MiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMTo1MS44NDcyMjlaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzE6NTEuOTI0MjI3WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMTo1Mi4wNzg0MjBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTM4NWUtNzhiMS04OTViLTBlODQ2
-        ODBjMTFmNy8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpycG0ucnBtcmVwb3NpdG9yeTowMTkyZGYyMC05OThjLTcxZmQt
-        OWMxNy02OWQ4NDFmMDliOTMiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAx
-        OTJkZWFiLTE2NDctNzY1NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:52 GMT
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiOTgwMDc4
+        YTIxYWQ5NDcyOWEzZjdiMWU3ZDQxZDNlNGQiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjUzLjE1NzYyOFoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjo1My4yNjQwMjJaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjUzLjYzMDUxNFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmNmMC03ZjU5LWFhZmEtYzAyYzY0YmU5Nzk2LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10s
+        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOnJwbS5ycG1yZXBv
+        c2l0b3J5OjAxOTVlZTQzLWFkOTQtNzU4Yy1hNmIyLTI1YTA3MGI1YmFjMiIs
+        InNoYXJlZDpwcm46Y29yZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgy
+        NjQtNTI4YzI5MTI5YTEzIl19
+  recorded_at: Mon, 31 Mar 2025 22:12:53 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1585,7 +1584,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.22.2/ruby
+      - OpenAPI-Generator/0.22.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1598,13 +1597,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:52 GMT
+      - Mon, 31 Mar 2025 22:12:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1618,7 +1617,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3b26eb56760e425eaa41bbdff5d80dd4
+      - 6c06693267e845fa83321509491651d2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1628,7 +1627,385 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:52 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.3.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - cdbdad60c5d64282819a592de103c186
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.22.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3cd8b073b3394e84aef3985c2f0d5a88
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - c09f49d1d898469baa076f7a3a26e1f6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.4.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 005f477d0b76480bb59a98a6449855c3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.12.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - a41ee9f536c54e4f81303416a0204df4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.27.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 974a13ae764c407a9f05c6a71eafa8be
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.22.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - d0762bd66bd64f8eb5b5c7e9a02d5721
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:54 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -1652,13 +2029,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:52 GMT
+      - Mon, 31 Mar 2025 22:12:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1672,7 +2049,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3a4a735f3a334d6b86623c5bfe7e5fad
+      - 827982e908f44f2584a240a286612bfb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1682,7 +2059,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:52 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:55 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -1693,7 +2070,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.21.1/ruby
+      - OpenAPI-Generator/2.22.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1706,13 +2083,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:52 GMT
+      - Mon, 31 Mar 2025 22:12:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1726,7 +2103,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e6cd784a85af4d74a9a8d8601e0c8528
+      - 73f0cd3a9be84cdc8919249560cdb864
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1736,7 +2113,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:52 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:55 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -1747,7 +2124,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1760,13 +2137,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:52 GMT
+      - Mon, 31 Mar 2025 22:12:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1780,7 +2157,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 55e0f1128e3140d582c268fce0ca1932
+      - 9102997448424b169c65c681d6ef2bda
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1790,7 +2167,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:52 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:55 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -1801,7 +2178,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.4.4/ruby
+      - OpenAPI-Generator/2.4.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -1814,13 +2191,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:52 GMT
+      - Mon, 31 Mar 2025 22:12:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1834,7 +2211,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ded763eb3596423a9b5959c42fc87158
+      - 8a4bc52b27da458aa1efc8377742c92b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1844,7 +2221,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:52 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:55 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -1855,7 +2232,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.12.5/ruby
+      - OpenAPI-Generator/3.12.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -1868,13 +2245,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:52 GMT
+      - Mon, 31 Mar 2025 22:12:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1888,7 +2265,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 63a99fb9374e4c3db00e52b9f1ece144
+      - 3e234e705bad4df2a8070b79d392e3e1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1898,7 +2275,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:52 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:55 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -1922,13 +2299,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:52 GMT
+      - Mon, 31 Mar 2025 22:12:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1942,7 +2319,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a8428665a7b347758d1cefe643fd17d9
+      - 9717529de63b4f608545fbfab5f5b94e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1952,7 +2329,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:52 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:55 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/orphans/cleanup/
@@ -1965,7 +2342,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1978,13 +2355,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:52 GMT
+      - Mon, 31 Mar 2025 22:12:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - POST, OPTIONS
       X-Frame-Options:
@@ -1998,7 +2375,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 464f793014324304a5be59cce266d3a4
+      - 68128bad395b4f589bbad9503a6b40e7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2006,12 +2383,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWE5ZjUtN2Rh
-        OS1iOGU3LWE0OGIzZThhM2JkZC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:52 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWNkNjgtNzMz
+        NS1hMmNhLTlhYjAyODJhOGQ3ZS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:55 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-a9f5-7da9-b8e7-a48b3e8a3bdd/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-cd68-7335-a2ca-9ab0282a8d7e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2019,7 +2396,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2032,19 +2409,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:53 GMT
+      - Mon, 31 Mar 2025 22:12:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1077'
+      - '1058'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2052,7 +2429,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - dc968eaa4b8246e69551f61df7883c29
+      - 4f1965032efe4151a4ef38652155fbbe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2060,31 +2437,31 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtYTlm
-        NS03ZGE5LWI4ZTctYTQ4YjNlOGEzYmRkLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtYTlmNS03ZGE5LWI4ZTctYTQ4YjNlOGEzYmRkIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMTo1Mi44MjE4MTBaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjUyLjgyMTgyOFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtY2Q2
+        OC03MzM1LWEyY2EtOWFiMDI4MmE4ZDdlLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtY2Q2OC03MzM1LWEyY2EtOWFiMDI4MmE4ZDdlIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjo1NS43ODU1MDZaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjU1Ljc4NTUyOVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiI0NjRm
-        NzkzMDE0MzI0MzA0YTViZTU5Y2NlMjY2ZDNhNCIsImNyZWF0ZWRfYnkiOiIv
-        cHVscC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTEw
-        LTMwVDIwOjMxOjUyLjgzODAzOVoiLCJzdGFydGVkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMTo1Mi44ODY0NTNaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTEwLTMw
-        VDIwOjMxOjUzLjA3MzU2M1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1
-        bHAvYXBpL3YzL3dvcmtlcnMvMDE5MmRlYWMtMzg1ZS03OGIxLTg5NWItMGU4
-        NDY4MGMxMWY3LyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6
-        W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1l
-        c3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQ29udGVudCIsImNvZGUiOiJjbGVh
-        bi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwi
-        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJDbGVhbiB1cCBv
-        cnBoYW4gQXJ0aWZhY3RzIiwiY29kZSI6ImNsZWFuLXVwLmFydGlmYWN0cyIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jl
-        c291cmNlc19yZWNvcmQiOlsicGRybjowMTkyZGVhYi0xNjQ3LTc2NTQtOGJm
-        MS1iNWRmYmI3MzQ1OTE6b3JwaGFucyIsInNoYXJlZDpwcm46Y29yZS5kb21h
-        aW46MDE5MmRlYWItMTY0Ny03NjU0LThiZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:31:53 GMT
+        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiI2ODEy
+        OGJhZDM5NWI0ZjU4OWJiYWQ5NTAzYTZiNDBlNyIsImNyZWF0ZWRfYnkiOm51
+        bGwsInVuYmxvY2tlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6NTUuODEwMjYy
+        WiIsInN0YXJ0ZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjU1Ljg4NjEwOVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6NTYuMjEyOTA3WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8w
+        MTk1ZDJlZS1iYWViLTdlN2UtOTQ1ZC1mZGVjOTYzMTNkOTAvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkNsZWFuIHVwIG9y
+        cGhhbiBDb250ZW50IiwiY29kZSI6ImNsZWFuLXVwLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51
+        bGx9LHsibWVzc2FnZSI6IkNsZWFuIHVwIG9ycGhhbiBBcnRpZmFjdHMiLCJj
+        b2RlIjoiY2xlYW4tdXAuYXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJw
+        ZHJuOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUyOGMyOTEyOWExMzpvcnBo
+        YW5zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo2ZDNjNjAxZi1mZWFmLTRi
+        OTMtODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:12:56 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/purge/
@@ -2097,7 +2474,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2110,13 +2487,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:53 GMT
+      - Mon, 31 Mar 2025 22:12:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - POST, OPTIONS
       X-Frame-Options:
@@ -2130,7 +2507,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6e496460ead24bf6878906e97d713da3
+      - e5f8e33282b843f4a91e8ad183ebe023
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2138,7 +2515,7 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWFiNmQtNzE2
-        Mi1hNTNjLTk1Y2ZiOWZhMWEyYi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:53 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWQwMmYtN2Rj
+        Ni1iZGEyLTU2ODZiNGYwNzJlMC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:56 GMT
 recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_policy.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_policy.yml
@@ -23,13 +23,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:07 GMT
+      - Mon, 31 Mar 2025 22:12:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a56a25295e3f4273a63e86b1f19aa924
+      - 625faf16e30c411db4e2a1f196adda7c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:07 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:23 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -77,13 +77,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:07 GMT
+      - Mon, 31 Mar 2025 22:12:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '0916af694b3849cda1cf04a8f67b70c5'
+      - 80221d0948ff42eb8770004751a84ca7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:07 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:23 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -131,13 +131,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:07 GMT
+      - Mon, 31 Mar 2025 22:12:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bc80fbbefde24168928a62752e697604
+      - fac60b86dcf84140b9a7d8f344aae51a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:07 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:23 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -185,13 +185,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:07 GMT
+      - Mon, 31 Mar 2025 22:12:23 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 51431d3e1ada4179b80bafbaba9c3e94
+      - 98962743c7b340dea2f49ca3531995d4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:07 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:23 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -247,15 +247,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:07 GMT
+      - Mon, 31 Mar 2025 22:12:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/0192df20-e361-7d38-95f1-974a3dfa37cc/"
+      - "/pulp/api/v3/remotes/rpm/rpm/0195ee43-51bb-7983-b31d-17b1f8c1b27e/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -269,7 +269,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ac0bc0abfa8e4cb890175ddd8651ba3a
+      - 3c8e88758cd4442091411262d3bdb4a2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -278,11 +278,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OTJkZjIwLWUzNjEtN2QzOC05NWYxLTk3NGEzZGZhMzdjYy8iLCJwcm4iOiJw
-        cm46cnBtLnJwbXJlbW90ZTowMTkyZGYyMC1lMzYxLTdkMzgtOTVmMS05NzRh
-        M2RmYTM3Y2MiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjA3
-        LjUyMjA0MFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMTAtMzBUMjA6
-        MzI6MDcuNTIyMDU4WiIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0
+        OTVlZTQzLTUxYmItNzk4My1iMzFkLTE3YjFmOGMxYjI3ZS8iLCJwcm4iOiJw
+        cm46cnBtLnJwbXJlbW90ZTowMTk1ZWU0My01MWJiLTc5ODMtYjMxZC0xN2Ix
+        ZjhjMWIyN2UiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjI0
+        LjEyNDE3MFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUtMDMtMzFUMjI6
+        MTI6MjQuMTI0MTkxWiIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0
         dHA6Ly9teXJlcG8uY29tIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQi
         Om51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGws
         InB1bHBfbGFiZWxzIjp7fSwiZG93bmxvYWRfY29uY3VycmVuY3kiOm51bGws
@@ -295,7 +295,7 @@ http_interactions:
         bWUiOiJwcm94eV9wYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6
         InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfV0sInNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
-  recorded_at: Wed, 30 Oct 2024 20:32:07 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:24 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -321,21 +321,21 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:07 GMT
+      - Mon, 31 Mar 2025 22:12:24 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/0192df20-e421-7336-8dbd-9acf223ca19e/"
+      - "/pulp/api/v3/repositories/rpm/rpm/0195ee43-52ce-7d01-9059-295aacefefad/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '880'
+      - '894'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -343,7 +343,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 71c9505669b140efb8b4ac931c3960ab
+      - 239d992445314438979e32ce811693c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -352,16 +352,16 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMDE5MmRmMjAtZTQyMS03MzM2LThkYmQtOWFjZjIyM2NhMTllLyIsInBy
-        biI6InBybjpycG0ucnBtcmVwb3NpdG9yeTowMTkyZGYyMC1lNDIxLTczMzYt
-        OGRiZC05YWNmMjIzY2ExOWUiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMw
-        VDIwOjMyOjA3LjcxNDIzN1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQt
-        MTAtMzBUMjA6MzI6MDcuNzIzODY0WiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAtZTQyMS03
-        MzM2LThkYmQtOWFjZjIyM2NhMTllL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
+        cG0vMDE5NWVlNDMtNTJjZS03ZDAxLTkwNTktMjk1YWFjZWZlZmFkLyIsInBy
+        biI6InBybjpycG0ucnBtcmVwb3NpdG9yeTowMTk1ZWU0My01MmNlLTdkMDEt
+        OTA1OS0yOTVhYWNlZmVmYWQiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMx
+        VDIyOjEyOjI0LjQwMDM1MVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUt
+        MDMtMzFUMjI6MTI6MjQuNDA1MTQ3WiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDMtNTJjZS03
+        ZDAxLTkwNTktMjk1YWFjZWZlZmFkL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
         Ijp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcnBtL3JwbS8wMTkyZGYyMC1lNDIxLTczMzYtOGRiZC05YWNm
-        MjIzY2ExOWUvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJk
+        c2l0b3JpZXMvcnBtL3JwbS8wMTk1ZWU0My01MmNlLTdkMDEtOTA1OS0yOTVh
+        YWNlZmVmYWQvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJk
         ZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGws
         InJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9z
         aWduaW5nX3NlcnZpY2UiOm51bGwsInBhY2thZ2Vfc2lnbmluZ19zZXJ2aWNl
@@ -370,8 +370,8 @@ http_interactions:
         bWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjpudWxsLCJncGdjaGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6
         bnVsbCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9
-        LCJjb21wcmVzc2lvbl90eXBlIjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:07 GMT
+        LCJjb21wcmVzc2lvbl90eXBlIjpudWxsLCJsYXlvdXQiOm51bGx9
+  recorded_at: Mon, 31 Mar 2025 22:12:24 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -379,8 +379,8 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE5MmRmMjAtZTQyMS03MzM2LThkYmQtOWFjZjIyM2Nh
-        MTllL3ZlcnNpb25zLzAvIiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiJ9
+        aWVzL3JwbS9ycG0vMDE5NWVlNDMtNTJjZS03ZDAxLTkwNTktMjk1YWFjZWZl
+        ZmFkL3ZlcnNpb25zLzAvIiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiJ9
     headers:
       Content-Type:
       - application/json
@@ -398,13 +398,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:08 GMT
+      - Mon, 31 Mar 2025 22:12:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -418,7 +418,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 330780e821654fe7bbcea12c1a76e2c5
+      - ebe047481a1c4d38bbdca6c2ddf6d726
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -426,12 +426,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWU2MjItNzQ1
-        OS04OTIxLWM4MzM2YWUyYzQ4OS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:08 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTU1NGUtN2U3
+        ZC1hNTFlLWE5NjNmYWVlMDg2ZS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:25 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-e622-7459-8921-c8336ae2c489/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-554e-7e7d-a51e-a963faee086e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -439,7 +439,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -452,19 +452,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:08 GMT
+      - Mon, 31 Mar 2025 22:12:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1060'
+      - '1041'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -472,7 +472,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 76ef81d6efd641dfb4a115d50b7de8bc
+      - 76c05b39a66a4f26ada4dabb2932ade9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -480,31 +480,31 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtZTYy
-        Mi03NDU5LTg5MjEtYzgzMzZhZTJjNDg5LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtZTYyMi03NDU5LTg5MjEtYzgzMzZhZTJjNDg5IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjowOC4yMjY1MDJaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjA4LjIyNjUyMFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtNTU0
+        ZS03ZTdkLWE1MWUtYTk2M2ZhZWUwODZlLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtNTU0ZS03ZTdkLWE1MWUtYTk2M2ZhZWUwODZlIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjoyNS4wMzkzNjRaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjI1LjAzOTM4Nloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFz
-        a3MucHVibGlzaGluZy5wdWJsaXNoIiwibG9nZ2luZ19jaWQiOiIzMzA3ODBl
-        ODIxNjU0ZmU3YmJjZWExMmMxYTc2ZTJjNSIsImNyZWF0ZWRfYnkiOiIvcHVs
-        cC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTEwLTMw
-        VDIwOjMyOjA4LjI0NDAyM1oiLCJzdGFydGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjowOC4yOTkzMzRaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTEwLTMwVDIw
-        OjMyOjA4LjQ5MDg2MVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
-        YXBpL3YzL3dvcmtlcnMvMDE5MmRlYWMtM2E0Mi03ZDI0LWFiNWYtODhkY2Nj
-        MjhiM2JkLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10s
-        InRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3Nh
-        Z2UiOiJHZW5lcmF0aW5nIHJlcG9zaXRvcnkgbWV0YWRhdGEiLCJjb2RlIjoi
-        cHVibGlzaC5nZW5lcmF0aW5nX21ldGFkYXRhIiwic3RhdGUiOiJjb21wbGV0
-        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
-        ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBt
-        L3JwbS8wMTkyZGYyMC1lNjdmLTdiNDgtOWNkOC1jYmI3YzFiOWRlMmUvIl0s
-        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsic2hhcmVkOnBybjpycG0u
-        cnBtcmVwb3NpdG9yeTowMTkyZGYyMC1lNDIxLTczMzYtOGRiZC05YWNmMjIz
-        Y2ExOWUiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAxOTJkZWFiLTE2NDct
-        NzY1NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:08 GMT
+        a3MucHVibGlzaGluZy5wdWJsaXNoIiwibG9nZ2luZ19jaWQiOiJlYmUwNDc0
+        ODFhMWM0ZDM4YmJkY2E2YzJkZGY2ZDcyNiIsImNyZWF0ZWRfYnkiOm51bGws
+        InVuYmxvY2tlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6MjUuMDY5MDQzWiIs
+        InN0YXJ0ZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjI1LjE0NjcyOVoiLCJm
+        aW5pc2hlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6MjUuNDc3ODYyWiIsImVy
+        cm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTk1
+        ZDJlZS1iYjkyLTdjM2ItOWY1MS1lOThhOWVlMjhiYTQvIiwicGFyZW50X3Rh
+        c2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVsbCwi
+        cHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkdlbmVyYXRpbmcgcmVw
+        b3NpdG9yeSBtZXRhZGF0YSIsImNvZGUiOiJwdWJsaXNoLmdlbmVyYXRpbmdf
+        bWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25l
+        IjoxLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1
+        bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBtLzAxOTVlZTQzLTU1ZDgt
+        N2M4Yi04MjA1LWU2MWVjNzIyN2EyYi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
+        X3JlY29yZCI6WyJzaGFyZWQ6cHJuOnJwbS5ycG1yZXBvc2l0b3J5OjAxOTVl
+        ZTQzLTUyY2UtN2QwMS05MDU5LTI5NWFhY2VmZWZhZCIsInNoYXJlZDpwcm46
+        Y29yZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgyNjQtNTI4YzI5MTI5
+        YTEzIl19
+  recorded_at: Mon, 31 Mar 2025 22:12:25 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -528,13 +528,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:08 GMT
+      - Mon, 31 Mar 2025 22:12:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -548,7 +548,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e94feceaa0bc413aa5a5694677ef582f
+      - e805fa5df66544bea147f017ecefdbf7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -558,10 +558,10 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:08 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:25 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df20-e67f-7b48-9cd8-cbb7c1b9de2e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee43-55d8-7c8b-8205-e61ec7227a2b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -582,19 +582,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:08 GMT
+      - Mon, 31 Mar 2025 22:12:25 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -602,7 +602,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e430f8d95b974bc887824950a764b60f
+      - 6ace9c648129484aae6be9fa7b80a04f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -611,21 +611,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtZTY3Zi03YjQ4LTljZDgtY2JiN2MxYjlkZTJlLyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjAtZTY3Zi03YjQ4
-        LTljZDgtY2JiN2MxYjlkZTJlIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMjowOC4zMjE0MThaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMyOjA4LjQ4MjEwM1oiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAt
-        ZTQyMS03MzM2LThkYmQtOWFjZjIyM2NhMTllL3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDMtNTVkOC03YzhiLTgyMDUtZTYxZWM3MjI3YTJiLyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDMtNTVkOC03Yzhi
+        LTgyMDUtZTYxZWM3MjI3YTJiIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMjoyNS4xODI5NDBaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjEyOjI1LjQ2ODg4NVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDMt
+        NTJjZS03ZDAxLTkwNTktMjk1YWFjZWZlZmFkL3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMC1lNDIxLTczMzYtOGRiZC05YWNmMjIzY2ExOWUvIiwiY2hlY2tz
+        MTk1ZWU0My01MmNlLTdkMDEtOTA1OS0yOTVhYWNlZmVmYWQvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:08 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:25 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/
@@ -635,8 +635,8 @@ http_interactions:
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vMDE5MmRmMjAtZTY3Zi03YjQ4LTljZDgtY2Ji
-        N2MxYjlkZTJlLyJ9
+        bGljYXRpb25zL3JwbS9ycG0vMDE5NWVlNDMtNTVkOC03YzhiLTgyMDUtZTYx
+        ZWM3MjI3YTJiLyJ9
     headers:
       Content-Type:
       - application/json
@@ -654,13 +654,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:08 GMT
+      - Mon, 31 Mar 2025 22:12:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -674,7 +674,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 94e177f3c6724daabf0fba2d3670502e
+      - 3ae4f0d0ad444aa6b4126bc202da348b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -682,12 +682,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWU4NzQtNzRk
-        ZC05NTY5LTNmZDRhMjllYTBiNy8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:08 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTU5ODEtNzEy
+        ZC1hNjFjLTVjMGIzMWYwNWYwZi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:26 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-e874-74dd-9569-3fd4a29ea0b7/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-5981-712d-a61c-5c0b31f05f0f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -695,7 +695,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -708,19 +708,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:09 GMT
+      - Mon, 31 Mar 2025 22:12:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '918'
+      - '899'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -728,7 +728,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e10882abc4e3494ab73b1d9a0cb6784f
+      - 2aabf6958c31417a8993b2e809ed2b6e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -736,31 +736,30 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtZTg3
-        NC03NGRkLTk1NjktM2ZkNGEyOWVhMGI3LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtZTg3NC03NGRkLTk1NjktM2ZkNGEyOWVhMGI3IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjowOC44MjEzMjJaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjA4LjgyMTM0N1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtNTk4
+        MS03MTJkLWE2MWMtNWMwYjMxZjA1ZjBmLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtNTk4MS03MTJkLWE2MWMtNWMwYjMxZjA1ZjBmIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjoyNi4xMTUwNDBaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjI2LjExNTA2M1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiOTRlMTc3
-        ZjNjNjcyNGRhYWJmMGZiYTJkMzY3MDUwMmUiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjowOC44NDMwMjNaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MDguOTA2MTMxWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjowOS4yMTkyNDlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTM4NWUtNzhiMS04OTViLTBlODQ2
-        ODBjMTFmNy8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
-        cnBtL3JwbS8wMTkyZGYyMC1lOWViLTdhNjItOWM1ZS1mOWQ2NjI3YzY2ODAv
-        Il0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicGRybjowMTkyZGVh
-        Yi0xNjQ3LTc2NTQtOGJmMS1iNWRmYmI3MzQ1OTE6ZGlzdHJpYnV0aW9ucyIs
-        InNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmRlYWItMTY0Ny03NjU0LThi
-        ZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:32:09 GMT
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiM2FlNGYw
+        ZDBhZDQ0NGFhNmI0MTI2YmMyMDJkYTM0OGIiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjI2LjEzNzM4N1oi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjoyNi4yMTgwMTRaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjI2LjgyMzU2OFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmI5Mi03YzNiLTlmNTEtZTk4YTllZTI4YmE0LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIv
+        cHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0vcnBtLzAxOTVlZTQzLTVj
+        MjMtN2Y3MS1hMjc2LTE4MDk0ZjI5NThmMy8iXSwicmVzZXJ2ZWRfcmVzb3Vy
+        Y2VzX3JlY29yZCI6WyJwZHJuOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUy
+        OGMyOTEyOWExMzpkaXN0cmlidXRpb25zIiwic2hhcmVkOnBybjpjb3JlLmRv
+        bWFpbjo2ZDNjNjAxZi1mZWFmLTRiOTMtODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:12:26 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-e9eb-7a62-9c5e-f9d6627c6680/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-5c23-7f71-a276-18094f2958f3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -781,13 +780,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:09 GMT
+      - Mon, 31 Mar 2025 22:12:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -801,7 +800,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4bd170ad2ecb47578360590bdf4600f7
+      - b7d1e8e9721c402594c53ffff72b65b1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -810,22 +809,22 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzAxOTJkZjIwLWU5ZWItN2E2Mi05YzVlLWY5ZDY2MjdjNjY4MC8iLCJw
-        cm4iOiJwcm46cnBtLnJwbWRpc3RyaWJ1dGlvbjowMTkyZGYyMC1lOWViLTdh
-        NjItOWM1ZS1mOWQ2NjI3YzY2ODAiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEw
-        LTMwVDIwOjMyOjA5LjE5NzYzMFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
-        MjQtMTAtMzBUMjA6MzI6MDkuMTk3NjY5WiIsImJhc2VfcGF0aCI6IkFDTUVf
+        cnBtLzAxOTVlZTQzLTVjMjMtN2Y3MS1hMjc2LTE4MDk0ZjI5NThmMy8iLCJw
+        cm4iOiJwcm46cnBtLnJwbWRpc3RyaWJ1dGlvbjowMTk1ZWU0My01YzIzLTdm
+        NzEtYTI3Ni0xODA5NGYyOTU4ZjMiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAz
+        LTMxVDIyOjEyOjI2Ljc5MDIyM1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
+        MjUtMDMtMzFUMjI6MTI6MjYuNzkwMjQ2WiIsImJhc2VfcGF0aCI6IkFDTUVf
         Q29ycG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJi
         YXNlX3VybCI6Imh0dHBzOi8vY2VudG9zOS1rYXRlbGxvLWRldmVsLXN0YWJs
         ZS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9k
         ZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJk
-        IjpudWxsLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MDkuMTk3NjY5WiIsImhpZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxz
+        IjpudWxsLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6IjIwMjUtMDMtMzFU
+        MjI6MTI6MjYuNzkwMjQ2WiIsImhpZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxz
         Ijp7fSwibmFtZSI6IjJfZHVwbGljYXRlIiwicmVwb3NpdG9yeSI6bnVsbCwi
         cHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtZTY3Zi03YjQ4LTljZDgtY2JiN2MxYjlkZTJlLyIsImdl
+        cG0vMDE5NWVlNDMtNTVkOC03YzhiLTgyMDUtZTYxZWM3MjI3YTJiLyIsImdl
         bmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX0=
-  recorded_at: Wed, 30 Oct 2024 20:32:09 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:27 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -860,15 +859,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:09 GMT
+      - Mon, 31 Mar 2025 22:12:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/0192df20-ebb2-7a06-8263-e5e57167c459/"
+      - "/pulp/api/v3/remotes/rpm/rpm/0195ee43-5e5a-7ba9-a742-d495eda527d8/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -882,7 +881,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d9ced39f6c4a4b7cb7c0bd7b046a7b30
+      - f8ff2c6365c84692bcafa5198f32e6a5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -891,11 +890,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OTJkZjIwLWViYjItN2EwNi04MjYzLWU1ZTU3MTY3YzQ1OS8iLCJwcm4iOiJw
-        cm46cnBtLnJwbXJlbW90ZTowMTkyZGYyMC1lYmIyLTdhMDYtODI2My1lNWU1
-        NzE2N2M0NTkiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjA5
-        LjY1MTQ5N1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMTAtMzBUMjA6
-        MzI6MDkuNjUxNTE4WiIsIm5hbWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJs
+        OTVlZTQzLTVlNWEtN2JhOS1hNzQyLWQ0OTVlZGE1MjdkOC8iLCJwcm4iOiJw
+        cm46cnBtLnJwbXJlbW90ZTowMTk1ZWU0My01ZTVhLTdiYTktYTc0Mi1kNDk1
+        ZWRhNTI3ZDgiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjI3
+        LjM1NTI5MloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUtMDMtMzFUMjI6
+        MTI6MjcuMzU1MzE3WiIsIm5hbWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJs
         IjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0IjoiS0pMOktERiooREYm
         KigqJCYoKiMkSkxLSkQoRCgoRCIsImNsaWVudF9jZXJ0IjoiS0pMOktERioo
         REYmKigqJCYoKiMkSkxLSkQoRCgoRCIsInRsc192YWxpZGF0aW9uIjpmYWxz
@@ -910,10 +909,10 @@ http_interactions:
         dCI6ZmFsc2V9LHsibmFtZSI6InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0s
         eyJuYW1lIjoicGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfV0sInNsZXNfYXV0
         aF90b2tlbiI6bnVsbH0=
-  recorded_at: Wed, 30 Oct 2024 20:32:09 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:27 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df20-ebb2-7a06-8263-e5e57167c459/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee43-5e5a-7ba9-a742-d495eda527d8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -934,13 +933,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:09 GMT
+      - Mon, 31 Mar 2025 22:12:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -954,7 +953,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6b38b895d1d14b048846ddef9de40bb3
+      - 3f314b1a84094130bbf31b6f023c1d81
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -962,12 +961,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWVjMDAtN2Ji
-        MC04YTIyLWY1NTkyMmMxY2QzMC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:09 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTVlZGEtN2Q4
+        MS04NDk3LTg5NDU3MGU0YjhmYS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:27 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0192df20-e421-7336-8dbd-9acf223ca19e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0195ee43-52ce-7d01-9059-295aacefefad/
     body:
       encoding: UTF-8
       base64_string: |
@@ -990,13 +989,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:10 GMT
+      - Mon, 31 Mar 2025 22:12:27 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1010,7 +1009,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ab44df209d4848ecb68f854d40981465
+      - 19a3a35c397e4f9a8b96eae48065ecb3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1018,12 +1017,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWVkZGEtNzNj
-        NC1hYWExLWVkOTNjMDNlMzM0YS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:10 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTYwMWMtNzQx
+        NC04NWFmLWU3OTdiNjA5YjczMS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:27 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df20-e361-7d38-95f1-974a3dfa37cc/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee43-51bb-7983-b31d-17b1f8c1b27e/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1055,13 +1054,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:10 GMT
+      - Mon, 31 Mar 2025 22:12:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1075,7 +1074,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e2bf15705e5a46d9864725ba69e2b530
+      - cc4c9da4d9d243368d67dd475091edd3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1083,12 +1082,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWVlN2MtN2Mx
-        NS1iYzM4LTAyYmJiNDYzNTE4My8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:10 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTYxMTItN2Zl
+        Ni1iNDZlLTU1MWY2ZTE1YjMyMy8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:28 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-ee7c-7c15-bc38-02bbb4635183/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-6112-7fe6-b46e-551f6e15b323/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1096,7 +1095,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1109,19 +1108,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:10 GMT
+      - Mon, 31 Mar 2025 22:12:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '787'
+      - '768'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1129,7 +1128,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4d649944701b4589bf12af8182d46688
+      - 2ddee499071b428f9b98cb04da6bb58a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1137,25 +1136,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtZWU3
-        Yy03YzE1LWJjMzgtMDJiYmI0NjM1MTgzLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtZWU3Yy03YzE1LWJjMzgtMDJiYmI0NjM1MTgzIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoxMC4zNjUwMDRaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjEwLjM2NTAyMVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtNjEx
+        Mi03ZmU2LWI0NmUtNTUxZjZlMTViMzIzLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtNjExMi03ZmU2LWI0NmUtNTUxZjZlMTViMzIzIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjoyOC4wNTE3MjJaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjI4LjA1MTc0Nloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiZTJiZjE1
-        NzA1ZTVhNDZkOTg2NDcyNWJhNjllMmI1MzAiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoxMC4zODc4MTZaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MTAuMzkxMjY1WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoxMC40MDQ5MDBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46cnBt
-        LnJwbXJlbW90ZTowMTkyZGYyMC1lMzYxLTdkMzgtOTVmMS05NzRhM2RmYTM3
-        Y2MiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAxOTJkZWFiLTE2NDctNzY1
-        NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:10 GMT
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiY2M0Yzlk
+        YTRkOWQyNDMzNjhkNjdkZDQ3NTA5MWVkZDMiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjI4LjA3NDA2N1oi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjoyOC4wNzcwNjNaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjI4LjA5NDk0NFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjpudWxsLCJwYXJlbnRfdGFzayI6bnVsbCwi
+        Y2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19y
+        ZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbInBybjpycG0ucnBtcmVtb3RlOjAxOTVlZTQz
+        LTUxYmItNzk4My1iMzFkLTE3YjFmOGMxYjI3ZSIsInNoYXJlZDpwcm46Y29y
+        ZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgyNjQtNTI4YzI5MTI5YTEz
+        Il19
+  recorded_at: Mon, 31 Mar 2025 22:12:28 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -1179,13 +1178,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:10 GMT
+      - Mon, 31 Mar 2025 22:12:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1199,7 +1198,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 725b86c61646414d97e8df016c796ec8
+      - 45b55eee2910408b98a29a112d2f3659
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1209,25 +1208,25 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMDE5MmRmMjAtZTllYi03YTYyLTljNWUtZjlkNjYyN2M2Njgw
-        LyIsInBybiI6InBybjpycG0ucnBtZGlzdHJpYnV0aW9uOjAxOTJkZjIwLWU5
-        ZWItN2E2Mi05YzVlLWY5ZDY2MjdjNjY4MCIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMTAtMzBUMjA6MzI6MDkuMTk3NjMwWiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0xMC0zMFQyMDozMjowOS4xOTc2NjlaIiwiYmFzZV9wYXRoIjoi
+        L3JwbS9ycG0vMDE5NWVlNDMtNWMyMy03ZjcxLWEyNzYtMTgwOTRmMjk1OGYz
+        LyIsInBybiI6InBybjpycG0ucnBtZGlzdHJpYnV0aW9uOjAxOTVlZTQzLTVj
+        MjMtN2Y3MS1hMjc2LTE4MDk0ZjI5NThmMyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjUtMDMtMzFUMjI6MTI6MjYuNzkwMjIzWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNS0wMy0zMVQyMjoxMjoyNi43OTAyNDZaIiwiYmFzZV9wYXRoIjoi
         QUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJl
         bCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwt
         c3RhYmxlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01FX0NvcnBvcmF0
         aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIsImNvbnRlbnRf
-        Z3VhcmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNC0x
-        MC0zMFQyMDozMjowOS4xOTc2NjlaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9s
+        Z3VhcmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNS0w
+        My0zMVQyMjoxMjoyNi43OTAyNDZaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9s
         YWJlbHMiOnt9LCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJyZXBvc2l0b3J5Ijpu
         dWxsLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
-        cnBtL3JwbS8wMTkyZGYyMC1lNjdmLTdiNDgtOWNkOC1jYmI3YzFiOWRlMmUv
+        cnBtL3JwbS8wMTk1ZWU0My01NWQ4LTdjOGItODIwNS1lNjFlYzcyMjdhMmIv
         IiwiZ2VuZXJhdGVfcmVwb19jb25maWciOmZhbHNlfV19
-  recorded_at: Wed, 30 Oct 2024 20:32:10 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:28 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df20-e67f-7b48-9cd8-cbb7c1b9de2e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee43-55d8-7c8b-8205-e61ec7227a2b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1248,19 +1247,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:10 GMT
+      - Mon, 31 Mar 2025 22:12:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1268,7 +1267,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cd2555bfd4864b1aa73089442d6b46a8
+      - a1070462564348bca58753ca7525208f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1277,31 +1276,31 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtZTY3Zi03YjQ4LTljZDgtY2JiN2MxYjlkZTJlLyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjAtZTY3Zi03YjQ4
-        LTljZDgtY2JiN2MxYjlkZTJlIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMjowOC4zMjE0MThaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMyOjA4LjQ4MjEwM1oiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAt
-        ZTQyMS03MzM2LThkYmQtOWFjZjIyM2NhMTllL3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDMtNTVkOC03YzhiLTgyMDUtZTYxZWM3MjI3YTJiLyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDMtNTVkOC03Yzhi
+        LTgyMDUtZTYxZWM3MjI3YTJiIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMjoyNS4xODI5NDBaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjEyOjI1LjQ2ODg4NVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDMt
+        NTJjZS03ZDAxLTkwNTktMjk1YWFjZWZlZmFkL3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMC1lNDIxLTczMzYtOGRiZC05YWNmMjIzY2ExOWUvIiwiY2hlY2tz
+        MTk1ZWU0My01MmNlLTdkMDEtOTA1OS0yOTVhYWNlZmVmYWQvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:10 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:28 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-e9eb-7a62-9c5e-f9d6627c6680/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-5c23-7f71-a276-18094f2958f3/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE5
-        MmRmMjAtZTY3Zi03YjQ4LTljZDgtY2JiN2MxYjlkZTJlLyJ9
+        NWVlNDMtNTVkOC03YzhiLTgyMDUtZTYxZWM3MjI3YTJiLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1319,13 +1318,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:10 GMT
+      - Mon, 31 Mar 2025 22:12:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1339,7 +1338,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6463cbc060dc47d4bdd76474d3837776
+      - 1764ab6043ff4d4cb41eabf9b2e562a8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1347,12 +1346,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWVmZDgtN2U3
-        Yi1hYzhlLWY0MzM4ZDI3YmY0YS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:10 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTYzODgtNzNl
+        Yi1iZGJjLWE1Y2YyODI1NzIzYi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:28 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-efd8-7e7b-ac8e-f4338d27bf4a/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-6388-73eb-bdbc-a5cf2825723b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1360,7 +1359,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1373,19 +1372,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:10 GMT
+      - Mon, 31 Mar 2025 22:12:28 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '788'
+      - '769'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1393,7 +1392,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5f3058d3c093433499d0eedc0e9aabfd
+      - 993af33703cb4313be141384589f1414
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1401,28 +1400,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtZWZk
-        OC03ZTdiLWFjOGUtZjQzMzhkMjdiZjRhLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtZWZkOC03ZTdiLWFjOGUtZjQzMzhkMjdiZjRhIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoxMC43MTMwOTFaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjEwLjcxMzEwN1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtNjM4
+        OC03M2ViLWJkYmMtYTVjZjI4MjU3MjNiLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtNjM4OC03M2ViLWJkYmMtYTVjZjI4MjU3MjNiIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjoyOC42ODIwMTBaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjI4LjY4MjAzNFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiNjQ2M2Ni
-        YzA2MGRjNDdkNGJkZDc2NDc0ZDM4Mzc3NzYiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoxMC43MjYxNDdaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MTAuNzI4ODcwWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoxMC43NDMxOTdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJkZWFiLTE2NDctNzY1NC04YmYxLWI1ZGZiYjczNDU5MTpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyZGVhYi0xNjQ3LTc2
-        NTQtOGJmMS1iNWRmYmI3MzQ1OTEiXX0=
-  recorded_at: Wed, 30 Oct 2024 20:32:10 GMT
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiMTc2NGFi
+        NjA0M2ZmNGQ0Y2I0MWVhYmY5YjJlNTYyYTgiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjI4LjcwMDMzMVoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjoyOC43MDM1NzdaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjI4LjczMTE0MloiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjpudWxsLCJwYXJlbnRfdGFzayI6bnVsbCwi
+        Y2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19y
+        ZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbInBkcm46NmQzYzYwMWYtZmVhZi00YjkzLTgy
+        NjQtNTI4YzI5MTI5YTEzOmRpc3RyaWJ1dGlvbnMiLCJzaGFyZWQ6cHJuOmNv
+        cmUuZG9tYWluOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUyOGMyOTEyOWEx
+        MyJdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:28 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df20-e67f-7b48-9cd8-cbb7c1b9de2e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee43-55d8-7c8b-8205-e61ec7227a2b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1443,19 +1442,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:10 GMT
+      - Mon, 31 Mar 2025 22:12:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1463,7 +1462,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9599e849a1de4d1a9ea78c9935803f87
+      - e802eeb3c75747299d43cc98768f8039
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1472,31 +1471,31 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtZTY3Zi03YjQ4LTljZDgtY2JiN2MxYjlkZTJlLyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjAtZTY3Zi03YjQ4
-        LTljZDgtY2JiN2MxYjlkZTJlIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMjowOC4zMjE0MThaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMyOjA4LjQ4MjEwM1oiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAt
-        ZTQyMS03MzM2LThkYmQtOWFjZjIyM2NhMTllL3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDMtNTVkOC03YzhiLTgyMDUtZTYxZWM3MjI3YTJiLyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDMtNTVkOC03Yzhi
+        LTgyMDUtZTYxZWM3MjI3YTJiIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMjoyNS4xODI5NDBaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjEyOjI1LjQ2ODg4NVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDMt
+        NTJjZS03ZDAxLTkwNTktMjk1YWFjZWZlZmFkL3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMC1lNDIxLTczMzYtOGRiZC05YWNmMjIzY2ExOWUvIiwiY2hlY2tz
+        MTk1ZWU0My01MmNlLTdkMDEtOTA1OS0yOTVhYWNlZmVmYWQvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:10 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:29 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-e9eb-7a62-9c5e-f9d6627c6680/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-5c23-7f71-a276-18094f2958f3/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE5
-        MmRmMjAtZTY3Zi03YjQ4LTljZDgtY2JiN2MxYjlkZTJlLyJ9
+        NWVlNDMtNTVkOC03YzhiLTgyMDUtZTYxZWM3MjI3YTJiLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1514,13 +1513,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:10 GMT
+      - Mon, 31 Mar 2025 22:12:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1534,7 +1533,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 854afbf4c06245a99ca003a7c4fc6102
+      - 9f8a1dcc64404fc1bc5b3b420f8256a4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1542,9 +1541,9 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWYwY2EtNzIz
-        Mi05Y2I5LTgwOGM0ZTg0ZWFmMi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:10 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTY1OGUtNzQy
+        YS04YWJjLWY5MjdkOGQxM2UzOC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:29 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -1568,13 +1567,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:11 GMT
+      - Mon, 31 Mar 2025 22:12:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1588,7 +1587,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d160af3fdde64698bf6eda4d881d0ed1
+      - 8c7ced7ecc20460b88d3ae018ad19153
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1598,11 +1597,11 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9y
-        cG0vMDE5MmRmMjAtZTM2MS03ZDM4LTk1ZjEtOTc0YTNkZmEzN2NjLyIsInBy
-        biI6InBybjpycG0ucnBtcmVtb3RlOjAxOTJkZjIwLWUzNjEtN2QzOC05NWYx
-        LTk3NGEzZGZhMzdjYyIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMTAtMzBUMjA6
-        MzI6MDcuNTIyMDQwWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMjoxMC4zOTgwODhaIiwibmFtZSI6IjJfZHVwbGljYXRlIiwidXJs
+        cG0vMDE5NWVlNDMtNTFiYi03OTgzLWIzMWQtMTdiMWY4YzFiMjdlLyIsInBy
+        biI6InBybjpycG0ucnBtcmVtb3RlOjAxOTVlZTQzLTUxYmItNzk4My1iMzFk
+        LTE3YjFmOGMxYjI3ZSIsInB1bHBfY3JlYXRlZCI6IjIwMjUtMDMtMzFUMjI6
+        MTI6MjQuMTI0MTcwWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMjoyOC4wODg5NjZaIiwibmFtZSI6IjJfZHVwbGljYXRlIiwidXJs
         IjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0IjoiS0pMOktERiooREYm
         KigqJCYoKiMkSkxLSkQoRCgoRCIsImNsaWVudF9jZXJ0IjoiS0pMOktERioo
         REYmKigqJCYoKiMkSkxLSkQoRCgoRCIsInRsc192YWxpZGF0aW9uIjpmYWxz
@@ -1617,10 +1616,10 @@ http_interactions:
         dCI6ZmFsc2V9LHsibmFtZSI6InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0s
         eyJuYW1lIjoicGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfV0sInNsZXNfYXV0
         aF90b2tlbiI6bnVsbH1dfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:11 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:29 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-e9eb-7a62-9c5e-f9d6627c6680/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-5c23-7f71-a276-18094f2958f3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1641,13 +1640,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:11 GMT
+      - Mon, 31 Mar 2025 22:12:29 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1661,7 +1660,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b6252473226649bbacfd02dc483eea80
+      - 1e3d28061c1c449c86a7606bcc61dc40
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1669,12 +1668,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWYxODItNzY1
-        ZC04N2JjLTc1ZmZlZmU4YWM5ZC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:11 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTY3MTgtNzk1
+        ZS04YzkyLWExN2YxM2ZkYTFjMC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:29 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df20-e361-7d38-95f1-974a3dfa37cc/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee43-51bb-7983-b31d-17b1f8c1b27e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1695,13 +1694,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:11 GMT
+      - Mon, 31 Mar 2025 22:12:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1715,7 +1714,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - baca42e365cb429b8d2b1780fb290da9
+      - 2a9c0eaca9f04b58817d13a81edd9438
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1723,12 +1722,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWYyNmYtNzJi
-        MS04NTNiLWYwNGIzM2YzYjNhNy8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:11 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTY5M2ItNzVh
+        Mi1iN2UzLTlmZGE3Y2IyYTZiMi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:30 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-f26f-72b1-853b-f04b33f3b3a7/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-693b-75a2-b7e3-9fda7cb2a6b2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1736,7 +1735,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1749,19 +1748,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:11 GMT
+      - Mon, 31 Mar 2025 22:12:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '843'
+      - '824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1769,7 +1768,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e481ac5ec20a4f01ac80b99319cea82f
+      - bcc0771305b041b4be0fbe60969b2352
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1777,29 +1776,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtZjI2
-        Zi03MmIxLTg1M2ItZjA0YjMzZjNiM2E3LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtZjI2Zi03MmIxLTg1M2ItZjA0YjMzZjNiM2E3IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoxMS4zNzYwNzZaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjExLjM3NjA5Mloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtNjkz
+        Yi03NWEyLWI3ZTMtOWZkYTdjYjJhNmIyLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtNjkzYi03NWEyLWI3ZTMtOWZkYTdjYjJhNmIyIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjozMC4xNDAzOThaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjMwLjE0MDQyMloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiYmFjYTQy
-        ZTM2NWNiNDI5YjhkMmIxNzgwZmIyOTBkYTkiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoxMS4zOTAyNjhaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MTEuNDM5NTE0WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoxMS40ODQ5NDBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTM5NTktN2UwNi05MmY4LWZkOWI1
-        MTgxYjdlZS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpycG0ucnBtcmVtb3RlOjAxOTJkZjIwLWUzNjEtN2QzOC05NWYx
-        LTk3NGEzZGZhMzdjYyIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmRl
-        YWItMTY0Ny03NjU0LThiZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:32:11 GMT
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiMmE5YzBl
+        YWNhOWYwNGI1ODgxN2QxM2E4MWVkZDk0MzgiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjMwLjE2MjgzNVoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjozMC4yNDY5MjVaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjMwLjMzOTE0MFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmFlYi03ZTdlLTk0NWQtZmRlYzk2MzEzZDkwLyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10s
+        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOnJwbS5ycG1yZW1v
+        dGU6MDE5NWVlNDMtNTFiYi03OTgzLWIzMWQtMTdiMWY4YzFiMjdlIiwic2hh
+        cmVkOnBybjpjb3JlLmRvbWFpbjo2ZDNjNjAxZi1mZWFmLTRiOTMtODI2NC01
+        MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:12:30 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0192df20-e421-7336-8dbd-9acf223ca19e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0195ee43-52ce-7d01-9059-295aacefefad/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1820,13 +1819,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:11 GMT
+      - Mon, 31 Mar 2025 22:12:30 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1840,7 +1839,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1392d1a0602745bfa12e51ec1a6d00c2
+      - 32d78a1967934b9d9810aa637cac46d9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1848,12 +1847,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWYzYWMtN2Ux
-        ZC1iMDNmLWIzMmJkZTNmYTIzMi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:11 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTZiYjUtNzEw
+        Ny05MjdhLTVmYzQ0YTY5YzU0MC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:30 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-f3ac-7e1d-b03f-b32bde3fa232/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-6bb5-7107-927a-5fc44a69c540/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1861,7 +1860,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1874,19 +1873,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:12 GMT
+      - Mon, 31 Mar 2025 22:12:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '847'
+      - '828'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1894,7 +1893,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 402c97951dc94a02a6617c53315a0942
+      - 1d21bd41f3644ca6adac5d73476da86e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1902,29 +1901,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtZjNh
-        Yy03ZTFkLWIwM2YtYjMyYmRlM2ZhMjMyLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtZjNhYy03ZTFkLWIwM2YtYjMyYmRlM2ZhMjMyIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoxMS42OTM0MzhaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjExLjY5MzQ1NVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtNmJi
+        NS03MTA3LTkyN2EtNWZjNDRhNjljNTQwLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtNmJiNS03MTA3LTkyN2EtNWZjNDRhNjljNTQwIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjozMC43NzQ5MDBaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjMwLjc3NDkyMloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiMTM5MmQx
-        YTA2MDI3NDViZmExMmU1MWVjMWE2ZDAwYzIiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoxMS43MDk0MzhaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MTEuNzU0NTAwWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoxMS45MDA3MThaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTM5NTktN2UwNi05MmY4LWZkOWI1
-        MTgxYjdlZS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpycG0ucnBtcmVwb3NpdG9yeTowMTkyZGYyMC1lNDIxLTczMzYt
-        OGRiZC05YWNmMjIzY2ExOWUiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAx
-        OTJkZWFiLTE2NDctNzY1NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:12 GMT
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiMzJkNzhh
+        MTk2NzkzNGI5ZDk4MTBhYTYzN2NhYzQ2ZDkiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjMwLjgxMjM3OVoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjozMC44ODQ4MTRaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjMxLjE4NjY5N1oiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmI5Mi03YzNiLTlmNTEtZTk4YTllZTI4YmE0LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10s
+        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOnJwbS5ycG1yZXBv
+        c2l0b3J5OjAxOTVlZTQzLTUyY2UtN2QwMS05MDU5LTI5NWFhY2VmZWZhZCIs
+        InNoYXJlZDpwcm46Y29yZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgy
+        NjQtNTI4YzI5MTI5YTEzIl19
+  recorded_at: Mon, 31 Mar 2025 22:12:31 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1932,7 +1931,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.22.2/ruby
+      - OpenAPI-Generator/0.22.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1945,13 +1944,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:12 GMT
+      - Mon, 31 Mar 2025 22:12:31 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1965,7 +1964,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 51d0381c5b9d46149ea77caa0186aa3c
+      - ac0a5946bafe46f1b5b556c807086a88
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1975,7 +1974,385 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:12 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:31 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.3.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - e35b40d8865d46bebeb72cd4fbb296e7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:31 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.22.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - c2903d6d895747579aaa734ed64d56c0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:32 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3c240ed3c94d4c71ae9ed49d5cefc7d0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:32 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.4.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 80d347e9e56b4f08948de1a26c9c4cfb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:32 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.12.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3ec3dea79fdd414f9793e49c344d9e35
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:32 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.27.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7b8b018c0cb4477485349fefcf2af2c2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:32 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.22.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:32 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 54fc6a038d204190ab6c6f023d09d6b6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:32 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -1999,13 +2376,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:12 GMT
+      - Mon, 31 Mar 2025 22:12:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2019,7 +2396,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cd0e5bad4e5e4fa38af589c559e19ac4
+      - bf076ae8e02542aaaff10a3774628ae2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2029,7 +2406,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:12 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:32 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -2040,7 +2417,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.21.1/ruby
+      - OpenAPI-Generator/2.22.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -2053,13 +2430,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:12 GMT
+      - Mon, 31 Mar 2025 22:12:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2073,7 +2450,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6e00f81b715044308c42a6e95fad4004
+      - 5ab2a493a0fc415d8c5d88aa08f81e9c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2083,7 +2460,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:12 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:32 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -2094,7 +2471,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2107,13 +2484,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:12 GMT
+      - Mon, 31 Mar 2025 22:12:32 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2127,7 +2504,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d7027d9719ea414a9801912e799293ff
+      - 1f8401dcaeea4398aac7fc5cca398e18
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2137,7 +2514,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:12 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:32 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -2148,7 +2525,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.4.4/ruby
+      - OpenAPI-Generator/2.4.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -2161,13 +2538,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:12 GMT
+      - Mon, 31 Mar 2025 22:12:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2181,7 +2558,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 40993f6a67484283a69101458f866df2
+      - fd6ea0fd46e34700aeb1e975dbd60598
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2191,7 +2568,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:12 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:33 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -2202,7 +2579,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.12.5/ruby
+      - OpenAPI-Generator/3.12.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -2215,13 +2592,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:12 GMT
+      - Mon, 31 Mar 2025 22:12:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2235,7 +2612,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c56980dfa2924305ba5dbada4fea3698
+      - 956033fcfb9044d9a0bf11ab0a2a5068
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2245,7 +2622,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:12 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:33 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -2269,13 +2646,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:12 GMT
+      - Mon, 31 Mar 2025 22:12:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2289,7 +2666,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a7472a8268a149f3be6974064fe8d6e3
+      - 93680c5313374f90af7c97117e7c256f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2299,7 +2676,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:12 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:33 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/orphans/cleanup/
@@ -2312,7 +2689,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2325,13 +2702,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:12 GMT
+      - Mon, 31 Mar 2025 22:12:33 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - POST, OPTIONS
       X-Frame-Options:
@@ -2345,7 +2722,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ffee61ef0f374ef89d3e0ffa0ebbbb54
+      - 12c88d7653784623a3ed7fe61762829f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2353,12 +2730,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWY4NzYtNzY0
-        NS1hNDUzLWJlOGUwOTFlNzE0YS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:12 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTc2M2MtN2Fk
+        Ny04MTU4LTA0YjI4OGJhNjljOC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:33 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-f876-7645-a453-be8e091e714a/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-763c-7ad7-8158-04b288ba69c8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2366,7 +2743,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2379,19 +2756,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:13 GMT
+      - Mon, 31 Mar 2025 22:12:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1077'
+      - '1058'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2399,7 +2776,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b4c7cd9e89cf4f23bdbe35c34049dc81
+      - e28ebbeac5114c9d8e4323fef60ee11b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2407,31 +2784,31 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtZjg3
-        Ni03NjQ1LWE0NTMtYmU4ZTA5MWU3MTRhLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtZjg3Ni03NjQ1LWE0NTMtYmU4ZTA5MWU3MTRhIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoxMi45MTg3OThaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjEyLjkxODgxNFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtNzYz
+        Yy03YWQ3LTgxNTgtMDRiMjg4YmE2OWM4LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtNzYzYy03YWQ3LTgxNTgtMDRiMjg4YmE2OWM4IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjozMy40Njk3MzZaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjMzLjQ2OTc2MVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiJmZmVl
-        NjFlZjBmMzc0ZWY4OWQzZTBmZmEwZWJiYmI1NCIsImNyZWF0ZWRfYnkiOiIv
-        cHVscC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTEw
-        LTMwVDIwOjMyOjEyLjkzNDI0NVoiLCJzdGFydGVkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoxMi45ODczMjhaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTEwLTMw
-        VDIwOjMyOjEzLjE2MjQxN1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1
-        bHAvYXBpL3YzL3dvcmtlcnMvMDE5MmRlYWMtM2E0Mi03ZDI0LWFiNWYtODhk
-        Y2NjMjhiM2JkLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6
-        W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1l
-        c3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQ29udGVudCIsImNvZGUiOiJjbGVh
-        bi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwi
-        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJDbGVhbiB1cCBv
-        cnBoYW4gQXJ0aWZhY3RzIiwiY29kZSI6ImNsZWFuLXVwLmFydGlmYWN0cyIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jl
-        c291cmNlc19yZWNvcmQiOlsicGRybjowMTkyZGVhYi0xNjQ3LTc2NTQtOGJm
-        MS1iNWRmYmI3MzQ1OTE6b3JwaGFucyIsInNoYXJlZDpwcm46Y29yZS5kb21h
-        aW46MDE5MmRlYWItMTY0Ny03NjU0LThiZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:32:13 GMT
+        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiIxMmM4
+        OGQ3NjUzNzg0NjIzYTNlZDdmZTYxNzYyODI5ZiIsImNyZWF0ZWRfYnkiOm51
+        bGwsInVuYmxvY2tlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6MzMuNDk1Mjg0
+        WiIsInN0YXJ0ZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjMzLjU2NDAyMloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6MzMuODQyMTI3WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8w
+        MTk1ZDJlZS1iYjkyLTdjM2ItOWY1MS1lOThhOWVlMjhiYTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkNsZWFuIHVwIG9y
+        cGhhbiBDb250ZW50IiwiY29kZSI6ImNsZWFuLXVwLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51
+        bGx9LHsibWVzc2FnZSI6IkNsZWFuIHVwIG9ycGhhbiBBcnRpZmFjdHMiLCJj
+        b2RlIjoiY2xlYW4tdXAuYXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJw
+        ZHJuOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUyOGMyOTEyOWExMzpvcnBo
+        YW5zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo2ZDNjNjAxZi1mZWFmLTRi
+        OTMtODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:12:34 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/purge/
@@ -2444,7 +2821,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2457,13 +2834,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:13 GMT
+      - Mon, 31 Mar 2025 22:12:34 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - POST, OPTIONS
       X-Frame-Options:
@@ -2477,7 +2854,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ac0dc40490bc46b59995963307d4d9bb
+      - 226818cb0cd24e0e86d882493529cb52
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2485,7 +2862,7 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWY5ZGEtNzE2
-        YS1iNTNiLTVmOGE4OTk3YTExZC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:13 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTc4ZjYtN2Ri
+        Zi04MGUxLTkxOTllODM0ZGE5ZC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:34 GMT
 recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_set_unprotected.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_set_unprotected.yml
@@ -23,13 +23,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:54 GMT
+      - Mon, 31 Mar 2025 22:11:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5aab197b1a4a4ad9ad8d8973cd650be8
+      - 54dde8e5ad3646f29f4e87f547b22f80
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:54 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:57 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -77,13 +77,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:54 GMT
+      - Mon, 31 Mar 2025 22:11:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0603e63901a149beb9918e51a4994c3c
+      - 90791a555a694252b5e4aa95c729fc10
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:54 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:57 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -131,13 +131,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:54 GMT
+      - Mon, 31 Mar 2025 22:11:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 10022860969f4a6a93b97ce1d2b0c023
+      - aff72e3bf32e45c18660141b50b762ea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:54 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:58 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -185,13 +185,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:54 GMT
+      - Mon, 31 Mar 2025 22:11:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '09981004720543159409dac31344ec31'
+      - 35cb3aaffdf14ee5b99d67ea4b9460aa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:54 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:58 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -247,15 +247,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:54 GMT
+      - Mon, 31 Mar 2025 22:11:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/0192df20-b04c-7907-a542-9c1ce9cec41a/"
+      - "/pulp/api/v3/remotes/rpm/rpm/0195ee42-ece6-72d9-be0b-540cf78cfbe9/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -269,7 +269,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2e8bcb8e4cf24fffa228e72801436608
+      - 656120b2b9ac4cc2bcb80b46c0e30e75
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -278,11 +278,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OTJkZjIwLWIwNGMtNzkwNy1hNTQyLTljMWNlOWNlYzQxYS8iLCJwcm4iOiJw
-        cm46cnBtLnJwbXJlbW90ZTowMTkyZGYyMC1iMDRjLTc5MDctYTU0Mi05YzFj
-        ZTljZWM0MWEiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjU0
-        LjQ0NDg3MVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMTAtMzBUMjA6
-        MzE6NTQuNDQ0ODg5WiIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0
+        OTVlZTQyLWVjZTYtNzJkOS1iZTBiLTU0MGNmNzhjZmJlOS8iLCJwcm4iOiJw
+        cm46cnBtLnJwbXJlbW90ZTowMTk1ZWU0Mi1lY2U2LTcyZDktYmUwYi01NDBj
+        Zjc4Y2ZiZTkiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMxVDIyOjExOjU4
+        LjMxMTI1OFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUtMDMtMzFUMjI6
+        MTE6NTguMzExMjgxWiIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0
         dHA6Ly9teXJlcG8uY29tIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQi
         Om51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGws
         InB1bHBfbGFiZWxzIjp7fSwiZG93bmxvYWRfY29uY3VycmVuY3kiOm51bGws
@@ -295,7 +295,7 @@ http_interactions:
         bWUiOiJwcm94eV9wYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6
         InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfV0sInNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
-  recorded_at: Wed, 30 Oct 2024 20:31:54 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:58 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -321,21 +321,21 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:54 GMT
+      - Mon, 31 Mar 2025 22:11:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/0192df20-b0f7-7c57-9706-1f4c5b9ad18d/"
+      - "/pulp/api/v3/repositories/rpm/rpm/0195ee42-ee15-7dc6-81eb-c52a12ae261f/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '880'
+      - '894'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -343,7 +343,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ba27a8a9ae354beda12aba696bc00e1e
+      - 5006b11d9b564274bd68d5ceaecd6a9f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -352,16 +352,16 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMDE5MmRmMjAtYjBmNy03YzU3LTk3MDYtMWY0YzViOWFkMThkLyIsInBy
-        biI6InBybjpycG0ucnBtcmVwb3NpdG9yeTowMTkyZGYyMC1iMGY3LTdjNTct
-        OTcwNi0xZjRjNWI5YWQxOGQiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMw
-        VDIwOjMxOjU0LjYxNjQyMVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQt
-        MTAtMzBUMjA6MzE6NTQuNjIzODQ5WiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAtYjBmNy03
-        YzU3LTk3MDYtMWY0YzViOWFkMThkL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
+        cG0vMDE5NWVlNDItZWUxNS03ZGM2LTgxZWItYzUyYTEyYWUyNjFmLyIsInBy
+        biI6InBybjpycG0ucnBtcmVwb3NpdG9yeTowMTk1ZWU0Mi1lZTE1LTdkYzYt
+        ODFlYi1jNTJhMTJhZTI2MWYiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMx
+        VDIyOjExOjU4LjYxNTEzMFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUt
+        MDMtMzFUMjI6MTE6NTguNjIwMjMwWiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDItZWUxNS03
+        ZGM2LTgxZWItYzUyYTEyYWUyNjFmL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
         Ijp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcnBtL3JwbS8wMTkyZGYyMC1iMGY3LTdjNTctOTcwNi0xZjRj
-        NWI5YWQxOGQvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJk
+        c2l0b3JpZXMvcnBtL3JwbS8wMTk1ZWU0Mi1lZTE1LTdkYzYtODFlYi1jNTJh
+        MTJhZTI2MWYvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJk
         ZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGws
         InJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9z
         aWduaW5nX3NlcnZpY2UiOm51bGwsInBhY2thZ2Vfc2lnbmluZ19zZXJ2aWNl
@@ -370,8 +370,8 @@ http_interactions:
         bWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjpudWxsLCJncGdjaGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6
         bnVsbCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9
-        LCJjb21wcmVzc2lvbl90eXBlIjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:54 GMT
+        LCJjb21wcmVzc2lvbl90eXBlIjpudWxsLCJsYXlvdXQiOm51bGx9
+  recorded_at: Mon, 31 Mar 2025 22:11:58 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -379,8 +379,8 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE5MmRmMjAtYjBmNy03YzU3LTk3MDYtMWY0YzViOWFk
-        MThkL3ZlcnNpb25zLzAvIiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiJ9
+        aWVzL3JwbS9ycG0vMDE5NWVlNDItZWUxNS03ZGM2LTgxZWItYzUyYTEyYWUy
+        NjFmL3ZlcnNpb25zLzAvIiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiJ9
     headers:
       Content-Type:
       - application/json
@@ -398,13 +398,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:54 GMT
+      - Mon, 31 Mar 2025 22:11:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -418,7 +418,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e1c306ba0f7246df92c5336d8e0542b6
+      - eca98dcb2d7e4e77b2b558b1cd807ace
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -426,12 +426,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWIyNTktN2E4
-        OS04YTVhLWE4MjdlMGE4MTAyOS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:54 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQyLWYwN2MtNzc1
+        Ny04Mzk4LWNlYTZlZjdlYzFmZi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:59 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-b259-7a89-8a5a-a827e0a81029/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee42-f07c-7757-8398-cea6ef7ec1ff/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -439,7 +439,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -452,19 +452,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:55 GMT
+      - Mon, 31 Mar 2025 22:11:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1060'
+      - '1041'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -472,7 +472,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4a0227239ff749cebd2024e8a2926ce3
+      - f2a5499382764010979b41dd73c7e335
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -480,31 +480,31 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtYjI1
-        OS03YTg5LThhNWEtYTgyN2UwYTgxMDI5LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtYjI1OS03YTg5LThhNWEtYTgyN2UwYTgxMDI5IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMTo1NC45Njk5NDFaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjU0Ljk2OTk1OFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDItZjA3
+        Yy03NzU3LTgzOTgtY2VhNmVmN2VjMWZmLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDItZjA3Yy03NzU3LTgzOTgtY2VhNmVmN2VjMWZmIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMTo1OS4yMjk4MTRaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjExOjU5LjIyOTgzN1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFz
-        a3MucHVibGlzaGluZy5wdWJsaXNoIiwibG9nZ2luZ19jaWQiOiJlMWMzMDZi
-        YTBmNzI0NmRmOTJjNTMzNmQ4ZTA1NDJiNiIsImNyZWF0ZWRfYnkiOiIvcHVs
-        cC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTEwLTMw
-        VDIwOjMxOjU0Ljk4ODIwMFoiLCJzdGFydGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMTo1NS4wNDYxNDZaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTEwLTMwVDIw
-        OjMxOjU1LjIxMTE0MloiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
-        YXBpL3YzL3dvcmtlcnMvMDE5MmRlYWMtMzljZi03NmQ1LTk4NDktZjUwZGY2
-        NjFlZmI0LyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10s
-        InRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3Nh
-        Z2UiOiJHZW5lcmF0aW5nIHJlcG9zaXRvcnkgbWV0YWRhdGEiLCJjb2RlIjoi
-        cHVibGlzaC5nZW5lcmF0aW5nX21ldGFkYXRhIiwic3RhdGUiOiJjb21wbGV0
-        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
-        ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBt
-        L3JwbS8wMTkyZGYyMC1iMmI1LTdmZTAtYWVmNy00MDA1ZDYzZDM5NmUvIl0s
-        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsic2hhcmVkOnBybjpycG0u
-        cnBtcmVwb3NpdG9yeTowMTkyZGYyMC1iMGY3LTdjNTctOTcwNi0xZjRjNWI5
-        YWQxOGQiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAxOTJkZWFiLTE2NDct
-        NzY1NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:55 GMT
+        a3MucHVibGlzaGluZy5wdWJsaXNoIiwibG9nZ2luZ19jaWQiOiJlY2E5OGRj
+        YjJkN2U0ZTc3YjJiNTU4YjFjZDgwN2FjZSIsImNyZWF0ZWRfYnkiOm51bGws
+        InVuYmxvY2tlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTE6NTkuMjU0OTIwWiIs
+        InN0YXJ0ZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjExOjU5LjM0MDQyMFoiLCJm
+        aW5pc2hlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTE6NTkuNjcyOTMzWiIsImVy
+        cm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTk1
+        ZDJlZS1iYjkyLTdjM2ItOWY1MS1lOThhOWVlMjhiYTQvIiwicGFyZW50X3Rh
+        c2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVsbCwi
+        cHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkdlbmVyYXRpbmcgcmVw
+        b3NpdG9yeSBtZXRhZGF0YSIsImNvZGUiOiJwdWJsaXNoLmdlbmVyYXRpbmdf
+        bWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25l
+        IjoxLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1
+        bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBtLzAxOTVlZTQyLWYxMDYt
+        Nzk4Ny1hODA2LTMxNzJjN2RiZTUyNi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
+        X3JlY29yZCI6WyJzaGFyZWQ6cHJuOnJwbS5ycG1yZXBvc2l0b3J5OjAxOTVl
+        ZTQyLWVlMTUtN2RjNi04MWViLWM1MmExMmFlMjYxZiIsInNoYXJlZDpwcm46
+        Y29yZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgyNjQtNTI4YzI5MTI5
+        YTEzIl19
+  recorded_at: Mon, 31 Mar 2025 22:11:59 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -528,13 +528,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:55 GMT
+      - Mon, 31 Mar 2025 22:12:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -548,7 +548,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 283ac543034843188093cf345bbf9309
+      - 4881658d0d3c4f898e987672f121f0ba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -558,10 +558,10 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:55 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:00 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df20-b2b5-7fe0-aef7-4005d63d396e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee42-f106-7987-a806-3172c7dbe526/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -582,19 +582,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:55 GMT
+      - Mon, 31 Mar 2025 22:12:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -602,7 +602,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cddec781e5284bdda475d84754211762
+      - 48c369cee849406099a073fad56c8547
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -611,21 +611,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtYjJiNS03ZmUwLWFlZjctNDAwNWQ2M2QzOTZlLyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjAtYjJiNS03ZmUw
-        LWFlZjctNDAwNWQ2M2QzOTZlIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMTo1NS4wNjM0NjdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMxOjU1LjIwMzkzNVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAt
-        YjBmNy03YzU3LTk3MDYtMWY0YzViOWFkMThkL3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDItZjEwNi03OTg3LWE4MDYtMzE3MmM3ZGJlNTI2LyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDItZjEwNi03OTg3
+        LWE4MDYtMzE3MmM3ZGJlNTI2IiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMTo1OS4zNjk4OTVaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjExOjU5LjY2MzI0MloiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDIt
+        ZWUxNS03ZGM2LTgxZWItYzUyYTEyYWUyNjFmL3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMC1iMGY3LTdjNTctOTcwNi0xZjRjNWI5YWQxOGQvIiwiY2hlY2tz
+        MTk1ZWU0Mi1lZTE1LTdkYzYtODFlYi1jNTJhMTJhZTI2MWYvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:55 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:00 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/
@@ -635,8 +635,8 @@ http_interactions:
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vMDE5MmRmMjAtYjJiNS03ZmUwLWFlZjctNDAw
-        NWQ2M2QzOTZlLyJ9
+        bGljYXRpb25zL3JwbS9ycG0vMDE5NWVlNDItZjEwNi03OTg3LWE4MDYtMzE3
+        MmM3ZGJlNTI2LyJ9
     headers:
       Content-Type:
       - application/json
@@ -654,13 +654,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:55 GMT
+      - Mon, 31 Mar 2025 22:12:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -674,7 +674,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a6bd98f5846243258d0d9e90ce1958d2
+      - 35dff6256fe84f64a90ee24e5919f546
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -682,12 +682,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWI0NGQtN2Nh
-        YS05YzVjLTQyYmUxMDI5YjdlZC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:55 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQyLWY0YzAtNzNl
+        MS1iMTAwLWQ5NGVkYzQ2NTI3ZC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:00 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-b44d-7caa-9c5c-42be1029b7ed/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee42-f4c0-73e1-b100-d94edc46527d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -695,7 +695,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -708,19 +708,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:55 GMT
+      - Mon, 31 Mar 2025 22:12:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '918'
+      - '899'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -728,7 +728,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 04a64b56c10b4702b47e2dee7d3b7fe3
+      - 1fd296d749924cadab7678d2ecbf749d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -736,31 +736,30 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtYjQ0
-        ZC03Y2FhLTljNWMtNDJiZTEwMjliN2VkLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtYjQ0ZC03Y2FhLTljNWMtNDJiZTEwMjliN2VkIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMTo1NS40NzAxNDVaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjU1LjQ3MDE2Nloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDItZjRj
+        MC03M2UxLWIxMDAtZDk0ZWRjNDY1MjdkLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDItZjRjMC03M2UxLWIxMDAtZDk0ZWRjNDY1MjdkIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjowMC4zMjE5MzBaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjAwLjMyMTk1M1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiYTZiZDk4
-        ZjU4NDYyNDMyNThkMGQ5ZTkwY2UxOTU4ZDIiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMTo1NS40ODc3MjRaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzE6NTUuNTQ4NzIwWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMTo1NS43OTQ5ODNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTM5Y2YtNzZkNS05ODQ5LWY1MGRm
-        NjYxZWZiNC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
-        cnBtL3JwbS8wMTkyZGYyMC1iNTdmLTcxM2MtOGJmMy05NWFlZjYxOWZjZjcv
-        Il0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicGRybjowMTkyZGVh
-        Yi0xNjQ3LTc2NTQtOGJmMS1iNWRmYmI3MzQ1OTE6ZGlzdHJpYnV0aW9ucyIs
-        InNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmRlYWItMTY0Ny03NjU0LThi
-        ZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:31:55 GMT
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiMzVkZmY2
+        MjU2ZmU4NGY2NGE5MGVlMjRlNTkxOWY1NDYiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjAwLjM0ODE1MFoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjowMC40Mzk5MDRaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjAxLjA0MDM3N1oiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmEzYS03NDYzLWExNTUtOTg3Y2NjOWU1YTc0LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIv
+        cHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0vcnBtLzAxOTVlZTQyLWY3
+        NzQtNzBjMC1iMWY4LWViYTFlNTcyYTdiYi8iXSwicmVzZXJ2ZWRfcmVzb3Vy
+        Y2VzX3JlY29yZCI6WyJwZHJuOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUy
+        OGMyOTEyOWExMzpkaXN0cmlidXRpb25zIiwic2hhcmVkOnBybjpjb3JlLmRv
+        bWFpbjo2ZDNjNjAxZi1mZWFmLTRiOTMtODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:12:01 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-b57f-713c-8bf3-95aef619fcf7/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee42-f774-70c0-b1f8-eba1e572a7bb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -781,13 +780,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:55 GMT
+      - Mon, 31 Mar 2025 22:12:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -801,7 +800,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e0ddcfcc574d41959ae6f36aa7eab2d8
+      - d52004b62ba54c9ca7c984bf6011efce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -810,22 +809,22 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzAxOTJkZjIwLWI1N2YtNzEzYy04YmYzLTk1YWVmNjE5ZmNmNy8iLCJw
-        cm4iOiJwcm46cnBtLnJwbWRpc3RyaWJ1dGlvbjowMTkyZGYyMC1iNTdmLTcx
-        M2MtOGJmMy05NWFlZjYxOWZjZjciLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEw
-        LTMwVDIwOjMxOjU1Ljc3NzE4OVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
-        MjQtMTAtMzBUMjA6MzE6NTUuNzc3MjA4WiIsImJhc2VfcGF0aCI6IkFDTUVf
+        cnBtLzAxOTVlZTQyLWY3NzQtNzBjMC1iMWY4LWViYTFlNTcyYTdiYi8iLCJw
+        cm4iOiJwcm46cnBtLnJwbWRpc3RyaWJ1dGlvbjowMTk1ZWU0Mi1mNzc0LTcw
+        YzAtYjFmOC1lYmExZTU3MmE3YmIiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAz
+        LTMxVDIyOjEyOjAxLjAxNTYxOVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
+        MjUtMDMtMzFUMjI6MTI6MDEuMDE1NzA3WiIsImJhc2VfcGF0aCI6IkFDTUVf
         Q29ycG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJi
         YXNlX3VybCI6Imh0dHBzOi8vY2VudG9zOS1rYXRlbGxvLWRldmVsLXN0YWJs
         ZS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9k
         ZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJk
-        IjpudWxsLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6IjIwMjQtMTAtMzBU
-        MjA6MzE6NTUuNzc3MjA4WiIsImhpZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxz
+        IjpudWxsLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6IjIwMjUtMDMtMzFU
+        MjI6MTI6MDEuMDE1NzA3WiIsImhpZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxz
         Ijp7fSwibmFtZSI6IjJfZHVwbGljYXRlIiwicmVwb3NpdG9yeSI6bnVsbCwi
         cHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtYjJiNS03ZmUwLWFlZjctNDAwNWQ2M2QzOTZlLyIsImdl
+        cG0vMDE5NWVlNDItZjEwNi03OTg3LWE4MDYtMzE3MmM3ZGJlNTI2LyIsImdl
         bmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX0=
-  recorded_at: Wed, 30 Oct 2024 20:31:55 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:01 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -860,15 +859,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:56 GMT
+      - Mon, 31 Mar 2025 22:12:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/0192df20-b6c1-72e8-af9d-08bba75689c3/"
+      - "/pulp/api/v3/remotes/rpm/rpm/0195ee42-f98c-7d4b-b304-3282a0527739/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -882,7 +881,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b5e854e86dac43969fc1f7f96cf52c6f
+      - edbb349b0d5b480183e5ab25a1db0bdc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -891,11 +890,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OTJkZjIwLWI2YzEtNzJlOC1hZjlkLTA4YmJhNzU2ODljMy8iLCJwcm4iOiJw
-        cm46cnBtLnJwbXJlbW90ZTowMTkyZGYyMC1iNmMxLTcyZTgtYWY5ZC0wOGJi
-        YTc1Njg5YzMiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjU2
-        LjA5ODAwNVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMTAtMzBUMjA6
-        MzE6NTYuMDk4MDY1WiIsIm5hbWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJs
+        OTVlZTQyLWY5OGMtN2Q0Yi1iMzA0LTMyODJhMDUyNzczOS8iLCJwcm4iOiJw
+        cm46cnBtLnJwbXJlbW90ZTowMTk1ZWU0Mi1mOThjLTdkNGItYjMwNC0zMjgy
+        YTA1Mjc3MzkiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjAx
+        LjU0OTQyOFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUtMDMtMzFUMjI6
+        MTI6MDEuNTQ5NDk2WiIsIm5hbWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJs
         IjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0IjoiS0pMOktERiooREYm
         KigqJCYoKiMkSkxLSkQoRCgoRCIsImNsaWVudF9jZXJ0IjoiS0pMOktERioo
         REYmKigqJCYoKiMkSkxLSkQoRCgoRCIsInRsc192YWxpZGF0aW9uIjpmYWxz
@@ -910,10 +909,10 @@ http_interactions:
         dCI6ZmFsc2V9LHsibmFtZSI6InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0s
         eyJuYW1lIjoicGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfV0sInNsZXNfYXV0
         aF90b2tlbiI6bnVsbH0=
-  recorded_at: Wed, 30 Oct 2024 20:31:56 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:01 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df20-b6c1-72e8-af9d-08bba75689c3/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee42-f98c-7d4b-b304-3282a0527739/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -934,13 +933,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:56 GMT
+      - Mon, 31 Mar 2025 22:12:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -954,7 +953,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 84950c72d1924a949505c9ddbbaae88b
+      - 48600ccab5304ba9a6bf82766b20dc16
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -962,12 +961,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWI3MDEtNzhj
-        Ny1hMmRhLTQ3OWE3OWNkZTZlZC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:56 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQyLWZhMGMtN2M4
+        MS1hZWE3LTM3NjYwNmViZDYxOS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:01 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0192df20-b0f7-7c57-9706-1f4c5b9ad18d/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0195ee42-ee15-7dc6-81eb-c52a12ae261f/
     body:
       encoding: UTF-8
       base64_string: |
@@ -990,13 +989,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:56 GMT
+      - Mon, 31 Mar 2025 22:12:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1010,7 +1009,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fb76f45f372141159f7406d7977ada81
+      - d2524c75fe2b4983b1cbbb2f3ddffdb4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1018,12 +1017,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWI3ZGYtNzky
-        OS1hYjcyLTNiNmRmYjY5MTQ3Mi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:56 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQyLWZiNTYtNzRl
+        ZS04YjkzLWFmOTdmNzhkNGM1My8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:02 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df20-b04c-7907-a542-9c1ce9cec41a/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee42-ece6-72d9-be0b-540cf78cfbe9/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1055,13 +1054,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:56 GMT
+      - Mon, 31 Mar 2025 22:12:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1075,7 +1074,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8de4a2b9c52d47fca9fdef82135dac87
+      - 7b5f3af8fd0b436e94808171a778c293
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1083,12 +1082,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWI4NWEtNzIy
-        MS1hNjAwLWIyMWM0YzQxNmYwOC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:56 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQyLWZjNGYtN2Rm
+        Zi05YjNlLTc4OWQxODYzMjYyMS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:02 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-b85a-7221-a600-b21c4c416f08/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee42-fc4f-7dff-9b3e-789d18632621/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1096,7 +1095,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1109,19 +1108,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:56 GMT
+      - Mon, 31 Mar 2025 22:12:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '787'
+      - '768'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1129,7 +1128,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3a88a7d520db4c9ca12a9406743a751c
+      - 51ceaf2fe41f4be4a27b86fd2754e44d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1137,25 +1136,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtYjg1
-        YS03MjIxLWE2MDAtYjIxYzRjNDE2ZjA4LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtYjg1YS03MjIxLWE2MDAtYjIxYzRjNDE2ZjA4IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMTo1Ni41MDY2MTlaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjU2LjUwNjYzNVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDItZmM0
+        Zi03ZGZmLTliM2UtNzg5ZDE4NjMyNjIxLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDItZmM0Zi03ZGZmLTliM2UtNzg5ZDE4NjMyNjIxIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjowMi4yNTY2MTNaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjAyLjI1NjcyNFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiOGRlNGEy
-        YjljNTJkNDdmY2E5ZmRlZjgyMTM1ZGFjODciLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMTo1Ni41MjE4MDZaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzE6NTYuNTI0NTI4WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMTo1Ni41MzYyMTlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46cnBt
-        LnJwbXJlbW90ZTowMTkyZGYyMC1iMDRjLTc5MDctYTU0Mi05YzFjZTljZWM0
-        MWEiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAxOTJkZWFiLTE2NDctNzY1
-        NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:56 GMT
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiN2I1ZjNh
+        ZjhmZDBiNDM2ZTk0ODA4MTcxYTc3OGMyOTMiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjAyLjI3ODkzMVoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjowMi4yODE2MjlaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjAyLjI5OTcyM1oiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjpudWxsLCJwYXJlbnRfdGFzayI6bnVsbCwi
+        Y2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19y
+        ZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbInBybjpycG0ucnBtcmVtb3RlOjAxOTVlZTQy
+        LWVjZTYtNzJkOS1iZTBiLTU0MGNmNzhjZmJlOSIsInNoYXJlZDpwcm46Y29y
+        ZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgyNjQtNTI4YzI5MTI5YTEz
+        Il19
+  recorded_at: Mon, 31 Mar 2025 22:12:02 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
@@ -1166,7 +1165,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1179,13 +1178,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:56 GMT
+      - Mon, 31 Mar 2025 22:12:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1199,7 +1198,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e9237003db9e408b8c1e4ec0d48d7b08
+      - f2d490a7e85d488d9a102361b232b049
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1209,7 +1208,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:56 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:02 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/
@@ -1346,7 +1345,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1359,15 +1358,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:56 GMT
+      - Mon, 31 Mar 2025 22:12:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/contentguards/certguard/rhsm/0192df20-b934-7ac7-ae5e-ca6e5e6dafbc/"
+      - "/pulp/api/v3/contentguards/certguard/rhsm/0195ee42-fe2a-79a5-a697-2f7714b4af5f/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1381,7 +1380,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ccde42deb7594dad862d1b7c998a9834
+      - 9b9e25e060624f0fad6dde5bb363cff6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1390,11 +1389,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudGd1YXJkcy9jZXJ0
-        Z3VhcmQvcmhzbS8wMTkyZGYyMC1iOTM0LTdhYzctYWU1ZS1jYTZlNWU2ZGFm
-        YmMvIiwicHJuIjoicHJuOmNlcnRndWFyZC5yaHNtY2VydGd1YXJkOjAxOTJk
-        ZjIwLWI5MzQtN2FjNy1hZTVlLWNhNmU1ZTZkYWZiYyIsInB1bHBfY3JlYXRl
-        ZCI6IjIwMjQtMTAtMzBUMjA6MzE6NTYuNzI1NDg2WiIsInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyNC0xMC0zMFQyMDozMTo1Ni43MjU1MDNaIiwibmFtZSI6
+        Z3VhcmQvcmhzbS8wMTk1ZWU0Mi1mZTJhLTc5YTUtYTY5Ny0yZjc3MTRiNGFm
+        NWYvIiwicHJuIjoicHJuOmNlcnRndWFyZC5yaHNtY2VydGd1YXJkOjAxOTVl
+        ZTQyLWZlMmEtNzlhNS1hNjk3LTJmNzcxNGI0YWY1ZiIsInB1bHBfY3JlYXRl
+        ZCI6IjIwMjUtMDMtMzFUMjI6MTI6MDIuNzMyMTQ5WiIsInB1bHBfbGFzdF91
+        cGRhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjowMi43MzIxNzNaIiwibmFtZSI6
         IlJIU01DZXJ0R3VhcmQiLCJkZXNjcmlwdGlvbiI6bnVsbCwiY2FfY2VydGlm
         aWNhdGUiOiJDZXJ0aWZpY2F0ZTpcbiAgICBEYXRhOlxuICAgICAgICBWZXJz
         aW9uOiAzICgweDIpXG4gICAgICAgIFNlcmlhbCBOdW1iZXI6XG4gICAgICAg
@@ -1521,7 +1520,7 @@ http_interactions:
         OFRsYkI0ZEJPN2ZqXG5HNmgrVVZKT1ppQ3h6Y1d1M2hjNjE4NEhOOWhlaU8v
         amxNQ1lQc01OVVVROVUxTC9YZ3NiVzJ5YnBnPT1cbi0tLS0tRU5EIENFUlRJ
         RklDQVRFLS0tLS0ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:56 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:02 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -1545,13 +1544,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:56 GMT
+      - Mon, 31 Mar 2025 22:12:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1565,7 +1564,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fcbf639d3e0e4276a7ba47ba66db8250
+      - 7f1d32615ceb4ad6939d101df9cd027b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1575,25 +1574,25 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMDE5MmRmMjAtYjU3Zi03MTNjLThiZjMtOTVhZWY2MTlmY2Y3
-        LyIsInBybiI6InBybjpycG0ucnBtZGlzdHJpYnV0aW9uOjAxOTJkZjIwLWI1
-        N2YtNzEzYy04YmYzLTk1YWVmNjE5ZmNmNyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMTAtMzBUMjA6MzE6NTUuNzc3MTg5WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0xMC0zMFQyMDozMTo1NS43NzcyMDhaIiwiYmFzZV9wYXRoIjoi
+        L3JwbS9ycG0vMDE5NWVlNDItZjc3NC03MGMwLWIxZjgtZWJhMWU1NzJhN2Ji
+        LyIsInBybiI6InBybjpycG0ucnBtZGlzdHJpYnV0aW9uOjAxOTVlZTQyLWY3
+        NzQtNzBjMC1iMWY4LWViYTFlNTcyYTdiYiIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjUtMDMtMzFUMjI6MTI6MDEuMDE1NjE5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNS0wMy0zMVQyMjoxMjowMS4wMTU3MDdaIiwiYmFzZV9wYXRoIjoi
         QUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJl
         bCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwt
         c3RhYmxlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01FX0NvcnBvcmF0
         aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIsImNvbnRlbnRf
-        Z3VhcmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNC0x
-        MC0zMFQyMDozMTo1NS43NzcyMDhaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9s
+        Z3VhcmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNS0w
+        My0zMVQyMjoxMjowMS4wMTU3MDdaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9s
         YWJlbHMiOnt9LCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJyZXBvc2l0b3J5Ijpu
         dWxsLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
-        cnBtL3JwbS8wMTkyZGYyMC1iMmI1LTdmZTAtYWVmNy00MDA1ZDYzZDM5NmUv
+        cnBtL3JwbS8wMTk1ZWU0Mi1mMTA2LTc5ODctYTgwNi0zMTcyYzdkYmU1MjYv
         IiwiZ2VuZXJhdGVfcmVwb19jb25maWciOmZhbHNlfV19
-  recorded_at: Wed, 30 Oct 2024 20:31:56 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:02 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df20-b2b5-7fe0-aef7-4005d63d396e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee42-f106-7987-a806-3172c7dbe526/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1614,19 +1613,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:56 GMT
+      - Mon, 31 Mar 2025 22:12:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1634,7 +1633,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9141973c163449b88a729edb675ee10e
+      - c235538c81844dc2aa0d4fcdb8e649ad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1643,33 +1642,33 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtYjJiNS03ZmUwLWFlZjctNDAwNWQ2M2QzOTZlLyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjAtYjJiNS03ZmUw
-        LWFlZjctNDAwNWQ2M2QzOTZlIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMTo1NS4wNjM0NjdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMxOjU1LjIwMzkzNVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAt
-        YjBmNy03YzU3LTk3MDYtMWY0YzViOWFkMThkL3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDItZjEwNi03OTg3LWE4MDYtMzE3MmM3ZGJlNTI2LyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDItZjEwNi03OTg3
+        LWE4MDYtMzE3MmM3ZGJlNTI2IiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMTo1OS4zNjk4OTVaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjExOjU5LjY2MzI0MloiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDIt
+        ZWUxNS03ZGM2LTgxZWItYzUyYTEyYWUyNjFmL3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMC1iMGY3LTdjNTctOTcwNi0xZjRjNWI5YWQxOGQvIiwiY2hlY2tz
+        MTk1ZWU0Mi1lZTE1LTdkYzYtODFlYi1jNTJhMTJhZTI2MWYvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:56 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:03 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-b57f-713c-8bf3-95aef619fcf7/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee42-f774-70c0-b1f8-eba1e572a7bb/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
-        Y2VydGd1YXJkL3Joc20vMDE5MmRmMjAtYjkzNC03YWM3LWFlNWUtY2E2ZTVl
-        NmRhZmJjLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        Y2VydGd1YXJkL3Joc20vMDE5NWVlNDItZmUyYS03OWE1LWE2OTctMmY3NzE0
+        YjRhZjVmLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMTkyZGYyMC1iMmI1LTdm
-        ZTAtYWVmNy00MDA1ZDYzZDM5NmUvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMTk1ZWU0Mi1mMTA2LTc5
+        ODctYTgwNi0zMTcyYzdkYmU1MjYvIn0=
     headers:
       Content-Type:
       - application/json
@@ -1687,13 +1686,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:57 GMT
+      - Mon, 31 Mar 2025 22:12:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1707,7 +1706,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4e787acf6b924c02a14475dd099289ce
+      - '063966ccb29443fbbbd08c106c740ffb'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1715,12 +1714,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWJhMjYtNzBm
-        ZS04YWUyLTMwZTZiMzJhNjQ4Ni8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:57 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTAwNGEtN2Nh
+        Yy1iZDhhLTY3OTVmMTMyYmNjNC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:03 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-ba26-70fe-8ae2-30e6b32a6486/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-004a-7cac-bd8a-6795f132bcc4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1728,7 +1727,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1741,19 +1740,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:57 GMT
+      - Mon, 31 Mar 2025 22:12:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '788'
+      - '769'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1761,7 +1760,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - aed4801abe134c359cbac6b040f3b5fa
+      - 6435ea8ca0b14829827c74316d7a4c95
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1769,28 +1768,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtYmEy
-        Ni03MGZlLThhZTItMzBlNmIzMmE2NDg2LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtYmEyNi03MGZlLThhZTItMzBlNmIzMmE2NDg2IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMTo1Ni45NjcxMjRaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjU2Ljk2NzE0M1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtMDA0
+        YS03Y2FjLWJkOGEtNjc5NWYxMzJiY2M0LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtMDA0YS03Y2FjLWJkOGEtNjc5NWYxMzJiY2M0IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjowMy4yNzYxMjNaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjAzLjI3NjE0Nloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiNGU3ODdh
-        Y2Y2YjkyNGMwMmExNDQ3NWRkMDk5Mjg5Y2UiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMTo1Ni45OTIxMzZaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzE6NTYuOTk3NjIyWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMTo1Ny4wMTkwMjZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJkZWFiLTE2NDctNzY1NC04YmYxLWI1ZGZiYjczNDU5MTpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyZGVhYi0xNjQ3LTc2
-        NTQtOGJmMS1iNWRmYmI3MzQ1OTEiXX0=
-  recorded_at: Wed, 30 Oct 2024 20:31:57 GMT
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiMDYzOTY2
+        Y2NiMjk0NDNmYmJiZDA4YzEwNmM3NDBmZmIiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjAzLjI5NDgyN1oi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjowMy4yOTg3OThaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjAzLjM0MDIxNFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjpudWxsLCJwYXJlbnRfdGFzayI6bnVsbCwi
+        Y2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19y
+        ZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbInBkcm46NmQzYzYwMWYtZmVhZi00YjkzLTgy
+        NjQtNTI4YzI5MTI5YTEzOmRpc3RyaWJ1dGlvbnMiLCJzaGFyZWQ6cHJuOmNv
+        cmUuZG9tYWluOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUyOGMyOTEyOWEx
+        MyJdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:03 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df20-b2b5-7fe0-aef7-4005d63d396e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee42-f106-7987-a806-3172c7dbe526/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1811,19 +1810,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:57 GMT
+      - Mon, 31 Mar 2025 22:12:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1831,7 +1830,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1c2a89fe3bf748efa40c199316dbd720
+      - 89cb385988304baba7d9f2d69bfe1334
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1840,33 +1839,33 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtYjJiNS03ZmUwLWFlZjctNDAwNWQ2M2QzOTZlLyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjAtYjJiNS03ZmUw
-        LWFlZjctNDAwNWQ2M2QzOTZlIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMTo1NS4wNjM0NjdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMxOjU1LjIwMzkzNVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAt
-        YjBmNy03YzU3LTk3MDYtMWY0YzViOWFkMThkL3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDItZjEwNi03OTg3LWE4MDYtMzE3MmM3ZGJlNTI2LyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDItZjEwNi03OTg3
+        LWE4MDYtMzE3MmM3ZGJlNTI2IiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMTo1OS4zNjk4OTVaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjExOjU5LjY2MzI0MloiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDIt
+        ZWUxNS03ZGM2LTgxZWItYzUyYTEyYWUyNjFmL3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMC1iMGY3LTdjNTctOTcwNi0xZjRjNWI5YWQxOGQvIiwiY2hlY2tz
+        MTk1ZWU0Mi1lZTE1LTdkYzYtODFlYi1jNTJhMTJhZTI2MWYvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:57 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:03 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-b57f-713c-8bf3-95aef619fcf7/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee42-f774-70c0-b1f8-eba1e572a7bb/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
-        Y2VydGd1YXJkL3Joc20vMDE5MmRmMjAtYjkzNC03YWM3LWFlNWUtY2E2ZTVl
-        NmRhZmJjLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        Y2VydGd1YXJkL3Joc20vMDE5NWVlNDItZmUyYS03OWE1LWE2OTctMmY3NzE0
+        YjRhZjVmLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMTkyZGYyMC1iMmI1LTdm
-        ZTAtYWVmNy00MDA1ZDYzZDM5NmUvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMTk1ZWU0Mi1mMTA2LTc5
+        ODctYTgwNi0zMTcyYzdkYmU1MjYvIn0=
     headers:
       Content-Type:
       - application/json
@@ -1884,13 +1883,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:57 GMT
+      - Mon, 31 Mar 2025 22:12:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1904,7 +1903,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 99b7200537e34baeb3e7acc5cf05f62e
+      - 02ef757c74a846fbb0ca98bf68511324
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1912,9 +1911,9 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWJiM2QtN2Fl
-        OS04MmExLWE1ZTg1OTBjMmI2YS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:57 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTAyY2QtNzc3
+        Zi04MTg4LTRlNTg5MmQ0NjljMS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:03 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -1949,15 +1948,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:57 GMT
+      - Mon, 31 Mar 2025 22:12:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/0192df20-bc09-7a47-9bee-bd794ddaf0e4/"
+      - "/pulp/api/v3/remotes/rpm/rpm/0195ee43-0428-77b5-8fa4-74565c397d34/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1971,7 +1970,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 716e444d18844df0ab7d0858bd479e8e
+      - 5ed556e2440344a08b5dc43955addb07
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1980,11 +1979,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OTJkZjIwLWJjMDktN2E0Ny05YmVlLWJkNzk0ZGRhZjBlNC8iLCJwcm4iOiJw
-        cm46cnBtLnJwbXJlbW90ZTowMTkyZGYyMC1iYzA5LTdhNDctOWJlZS1iZDc5
-        NGRkYWYwZTQiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjU3
-        LjQ0OTUxN1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMTAtMzBUMjA6
-        MzE6NTcuNDQ5NTU4WiIsIm5hbWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJs
+        OTVlZTQzLTA0MjgtNzdiNS04ZmE0LTc0NTY1YzM5N2QzNC8iLCJwcm4iOiJw
+        cm46cnBtLnJwbXJlbW90ZTowMTk1ZWU0My0wNDI4LTc3YjUtOGZhNC03NDU2
+        NWMzOTdkMzQiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjA0
+        LjI2NTM5NloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUtMDMtMzFUMjI6
+        MTI6MDQuMjY1NDE5WiIsIm5hbWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJs
         IjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0IjoiS0pMOktERiooREYm
         KigqJCYoKiMkSkxLSkQoRCgoRCIsImNsaWVudF9jZXJ0IjoiS0pMOktERioo
         REYmKigqJCYoKiMkSkxLSkQoRCgoRCIsInRsc192YWxpZGF0aW9uIjpmYWxz
@@ -1999,10 +1998,10 @@ http_interactions:
         dCI6ZmFsc2V9LHsibmFtZSI6InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0s
         eyJuYW1lIjoicGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfV0sInNsZXNfYXV0
         aF90b2tlbiI6bnVsbH0=
-  recorded_at: Wed, 30 Oct 2024 20:31:57 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:04 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df20-bc09-7a47-9bee-bd794ddaf0e4/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee43-0428-77b5-8fa4-74565c397d34/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2023,13 +2022,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:57 GMT
+      - Mon, 31 Mar 2025 22:12:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -2043,7 +2042,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 84e6b469250c4226aa9593b0ffc86f9e
+      - f2a0ff8cad564522ab6153fb0c38bcbb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2051,12 +2050,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWJjNGItNzBj
-        YS05MmVhLTkwN2Q3MzA4ZGI1ZC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:57 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTA0YTgtNzky
+        My1hMzJjLTA2MzA4NjcyOWM4OS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:04 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0192df20-b0f7-7c57-9706-1f4c5b9ad18d/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0195ee42-ee15-7dc6-81eb-c52a12ae261f/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2079,13 +2078,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:57 GMT
+      - Mon, 31 Mar 2025 22:12:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -2099,7 +2098,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2e96a897824a454aad77f85cec6c2f8c
+      - c8820cf628a841aea9de9c228be72fe8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2107,12 +2106,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWJkMjgtN2E0
-        Yy04MGQzLTAxOGI5MmVhZWU0YS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:57 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTA1ZWYtN2Jh
+        ZS05M2I3LTlhNDJmNjJhMTU4NC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:04 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df20-b04c-7907-a542-9c1ce9cec41a/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee42-ece6-72d9-be0b-540cf78cfbe9/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2144,13 +2143,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:57 GMT
+      - Mon, 31 Mar 2025 22:12:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -2164,7 +2163,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c66847d0ef7c43b79b1e65085c9f011d
+      - ac79379df86a4f28a8bc01a2fbc88628
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2172,12 +2171,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWJkOWUtNzE4
-        Ny05M2MyLTdlMTA5MzdmNDhmZS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:57 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTA2ZjEtNzIx
+        Yi1iZmJmLWE3YjA1YTE4MmU4My8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:05 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-bd9e-7187-93c2-7e10937f48fe/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-06f1-721b-bfbf-a7b05a182e83/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2185,7 +2184,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2198,19 +2197,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:57 GMT
+      - Mon, 31 Mar 2025 22:12:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '787'
+      - '768'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2218,7 +2217,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1e4b6897df5640c28dba116301aa6eb4
+      - 377f5732e46b4269896dd4e209cf6526
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2226,25 +2225,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtYmQ5
-        ZS03MTg3LTkzYzItN2UxMDkzN2Y0OGZlLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtYmQ5ZS03MTg3LTkzYzItN2UxMDkzN2Y0OGZlIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMTo1Ny44NTUxMjhaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjU3Ljg1NTE0N1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtMDZm
+        MS03MjFiLWJmYmYtYTdiMDVhMTgyZTgzLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtMDZmMS03MjFiLWJmYmYtYTdiMDVhMTgyZTgzIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjowNC45Nzg5MDVaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjA0Ljk3ODk0M1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYzY2ODQ3
-        ZDBlZjdjNDNiNzliMWU2NTA4NWM5ZjAxMWQiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMTo1Ny44NzQxMzZaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzE6NTcuODc3MTE2WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMTo1Ny44OTEwODhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46cnBt
-        LnJwbXJlbW90ZTowMTkyZGYyMC1iMDRjLTc5MDctYTU0Mi05YzFjZTljZWM0
-        MWEiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAxOTJkZWFiLTE2NDctNzY1
-        NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:57 GMT
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYWM3OTM3
+        OWRmODZhNGYyOGE4YmMwMWEyZmJjODg2MjgiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjA1LjAwMjYyN1oi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjowNS4wMDU5MDhaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjA1LjAyMjQ4N1oiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjpudWxsLCJwYXJlbnRfdGFzayI6bnVsbCwi
+        Y2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19y
+        ZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbInBybjpycG0ucnBtcmVtb3RlOjAxOTVlZTQy
+        LWVjZTYtNzJkOS1iZTBiLTU0MGNmNzhjZmJlOSIsInNoYXJlZDpwcm46Y29y
+        ZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgyNjQtNTI4YzI5MTI5YTEz
+        Il19
+  recorded_at: Mon, 31 Mar 2025 22:12:05 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -2268,13 +2267,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:58 GMT
+      - Mon, 31 Mar 2025 22:12:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2288,7 +2287,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fa3fb0f144e6476597aeefa3cd60cf87
+      - efef8d9391a14c34b490de64b753b026
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2298,27 +2297,27 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMDE5MmRmMjAtYjU3Zi03MTNjLThiZjMtOTVhZWY2MTlmY2Y3
-        LyIsInBybiI6InBybjpycG0ucnBtZGlzdHJpYnV0aW9uOjAxOTJkZjIwLWI1
-        N2YtNzEzYy04YmYzLTk1YWVmNjE5ZmNmNyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMTAtMzBUMjA6MzE6NTUuNzc3MTg5WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0xMC0zMFQyMDozMTo1Ny4yNzg1NzhaIiwiYmFzZV9wYXRoIjoi
+        L3JwbS9ycG0vMDE5NWVlNDItZjc3NC03MGMwLWIxZjgtZWJhMWU1NzJhN2Ji
+        LyIsInBybiI6InBybjpycG0ucnBtZGlzdHJpYnV0aW9uOjAxOTVlZTQyLWY3
+        NzQtNzBjMC1iMWY4LWViYTFlNTcyYTdiYiIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjUtMDMtMzFUMjI6MTI6MDEuMDE1NjE5WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNS0wMy0zMVQyMjoxMjowMy45NzI5MjVaIiwiYmFzZV9wYXRoIjoi
         QUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJl
         bCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwt
         c3RhYmxlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01FX0NvcnBvcmF0
         aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIsImNvbnRlbnRf
         Z3VhcmQiOiIvcHVscC9hcGkvdjMvY29udGVudGd1YXJkcy9jZXJ0Z3VhcmQv
-        cmhzbS8wMTkyZGYyMC1iOTM0LTdhYzctYWU1ZS1jYTZlNWU2ZGFmYmMvIiwi
-        bm9fY29udGVudF9jaGFuZ2Vfc2luY2UiOiIyMDI0LTEwLTMwVDIwOjMxOjU3
-        LjI3ODU3OFoiLCJoaWRkZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5h
+        cmhzbS8wMTk1ZWU0Mi1mZTJhLTc5YTUtYTY5Ny0yZjc3MTRiNGFmNWYvIiwi
+        bm9fY29udGVudF9jaGFuZ2Vfc2luY2UiOiIyMDI1LTAzLTMxVDIyOjEyOjAz
+        Ljk3MjkyNVoiLCJoaWRkZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5h
         bWUiOiIyX2R1cGxpY2F0ZSIsInJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0
-        aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBtLzAxOTJk
-        ZjIwLWIyYjUtN2ZlMC1hZWY3LTQwMDVkNjNkMzk2ZS8iLCJnZW5lcmF0ZV9y
+        aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBtLzAxOTVl
+        ZTQyLWYxMDYtNzk4Ny1hODA2LTMxNzJjN2RiZTUyNi8iLCJnZW5lcmF0ZV9y
         ZXBvX2NvbmZpZyI6ZmFsc2V9XX0=
-  recorded_at: Wed, 30 Oct 2024 20:31:58 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:05 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df20-b2b5-7fe0-aef7-4005d63d396e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee42-f106-7987-a806-3172c7dbe526/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2339,19 +2338,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:58 GMT
+      - Mon, 31 Mar 2025 22:12:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2359,7 +2358,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a8eb2db283684a13bfc9ff8026e27527
+      - 66247ab15b6a43e49c3d4d4f70a23023
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2368,31 +2367,31 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtYjJiNS03ZmUwLWFlZjctNDAwNWQ2M2QzOTZlLyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjAtYjJiNS03ZmUw
-        LWFlZjctNDAwNWQ2M2QzOTZlIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMTo1NS4wNjM0NjdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMxOjU1LjIwMzkzNVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAt
-        YjBmNy03YzU3LTk3MDYtMWY0YzViOWFkMThkL3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDItZjEwNi03OTg3LWE4MDYtMzE3MmM3ZGJlNTI2LyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDItZjEwNi03OTg3
+        LWE4MDYtMzE3MmM3ZGJlNTI2IiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMTo1OS4zNjk4OTVaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjExOjU5LjY2MzI0MloiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDIt
+        ZWUxNS03ZGM2LTgxZWItYzUyYTEyYWUyNjFmL3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMC1iMGY3LTdjNTctOTcwNi0xZjRjNWI5YWQxOGQvIiwiY2hlY2tz
+        MTk1ZWU0Mi1lZTE1LTdkYzYtODFlYi1jNTJhMTJhZTI2MWYvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:58 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:05 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-b57f-713c-8bf3-95aef619fcf7/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee42-f774-70c0-b1f8-eba1e572a7bb/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE5
-        MmRmMjAtYjJiNS03ZmUwLWFlZjctNDAwNWQ2M2QzOTZlLyJ9
+        NWVlNDItZjEwNi03OTg3LWE4MDYtMzE3MmM3ZGJlNTI2LyJ9
     headers:
       Content-Type:
       - application/json
@@ -2410,13 +2409,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:58 GMT
+      - Mon, 31 Mar 2025 22:12:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -2430,7 +2429,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2bda8a85fdd9472c833d174da956039c
+      - 83068106e0324ac7910cb870d0ddba5d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2438,12 +2437,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWJlY2QtN2Zh
-        Mi05MzBiLTdmNjZiMWVlMzliOS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:58 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTA5NTEtNzk3
+        OS1iZjIwLWY2ZjdkOGM1M2NmNC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:05 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-becd-7fa2-930b-7f66b1ee39b9/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-0951-7979-bf20-f6f7d8c53cf4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2451,7 +2450,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2464,19 +2463,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:58 GMT
+      - Mon, 31 Mar 2025 22:12:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '788'
+      - '769'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2484,7 +2483,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c0b2a4343e284fdf93cadee4fabbfd4f
+      - ce1024b06e904459938cc3f8ddc34775
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2492,28 +2491,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtYmVj
-        ZC03ZmEyLTkzMGItN2Y2NmIxZWUzOWI5LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtYmVjZC03ZmEyLTkzMGItN2Y2NmIxZWUzOWI5IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMTo1OC4xNTc5MDVaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjU4LjE1NzkyM1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtMDk1
+        MS03OTc5LWJmMjAtZjZmN2Q4YzUzY2Y0LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtMDk1MS03OTc5LWJmMjAtZjZmN2Q4YzUzY2Y0IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjowNS41ODY1ODBaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjA1LjU4NjYwM1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiMmJkYThh
-        ODVmZGQ5NDcyYzgzM2QxNzRkYTk1NjAzOWMiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMTo1OC4xNzMwNDhaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzE6NTguMTc3MjEzWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMTo1OC4xOTQzNjJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJkZWFiLTE2NDctNzY1NC04YmYxLWI1ZGZiYjczNDU5MTpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyZGVhYi0xNjQ3LTc2
-        NTQtOGJmMS1iNWRmYmI3MzQ1OTEiXX0=
-  recorded_at: Wed, 30 Oct 2024 20:31:58 GMT
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiODMwNjgx
+        MDZlMDMyNGFjNzkxMGNiODcwZDBkZGJhNWQiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjA1LjYwNjg1Nloi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjowNS42MTAyMzBaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjA1LjY0MTk0NVoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjpudWxsLCJwYXJlbnRfdGFzayI6bnVsbCwi
+        Y2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19y
+        ZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbInBkcm46NmQzYzYwMWYtZmVhZi00YjkzLTgy
+        NjQtNTI4YzI5MTI5YTEzOmRpc3RyaWJ1dGlvbnMiLCJzaGFyZWQ6cHJuOmNv
+        cmUuZG9tYWluOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUyOGMyOTEyOWEx
+        MyJdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:05 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df20-b2b5-7fe0-aef7-4005d63d396e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee42-f106-7987-a806-3172c7dbe526/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2534,19 +2533,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:58 GMT
+      - Mon, 31 Mar 2025 22:12:05 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2554,7 +2553,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fa8c59d04f81407abfaec799c9c8e861
+      - 62621885c4344e5faf26419786252442
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2563,31 +2562,31 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtYjJiNS03ZmUwLWFlZjctNDAwNWQ2M2QzOTZlLyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjAtYjJiNS03ZmUw
-        LWFlZjctNDAwNWQ2M2QzOTZlIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMTo1NS4wNjM0NjdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMxOjU1LjIwMzkzNVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAt
-        YjBmNy03YzU3LTk3MDYtMWY0YzViOWFkMThkL3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDItZjEwNi03OTg3LWE4MDYtMzE3MmM3ZGJlNTI2LyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDItZjEwNi03OTg3
+        LWE4MDYtMzE3MmM3ZGJlNTI2IiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMTo1OS4zNjk4OTVaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjExOjU5LjY2MzI0MloiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDIt
+        ZWUxNS03ZGM2LTgxZWItYzUyYTEyYWUyNjFmL3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMC1iMGY3LTdjNTctOTcwNi0xZjRjNWI5YWQxOGQvIiwiY2hlY2tz
+        MTk1ZWU0Mi1lZTE1LTdkYzYtODFlYi1jNTJhMTJhZTI2MWYvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:58 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:05 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-b57f-713c-8bf3-95aef619fcf7/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee42-f774-70c0-b1f8-eba1e572a7bb/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE5
-        MmRmMjAtYjJiNS03ZmUwLWFlZjctNDAwNWQ2M2QzOTZlLyJ9
+        NWVlNDItZjEwNi03OTg3LWE4MDYtMzE3MmM3ZGJlNTI2LyJ9
     headers:
       Content-Type:
       - application/json
@@ -2605,13 +2604,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:58 GMT
+      - Mon, 31 Mar 2025 22:12:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -2625,7 +2624,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ccc8a11da25143c285c997b98dce9622
+      - d0d2a99b29ca450281d69e93b0d4a8b7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2633,12 +2632,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWJmYzgtN2E4
-        Yy05NjhhLTNlYWM5M2Q0ZGQwMy8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:58 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTBiNzAtNzUz
+        ZC05MGY2LWVkMjVjNDQwODBmYi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:06 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-b57f-713c-8bf3-95aef619fcf7/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee42-f774-70c0-b1f8-eba1e572a7bb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2659,13 +2658,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:58 GMT
+      - Mon, 31 Mar 2025 22:12:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -2679,7 +2678,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d3a4f9495f1e4972a9e16eea69cd038e
+      - c6fee398f6744d0ea419ee42f3d0d360
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2687,12 +2686,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWMwNDYtN2Zi
-        OS1hZGI0LTk0NjhkOWNmMzljYy8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:58 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTBjNWMtN2E3
+        Ny1hMTkyLTgxNjExYTYxYmU3OS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:06 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df20-b04c-7907-a542-9c1ce9cec41a/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee42-ece6-72d9-be0b-540cf78cfbe9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2713,13 +2712,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:58 GMT
+      - Mon, 31 Mar 2025 22:12:06 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -2733,7 +2732,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5aded97759ff44b0b56d2556e74b1dee
+      - ed45b0c1290a4993875179ffd3d6eaad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2741,12 +2740,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWMxMjUtNzI4
-        OC1iNTgzLTQ5MGMzNmMyMWU5OC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:58 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTBkY2MtN2Fh
+        ZS05MTk5LWZhYzJkYWU4MzRkOS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:06 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-c125-7288-b583-490c36c21e98/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-0dcc-7aae-9199-fac2dae834d9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2754,7 +2753,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2767,19 +2766,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:58 GMT
+      - Mon, 31 Mar 2025 22:12:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '843'
+      - '824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2787,7 +2786,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d88013a6683e486390aadedbccbc2a4d
+      - 3732b7ce01ff4a388eac095f79c152c5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2795,29 +2794,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtYzEy
-        NS03Mjg4LWI1ODMtNDkwYzM2YzIxZTk4LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtYzEyNS03Mjg4LWI1ODMtNDkwYzM2YzIxZTk4IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMTo1OC43NTgzOTZaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjU4Ljc1ODQxMloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtMGRj
+        Yy03YWFlLTkxOTktZmFjMmRhZTgzNGQ5LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtMGRjYy03YWFlLTkxOTktZmFjMmRhZTgzNGQ5IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjowNi43MzM1ODRaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjA2LjczMzYwNloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiNWFkZWQ5
-        Nzc1OWZmNDRiMGI1NmQyNTU2ZTc0YjFkZWUiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMTo1OC43NzQ5OTlaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzE6NTguODE2NDk5WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMTo1OC44NTc5MjlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTM5NTktN2UwNi05MmY4LWZkOWI1
-        MTgxYjdlZS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpycG0ucnBtcmVtb3RlOjAxOTJkZjIwLWIwNGMtNzkwNy1hNTQy
-        LTljMWNlOWNlYzQxYSIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmRl
-        YWItMTY0Ny03NjU0LThiZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:31:58 GMT
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiZWQ0NWIw
+        YzEyOTBhNDk5Mzg3NTE3OWZmZDNkNmVhYWQiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjA2Ljc1MzI5MFoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjowNi44Mjc1MjVaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjA2Ljg5OTIyNVoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmNmMC03ZjU5LWFhZmEtYzAyYzY0YmU5Nzk2LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10s
+        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOnJwbS5ycG1yZW1v
+        dGU6MDE5NWVlNDItZWNlNi03MmQ5LWJlMGItNTQwY2Y3OGNmYmU5Iiwic2hh
+        cmVkOnBybjpjb3JlLmRvbWFpbjo2ZDNjNjAxZi1mZWFmLTRiOTMtODI2NC01
+        MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:12:07 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0192df20-b0f7-7c57-9706-1f4c5b9ad18d/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0195ee42-ee15-7dc6-81eb-c52a12ae261f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2838,13 +2837,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:59 GMT
+      - Mon, 31 Mar 2025 22:12:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -2858,7 +2857,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9e8bb426f7be41a099d1b09878da6398
+      - 4e38e444e0ba409899f275fca5000cda
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2866,12 +2865,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWMyNDYtN2Qy
-        ZC04Mjc0LThmYjNmYzkyMGVmNi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:59 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTEwMjItNzBh
+        Mi1hYWIzLWI2YWYzMzExM2M3ZS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:07 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-c246-7d2d-8274-8fb3fc920ef6/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-1022-70a2-aab3-b6af33113c7e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2879,7 +2878,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2892,19 +2891,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:59 GMT
+      - Mon, 31 Mar 2025 22:12:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '847'
+      - '828'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2912,7 +2911,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 79da45aff8834ac1bee27e4654e601e6
+      - 4d33b0080c7e46efa4f7c0db94328aa6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2920,29 +2919,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtYzI0
-        Ni03ZDJkLTgyNzQtOGZiM2ZjOTIwZWY2LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtYzI0Ni03ZDJkLTgyNzQtOGZiM2ZjOTIwZWY2IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMTo1OS4wNDY3NzhaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjU5LjA0Njc5M1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtMTAy
+        Mi03MGEyLWFhYjMtYjZhZjMzMTEzYzdlLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtMTAyMi03MGEyLWFhYjMtYjZhZjMzMTEzYzdlIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjowNy4zMzIxNDhaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjA3LjMzMjE4Nloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiOWU4YmI0
-        MjZmN2JlNDFhMDk5ZDFiMDk4NzhkYTYzOTgiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMTo1OS4wNjU0MzVaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzE6NTkuMTEzMzMyWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMTo1OS4yNzA4ODFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTNhNDItN2QyNC1hYjVmLTg4ZGNj
-        YzI4YjNiZC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpycG0ucnBtcmVwb3NpdG9yeTowMTkyZGYyMC1iMGY3LTdjNTct
-        OTcwNi0xZjRjNWI5YWQxOGQiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAx
-        OTJkZWFiLTE2NDctNzY1NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:59 GMT
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiNGUzOGU0
+        NDRlMGJhNDA5ODk5ZjI3NWZjYTUwMDBjZGEiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjA3LjM1NjA0NVoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjowNy40MjYxOThaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjA3LjczMDkyOFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmNmMC03ZjU5LWFhZmEtYzAyYzY0YmU5Nzk2LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10s
+        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOnJwbS5ycG1yZXBv
+        c2l0b3J5OjAxOTVlZTQyLWVlMTUtN2RjNi04MWViLWM1MmExMmFlMjYxZiIs
+        InNoYXJlZDpwcm46Y29yZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgy
+        NjQtNTI4YzI5MTI5YTEzIl19
+  recorded_at: Mon, 31 Mar 2025 22:12:07 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2950,7 +2949,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.22.2/ruby
+      - OpenAPI-Generator/0.22.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2963,13 +2962,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:59 GMT
+      - Mon, 31 Mar 2025 22:12:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2983,7 +2982,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 062f752573df40ad8a1a4ad52252738a
+      - 203e42fba35f4c418ce11be29c360f75
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2993,7 +2992,385 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:59 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:08 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.3.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - ec84d55ac97f4844b0c7d9fbe3a1da82
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:08 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.22.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - dce718b1193e45c4ba3dee17c5f5087a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:08 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - b77acbfae614472cac7a272c5c9a94fb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:08 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.4.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - a7333f3aa7b3412b88cd89110ae74029
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:08 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.12.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7c8c051bc8b940049954c582e5db77c9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:08 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.27.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:08 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - a8d5ff55ce80428289c16add1e423346
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:08 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.22.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:09 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3dc65ad0f1434eb09d77727172431e58
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:09 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -3017,13 +3394,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:59 GMT
+      - Mon, 31 Mar 2025 22:12:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -3037,7 +3414,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 42f5ae4be0c74981ad4d13ca1aaa312e
+      - 6a4dc3298c4643c8b87b889c0ad1ecff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3047,7 +3424,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:59 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:09 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -3058,7 +3435,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.21.1/ruby
+      - OpenAPI-Generator/2.22.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -3071,13 +3448,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:59 GMT
+      - Mon, 31 Mar 2025 22:12:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -3091,7 +3468,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 25560986680a432ea7e9e5d380e8d362
+      - 1e00e7662293450aa4f0edc479cb3206
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3101,7 +3478,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:59 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:09 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -3112,7 +3489,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -3125,13 +3502,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:59 GMT
+      - Mon, 31 Mar 2025 22:12:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -3145,7 +3522,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f6ef750930eb4ca5bd3aee2e93e09fc0
+      - 5cde4efe74884b75a5c740800e4f06ef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3155,7 +3532,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:59 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:09 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -3166,7 +3543,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.4.4/ruby
+      - OpenAPI-Generator/2.4.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -3179,13 +3556,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:59 GMT
+      - Mon, 31 Mar 2025 22:12:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -3199,7 +3576,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ca0c425709d4454baa9f0a2979e6d860
+      - '09fc7103c9c74ec18c61752bbd509517'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3209,7 +3586,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:59 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:09 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -3220,7 +3597,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.12.5/ruby
+      - OpenAPI-Generator/3.12.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -3233,13 +3610,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:59 GMT
+      - Mon, 31 Mar 2025 22:12:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -3253,7 +3630,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7f0ac6e78d664b2da4911529cc1564da
+      - 510ca868bb644c3286fc65b3eef53733
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3263,7 +3640,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:59 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:09 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -3287,13 +3664,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:59 GMT
+      - Mon, 31 Mar 2025 22:12:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -3307,7 +3684,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9992df9243af44518ded97b043cac17b
+      - a8622bfbf4e049048ada98db1cb0092c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3317,7 +3694,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:59 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:09 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/orphans/cleanup/
@@ -3330,7 +3707,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -3343,13 +3720,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:31:59 GMT
+      - Mon, 31 Mar 2025 22:12:09 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - POST, OPTIONS
       X-Frame-Options:
@@ -3363,7 +3740,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 817fe8a7266a466b9ce9938813618e2b
+      - 7dd5920138e24d5683d2787d960f28d0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3371,12 +3748,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWM1ZTItNzI1
-        YS1iMmZmLWZhZDVlZWVjOTI5MS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:31:59 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTFhNjEtNzBm
+        ZS04ZWI5LWY0M2E2MGI5YWQ3MC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:09 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-c5e2-725a-b2ff-fad5eeec9291/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-1a61-70fe-8eb9-f43a60b9ad70/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3384,7 +3761,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -3397,19 +3774,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:00 GMT
+      - Mon, 31 Mar 2025 22:12:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1077'
+      - '1058'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -3417,7 +3794,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - eda2a90feb9d412c970afaa372b3726d
+      - 5be1f93c3f4b4fb38737d9a0f8029a87
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3425,31 +3802,31 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtYzVl
-        Mi03MjVhLWIyZmYtZmFkNWVlZWM5MjkxLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtYzVlMi03MjVhLWIyZmYtZmFkNWVlZWM5MjkxIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMTo1OS45NzA2NzNaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjU5Ljk3MDY4OFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtMWE2
+        MS03MGZlLThlYjktZjQzYTYwYjlhZDcwLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtMWE2MS03MGZlLThlYjktZjQzYTYwYjlhZDcwIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjowOS45NTUwMjJaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjA5Ljk1NTA1NVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiI4MTdm
-        ZThhNzI2NmE0NjZiOWNlOTkzODgxMzYxOGUyYiIsImNyZWF0ZWRfYnkiOiIv
-        cHVscC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTEw
-        LTMwVDIwOjMxOjU5Ljk4NzI4NFoiLCJzdGFydGVkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjowMC4wMzc3MzFaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTEwLTMw
-        VDIwOjMyOjAwLjIyMjEwNVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1
-        bHAvYXBpL3YzL3dvcmtlcnMvMDE5MmRlYWMtMzk1OS03ZTA2LTkyZjgtZmQ5
-        YjUxODFiN2VlLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6
-        W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1l
-        c3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQ29udGVudCIsImNvZGUiOiJjbGVh
-        bi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwi
-        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJDbGVhbiB1cCBv
-        cnBoYW4gQXJ0aWZhY3RzIiwiY29kZSI6ImNsZWFuLXVwLmFydGlmYWN0cyIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jl
-        c291cmNlc19yZWNvcmQiOlsicGRybjowMTkyZGVhYi0xNjQ3LTc2NTQtOGJm
-        MS1iNWRmYmI3MzQ1OTE6b3JwaGFucyIsInNoYXJlZDpwcm46Y29yZS5kb21h
-        aW46MDE5MmRlYWItMTY0Ny03NjU0LThiZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:32:00 GMT
+        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiI3ZGQ1
+        OTIwMTM4ZTI0ZDU2ODNkMjc4N2Q5NjBmMjhkMCIsImNyZWF0ZWRfYnkiOm51
+        bGwsInVuYmxvY2tlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6MDkuOTc4NzQ3
+        WiIsInN0YXJ0ZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjEwLjA1OTM1NFoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6MTAuMzQzMjUyWiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8w
+        MTk1ZDJlZS1iYjkyLTdjM2ItOWY1MS1lOThhOWVlMjhiYTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkNsZWFuIHVwIG9y
+        cGhhbiBDb250ZW50IiwiY29kZSI6ImNsZWFuLXVwLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51
+        bGx9LHsibWVzc2FnZSI6IkNsZWFuIHVwIG9ycGhhbiBBcnRpZmFjdHMiLCJj
+        b2RlIjoiY2xlYW4tdXAuYXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJw
+        ZHJuOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUyOGMyOTEyOWExMzpvcnBo
+        YW5zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo2ZDNjNjAxZi1mZWFmLTRi
+        OTMtODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:12:10 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/purge/
@@ -3462,7 +3839,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -3475,13 +3852,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:00 GMT
+      - Mon, 31 Mar 2025 22:12:10 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - POST, OPTIONS
       X-Frame-Options:
@@ -3495,7 +3872,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 91c1247a84114723a99206b53d6a3297
+      - 9af6b2fb197242979460a413cc45c89d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -3503,7 +3880,7 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWM3NGYtNzY1
-        OC05N2Y4LWY5ZWE4ZTM1MGJlNC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:00 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTFkMTUtNzAw
+        YS04NTgyLTMzZWJjMmZmNTM5Ni8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:10 GMT
 recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_ssl_validation.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_ssl_validation.yml
@@ -23,13 +23,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:01 GMT
+      - Mon, 31 Mar 2025 22:11:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0422e965da23446b994fb52a093f54d3
+      - b53d80f35b5d44b0a6ecfe1a9b5b015c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:01 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:45 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -77,13 +77,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:01 GMT
+      - Mon, 31 Mar 2025 22:11:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4918a770243b4efc88a9003a8cd1e7b8
+      - 89a77b00cec34cbea6ec668809ba64ac
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:01 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:45 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -131,13 +131,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:01 GMT
+      - Mon, 31 Mar 2025 22:11:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bad07f61a16845ff8db4f9100f63735c
+      - 17ebe560a9f44fbf898994034aa26f5a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:01 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:46 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -185,13 +185,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:01 GMT
+      - Mon, 31 Mar 2025 22:11:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 85bf8e114a484d14b9c3dad223a389a8
+      - 69ad1c4cce884bca857aa5efff97f468
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:01 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:46 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -247,15 +247,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:01 GMT
+      - Mon, 31 Mar 2025 22:11:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/0192df20-cbed-706a-8fa4-3a55aa6d6fa7/"
+      - "/pulp/api/v3/remotes/rpm/rpm/0195ee42-be60-7bb8-82dd-2458f2148918/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -269,7 +269,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6d406bdc7be04e1dbc27860ade5bc4a1
+      - ee55a9622f7c4504a25c53223ade2b76
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -278,11 +278,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OTJkZjIwLWNiZWQtNzA2YS04ZmE0LTNhNTVhYTZkNmZhNy8iLCJwcm4iOiJw
-        cm46cnBtLnJwbXJlbW90ZTowMTkyZGYyMC1jYmVkLTcwNmEtOGZhNC0zYTU1
-        YWE2ZDZmYTciLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjAx
-        LjUxNzk0NFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMTAtMzBUMjA6
-        MzI6MDEuNTE3OTYwWiIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0
+        OTVlZTQyLWJlNjAtN2JiOC04MmRkLTI0NThmMjE0ODkxOC8iLCJwcm4iOiJw
+        cm46cnBtLnJwbXJlbW90ZTowMTk1ZWU0Mi1iZTYwLTdiYjgtODJkZC0yNDU4
+        ZjIxNDg5MTgiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMxVDIyOjExOjQ2
+        LjQwMjkxM1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUtMDMtMzFUMjI6
+        MTE6NDYuNDAyOTM3WiIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0
         dHA6Ly9teXJlcG8uY29tIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQi
         Om51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGws
         InB1bHBfbGFiZWxzIjp7fSwiZG93bmxvYWRfY29uY3VycmVuY3kiOm51bGws
@@ -295,7 +295,7 @@ http_interactions:
         bWUiOiJwcm94eV9wYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6
         InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfV0sInNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
-  recorded_at: Wed, 30 Oct 2024 20:32:01 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:46 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -321,21 +321,21 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:01 GMT
+      - Mon, 31 Mar 2025 22:11:46 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/0192df20-cc94-7341-bd13-20512beec2a6/"
+      - "/pulp/api/v3/repositories/rpm/rpm/0195ee42-bfb9-7271-a174-ad6e1b298e76/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '880'
+      - '894'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -343,7 +343,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fe693be5373841e7be8f50bcb4339fb6
+      - 71bd5346024748738f1efb34fc9e065a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -352,16 +352,16 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMDE5MmRmMjAtY2M5NC03MzQxLWJkMTMtMjA1MTJiZWVjMmE2LyIsInBy
-        biI6InBybjpycG0ucnBtcmVwb3NpdG9yeTowMTkyZGYyMC1jYzk0LTczNDEt
-        YmQxMy0yMDUxMmJlZWMyYTYiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMw
-        VDIwOjMyOjAxLjY4NTY1MVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQt
-        MTAtMzBUMjA6MzI6MDEuNjkzOTgwWiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAtY2M5NC03
-        MzQxLWJkMTMtMjA1MTJiZWVjMmE2L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
+        cG0vMDE5NWVlNDItYmZiOS03MjcxLWExNzQtYWQ2ZTFiMjk4ZTc2LyIsInBy
+        biI6InBybjpycG0ucnBtcmVwb3NpdG9yeTowMTk1ZWU0Mi1iZmI5LTcyNzEt
+        YTE3NC1hZDZlMWIyOThlNzYiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMx
+        VDIyOjExOjQ2Ljc0ODg2NloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUt
+        MDMtMzFUMjI6MTE6NDYuNzU0NDE5WiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDItYmZiOS03
+        MjcxLWExNzQtYWQ2ZTFiMjk4ZTc2L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
         Ijp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcnBtL3JwbS8wMTkyZGYyMC1jYzk0LTczNDEtYmQxMy0yMDUx
-        MmJlZWMyYTYvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJk
+        c2l0b3JpZXMvcnBtL3JwbS8wMTk1ZWU0Mi1iZmI5LTcyNzEtYTE3NC1hZDZl
+        MWIyOThlNzYvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJk
         ZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGws
         InJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9z
         aWduaW5nX3NlcnZpY2UiOm51bGwsInBhY2thZ2Vfc2lnbmluZ19zZXJ2aWNl
@@ -370,8 +370,8 @@ http_interactions:
         bWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjpudWxsLCJncGdjaGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6
         bnVsbCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9
-        LCJjb21wcmVzc2lvbl90eXBlIjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:01 GMT
+        LCJjb21wcmVzc2lvbl90eXBlIjpudWxsLCJsYXlvdXQiOm51bGx9
+  recorded_at: Mon, 31 Mar 2025 22:11:46 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -379,8 +379,8 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE5MmRmMjAtY2M5NC03MzQxLWJkMTMtMjA1MTJiZWVj
-        MmE2L3ZlcnNpb25zLzAvIiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiJ9
+        aWVzL3JwbS9ycG0vMDE5NWVlNDItYmZiOS03MjcxLWExNzQtYWQ2ZTFiMjk4
+        ZTc2L3ZlcnNpb25zLzAvIiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiJ9
     headers:
       Content-Type:
       - application/json
@@ -398,13 +398,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:02 GMT
+      - Mon, 31 Mar 2025 22:11:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -418,7 +418,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3df49d4cd9d04ecda46e312294c99ed5
+      - 3769c7c64aa24d1aa7d17962be10a81f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -426,12 +426,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWNlMTctNzI3
-        ZC05MWFjLTVhNzM4MWNhYWI4MC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:02 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQyLWMyNTUtNzVi
+        ZC1hNjYxLWMzNDcxMDA0YmU3Ny8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:47 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-ce17-727d-91ac-5a7381caab80/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee42-c255-75bd-a661-c3471004be77/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -439,7 +439,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -452,19 +452,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:02 GMT
+      - Mon, 31 Mar 2025 22:11:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1060'
+      - '1041'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -472,7 +472,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 31bd78eeac204db68dc76da4b1dbfd26
+      - 538a952dc92640b7a50aa2fb08b91468
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -480,31 +480,31 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtY2Ux
-        Ny03MjdkLTkxYWMtNWE3MzgxY2FhYjgwLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtY2UxNy03MjdkLTkxYWMtNWE3MzgxY2FhYjgwIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjowMi4wNzE2MzdaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjAyLjA3MTY2NVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDItYzI1
+        NS03NWJkLWE2NjEtYzM0NzEwMDRiZTc3LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDItYzI1NS03NWJkLWE2NjEtYzM0NzEwMDRiZTc3IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMTo0Ny40MTQ2MTlaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjExOjQ3LjQxNDczOVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFz
-        a3MucHVibGlzaGluZy5wdWJsaXNoIiwibG9nZ2luZ19jaWQiOiIzZGY0OWQ0
-        Y2Q5ZDA0ZWNkYTQ2ZTMxMjI5NGM5OWVkNSIsImNyZWF0ZWRfYnkiOiIvcHVs
-        cC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTEwLTMw
-        VDIwOjMyOjAyLjA4NzgxMloiLCJzdGFydGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjowMi4xNDI2NjRaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTEwLTMwVDIw
-        OjMyOjAyLjM1NzIyN1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
-        YXBpL3YzL3dvcmtlcnMvMDE5MmRlYWMtMzg1ZS03OGIxLTg5NWItMGU4NDY4
-        MGMxMWY3LyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10s
-        InRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3Nh
-        Z2UiOiJHZW5lcmF0aW5nIHJlcG9zaXRvcnkgbWV0YWRhdGEiLCJjb2RlIjoi
-        cHVibGlzaC5nZW5lcmF0aW5nX21ldGFkYXRhIiwic3RhdGUiOiJjb21wbGV0
-        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
-        ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBt
-        L3JwbS8wMTkyZGYyMC1jZTc0LTc3NzEtOTMyZC1kZTZmOWFjZDQwOTAvIl0s
-        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsic2hhcmVkOnBybjpycG0u
-        cnBtcmVwb3NpdG9yeTowMTkyZGYyMC1jYzk0LTczNDEtYmQxMy0yMDUxMmJl
-        ZWMyYTYiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAxOTJkZWFiLTE2NDct
-        NzY1NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:02 GMT
+        a3MucHVibGlzaGluZy5wdWJsaXNoIiwibG9nZ2luZ19jaWQiOiIzNzY5Yzdj
+        NjRhYTI0ZDFhYTdkMTc5NjJiZTEwYTgxZiIsImNyZWF0ZWRfYnkiOm51bGws
+        InVuYmxvY2tlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTE6NDcuNDQ0MDYyWiIs
+        InN0YXJ0ZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjExOjQ3LjUxODE2NFoiLCJm
+        aW5pc2hlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTE6NDcuODg3NjMyWiIsImVy
+        cm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTk1
+        ZDJlZS1iYjkyLTdjM2ItOWY1MS1lOThhOWVlMjhiYTQvIiwicGFyZW50X3Rh
+        c2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVsbCwi
+        cHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkdlbmVyYXRpbmcgcmVw
+        b3NpdG9yeSBtZXRhZGF0YSIsImNvZGUiOiJwdWJsaXNoLmdlbmVyYXRpbmdf
+        bWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25l
+        IjoxLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1
+        bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBtLzAxOTVlZTQyLWMyZTQt
+        NzQ1MS1iZmNkLTdhZWE2MzgyNDAwZi8iXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
+        X3JlY29yZCI6WyJzaGFyZWQ6cHJuOnJwbS5ycG1yZXBvc2l0b3J5OjAxOTVl
+        ZTQyLWJmYjktNzI3MS1hMTc0LWFkNmUxYjI5OGU3NiIsInNoYXJlZDpwcm46
+        Y29yZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgyNjQtNTI4YzI5MTI5
+        YTEzIl19
+  recorded_at: Mon, 31 Mar 2025 22:11:47 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -528,13 +528,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:02 GMT
+      - Mon, 31 Mar 2025 22:11:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -548,7 +548,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 103c52e4e9464777bab0b8b3983ec150
+      - adf970ab5f6e4056843918394b8ec357
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -558,10 +558,10 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:02 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:48 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df20-ce74-7771-932d-de6f9acd4090/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee42-c2e4-7451-bfcd-7aea6382400f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -582,19 +582,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:02 GMT
+      - Mon, 31 Mar 2025 22:11:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -602,7 +602,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d584f7fb68f447cb856430798cfe3ca5
+      - 8c230b26a2bf47cd8113d20d65b16db6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -611,21 +611,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtY2U3NC03NzcxLTkzMmQtZGU2ZjlhY2Q0MDkwLyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjAtY2U3NC03Nzcx
-        LTkzMmQtZGU2ZjlhY2Q0MDkwIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMjowMi4xNjY0MTBaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMyOjAyLjM0OTMwMVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAt
-        Y2M5NC03MzQxLWJkMTMtMjA1MTJiZWVjMmE2L3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDItYzJlNC03NDUxLWJmY2QtN2FlYTYzODI0MDBmLyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDItYzJlNC03NDUx
+        LWJmY2QtN2FlYTYzODI0MDBmIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMTo0Ny41NTk1NDFaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjExOjQ3Ljg3ODM4M1oiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDIt
+        YmZiOS03MjcxLWExNzQtYWQ2ZTFiMjk4ZTc2L3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMC1jYzk0LTczNDEtYmQxMy0yMDUxMmJlZWMyYTYvIiwiY2hlY2tz
+        MTk1ZWU0Mi1iZmI5LTcyNzEtYTE3NC1hZDZlMWIyOThlNzYvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:02 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:48 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/
@@ -635,8 +635,8 @@ http_interactions:
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vMDE5MmRmMjAtY2U3NC03NzcxLTkzMmQtZGU2
-        ZjlhY2Q0MDkwLyJ9
+        bGljYXRpb25zL3JwbS9ycG0vMDE5NWVlNDItYzJlNC03NDUxLWJmY2QtN2Fl
+        YTYzODI0MDBmLyJ9
     headers:
       Content-Type:
       - application/json
@@ -654,13 +654,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:02 GMT
+      - Mon, 31 Mar 2025 22:11:48 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -674,7 +674,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a6360476028b4c03874ec24fabb776d8
+      - d6b869c76e274b0fa57c326b770532ee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -682,12 +682,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWQwNzItNzA0
-        Mi04Mjg5LTI0MDMzM2JmNGU2MC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:02 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQyLWM2ZTgtNzgy
+        YS05ZmY1LTcxOGJlMmI0OThjYS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:48 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-d072-7042-8289-240333bf4e60/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee42-c6e8-782a-9ff5-718be2b498ca/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -695,7 +695,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -708,19 +708,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:03 GMT
+      - Mon, 31 Mar 2025 22:11:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '918'
+      - '899'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -728,7 +728,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a07913fe5a9345dea1f38fce9eed1cde
+      - 2269436c3a274db796b290f75f974c1a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -736,31 +736,30 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtZDA3
-        Mi03MDQyLTgyODktMjQwMzMzYmY0ZTYwLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtZDA3Mi03MDQyLTgyODktMjQwMzMzYmY0ZTYwIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjowMi42NzQ0NTVaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjAyLjY3NDQ4NVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDItYzZl
+        OC03ODJhLTlmZjUtNzE4YmUyYjQ5OGNhLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDItYzZlOC03ODJhLTlmZjUtNzE4YmUyYjQ5OGNhIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMTo0OC41ODYxNDhaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjExOjQ4LjU4NjE3Mloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiYTYzNjA0
-        NzYwMjhiNGMwMzg3NGVjMjRmYWJiNzc2ZDgiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjowMi42OTIzMTVaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MDIuNzQwMDc3WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjowMi45ODE3NjJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTM4NWUtNzhiMS04OTViLTBlODQ2
-        ODBjMTFmNy8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
-        cnBtL3JwbS8wMTkyZGYyMC1kMTk0LTdhYTQtYjJlYS1mNzllMzVlNjVhYjEv
-        Il0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicGRybjowMTkyZGVh
-        Yi0xNjQ3LTc2NTQtOGJmMS1iNWRmYmI3MzQ1OTE6ZGlzdHJpYnV0aW9ucyIs
-        InNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmRlYWItMTY0Ny03NjU0LThi
-        ZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:32:03 GMT
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiZDZiODY5
+        Yzc2ZTI3NGIwZmE1N2MzMjZiNzcwNTMyZWUiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjExOjQ4LjYwOTExOFoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMTo0OC42OTA1OTVaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjExOjQ5LjI2OTM2NFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmEzYS03NDYzLWExNTUtOTg3Y2NjOWU1YTc0LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIv
+        cHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0vcnBtLzAxOTVlZTQyLWM5
+        N2YtNzdlZi1iN2JkLWUwZTVmNGJlMDM1Zi8iXSwicmVzZXJ2ZWRfcmVzb3Vy
+        Y2VzX3JlY29yZCI6WyJwZHJuOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUy
+        OGMyOTEyOWExMzpkaXN0cmlidXRpb25zIiwic2hhcmVkOnBybjpjb3JlLmRv
+        bWFpbjo2ZDNjNjAxZi1mZWFmLTRiOTMtODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:11:49 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-d194-7aa4-b2ea-f79e35e65ab1/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee42-c97f-77ef-b7bd-e0e5f4be035f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -781,13 +780,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:03 GMT
+      - Mon, 31 Mar 2025 22:11:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -801,7 +800,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6c03854a1d9341acbbf8b69440095db9
+      - 636255879c6f498fa9809ee3109906b8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -810,22 +809,22 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzAxOTJkZjIwLWQxOTQtN2FhNC1iMmVhLWY3OWUzNWU2NWFiMS8iLCJw
-        cm4iOiJwcm46cnBtLnJwbWRpc3RyaWJ1dGlvbjowMTkyZGYyMC1kMTk0LTdh
-        YTQtYjJlYS1mNzllMzVlNjVhYjEiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEw
-        LTMwVDIwOjMyOjAyLjk2NTM2N1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
-        MjQtMTAtMzBUMjA6MzI6MDIuOTY1Mzg4WiIsImJhc2VfcGF0aCI6IkFDTUVf
+        cnBtLzAxOTVlZTQyLWM5N2YtNzdlZi1iN2JkLWUwZTVmNGJlMDM1Zi8iLCJw
+        cm4iOiJwcm46cnBtLnJwbWRpc3RyaWJ1dGlvbjowMTk1ZWU0Mi1jOTdmLTc3
+        ZWYtYjdiZC1lMGU1ZjRiZTAzNWYiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAz
+        LTMxVDIyOjExOjQ5LjI1MDc4N1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
+        MjUtMDMtMzFUMjI6MTE6NDkuMjUwODA3WiIsImJhc2VfcGF0aCI6IkFDTUVf
         Q29ycG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJi
         YXNlX3VybCI6Imh0dHBzOi8vY2VudG9zOS1rYXRlbGxvLWRldmVsLXN0YWJs
         ZS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9k
         ZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJk
-        IjpudWxsLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MDIuOTY1Mzg4WiIsImhpZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxz
+        IjpudWxsLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6IjIwMjUtMDMtMzFU
+        MjI6MTE6NDkuMjUwODA3WiIsImhpZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxz
         Ijp7fSwibmFtZSI6IjJfZHVwbGljYXRlIiwicmVwb3NpdG9yeSI6bnVsbCwi
         cHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtY2U3NC03NzcxLTkzMmQtZGU2ZjlhY2Q0MDkwLyIsImdl
+        cG0vMDE5NWVlNDItYzJlNC03NDUxLWJmY2QtN2FlYTYzODI0MDBmLyIsImdl
         bmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX0=
-  recorded_at: Wed, 30 Oct 2024 20:32:03 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:49 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -860,15 +859,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:03 GMT
+      - Mon, 31 Mar 2025 22:11:49 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/0192df20-d2f3-79ca-8b36-93881faf17c8/"
+      - "/pulp/api/v3/remotes/rpm/rpm/0195ee42-cc3b-7344-bbf7-b40227487f4e/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -882,7 +881,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7f8b7d2be7824aeda1e4027d6f6362b6
+      - 443ca23def8d4564a4a981607c2d73f3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -891,11 +890,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OTJkZjIwLWQyZjMtNzljYS04YjM2LTkzODgxZmFmMTdjOC8iLCJwcm4iOiJw
-        cm46cnBtLnJwbXJlbW90ZTowMTkyZGYyMC1kMmYzLTc5Y2EtOGIzNi05Mzg4
-        MWZhZjE3YzgiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjAz
-        LjMxNTk4MloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMTAtMzBUMjA6
-        MzI6MDMuMzE2MDAwWiIsIm5hbWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJs
+        OTVlZTQyLWNjM2ItNzM0NC1iYmY3LWI0MDIyNzQ4N2Y0ZS8iLCJwcm4iOiJw
+        cm46cnBtLnJwbXJlbW90ZTowMTk1ZWU0Mi1jYzNiLTczNDQtYmJmNy1iNDAy
+        Mjc0ODdmNGUiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMxVDIyOjExOjQ5
+        Ljk0OTE1NloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUtMDMtMzFUMjI6
+        MTE6NDkuOTQ5MTgwWiIsIm5hbWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJs
         IjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0IjoiS0pMOktERiooREYm
         KigqJCYoKiMkSkxLSkQoRCgoRCIsImNsaWVudF9jZXJ0IjoiS0pMOktERioo
         REYmKigqJCYoKiMkSkxLSkQoRCgoRCIsInRsc192YWxpZGF0aW9uIjp0cnVl
@@ -910,10 +909,10 @@ http_interactions:
         IjpmYWxzZX0seyJuYW1lIjoidXNlcm5hbWUiLCJpc19zZXQiOmZhbHNlfSx7
         Im5hbWUiOiJwYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9XSwic2xlc19hdXRo
         X3Rva2VuIjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:03 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:49 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df20-d2f3-79ca-8b36-93881faf17c8/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee42-cc3b-7344-bbf7-b40227487f4e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -934,13 +933,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:03 GMT
+      - Mon, 31 Mar 2025 22:11:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -954,7 +953,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4085bc604f7248e3a411c1eee595cf7a
+      - fe7640bfc2554352a2f628c1e3c8467a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -962,12 +961,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWQzMzktN2I0
-        Yi04OTcwLWM5OWQzZDRjYmU0ZS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:03 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQyLWNjY2EtNzdm
+        ZS1hNTgxLWVhMjA3MTNkMDc0Zi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:50 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0192df20-cc94-7341-bd13-20512beec2a6/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0195ee42-bfb9-7271-a174-ad6e1b298e76/
     body:
       encoding: UTF-8
       base64_string: |
@@ -990,13 +989,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:03 GMT
+      - Mon, 31 Mar 2025 22:11:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1010,7 +1009,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0de8ddb19dd0438a930a81a74adee8df
+      - 4048ea827c4e424db8931f59d277f0ff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1018,12 +1017,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWQ0MGYtNzIx
-        Yi1hMTYyLWJhYTVlYzkzMmQ5ZC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:03 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQyLWNlMTUtNzc3
+        MS05OTlmLTc2YWQ1YTk0MTk5MC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:50 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df20-cbed-706a-8fa4-3a55aa6d6fa7/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee42-be60-7bb8-82dd-2458f2148918/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1055,13 +1054,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:03 GMT
+      - Mon, 31 Mar 2025 22:11:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1075,7 +1074,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ac463ddc59e74235bb9b615d8887fd68
+      - 1b1efcb6efce468a9ca15a4c5c30a310
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1083,12 +1082,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWQ0ODctN2Zh
-        Yi1iNDUzLWZiZTU1N2UwMzg0Zi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:03 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQyLWNmMGMtNzgz
+        Ni1iMDY1LTQxNjI3YzdmYmRmZS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:50 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-d487-7fab-b453-fbe557e0384f/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee42-cf0c-7836-b065-41627c7fbdfe/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1096,7 +1095,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1109,19 +1108,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:03 GMT
+      - Mon, 31 Mar 2025 22:11:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '787'
+      - '768'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1129,7 +1128,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 826bad034d7f41aa961b4e374d4b1196
+      - 76aeea7bb11d47aba51920f0fc88fef0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1137,25 +1136,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtZDQ4
-        Ny03ZmFiLWI0NTMtZmJlNTU3ZTAzODRmLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtZDQ4Ny03ZmFiLWI0NTMtZmJlNTU3ZTAzODRmIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjowMy43MTk1OTVaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjAzLjcxOTYxMVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDItY2Yw
+        Yy03ODM2LWIwNjUtNDE2MjdjN2ZiZGZlLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDItY2YwYy03ODM2LWIwNjUtNDE2MjdjN2ZiZGZlIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMTo1MC42NzAzMzBaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjExOjUwLjY3MDM1NFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYWM0NjNk
-        ZGM1OWU3NDIzNWJiOWI2MTVkODg4N2ZkNjgiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjowMy43MzM0MTVaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MDMuNzM1ODkxWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjowMy43NDUxODRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46cnBt
-        LnJwbXJlbW90ZTowMTkyZGYyMC1jYmVkLTcwNmEtOGZhNC0zYTU1YWE2ZDZm
-        YTciLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAxOTJkZWFiLTE2NDctNzY1
-        NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:03 GMT
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiMWIxZWZj
+        YjZlZmNlNDY4YTljYTE1YTRjNWMzMGEzMTAiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjExOjUwLjY5Njc2NFoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMTo1MC43MDA1NDlaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjExOjUwLjczMTQyOFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjpudWxsLCJwYXJlbnRfdGFzayI6bnVsbCwi
+        Y2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19y
+        ZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbInBybjpycG0ucnBtcmVtb3RlOjAxOTVlZTQy
+        LWJlNjAtN2JiOC04MmRkLTI0NThmMjE0ODkxOCIsInNoYXJlZDpwcm46Y29y
+        ZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgyNjQtNTI4YzI5MTI5YTEz
+        Il19
+  recorded_at: Mon, 31 Mar 2025 22:11:50 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -1179,13 +1178,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:03 GMT
+      - Mon, 31 Mar 2025 22:11:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1199,7 +1198,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d079b858ed2149c19f9d076471a77eab
+      - ba6156d15e9148b891d4fe21a95a206e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1209,25 +1208,25 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMDE5MmRmMjAtZDE5NC03YWE0LWIyZWEtZjc5ZTM1ZTY1YWIx
-        LyIsInBybiI6InBybjpycG0ucnBtZGlzdHJpYnV0aW9uOjAxOTJkZjIwLWQx
-        OTQtN2FhNC1iMmVhLWY3OWUzNWU2NWFiMSIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMTAtMzBUMjA6MzI6MDIuOTY1MzY3WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0xMC0zMFQyMDozMjowMi45NjUzODhaIiwiYmFzZV9wYXRoIjoi
+        L3JwbS9ycG0vMDE5NWVlNDItYzk3Zi03N2VmLWI3YmQtZTBlNWY0YmUwMzVm
+        LyIsInBybiI6InBybjpycG0ucnBtZGlzdHJpYnV0aW9uOjAxOTVlZTQyLWM5
+        N2YtNzdlZi1iN2JkLWUwZTVmNGJlMDM1ZiIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjUtMDMtMzFUMjI6MTE6NDkuMjUwNzg3WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNS0wMy0zMVQyMjoxMTo0OS4yNTA4MDdaIiwiYmFzZV9wYXRoIjoi
         QUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJl
         bCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwt
         c3RhYmxlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01FX0NvcnBvcmF0
         aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIsImNvbnRlbnRf
-        Z3VhcmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNC0x
-        MC0zMFQyMDozMjowMi45NjUzODhaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9s
+        Z3VhcmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNS0w
+        My0zMVQyMjoxMTo0OS4yNTA4MDdaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9s
         YWJlbHMiOnt9LCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJyZXBvc2l0b3J5Ijpu
         dWxsLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
-        cnBtL3JwbS8wMTkyZGYyMC1jZTc0LTc3NzEtOTMyZC1kZTZmOWFjZDQwOTAv
+        cnBtL3JwbS8wMTk1ZWU0Mi1jMmU0LTc0NTEtYmZjZC03YWVhNjM4MjQwMGYv
         IiwiZ2VuZXJhdGVfcmVwb19jb25maWciOmZhbHNlfV19
-  recorded_at: Wed, 30 Oct 2024 20:32:03 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df20-ce74-7771-932d-de6f9acd4090/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee42-c2e4-7451-bfcd-7aea6382400f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1248,19 +1247,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:03 GMT
+      - Mon, 31 Mar 2025 22:11:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1268,7 +1267,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2ef11802ba8345c885687a50ec132379
+      - 8ec8fa869b9044ef98af60b515929f70
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1277,31 +1276,31 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtY2U3NC03NzcxLTkzMmQtZGU2ZjlhY2Q0MDkwLyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjAtY2U3NC03Nzcx
-        LTkzMmQtZGU2ZjlhY2Q0MDkwIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMjowMi4xNjY0MTBaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMyOjAyLjM0OTMwMVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAt
-        Y2M5NC03MzQxLWJkMTMtMjA1MTJiZWVjMmE2L3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDItYzJlNC03NDUxLWJmY2QtN2FlYTYzODI0MDBmLyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDItYzJlNC03NDUx
+        LWJmY2QtN2FlYTYzODI0MDBmIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMTo0Ny41NTk1NDFaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjExOjQ3Ljg3ODM4M1oiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDIt
+        YmZiOS03MjcxLWExNzQtYWQ2ZTFiMjk4ZTc2L3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMC1jYzk0LTczNDEtYmQxMy0yMDUxMmJlZWMyYTYvIiwiY2hlY2tz
+        MTk1ZWU0Mi1iZmI5LTcyNzEtYTE3NC1hZDZlMWIyOThlNzYvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:03 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:51 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-d194-7aa4-b2ea-f79e35e65ab1/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee42-c97f-77ef-b7bd-e0e5f4be035f/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE5
-        MmRmMjAtY2U3NC03NzcxLTkzMmQtZGU2ZjlhY2Q0MDkwLyJ9
+        NWVlNDItYzJlNC03NDUxLWJmY2QtN2FlYTYzODI0MDBmLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1319,13 +1318,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:04 GMT
+      - Mon, 31 Mar 2025 22:11:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1339,7 +1338,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 24a3a720c02740b0a1bf9ad0787a55c5
+      - bc49b98f7a83464abcc2488c6e3b61f2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1347,12 +1346,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWQ1YzEtNzA0
-        NS1hZDg4LTk1ZDY5ZTAwZjVkMi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:04 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQyLWQxYTUtN2Vi
+        Yi04NjhkLTY3MTI1YTQzNjU3Yy8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-d5c1-7045-ad88-95d69e00f5d2/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee42-d1a5-7ebb-868d-67125a43657c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1360,7 +1359,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1373,19 +1372,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:04 GMT
+      - Mon, 31 Mar 2025 22:11:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '788'
+      - '769'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1393,7 +1392,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 24f8bb0ca8ee43cd926b8644c2e6bce6
+      - cc3cfca7f00940bfa302ebf313049bc4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1401,28 +1400,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtZDVj
-        MS03MDQ1LWFkODgtOTVkNjllMDBmNWQyLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtZDVjMS03MDQ1LWFkODgtOTVkNjllMDBmNWQyIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjowNC4wMzM3NjFaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjA0LjAzMzc3OVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDItZDFh
+        NS03ZWJiLTg2OGQtNjcxMjVhNDM2NTdjLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDItZDFhNS03ZWJiLTg2OGQtNjcxMjVhNDM2NTdjIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMTo1MS4zMzUxOTZaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjExOjUxLjMzNTIyMloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiMjRhM2E3
-        MjBjMDI3NDBiMGExYmY5YWQwNzg3YTU1YzUiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjowNC4wNDk4MTNaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MDQuMDUyNTA5WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjowNC4wNzI0MDZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJkZWFiLTE2NDctNzY1NC04YmYxLWI1ZGZiYjczNDU5MTpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyZGVhYi0xNjQ3LTc2
-        NTQtOGJmMS1iNWRmYmI3MzQ1OTEiXX0=
-  recorded_at: Wed, 30 Oct 2024 20:32:04 GMT
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYmM0OWI5
+        OGY3YTgzNDY0YWJjYzI0ODhjNmUzYjYxZjIiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjExOjUxLjM1ODMwNloi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMTo1MS4zNjIwNDNaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjExOjUxLjM5MjI4M1oiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjpudWxsLCJwYXJlbnRfdGFzayI6bnVsbCwi
+        Y2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19y
+        ZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbInBkcm46NmQzYzYwMWYtZmVhZi00YjkzLTgy
+        NjQtNTI4YzI5MTI5YTEzOmRpc3RyaWJ1dGlvbnMiLCJzaGFyZWQ6cHJuOmNv
+        cmUuZG9tYWluOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUyOGMyOTEyOWEx
+        MyJdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df20-ce74-7771-932d-de6f9acd4090/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee42-c2e4-7451-bfcd-7aea6382400f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1443,19 +1442,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:04 GMT
+      - Mon, 31 Mar 2025 22:11:51 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1463,7 +1462,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d975d5f84c0040fa995fb001c901fa2c
+      - 87d5dd43ac44448c86af1856338126a2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1472,31 +1471,31 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjAtY2U3NC03NzcxLTkzMmQtZGU2ZjlhY2Q0MDkwLyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjAtY2U3NC03Nzcx
-        LTkzMmQtZGU2ZjlhY2Q0MDkwIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMjowMi4xNjY0MTBaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMyOjAyLjM0OTMwMVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAt
-        Y2M5NC03MzQxLWJkMTMtMjA1MTJiZWVjMmE2L3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDItYzJlNC03NDUxLWJmY2QtN2FlYTYzODI0MDBmLyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDItYzJlNC03NDUx
+        LWJmY2QtN2FlYTYzODI0MDBmIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMTo0Ny41NTk1NDFaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjExOjQ3Ljg3ODM4M1oiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDIt
+        YmZiOS03MjcxLWExNzQtYWQ2ZTFiMjk4ZTc2L3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMC1jYzk0LTczNDEtYmQxMy0yMDUxMmJlZWMyYTYvIiwiY2hlY2tz
+        MTk1ZWU0Mi1iZmI5LTcyNzEtYTE3NC1hZDZlMWIyOThlNzYvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:04 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:51 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-d194-7aa4-b2ea-f79e35e65ab1/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee42-c97f-77ef-b7bd-e0e5f4be035f/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE5
-        MmRmMjAtY2U3NC03NzcxLTkzMmQtZGU2ZjlhY2Q0MDkwLyJ9
+        NWVlNDItYzJlNC03NDUxLWJmY2QtN2FlYTYzODI0MDBmLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1514,13 +1513,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:04 GMT
+      - Mon, 31 Mar 2025 22:11:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1534,7 +1533,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 77aa8ea8fa354606a5d4ed7592f96699
+      - 0071e8b5df614a3a80597b8ea0625127
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1542,12 +1541,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWQ2ZDEtNzk3
-        NS1hMDM5LTA3ZTRhNzg3MmI1Yi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:04 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQyLWQ0MTItN2Ni
+        Mi05MjAwLWU0Nzg4Y2Y0MTRhZC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:52 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df20-d194-7aa4-b2ea-f79e35e65ab1/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee42-c97f-77ef-b7bd-e0e5f4be035f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1568,13 +1567,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:04 GMT
+      - Mon, 31 Mar 2025 22:11:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1588,7 +1587,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bb53aea522ff4af48cd5812f37c36acf
+      - 5bfc5672daab4087a47c4772fde4d922
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1596,12 +1595,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWQ3NjAtN2Rk
-        My1hNGYyLTg4YTZkY2JjODU0Yi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:04 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQyLWQ1MTAtNzVi
+        YS05Yjg1LTM3MTk0NmI3NWM2Yy8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:52 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df20-cbed-706a-8fa4-3a55aa6d6fa7/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee42-be60-7bb8-82dd-2458f2148918/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1622,13 +1621,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:04 GMT
+      - Mon, 31 Mar 2025 22:11:52 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1642,7 +1641,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5a6757e9f50d49439c1b65fa08979efa
+      - e62392b96c9d410c81a26ef893d28cf7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1650,12 +1649,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWQ4NWEtNzUy
-        NC04OGU4LTI2YzdmZDgwYzUzZi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:04 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQyLWQ2ZDUtNzZl
+        YS1hZjlmLTFkYmMzY2JiZTU2Ni8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:52 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-d85a-7524-88e8-26c7fd80c53f/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee42-d6d5-76ea-af9f-1dbc3cbbe566/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1663,7 +1662,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1676,19 +1675,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:04 GMT
+      - Mon, 31 Mar 2025 22:11:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '843'
+      - '824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1696,7 +1695,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3971a2a2977d454586808724b5b680b6
+      - 543f27a3d5504bc48d88e60112f25e79
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1704,29 +1703,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtZDg1
-        YS03NTI0LTg4ZTgtMjZjN2ZkODBjNTNmLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtZDg1YS03NTI0LTg4ZTgtMjZjN2ZkODBjNTNmIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjowNC42OTkzOTFaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjA0LjY5OTQxMFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDItZDZk
+        NS03NmVhLWFmOWYtMWRiYzNjYmJlNTY2LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDItZDZkNS03NmVhLWFmOWYtMWRiYzNjYmJlNTY2IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMTo1Mi42NjI0MjZaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjExOjUyLjY2MjQ5N1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiNWE2NzU3
-        ZTlmNTBkNDk0MzljMWI2NWZhMDg5NzllZmEiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjowNC43MTkxMTdaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MDQuNzc2MDU0WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjowNC44MzAxNDRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTM5NTktN2UwNi05MmY4LWZkOWI1
-        MTgxYjdlZS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpycG0ucnBtcmVtb3RlOjAxOTJkZjIwLWNiZWQtNzA2YS04ZmE0
-        LTNhNTVhYTZkNmZhNyIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmRl
-        YWItMTY0Ny03NjU0LThiZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:32:04 GMT
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiZTYyMzky
+        Yjk2YzlkNDEwYzgxYTI2ZWY4OTNkMjhjZjciLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjExOjUyLjY4NDMyNVoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMTo1Mi43NzQzNjNaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjExOjUyLjg0MzU0MVoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmNmMC03ZjU5LWFhZmEtYzAyYzY0YmU5Nzk2LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10s
+        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOnJwbS5ycG1yZW1v
+        dGU6MDE5NWVlNDItYmU2MC03YmI4LTgyZGQtMjQ1OGYyMTQ4OTE4Iiwic2hh
+        cmVkOnBybjpjb3JlLmRvbWFpbjo2ZDNjNjAxZi1mZWFmLTRiOTMtODI2NC01
+        MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:11:53 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0192df20-cc94-7341-bd13-20512beec2a6/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0195ee42-bfb9-7271-a174-ad6e1b298e76/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1747,13 +1746,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:05 GMT
+      - Mon, 31 Mar 2025 22:11:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1767,7 +1766,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6b346c06280742b591583b2c74f5b27a
+      - '082ed117e0ef481b994aa8bd5eaeb03e'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1775,12 +1774,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWQ5YmEtNzcw
-        ZC1hYWQ1LWUyNGU0YThlY2VhNC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:05 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQyLWQ5M2ItN2Fm
+        Yy1iZGQ3LWQ0NjEzM2NkOGMxOS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:53 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-d9ba-770d-aad5-e24e4a8ecea4/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee42-d93b-7afc-bdd7-d46133cd8c19/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1788,7 +1787,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1801,19 +1800,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:05 GMT
+      - Mon, 31 Mar 2025 22:11:53 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '847'
+      - '828'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1821,7 +1820,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b866ed211c26410694d5ba2c4d48ddc6
+      - e4ec17f340324d6b898ad19371a16a3e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1829,29 +1828,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtZDli
-        YS03NzBkLWFhZDUtZTI0ZTRhOGVjZWE0LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtZDliYS03NzBkLWFhZDUtZTI0ZTRhOGVjZWE0IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjowNS4wNTEzODdaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjA1LjA1MTQwOFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDItZDkz
+        Yi03YWZjLWJkZDctZDQ2MTMzY2Q4YzE5LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDItZDkzYi03YWZjLWJkZDctZDQ2MTMzY2Q4YzE5IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMTo1My4yNzY5OTJaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjExOjUzLjI3NzAxNloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiNmIzNDZj
-        MDYyODA3NDJiNTkxNTgzYjJjNzRmNWIyN2EiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjowNS4wNjg4MDJaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MDUuMTI1MDE4WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjowNS4zMDkzMjlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTM5Y2YtNzZkNS05ODQ5LWY1MGRm
-        NjYxZWZiNC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpycG0ucnBtcmVwb3NpdG9yeTowMTkyZGYyMC1jYzk0LTczNDEt
-        YmQxMy0yMDUxMmJlZWMyYTYiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAx
-        OTJkZWFiLTE2NDctNzY1NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:05 GMT
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiMDgyZWQx
+        MTdlMGVmNDgxYjk5NGFhOGJkNWVhZWIwM2UiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjExOjUzLjI5NzkzOVoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMTo1My4zNzQ2MDVaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjExOjUzLjY5NTkzNFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmNmMC03ZjU5LWFhZmEtYzAyYzY0YmU5Nzk2LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10s
+        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOnJwbS5ycG1yZXBv
+        c2l0b3J5OjAxOTVlZTQyLWJmYjktNzI3MS1hMTc0LWFkNmUxYjI5OGU3NiIs
+        InNoYXJlZDpwcm46Y29yZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgy
+        NjQtNTI4YzI5MTI5YTEzIl19
+  recorded_at: Mon, 31 Mar 2025 22:11:53 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1859,7 +1858,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.22.2/ruby
+      - OpenAPI-Generator/0.22.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1872,13 +1871,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:05 GMT
+      - Mon, 31 Mar 2025 22:11:54 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1892,7 +1891,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c11abd2e4926481890d38f8ded3c0f7d
+      - ec9d27c2c1bb4c2ebf02198df6689b3a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1902,7 +1901,385 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:05 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.3.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:11:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 62176a8a6eca4857a652e0b3fb3302d5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.22.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:11:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0e24095e34ee446287874651f33e7c22
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:11:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - adff15898e6e4f3684a52634749c6c72
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.4.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:11:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - '095877ff955b4a77b5628a8001d428b8'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.12.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:11:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8a4081f1eb474ad49e864a857a9f2f10
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.27.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:11:54 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - f715f350c0e94fbbab8ebe6141d951cc
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:54 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.22.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:11:55 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - a768d593deeb4db5a5c21f1c684a150c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:55 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -1926,13 +2303,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:05 GMT
+      - Mon, 31 Mar 2025 22:11:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1946,7 +2323,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 830f1aac25c64735af64debdc63b528d
+      - 43e0e90e90344f428095d1b9eabd5447
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1956,7 +2333,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:05 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:55 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -1967,7 +2344,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.21.1/ruby
+      - OpenAPI-Generator/2.22.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1980,13 +2357,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:05 GMT
+      - Mon, 31 Mar 2025 22:11:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2000,7 +2377,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e7e658024c454aada1bc88c05d9cafa5
+      - ca6a6659ee3b412c9ba35bf762079ccd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2010,7 +2387,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:05 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:55 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -2021,7 +2398,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2034,13 +2411,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:05 GMT
+      - Mon, 31 Mar 2025 22:11:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2054,7 +2431,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e78ca49a0fb04142a48655b014721e60
+      - 1b84f63b9a904e7a981844c5895fdb16
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2064,7 +2441,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:05 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:55 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -2075,7 +2452,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.4.4/ruby
+      - OpenAPI-Generator/2.4.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -2088,13 +2465,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:05 GMT
+      - Mon, 31 Mar 2025 22:11:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2108,7 +2485,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 266001e53b444179ae09428ae4d35c8d
+      - fa42be987240472692873436ed291dbf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2118,7 +2495,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:05 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:55 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -2129,7 +2506,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.12.5/ruby
+      - OpenAPI-Generator/3.12.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -2142,13 +2519,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:05 GMT
+      - Mon, 31 Mar 2025 22:11:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2162,7 +2539,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9ffcbcd7a6f64224abb4b81c370af547
+      - 3de41633cbb9413fbc0bd2266623e9cb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2172,7 +2549,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:05 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:55 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -2196,13 +2573,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:06 GMT
+      - Mon, 31 Mar 2025 22:11:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2216,7 +2593,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0f7c3d112fee440b972fb2a7821c87e7
+      - af7d777b97544442bd1de305c28f632e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2226,7 +2603,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:06 GMT
+  recorded_at: Mon, 31 Mar 2025 22:11:55 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/orphans/cleanup/
@@ -2239,7 +2616,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2252,13 +2629,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:06 GMT
+      - Mon, 31 Mar 2025 22:11:55 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - POST, OPTIONS
       X-Frame-Options:
@@ -2272,7 +2649,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1bdc944f764e492591a83e64ac7ce6ec
+      - 0c9bab033bb840d597092080465c90fb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2280,12 +2657,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWRkYzctNzMy
-        Mi05NmZhLWZlNGNjMGIwMDc1NC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:06 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQyLWUzYTYtN2M5
+        ZC04NjQ0LWIxOTBmYTQ5MTdhNi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:55 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-ddc7-7322-96fa-fe4cc0b00754/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee42-e3a6-7c9d-8644-b190fa4917a6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2293,7 +2670,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2306,19 +2683,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:06 GMT
+      - Mon, 31 Mar 2025 22:11:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1077'
+      - '1058'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2326,7 +2703,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 779ccdb955b74d949d91678a16d41a32
+      - a1c970102dc0458595816667f5ae34a3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2334,31 +2711,31 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtZGRj
-        Ny03MzIyLTk2ZmEtZmU0Y2MwYjAwNzU0LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtZGRjNy03MzIyLTk2ZmEtZmU0Y2MwYjAwNzU0IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjowNi4wODg0NjJaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjA2LjA4ODQ4MVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDItZTNh
+        Ni03YzlkLTg2NDQtYjE5MGZhNDkxN2E2LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDItZTNhNi03YzlkLTg2NDQtYjE5MGZhNDkxN2E2IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMTo1NS45NDM4NDVaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjExOjU1Ljk0Mzg2Nloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiIxYmRj
-        OTQ0Zjc2NGU0OTI1OTFhODNlNjRhYzdjZTZlYyIsImNyZWF0ZWRfYnkiOiIv
-        cHVscC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTEw
-        LTMwVDIwOjMyOjA2LjExMTM4OFoiLCJzdGFydGVkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjowNi4xNjMwOTVaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTEwLTMw
-        VDIwOjMyOjA2LjM2Njg3OFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1
-        bHAvYXBpL3YzL3dvcmtlcnMvMDE5MmRlYWMtM2E0Mi03ZDI0LWFiNWYtODhk
-        Y2NjMjhiM2JkLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6
-        W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1l
-        c3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQ29udGVudCIsImNvZGUiOiJjbGVh
-        bi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwi
-        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJDbGVhbiB1cCBv
-        cnBoYW4gQXJ0aWZhY3RzIiwiY29kZSI6ImNsZWFuLXVwLmFydGlmYWN0cyIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jl
-        c291cmNlc19yZWNvcmQiOlsicGRybjowMTkyZGVhYi0xNjQ3LTc2NTQtOGJm
-        MS1iNWRmYmI3MzQ1OTE6b3JwaGFucyIsInNoYXJlZDpwcm46Y29yZS5kb21h
-        aW46MDE5MmRlYWItMTY0Ny03NjU0LThiZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:32:06 GMT
+        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiIwYzli
+        YWIwMzNiYjg0MGQ1OTcwOTIwODA0NjVjOTBmYiIsImNyZWF0ZWRfYnkiOm51
+        bGwsInVuYmxvY2tlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTE6NTUuOTcwMzIw
+        WiIsInN0YXJ0ZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjExOjU2LjA1OTk4Nloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTE6NTYuMzYyMTM2WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8w
+        MTk1ZDJlZS1iYjkyLTdjM2ItOWY1MS1lOThhOWVlMjhiYTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkNsZWFuIHVwIG9y
+        cGhhbiBDb250ZW50IiwiY29kZSI6ImNsZWFuLXVwLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51
+        bGx9LHsibWVzc2FnZSI6IkNsZWFuIHVwIG9ycGhhbiBBcnRpZmFjdHMiLCJj
+        b2RlIjoiY2xlYW4tdXAuYXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJw
+        ZHJuOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUyOGMyOTEyOWExMzpvcnBo
+        YW5zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo2ZDNjNjAxZi1mZWFmLTRi
+        OTMtODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:11:56 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/purge/
@@ -2371,7 +2748,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2384,13 +2761,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:06 GMT
+      - Mon, 31 Mar 2025 22:11:56 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - POST, OPTIONS
       X-Frame-Options:
@@ -2404,7 +2781,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8fc1d48a7df9454092eff5fba17920ab
+      - 482a2a69cf864f99aef9e3baf730be3e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2412,7 +2789,7 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWRmNTAtNzZh
-        Ny04NTdhLWIxN2Q2NjA3ZWI5Zi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:06 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQyLWU2NTQtN2Yw
+        Ny1iMWU1LTE2OTI5NDBmOWRlZC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:11:56 GMT
 recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_unset_unprotected.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_unset_unprotected.yml
@@ -23,13 +23,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:13 GMT
+      - Mon, 31 Mar 2025 22:12:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bdc7e4c144b14046b80226938f28a17c
+      - a8b9a0d0055543ca9015d354a78deb3e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:13 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:11 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -77,13 +77,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:14 GMT
+      - Mon, 31 Mar 2025 22:12:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - af29acd5b14245119a472e75750f2032
+      - 81e8ce7551f743c592cb0ec49939cce3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:14 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:11 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -131,13 +131,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:14 GMT
+      - Mon, 31 Mar 2025 22:12:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f6ddcf54d6de4e6c985487ac69caadc1
+      - c0230adee0f94db3b8efaa0806cfb7fa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:14 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:11 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -185,13 +185,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:14 GMT
+      - Mon, 31 Mar 2025 22:12:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 528833373e8a4c9196e92ee62813ebc1
+      - 3eab35acc92f48e0be92fb86a67bc78b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:14 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:12 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -247,15 +247,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:14 GMT
+      - Mon, 31 Mar 2025 22:12:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/0192df20-fdd4-746a-9b7f-057eee8f85b6/"
+      - "/pulp/api/v3/remotes/rpm/rpm/0195ee43-238b-7a92-997d-23d04ba25011/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -269,7 +269,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 23c1b21a09c443cdab9ad526865a5cbc
+      - a9f904d9353d44a2926a9da83c0a14f0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -278,11 +278,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OTJkZjIwLWZkZDQtNzQ2YS05YjdmLTA1N2VlZThmODViNi8iLCJwcm4iOiJw
-        cm46cnBtLnJwbXJlbW90ZTowMTkyZGYyMC1mZGQ0LTc0NmEtOWI3Zi0wNTdl
-        ZWU4Zjg1YjYiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjE0
-        LjI5MzExNloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMTAtMzBUMjA6
-        MzI6MTQuMjkzMTMxWiIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0
+        OTVlZTQzLTIzOGItN2E5Mi05OTdkLTIzZDA0YmEyNTAxMS8iLCJwcm4iOiJw
+        cm46cnBtLnJwbXJlbW90ZTowMTk1ZWU0My0yMzhiLTdhOTItOTk3ZC0yM2Qw
+        NGJhMjUwMTEiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjEy
+        LjMwMDg4NloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUtMDMtMzFUMjI6
+        MTI6MTIuMzAwOTA5WiIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0
         dHA6Ly9teXJlcG8uY29tIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQi
         Om51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGws
         InB1bHBfbGFiZWxzIjp7fSwiZG93bmxvYWRfY29uY3VycmVuY3kiOm51bGws
@@ -295,7 +295,7 @@ http_interactions:
         bWUiOiJwcm94eV9wYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6
         InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfV0sInNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
-  recorded_at: Wed, 30 Oct 2024 20:32:14 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:12 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -321,21 +321,21 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:14 GMT
+      - Mon, 31 Mar 2025 22:12:12 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/0192df20-fe70-7d70-8c37-4f02b058bffb/"
+      - "/pulp/api/v3/repositories/rpm/rpm/0195ee43-24a8-7d15-9aa2-896de0d749b1/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '880'
+      - '894'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -343,7 +343,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0e95f26e5fa84f8badc8457c6b1277d6
+      - 5fc0e7fad6e9444f9ac788a2368bf62a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -352,16 +352,16 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMDE5MmRmMjAtZmU3MC03ZDcwLThjMzctNGYwMmIwNThiZmZiLyIsInBy
-        biI6InBybjpycG0ucnBtcmVwb3NpdG9yeTowMTkyZGYyMC1mZTcwLTdkNzAt
-        OGMzNy00ZjAyYjA1OGJmZmIiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMw
-        VDIwOjMyOjE0LjQ0OTAzOFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQt
-        MTAtMzBUMjA6MzI6MTQuNDU3MDYyWiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAtZmU3MC03
-        ZDcwLThjMzctNGYwMmIwNThiZmZiL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
+        cG0vMDE5NWVlNDMtMjRhOC03ZDE1LTlhYTItODk2ZGUwZDc0OWIxLyIsInBy
+        biI6InBybjpycG0ucnBtcmVwb3NpdG9yeTowMTk1ZWU0My0yNGE4LTdkMTUt
+        OWFhMi04OTZkZTBkNzQ5YjEiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMx
+        VDIyOjEyOjEyLjU4Njc3NFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUt
+        MDMtMzFUMjI6MTI6MTIuNTkyMDc5WiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDMtMjRhOC03
+        ZDE1LTlhYTItODk2ZGUwZDc0OWIxL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
         Ijp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcnBtL3JwbS8wMTkyZGYyMC1mZTcwLTdkNzAtOGMzNy00ZjAy
-        YjA1OGJmZmIvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJk
+        c2l0b3JpZXMvcnBtL3JwbS8wMTk1ZWU0My0yNGE4LTdkMTUtOWFhMi04OTZk
+        ZTBkNzQ5YjEvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJk
         ZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGws
         InJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9z
         aWduaW5nX3NlcnZpY2UiOm51bGwsInBhY2thZ2Vfc2lnbmluZ19zZXJ2aWNl
@@ -370,8 +370,8 @@ http_interactions:
         bWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjpudWxsLCJncGdjaGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6
         bnVsbCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9
-        LCJjb21wcmVzc2lvbl90eXBlIjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:14 GMT
+        LCJjb21wcmVzc2lvbl90eXBlIjpudWxsLCJsYXlvdXQiOm51bGx9
+  recorded_at: Mon, 31 Mar 2025 22:12:12 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -379,8 +379,8 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE5MmRmMjAtZmU3MC03ZDcwLThjMzctNGYwMmIwNThi
-        ZmZiL3ZlcnNpb25zLzAvIiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiJ9
+        aWVzL3JwbS9ycG0vMDE5NWVlNDMtMjRhOC03ZDE1LTlhYTItODk2ZGUwZDc0
+        OWIxL3ZlcnNpb25zLzAvIiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiJ9
     headers:
       Content-Type:
       - application/json
@@ -398,13 +398,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:14 GMT
+      - Mon, 31 Mar 2025 22:12:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -418,7 +418,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 47f9fa81e67e42f68f9640e2dadbfc84
+      - '0885e98b33b84bf8a93c0103023f65fd'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -426,12 +426,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIwLWZmZTYtNzNl
-        My04MjRmLTU5ZjZmNjk3MzdkZi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:14 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTI3MTUtN2Y3
+        OC04MDFjLTJiYmZmOWE1M2U1NC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:13 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df20-ffe6-73e3-824f-59f6f69737df/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-2715-7f78-801c-2bbff9a53e54/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -439,7 +439,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -452,19 +452,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:15 GMT
+      - Mon, 31 Mar 2025 22:12:13 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1060'
+      - '1041'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -472,7 +472,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8679ea79e646422bb7876f41cc455be7
+      - dda673db0e7341c8955c7f6124121e69
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -480,31 +480,31 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjAtZmZl
-        Ni03M2UzLTgyNGYtNTlmNmY2OTczN2RmLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjAtZmZlNi03M2UzLTgyNGYtNTlmNmY2OTczN2RmIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoxNC44MjMxMzJaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjE0LjgyMzE1MFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtMjcx
+        NS03Zjc4LTgwMWMtMmJiZmY5YTUzZTU0LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtMjcxNS03Zjc4LTgwMWMtMmJiZmY5YTUzZTU0IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjoxMy4yMDYyOTNaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjEzLjIwNjMxNVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFz
-        a3MucHVibGlzaGluZy5wdWJsaXNoIiwibG9nZ2luZ19jaWQiOiI0N2Y5ZmE4
-        MWU2N2U0MmY2OGY5NjQwZTJkYWRiZmM4NCIsImNyZWF0ZWRfYnkiOiIvcHVs
-        cC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTEwLTMw
-        VDIwOjMyOjE0LjgzNzU4MloiLCJzdGFydGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoxNC44ODkxNzBaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTEwLTMwVDIw
-        OjMyOjE1LjA2MzM2NloiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
-        YXBpL3YzL3dvcmtlcnMvMDE5MmRlYWMtM2E0Mi03ZDI0LWFiNWYtODhkY2Nj
-        MjhiM2JkLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10s
-        InRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3Nh
-        Z2UiOiJHZW5lcmF0aW5nIHJlcG9zaXRvcnkgbWV0YWRhdGEiLCJjb2RlIjoi
-        cHVibGlzaC5nZW5lcmF0aW5nX21ldGFkYXRhIiwic3RhdGUiOiJjb21wbGV0
-        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
-        ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBt
-        L3JwbS8wMTkyZGYyMS0wMDM3LTdjMDYtOTI3MC04YjJlOWYzMmI3YWUvIl0s
-        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsic2hhcmVkOnBybjpycG0u
-        cnBtcmVwb3NpdG9yeTowMTkyZGYyMC1mZTcwLTdkNzAtOGMzNy00ZjAyYjA1
-        OGJmZmIiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAxOTJkZWFiLTE2NDct
-        NzY1NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:15 GMT
+        a3MucHVibGlzaGluZy5wdWJsaXNoIiwibG9nZ2luZ19jaWQiOiIwODg1ZTk4
+        YjMzYjg0YmY4YTkzYzAxMDMwMjNmNjVmZCIsImNyZWF0ZWRfYnkiOm51bGws
+        InVuYmxvY2tlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6MTMuMjI3NzQ0WiIs
+        InN0YXJ0ZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjEzLjMwNDU4MloiLCJm
+        aW5pc2hlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6MTMuNjA1MDExWiIsImVy
+        cm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTk1
+        ZDJlZS1iY2YwLTdmNTktYWFmYS1jMDJjNjRiZTk3OTYvIiwicGFyZW50X3Rh
+        c2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVsbCwi
+        cHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkdlbmVyYXRpbmcgcmVw
+        b3NpdG9yeSBtZXRhZGF0YSIsImNvZGUiOiJwdWJsaXNoLmdlbmVyYXRpbmdf
+        bWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25l
+        IjoxLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1
+        bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBtLzAxOTVlZTQzLTI3OTgt
+        NzFmMi1iMDU2LTZjNDdhYWFhYjJhNy8iXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
+        X3JlY29yZCI6WyJzaGFyZWQ6cHJuOnJwbS5ycG1yZXBvc2l0b3J5OjAxOTVl
+        ZTQzLTI0YTgtN2QxNS05YWEyLTg5NmRlMGQ3NDliMSIsInNoYXJlZDpwcm46
+        Y29yZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgyNjQtNTI4YzI5MTI5
+        YTEzIl19
+  recorded_at: Mon, 31 Mar 2025 22:12:13 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -528,13 +528,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:15 GMT
+      - Mon, 31 Mar 2025 22:12:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -548,7 +548,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f381767775cb40a8857776dae6e6ab20
+      - 9a25d3cb54544b59b5384cd3c7b20c75
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -558,10 +558,10 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:15 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:14 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df21-0037-7c06-9270-8b2e9f32b7ae/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee43-2798-71f2-b056-6c47aaaab2a7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -582,19 +582,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:15 GMT
+      - Mon, 31 Mar 2025 22:12:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -602,7 +602,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8c29fbaf99f54b33801924c3d100ffa0
+      - 38288fa49f5746c38690dd38903e0803
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -611,21 +611,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjEtMDAzNy03YzA2LTkyNzAtOGIyZTlmMzJiN2FlLyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjEtMDAzNy03YzA2
-        LTkyNzAtOGIyZTlmMzJiN2FlIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMjoxNC45MDU0MzFaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMyOjE1LjA1NDQxNFoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAt
-        ZmU3MC03ZDcwLThjMzctNGYwMmIwNThiZmZiL3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDMtMjc5OC03MWYyLWIwNTYtNmM0N2FhYWFiMmE3LyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDMtMjc5OC03MWYy
+        LWIwNTYtNmM0N2FhYWFiMmE3IiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMjoxMy4zNDA0MDdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjEyOjEzLjU5NzMxNFoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDMt
+        MjRhOC03ZDE1LTlhYTItODk2ZGUwZDc0OWIxL3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMC1mZTcwLTdkNzAtOGMzNy00ZjAyYjA1OGJmZmIvIiwiY2hlY2tz
+        MTk1ZWU0My0yNGE4LTdkMTUtOWFhMi04OTZkZTBkNzQ5YjEvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:15 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:14 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/
@@ -635,8 +635,8 @@ http_interactions:
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vMDE5MmRmMjEtMDAzNy03YzA2LTkyNzAtOGIy
-        ZTlmMzJiN2FlLyJ9
+        bGljYXRpb25zL3JwbS9ycG0vMDE5NWVlNDMtMjc5OC03MWYyLWIwNTYtNmM0
+        N2FhYWFiMmE3LyJ9
     headers:
       Content-Type:
       - application/json
@@ -654,13 +654,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:15 GMT
+      - Mon, 31 Mar 2025 22:12:14 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -674,7 +674,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0d0fd5f015ff4d848fe85d87abc4acd1
+      - ab7063e4c0884776ac8c48728dcd56fa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -682,12 +682,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTAxY2UtN2Yx
-        My05YWFlLWM0NWUzYzRmZGJiZC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:15 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTJiMzAtNzdl
+        OS04NWUyLTcwOGEzYWVlOTY1Ni8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:14 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df21-01ce-7f13-9aae-c45e3c4fdbbd/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-2b30-77e9-85e2-708a3aee9656/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -695,7 +695,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -708,19 +708,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:15 GMT
+      - Mon, 31 Mar 2025 22:12:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '918'
+      - '899'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -728,7 +728,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - dbac66f85bed4d35a03392f7f1035647
+      - 8f75f92f15d04dea881c116fffd8434a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -736,31 +736,30 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjEtMDFj
-        ZS03ZjEzLTlhYWUtYzQ1ZTNjNGZkYmJkLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjEtMDFjZS03ZjEzLTlhYWUtYzQ1ZTNjNGZkYmJkIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoxNS4zMTEyNjRaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjE1LjMxMTI4OFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtMmIz
+        MC03N2U5LTg1ZTItNzA4YTNhZWU5NjU2LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtMmIzMC03N2U5LTg1ZTItNzA4YTNhZWU5NjU2IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjoxNC4yNTc1NDhaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjE0LjI1NzU3MVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiMGQwZmQ1
-        ZjAxNWZmNGQ4NDhmZTg1ZDg3YWJjNGFjZDEiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoxNS4zMjkxMTJaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MTUuMzgwODE5WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoxNS42MDMxMTlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTNhNDItN2QyNC1hYjVmLTg4ZGNj
-        YzI4YjNiZC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
-        cnBtL3JwbS8wMTkyZGYyMS0wMmU0LTc1NTUtYWRhNC00NDJhY2I1MThkZDcv
-        Il0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicGRybjowMTkyZGVh
-        Yi0xNjQ3LTc2NTQtOGJmMS1iNWRmYmI3MzQ1OTE6ZGlzdHJpYnV0aW9ucyIs
-        InNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmRlYWItMTY0Ny03NjU0LThi
-        ZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:32:15 GMT
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiYWI3MDYz
+        ZTRjMDg4NDc3NmFjOGM0ODcyOGRjZDU2ZmEiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjE0LjI3OTQyNloi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjoxNC4zNTk3NjVaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjE0Ljk1NjA2M1oiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmNmMC03ZjU5LWFhZmEtYzAyYzY0YmU5Nzk2LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIv
+        cHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0vcnBtLzAxOTVlZTQzLTJk
+        Y2UtNzk0YS04YTJiLWUxM2U5OWI4MmY1OS8iXSwicmVzZXJ2ZWRfcmVzb3Vy
+        Y2VzX3JlY29yZCI6WyJwZHJuOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUy
+        OGMyOTEyOWExMzpkaXN0cmlidXRpb25zIiwic2hhcmVkOnBybjpjb3JlLmRv
+        bWFpbjo2ZDNjNjAxZi1mZWFmLTRiOTMtODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:12:15 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df21-02e4-7555-ada4-442acb518dd7/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-2dce-794a-8a2b-e13e99b82f59/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -781,13 +780,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:15 GMT
+      - Mon, 31 Mar 2025 22:12:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -801,7 +800,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cd622be8e893404c9ea9a4277d3894c0
+      - 4d076cc2de424b66b200c9d9bd528680
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -810,22 +809,22 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzAxOTJkZjIxLTAyZTQtNzU1NS1hZGE0LTQ0MmFjYjUxOGRkNy8iLCJw
-        cm4iOiJwcm46cnBtLnJwbWRpc3RyaWJ1dGlvbjowMTkyZGYyMS0wMmU0LTc1
-        NTUtYWRhNC00NDJhY2I1MThkZDciLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEw
-        LTMwVDIwOjMyOjE1LjU4OTU3NloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
-        MjQtMTAtMzBUMjA6MzI6MTUuNTg5NTk2WiIsImJhc2VfcGF0aCI6IkFDTUVf
+        cnBtLzAxOTVlZTQzLTJkY2UtNzk0YS04YTJiLWUxM2U5OWI4MmY1OS8iLCJw
+        cm4iOiJwcm46cnBtLnJwbWRpc3RyaWJ1dGlvbjowMTk1ZWU0My0yZGNlLTc5
+        NGEtOGEyYi1lMTNlOTliODJmNTkiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAz
+        LTMxVDIyOjEyOjE0LjkyODk0NVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
+        MjUtMDMtMzFUMjI6MTI6MTQuOTI4OTc3WiIsImJhc2VfcGF0aCI6IkFDTUVf
         Q29ycG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJi
         YXNlX3VybCI6Imh0dHBzOi8vY2VudG9zOS1rYXRlbGxvLWRldmVsLXN0YWJs
         ZS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9k
         ZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJk
-        IjpudWxsLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MTUuNTg5NTk2WiIsImhpZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxz
+        IjpudWxsLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6IjIwMjUtMDMtMzFU
+        MjI6MTI6MTQuOTI4OTc3WiIsImhpZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxz
         Ijp7fSwibmFtZSI6IjJfZHVwbGljYXRlIiwicmVwb3NpdG9yeSI6bnVsbCwi
         cHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjEtMDAzNy03YzA2LTkyNzAtOGIyZTlmMzJiN2FlLyIsImdl
+        cG0vMDE5NWVlNDMtMjc5OC03MWYyLWIwNTYtNmM0N2FhYWFiMmE3LyIsImdl
         bmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX0=
-  recorded_at: Wed, 30 Oct 2024 20:32:15 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:15 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -860,15 +859,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:15 GMT
+      - Mon, 31 Mar 2025 22:12:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/0192df21-0420-71d2-9003-b3a73f9afb7e/"
+      - "/pulp/api/v3/remotes/rpm/rpm/0195ee43-3038-7e4b-9e63-f9ddc084f341/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -882,7 +881,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - aa4a6792beb04ea4ba3405fd08614423
+      - b57380071326413ca57ff4893ba03d8f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -891,11 +890,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OTJkZjIxLTA0MjAtNzFkMi05MDAzLWIzYTczZjlhZmI3ZS8iLCJwcm4iOiJw
-        cm46cnBtLnJwbXJlbW90ZTowMTkyZGYyMS0wNDIwLTcxZDItOTAwMy1iM2E3
-        M2Y5YWZiN2UiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjE1
-        LjkwNDcyNloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMTAtMzBUMjA6
-        MzI6MTUuOTA0NzQzWiIsIm5hbWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJs
+        OTVlZTQzLTMwMzgtN2U0Yi05ZTYzLWY5ZGRjMDg0ZjM0MS8iLCJwcm4iOiJw
+        cm46cnBtLnJwbXJlbW90ZTowMTk1ZWU0My0zMDM4LTdlNGItOWU2My1mOWRk
+        YzA4NGYzNDEiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjE1
+        LjU0NTU3NVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUtMDMtMzFUMjI6
+        MTI6MTUuNTQ1NjA2WiIsIm5hbWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJs
         IjoiaHR0cDovL215cmVwby5jb20iLCJjYV9jZXJ0IjoiS0pMOktERiooREYm
         KigqJCYoKiMkSkxLSkQoRCgoRCIsImNsaWVudF9jZXJ0IjoiS0pMOktERioo
         REYmKigqJCYoKiMkSkxLSkQoRCgoRCIsInRsc192YWxpZGF0aW9uIjpmYWxz
@@ -910,10 +909,10 @@ http_interactions:
         dCI6ZmFsc2V9LHsibmFtZSI6InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0s
         eyJuYW1lIjoicGFzc3dvcmQiLCJpc19zZXQiOmZhbHNlfV0sInNsZXNfYXV0
         aF90b2tlbiI6bnVsbH0=
-  recorded_at: Wed, 30 Oct 2024 20:32:15 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:15 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df21-0420-71d2-9003-b3a73f9afb7e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee43-3038-7e4b-9e63-f9ddc084f341/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -934,13 +933,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:15 GMT
+      - Mon, 31 Mar 2025 22:12:15 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -954,7 +953,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6b63dac4179e4cbabcd9f4938a88a014
+      - 9f9f4bc6393645a09fa3f2589e9374ca
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -962,12 +961,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTA0NjAtN2E2
-        My1hMDM0LTgyZjhmMDlkNDYzYi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:15 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTMwYjUtNzM0
+        Zi05MjUzLTg0MmFhM2IxM2U3ZS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:15 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0192df20-fe70-7d70-8c37-4f02b058bffb/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0195ee43-24a8-7d15-9aa2-896de0d749b1/
     body:
       encoding: UTF-8
       base64_string: |
@@ -990,13 +989,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:16 GMT
+      - Mon, 31 Mar 2025 22:12:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1010,7 +1009,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 723a03715d7c4a2d9166140a05adf3a0
+      - 9a6641f7f19e487187a2aa1768d05cb6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1018,12 +1017,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTA1NGUtNzdi
-        ZC1hODVlLTBiYzI0YjQ3NzQ4OS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:16 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTMyMTYtNzVk
+        OS1iNjI5LThkNTY4NGM4MjY3YS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:16 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df20-fdd4-746a-9b7f-057eee8f85b6/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee43-238b-7a92-997d-23d04ba25011/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1055,13 +1054,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:16 GMT
+      - Mon, 31 Mar 2025 22:12:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1075,7 +1074,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c5cb7d8ba958439d9b585ef9b47306a1
+      - a831332f239d4e0e8b8aea0cb5c104df
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1083,12 +1082,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTA1ZDMtNzk1
-        NS1hMTFjLTMzM2YyZjQ1MjI2YS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:16 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTMzMDQtN2Yw
+        Yi05ZjQ4LTBhZWE5M2RmMDYxOC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:16 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df21-05d3-7955-a11c-333f2f45226a/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-3304-7f0b-9f48-0aea93df0618/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1096,7 +1095,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1109,19 +1108,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:16 GMT
+      - Mon, 31 Mar 2025 22:12:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '787'
+      - '768'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1129,7 +1128,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 95734405e3a845d9bb34dbbe1723c81f
+      - b26c7fe35e674a14856b55e9fa676c68
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1137,25 +1136,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjEtMDVk
-        My03OTU1LWExMWMtMzMzZjJmNDUyMjZhLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjEtMDVkMy03OTU1LWExMWMtMzMzZjJmNDUyMjZhIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoxNi4zMzk4NjRaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjE2LjMzOTg4MVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtMzMw
+        NC03ZjBiLTlmNDgtMGFlYTkzZGYwNjE4LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtMzMwNC03ZjBiLTlmNDgtMGFlYTkzZGYwNjE4IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjoxNi4yNjE5MDRaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjE2LjI2MTkyN1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYzVjYjdk
-        OGJhOTU4NDM5ZDliNTg1ZWY5YjQ3MzA2YTEiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoxNi4zNTU0NDJaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MTYuMzU5MjM4WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoxNi4zNjk4NDRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46cnBt
-        LnJwbXJlbW90ZTowMTkyZGYyMC1mZGQ0LTc0NmEtOWI3Zi0wNTdlZWU4Zjg1
-        YjYiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAxOTJkZWFiLTE2NDctNzY1
-        NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:16 GMT
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYTgzMTMz
+        MmYyMzlkNGUwZThiOGFlYTBjYjVjMTA0ZGYiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjE2LjI4NDkxNloi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjoxNi4yODgyNDJaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjE2LjMwNjMyMFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjpudWxsLCJwYXJlbnRfdGFzayI6bnVsbCwi
+        Y2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19y
+        ZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbInBybjpycG0ucnBtcmVtb3RlOjAxOTVlZTQz
+        LTIzOGItN2E5Mi05OTdkLTIzZDA0YmEyNTAxMSIsInNoYXJlZDpwcm46Y29y
+        ZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgyNjQtNTI4YzI5MTI5YTEz
+        Il19
+  recorded_at: Mon, 31 Mar 2025 22:12:16 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
@@ -1166,7 +1165,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1179,13 +1178,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:16 GMT
+      - Mon, 31 Mar 2025 22:12:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1199,7 +1198,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e79de96441c747898d0dab4a7898b896
+      - 8e7767120d2043cda625efd6223e3c17
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1209,11 +1208,11 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzAxOTJkZjIwLWI5MzQtN2FjNy1hZTVlLWNhNmU1
-        ZTZkYWZiYy8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
-        MDE5MmRmMjAtYjkzNC03YWM3LWFlNWUtY2E2ZTVlNmRhZmJjIiwicHVscF9j
-        cmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMTo1Ni43MjU0ODZaIiwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMxOjU2LjcyNTUwM1oiLCJu
+        L2NlcnRndWFyZC9yaHNtLzAxOTVlZTQyLWZlMmEtNzlhNS1hNjk3LTJmNzcx
+        NGI0YWY1Zi8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
+        MDE5NWVlNDItZmUyYS03OWE1LWE2OTctMmY3NzE0YjRhZjVmIiwicHVscF9j
+        cmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjowMi43MzIxNDlaIiwicHVscF9s
+        YXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjAyLjczMjE3M1oiLCJu
         YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
         ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
         IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
@@ -1340,10 +1339,10 @@ http_interactions:
         T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
         aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
         Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
-  recorded_at: Wed, 30 Oct 2024 20:32:16 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:16 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/0192df20-b934-7ac7-ae5e-ca6e5e6dafbc/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/0195ee42-fe2a-79a5-a697-2f7714b4af5f/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1476,7 +1475,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1489,13 +1488,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:16 GMT
+      - Mon, 31 Mar 2025 22:12:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1509,7 +1508,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 56355e64dbe94f63ab6ac5718459e37c
+      - 251645de42394fb4ac04f6748f4ba306
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1518,11 +1517,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudGd1YXJkcy9jZXJ0
-        Z3VhcmQvcmhzbS8wMTkyZGYyMC1iOTM0LTdhYzctYWU1ZS1jYTZlNWU2ZGFm
-        YmMvIiwicHJuIjoicHJuOmNlcnRndWFyZC5yaHNtY2VydGd1YXJkOjAxOTJk
-        ZjIwLWI5MzQtN2FjNy1hZTVlLWNhNmU1ZTZkYWZiYyIsInB1bHBfY3JlYXRl
-        ZCI6IjIwMjQtMTAtMzBUMjA6MzE6NTYuNzI1NDg2WiIsInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoxNi41ODA4OTZaIiwibmFtZSI6
+        Z3VhcmQvcmhzbS8wMTk1ZWU0Mi1mZTJhLTc5YTUtYTY5Ny0yZjc3MTRiNGFm
+        NWYvIiwicHJuIjoicHJuOmNlcnRndWFyZC5yaHNtY2VydGd1YXJkOjAxOTVl
+        ZTQyLWZlMmEtNzlhNS1hNjk3LTJmNzcxNGI0YWY1ZiIsInB1bHBfY3JlYXRl
+        ZCI6IjIwMjUtMDMtMzFUMjI6MTI6MDIuNzMyMTQ5WiIsInB1bHBfbGFzdF91
+        cGRhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjoxNi43MTg2MjVaIiwibmFtZSI6
         IlJIU01DZXJ0R3VhcmQiLCJkZXNjcmlwdGlvbiI6bnVsbCwiY2FfY2VydGlm
         aWNhdGUiOiJDZXJ0aWZpY2F0ZTpcbiAgICBEYXRhOlxuICAgICAgICBWZXJz
         aW9uOiAzICgweDIpXG4gICAgICAgIFNlcmlhbCBOdW1iZXI6XG4gICAgICAg
@@ -1649,7 +1648,7 @@ http_interactions:
         OFRsYkI0ZEJPN2ZqXG5HNmgrVVZKT1ppQ3h6Y1d1M2hjNjE4NEhOOWhlaU8v
         amxNQ1lQc01OVVVROVUxTC9YZ3NiVzJ5YnBnPT1cbi0tLS0tRU5EIENFUlRJ
         RklDQVRFLS0tLS0ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:16 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:16 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -1673,13 +1672,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:16 GMT
+      - Mon, 31 Mar 2025 22:12:16 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1693,7 +1692,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cdfd9da2958d46d9802d1fabef16dbd6
+      - ef956d8c877b41f7bdd0b38b2841f2a6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1703,25 +1702,25 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMDE5MmRmMjEtMDJlNC03NTU1LWFkYTQtNDQyYWNiNTE4ZGQ3
-        LyIsInBybiI6InBybjpycG0ucnBtZGlzdHJpYnV0aW9uOjAxOTJkZjIxLTAy
-        ZTQtNzU1NS1hZGE0LTQ0MmFjYjUxOGRkNyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMTAtMzBUMjA6MzI6MTUuNTg5NTc2WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0xMC0zMFQyMDozMjoxNS41ODk1OTZaIiwiYmFzZV9wYXRoIjoi
+        L3JwbS9ycG0vMDE5NWVlNDMtMmRjZS03OTRhLThhMmItZTEzZTk5YjgyZjU5
+        LyIsInBybiI6InBybjpycG0ucnBtZGlzdHJpYnV0aW9uOjAxOTVlZTQzLTJk
+        Y2UtNzk0YS04YTJiLWUxM2U5OWI4MmY1OSIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjUtMDMtMzFUMjI6MTI6MTQuOTI4OTQ1WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNS0wMy0zMVQyMjoxMjoxNC45Mjg5NzdaIiwiYmFzZV9wYXRoIjoi
         QUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJl
         bCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwt
         c3RhYmxlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01FX0NvcnBvcmF0
         aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIsImNvbnRlbnRf
-        Z3VhcmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNC0x
-        MC0zMFQyMDozMjoxNS41ODk1OTZaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9s
+        Z3VhcmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNS0w
+        My0zMVQyMjoxMjoxNC45Mjg5NzdaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9s
         YWJlbHMiOnt9LCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJyZXBvc2l0b3J5Ijpu
         dWxsLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
-        cnBtL3JwbS8wMTkyZGYyMS0wMDM3LTdjMDYtOTI3MC04YjJlOWYzMmI3YWUv
+        cnBtL3JwbS8wMTk1ZWU0My0yNzk4LTcxZjItYjA1Ni02YzQ3YWFhYWIyYTcv
         IiwiZ2VuZXJhdGVfcmVwb19jb25maWciOmZhbHNlfV19
-  recorded_at: Wed, 30 Oct 2024 20:32:16 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:16 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df21-0037-7c06-9270-8b2e9f32b7ae/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee43-2798-71f2-b056-6c47aaaab2a7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1742,19 +1741,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:16 GMT
+      - Mon, 31 Mar 2025 22:12:17 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1762,7 +1761,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 510fd4999f27453b905c754f8efc7d4d
+      - 7c468294599a4216a633e3585ae6f2d0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1771,33 +1770,33 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjEtMDAzNy03YzA2LTkyNzAtOGIyZTlmMzJiN2FlLyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjEtMDAzNy03YzA2
-        LTkyNzAtOGIyZTlmMzJiN2FlIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMjoxNC45MDU0MzFaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMyOjE1LjA1NDQxNFoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAt
-        ZmU3MC03ZDcwLThjMzctNGYwMmIwNThiZmZiL3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDMtMjc5OC03MWYyLWIwNTYtNmM0N2FhYWFiMmE3LyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDMtMjc5OC03MWYy
+        LWIwNTYtNmM0N2FhYWFiMmE3IiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMjoxMy4zNDA0MDdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjEyOjEzLjU5NzMxNFoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDMt
+        MjRhOC03ZDE1LTlhYTItODk2ZGUwZDc0OWIxL3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMC1mZTcwLTdkNzAtOGMzNy00ZjAyYjA1OGJmZmIvIiwiY2hlY2tz
+        MTk1ZWU0My0yNGE4LTdkMTUtOWFhMi04OTZkZTBkNzQ5YjEvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:16 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:17 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df21-02e4-7555-ada4-442acb518dd7/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-2dce-794a-8a2b-e13e99b82f59/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
-        Y2VydGd1YXJkL3Joc20vMDE5MmRmMjAtYjkzNC03YWM3LWFlNWUtY2E2ZTVl
-        NmRhZmJjLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        Y2VydGd1YXJkL3Joc20vMDE5NWVlNDItZmUyYS03OWE1LWE2OTctMmY3NzE0
+        YjRhZjVmLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMTkyZGYyMS0wMDM3LTdj
-        MDYtOTI3MC04YjJlOWYzMmI3YWUvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMTk1ZWU0My0yNzk4LTcx
+        ZjItYjA1Ni02YzQ3YWFhYWIyYTcvIn0=
     headers:
       Content-Type:
       - application/json
@@ -1815,13 +1814,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:16 GMT
+      - Mon, 31 Mar 2025 22:12:17 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1835,7 +1834,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c2dacf1db6b943a3937dbb53c9c49767
+      - aed54fb7936f4ee986e72ecfa056527e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1843,12 +1842,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTA3YWItNzY0
-        MC05NGMzLTliYzA5M2RiMjUzYi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:16 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTM2OWMtNzEz
+        YS05NDBkLWM3OTJjODY3MzdjNi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:17 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df21-07ab-7640-94c3-9bc093db253b/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-369c-713a-940d-c792c86737c6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1856,7 +1855,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1869,19 +1868,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:16 GMT
+      - Mon, 31 Mar 2025 22:12:17 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '788'
+      - '769'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1889,7 +1888,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ea28f2356e924974a9f9af97f56e4d1e
+      - 1c9fc55d07ce45678c03e737e5447668
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1897,28 +1896,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjEtMDdh
-        Yi03NjQwLTk0YzMtOWJjMDkzZGIyNTNiLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjEtMDdhYi03NjQwLTk0YzMtOWJjMDkzZGIyNTNiIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoxNi44MTI0MDJaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjE2LjgxMjQyM1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtMzY5
+        Yy03MTNhLTk0MGQtYzc5MmM4NjczN2M2LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtMzY5Yy03MTNhLTk0MGQtYzc5MmM4NjczN2M2IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjoxNy4xODE5OTBaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjE3LjE4MjAxNFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYzJkYWNm
-        MWRiNmI5NDNhMzkzN2RiYjUzYzljNDk3NjciLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoxNi44Mjk1MTdaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MTYuODMyNjE5WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoxNi44NTIxMTdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJkZWFiLTE2NDctNzY1NC04YmYxLWI1ZGZiYjczNDU5MTpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyZGVhYi0xNjQ3LTc2
-        NTQtOGJmMS1iNWRmYmI3MzQ1OTEiXX0=
-  recorded_at: Wed, 30 Oct 2024 20:32:16 GMT
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYWVkNTRm
+        Yjc5MzZmNGVlOTg2ZTcyZWNmYTA1NjUyN2UiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjE3LjIwMTIxMFoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjoxNy4yMDQzODVaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjE3LjIzOTI5N1oiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjpudWxsLCJwYXJlbnRfdGFzayI6bnVsbCwi
+        Y2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19y
+        ZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbInBkcm46NmQzYzYwMWYtZmVhZi00YjkzLTgy
+        NjQtNTI4YzI5MTI5YTEzOmRpc3RyaWJ1dGlvbnMiLCJzaGFyZWQ6cHJuOmNv
+        cmUuZG9tYWluOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUyOGMyOTEyOWEx
+        MyJdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:17 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df21-0037-7c06-9270-8b2e9f32b7ae/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee43-2798-71f2-b056-6c47aaaab2a7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1939,19 +1938,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:17 GMT
+      - Mon, 31 Mar 2025 22:12:17 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1959,7 +1958,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a75e3844691b4ba688dc0132e4c3b096
+      - 99e8e64081c5479ca00b5b8aef69ddd1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1968,33 +1967,33 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjEtMDAzNy03YzA2LTkyNzAtOGIyZTlmMzJiN2FlLyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjEtMDAzNy03YzA2
-        LTkyNzAtOGIyZTlmMzJiN2FlIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMjoxNC45MDU0MzFaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMyOjE1LjA1NDQxNFoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjAt
-        ZmU3MC03ZDcwLThjMzctNGYwMmIwNThiZmZiL3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDMtMjc5OC03MWYyLWIwNTYtNmM0N2FhYWFiMmE3LyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDMtMjc5OC03MWYy
+        LWIwNTYtNmM0N2FhYWFiMmE3IiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMjoxMy4zNDA0MDdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjEyOjEzLjU5NzMxNFoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDMt
+        MjRhOC03ZDE1LTlhYTItODk2ZGUwZDc0OWIxL3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMC1mZTcwLTdkNzAtOGMzNy00ZjAyYjA1OGJmZmIvIiwiY2hlY2tz
+        MTk1ZWU0My0yNGE4LTdkMTUtOWFhMi04OTZkZTBkNzQ5YjEvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:17 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:17 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df21-02e4-7555-ada4-442acb518dd7/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-2dce-794a-8a2b-e13e99b82f59/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
-        Y2VydGd1YXJkL3Joc20vMDE5MmRmMjAtYjkzNC03YWM3LWFlNWUtY2E2ZTVl
-        NmRhZmJjLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
+        Y2VydGd1YXJkL3Joc20vMDE5NWVlNDItZmUyYS03OWE1LWE2OTctMmY3NzE0
+        YjRhZjVmLyIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2Zl
         ZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJwdWJsaWNhdGlvbiI6Ii9wdWxw
-        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMTkyZGYyMS0wMDM3LTdj
-        MDYtOTI3MC04YjJlOWYzMmI3YWUvIn0=
+        L2FwaS92My9wdWJsaWNhdGlvbnMvcnBtL3JwbS8wMTk1ZWU0My0yNzk4LTcx
+        ZjItYjA1Ni02YzQ3YWFhYWIyYTcvIn0=
     headers:
       Content-Type:
       - application/json
@@ -2012,13 +2011,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:17 GMT
+      - Mon, 31 Mar 2025 22:12:17 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -2032,7 +2031,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e935adc51dc342e1802e466dada7e7fa
+      - 3d440d166bb54be4ad9fb4729c82bfc8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2040,12 +2039,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTA4YjUtN2Q4
-        MC1hYmNhLTUxYTQ0Nzc0ZDE5Yy8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:17 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTM4YzAtN2Vm
+        OC04M2UwLTllMTM5NjJmNDc3Ni8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:17 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df21-02e4-7555-ada4-442acb518dd7/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-2dce-794a-8a2b-e13e99b82f59/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2066,13 +2065,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:17 GMT
+      - Mon, 31 Mar 2025 22:12:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -2086,7 +2085,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 16e8eae89c1d474eaead5200964068b0
+      - 3f417d4181314423a80122392a937fd7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2094,12 +2093,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTA5NGQtN2M0
-        MS1iODBjLTE5NDEwMjQ5Y2FlNy8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:17 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTM5YzQtNzg5
+        Zi05NTM1LTdkOThkOGE0OGMwZi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:18 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df20-fdd4-746a-9b7f-057eee8f85b6/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee43-238b-7a92-997d-23d04ba25011/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2120,13 +2119,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:17 GMT
+      - Mon, 31 Mar 2025 22:12:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -2140,7 +2139,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 78016a6d19f54dabaf3c234c6c96c9b8
+      - '0183225ffb264fa79e141f60609c5145'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2148,12 +2147,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTBhMzgtNzhl
-        YS04MGI3LTZhZjgwMDk1NjhiNS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:17 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTNiNTgtNzQx
+        Ny1iZGRmLTE5Y2E5ZjRlMTQ3ZC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:18 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df21-0a38-78ea-80b7-6af8009568b5/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-3b58-7417-bddf-19ca9f4e147d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2161,7 +2160,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2174,19 +2173,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:17 GMT
+      - Mon, 31 Mar 2025 22:12:18 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '843'
+      - '824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2194,7 +2193,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b1c6bf0a500744ae9d4c3c0c8e428154
+      - 3a479934940f4b718d529770dc18a292
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2202,29 +2201,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjEtMGEz
-        OC03OGVhLTgwYjctNmFmODAwOTU2OGI1LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjEtMGEzOC03OGVhLTgwYjctNmFmODAwOTU2OGI1IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoxNy40NjQ5OTRaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjE3LjQ2NTAxMFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtM2I1
+        OC03NDE3LWJkZGYtMTljYTlmNGUxNDdkLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtM2I1OC03NDE3LWJkZGYtMTljYTlmNGUxNDdkIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjoxOC4zOTQxNDFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjE4LjM5NDE4MFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiNzgwMTZh
-        NmQxOWY1NGRhYmFmM2MyMzRjNmM5NmM5YjgiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoxNy40ODAyNzVaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MTcuNTM0MDk1WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoxNy41Nzc1NjZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTM5NTktN2UwNi05MmY4LWZkOWI1
-        MTgxYjdlZS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpycG0ucnBtcmVtb3RlOjAxOTJkZjIwLWZkZDQtNzQ2YS05Yjdm
-        LTA1N2VlZThmODViNiIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmRl
-        YWItMTY0Ny03NjU0LThiZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:32:17 GMT
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiMDE4MzIy
+        NWZmYjI2NGZhNzllMTQxZjYwNjA5YzUxNDUiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjE4LjQxOTAyMloi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjoxOC41MjM4MzFaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjE4LjYzMjM5OFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmFlYi03ZTdlLTk0NWQtZmRlYzk2MzEzZDkwLyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10s
+        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOnJwbS5ycG1yZW1v
+        dGU6MDE5NWVlNDMtMjM4Yi03YTkyLTk5N2QtMjNkMDRiYTI1MDExIiwic2hh
+        cmVkOnBybjpjb3JlLmRvbWFpbjo2ZDNjNjAxZi1mZWFmLTRiOTMtODI2NC01
+        MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:12:18 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0192df20-fe70-7d70-8c37-4f02b058bffb/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0195ee43-24a8-7d15-9aa2-896de0d749b1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2245,13 +2244,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:17 GMT
+      - Mon, 31 Mar 2025 22:12:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -2265,7 +2264,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 73f7fd71eba84ecda11abb5bf6efa86d
+      - d8adc940e6d44ac484f62c837a2c010b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2273,12 +2272,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTBiNmMtN2Ew
-        Ny05ZGRhLWU1Mzg3YmIxOGM0Ny8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:17 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTNkYmUtNzU5
+        Ny1hZDJmLTNlNmZlYzgwZDMzNi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:19 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df21-0b6c-7a07-9dda-e5387bb18c47/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-3dbe-7597-ad2f-3e6fec80d336/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2286,7 +2285,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2299,19 +2298,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:18 GMT
+      - Mon, 31 Mar 2025 22:12:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '847'
+      - '828'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2319,7 +2318,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 79b72f611dc244f5b5f4585894a35598
+      - be799591cd184c1ca9c86193e9583b76
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2327,29 +2326,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjEtMGI2
-        Yy03YTA3LTlkZGEtZTUzODdiYjE4YzQ3LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjEtMGI2Yy03YTA3LTlkZGEtZTUzODdiYjE4YzQ3IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoxNy43NzMxNTZaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjE3Ljc3MzE3MVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtM2Ri
+        ZS03NTk3LWFkMmYtM2U2ZmVjODBkMzM2LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtM2RiZS03NTk3LWFkMmYtM2U2ZmVjODBkMzM2IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjoxOS4wMDc0MTdaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjE5LjAwNzQzOVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiNzNmN2Zk
-        NzFlYmE4NGVjZGExMWFiYjViZjZlZmE4NmQiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoxNy43ODcwMDdaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MTcuODM1ODcxWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoxOC4wMDMyNTBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTM5Y2YtNzZkNS05ODQ5LWY1MGRm
-        NjYxZWZiNC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpycG0ucnBtcmVwb3NpdG9yeTowMTkyZGYyMC1mZTcwLTdkNzAt
-        OGMzNy00ZjAyYjA1OGJmZmIiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAx
-        OTJkZWFiLTE2NDctNzY1NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:18 GMT
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiZDhhZGM5
+        NDBlNmQ0NGFjNDg0ZjYyYzgzN2EyYzAxMGIiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjE5LjAyODM5M1oi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjoxOS4xMDUyNzJaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjE5LjQwODIxMFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmNmMC03ZjU5LWFhZmEtYzAyYzY0YmU5Nzk2LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10s
+        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOnJwbS5ycG1yZXBv
+        c2l0b3J5OjAxOTVlZTQzLTI0YTgtN2QxNS05YWEyLTg5NmRlMGQ3NDliMSIs
+        InNoYXJlZDpwcm46Y29yZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgy
+        NjQtNTI4YzI5MTI5YTEzIl19
+  recorded_at: Mon, 31 Mar 2025 22:12:19 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2357,7 +2356,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.22.2/ruby
+      - OpenAPI-Generator/0.22.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2370,13 +2369,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:18 GMT
+      - Mon, 31 Mar 2025 22:12:19 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2390,7 +2389,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 548f66365c194194a9408c62fcab95bd
+      - 835333fbfaf545b6be1538c70de35f7e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2400,7 +2399,385 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:18 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:19 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.3.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:20 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - effc3f712d0b402894b6cfb390381fa7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:20 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.22.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:20 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 88ff80f7b30e4eb9996a1d52d8c6f649
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:20 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:20 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6a1a1c923d56414b9ca5bcd9f6ab7d38
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:20 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.4.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:20 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7137fc82eced4e3d9b270b00d7f3fd65
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:20 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.12.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:20 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - d0a592b8b99c4342aca7949d22f1be2d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:20 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.27.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:20 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1793eb5ae8e5428d8b5430688f06a350
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:20 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.22.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:20 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 967d470cf890445bb27945c590354611
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:20 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -2424,13 +2801,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:18 GMT
+      - Mon, 31 Mar 2025 22:12:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2444,7 +2821,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9ad55c90a26f4013ace495d20fea1af9
+      - 1cffa432ebe74d6a9fb1de7dd2d3864d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2454,7 +2831,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:18 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:21 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -2465,7 +2842,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.21.1/ruby
+      - OpenAPI-Generator/2.22.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -2478,13 +2855,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:18 GMT
+      - Mon, 31 Mar 2025 22:12:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2498,7 +2875,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 45c9e0d37ecd483185615d045bddb76f
+      - '0694700d9d0b4efeb0b6d56525fdc894'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2508,7 +2885,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:18 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:21 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -2519,7 +2896,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2532,13 +2909,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:18 GMT
+      - Mon, 31 Mar 2025 22:12:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2552,7 +2929,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 170fdeeaebd24e7f91a35dd7d330ec34
+      - 881d1be9c04246aa8293f680c8de7040
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2562,7 +2939,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:18 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:21 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -2573,7 +2950,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.4.4/ruby
+      - OpenAPI-Generator/2.4.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -2586,13 +2963,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:18 GMT
+      - Mon, 31 Mar 2025 22:12:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2606,7 +2983,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 856a819d40c2415ea2282e22e58b1e6a
+      - d23018fdda45459eaaf6751fa93114de
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2616,7 +2993,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:18 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:21 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -2627,7 +3004,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.12.5/ruby
+      - OpenAPI-Generator/3.12.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -2640,13 +3017,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:18 GMT
+      - Mon, 31 Mar 2025 22:12:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2660,7 +3037,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - da71f77ccdb94f0da79d6c3586416182
+      - 132f0f63c0c142f9834fcd30c46dd386
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2670,7 +3047,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:18 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:21 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -2694,13 +3071,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:18 GMT
+      - Mon, 31 Mar 2025 22:12:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2714,7 +3091,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 32770f7f368c40ccb5cbbcebb24adfe6
+      - da58bd0fc3b34874b156979b26561bbb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2724,7 +3101,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:18 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:21 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/orphans/cleanup/
@@ -2737,7 +3114,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2750,13 +3127,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:18 GMT
+      - Mon, 31 Mar 2025 22:12:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - POST, OPTIONS
       X-Frame-Options:
@@ -2770,7 +3147,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4947db30bf2843c0aab5f04480de0e9d
+      - f8fc83f3547a4815a0fb6ef34d6d21d9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2778,12 +3155,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTBmMWUtN2Ji
-        Ny04ZWViLWY1MGExMjE4ZGU5MC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:18 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTQ4OTEtN2U0
+        OC1hNzllLWJlMjIwYmY2NTIwZC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:21 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df21-0f1e-7bb7-8eeb-f50a1218de90/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-4891-7e48-a79e-be220bf6520d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2791,7 +3168,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2804,19 +3181,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:19 GMT
+      - Mon, 31 Mar 2025 22:12:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1077'
+      - '1058'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2824,7 +3201,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5130c26e732b4e238405f456e4846dfa
+      - 728db173742b4257a7447bbbb17c350d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2832,31 +3209,31 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjEtMGYx
-        ZS03YmI3LThlZWItZjUwYTEyMThkZTkwLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjEtMGYxZS03YmI3LThlZWItZjUwYTEyMThkZTkwIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoxOC43MjAxMDdaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjE4LjcyMDEzM1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtNDg5
+        MS03ZTQ4LWE3OWUtYmUyMjBiZjY1MjBkLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtNDg5MS03ZTQ4LWE3OWUtYmUyMjBiZjY1MjBkIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjoyMS43NzkxMTFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjIxLjc3OTEzMloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiI0OTQ3
-        ZGIzMGJmMjg0M2MwYWFiNWYwNDQ4MGRlMGU5ZCIsImNyZWF0ZWRfYnkiOiIv
-        cHVscC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTEw
-        LTMwVDIwOjMyOjE4LjczOTE1OVoiLCJzdGFydGVkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoxOC43OTY5NTBaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTEwLTMw
-        VDIwOjMyOjE4Ljk4MzM2OFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1
-        bHAvYXBpL3YzL3dvcmtlcnMvMDE5MmRlYWMtMzljZi03NmQ1LTk4NDktZjUw
-        ZGY2NjFlZmI0LyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6
-        W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1l
-        c3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQ29udGVudCIsImNvZGUiOiJjbGVh
-        bi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwi
-        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJDbGVhbiB1cCBv
-        cnBoYW4gQXJ0aWZhY3RzIiwiY29kZSI6ImNsZWFuLXVwLmFydGlmYWN0cyIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jl
-        c291cmNlc19yZWNvcmQiOlsicGRybjowMTkyZGVhYi0xNjQ3LTc2NTQtOGJm
-        MS1iNWRmYmI3MzQ1OTE6b3JwaGFucyIsInNoYXJlZDpwcm46Y29yZS5kb21h
-        aW46MDE5MmRlYWItMTY0Ny03NjU0LThiZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:32:19 GMT
+        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiJmOGZj
+        ODNmMzU0N2E0ODE1YTBmYjZlZjM0ZDZkMjFkOSIsImNyZWF0ZWRfYnkiOm51
+        bGwsInVuYmxvY2tlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6MjEuODA3MjAz
+        WiIsInN0YXJ0ZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjIxLjg4NTgwM1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6MjIuMTk0NDExWiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8w
+        MTk1ZDJlZS1iYjkyLTdjM2ItOWY1MS1lOThhOWVlMjhiYTQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkNsZWFuIHVwIG9y
+        cGhhbiBDb250ZW50IiwiY29kZSI6ImNsZWFuLXVwLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51
+        bGx9LHsibWVzc2FnZSI6IkNsZWFuIHVwIG9ycGhhbiBBcnRpZmFjdHMiLCJj
+        b2RlIjoiY2xlYW4tdXAuYXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJw
+        ZHJuOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUyOGMyOTEyOWExMzpvcnBo
+        YW5zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo2ZDNjNjAxZi1mZWFmLTRi
+        OTMtODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:12:22 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/purge/
@@ -2869,7 +3246,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2882,13 +3259,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:19 GMT
+      - Mon, 31 Mar 2025 22:12:22 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - POST, OPTIONS
       X-Frame-Options:
@@ -2902,7 +3279,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b64d379d4ad64c599520439b6cab7bff
+      - '0979bd2770e94e08be98df78bfe02dda'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2910,7 +3287,7 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTEwODEtN2Zj
-        NC1iYTU4LWE1Zjk4MTRjOWI3OS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:19 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTRiNjktN2Qy
+        ZS1hNTVmLWM3ZGRmMjNiYTFlOS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:22 GMT
 recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_url.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/yum_update/update_url.yml
@@ -23,13 +23,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:19 GMT
+      - Mon, 31 Mar 2025 22:12:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a98a80adec724b6eb02c19796ced5319
+      - 1609e267cc764f20a70c51f4891ec159
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:19 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:35 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -77,13 +77,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:19 GMT
+      - Mon, 31 Mar 2025 22:12:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1019cd0948c64382b4f457fd46657afd
+      - 6c153e93ae0d4a78b9134ca1bbf5a56e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:19 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:35 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -131,13 +131,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:20 GMT
+      - Mon, 31 Mar 2025 22:12:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f68fc0d77c374b298c4b1a24a1e2eefd
+      - f4b333906dba460aabb9f576c30fecdb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:20 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:35 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -185,13 +185,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:20 GMT
+      - Mon, 31 Mar 2025 22:12:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 06e410b0edfb4cac980a6c423d7e12c1
+      - 64e6d8ec963647d3976db7809d419d25
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:20 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:35 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -247,15 +247,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:20 GMT
+      - Mon, 31 Mar 2025 22:12:35 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/0192df21-14e5-7f08-8f0c-d85cfc42b716/"
+      - "/pulp/api/v3/remotes/rpm/rpm/0195ee43-7f80-7a2e-a8c7-f11a121342a4/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -269,7 +269,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 66a9d2403bdc4e06b96824113c9ef248
+      - 2fcde0f9190c44c99b148eda037d36d7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -278,11 +278,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OTJkZjIxLTE0ZTUtN2YwOC04ZjBjLWQ4NWNmYzQyYjcxNi8iLCJwcm4iOiJw
-        cm46cnBtLnJwbXJlbW90ZTowMTkyZGYyMS0xNGU1LTdmMDgtOGYwYy1kODVj
-        ZmM0MmI3MTYiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjIw
-        LjE5NzkzNFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMTAtMzBUMjA6
-        MzI6MjAuMTk3OTU0WiIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0
+        OTVlZTQzLTdmODAtN2EyZS1hOGM3LWYxMWExMjEzNDJhNC8iLCJwcm4iOiJw
+        cm46cnBtLnJwbXJlbW90ZTowMTk1ZWU0My03ZjgwLTdhMmUtYThjNy1mMTFh
+        MTIxMzQyYTQiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjM1
+        Ljg0MTIxN1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUtMDMtMzFUMjI6
+        MTI6MzUuODQxMjM5WiIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0
         dHA6Ly9teXJlcG8uY29tIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQi
         Om51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGws
         InB1bHBfbGFiZWxzIjp7fSwiZG93bmxvYWRfY29uY3VycmVuY3kiOm51bGws
@@ -295,7 +295,7 @@ http_interactions:
         bWUiOiJwcm94eV9wYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6
         InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfV0sInNsZXNfYXV0aF90b2tlbiI6bnVsbH0=
-  recorded_at: Wed, 30 Oct 2024 20:32:20 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:35 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -321,21 +321,21 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:20 GMT
+      - Mon, 31 Mar 2025 22:12:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/0192df21-158a-7988-8c50-cc4af20e77ce/"
+      - "/pulp/api/v3/repositories/rpm/rpm/0195ee43-8099-7b25-a893-fcfade51d6fc/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '880'
+      - '894'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -343,7 +343,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 654fb63b15c94320b8c6efeacc49ce15
+      - 7b5e421af4f44fd78c96d248e4565cfa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -352,16 +352,16 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMDE5MmRmMjEtMTU4YS03OTg4LThjNTAtY2M0YWYyMGU3N2NlLyIsInBy
-        biI6InBybjpycG0ucnBtcmVwb3NpdG9yeTowMTkyZGYyMS0xNThhLTc5ODgt
-        OGM1MC1jYzRhZjIwZTc3Y2UiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMw
-        VDIwOjMyOjIwLjM2MzQyNloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQt
-        MTAtMzBUMjA6MzI6MjAuMzcwODQ4WiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjEtMTU4YS03
-        OTg4LThjNTAtY2M0YWYyMGU3N2NlL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
+        cG0vMDE5NWVlNDMtODA5OS03YjI1LWE4OTMtZmNmYWRlNTFkNmZjLyIsInBy
+        biI6InBybjpycG0ucnBtcmVwb3NpdG9yeTowMTk1ZWU0My04MDk5LTdiMjUt
+        YTg5My1mY2ZhZGU1MWQ2ZmMiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMx
+        VDIyOjEyOjM2LjEyMzIzOVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUt
+        MDMtMzFUMjI6MTI6MzYuMTI4MjcxWiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDMtODA5OS03
+        YjI1LWE4OTMtZmNmYWRlNTFkNmZjL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
         Ijp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcnBtL3JwbS8wMTkyZGYyMS0xNThhLTc5ODgtOGM1MC1jYzRh
-        ZjIwZTc3Y2UvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJk
+        c2l0b3JpZXMvcnBtL3JwbS8wMTk1ZWU0My04MDk5LTdiMjUtYTg5My1mY2Zh
+        ZGU1MWQ2ZmMvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJk
         ZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGws
         InJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9z
         aWduaW5nX3NlcnZpY2UiOm51bGwsInBhY2thZ2Vfc2lnbmluZ19zZXJ2aWNl
@@ -370,8 +370,8 @@ http_interactions:
         bWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjpudWxsLCJncGdjaGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6
         bnVsbCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9
-        LCJjb21wcmVzc2lvbl90eXBlIjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:20 GMT
+        LCJjb21wcmVzc2lvbl90eXBlIjpudWxsLCJsYXlvdXQiOm51bGx9
+  recorded_at: Mon, 31 Mar 2025 22:12:36 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/
@@ -379,8 +379,8 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL3JwbS9ycG0vMDE5MmRmMjEtMTU4YS03OTg4LThjNTAtY2M0YWYyMGU3
-        N2NlL3ZlcnNpb25zLzAvIiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiJ9
+        aWVzL3JwbS9ycG0vMDE5NWVlNDMtODA5OS03YjI1LWE4OTMtZmNmYWRlNTFk
+        NmZjL3ZlcnNpb25zLzAvIiwiY2hlY2tzdW1fdHlwZSI6InNoYTI1NiJ9
     headers:
       Content-Type:
       - application/json
@@ -398,13 +398,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:20 GMT
+      - Mon, 31 Mar 2025 22:12:36 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -418,7 +418,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 62776787f8f24249a9ef57762d2176e3
+      - 810d8284d394484eb72cd334b9e3f11f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -426,12 +426,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTE3MDItN2I5
-        NS1iYTkzLTM4NGI1NWUzNWFhOC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:20 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTgzMDItNzI2
+        Yy04NjkxLTZmNmUyMmJjYWRiNi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:36 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df21-1702-7b95-ba93-384b55e35aa8/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-8302-726c-8691-6f6e22bcadb6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -439,7 +439,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -452,19 +452,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:21 GMT
+      - Mon, 31 Mar 2025 22:12:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1060'
+      - '1041'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -472,7 +472,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cd958e07e11b40ce8723a007d638a76f
+      - fd57ab4071af423f97f646fa323ff6e5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -480,31 +480,31 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjEtMTcw
-        Mi03Yjk1LWJhOTMtMzg0YjU1ZTM1YWE4LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjEtMTcwMi03Yjk1LWJhOTMtMzg0YjU1ZTM1YWE4IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoyMC43Mzg4MzhaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjIwLjczODg1NFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtODMw
+        Mi03MjZjLTg2OTEtNmY2ZTIyYmNhZGI2LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtODMwMi03MjZjLTg2OTEtNmY2ZTIyYmNhZGI2IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjozNi43MzkzMjBaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjM2LjczOTM0Mloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX3JwbS5hcHAudGFz
-        a3MucHVibGlzaGluZy5wdWJsaXNoIiwibG9nZ2luZ19jaWQiOiI2Mjc3Njc4
-        N2Y4ZjI0MjQ5YTllZjU3NzYyZDIxNzZlMyIsImNyZWF0ZWRfYnkiOiIvcHVs
-        cC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTEwLTMw
-        VDIwOjMyOjIwLjc2MjE5MloiLCJzdGFydGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoyMC44MjE5NzdaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTEwLTMwVDIw
-        OjMyOjIxLjAwNzc0MVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
-        YXBpL3YzL3dvcmtlcnMvMDE5MmRlYWMtMzljZi03NmQ1LTk4NDktZjUwZGY2
-        NjFlZmI0LyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10s
-        InRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1lc3Nh
-        Z2UiOiJHZW5lcmF0aW5nIHJlcG9zaXRvcnkgbWV0YWRhdGEiLCJjb2RlIjoi
-        cHVibGlzaC5nZW5lcmF0aW5nX21ldGFkYXRhIiwic3RhdGUiOiJjb21wbGV0
-        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
-        ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBt
-        L3JwbS8wMTkyZGYyMS0xNzY1LTcyZGQtODUxOS0wMmJiNDg1NjkzZTQvIl0s
-        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsic2hhcmVkOnBybjpycG0u
-        cnBtcmVwb3NpdG9yeTowMTkyZGYyMS0xNThhLTc5ODgtOGM1MC1jYzRhZjIw
-        ZTc3Y2UiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAxOTJkZWFiLTE2NDct
-        NzY1NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:21 GMT
+        a3MucHVibGlzaGluZy5wdWJsaXNoIiwibG9nZ2luZ19jaWQiOiI4MTBkODI4
+        NGQzOTQ0ODRlYjcyY2QzMzRiOWUzZjExZiIsImNyZWF0ZWRfYnkiOm51bGws
+        InVuYmxvY2tlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6MzYuNzYyNDAyWiIs
+        InN0YXJ0ZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjM2LjgzNTIxM1oiLCJm
+        aW5pc2hlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6MzcuMTc1ODI4WiIsImVy
+        cm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTk1
+        ZDJlZS1iYWViLTdlN2UtOTQ1ZC1mZGVjOTYzMTNkOTAvIiwicGFyZW50X3Rh
+        c2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVsbCwi
+        cHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkdlbmVyYXRpbmcgcmVw
+        b3NpdG9yeSBtZXRhZGF0YSIsImNvZGUiOiJwdWJsaXNoLmdlbmVyYXRpbmdf
+        bWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJkb25l
+        IjoxLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1
+        bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBtLzAxOTVlZTQzLTgzODYt
+        N2IyNC05YTkxLWI5MDRjYWYyYWFhMC8iXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
+        X3JlY29yZCI6WyJzaGFyZWQ6cHJuOnJwbS5ycG1yZXBvc2l0b3J5OjAxOTVl
+        ZTQzLTgwOTktN2IyNS1hODkzLWZjZmFkZTUxZDZmYyIsInNoYXJlZDpwcm46
+        Y29yZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgyNjQtNTI4YzI5MTI5
+        YTEzIl19
+  recorded_at: Mon, 31 Mar 2025 22:12:37 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -528,13 +528,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:21 GMT
+      - Mon, 31 Mar 2025 22:12:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -548,7 +548,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 70f0714c5ef14ec9a9649b62bea8399f
+      - 5353266bb4244387b9ed660d8ac76efc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -558,10 +558,10 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:21 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:37 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df21-1765-72dd-8519-02bb485693e4/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee43-8386-7b24-9a91-b904caf2aaa0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -582,19 +582,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:21 GMT
+      - Mon, 31 Mar 2025 22:12:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -602,7 +602,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4aecba4139634f58bb857f423d8e2eee
+      - a07d0b5cd3c04f8ba3af79c432074d93
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -611,21 +611,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjEtMTc2NS03MmRkLTg1MTktMDJiYjQ4NTY5M2U0LyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjEtMTc2NS03MmRk
-        LTg1MTktMDJiYjQ4NTY5M2U0IiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMjoyMC44MzkwNzVaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMyOjIwLjk5NzkyM1oiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjEt
-        MTU4YS03OTg4LThjNTAtY2M0YWYyMGU3N2NlL3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDMtODM4Ni03YjI0LTlhOTEtYjkwNGNhZjJhYWEwLyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDMtODM4Ni03YjI0
+        LTlhOTEtYjkwNGNhZjJhYWEwIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMjozNi44NzQzMTFaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjEyOjM3LjE2NDM2MVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDMt
+        ODA5OS03YjI1LWE4OTMtZmNmYWRlNTFkNmZjL3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMS0xNThhLTc5ODgtOGM1MC1jYzRhZjIwZTc3Y2UvIiwiY2hlY2tz
+        MTk1ZWU0My04MDk5LTdiMjUtYTg5My1mY2ZhZGU1MWQ2ZmMvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:21 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:37 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/
@@ -635,8 +635,8 @@ http_interactions:
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
         ZHVwbGljYXRlX2xhYmVsIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6
         IjJfZHVwbGljYXRlIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVi
-        bGljYXRpb25zL3JwbS9ycG0vMDE5MmRmMjEtMTc2NS03MmRkLTg1MTktMDJi
-        YjQ4NTY5M2U0LyJ9
+        bGljYXRpb25zL3JwbS9ycG0vMDE5NWVlNDMtODM4Ni03YjI0LTlhOTEtYjkw
+        NGNhZjJhYWEwLyJ9
     headers:
       Content-Type:
       - application/json
@@ -654,13 +654,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:21 GMT
+      - Mon, 31 Mar 2025 22:12:37 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -674,7 +674,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - da4b0ebd1a784371847a6e4364dcd466
+      - 0f4a6b7d9a474e76ac3d64b7656f959d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -682,12 +682,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTE5MTgtNzcz
-        OC05ZTczLWVjYjk5YzllMjZiMy8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:21 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTg3MTMtN2Nj
+        Ny1hY2U0LTYxYjM4ZGVmODhkOS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:37 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df21-1918-7738-9e73-ecb99c9e26b3/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-8713-7cc7-ace4-61b38def88d9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -695,7 +695,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -708,19 +708,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:21 GMT
+      - Mon, 31 Mar 2025 22:12:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '918'
+      - '899'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -728,7 +728,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 44c76dc6fa3943adb5abe8ad025d443c
+      - f9f12a8b634c49ffb800083cf4366658
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -736,31 +736,30 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjEtMTkx
-        OC03NzM4LTllNzMtZWNiOTljOWUyNmIzLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjEtMTkxOC03NzM4LTllNzMtZWNiOTljOWUyNmIzIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoyMS4yNzMwMjVaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjIxLjI3MzA0MVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtODcx
+        My03Y2M3LWFjZTQtNjFiMzhkZWY4OGQ5LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtODcxMy03Y2M3LWFjZTQtNjFiMzhkZWY4OGQ5IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjozNy43ODExNjdaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjM3Ljc4MTE5Nloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiZGE0YjBl
-        YmQxYTc4NDM3MTg0N2E2ZTQzNjRkY2Q0NjYiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoyMS4yODkyNTRaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MjEuMzMxODQyWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoyMS41NTk4MTdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTM5Y2YtNzZkNS05ODQ5LWY1MGRm
-        NjYxZWZiNC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
-        cnBtL3JwbS8wMTkyZGYyMS0xYTI3LTc1ZmQtYjk3ZC1lZWMzMTkzODMwNWEv
-        Il0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicGRybjowMTkyZGVh
-        Yi0xNjQ3LTc2NTQtOGJmMS1iNWRmYmI3MzQ1OTE6ZGlzdHJpYnV0aW9ucyIs
-        InNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmRlYWItMTY0Ny03NjU0LThi
-        ZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:32:21 GMT
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiMGY0YTZi
+        N2Q5YTQ3NGU3NmFjM2Q2NGI3NjU2Zjk1OWQiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjM3LjgwMjgyMloi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjozNy45MDEzNjNaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjM4LjQ5OTk3OFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmEzYS03NDYzLWExNTUtOTg3Y2NjOWU1YTc0LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIv
+        cHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0vcnBtLzAxOTVlZTQzLTg5
+        Y2YtN2UwYi05Y2IxLWIwZmZiYTEyOGQ0Yy8iXSwicmVzZXJ2ZWRfcmVzb3Vy
+        Y2VzX3JlY29yZCI6WyJwZHJuOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUy
+        OGMyOTEyOWExMzpkaXN0cmlidXRpb25zIiwic2hhcmVkOnBybjpjb3JlLmRv
+        bWFpbjo2ZDNjNjAxZi1mZWFmLTRiOTMtODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:12:38 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df21-1a27-75fd-b97d-eec31938305a/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-89cf-7e0b-9cb1-b0ffba128d4c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -781,13 +780,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:21 GMT
+      - Mon, 31 Mar 2025 22:12:38 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -801,7 +800,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 509413d7b5714f60b3e33c864be1e87e
+      - c06e29d87887446d8e66d064564c257f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -810,22 +809,22 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzAxOTJkZjIxLTFhMjctNzVmZC1iOTdkLWVlYzMxOTM4MzA1YS8iLCJw
-        cm4iOiJwcm46cnBtLnJwbWRpc3RyaWJ1dGlvbjowMTkyZGYyMS0xYTI3LTc1
-        ZmQtYjk3ZC1lZWMzMTkzODMwNWEiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEw
-        LTMwVDIwOjMyOjIxLjU0NDUzNloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
-        MjQtMTAtMzBUMjA6MzI6MjEuNTQ0NTY3WiIsImJhc2VfcGF0aCI6IkFDTUVf
+        cnBtLzAxOTVlZTQzLTg5Y2YtN2UwYi05Y2IxLWIwZmZiYTEyOGQ0Yy8iLCJw
+        cm4iOiJwcm46cnBtLnJwbWRpc3RyaWJ1dGlvbjowMTk1ZWU0My04OWNmLTdl
+        MGItOWNiMS1iMGZmYmExMjhkNGMiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAz
+        LTMxVDIyOjEyOjM4LjQ4MjQzM1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
+        MjUtMDMtMzFUMjI6MTI6MzguNDgyNDkwWiIsImJhc2VfcGF0aCI6IkFDTUVf
         Q29ycG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJi
         YXNlX3VybCI6Imh0dHBzOi8vY2VudG9zOS1rYXRlbGxvLWRldmVsLXN0YWJs
         ZS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9k
         ZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbC8iLCJjb250ZW50X2d1YXJk
-        IjpudWxsLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MjEuNTQ0NTY3WiIsImhpZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxz
+        IjpudWxsLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6IjIwMjUtMDMtMzFU
+        MjI6MTI6MzguNDgyNDkwWiIsImhpZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxz
         Ijp7fSwibmFtZSI6IjJfZHVwbGljYXRlIiwicmVwb3NpdG9yeSI6bnVsbCwi
         cHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjEtMTc2NS03MmRkLTg1MTktMDJiYjQ4NTY5M2U0LyIsImdl
+        cG0vMDE5NWVlNDMtODM4Ni03YjI0LTlhOTEtYjkwNGNhZjJhYWEwLyIsImdl
         bmVyYXRlX3JlcG9fY29uZmlnIjpmYWxzZX0=
-  recorded_at: Wed, 30 Oct 2024 20:32:21 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:38 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -860,15 +859,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:21 GMT
+      - Mon, 31 Mar 2025 22:12:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/0192df21-1b82-7e95-a278-f9d6fd5de5da/"
+      - "/pulp/api/v3/remotes/rpm/rpm/0195ee43-8c87-79be-9cb7-104d1edf9fa8/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -882,7 +881,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4e46ff3ad3b849d28f6bc4b7ba2ad773
+      - 1ef94c7dad2b4f748731c773d3f35668
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -891,11 +890,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OTJkZjIxLTFiODItN2U5NS1hMjc4LWY5ZDZmZDVkZTVkYS8iLCJwcm4iOiJw
-        cm46cnBtLnJwbXJlbW90ZTowMTkyZGYyMS0xYjgyLTdlOTUtYTI3OC1mOWQ2
-        ZmQ1ZGU1ZGEiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjIx
-        Ljg5MDY5NVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMTAtMzBUMjA6
-        MzI6MjEuODkwNzEzWiIsIm5hbWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJs
+        OTVlZTQzLThjODctNzliZS05Y2I3LTEwNGQxZWRmOWZhOC8iLCJwcm4iOiJw
+        cm46cnBtLnJwbXJlbW90ZTowMTk1ZWU0My04Yzg3LTc5YmUtOWNiNy0xMDRk
+        MWVkZjlmYTgiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjM5
+        LjE3NjM5MloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUtMDMtMzFUMjI6
+        MTI6MzkuMTc2NDE0WiIsIm5hbWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJs
         IjoiaHR0cDovL3dlYnNpdGUuY29tLyIsImNhX2NlcnQiOiJLSkw6S0RGKihE
         RiYqKCokJigqIyRKTEtKRChEKChEIiwiY2xpZW50X2NlcnQiOiJLSkw6S0RG
         KihERiYqKCokJigqIyRKTEtKRChEKChEIiwidGxzX3ZhbGlkYXRpb24iOmZh
@@ -910,10 +909,10 @@ http_interactions:
         c2V0IjpmYWxzZX0seyJuYW1lIjoidXNlcm5hbWUiLCJpc19zZXQiOmZhbHNl
         fSx7Im5hbWUiOiJwYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9XSwic2xlc19h
         dXRoX3Rva2VuIjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:21 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:39 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df21-1b82-7e95-a278-f9d6fd5de5da/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee43-8c87-79be-9cb7-104d1edf9fa8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -934,13 +933,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:21 GMT
+      - Mon, 31 Mar 2025 22:12:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -954,7 +953,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fee61a562d7e470b86cd2aa56d79b1f5
+      - 17f1a48b6d7847bf8f4a1574547d2edc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -962,12 +961,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTFiZDEtNzZk
-        Yi1iNmYyLTU2MzMxOGQ1ZTQzMi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:21 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLThjZmItNzU5
+        ZC1hOTMwLWNmYzllY2YyOTk4Mi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:39 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0192df21-158a-7988-8c50-cc4af20e77ce/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0195ee43-8099-7b25-a893-fcfade51d6fc/
     body:
       encoding: UTF-8
       base64_string: |
@@ -990,13 +989,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:22 GMT
+      - Mon, 31 Mar 2025 22:12:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1010,7 +1009,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '030928cec83e4a16893afde55d1eabce'
+      - 6e64fc6165a347219a16a47ef73d3e42
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1018,12 +1017,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTFjYzUtNzZi
-        Yy1iM2RiLTNhZTE0ZWQ3M2FmZS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:22 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLThlMzUtNzhi
+        ZS05NmRhLWUyOTU3NDlkMTYwMi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:39 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df21-14e5-7f08-8f0c-d85cfc42b716/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee43-7f80-7a2e-a8c7-f11a121342a4/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1055,13 +1054,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:22 GMT
+      - Mon, 31 Mar 2025 22:12:39 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1075,7 +1074,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 39ef44c757ec48399235243b996cd425
+      - c86201df14bc450ca1d95b5c59aac894
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1083,12 +1082,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTFkNDItNzI1
-        OC1iNWRiLWUxNTQ5OWVkMjA0Yy8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:22 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLThmMjUtNzUx
+        Yi05Yzc1LTEwMzUyNTBjYWM3OS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:39 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df21-1d42-7258-b5db-e15499ed204c/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-8f25-751b-9c75-1035250cac79/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1096,7 +1095,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1109,19 +1108,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:22 GMT
+      - Mon, 31 Mar 2025 22:12:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '787'
+      - '768'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1129,7 +1128,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - acc85a4b15cf468b860c801548012d04
+      - c23578a0d0e347939f2759c787304bb1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1137,25 +1136,25 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjEtMWQ0
-        Mi03MjU4LWI1ZGItZTE1NDk5ZWQyMDRjLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjEtMWQ0Mi03MjU4LWI1ZGItZTE1NDk5ZWQyMDRjIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoyMi4zMzg5NzFaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjIyLjMzODk4N1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtOGYy
+        NS03NTFiLTljNzUtMTAzNTI1MGNhYzc5LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtOGYyNS03NTFiLTljNzUtMTAzNTI1MGNhYzc5IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjozOS44NDYyNDZaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjM5Ljg0NjI2OFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiMzllZjQ0
-        Yzc1N2VjNDgzOTkyMzUyNDNiOTk2Y2Q0MjUiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoyMi4zNTQxNjRaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MjIuMzU4NTc2WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoyMi4zNzMyNDNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46cnBt
-        LnJwbXJlbW90ZTowMTkyZGYyMS0xNGU1LTdmMDgtOGYwYy1kODVjZmM0MmI3
-        MTYiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAxOTJkZWFiLTE2NDctNzY1
-        NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:22 GMT
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYzg2MjAx
+        ZGYxNGJjNDUwY2ExZDk1YjVjNTlhYWM4OTQiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjM5Ljg2ODU0NFoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjozOS44NzE0NzhaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjM5Ljg4NzI5MFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjpudWxsLCJwYXJlbnRfdGFzayI6bnVsbCwi
+        Y2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19y
+        ZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbInBybjpycG0ucnBtcmVtb3RlOjAxOTVlZTQz
+        LTdmODAtN2EyZS1hOGM3LWYxMWExMjEzNDJhNCIsInNoYXJlZDpwcm46Y29y
+        ZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgyNjQtNTI4YzI5MTI5YTEz
+        Il19
+  recorded_at: Mon, 31 Mar 2025 22:12:40 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -1179,13 +1178,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:22 GMT
+      - Mon, 31 Mar 2025 22:12:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1199,7 +1198,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a88533bd3e2f4ff38933e16d3c7cd32d
+      - 714eebb06d7d44719dcafe59bf7ac054
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1209,25 +1208,25 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L3JwbS9ycG0vMDE5MmRmMjEtMWEyNy03NWZkLWI5N2QtZWVjMzE5MzgzMDVh
-        LyIsInBybiI6InBybjpycG0ucnBtZGlzdHJpYnV0aW9uOjAxOTJkZjIxLTFh
-        MjctNzVmZC1iOTdkLWVlYzMxOTM4MzA1YSIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjQtMTAtMzBUMjA6MzI6MjEuNTQ0NTM2WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNC0xMC0zMFQyMDozMjoyMS41NDQ1NjdaIiwiYmFzZV9wYXRoIjoi
+        L3JwbS9ycG0vMDE5NWVlNDMtODljZi03ZTBiLTljYjEtYjBmZmJhMTI4ZDRj
+        LyIsInBybiI6InBybjpycG0ucnBtZGlzdHJpYnV0aW9uOjAxOTVlZTQzLTg5
+        Y2YtN2UwYi05Y2IxLWIwZmZiYTEyOGQ0YyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjUtMDMtMzFUMjI6MTI6MzguNDgyNDMzWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNS0wMy0zMVQyMjoxMjozOC40ODI0OTBaIiwiYmFzZV9wYXRoIjoi
         QUNNRV9Db3Jwb3JhdGlvbi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJl
         bCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwt
         c3RhYmxlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01FX0NvcnBvcmF0
         aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsLyIsImNvbnRlbnRf
-        Z3VhcmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNC0x
-        MC0zMFQyMDozMjoyMS41NDQ1NjdaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9s
+        Z3VhcmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNS0w
+        My0zMVQyMjoxMjozOC40ODI0OTBaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9s
         YWJlbHMiOnt9LCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJyZXBvc2l0b3J5Ijpu
         dWxsLCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMv
-        cnBtL3JwbS8wMTkyZGYyMS0xNzY1LTcyZGQtODUxOS0wMmJiNDg1NjkzZTQv
+        cnBtL3JwbS8wMTk1ZWU0My04Mzg2LTdiMjQtOWE5MS1iOTA0Y2FmMmFhYTAv
         IiwiZ2VuZXJhdGVfcmVwb19jb25maWciOmZhbHNlfV19
-  recorded_at: Wed, 30 Oct 2024 20:32:22 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:40 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df21-1765-72dd-8519-02bb485693e4/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee43-8386-7b24-9a91-b904caf2aaa0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1248,19 +1247,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:22 GMT
+      - Mon, 31 Mar 2025 22:12:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1268,7 +1267,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 659ff4be33e14eb0a8c2ec07d1fb3f06
+      - b6ccd3d79ed6420dbed4e6cc02a1a989
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1277,31 +1276,31 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjEtMTc2NS03MmRkLTg1MTktMDJiYjQ4NTY5M2U0LyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjEtMTc2NS03MmRk
-        LTg1MTktMDJiYjQ4NTY5M2U0IiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMjoyMC44MzkwNzVaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMyOjIwLjk5NzkyM1oiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjEt
-        MTU4YS03OTg4LThjNTAtY2M0YWYyMGU3N2NlL3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDMtODM4Ni03YjI0LTlhOTEtYjkwNGNhZjJhYWEwLyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDMtODM4Ni03YjI0
+        LTlhOTEtYjkwNGNhZjJhYWEwIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMjozNi44NzQzMTFaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjEyOjM3LjE2NDM2MVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDMt
+        ODA5OS03YjI1LWE4OTMtZmNmYWRlNTFkNmZjL3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMS0xNThhLTc5ODgtOGM1MC1jYzRhZjIwZTc3Y2UvIiwiY2hlY2tz
+        MTk1ZWU0My04MDk5LTdiMjUtYTg5My1mY2ZhZGU1MWQ2ZmMvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:22 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:40 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df21-1a27-75fd-b97d-eec31938305a/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-89cf-7e0b-9cb1-b0ffba128d4c/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE5
-        MmRmMjEtMTc2NS03MmRkLTg1MTktMDJiYjQ4NTY5M2U0LyJ9
+        NWVlNDMtODM4Ni03YjI0LTlhOTEtYjkwNGNhZjJhYWEwLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1319,13 +1318,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:22 GMT
+      - Mon, 31 Mar 2025 22:12:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1339,7 +1338,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c8aee17c695242bd9f151e90c0c8132a
+      - 447bb5c447014728a32d78d98aadcbcf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1347,12 +1346,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTFlNzItNzI4
-        OS04MDI3LWZjNDhkMWJiZGQ5My8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:22 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTkxOGEtN2U2
+        NS05ZDYzLTY1MzVkOWM0ZmZjMS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:40 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df21-1e72-7289-8027-fc48d1bbdd93/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-918a-7e65-9d63-6535d9c4ffc1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1360,7 +1359,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1373,19 +1372,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:22 GMT
+      - Mon, 31 Mar 2025 22:12:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '788'
+      - '769'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1393,7 +1392,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c2eff269c53c4c40ac417bca861b7fb5
+      - f58654dc62934d7d9f383cbafb428bdd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1401,28 +1400,28 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjEtMWU3
-        Mi03Mjg5LTgwMjctZmM0OGQxYmJkZDkzLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjEtMWU3Mi03Mjg5LTgwMjctZmM0OGQxYmJkZDkzIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoyMi42NDI4MjVaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjIyLjY0Mjg0Mloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtOTE4
+        YS03ZTY1LTlkNjMtNjUzNWQ5YzRmZmMxLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtOTE4YS03ZTY1LTlkNjMtNjUzNWQ5YzRmZmMxIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjo0MC40NTkyODhaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjQwLjQ1OTMxMVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYzhhZWUx
-        N2M2OTUyNDJiZDlmMTUxZTkwYzBjODEzMmEiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoyMi42NTY3NDdaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MjIuNjYwNzgzWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoyMi42NzUyNTBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
-        cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
-        cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJkZWFiLTE2NDctNzY1NC04YmYxLWI1ZGZiYjczNDU5MTpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyZGVhYi0xNjQ3LTc2
-        NTQtOGJmMS1iNWRmYmI3MzQ1OTEiXX0=
-  recorded_at: Wed, 30 Oct 2024 20:32:22 GMT
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiNDQ3YmI1
+        YzQ0NzAxNDcyOGEzMmQ3OGQ5OGFhZGNiY2YiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjQwLjQ5NTEyNFoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjo0MC40OTkwMTFaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjQwLjUyNzk2OFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjpudWxsLCJwYXJlbnRfdGFzayI6bnVsbCwi
+        Y2hpbGRfdGFza3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19y
+        ZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbInBkcm46NmQzYzYwMWYtZmVhZi00YjkzLTgy
+        NjQtNTI4YzI5MTI5YTEzOmRpc3RyaWJ1dGlvbnMiLCJzaGFyZWQ6cHJuOmNv
+        cmUuZG9tYWluOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUyOGMyOTEyOWEx
+        MyJdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:40 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0192df21-1765-72dd-8519-02bb485693e4/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/rpm/rpm/0195ee43-8386-7b24-9a91-b904caf2aaa0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1443,19 +1442,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:22 GMT
+      - Mon, 31 Mar 2025 22:12:40 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '637'
+      - '670'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1463,7 +1462,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d3cca056167f4da9a2b7e1546087427e
+      - 94b96ec337c847088c8b04cecd9e0009
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1472,31 +1471,31 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9y
-        cG0vMDE5MmRmMjEtMTc2NS03MmRkLTg1MTktMDJiYjQ4NTY5M2U0LyIsInBy
-        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5MmRmMjEtMTc2NS03MmRk
-        LTg1MTktMDJiYjQ4NTY5M2U0IiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMC0z
-        MFQyMDozMjoyMC44MzkwNzVaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0
-        LTEwLTMwVDIwOjMyOjIwLjk5NzkyM1oiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjEt
-        MTU4YS03OTg4LThjNTAtY2M0YWYyMGU3N2NlL3ZlcnNpb25zLzAvIiwicmVw
+        cG0vMDE5NWVlNDMtODM4Ni03YjI0LTlhOTEtYjkwNGNhZjJhYWEwLyIsInBy
+        biI6InBybjpycG0ucnBtcHVibGljYXRpb246MDE5NWVlNDMtODM4Ni03YjI0
+        LTlhOTEtYjkwNGNhZjJhYWEwIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wMy0z
+        MVQyMjoxMjozNi44NzQzMTFaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1
+        LTAzLTMxVDIyOjEyOjM3LjE2NDM2MVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDMt
+        ODA5OS03YjI1LWE4OTMtZmNmYWRlNTFkNmZjL3ZlcnNpb25zLzAvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvcnBtL3JwbS8w
-        MTkyZGYyMS0xNThhLTc5ODgtOGM1MC1jYzRhZjIwZTc3Y2UvIiwiY2hlY2tz
+        MTk1ZWU0My04MDk5LTdiMjUtYTg5My1mY2ZhZGU1MWQ2ZmMvIiwiY2hlY2tz
         dW1fdHlwZSI6InNoYTI1NiIsIm1ldGFkYXRhX2NoZWNrc3VtX3R5cGUiOiJz
         aGEyNTYiLCJwYWNrYWdlX2NoZWNrc3VtX3R5cGUiOiJzaGEyNTYiLCJncGdj
         aGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6bnVsbCwic3FsaXRlX21ldGFk
         YXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9LCJjb21wcmVzc2lvbl90eXBl
-        IjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:22 GMT
+        IjpudWxsLCJsYXlvdXQiOiJuZXN0ZWRfYWxwaGFiZXRpY2FsbHkifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:40 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df21-1a27-75fd-b97d-eec31938305a/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-89cf-7e0b-9cb1-b0ffba128d4c/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBv
         cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwicHVibGlj
         YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vMDE5
-        MmRmMjEtMTc2NS03MmRkLTg1MTktMDJiYjQ4NTY5M2U0LyJ9
+        NWVlNDMtODM4Ni03YjI0LTlhOTEtYjkwNGNhZjJhYWEwLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1514,13 +1513,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:22 GMT
+      - Mon, 31 Mar 2025 22:12:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1534,7 +1533,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cd6b245e188f4acf8b05439341226838
+      - 72ff45fb40874b6aa237955707e823cc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1542,12 +1541,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTFmNjUtNzk1
-        Ny1hMjlkLTU5OGNlYjYyMDRkMy8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:22 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTkzOGYtN2E5
+        My05OWExLWNkNmVmMGE5YWVhMi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:41 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df21-1a27-75fd-b97d-eec31938305a/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-89cf-7e0b-9cb1-b0ffba128d4c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1568,13 +1567,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:23 GMT
+      - Mon, 31 Mar 2025 22:12:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1588,7 +1587,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0f41f74a50044eb399a0e1974644cc39
+      - 2d293a2380864cb8bb4da99440354582
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1596,12 +1595,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTFmZTctN2Jl
-        OC1iYzE1LTkyMzU3ODI5M2MwYy8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:23 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTk0ODktNzQy
+        NC05MmVmLThiMzRiN2M4ZWZjZC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:41 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df21-14e5-7f08-8f0c-d85cfc42b716/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee43-7f80-7a2e-a8c7-f11a121342a4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1622,13 +1621,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:23 GMT
+      - Mon, 31 Mar 2025 22:12:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1642,7 +1641,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0b0dc3188fe94bbe941588f0d6c9ea61
+      - c288f3d2d1f040d4ad657a3ca83fb7a9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1650,12 +1649,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTIwY2ItNzIy
-        OC1hODYxLTE5Yzk3NTMzNDIxYy8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:23 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTk1ZmYtNzg3
+        YS1hYWYzLWFlZmRhNzk4ZDdiMi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:41 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df21-20cb-7228-a861-19c97533421c/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-95ff-787a-aaf3-aefda798d7b2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1663,7 +1662,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1676,19 +1675,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:23 GMT
+      - Mon, 31 Mar 2025 22:12:41 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '843'
+      - '824'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1696,7 +1695,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 276b27efbad44468979db61b5e4ca76a
+      - 4d4ad1a01c974e60a287d9e6263ee577
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1704,29 +1703,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjEtMjBj
-        Yi03MjI4LWE4NjEtMTljOTc1MzM0MjFjLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjEtMjBjYi03MjI4LWE4NjEtMTljOTc1MzM0MjFjIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoyMy4yNDM1OTVaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjIzLjI0MzYxMloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtOTVm
+        Zi03ODdhLWFhZjMtYWVmZGE3OThkN2IyLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtOTVmZi03ODdhLWFhZjMtYWVmZGE3OThkN2IyIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjo0MS42MDAwOTNaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjQxLjYwMDExNVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiMGIwZGMz
-        MTg4ZmU5NGJiZTk0MTU4OGYwZDZjOWVhNjEiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoyMy4yNTg2MzVaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MjMuMzA3NTg4WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoyMy4zNDc3NzJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTM5NTktN2UwNi05MmY4LWZkOWI1
-        MTgxYjdlZS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpycG0ucnBtcmVtb3RlOjAxOTJkZjIxLTE0ZTUtN2YwOC04ZjBj
-        LWQ4NWNmYzQyYjcxNiIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmRl
-        YWItMTY0Ny03NjU0LThiZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:32:23 GMT
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiYzI4OGYz
+        ZDJkMWYwNDBkNGFkNjU3YTNjYTgzZmI3YTkiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjQxLjYyMDgxNloi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjo0MS42OTMzMjhaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjQxLjc2OTk2MFoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmFlYi03ZTdlLTk0NWQtZmRlYzk2MzEzZDkwLyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10s
+        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOnJwbS5ycG1yZW1v
+        dGU6MDE5NWVlNDMtN2Y4MC03YTJlLWE4YzctZjExYTEyMTM0MmE0Iiwic2hh
+        cmVkOnBybjpjb3JlLmRvbWFpbjo2ZDNjNjAxZi1mZWFmLTRiOTMtODI2NC01
+        MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:12:41 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0192df21-158a-7988-8c50-cc4af20e77ce/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0195ee43-8099-7b25-a893-fcfade51d6fc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1747,13 +1746,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:23 GMT
+      - Mon, 31 Mar 2025 22:12:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1767,7 +1766,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bfe906e7c20941f3bff023fb9d15f41c
+      - 27d780a2e09441de8e59e32c482504b5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1775,12 +1774,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTIxZDktNzdj
-        ZS1hODU4LWJhZWE4MWRhN2E2NC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:23 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLTk4NDgtN2Jl
+        OS05MDVhLTZiMzFkNDNiZTkyNC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:42 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df21-21d9-77ce-a858-baea81da7a64/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-9848-7be9-905a-6b31d43be924/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1788,7 +1787,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1801,19 +1800,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:23 GMT
+      - Mon, 31 Mar 2025 22:12:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '847'
+      - '828'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1821,7 +1820,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 73d0cb2b82b943f0babd4387eab1bab4
+      - 3612267ac38f47e38dadaf62f5ebc46d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1829,29 +1828,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjEtMjFk
-        OS03N2NlLWE4NTgtYmFlYTgxZGE3YTY0LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjEtMjFkOS03N2NlLWE4NTgtYmFlYTgxZGE3YTY0IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoyMy41MTM3OTlaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjIzLjUxMzgxNVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtOTg0
+        OC03YmU5LTkwNWEtNmIzMWQ0M2JlOTI0LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtOTg0OC03YmU5LTkwNWEtNmIzMWQ0M2JlOTI0IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjo0Mi4xODYwMjFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjQyLjE4NjA0M1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiYmZlOTA2
-        ZTdjMjA5NDFmM2JmZjAyM2ZiOWQxNWY0MWMiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoyMy41Mjc5MTlaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MjMuNTczMjkyWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoyMy43MzQxNDhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTNhNDItN2QyNC1hYjVmLTg4ZGNj
-        YzI4YjNiZC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpycG0ucnBtcmVwb3NpdG9yeTowMTkyZGYyMS0xNThhLTc5ODgt
-        OGM1MC1jYzRhZjIwZTc3Y2UiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAx
-        OTJkZWFiLTE2NDctNzY1NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:23 GMT
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiMjdkNzgw
+        YTJlMDk0NDFkZThlNTllMzJjNDgyNTA0YjUiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjQyLjIwNzgyNVoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMjo0Mi4yNzk3MjlaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjQyLjU2NTIwOVoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmNmMC03ZjU5LWFhZmEtYzAyYzY0YmU5Nzk2LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10s
+        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOnJwbS5ycG1yZXBv
+        c2l0b3J5OjAxOTVlZTQzLTgwOTktN2IyNS1hODkzLWZjZmFkZTUxZDZmYyIs
+        InNoYXJlZDpwcm46Y29yZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgy
+        NjQtNTI4YzI5MTI5YTEzIl19
+  recorded_at: Mon, 31 Mar 2025 22:12:42 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1859,7 +1858,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.22.2/ruby
+      - OpenAPI-Generator/0.22.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1872,13 +1871,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:24 GMT
+      - Mon, 31 Mar 2025 22:12:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1892,7 +1891,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b20f6093a8a148f0a050599c908caf2b
+      - 85e640c3e0b04adeb8d8df26a8c9cc87
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1902,7 +1901,385 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:24 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:43 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.3.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - a11c080c20914f8da2682b5c09533068
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:43 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.22.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9abea77a083145f4995a483aa9f350c9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:43 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - d5f8c49d15df4b1c832de4f96a188f6e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:43 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.4.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 972d787de6164dce8bbedb5a2002706d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:43 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.12.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2034285a81d248d79f5fcfc5dd66e872
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:43 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.27.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5913fbefa87040048296b1afa3cabfa4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:43 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.22.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:12:44 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8a3b572d92974519b599ce902ab8c297
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:44 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -1926,13 +2303,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:24 GMT
+      - Mon, 31 Mar 2025 22:12:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1946,7 +2323,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - aa785e4e2a8543d895ddf9e928d59f53
+      - fe2d740e733d4732bf6f2563352f807a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1956,7 +2333,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:24 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:44 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -1967,7 +2344,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.21.1/ruby
+      - OpenAPI-Generator/2.22.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1980,13 +2357,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:24 GMT
+      - Mon, 31 Mar 2025 22:12:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2000,7 +2377,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cb9196dcd635442da41953b993b7cc7b
+      - 432528eafefc4aababad334d1e673cde
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2010,7 +2387,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:24 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:44 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -2021,7 +2398,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2034,13 +2411,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:24 GMT
+      - Mon, 31 Mar 2025 22:12:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2054,7 +2431,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4eea2e777fcf417c8340ff424245de57
+      - 3860ac915e754d26907ce0e4133e4c52
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2064,7 +2441,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:24 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:44 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -2075,7 +2452,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.4.4/ruby
+      - OpenAPI-Generator/2.4.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -2088,13 +2465,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:24 GMT
+      - Mon, 31 Mar 2025 22:12:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2108,7 +2485,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a9db53bd1bf64f5ea5c6b7ef2e9d43ce
+      - 332dcee3aa2d4d8da3b632eacb9c0543
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2118,7 +2495,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:24 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:44 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -2129,7 +2506,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.12.5/ruby
+      - OpenAPI-Generator/3.12.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -2142,13 +2519,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:24 GMT
+      - Mon, 31 Mar 2025 22:12:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2162,7 +2539,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9ed107f9b04646d0bb5e631f503d19c2
+      - b4f087107f1743c2ad4eade4c5da58a1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2172,7 +2549,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:24 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:44 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -2196,13 +2573,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:24 GMT
+      - Mon, 31 Mar 2025 22:12:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -2216,7 +2593,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c64feb4fa83f4eabbc51936cbe152601
+      - e92208a581c04a8cb747fba347d662d2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2226,7 +2603,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:24 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:44 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/orphans/cleanup/
@@ -2239,7 +2616,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2252,13 +2629,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:24 GMT
+      - Mon, 31 Mar 2025 22:12:44 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - POST, OPTIONS
       X-Frame-Options:
@@ -2272,7 +2649,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b47ff6e628994b9e853a47a1e4f4e8a5
+      - adf1b36eb6594ef1b50c27747ca73343
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2280,12 +2657,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTI1NmEtN2Jm
-        Zi05ZGY0LWNkNzllYzFlYmZmOC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:24 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWEyZjgtN2Rj
+        Yi1hMTVhLTIyMGNiOTlmZTg0My8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:44 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df21-256a-7bff-9df4-cd79ec1ebff8/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-a2f8-7dcb-a15a-220cb99fe843/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2293,7 +2670,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2306,19 +2683,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:24 GMT
+      - Mon, 31 Mar 2025 22:12:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1077'
+      - '1058'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2326,7 +2703,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b779af0c952f444e8a4e3b8969eee354
+      - 6e2613aa7b0c4ff99eca56bd74a7b0a3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2334,31 +2711,31 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjEtMjU2
-        YS03YmZmLTlkZjQtY2Q3OWVjMWViZmY4LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjEtMjU2YS03YmZmLTlkZjQtY2Q3OWVjMWViZmY4IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoyNC40MjcyMjdaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjI0LjQyNzI0MFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtYTJm
+        OC03ZGNiLWExNWEtMjIwY2I5OWZlODQzLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtYTJmOC03ZGNiLWExNWEtMjIwY2I5OWZlODQzIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMjo0NC45MjE3MTZaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjQ0LjkyMTczOVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiJiNDdm
-        ZjZlNjI4OTk0YjllODUzYTQ3YTFlNGY0ZThhNSIsImNyZWF0ZWRfYnkiOiIv
-        cHVscC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTEw
-        LTMwVDIwOjMyOjI0LjQ0MjM3MFoiLCJzdGFydGVkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoyNC40ODk2MDVaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTEwLTMw
-        VDIwOjMyOjI0LjY2Njg2N1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1
-        bHAvYXBpL3YzL3dvcmtlcnMvMDE5MmRlYWMtMzljZi03NmQ1LTk4NDktZjUw
-        ZGY2NjFlZmI0LyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6
-        W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1l
-        c3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQ29udGVudCIsImNvZGUiOiJjbGVh
-        bi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwi
-        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJDbGVhbiB1cCBv
-        cnBoYW4gQXJ0aWZhY3RzIiwiY29kZSI6ImNsZWFuLXVwLmFydGlmYWN0cyIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jl
-        c291cmNlc19yZWNvcmQiOlsicGRybjowMTkyZGVhYi0xNjQ3LTc2NTQtOGJm
-        MS1iNWRmYmI3MzQ1OTE6b3JwaGFucyIsInNoYXJlZDpwcm46Y29yZS5kb21h
-        aW46MDE5MmRlYWItMTY0Ny03NjU0LThiZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:32:24 GMT
+        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiJhZGYx
+        YjM2ZWI2NTk0ZWYxYjUwYzI3NzQ3Y2E3MzM0MyIsImNyZWF0ZWRfYnkiOm51
+        bGwsInVuYmxvY2tlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6NDQuOTQ3MzA1
+        WiIsInN0YXJ0ZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEyOjQ1LjA0OTcwOFoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTI6NDUuMzkzNjIxWiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8w
+        MTk1ZDJlZS1iYTNhLTc0NjMtYTE1NS05ODdjY2M5ZTVhNzQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkNsZWFuIHVwIG9y
+        cGhhbiBDb250ZW50IiwiY29kZSI6ImNsZWFuLXVwLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51
+        bGx9LHsibWVzc2FnZSI6IkNsZWFuIHVwIG9ycGhhbiBBcnRpZmFjdHMiLCJj
+        b2RlIjoiY2xlYW4tdXAuYXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJw
+        ZHJuOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUyOGMyOTEyOWExMzpvcnBo
+        YW5zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo2ZDNjNjAxZi1mZWFmLTRi
+        OTMtODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:12:45 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/purge/
@@ -2371,7 +2748,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2384,13 +2761,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:24 GMT
+      - Mon, 31 Mar 2025 22:12:45 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - POST, OPTIONS
       X-Frame-Options:
@@ -2404,7 +2781,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 231462af41a54316b9f6e98eb3d1caea
+      - 3eed0015c127427c81c0779c4a88ebda
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -2412,7 +2789,7 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTI2ZDEtN2Vm
-        Ni04YzA2LTZjYTRmZGQ0ZWNlYy8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:24 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWE1ZGMtNzY0
+        Zi04ZjJlLTI4NjY2MjQ4NDA4YS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:45 GMT
 recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/actions/pulp3/yum_update_no_url/addurl.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/yum_update_no_url/addurl.yml
@@ -23,13 +23,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:25 GMT
+      - Mon, 31 Mar 2025 22:12:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -43,7 +43,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f421be23584f45bc92fb73f93e716654
+      - 8d8f6a67ce504475a7b706aca2a043d8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -53,7 +53,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:25 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:57 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -77,13 +77,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:25 GMT
+      - Mon, 31 Mar 2025 22:12:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -97,7 +97,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ffea022e532d4213b3a31363c18343c9
+      - 02c79798c07f4f5c8811b3128aca4936
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -107,7 +107,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:25 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:57 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -131,13 +131,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:25 GMT
+      - Mon, 31 Mar 2025 22:12:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -151,7 +151,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - be40f9b6f94d4386b246f0eda6608fb9
+      - 982ace9856174d738d176909f2a249dd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -161,7 +161,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:25 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:57 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -185,13 +185,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:25 GMT
+      - Mon, 31 Mar 2025 22:12:57 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -205,7 +205,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e821bcaea1e44ec0bdb998806a149919
+      - 519a9d5852b047aa8e32bed0380acf6d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -215,7 +215,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:25 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:57 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?name=2_duplicate
@@ -239,13 +239,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:25 GMT
+      - Mon, 31 Mar 2025 22:12:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -259,7 +259,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 65c9039c4e2c4edea3387840b69b9285
+      - 45a0670990074858ac4a8018dbc01d6d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -269,7 +269,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:25 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:58 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
@@ -293,13 +293,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:25 GMT
+      - Mon, 31 Mar 2025 22:12:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -313,7 +313,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5bed0f54a82c44f0a0006b19b3647719
+      - 854318a036da41f38076da4795e60ba8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -323,7 +323,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:25 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:58 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
@@ -347,13 +347,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:26 GMT
+      - Mon, 31 Mar 2025 22:12:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -367,7 +367,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0d25c6b82a16407f9eb18c17c4118c21
+      - da20d727ff3d43e4a6d498bdb7a0b47e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -377,7 +377,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:26 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:58 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -401,13 +401,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:26 GMT
+      - Mon, 31 Mar 2025 22:12:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -421,7 +421,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 99ea9752fd054c0ab0d5b9ac1609a062
+      - b7509087a4f846ed8171700c0108e28c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -431,7 +431,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:26 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:58 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/
@@ -457,21 +457,21 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:26 GMT
+      - Mon, 31 Mar 2025 22:12:58 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/rpm/rpm/0192df21-2c8e-7f7b-ab70-4349bf138d3e/"
+      - "/pulp/api/v3/repositories/rpm/rpm/0195ee43-d8db-73e8-8361-8155db871212/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '880'
+      - '894'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -479,7 +479,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 41ba42d2735641c9a713838603abec9a
+      - b0e24ab7029042f899d6f7842ae335a4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -488,16 +488,16 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9y
-        cG0vMDE5MmRmMjEtMmM4ZS03ZjdiLWFiNzAtNDM0OWJmMTM4ZDNlLyIsInBy
-        biI6InBybjpycG0ucnBtcmVwb3NpdG9yeTowMTkyZGYyMS0yYzhlLTdmN2It
-        YWI3MC00MzQ5YmYxMzhkM2UiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMw
-        VDIwOjMyOjI2LjI1NDU4MloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQt
-        MTAtMzBUMjA6MzI6MjYuMjYxMjc4WiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5MmRmMjEtMmM4ZS03
-        ZjdiLWFiNzAtNDM0OWJmMTM4ZDNlL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
+        cG0vMDE5NWVlNDMtZDhkYi03M2U4LTgzNjEtODE1NWRiODcxMjEyLyIsInBy
+        biI6InBybjpycG0ucnBtcmVwb3NpdG9yeTowMTk1ZWU0My1kOGRiLTczZTgt
+        ODM2MS04MTU1ZGI4NzEyMTIiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMx
+        VDIyOjEyOjU4LjcxNzAzNFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUt
+        MDMtMzFUMjI6MTI6NTguNzIxNjE1WiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL3JwbS9ycG0vMDE5NWVlNDMtZDhkYi03
+        M2U4LTgzNjEtODE1NWRiODcxMjEyL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
         Ijp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvcnBtL3JwbS8wMTkyZGYyMS0yYzhlLTdmN2ItYWI3MC00MzQ5
-        YmYxMzhkM2UvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJk
+        c2l0b3JpZXMvcnBtL3JwbS8wMTk1ZWU0My1kOGRiLTczZTgtODM2MS04MTU1
+        ZGI4NzEyMTIvdmVyc2lvbnMvMC8iLCJuYW1lIjoiMl9kdXBsaWNhdGUiLCJk
         ZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lvbnMiOm51bGws
         InJlbW90ZSI6bnVsbCwiYXV0b3B1Ymxpc2giOmZhbHNlLCJtZXRhZGF0YV9z
         aWduaW5nX3NlcnZpY2UiOm51bGwsInBhY2thZ2Vfc2lnbmluZ19zZXJ2aWNl
@@ -506,8 +506,8 @@ http_interactions:
         bWV0YWRhdGFfY2hlY2tzdW1fdHlwZSI6bnVsbCwicGFja2FnZV9jaGVja3N1
         bV90eXBlIjpudWxsLCJncGdjaGVjayI6bnVsbCwicmVwb19ncGdjaGVjayI6
         bnVsbCwic3FsaXRlX21ldGFkYXRhIjpmYWxzZSwicmVwb19jb25maWciOnt9
-        LCJjb21wcmVzc2lvbl90eXBlIjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:26 GMT
+        LCJjb21wcmVzc2lvbl90eXBlIjpudWxsLCJsYXlvdXQiOm51bGx9
+  recorded_at: Mon, 31 Mar 2025 22:12:58 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -539,15 +539,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:26 GMT
+      - Mon, 31 Mar 2025 22:12:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/0192df21-2d7b-7463-b5e1-277fdf7b9464/"
+      - "/pulp/api/v3/remotes/rpm/rpm/0195ee43-da64-751a-a62f-c85c76d17ce2/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -561,7 +561,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 15764cba757647859baab7246d5c2d22
+      - 11d53a2c1ee64a63ba70742462e358c9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -570,11 +570,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OTJkZjIxLTJkN2ItNzQ2My1iNWUxLTI3N2ZkZjdiOTQ2NC8iLCJwcm4iOiJw
-        cm46cnBtLnJwbXJlbW90ZTowMTkyZGYyMS0yZDdiLTc0NjMtYjVlMS0yNzdm
-        ZGY3Yjk0NjQiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjI2
-        LjQ5MTk5NloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMTAtMzBUMjA6
-        MzI6MjYuNDkyMDE0WiIsIm5hbWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJs
+        OTVlZTQzLWRhNjQtNzUxYS1hNjJmLWM4NWM3NmQxN2NlMi8iLCJwcm4iOiJw
+        cm46cnBtLnJwbXJlbW90ZTowMTk1ZWU0My1kYTY0LTc1MWEtYTYyZi1jODVj
+        NzZkMTdjZTIiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjU5
+        LjEwODg3NFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUtMDMtMzFUMjI6
+        MTI6NTkuMTA4ODk3WiIsIm5hbWUiOiJ0ZXN0X3JlbW90ZV9uYW1lIiwidXJs
         IjoiaHR0cDovL3NvbWVvdGhlcnVybCIsImNhX2NlcnQiOm51bGwsImNsaWVu
         dF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJs
         IjpudWxsLCJwdWxwX2xhYmVscyI6e30sImRvd25sb2FkX2NvbmN1cnJlbmN5
@@ -588,10 +588,10 @@ http_interactions:
         Im5hbWUiOiJ1c2VybmFtZSIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6InBh
         c3N3b3JkIiwiaXNfc2V0IjpmYWxzZX1dLCJzbGVzX2F1dGhfdG9rZW4iOm51
         bGx9
-  recorded_at: Wed, 30 Oct 2024 20:32:26 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:59 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0192df21-2d7b-7463-b5e1-277fdf7b9464/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/0195ee43-da64-751a-a62f-c85c76d17ce2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -612,13 +612,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:26 GMT
+      - Mon, 31 Mar 2025 22:12:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -632,7 +632,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e71b0a3e196f4e69ae56331212dc4c49
+      - f8f139bb3d264c65880c465a2776d967
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -640,12 +640,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTJkYmQtNzYy
-        My04OTQ1LWZiNGM0ODdjNTQxMy8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:26 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWRhZTAtNzhl
+        Yi1iNDEyLWI0ODU0YjU1MzIzMC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:59 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0192df21-2c8e-7f7b-ab70-4349bf138d3e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0195ee43-d8db-73e8-8361-8155db871212/
     body:
       encoding: UTF-8
       base64_string: |
@@ -668,13 +668,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:26 GMT
+      - Mon, 31 Mar 2025 22:12:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -688,7 +688,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 53a0f87b8a85496f9f68d2ee0567d5ae
+      - 60c815f3dacb4fc7bd6ad619813eff00
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -696,9 +696,9 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTJlOGMtNzMz
-        Yi05YjZjLTA1MmNlYTQ5M2IxNy8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:26 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWRjM2QtNzM2
+        Ny1hNmNjLTcwODEyZWMwNmFlOC8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:12:59 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/rpm/rpm/
@@ -730,15 +730,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:26 GMT
+      - Mon, 31 Mar 2025 22:12:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/rpm/rpm/0192df21-2efa-7c15-84ee-727d27588cc6/"
+      - "/pulp/api/v3/remotes/rpm/rpm/0195ee43-dd27-797f-970f-44de2362651c/"
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -752,7 +752,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 757ced0df2b340a1b5bc8fc5382687dc
+      - 704582abb98b44bd9ab8c1bee2dcce76
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -761,11 +761,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzAx
-        OTJkZjIxLTJlZmEtN2MxNS04NGVlLTcyN2QyNzU4OGNjNi8iLCJwcm4iOiJw
-        cm46cnBtLnJwbXJlbW90ZTowMTkyZGYyMS0yZWZhLTdjMTUtODRlZS03Mjdk
-        Mjc1ODhjYzYiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjI2
-        Ljg3NTAxMFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQtMTAtMzBUMjA6
-        MzI6MjYuODc1MDI3WiIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0
+        OTVlZTQzLWRkMjctNzk3Zi05NzBmLTQ0ZGUyMzYyNjUxYy8iLCJwcm4iOiJw
+        cm46cnBtLnJwbXJlbW90ZTowMTk1ZWU0My1kZDI3LTc5N2YtOTcwZi00NGRl
+        MjM2MjY1MWMiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEyOjU5
+        LjgxNjU1MVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUtMDMtMzFUMjI6
+        MTI6NTkuODE2NTczWiIsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInVybCI6Imh0
         dHA6Ly9zb21lb3RoZXJ1cmwiLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2Vy
         dCI6bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVs
         bCwicHVscF9sYWJlbHMiOnt9LCJkb3dubG9hZF9jb25jdXJyZW5jeSI6bnVs
@@ -778,7 +778,7 @@ http_interactions:
         bmFtZSI6InByb3h5X3Bhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1l
         IjoidXNlcm5hbWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwYXNzd29y
         ZCIsImlzX3NldCI6ZmFsc2V9XSwic2xlc19hdXRoX3Rva2VuIjpudWxsfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:26 GMT
+  recorded_at: Mon, 31 Mar 2025 22:12:59 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
@@ -802,13 +802,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:26 GMT
+      - Mon, 31 Mar 2025 22:13:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -822,7 +822,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fdb997d00fb64bc1b41e999692699368
+      - 973e72da07664effbf5b7bf2230dc4a3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -832,7 +832,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:26 GMT
+  recorded_at: Mon, 31 Mar 2025 22:13:00 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/
@@ -859,13 +859,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:27 GMT
+      - Mon, 31 Mar 2025 22:13:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -879,7 +879,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3ce8eae358eb4fb8a17cbcd9d1e21e09
+      - 843cb478e72543ebb9a1c2154dd6cb73
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -887,12 +887,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTJmOWMtN2I2
-        MS1hZGE1LTY4NGU3NGFhM2U3Mi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:27 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWRlNzYtNzA2
+        MC1hNzg4LWYzMDYxYTYzM2JlYy8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:13:00 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df21-2f9c-7b61-ada5-684e74aa3e72/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-de76-7060-a788-f3061a633bec/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -900,7 +900,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -913,19 +913,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:27 GMT
+      - Mon, 31 Mar 2025 22:13:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '918'
+      - '899'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -933,7 +933,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3baee19593794c468bd3c2ff4811ebc5
+      - 7acc87d9cead4744aeb26d34586514ea
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -941,31 +941,30 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjEtMmY5
-        Yy03YjYxLWFkYTUtNjg0ZTc0YWEzZTcyLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjEtMmY5Yy03YjYxLWFkYTUtNjg0ZTc0YWEzZTcyIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoyNy4wMzc0MDlaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjI3LjAzNzQyNloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtZGU3
+        Ni03MDYwLWE3ODgtZjMwNjFhNjMzYmVjLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtZGU3Ni03MDYwLWE3ODgtZjMwNjFhNjMzYmVjIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMzowMC4xNTEyNjhaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEzOjAwLjE1MTI5MVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiM2NlOGVh
-        ZTM1OGViNGZiOGExN2NiY2Q5ZDFlMjFlMDkiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoyNy4wNTMxNDhaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MjcuMTEwMTE4WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoyNy4xODgxOTVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTM4NWUtNzhiMS04OTViLTBlODQ2
-        ODBjMTFmNy8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
-        cnBtL3JwbS8wMTkyZGYyMS0zMDIxLTc4MDktYjFhMC03OTg3Nzg3NGNmMGMv
-        Il0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicGRybjowMTkyZGVh
-        Yi0xNjQ3LTc2NTQtOGJmMS1iNWRmYmI3MzQ1OTE6ZGlzdHJpYnV0aW9ucyIs
-        InNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmRlYWItMTY0Ny03NjU0LThi
-        ZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:32:27 GMT
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiODQzY2I0
+        NzhlNzI1NDNlYmI5YTFjMjE1NGRkNmNiNzMiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEzOjAwLjE3Mjc4N1oi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMzowMC4yNTY1OTZaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEzOjAwLjM4NzE4M1oiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmNmMC03ZjU5LWFhZmEtYzAyYzY0YmU5Nzk2LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIv
+        cHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0vcnBtLzAxOTVlZTQzLWRm
+        NGMtN2VlZi1iMzQyLTY2MjVjYTE0NjYwNC8iXSwicmVzZXJ2ZWRfcmVzb3Vy
+        Y2VzX3JlY29yZCI6WyJwZHJuOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUy
+        OGMyOTEyOWExMzpkaXN0cmlidXRpb25zIiwic2hhcmVkOnBybjpjb3JlLmRv
+        bWFpbjo2ZDNjNjAxZi1mZWFmLTRiOTMtODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:13:00 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df21-3021-7809-b1a0-79877874cf0c/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-df4c-7eef-b342-6625ca146604/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -986,13 +985,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:27 GMT
+      - Mon, 31 Mar 2025 22:13:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1006,7 +1005,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 327085b852bc41cfa52b90ffb0092768
+      - 9cdc063f482a4ebe8fec2f265f346c95
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1015,11 +1014,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
-        cnBtLzAxOTJkZjIxLTMwMjEtNzgwOS1iMWEwLTc5ODc3ODc0Y2YwYy8iLCJw
-        cm4iOiJwcm46cnBtLnJwbWRpc3RyaWJ1dGlvbjowMTkyZGYyMS0zMDIxLTc4
-        MDktYjFhMC03OTg3Nzg3NGNmMGMiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTEw
-        LTMwVDIwOjMyOjI3LjE3MTA3MVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
-        MjQtMTAtMzBUMjA6MzI6MjcuMTcxMDkyWiIsImJhc2VfcGF0aCI6IkFDTUVf
+        cnBtLzAxOTVlZTQzLWRmNGMtN2VlZi1iMzQyLTY2MjVjYTE0NjYwNC8iLCJw
+        cm4iOiJwcm46cnBtLnJwbWRpc3RyaWJ1dGlvbjowMTk1ZWU0My1kZjRjLTdl
+        ZWYtYjM0Mi02NjI1Y2ExNDY2MDQiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTAz
+        LTMxVDIyOjEzOjAwLjM2NzMzM1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
+        MjUtMDMtMzFUMjI6MTM6MDAuMzY3MzY2WiIsImJhc2VfcGF0aCI6IkFDTUVf
         Q29ycG9yYXRpb24vZGV2L2ZlZG9yYV8xN19kdXBsaWNhdGVfbGFiZWwiLCJi
         YXNlX3VybCI6Imh0dHBzOi8vY2VudG9zOS1rYXRlbGxvLWRldmVsLXN0YWJs
         ZS5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9k
@@ -1028,10 +1027,10 @@ http_interactions:
         IjpmYWxzZSwicHVscF9sYWJlbHMiOnt9LCJuYW1lIjoiMl9kdXBsaWNhdGUi
         LCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6bnVsbCwiZ2VuZXJh
         dGVfcmVwb19jb25maWciOmZhbHNlfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:27 GMT
+  recorded_at: Mon, 31 Mar 2025 22:13:00 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0192df21-3021-7809-b1a0-79877874cf0c/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/0195ee43-df4c-7eef-b342-6625ca146604/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1052,13 +1051,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:27 GMT
+      - Mon, 31 Mar 2025 22:13:00 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1072,7 +1071,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 49d1b3c606a34fa6ab895e43fcfd607b
+      - 61a85b61d3214eb99d115635ad359400
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1080,12 +1079,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTMxMTAtN2Q2
-        Mi05YWYzLTE1NzZlMzAwYjBmNi8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:27 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWUxODUtNzVi
+        NC04NWUzLTMxMmFmMGQ4YjVmNS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:13:00 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0192df21-2c8e-7f7b-ab70-4349bf138d3e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/0195ee43-d8db-73e8-8361-8155db871212/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1106,13 +1105,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:27 GMT
+      - Mon, 31 Mar 2025 22:13:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
@@ -1126,7 +1125,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 519a2c7f48e3437980b4649ce67b8376
+      - 9db616de152741fd9d72022ac5b9e340
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1134,12 +1133,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTMyMDgtNzE0
-        NC1iN2Y4LTcwZjkyMTgwZTc0NS8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:27 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWUzNDMtN2Zl
+        MC1hOWYzLWZlYjQyYzFiMzA3Yi8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:13:01 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df21-3208-7144-b7f8-70f92180e745/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-e343-7fe0-a9f3-feb42c1b307b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1147,7 +1146,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1160,19 +1159,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:27 GMT
+      - Mon, 31 Mar 2025 22:13:01 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '847'
+      - '828'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1180,7 +1179,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b84497302da24b269fd3cdd191e9f366
+      - bc66057c84af426788a538c42a41c598
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1188,29 +1187,29 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjEtMzIw
-        OC03MTQ0LWI3ZjgtNzBmOTIxODBlNzQ1LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjEtMzIwOC03MTQ0LWI3ZjgtNzBmOTIxODBlNzQ1IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoyNy42NTc1MDJaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjI3LjY1NzUyMloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtZTM0
+        My03ZmUwLWE5ZjMtZmViNDJjMWIzMDdiLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtZTM0My03ZmUwLWE5ZjMtZmViNDJjMWIzMDdiIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMzowMS4zODA4ODdaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEzOjAxLjM4MDkwOVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiNTE5YTJj
-        N2Y0OGUzNDM3OTgwYjQ2NDljZTY3YjgzNzYiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoyNy42NzQyNDVaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTAtMzBU
-        MjA6MzI6MjcuNzI1MDc0WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMC0zMFQy
-        MDozMjoyNy43OTk3MjRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTJkZWFjLTNhNDItN2QyNC1hYjVmLTg4ZGNj
-        YzI4YjNiZC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
-        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
-        YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpycG0ucnBtcmVwb3NpdG9yeTowMTkyZGYyMS0yYzhlLTdmN2It
-        YWI3MC00MzQ5YmYxMzhkM2UiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjAx
-        OTJkZWFiLTE2NDctNzY1NC04YmYxLWI1ZGZiYjczNDU5MSJdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:27 GMT
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiOWRiNjE2
+        ZGUxNTI3NDFmZDlkNzIwMjJhYzViOWUzNDAiLCJjcmVhdGVkX2J5IjpudWxs
+        LCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEzOjAxLjQwNjYxNFoi
+        LCJzdGFydGVkX2F0IjoiMjAyNS0wMy0zMVQyMjoxMzowMS40OTc5NDVaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEzOjAxLjYyNjE2MVoiLCJl
+        cnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDE5
+        NWQyZWUtYmEzYS03NDYzLWExNTUtOTg3Y2NjOWU1YTc0LyIsInBhcmVudF90
+        YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3JvdXAiOm51bGws
+        InByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10s
+        InJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOnJwbS5ycG1yZXBv
+        c2l0b3J5OjAxOTVlZTQzLWQ4ZGItNzNlOC04MzYxLTgxNTVkYjg3MTIxMiIs
+        InNoYXJlZDpwcm46Y29yZS5kb21haW46NmQzYzYwMWYtZmVhZi00YjkzLTgy
+        NjQtNTI4YzI5MTI5YTEzIl19
+  recorded_at: Mon, 31 Mar 2025 22:13:01 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1218,7 +1217,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.22.2/ruby
+      - OpenAPI-Generator/0.22.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -1231,13 +1230,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:28 GMT
+      - Mon, 31 Mar 2025 22:13:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1251,7 +1250,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a2d9b1597ece4714840e7f8d0133d19d
+      - 8ee1fe2b1ef1478d95920639f74496b0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1261,7 +1260,385 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:28 GMT
+  recorded_at: Mon, 31 Mar 2025 22:13:02 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.3.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:13:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4de337ee4e4b412abbfcc127425ae3fa
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:13:02 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/container/container/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.22.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:13:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5bcec917979944fc93d42af700542188
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:13:02 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.63.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:13:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 94bcc56cc046492fbb98ece54dafc62a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:13:02 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/ostree/ostree/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/2.4.5/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:13:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - a1f74eaecc734e3fa2c6872693e196e4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:13:02 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/python/pypi/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.12.6/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:13:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 37c972aa7af449ca895dbce63319ef8d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:13:02 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/rpm/rpm/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.27.2/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:13:02 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - a3fc905725e84ef4a743b6abe02d1e51
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:13:02 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.22.4/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 31 Mar 2025 22:13:03 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - eb3382fe53eb40c2a318e1c22f67cdf3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 31 Mar 2025 22:13:03 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
@@ -1285,13 +1662,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:28 GMT
+      - Mon, 31 Mar 2025 22:13:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1305,7 +1682,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3282e9f93577461caa949f81d0fbb372
+      - ec7bfd19bb324de49f659a1baaa74350
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1315,7 +1692,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:28 GMT
+  recorded_at: Mon, 31 Mar 2025 22:13:03 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
@@ -1326,7 +1703,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.21.1/ruby
+      - OpenAPI-Generator/2.22.1/ruby
       Accept:
       - application/json
       Authorization:
@@ -1339,13 +1716,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:28 GMT
+      - Mon, 31 Mar 2025 22:13:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1359,7 +1736,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c26be3af7c10479dbccff7cf5fb9a0a5
+      - 73aae687d80041b5a288ba955576919a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1369,7 +1746,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:28 GMT
+  recorded_at: Mon, 31 Mar 2025 22:13:03 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
@@ -1380,7 +1757,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1393,13 +1770,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:28 GMT
+      - Mon, 31 Mar 2025 22:13:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1413,7 +1790,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 37ee9b4aca5343d4ac426ca2cc2f8d32
+      - 03124def4312427782aabb913922d9a2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1423,7 +1800,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:28 GMT
+  recorded_at: Mon, 31 Mar 2025 22:13:03 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
@@ -1434,7 +1811,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.4.4/ruby
+      - OpenAPI-Generator/2.4.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -1447,13 +1824,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:28 GMT
+      - Mon, 31 Mar 2025 22:13:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1467,7 +1844,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c794d16265c2465087094ad6e8086627
+      - 9db0fa379afa4c96802b4a7a82dc9e0d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1477,7 +1854,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:28 GMT
+  recorded_at: Mon, 31 Mar 2025 22:13:03 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
@@ -1488,7 +1865,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.12.5/ruby
+      - OpenAPI-Generator/3.12.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -1501,13 +1878,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:28 GMT
+      - Mon, 31 Mar 2025 22:13:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1521,7 +1898,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fc3ddedf57a7400481a29e5180454829
+      - 6669b49877e849b09ff13f555864caeb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1531,7 +1908,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:28 GMT
+  recorded_at: Mon, 31 Mar 2025 22:13:03 GMT
 - request:
     method: get
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
@@ -1555,13 +1932,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:28 GMT
+      - Mon, 31 Mar 2025 22:13:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, POST, HEAD, OPTIONS
       X-Frame-Options:
@@ -1575,7 +1952,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9f1d27a070554d3dbb70ee021fca023e
+      - b7f8aa7bc01c4e388d55084d2a8b96fb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1585,7 +1962,7 @@ http_interactions:
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:28 GMT
+  recorded_at: Mon, 31 Mar 2025 22:13:03 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/orphans/cleanup/
@@ -1598,7 +1975,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1611,13 +1988,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:28 GMT
+      - Mon, 31 Mar 2025 22:13:03 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - POST, OPTIONS
       X-Frame-Options:
@@ -1631,7 +2008,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 10e3a425dede47ab9da90c9a91474128
+      - ca43dfa174184189bebccee1595df987
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1639,12 +2016,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTM1NWItNzI5
-        Yy1iNGFiLTMxNTFhYzQ3YTZkMy8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:28 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWVjZWYtNzY3
+        Ni1iNjg2LTg0M2RmZmVhMDZjYS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:13:03 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0192df21-355b-729c-b4ab-3151ac47a6d3/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/0195ee43-ecef-7676-b686-843dffea06ca/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1652,7 +2029,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1665,19 +2042,19 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:28 GMT
+      - Mon, 31 Mar 2025 22:13:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1077'
+      - '1058'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1685,7 +2062,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c6a2e0fd6af843f3a018496068eece6c
+      - 752ef73689d6449ebf46038b70c2f175
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1693,31 +2070,31 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MmRmMjEtMzU1
-        Yi03MjljLWI0YWItMzE1MWFjNDdhNmQzLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MmRmMjEtMzU1Yi03MjljLWI0YWItMzE1MWFjNDdhNmQzIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMC0zMFQyMDozMjoyOC41MDgxMDlaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTEwLTMwVDIwOjMyOjI4LjUwODEyNloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWVlNDMtZWNl
+        Zi03Njc2LWI2ODYtODQzZGZmZWEwNmNhLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NWVlNDMtZWNlZi03Njc2LWI2ODYtODQzZGZmZWEwNmNhIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wMy0zMVQyMjoxMzowMy44NTcwODhaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTAzLTMxVDIyOjEzOjAzLjg1NzExMloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiIxMGUz
-        YTQyNWRlZGU0N2FiOWRhOTBjOWE5MTQ3NDEyOCIsImNyZWF0ZWRfYnkiOiIv
-        cHVscC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI0LTEw
-        LTMwVDIwOjMyOjI4LjUyMzYxOFoiLCJzdGFydGVkX2F0IjoiMjAyNC0xMC0z
-        MFQyMDozMjoyOC41NzQ0MDdaIiwiZmluaXNoZWRfYXQiOiIyMDI0LTEwLTMw
-        VDIwOjMyOjI4LjgwNTU5OFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1
-        bHAvYXBpL3YzL3dvcmtlcnMvMDE5MmRlYWMtMzk1OS03ZTA2LTkyZjgtZmQ5
-        YjUxODFiN2VlLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6
-        W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1l
-        c3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQ29udGVudCIsImNvZGUiOiJjbGVh
-        bi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwi
-        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJDbGVhbiB1cCBv
-        cnBoYW4gQXJ0aWZhY3RzIiwiY29kZSI6ImNsZWFuLXVwLmFydGlmYWN0cyIs
-        InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZp
-        eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jl
-        c291cmNlc19yZWNvcmQiOlsicGRybjowMTkyZGVhYi0xNjQ3LTc2NTQtOGJm
-        MS1iNWRmYmI3MzQ1OTE6b3JwaGFucyIsInNoYXJlZDpwcm46Y29yZS5kb21h
-        aW46MDE5MmRlYWItMTY0Ny03NjU0LThiZjEtYjVkZmJiNzM0NTkxIl19
-  recorded_at: Wed, 30 Oct 2024 20:32:28 GMT
+        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiJjYTQz
+        ZGZhMTc0MTg0MTg5YmViY2NlZTE1OTVkZjk4NyIsImNyZWF0ZWRfYnkiOm51
+        bGwsInVuYmxvY2tlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTM6MDMuODc3NTU3
+        WiIsInN0YXJ0ZWRfYXQiOiIyMDI1LTAzLTMxVDIyOjEzOjAzLjk2NDA2N1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMjUtMDMtMzFUMjI6MTM6MDQuMjQyNTUxWiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy8w
+        MTk1ZDJlZS1iYTNhLTc0NjMtYTE1NS05ODdjY2M5ZTVhNzQvIiwicGFyZW50
+        X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91cCI6bnVs
+        bCwicHJvZ3Jlc3NfcmVwb3J0cyI6W3sibWVzc2FnZSI6IkNsZWFuIHVwIG9y
+        cGhhbiBDb250ZW50IiwiY29kZSI6ImNsZWFuLXVwLmNvbnRlbnQiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51
+        bGx9LHsibWVzc2FnZSI6IkNsZWFuIHVwIG9ycGhhbiBBcnRpZmFjdHMiLCJj
+        b2RlIjoiY2xlYW4tdXAuYXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNyZWF0ZWRf
+        cmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJw
+        ZHJuOjZkM2M2MDFmLWZlYWYtNGI5My04MjY0LTUyOGMyOTEyOWExMzpvcnBo
+        YW5zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo2ZDNjNjAxZi1mZWFmLTRi
+        OTMtODI2NC01MjhjMjkxMjlhMTMiXX0=
+  recorded_at: Mon, 31 Mar 2025 22:13:04 GMT
 - request:
     method: post
     uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/purge/
@@ -1730,7 +2107,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.1/ruby
+      - OpenAPI-Generator/3.63.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1743,13 +2120,13 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 30 Oct 2024 20:32:29 GMT
+      - Mon, 31 Mar 2025 22:13:04 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Vary:
-      - Accept,Cookie
+      - Accept
       Allow:
       - POST, OPTIONS
       X-Frame-Options:
@@ -1763,7 +2140,7 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '09a85182ee7f41a7bbd39c81193bffce'
+      - 2b9e156852924f4a94fda035f9d5196b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
@@ -1771,7 +2148,7 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTJkZjIxLTM3NmQtN2M0
-        Ni05MWY0LTg1Y2IxZjU2N2U0MC8ifQ==
-  recorded_at: Wed, 30 Oct 2024 20:32:29 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVlZTQzLWVmZTktNzQ0
+        OS05MzliLTUxNjJhYjM0ODM1ZS8ifQ==
+  recorded_at: Mon, 31 Mar 2025 22:13:04 GMT
 recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/repository_orphan/delete_orphan_repository_versions.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/repository_orphan/delete_orphan_repository_versions.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:21 GMT
+      - Fri, 04 Apr 2025 14:11:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,20 +43,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - eafa03468d5c40fa8590548c06227259
+      - c66898d2a3684815811eaaaea9c486e0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:21 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:07 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:21 GMT
+      - Fri, 04 Apr 2025 14:11:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,20 +97,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3416bf2d45a24995a1a955ea00aa8c3b
+      - 64956884a61946dcb01f112bc0ff8ef1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:21 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:07 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -118,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:22 GMT
+      - Fri, 04 Apr 2025 14:11:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,20 +151,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 61527bbbee3d4c12bbb70a3213cdeab2
+      - efa048689df24bd0abd32f1b0c04b67b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:22 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:07 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -172,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:22 GMT
+      - Fri, 04 Apr 2025 14:11:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,20 +205,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7ee4800863c743aeac164a85eb33ba45
+      - 617fa0f038b046e88808e84311336910
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:22 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:07 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -226,7 +226,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -239,7 +239,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:22 GMT
+      - Fri, 04 Apr 2025 14:11:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -259,20 +259,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 82fa12e7085047c0add17a7f99fe25b0
+      - 237402e0a1164197bf9ad084a9340392
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:22 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:07 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -280,7 +280,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -293,7 +293,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:22 GMT
+      - Fri, 04 Apr 2025 14:11:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -313,20 +313,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b65231cb57f043fab59eb46fcb4b92ce
+      - 988a0e09ee5b413da43c78218c9f45bb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:22 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:07 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -334,7 +334,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -347,7 +347,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:22 GMT
+      - Fri, 04 Apr 2025 14:11:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -367,20 +367,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 499a2751a8ae4454942f98b963f18b5e
+      - '05748104623a4861b5919d2e9ed07a87'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:22 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:07 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -388,7 +388,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -401,7 +401,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:22 GMT
+      - Fri, 04 Apr 2025 14:11:07 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -421,20 +421,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7f829dc470e14d60bbc2d8d9d5618dc8
+      - ed39ad2bb14a4f17a6eeba443a9399c5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:22 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:07 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -452,7 +452,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -465,13 +465,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:22 GMT
+      - Fri, 04 Apr 2025 14:11:07 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/0193253a-5da8-7cb6-a57e-7c59fba08493/"
+      - "/pulp/api/v3/remotes/file/file/01960124-243c-7f76-94fc-dc88ba842a36/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -487,20 +487,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7423f3c2e91c432e9c14f5a50110379e
+      - aaff74898e0b460e8a671326d79ac57d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE5MzI1M2EtNWRhOC03Y2I2LWE1N2UtN2M1OWZiYTA4NDkzLyIsInBybiI6
-        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5MzI1M2EtNWRhOC03Y2I2LWE1N2Ut
-        N2M1OWZiYTA4NDkzIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMTox
-        MzoyMi4zNDQ4MTlaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEz
-        VDExOjEzOjIyLjM0NDgzMloiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        MDE5NjAxMjQtMjQzYy03Zjc2LTk0ZmMtZGM4OGJhODQyYTM2LyIsInBybiI6
+        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NjAxMjQtMjQzYy03Zjc2LTk0ZmMt
+        ZGM4OGJhODQyYTM2IiwicHVscF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDox
+        MTowNy45NjUxMjJaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0
+        VDE0OjExOjA3Ljk2NTEzNVoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
         b24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJ1cmwiOiJodHRwczovL2ZpeHR1
         cmVzLnB1bHBwcm9qZWN0Lm9yZy9maWxlMi8vUFVMUF9NQU5JRkVTVCIsImNh
         X2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlv
@@ -514,10 +514,10 @@ http_interactions:
         YW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicHJveHlfcGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJ1c2VybmFtZSIsImlzX3NldCI6
         ZmFsc2V9LHsibmFtZSI6InBhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX1dfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:22 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:07 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -527,7 +527,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -540,13 +540,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:22 GMT
+      - Fri, 04 Apr 2025 14:11:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/0193253a-5e22-723e-a0f5-2ce9e3826c7b/"
+      - "/pulp/api/v3/repositories/file/file/01960124-24cf-789d-af6a-4050cd5fa2eb/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -562,33 +562,33 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e51f9b74ee12406f95d99352b65a12f0
+      - 07d439bdbbba4fe7b9764e3d613019af
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMTkzMjUzYS01ZTIyLTcyM2UtYTBmNS0yY2U5ZTM4MjZjN2IvIiwi
-        cHJuIjoicHJuOmZpbGUuZmlsZXJlcG9zaXRvcnk6MDE5MzI1M2EtNWUyMi03
-        MjNlLWEwZjUtMmNlOWUzODI2YzdiIiwicHVscF9jcmVhdGVkIjoiMjAyNC0x
-        MS0xM1QxMToxMzoyMi40NjcxNzRaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIy
-        MDI0LTExLTEzVDExOjEzOjIyLjQ3MjU3OFoiLCJ2ZXJzaW9uc19ocmVmIjoi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1M2Et
-        NWUyMi03MjNlLWEwZjUtMmNlOWUzODI2YzdiL3ZlcnNpb25zLyIsInB1bHBf
+        ZmlsZS8wMTk2MDEyNC0yNGNmLTc4OWQtYWY2YS00MDUwY2Q1ZmEyZWIvIiwi
+        cHJuIjoicHJuOmZpbGUuZmlsZXJlcG9zaXRvcnk6MDE5NjAxMjQtMjRjZi03
+        ODlkLWFmNmEtNDA1MGNkNWZhMmViIiwicHVscF9jcmVhdGVkIjoiMjAyNS0w
+        NC0wNFQxNDoxMTowOC4xMTI1NjhaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIy
+        MDI1LTA0LTA0VDE0OjExOjA4LjExOTQyMFoiLCJ2ZXJzaW9uc19ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NjAxMjQt
+        MjRjZi03ODlkLWFmNmEtNDA1MGNkNWZhMmViL3ZlcnNpb25zLyIsInB1bHBf
         bGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTMyNTNhLTVlMjItNzIzZS1h
-        MGY1LTJjZTllMzgyNmM3Yi92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTYwMTI0LTI0Y2YtNzg5ZC1h
+        ZjZhLTQwNTBjZDVmYTJlYi92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0
         X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIsImRlc2NyaXB0
         aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3Rl
         IjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1hbmlmZXN0IjoiUFVMUF9N
         QU5JRkVTVCJ9
-  recorded_at: Wed, 13 Nov 2024 11:13:22 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:08 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -605,7 +605,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -618,13 +618,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:22 GMT
+      - Fri, 04 Apr 2025 14:11:08 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/0193253a-5ec0-778f-8032-8f557767d9f2/"
+      - "/pulp/api/v3/remotes/file/file/01960124-25a1-7d07-85f5-afcda63cd2d3/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -640,20 +640,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c6c6593ab6934e04aa3b8bc2e63193c4
+      - d7bb81cd3b0c49ffae0f7c7a619f0325
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE5MzI1M2EtNWVjMC03NzhmLTgwMzItOGY1NTc3NjdkOWYyLyIsInBybiI6
-        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5MzI1M2EtNWVjMC03NzhmLTgwMzIt
-        OGY1NTc3NjdkOWYyIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMTox
-        MzoyMi42MjQ3MTNaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEz
-        VDExOjEzOjIyLjYyNDczM1oiLCJuYW1lIjoidGVzdF9yZW1vdGVfbmFtZSIs
+        MDE5NjAxMjQtMjVhMS03ZDA3LTg1ZjUtYWZjZGE2M2NkMmQzLyIsInBybiI6
+        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NjAxMjQtMjVhMS03ZDA3LTg1ZjUt
+        YWZjZGE2M2NkMmQzIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDox
+        MTowOC4zMjE4NjBaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0
+        VDE0OjExOjA4LjMyMTg3NFoiLCJuYW1lIjoidGVzdF9yZW1vdGVfbmFtZSIs
         InVybCI6Imh0dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL2ZpbGUy
         Ly9QVUxQX01BTklGRVNUIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQi
         Om51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGws
@@ -667,10 +667,10 @@ http_interactions:
         bWUiOiJwcm94eV9wYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6
         InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfV19
-  recorded_at: Wed, 13 Nov 2024 11:13:22 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:08 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193253a-5ec0-778f-8032-8f557767d9f2/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/01960124-25a1-7d07-85f5-afcda63cd2d3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -678,7 +678,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -691,7 +691,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:22 GMT
+      - Fri, 04 Apr 2025 14:11:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -711,20 +711,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c1ed87fac67e4fe5899aafdd8704f007
+      - 54e6089002384d6abad2d1bb71d1515e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTVlZjUtN2Zi
-        MC1iZTg3LWFiODJiNGJhNzkxMC8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:22 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTI1ZGYtNzM5
+        YS1iMjQxLWI1ZDM5NmI4Y2RhMC8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:08 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193253a-5e22-723e-a0f5-2ce9e3826c7b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/01960124-24cf-789d-af6a-4050cd5fa2eb/
     body:
       encoding: UTF-8
       base64_string: |
@@ -734,7 +734,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -747,7 +747,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:22 GMT
+      - Fri, 04 Apr 2025 14:11:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -767,20 +767,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 69dedfd27c974c0895fd677133f4062f
+      - b1538e6b7b5c44b9bdb5c4659c1fc45d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTVmODgtNzBl
-        ZC1iZTE4LWZjOTljNzliZjM0My8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:22 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTI2YTQtN2Iz
+        OS05NmY2LTQyYWIxM2IxNzI4MC8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:08 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193253a-5da8-7cb6-a57e-7c59fba08493/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/01960124-243c-7f76-94fc-dc88ba842a36/
     body:
       encoding: UTF-8
       base64_string: |
@@ -798,7 +798,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -811,7 +811,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:22 GMT
+      - Fri, 04 Apr 2025 14:11:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -831,20 +831,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7ef8252716794581b4d1639730aecd18
+      - 9ef9c9ba13434593b712cac26d45c72e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTVmZWEtN2Y1
-        NS04MTBjLWE3MmZhYTJiN2Q1Mi8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:22 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTI3MjMtNzU2
+        Ni05OWNkLTQxZmE0NDY0OTE2YS8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:08 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-5fea-7f55-810c-a72faa2b7d52/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-2723-7566-99cd-41fa4464916a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -852,7 +852,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -865,7 +865,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:22 GMT
+      - Fri, 04 Apr 2025 14:11:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -885,36 +885,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0e7090716c5b4521bdbe051477b819e7
+      - 0e05b4e1915d4dd98fc57ed855f6c558
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtNWZl
-        YS03ZjU1LTgxMGMtYTcyZmFhMmI3ZDUyLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtNWZlYS03ZjU1LTgxMGMtYTcyZmFhMmI3ZDUyIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzoyMi45MjI1MTRaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjIyLjkyMjUyNFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMjcy
+        My03NTY2LTk5Y2QtNDFmYTQ0NjQ5MTZhLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMjcyMy03NTY2LTk5Y2QtNDFmYTQ0NjQ5MTZhIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowOC43MDgyNDZaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjA4LjcwODI2MVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiN2VmODI1
-        MjcxNjc5NDU4MWI0ZDE2Mzk3MzBhZWNkMTgiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzoyMi45MzI4NDRaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MjIuOTM0ODE1WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzoyMi45NDI0ODJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiOWVmOWM5
+        YmExMzQzNDU5M2I3MTJjYWMyNmQ0NWM3MmUiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMTowOC43MjIzNzNaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MDguNzI1MTQ0WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMTowOC43MzcxOTlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46Zmls
-        ZS5maWxlcmVtb3RlOjAxOTMyNTNhLTVkYTgtN2NiNi1hNTdlLTdjNTlmYmEw
-        ODQ5MyIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmM1N2QtZmI5NS03
-        OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 11:13:22 GMT
+        ZS5maWxlcmVtb3RlOjAxOTYwMTI0LTI0M2MtN2Y3Ni05NGZjLWRjODhiYTg0
+        MmEzNiIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5NTYyMTctZmM5ZS03
+        NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Fri, 04 Apr 2025 14:11:08 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -922,7 +922,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -935,7 +935,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:23 GMT
+      - Fri, 04 Apr 2025 14:11:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -955,20 +955,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3adf0a835f8b4c8e8e8c1163e975a765
+      - de7f3fcb6ce44174bec484e9f5b1265c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:23 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:08 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -980,7 +980,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -993,7 +993,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:23 GMT
+      - Fri, 04 Apr 2025 14:11:08 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1013,20 +1013,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4d7ce83d297f4c70bc6b634d6cda120d
+      - 7168d970244f4e73b828f7ecf1e59a3e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTYwYTEtNzM3
-        OC05MjhkLWJhZDcxNjNhMzZjOS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:23 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTI4MTctN2I3
+        OS1iYjQ1LWNkZWY3MmNiNjI3MC8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:08 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-60a1-7378-928d-bad7163a36c9/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-2817-7b79-bb45-cdef72cb6270/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1034,7 +1034,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1047,7 +1047,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:23 GMT
+      - Fri, 04 Apr 2025 14:11:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1067,39 +1067,39 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - faf30907ef9b43c48b4ddb588ab3fbce
+      - c420a4b3065346f8ade9e1481cc7df5c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtNjBh
-        MS03Mzc4LTkyOGQtYmFkNzE2M2EzNmM5LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtNjBhMS03Mzc4LTkyOGQtYmFkNzE2M2EzNmM5IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzoyMy4xMDYyNDBaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjIzLjEwNjI1MFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMjgx
+        Ny03Yjc5LWJiNDUtY2RlZjcyY2I2MjcwLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMjgxNy03Yjc5LWJiNDUtY2RlZjcyY2I2MjcwIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowOC45NTE4ODJaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjA4Ljk1MTg5N1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiNGQ3Y2U4
-        M2QyOTdmNGM3MGJjNmI2MzRkNmNkYTEyMGQiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzoyMy4xMTc2NzNaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MjMuMTQ2MTUxWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzoyMy4xOTIxODRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTMyNTIzLTkwMWUtN2ZiMC05ZTA3LTljZGY0
-        ZDJiMWNhMC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiNzE2OGQ5
+        NzAyNDRmNGU3M2I4MjhmN2VjZjFlNTlhM2UiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMTowOC45Njc0MzFaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MDkuMDIwNTgxWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMTowOS4wOTI2NzVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOTVmZDg0LTc1YjUtNzFhMy1hM2RiLTFhZDFl
+        Mjk3MmMwNy8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
-        ZmlsZS9maWxlLzAxOTMyNTNhLTYwZTktNzRmZC1iYTU0LTc4NDg3YjJjMmU0
-        MC8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAxOTJj
-        NTdkLWZiOTUtNzkxOC04N2U0LTlkZTViMTVhYjUzNjpkaXN0cmlidXRpb25z
-        Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyYzU3ZC1mYjk1LTc5MTgt
-        ODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:23 GMT
+        ZmlsZS9maWxlLzAxOTYwMTI0LTI4OTAtNzUzOS04OWMwLWQzZjU4ZTM1OTBh
+        Yy8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAxOTU2
+        MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRpb25z
+        Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0Y2Yt
+        OTAyNC1lODAzNDY3ZmU0ZDAiXX0=
+  recorded_at: Fri, 04 Apr 2025 14:11:09 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193253a-60e9-74fd-ba54-78487b2c2e40/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/01960124-2890-7539-89c0-d3f58e3590ac/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1107,7 +1107,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1120,7 +1120,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:23 GMT
+      - Fri, 04 Apr 2025 14:11:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1132,7 +1132,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '607'
+      - '605'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1140,32 +1140,32 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 04752700bd96407ead1acfeb35bbbab7
+      - '078b12b34fd44dbc9a8cf751eeaca166'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
-        L2ZpbGUvMDE5MzI1M2EtNjBlOS03NGZkLWJhNTQtNzg0ODdiMmMyZTQwLyIs
-        InBybiI6InBybjpmaWxlLmZpbGVkaXN0cmlidXRpb246MDE5MzI1M2EtNjBl
-        OS03NGZkLWJhNTQtNzg0ODdiMmMyZTQwIiwicHVscF9jcmVhdGVkIjoiMjAy
-        NC0xMS0xM1QxMToxMzoyMy4xNzg0NTBaIiwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDI0LTExLTEzVDExOjEzOjIzLjE3ODQ2MVoiLCJiYXNlX3BhdGgiOiJE
+        L2ZpbGUvMDE5NjAxMjQtMjg5MC03NTM5LTg5YzAtZDNmNThlMzU5MGFjLyIs
+        InBybiI6InBybjpmaWxlLmZpbGVkaXN0cmlidXRpb246MDE5NjAxMjQtMjg5
+        MC03NTM5LTg5YzAtZDNmNThlMzU5MGFjIiwicHVscF9jcmVhdGVkIjoiMjAy
+        NS0wNC0wNFQxNDoxMTowOS4wNzQwMDhaIiwicHVscF9sYXN0X3VwZGF0ZWQi
+        OiIyMDI1LTA0LTA0VDE0OjExOjA5LjA3NDAzNFoiLCJiYXNlX3BhdGgiOiJE
         ZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsImJh
-        c2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwuZGljZXJv
-        czIwMjMuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5p
-        emF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3VhcmQi
-        Om51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjpudWxsLCJoaWRkZW4i
-        OmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
-        aXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnkiOm51
-        bGwsInB1YmxpY2F0aW9uIjpudWxsfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:23 GMT
+        c2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwubWFuaWNv
+        dHRvLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2FuaXph
+        dGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMS8iLCJjb250ZW50X2d1YXJkIjpu
+        dWxsLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6bnVsbCwiaGlkZGVuIjpm
+        YWxzZSwicHVscF9sYWJlbHMiOnt9LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJyZXBvc2l0b3J5IjpudWxs
+        LCJwdWJsaWNhdGlvbiI6bnVsbH0=
+  recorded_at: Fri, 04 Apr 2025 14:11:09 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193253a-5da8-7cb6-a57e-7c59fba08493/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/01960124-243c-7f76-94fc-dc88ba842a36/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1183,7 +1183,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1196,7 +1196,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:23 GMT
+      - Fri, 04 Apr 2025 14:11:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1216,20 +1216,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ffee17b938c14969a6fd8f7351dbeb88
+      - d2d2507095954fe9a1b56c251d20178b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTYyNGUtNzc5
-        Mi1hOTZmLTc4N2NkMWViYjc0Yy8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:23 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTJhNDItNzIz
+        Yy04OTU0LTQ4MGY2M2U3YTRjOS8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:09 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-624e-7792-a96f-787cd1ebb74c/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-2a42-723c-8954-480f63e7a4c9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1237,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1250,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:23 GMT
+      - Fri, 04 Apr 2025 14:11:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1270,47 +1270,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bdf06e9d94e945b780ef26ad5ee276e8
+      - a568ee669370414a8044fb66043dcb85
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtNjI0
-        ZS03NzkyLWE5NmYtNzg3Y2QxZWJiNzRjLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtNjI0ZS03NzkyLWE5NmYtNzg3Y2QxZWJiNzRjIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzoyMy41MzQzMjBaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjIzLjUzNDMzMFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMmE0
+        Mi03MjNjLTg5NTQtNDgwZjYzZTdhNGM5LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMmE0Mi03MjNjLTg5NTQtNDgwZjYzZTdhNGM5IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowOS41MDY4NzFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjA5LjUwNjg4NFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiZmZlZTE3
-        YjkzOGMxNDk2OWE2ZmQ4ZjczNTFkYmViODgiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzoyMy41NDM3NDBaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MjMuNTQ3MDc2WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzoyMy41NTUwNzJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiZDJkMjUw
+        NzA5NTk1NGZlOWExYjU2YzI1MWQyMDE3OGIiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMTowOS41MjAxNDFaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MDkuNTIyODY0WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMTowOS41MzM3NDNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46Zmls
-        ZS5maWxlcmVtb3RlOjAxOTMyNTNhLTVkYTgtN2NiNi1hNTdlLTdjNTlmYmEw
-        ODQ5MyIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmM1N2QtZmI5NS03
-        OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 11:13:23 GMT
+        ZS5maWxlcmVtb3RlOjAxOTYwMTI0LTI0M2MtN2Y3Ni05NGZjLWRjODhiYTg0
+        MmEzNiIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5NTYyMTctZmM5ZS03
+        NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Fri, 04 Apr 2025 14:11:09 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193253a-5e22-723e-a0f5-2ce9e3826c7b/sync/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/01960124-24cf-789d-af6a-4050cd5fa2eb/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE5
-        MzI1M2EtNWRhOC03Y2I2LWE1N2UtN2M1OWZiYTA4NDkzLyIsIm1pcnJvciI6
+        NjAxMjQtMjQzYy03Zjc2LTk0ZmMtZGM4OGJhODQyYTM2LyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1323,7 +1323,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:23 GMT
+      - Fri, 04 Apr 2025 14:11:09 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1343,20 +1343,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 74aa6360215f48088aa67c3e1763cdca
+      - dacd22b612fb4f91b5bb0b4cf320d0cf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTYyY2UtNzEy
-        NC1iNTJjLWI5MWU3Y2UyMmQ2MC8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:23 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTJhZjktN2Jl
+        Ni05ZjY0LWYxYTlhNDdiNWRkNC8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:09 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-62ce-7124-b52c-b91e7ce22d60/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-2af9-7be6-9f64-f1a9a47b5dd4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1364,7 +1364,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1377,7 +1377,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:24 GMT
+      - Fri, 04 Apr 2025 14:11:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1397,28 +1397,28 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c641bde36bf74377bb18f2c690676d0d
+      - 235b08358dc34c0ba396c7aee8d0de3b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtNjJj
-        ZS03MTI0LWI1MmMtYjkxZTdjZTIyZDYwLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtNjJjZS03MTI0LWI1MmMtYjkxZTdjZTIyZDYwIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzoyMy42NjMyNjhaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjIzLjY2MzI3OFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMmFm
+        OS03YmU2LTlmNjQtZjFhOWE0N2I1ZGQ0LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMmFmOS03YmU2LTlmNjQtZjFhOWE0N2I1ZGQ0IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowOS42ODk2ODdaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjA5LjY4OTY5OVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX2ZpbGUuYXBwLnRh
         c2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25pemUiLCJsb2dnaW5nX2NpZCI6
-        Ijc0YWE2MzYwMjE1ZjQ4MDg4YWE2N2MzZTE3NjNjZGNhIiwiY3JlYXRlZF9i
+        ImRhY2QyMmI2MTJmYjRmOTFiNWJiMGI0Y2YzMjBkMGNmIiwiY3JlYXRlZF9i
         eSI6Ii9wdWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIw
-        MjQtMTEtMTNUMTE6MTM6MjMuNjczMzI2WiIsInN0YXJ0ZWRfYXQiOiIyMDI0
-        LTExLTEzVDExOjEzOjIzLjY5ODY0NloiLCJmaW5pc2hlZF9hdCI6IjIwMjQt
-        MTEtMTNUMTE6MTM6MjQuNDgzMzAyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
-        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTkzMjUyMy04ZmVhLTc0MTYtYjkx
-        Ny1hMmQwYTJhYjNkZjcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
+        MjUtMDQtMDRUMTQ6MTE6MDkuNzAyNTM2WiIsInN0YXJ0ZWRfYXQiOiIyMDI1
+        LTA0LTA0VDE0OjExOjA5Ljc1OTYwNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjUt
+        MDQtMDRUMTQ6MTE6MTAuMjk0MjU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTk1ZmQ4NC03NjNhLTdmNTctOTNk
+        ZS01Y2Y5ZmZiYzU3NzcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
         c2tzIjpbXSwidGFza19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6
         W3sibWVzc2FnZSI6IkRvd25sb2FkaW5nIE1ldGFkYXRhIiwiY29kZSI6InN5
         bmMuZG93bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
@@ -1435,18 +1435,18 @@ http_interactions:
         ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9y
         ZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2Zp
-        bGUvMDE5MzI1M2EtNWUyMi03MjNlLWEwZjUtMmNlOWUzODI2YzdiL3ZlcnNp
+        bGUvMDE5NjAxMjQtMjRjZi03ODlkLWFmNmEtNDA1MGNkNWZhMmViL3ZlcnNp
         b25zLzEvIiwiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUv
-        MDE5MzI1M2EtNjVkNC03NGQ0LTk5OTEtZTY3MTgxZjczZWJlLyJdLCJyZXNl
+        MDE5NjAxMjQtMmQyMS03YThkLWIwNGItMWIzNGZjZjE5YTMwLyJdLCJyZXNl
         cnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpmaWxlLmZpbGVyZXBvc2l0
-        b3J5OjAxOTMyNTNhLTVlMjItNzIzZS1hMGY1LTJjZTllMzgyNmM3YiIsInNo
-        YXJlZDpwcm46ZmlsZS5maWxlcmVtb3RlOjAxOTMyNTNhLTVkYTgtN2NiNi1h
-        NTdlLTdjNTlmYmEwODQ5MyIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5
-        MmM1N2QtZmI5NS03OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 11:13:24 GMT
+        b3J5OjAxOTYwMTI0LTI0Y2YtNzg5ZC1hZjZhLTQwNTBjZDVmYTJlYiIsInNo
+        YXJlZDpwcm46ZmlsZS5maWxlcmVtb3RlOjAxOTYwMTI0LTI0M2MtN2Y3Ni05
+        NGZjLWRjODhiYTg0MmEzNiIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5
+        NTYyMTctZmM5ZS03NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Fri, 04 Apr 2025 14:11:10 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1454,7 +1454,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1467,7 +1467,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:24 GMT
+      - Fri, 04 Apr 2025 14:11:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1479,7 +1479,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '659'
+      - '657'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1487,45 +1487,45 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - da0f7779c2d9458eb9544437bb42b32b
+      - 8e042927594242baa0c7119fcc8c218c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMTkzMjUzYS02MGU5LTc0ZmQtYmE1NC03ODQ4N2IyYzJl
-        NDAvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTkzMjUz
-        YS02MGU5LTc0ZmQtYmE1NC03ODQ4N2IyYzJlNDAiLCJwdWxwX2NyZWF0ZWQi
-        OiIyMDI0LTExLTEzVDExOjEzOjIzLjE3ODQ1MFoiLCJwdWxwX2xhc3RfdXBk
-        YXRlZCI6IjIwMjQtMTEtMTNUMTE6MTM6MjMuMTc4NDYxWiIsImJhc2VfcGF0
+        L2ZpbGUvZmlsZS8wMTk2MDEyNC0yODkwLTc1MzktODljMC1kM2Y1OGUzNTkw
+        YWMvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk2MDEy
+        NC0yODkwLTc1MzktODljMC1kM2Y1OGUzNTkwYWMiLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDI1LTA0LTA0VDE0OjExOjA5LjA3NDAwOFoiLCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjUtMDQtMDRUMTQ6MTE6MDkuMDc0MDM0WiIsImJhc2VfcGF0
         aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8x
-        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5k
-        aWNlcm9zMjAyMy5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9P
-        cmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19GaWxlXzEvIiwiY29udGVudF9n
-        dWFyZCI6bnVsbCwibm9fY29udGVudF9jaGFuZ2Vfc2luY2UiOm51bGwsImhp
-        ZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IkRlZmF1bHRf
-        T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwicmVwb3NpdG9y
-        eSI6bnVsbCwicHVibGljYXRpb24iOm51bGx9XX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:24 GMT
+        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5t
+        YW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3Vh
+        cmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjpudWxsLCJoaWRk
+        ZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09y
+        Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnki
+        Om51bGwsInB1YmxpY2F0aW9uIjpudWxsfV19
+  recorded_at: Fri, 04 Apr 2025 14:11:10 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193253a-60e9-74fd-ba54-78487b2c2e40/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/01960124-2890-7539-89c0-d3f58e3590ac/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtNjVkNC03NGQ0LTk5OTEtZTY3MTgxZjczZWJlLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NjAx
+        MjQtMmQyMS03YThkLWIwNGItMWIzNGZjZjE5YTMwLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1538,7 +1538,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:24 GMT
+      - Fri, 04 Apr 2025 14:11:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1558,20 +1558,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e40394daf159480dac61691eb73fcbb2
+      - 21299592514b4ca092ffaa08ca621327
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTY2ZjUtN2Qy
-        NS1hN2I1LWYyOTdhZTFjMjlmMy8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:24 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTJlYTctNzMz
+        OC04NGY0LWEwODc2NDJlYTI5Zi8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:10 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-66f5-7d25-a7b5-f297ae1c29f3/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-2ea7-7338-84f4-a087642ea29f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1579,7 +1579,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1592,7 +1592,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:24 GMT
+      - Fri, 04 Apr 2025 14:11:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1612,48 +1612,48 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 416d317addf1440a8691a20aabed9b14
+      - 12cf2a20fd0a4f94b8ef9ebd62573091
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtNjZm
-        NS03ZDI1LWE3YjUtZjI5N2FlMWMyOWYzLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtNjZmNS03ZDI1LWE3YjUtZjI5N2FlMWMyOWYzIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzoyNC43MjYxNjZaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjI0LjcyNjE3OFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMmVh
+        Ny03MzM4LTg0ZjQtYTA4NzY0MmVhMjlmLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMmVhNy03MzM4LTg0ZjQtYTA4NzY0MmVhMjlmIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMToxMC42MzE4OTBaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjEwLjYzMTkwM1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiZTQwMzk0
-        ZGFmMTU5NDgwZGFjNjE2OTFlYjczZmNiYjIiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzoyNC43MzYzOTdaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MjQuNzM5MTI4WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzoyNC43NTg0NDFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiMjEyOTk1
+        OTI1MTRiNGNhMDkyZmZhYTA4Y2E2MjEzMjciLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMToxMC42NDM3NDFaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MTAuNjQ2NDQwWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMToxMC42NjExMDFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJjNTdkLWZiOTUtNzkxOC04N2U0LTlkZTViMTVhYjUzNjpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyYzU3ZC1mYjk1LTc5
-        MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:24 GMT
+        OTU2MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRp
+        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0
+        Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
+  recorded_at: Fri, 04 Apr 2025 14:11:10 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193253a-60e9-74fd-ba54-78487b2c2e40/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/01960124-2890-7539-89c0-d3f58e3590ac/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtNjVkNC03NGQ0LTk5OTEtZTY3MTgxZjczZWJlLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NjAx
+        MjQtMmQyMS03YThkLWIwNGItMWIzNGZjZjE5YTMwLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1666,7 +1666,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:24 GMT
+      - Fri, 04 Apr 2025 14:11:10 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1686,20 +1686,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d38ca32f4f5b411a9af935144a47feab
+      - 738efd3ba6474c77af6226e04509fab0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTY3OWItNzJk
-        MS1iNDk2LTBkZGU4ZGU4MTM1YS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:24 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTJmNjYtNzQz
+        My1iZTMxLTJjZTdhYTZmNmZhMi8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:10 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1716,7 +1716,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1729,13 +1729,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:25 GMT
+      - Fri, 04 Apr 2025 14:11:11 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/0193253a-6852-738e-9296-6f7f10db8bd7/"
+      - "/pulp/api/v3/remotes/file/file/01960124-304b-758d-975f-937111f631f9/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1751,20 +1751,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a5c6fc235e154b55ae3a74ef23b82ab5
+      - 261cf53cdc7e4eb2baec03e419d6c9c9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE5MzI1M2EtNjg1Mi03MzhlLTkyOTYtNmY3ZjEwZGI4YmQ3LyIsInBybiI6
-        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5MzI1M2EtNjg1Mi03MzhlLTkyOTYt
-        NmY3ZjEwZGI4YmQ3IiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMTox
-        MzoyNS4wNzQ2NjdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEz
-        VDExOjEzOjI1LjA3NDY3OFoiLCJuYW1lIjoidGVzdF9yZW1vdGVfbmFtZSIs
+        MDE5NjAxMjQtMzA0Yi03NThkLTk3NWYtOTM3MTExZjYzMWY5LyIsInBybiI6
+        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NjAxMjQtMzA0Yi03NThkLTk3NWYt
+        OTM3MTExZjYzMWY5IiwicHVscF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDox
+        MToxMS4wNTE1MjJaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0
+        VDE0OjExOjExLjA1MTUzNVoiLCJuYW1lIjoidGVzdF9yZW1vdGVfbmFtZSIs
         InVybCI6Imh0dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL2ZpbGUv
         L1BVTFBfTUFOSUZFU1QiLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6
         bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwi
@@ -1778,10 +1778,10 @@ http_interactions:
         ZSI6InByb3h5X3Bhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoi
         dXNlcm5hbWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwYXNzd29yZCIs
         ImlzX3NldCI6ZmFsc2V9XX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:25 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:11 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193253a-6852-738e-9296-6f7f10db8bd7/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/01960124-304b-758d-975f-937111f631f9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1789,7 +1789,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1802,7 +1802,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:25 GMT
+      - Fri, 04 Apr 2025 14:11:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1822,20 +1822,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ab5e97dc018244d3a130801c1a18f14d
+      - 9438db8f39894ff59f0c595fd336ee81
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTY4ODMtNzNh
-        Mi05NTRmLTUxMWI2YWZkNDhiZC8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:25 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTMwOGYtNzY2
+        ZC04YzEyLTU0NWZhMTM2ODcxNi8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:11 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193253a-5e22-723e-a0f5-2ce9e3826c7b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/01960124-24cf-789d-af6a-4050cd5fa2eb/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1845,7 +1845,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1858,7 +1858,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:25 GMT
+      - Fri, 04 Apr 2025 14:11:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1878,20 +1878,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 022fa627e5d24ac2be462ff87acecce7
+      - ebf8f6d3f4274807a008ca8440f351b0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTY5MWMtNzI4
-        YS05YmJkLTE4YzNiMzVmNjEyZS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:25 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTMxNDktNzM1
+        OC04NzYzLTU0YTI4NmYzZmEzOC8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:11 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193253a-5da8-7cb6-a57e-7c59fba08493/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/01960124-243c-7f76-94fc-dc88ba842a36/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1909,7 +1909,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1922,7 +1922,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:25 GMT
+      - Fri, 04 Apr 2025 14:11:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1942,20 +1942,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5d2dbfdd84f041a8a51891f1ee3841eb
+      - 6f0f1bf31b904dec97ddf2ec857eda5a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTY5N2EtNzY3
-        Yy1hZjU3LTdjODM4NDRlOGQyYS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:25 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTMxYzktNzYw
+        MS05ZTIyLTIwMzNkNTVjYjA5Ni8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:11 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-697a-767c-af57-7c83844e8d2a/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-31c9-7601-9e22-2033d55cb096/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1963,7 +1963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1976,7 +1976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:25 GMT
+      - Fri, 04 Apr 2025 14:11:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1996,36 +1996,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 152f6c6356c74fdeb407a946fd729036
+      - 5ab61f946a2c4fa6be0712f63070e455
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtNjk3
-        YS03NjdjLWFmNTctN2M4Mzg0NGU4ZDJhLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtNjk3YS03NjdjLWFmNTctN2M4Mzg0NGU4ZDJhIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzoyNS4zNzA0NDRaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjI1LjM3MDQ1NFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMzFj
+        OS03NjAxLTllMjItMjAzM2Q1NWNiMDk2LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMzFjOS03NjAxLTllMjItMjAzM2Q1NWNiMDk2IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMToxMS40MzQxODlaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjExLjQzNDIwNFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiNWQyZGJm
-        ZGQ4NGYwNDFhOGE1MTg5MWYxZWUzODQxZWIiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzoyNS4zODAzMDNaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MjUuMzgzMjEwWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzoyNS4zOTIyNjZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiNmYwZjFi
+        ZjMxYjkwNGRlYzk3ZGRmMmVjODU3ZWRhNWEiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMToxMS40NDgzODJaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MTEuNDUyMTI3WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMToxMS40NjE1MzVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46Zmls
-        ZS5maWxlcmVtb3RlOjAxOTMyNTNhLTVkYTgtN2NiNi1hNTdlLTdjNTlmYmEw
-        ODQ5MyIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmM1N2QtZmI5NS03
-        OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 11:13:25 GMT
+        ZS5maWxlcmVtb3RlOjAxOTYwMTI0LTI0M2MtN2Y3Ni05NGZjLWRjODhiYTg0
+        MmEzNiIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5NTYyMTctZmM5ZS03
+        NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Fri, 04 Apr 2025 14:11:11 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2033,7 +2033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2046,7 +2046,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:25 GMT
+      - Fri, 04 Apr 2025 14:11:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2058,7 +2058,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '755'
+      - '753'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2066,47 +2066,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0c7f9b8e40794d5a97718a6bfb527b14
+      - 281705b0d30a41dbb4a85b38698109f4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMTkzMjUzYS02MGU5LTc0ZmQtYmE1NC03ODQ4N2IyYzJl
-        NDAvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTkzMjUz
-        YS02MGU5LTc0ZmQtYmE1NC03ODQ4N2IyYzJlNDAiLCJwdWxwX2NyZWF0ZWQi
-        OiIyMDI0LTExLTEzVDExOjEzOjIzLjE3ODQ1MFoiLCJwdWxwX2xhc3RfdXBk
-        YXRlZCI6IjIwMjQtMTEtMTNUMTE6MTM6MjQuOTE2MjMxWiIsImJhc2VfcGF0
+        L2ZpbGUvZmlsZS8wMTk2MDEyNC0yODkwLTc1MzktODljMC1kM2Y1OGUzNTkw
+        YWMvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk2MDEy
+        NC0yODkwLTc1MzktODljMC1kM2Y1OGUzNTkwYWMiLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDI1LTA0LTA0VDE0OjExOjA5LjA3NDAwOFoiLCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjUtMDQtMDRUMTQ6MTE6MTAuODUxNjk2WiIsImJhc2VfcGF0
         aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8x
-        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5k
-        aWNlcm9zMjAyMy5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9P
-        cmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19GaWxlXzEvIiwiY29udGVudF9n
-        dWFyZCI6bnVsbCwibm9fY29udGVudF9jaGFuZ2Vfc2luY2UiOiIyMDI0LTEx
-        LTEzVDExOjEzOjI0LjkxNjIzMVoiLCJoaWRkZW4iOmZhbHNlLCJwdWxwX2xh
-        YmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0
-        LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtNjVkNC03NGQ0LTk5OTEtZTY3MTgxZjczZWJlLyJ9XX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:25 GMT
+        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5t
+        YW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3Vh
+        cmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNS0wNC0w
+        NFQxNDoxMToxMC44NTE2OTZaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9sYWJl
+        bHMiOnt9LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1w
+        dWxwM19GaWxlXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6
+        Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOTYwMTI0
+        LTJkMjEtN2E4ZC1iMDRiLTFiMzRmY2YxOWEzMC8ifV19
+  recorded_at: Fri, 04 Apr 2025 14:11:11 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193253a-60e9-74fd-ba54-78487b2c2e40/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/01960124-2890-7539-89c0-d3f58e3590ac/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtNjVkNC03NGQ0LTk5OTEtZTY3MTgxZjczZWJlLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NjAx
+        MjQtMmQyMS03YThkLWIwNGItMWIzNGZjZjE5YTMwLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2119,7 +2119,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:25 GMT
+      - Fri, 04 Apr 2025 14:11:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2139,20 +2139,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8901e6b3057444bda6e2b1687ca8eee4
+      - c02bd3107ac24f6e82f0b7a60ed9ee3e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTZhMzItNzkx
-        YS05YTliLWU3Yjc4ZWM1YTgxZC8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:25 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTMyYzMtN2Nm
+        Mi04ZmEwLTJjNGJmZTJiOTMyZS8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:11 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-6a32-791a-9a9b-e7b78ec5a81d/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-32c3-7cf2-8fa0-2c4bfe2b932e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2160,7 +2160,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2173,7 +2173,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:25 GMT
+      - Fri, 04 Apr 2025 14:11:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2193,48 +2193,48 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b0ab82c7cae74d18b4856fb04da9b9df
+      - 4f6946a2d13e40238917c6893ac70e42
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtNmEz
-        Mi03OTFhLTlhOWItZTdiNzhlYzVhODFkLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtNmEzMi03OTFhLTlhOWItZTdiNzhlYzVhODFkIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzoyNS41NTUwNTBaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjI1LjU1NTA3MFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMzJj
+        My03Y2YyLThmYTAtMmM0YmZlMmI5MzJlLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMzJjMy03Y2YyLThmYTAtMmM0YmZlMmI5MzJlIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMToxMS42ODM1NzFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjExLjY4MzU4NFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiODkwMWU2
-        YjMwNTc0NDRiZGE2ZTJiMTY4N2NhOGVlZTQiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzoyNS41NjQ3NDlaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MjUuNTY3NTExWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzoyNS41ODAwOTFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYzAyYmQz
+        MTA3YWMyNGY2ZTgyZjBiN2E2MGVkOWVlM2UiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMToxMS42OTYxNTZaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MTEuNjk4OTMxWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMToxMS43MTU3ODRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJjNTdkLWZiOTUtNzkxOC04N2U0LTlkZTViMTVhYjUzNjpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyYzU3ZC1mYjk1LTc5
-        MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:25 GMT
+        OTU2MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRp
+        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0
+        Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
+  recorded_at: Fri, 04 Apr 2025 14:11:11 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193253a-60e9-74fd-ba54-78487b2c2e40/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/01960124-2890-7539-89c0-d3f58e3590ac/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtNjVkNC03NGQ0LTk5OTEtZTY3MTgxZjczZWJlLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NjAx
+        MjQtMmQyMS03YThkLWIwNGItMWIzNGZjZjE5YTMwLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2247,7 +2247,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:25 GMT
+      - Fri, 04 Apr 2025 14:11:11 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2267,20 +2267,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - befa81fcfef147debcdebed89f16d053
+      - c234e85a13494862a62bfb8e413f8388
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTZhYzUtN2U2
-        MC05NTFhLThlNzQxOWU2NTg2NS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:25 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTMzOGEtN2Fm
+        MS05ZWJiLWU1ODA5MmJkNGQ5ZC8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:11 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193253a-5da8-7cb6-a57e-7c59fba08493/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/01960124-243c-7f76-94fc-dc88ba842a36/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2298,7 +2298,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2311,7 +2311,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:25 GMT
+      - Fri, 04 Apr 2025 14:11:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2331,20 +2331,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0acd2fa073f24fd09718d4cd79f612e8
+      - b8cfe3e3d5d7451e88467847e46d4bfd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTZiYzctNzYw
-        MC05OGQ2LTA0MzhmZWY1MTE0Yi8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:25 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTM0ZDUtNzNj
+        OC04YjM4LWRmNGZlYjNkNjcwNy8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:12 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-6bc7-7600-98d6-0438fef5114b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-34d5-73c8-8b38-df4feb3d6707/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2352,7 +2352,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2365,7 +2365,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:26 GMT
+      - Fri, 04 Apr 2025 14:11:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2385,47 +2385,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3e30ac6466a84f9889d83bbe6a1096ef
+      - 804f05e7a6e848b9a8927c5a2ecd79aa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtNmJj
-        Ny03NjAwLTk4ZDYtMDQzOGZlZjUxMTRiLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtNmJjNy03NjAwLTk4ZDYtMDQzOGZlZjUxMTRiIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzoyNS45NTk2MzRaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjI1Ljk1OTY0M1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMzRk
+        NS03M2M4LThiMzgtZGY0ZmViM2Q2NzA3LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMzRkNS03M2M4LThiMzgtZGY0ZmViM2Q2NzA3IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMToxMi4yMTQzNTBaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjEyLjIxNDM2NFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiMGFjZDJm
-        YTA3M2YyNGZkMDk3MThkNGNkNzlmNjEyZTgiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzoyNS45Njk1OTVaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MjUuOTcxNTQwWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzoyNS45ODAzMjlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYjhjZmUz
+        ZTNkNWQ3NDUxZTg4NDY3ODQ3ZTQ2ZDRiZmQiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMToxMi4yMjk5MjZaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MTIuMjMyNjcxWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMToxMi4yNDI0NzlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46Zmls
-        ZS5maWxlcmVtb3RlOjAxOTMyNTNhLTVkYTgtN2NiNi1hNTdlLTdjNTlmYmEw
-        ODQ5MyIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmM1N2QtZmI5NS03
-        OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 11:13:26 GMT
+        ZS5maWxlcmVtb3RlOjAxOTYwMTI0LTI0M2MtN2Y3Ni05NGZjLWRjODhiYTg0
+        MmEzNiIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5NTYyMTctZmM5ZS03
+        NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Fri, 04 Apr 2025 14:11:12 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193253a-5e22-723e-a0f5-2ce9e3826c7b/sync/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/01960124-24cf-789d-af6a-4050cd5fa2eb/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE5
-        MzI1M2EtNWRhOC03Y2I2LWE1N2UtN2M1OWZiYTA4NDkzLyIsIm1pcnJvciI6
+        NjAxMjQtMjQzYy03Zjc2LTk0ZmMtZGM4OGJhODQyYTM2LyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2438,7 +2438,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:26 GMT
+      - Fri, 04 Apr 2025 14:11:12 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2458,20 +2458,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5623e9fd63754bc88240a4156a76d20d
+      - 2e8ce3e57ef8436688326f737beff5f5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTZjNGMtN2U4
-        OS05MTJlLWM2ZjNlZGU1MWQ5ZS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:26 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTM1OTAtN2U5
+        ZC1iYjI2LWYzNzAzOWUwMzBkYy8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:12 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-6c4c-7e89-912e-c6f3ede51d9e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-3590-7e9d-bb26-f37039e030dc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2479,7 +2479,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2492,7 +2492,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:27 GMT
+      - Fri, 04 Apr 2025 14:11:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2512,28 +2512,28 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4bbd8962cef9447497c7138fbe612d37
+      - b31b3e119d9a44f3b2ece4023c7e2260
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtNmM0
-        Yy03ZTg5LTkxMmUtYzZmM2VkZTUxZDllLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtNmM0Yy03ZTg5LTkxMmUtYzZmM2VkZTUxZDllIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzoyNi4wOTI4NjlaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjI2LjA5Mjg3OVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMzU5
+        MC03ZTlkLWJiMjYtZjM3MDM5ZTAzMGRjLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMzU5MC03ZTlkLWJiMjYtZjM3MDM5ZTAzMGRjIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMToxMi40MDEzNjJaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjEyLjQwMTM3N1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX2ZpbGUuYXBwLnRh
         c2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25pemUiLCJsb2dnaW5nX2NpZCI6
-        IjU2MjNlOWZkNjM3NTRiYzg4MjQwYTQxNTZhNzZkMjBkIiwiY3JlYXRlZF9i
+        IjJlOGNlM2U1N2VmODQzNjY4ODMyNmY3MzdiZWZmNWY1IiwiY3JlYXRlZF9i
         eSI6Ii9wdWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIw
-        MjQtMTEtMTNUMTE6MTM6MjYuMTA2MTk4WiIsInN0YXJ0ZWRfYXQiOiIyMDI0
-        LTExLTEzVDExOjEzOjI2LjEzNTU4MloiLCJmaW5pc2hlZF9hdCI6IjIwMjQt
-        MTEtMTNUMTE6MTM6MjcuNDg2MTkwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
-        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTkzMjUyMy04ZmVhLTc0MTYtYjkx
-        Ny1hMmQwYTJhYjNkZjcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
+        MjUtMDQtMDRUMTQ6MTE6MTIuNDE0Njk3WiIsInN0YXJ0ZWRfYXQiOiIyMDI1
+        LTA0LTA0VDE0OjExOjEyLjQ2OTE0OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjUt
+        MDQtMDRUMTQ6MTE6MTMuMDMyNzUyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTk1ZmQ4NC03NWVkLTc1NDEtODFh
+        My1hNzc1ZjU1ZGUzNjgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
         c2tzIjpbXSwidGFza19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6
         W3sibWVzc2FnZSI6IkRvd25sb2FkaW5nIE1ldGFkYXRhIiwiY29kZSI6InN5
         bmMuZG93bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
@@ -2542,7 +2542,7 @@ http_interactions:
         aW5nLm1ldGFkYXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6Mywi
         ZG9uZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGlu
         ZyBBcnRpZmFjdHMiLCJjb2RlIjoic3luYy5kb3dubG9hZGluZy5hcnRpZmFj
-        dHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoz
+        dHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjow
         LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENv
         bnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUi
         OiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6Mywic3VmZml4Ijpu
@@ -2550,18 +2550,18 @@ http_interactions:
         ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9y
         ZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2Zp
-        bGUvMDE5MzI1M2EtNWUyMi03MjNlLWEwZjUtMmNlOWUzODI2YzdiL3ZlcnNp
+        bGUvMDE5NjAxMjQtMjRjZi03ODlkLWFmNmEtNDA1MGNkNWZhMmViL3ZlcnNp
         b25zLzIvIiwiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUv
-        MDE5MzI1M2EtNzE5Yy03OTdjLWJlODktNWE3Y2E5YzVkMmU4LyJdLCJyZXNl
+        MDE5NjAxMjQtMzdkYS03MzkwLWEzZTAtODA5MWU1Yzg4ZmU1LyJdLCJyZXNl
         cnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpmaWxlLmZpbGVyZXBvc2l0
-        b3J5OjAxOTMyNTNhLTVlMjItNzIzZS1hMGY1LTJjZTllMzgyNmM3YiIsInNo
-        YXJlZDpwcm46ZmlsZS5maWxlcmVtb3RlOjAxOTMyNTNhLTVkYTgtN2NiNi1h
-        NTdlLTdjNTlmYmEwODQ5MyIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5
-        MmM1N2QtZmI5NS03OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 11:13:27 GMT
+        b3J5OjAxOTYwMTI0LTI0Y2YtNzg5ZC1hZjZhLTQwNTBjZDVmYTJlYiIsInNo
+        YXJlZDpwcm46ZmlsZS5maWxlcmVtb3RlOjAxOTYwMTI0LTI0M2MtN2Y3Ni05
+        NGZjLWRjODhiYTg0MmEzNiIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5
+        NTYyMTctZmM5ZS03NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Fri, 04 Apr 2025 14:11:13 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2569,7 +2569,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2582,7 +2582,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:27 GMT
+      - Fri, 04 Apr 2025 14:11:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2594,7 +2594,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '755'
+      - '753'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2602,47 +2602,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d270dbd9de6643a3af7ffbbbf9dc5369
+      - bf3af2ed484d4c578f508d3b32f2f040
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMTkzMjUzYS02MGU5LTc0ZmQtYmE1NC03ODQ4N2IyYzJl
-        NDAvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTkzMjUz
-        YS02MGU5LTc0ZmQtYmE1NC03ODQ4N2IyYzJlNDAiLCJwdWxwX2NyZWF0ZWQi
-        OiIyMDI0LTExLTEzVDExOjEzOjIzLjE3ODQ1MFoiLCJwdWxwX2xhc3RfdXBk
-        YXRlZCI6IjIwMjQtMTEtMTNUMTE6MTM6MjUuNzIyMTk2WiIsImJhc2VfcGF0
+        L2ZpbGUvZmlsZS8wMTk2MDEyNC0yODkwLTc1MzktODljMC1kM2Y1OGUzNTkw
+        YWMvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk2MDEy
+        NC0yODkwLTc1MzktODljMC1kM2Y1OGUzNTkwYWMiLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDI1LTA0LTA0VDE0OjExOjA5LjA3NDAwOFoiLCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjUtMDQtMDRUMTQ6MTE6MTEuOTExOTc0WiIsImJhc2VfcGF0
         aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8x
-        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5k
-        aWNlcm9zMjAyMy5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9P
-        cmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19GaWxlXzEvIiwiY29udGVudF9n
-        dWFyZCI6bnVsbCwibm9fY29udGVudF9jaGFuZ2Vfc2luY2UiOiIyMDI0LTEx
-        LTEzVDExOjEzOjI1LjcyMjE5NloiLCJoaWRkZW4iOmZhbHNlLCJwdWxwX2xh
-        YmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0
-        LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtNjVkNC03NGQ0LTk5OTEtZTY3MTgxZjczZWJlLyJ9XX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:27 GMT
+        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5t
+        YW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3Vh
+        cmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNS0wNC0w
+        NFQxNDoxMToxMS45MTE5NzRaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9sYWJl
+        bHMiOnt9LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1w
+        dWxwM19GaWxlXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6
+        Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOTYwMTI0
+        LTJkMjEtN2E4ZC1iMDRiLTFiMzRmY2YxOWEzMC8ifV19
+  recorded_at: Fri, 04 Apr 2025 14:11:13 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193253a-60e9-74fd-ba54-78487b2c2e40/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/01960124-2890-7539-89c0-d3f58e3590ac/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtNzE5Yy03OTdjLWJlODktNWE3Y2E5YzVkMmU4LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NjAx
+        MjQtMzdkYS03MzkwLWEzZTAtODA5MWU1Yzg4ZmU1LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2655,7 +2655,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:27 GMT
+      - Fri, 04 Apr 2025 14:11:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,20 +2675,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d9c88bbbe4db45b98765f726f856b072
+      - 16da961e81e0488ca93499d2d20459eb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTcyYjEtN2Ey
-        My04MDcxLTBkNmNlOTM0NGMxNi8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:27 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTM5NDQtNzUy
+        Ny1hMDBiLWEyZmFmYzJkY2NkNC8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:13 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-72b1-7a23-8071-0d6ce9344c16/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-3944-7527-a00b-a2fafc2dccd4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2696,7 +2696,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2709,7 +2709,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:27 GMT
+      - Fri, 04 Apr 2025 14:11:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2729,48 +2729,48 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5d22d9e9b2e6428d8711aa6fe3a03c78
+      - 37c30ff709ae470ca316dde0c6dabb90
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtNzJi
-        MS03YTIzLTgwNzEtMGQ2Y2U5MzQ0YzE2LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtNzJiMS03YTIzLTgwNzEtMGQ2Y2U5MzQ0YzE2IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzoyNy43Mjk4MTVaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjI3LjcyOTgyNVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMzk0
+        NC03NTI3LWEwMGItYTJmYWZjMmRjY2Q0LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMzk0NC03NTI3LWEwMGItYTJmYWZjMmRjY2Q0IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMToxMy4zNDkxMTVaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjEzLjM0OTEzMFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiZDljODhi
-        YmJlNGRiNDViOTg3NjVmNzI2Zjg1NmIwNzIiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzoyNy43NDIxNjVaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MjcuNzQ0NTgyWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzoyNy43NjEzMDZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiMTZkYTk2
+        MWU4MWUwNDg4Y2E5MzQ5OWQyZDIwNDU5ZWIiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMToxMy4zNjQxMjhaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MTMuMzY3MTQwWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMToxMy4zODQ1NDVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJjNTdkLWZiOTUtNzkxOC04N2U0LTlkZTViMTVhYjUzNjpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyYzU3ZC1mYjk1LTc5
-        MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:27 GMT
+        OTU2MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRp
+        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0
+        Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
+  recorded_at: Fri, 04 Apr 2025 14:11:13 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193253a-60e9-74fd-ba54-78487b2c2e40/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/01960124-2890-7539-89c0-d3f58e3590ac/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtNzE5Yy03OTdjLWJlODktNWE3Y2E5YzVkMmU4LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NjAx
+        MjQtMzdkYS03MzkwLWEzZTAtODA5MWU1Yzg4ZmU1LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2783,7 +2783,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:27 GMT
+      - Fri, 04 Apr 2025 14:11:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2803,20 +2803,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d5ffd5af263845018b81fde20c243f67
+      - 63fe2c13fe5443d7997186160d9f3532
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTczNDYtNzk5
-        ZC05ZTRmLTZlOGY4OGI3NWMyZi8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:27 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTNhMGItNzk4
+        Mi04NzJiLTRjNjdiODZkYzU4ZS8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:13 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2824,7 +2824,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.22.3/ruby
+      - OpenAPI-Generator/0.22.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2837,7 +2837,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:28 GMT
+      - Fri, 04 Apr 2025 14:11:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2857,20 +2857,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3276ad4a1c5e41d1abddde870ba50f1c
+      - 4a53d8a4ba1a4744812c5b362491f655
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:28 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:13 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2891,7 +2891,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:28 GMT
+      - Fri, 04 Apr 2025 14:11:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2911,20 +2911,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 86b055841ace4b18af0fa2a7615b6fdb
+      - 57033939c70c41d5b0cd710d1d1c2b6a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:28 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:13 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2932,7 +2932,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.22.0/ruby
+      - OpenAPI-Generator/2.22.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -2945,7 +2945,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:28 GMT
+      - Fri, 04 Apr 2025 14:11:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2965,20 +2965,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 913869500c1a41968e99eb60dcecf273
+      - '082d6b2c346243178e01b7c2f3432d4f'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:28 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:13 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2986,7 +2986,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2999,7 +2999,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:28 GMT
+      - Fri, 04 Apr 2025 14:11:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3019,34 +3019,34 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - de73227e300a4c0da5e3106b0e40e413
+      - ac57a74cdc554e1196313dc4c7f46ca0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTMyNTNhLTVlMjItNzIzZS1hMGY1LTJjZTllMzgyNmM3
-        Yi8iLCJwcm4iOiJwcm46ZmlsZS5maWxlcmVwb3NpdG9yeTowMTkzMjUzYS01
-        ZTIyLTcyM2UtYTBmNS0yY2U5ZTM4MjZjN2IiLCJwdWxwX2NyZWF0ZWQiOiIy
-        MDI0LTExLTEzVDExOjEzOjIyLjQ2NzE3NFoiLCJwdWxwX2xhc3RfdXBkYXRl
-        ZCI6IjIwMjQtMTEtMTNUMTE6MTM6MjcuNDQwNzYyWiIsInZlcnNpb25zX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTkz
-        MjUzYS01ZTIyLTcyM2UtYTBmNS0yY2U5ZTM4MjZjN2IvdmVyc2lvbnMvIiwi
+        ZmlsZS9maWxlLzAxOTYwMTI0LTI0Y2YtNzg5ZC1hZjZhLTQwNTBjZDVmYTJl
+        Yi8iLCJwcm4iOiJwcm46ZmlsZS5maWxlcmVwb3NpdG9yeTowMTk2MDEyNC0y
+        NGNmLTc4OWQtYWY2YS00MDUwY2Q1ZmEyZWIiLCJwdWxwX2NyZWF0ZWQiOiIy
+        MDI1LTA0LTA0VDE0OjExOjA4LjExMjU2OFoiLCJwdWxwX2xhc3RfdXBkYXRl
+        ZCI6IjIwMjUtMDQtMDRUMTQ6MTE6MTIuOTcwNzkyWiIsInZlcnNpb25zX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk2
+        MDEyNC0yNGNmLTc4OWQtYWY2YS00MDUwY2Q1ZmEyZWIvdmVyc2lvbnMvIiwi
         cHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1M2EtNWUyMi03
-        MjNlLWEwZjUtMmNlOWUzODI2YzdiL3ZlcnNpb25zLzIvIiwibmFtZSI6IkRl
+        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NjAxMjQtMjRjZi03
+        ODlkLWFmNmEtNDA1MGNkNWZhMmViL3ZlcnNpb25zLzIvIiwibmFtZSI6IkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwiZGVz
         Y3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJy
         ZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWFuaWZlc3QiOiJQ
         VUxQX01BTklGRVNUIn1dfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:28 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:13 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193253a-5e22-723e-a0f5-2ce9e3826c7b/versions/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/01960124-24cf-789d-af6a-4050cd5fa2eb/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3054,7 +3054,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3067,7 +3067,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:28 GMT
+      - Fri, 04 Apr 2025 14:11:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3087,69 +3087,69 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7b76d0be777a4b7086a76c93b4cf5e9b
+      - f5347da983de4fecb42124422f52c13b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTMyNTNhLTVlMjItNzIzZS1hMGY1LTJjZTllMzgyNmM3
+        ZmlsZS9maWxlLzAxOTYwMTI0LTI0Y2YtNzg5ZC1hZjZhLTQwNTBjZDVmYTJl
         Yi92ZXJzaW9ucy8yLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
-        aW9uOjAxOTMyNTNhLTZjODQtN2FmNS04YjU4LTk5Mzc5MGY2ODUxZCIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMTEtMTNUMTE6MTM6MjYuMTQ4NzkxWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzoyNy40NDI0OTRa
+        aW9uOjAxOTYwMTI0LTM1ZTEtNzAxNi1hZWFiLWVjZGEzYjU3MGFlZCIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjUtMDQtMDRUMTQ6MTE6MTIuNDgxOTI1WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMToxMi45NzMwNDNa
         IiwibnVtYmVyIjoyLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1M2EtNWUyMi03MjNlLWEwZjUtMmNl
-        OWUzODI2YzdiLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
+        aXRvcmllcy9maWxlL2ZpbGUvMDE5NjAxMjQtMjRjZi03ODlkLWFmNmEtNDA1
+        MGNkNWZhMmViLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
         YXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6
         Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlf
         dmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMTkzMjUzYS01ZTIyLTcyM2UtYTBmNS0yY2U5ZTM4MjZjN2IvdmVy
+        ZmlsZS8wMTk2MDEyNC0yNGNmLTc4OWQtYWY2YS00MDUwY2Q1ZmEyZWIvdmVy
         c2lvbnMvMi8ifX0sInJlbW92ZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50Ijoz
         LCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVw
         b3NpdG9yeV92ZXJzaW9uX3JlbW92ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9maWxlL2ZpbGUvMDE5MzI1M2EtNWUyMi03MjNlLWEwZjUtMmNlOWUz
-        ODI2YzdiL3ZlcnNpb25zLzIvIn19LCJwcmVzZW50Ijp7ImZpbGUuZmlsZSI6
+        cmllcy9maWxlL2ZpbGUvMDE5NjAxMjQtMjRjZi03ODlkLWFmNmEtNDA1MGNk
+        NWZhMmViL3ZlcnNpb25zLzIvIn19LCJwcmVzZW50Ijp7ImZpbGUuZmlsZSI6
         eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
         ZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2ZpbGUvZmlsZS8wMTkzMjUzYS01ZTIyLTcyM2UtYTBmNS0yY2U5
-        ZTM4MjZjN2IvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTMyNTNhLTVlMjIt
-        NzIzZS1hMGY1LTJjZTllMzgyNmM3Yi92ZXJzaW9ucy8xLyIsInBybiI6InBy
-        bjpjb3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOTMyNTNhLTYyZmMtNzhkNi04
-        YzY1LTE5NGM2NDZmZTg2NiIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MjMuNzA5MTQ0WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0x
-        MS0xM1QxMToxMzoyNC40MjUyMjNaIiwibnVtYmVyIjoxLCJyZXBvc2l0b3J5
-        IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtNWUyMi03MjNlLWEwZjUtMmNlOWUzODI2YzdiLyIsImJhc2VfdmVyc2lv
+        dG9yaWVzL2ZpbGUvZmlsZS8wMTk2MDEyNC0yNGNmLTc4OWQtYWY2YS00MDUw
+        Y2Q1ZmEyZWIvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTYwMTI0LTI0Y2Yt
+        Nzg5ZC1hZjZhLTQwNTBjZDVmYTJlYi92ZXJzaW9ucy8xLyIsInBybiI6InBy
+        bjpjb3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOTYwMTI0LTJiNGMtNzczMi04
+        ZDI3LWM2M2U3ZDI0ZjQ5MyIsInB1bHBfY3JlYXRlZCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MDkuNzczMTA5WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0w
+        NC0wNFQxNDoxMToxMC4yMjk5NjJaIiwibnVtYmVyIjoxLCJyZXBvc2l0b3J5
+        IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NjAx
+        MjQtMjRjZi03ODlkLWFmNmEtNDA1MGNkNWZhMmViLyIsImJhc2VfdmVyc2lv
         biI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmls
         ZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Zp
         bGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTkzMjUzYS01ZTIyLTcyM2Ut
-        YTBmNS0yY2U5ZTM4MjZjN2IvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk2MDEyNC0yNGNmLTc4OWQt
+        YWY2YS00MDUwY2Q1ZmEyZWIvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9
         LCJwcmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9w
         dWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVy
-        c2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTkz
-        MjUzYS01ZTIyLTcyM2UtYTBmNS0yY2U5ZTM4MjZjN2IvdmVyc2lvbnMvMS8i
+        c2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk2
+        MDEyNC0yNGNmLTc4OWQtYWY2YS00MDUwY2Q1ZmEyZWIvdmVyc2lvbnMvMS8i
         fX19fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTMyNTNhLTVlMjItNzIzZS1hMGY1LTJjZTllMzgyNmM3
+        ZmlsZS9maWxlLzAxOTYwMTI0LTI0Y2YtNzg5ZC1hZjZhLTQwNTBjZDVmYTJl
         Yi92ZXJzaW9ucy8wLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
-        aW9uOjAxOTMyNTNhLTVlMjgtN2Q3MS1iM2I2LWYxNDIwMzhkNmE1YSIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMTEtMTNUMTE6MTM6MjIuNDc0MTk1WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzoyMi40NzQyMDNa
+        aW9uOjAxOTYwMTI0LTI0ZDYtN2Y4Zi05NTg3LTQ0MWJmY2FiNDhkNiIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjUtMDQtMDRUMTQ6MTE6MDguMTIxNTY0WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowOC4xMjE1NzRa
         IiwibnVtYmVyIjowLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1M2EtNWUyMi03MjNlLWEwZjUtMmNl
-        OWUzODI2YzdiLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
+        aXRvcmllcy9maWxlL2ZpbGUvMDE5NjAxMjQtMjRjZi03ODlkLWFmNmEtNDA1
+        MGNkNWZhMmViLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
         YXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1d
         fQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:28 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:13 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3157,7 +3157,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.4.4/ruby
+      - OpenAPI-Generator/2.4.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -3170,7 +3170,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:28 GMT
+      - Fri, 04 Apr 2025 14:11:13 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3190,20 +3190,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f3c93bfa9635478f9e4973e12f59dcf6
+      - ec724453bb194e94978e5787c7087c09
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:28 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:14 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3211,7 +3211,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.12.5/ruby
+      - OpenAPI-Generator/3.12.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -3224,7 +3224,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:28 GMT
+      - Fri, 04 Apr 2025 14:11:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3244,20 +3244,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d0261a853a3041dcac12ebb0f45d77f5
+      - 13fb321aba464ffb8d675eac8d33d40c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:28 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:14 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3278,7 +3278,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:28 GMT
+      - Fri, 04 Apr 2025 14:11:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3298,20 +3298,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3ff3c8111c3c453a8a735ac3a6bdd292
+      - 628c59631f3d4ac3ac6b8579cc25a481
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:28 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:14 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193253a-5e22-723e-a0f5-2ce9e3826c7b/versions/1/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/01960124-24cf-789d-af6a-4050cd5fa2eb/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3319,7 +3319,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3332,7 +3332,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:28 GMT
+      - Fri, 04 Apr 2025 14:11:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3352,20 +3352,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '0791ba027883448aaa8594e1e6d15c8c'
+      - 21d849fba0684212bb1af887b80fed3f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTc1M2ItN2Jl
-        MC05ZTZiLWFmN2RiMWYzN2FhNi8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:28 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTNjNzItN2Y0
+        MC05NmJiLTlkMzgwMTJhYWY5ZS8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:14 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-753b-7be0-9e6b-af7db1f37aa6/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-3c72-7f40-96bb-9d38012aaf9e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3373,7 +3373,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3386,7 +3386,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:28 GMT
+      - Fri, 04 Apr 2025 14:11:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3406,37 +3406,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1a71875c72f24cb1a5c9fe10dd7fc10b
+      - e0ec517ccada4947847e2b3faa5aa8fe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtNzUz
-        Yi03YmUwLTllNmItYWY3ZGIxZjM3YWE2LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtNzUzYi03YmUwLTllNmItYWY3ZGIxZjM3YWE2IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzoyOC4zNzk2MjdaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjI4LjM3OTYzOFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtM2M3
+        Mi03ZjQwLTk2YmItOWQzODAxMmFhZjllLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtM2M3Mi03ZjQwLTk2YmItOWQzODAxMmFhZjllIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMToxNC4xNjMxNDlaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjE0LjE2MzE2MVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
         a3MucmVwb3NpdG9yeS5kZWxldGVfdmVyc2lvbiIsImxvZ2dpbmdfY2lkIjoi
-        MDc5MWJhMDI3ODgzNDQ4YWFhODU5NGUxZTZkMTVjOGMiLCJjcmVhdGVkX2J5
+        MjFkODQ5ZmJhMDY4NDIxMmJiMWFmODg3YjgwZmVkM2YiLCJjcmVhdGVkX2J5
         IjoiL3B1bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAy
-        NC0xMS0xM1QxMToxMzoyOC4zODkxNjZaIiwic3RhcnRlZF9hdCI6IjIwMjQt
-        MTEtMTNUMTE6MTM6MjguNDE5ODIyWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0x
-        MS0xM1QxMToxMzoyOC41MjQ4MzdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6
-        Ii9wdWxwL2FwaS92My93b3JrZXJzLzAxOTMyNTIzLThmZWEtNzQxNi1iOTE3
-        LWEyZDBhMmFiM2RmNy8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFz
+        NS0wNC0wNFQxNDoxMToxNC4xNzYyODBaIiwic3RhcnRlZF9hdCI6IjIwMjUt
+        MDQtMDRUMTQ6MTE6MTQuMjQwMTk5WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0w
+        NC0wNFQxNDoxMToxNC4zNDg5MzVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzAxOTVmZDg0LTc1ZWQtNzU0MS04MWEz
+        LWE3NzVmNTVkZTM2OC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFz
         a3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpb
         XSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNf
-        cmVjb3JkIjpbInBybjpmaWxlLmZpbGVyZXBvc2l0b3J5OjAxOTMyNTNhLTVl
-        MjItNzIzZS1hMGY1LTJjZTllMzgyNmM3YiIsInNoYXJlZDpwcm46Y29yZS5k
-        b21haW46MDE5MmM1N2QtZmI5NS03OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 11:13:28 GMT
+        cmVjb3JkIjpbInBybjpmaWxlLmZpbGVyZXBvc2l0b3J5OjAxOTYwMTI0LTI0
+        Y2YtNzg5ZC1hZjZhLTQwNTBjZDVmYTJlYiIsInNoYXJlZDpwcm46Y29yZS5k
+        b21haW46MDE5NTYyMTctZmM5ZS03NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Fri, 04 Apr 2025 14:11:14 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3444,7 +3444,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.22.3/ruby
+      - OpenAPI-Generator/0.22.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -3457,7 +3457,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:28 GMT
+      - Fri, 04 Apr 2025 14:11:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3477,20 +3477,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b1e61b763aab430883a6be65159c8434
+      - 3f4dc1389bc44f16a957f73f4a427b6b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:28 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:14 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3511,7 +3511,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:28 GMT
+      - Fri, 04 Apr 2025 14:11:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3531,20 +3531,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 16ae9c663f114dd38d0317ec130147eb
+      - 77a9d61224b64d40aa22d77849e9344e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:28 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:14 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3552,7 +3552,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.22.0/ruby
+      - OpenAPI-Generator/2.22.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -3565,7 +3565,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:28 GMT
+      - Fri, 04 Apr 2025 14:11:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3585,20 +3585,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5b65f8faf3074d7e9307899676357e59
+      - 1b0f476c6bfe4c138409d0a532027b16
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:28 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:14 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3606,7 +3606,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3619,7 +3619,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:28 GMT
+      - Fri, 04 Apr 2025 14:11:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3639,34 +3639,34 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0c8f83aa3f7e4a618ce3fce8992de09c
+      - 6a1a86cbeb6b46cdaa04abca7fadb5a3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTMyNTNhLTVlMjItNzIzZS1hMGY1LTJjZTllMzgyNmM3
-        Yi8iLCJwcm4iOiJwcm46ZmlsZS5maWxlcmVwb3NpdG9yeTowMTkzMjUzYS01
-        ZTIyLTcyM2UtYTBmNS0yY2U5ZTM4MjZjN2IiLCJwdWxwX2NyZWF0ZWQiOiIy
-        MDI0LTExLTEzVDExOjEzOjIyLjQ2NzE3NFoiLCJwdWxwX2xhc3RfdXBkYXRl
-        ZCI6IjIwMjQtMTEtMTNUMTE6MTM6MjcuNDQwNzYyWiIsInZlcnNpb25zX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTkz
-        MjUzYS01ZTIyLTcyM2UtYTBmNS0yY2U5ZTM4MjZjN2IvdmVyc2lvbnMvIiwi
+        ZmlsZS9maWxlLzAxOTYwMTI0LTI0Y2YtNzg5ZC1hZjZhLTQwNTBjZDVmYTJl
+        Yi8iLCJwcm4iOiJwcm46ZmlsZS5maWxlcmVwb3NpdG9yeTowMTk2MDEyNC0y
+        NGNmLTc4OWQtYWY2YS00MDUwY2Q1ZmEyZWIiLCJwdWxwX2NyZWF0ZWQiOiIy
+        MDI1LTA0LTA0VDE0OjExOjA4LjExMjU2OFoiLCJwdWxwX2xhc3RfdXBkYXRl
+        ZCI6IjIwMjUtMDQtMDRUMTQ6MTE6MTIuOTcwNzkyWiIsInZlcnNpb25zX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk2
+        MDEyNC0yNGNmLTc4OWQtYWY2YS00MDUwY2Q1ZmEyZWIvdmVyc2lvbnMvIiwi
         cHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1M2EtNWUyMi03
-        MjNlLWEwZjUtMmNlOWUzODI2YzdiL3ZlcnNpb25zLzIvIiwibmFtZSI6IkRl
+        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NjAxMjQtMjRjZi03
+        ODlkLWFmNmEtNDA1MGNkNWZhMmViL3ZlcnNpb25zLzIvIiwibmFtZSI6IkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwiZGVz
         Y3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJy
         ZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWFuaWZlc3QiOiJQ
         VUxQX01BTklGRVNUIn1dfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:28 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:14 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193253a-5e22-723e-a0f5-2ce9e3826c7b/versions/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/01960124-24cf-789d-af6a-4050cd5fa2eb/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3674,7 +3674,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3687,7 +3687,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:28 GMT
+      - Fri, 04 Apr 2025 14:11:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3707,47 +3707,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 95204956646b4688a8f759566c01f536
+      - e8127042059047c8bc470396730a4e21
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTMyNTNhLTVlMjItNzIzZS1hMGY1LTJjZTllMzgyNmM3
+        ZmlsZS9maWxlLzAxOTYwMTI0LTI0Y2YtNzg5ZC1hZjZhLTQwNTBjZDVmYTJl
         Yi92ZXJzaW9ucy8yLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
-        aW9uOjAxOTMyNTNhLTZjODQtN2FmNS04YjU4LTk5Mzc5MGY2ODUxZCIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMTEtMTNUMTE6MTM6MjYuMTQ4NzkxWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzoyNy40NDI0OTRa
+        aW9uOjAxOTYwMTI0LTM1ZTEtNzAxNi1hZWFiLWVjZGEzYjU3MGFlZCIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjUtMDQtMDRUMTQ6MTE6MTIuNDgxOTI1WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMToxMi45NzMwNDNa
         IiwibnVtYmVyIjoyLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1M2EtNWUyMi03MjNlLWEwZjUtMmNl
-        OWUzODI2YzdiLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
+        aXRvcmllcy9maWxlL2ZpbGUvMDE5NjAxMjQtMjRjZi03ODlkLWFmNmEtNDA1
+        MGNkNWZhMmViLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
         YXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6
         Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlf
         dmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMTkzMjUzYS01ZTIyLTcyM2UtYTBmNS0yY2U5ZTM4MjZjN2IvdmVy
+        ZmlsZS8wMTk2MDEyNC0yNGNmLTc4OWQtYWY2YS00MDUwY2Q1ZmEyZWIvdmVy
         c2lvbnMvMi8ifX0sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7ImZpbGUuZmls
         ZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Zp
         bGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTkzMjUzYS01ZTIyLTcyM2UtYTBmNS0y
-        Y2U5ZTM4MjZjN2IvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTMyNTNhLTVl
-        MjItNzIzZS1hMGY1LTJjZTllMzgyNmM3Yi92ZXJzaW9ucy8wLyIsInBybiI6
-        InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOTMyNTNhLTVlMjgtN2Q3
-        MS1iM2I2LWYxNDIwMzhkNmE1YSIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMTEt
-        MTNUMTE6MTM6MjIuNDc0MTk1WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        NC0xMS0xM1QxMToxMzoyMi40NzQyMDNaIiwibnVtYmVyIjowLCJyZXBvc2l0
+        b3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk2MDEyNC0yNGNmLTc4OWQtYWY2YS00
+        MDUwY2Q1ZmEyZWIvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTYwMTI0LTI0
+        Y2YtNzg5ZC1hZjZhLTQwNTBjZDVmYTJlYi92ZXJzaW9ucy8wLyIsInBybiI6
+        InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOTYwMTI0LTI0ZDYtN2Y4
+        Zi05NTg3LTQ0MWJmY2FiNDhkNiIsInB1bHBfY3JlYXRlZCI6IjIwMjUtMDQt
+        MDRUMTQ6MTE6MDguMTIxNTY0WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
+        NS0wNC0wNFQxNDoxMTowOC4xMjE1NzRaIiwibnVtYmVyIjowLCJyZXBvc2l0
         b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5
-        MzI1M2EtNWUyMi03MjNlLWEwZjUtMmNlOWUzODI2YzdiLyIsImJhc2VfdmVy
+        NjAxMjQtMjRjZi03ODlkLWFmNmEtNDA1MGNkNWZhMmViLyIsImJhc2VfdmVy
         c2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVt
         b3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:28 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:14 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3755,7 +3755,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.4.4/ruby
+      - OpenAPI-Generator/2.4.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -3768,7 +3768,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:28 GMT
+      - Fri, 04 Apr 2025 14:11:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3788,20 +3788,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ae36ee65801842b48b78fab3305e8173
+      - c281a36dbe194cd19627a32a23a39990
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:28 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:14 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3809,7 +3809,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.12.5/ruby
+      - OpenAPI-Generator/3.12.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -3822,7 +3822,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:29 GMT
+      - Fri, 04 Apr 2025 14:11:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3842,20 +3842,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - aa21abe9711846dc8e12a97f60e57048
+      - 6c521e2fb024427786dbaee83b29bb7e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:29 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:14 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3876,7 +3876,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:29 GMT
+      - Fri, 04 Apr 2025 14:11:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3896,20 +3896,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d2890b91481c43bc90d747055d8bd021
+      - 7ff363f6404a4761870847a51afd82f2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:29 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:14 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3917,7 +3917,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3930,7 +3930,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:29 GMT
+      - Fri, 04 Apr 2025 14:11:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3950,34 +3950,34 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a6dbfc2ac4e24002b9ee1cde3f8097c2
+      - bf93573aeac4442190bc5a31553203a1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTMyNTNhLTVlMjItNzIzZS1hMGY1LTJjZTllMzgyNmM3
-        Yi8iLCJwcm4iOiJwcm46ZmlsZS5maWxlcmVwb3NpdG9yeTowMTkzMjUzYS01
-        ZTIyLTcyM2UtYTBmNS0yY2U5ZTM4MjZjN2IiLCJwdWxwX2NyZWF0ZWQiOiIy
-        MDI0LTExLTEzVDExOjEzOjIyLjQ2NzE3NFoiLCJwdWxwX2xhc3RfdXBkYXRl
-        ZCI6IjIwMjQtMTEtMTNUMTE6MTM6MjcuNDQwNzYyWiIsInZlcnNpb25zX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTkz
-        MjUzYS01ZTIyLTcyM2UtYTBmNS0yY2U5ZTM4MjZjN2IvdmVyc2lvbnMvIiwi
+        ZmlsZS9maWxlLzAxOTYwMTI0LTI0Y2YtNzg5ZC1hZjZhLTQwNTBjZDVmYTJl
+        Yi8iLCJwcm4iOiJwcm46ZmlsZS5maWxlcmVwb3NpdG9yeTowMTk2MDEyNC0y
+        NGNmLTc4OWQtYWY2YS00MDUwY2Q1ZmEyZWIiLCJwdWxwX2NyZWF0ZWQiOiIy
+        MDI1LTA0LTA0VDE0OjExOjA4LjExMjU2OFoiLCJwdWxwX2xhc3RfdXBkYXRl
+        ZCI6IjIwMjUtMDQtMDRUMTQ6MTE6MTIuOTcwNzkyWiIsInZlcnNpb25zX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk2
+        MDEyNC0yNGNmLTc4OWQtYWY2YS00MDUwY2Q1ZmEyZWIvdmVyc2lvbnMvIiwi
         cHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1M2EtNWUyMi03
-        MjNlLWEwZjUtMmNlOWUzODI2YzdiL3ZlcnNpb25zLzIvIiwibmFtZSI6IkRl
+        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NjAxMjQtMjRjZi03
+        ODlkLWFmNmEtNDA1MGNkNWZhMmViL3ZlcnNpb25zLzIvIiwibmFtZSI6IkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwiZGVz
         Y3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJy
         ZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWFuaWZlc3QiOiJQ
         VUxQX01BTklGRVNUIn1dfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:29 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:14 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193253a-5e22-723e-a0f5-2ce9e3826c7b/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/01960124-24cf-789d-af6a-4050cd5fa2eb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3985,7 +3985,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3998,7 +3998,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:29 GMT
+      - Fri, 04 Apr 2025 14:11:14 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4018,20 +4018,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7a72073ea71b46a794a3224572b0a5ab
+      - 3ccf565d17e64a75bab9b43325b9b3d1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTc4YjYtN2Vj
-        MS1hMDRkLWU4YzFhZTdjMjdlYS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:29 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTNmODEtNzgy
+        Yy05YjAxLTFkYjg0NmViYzc4NC8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:14 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4039,7 +4039,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -4052,7 +4052,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:29 GMT
+      - Fri, 04 Apr 2025 14:11:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4072,21 +4072,21 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 128467dd4c9b4adba6b51346c909153a
+      - 7c4049dc9fc144ae9ef6a6028261cacb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUv
-        ZmlsZS8wMTkzMjUzYS01ZGE4LTdjYjYtYTU3ZS03YzU5ZmJhMDg0OTMvIiwi
-        cHJuIjoicHJuOmZpbGUuZmlsZXJlbW90ZTowMTkzMjUzYS01ZGE4LTdjYjYt
-        YTU3ZS03YzU5ZmJhMDg0OTMiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTExLTEz
-        VDExOjEzOjIyLjM0NDgxOVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQt
-        MTEtMTNUMTE6MTM6MjUuOTc2NzMwWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        ZmlsZS8wMTk2MDEyNC0yNDNjLTdmNzYtOTRmYy1kYzg4YmE4NDJhMzYvIiwi
+        cHJuIjoicHJuOmZpbGUuZmlsZXJlbW90ZTowMTk2MDEyNC0yNDNjLTdmNzYt
+        OTRmYy1kYzg4YmE4NDJhMzYiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTA0LTA0
+        VDE0OjExOjA3Ljk2NTEyMloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUt
+        MDQtMDRUMTQ6MTE6MTIuMjM4ODU5WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
         aXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIsInVybCI6Imh0dHBzOi8v
         Zml4dHVyZXMucHVscHByb2plY3Qub3JnL2ZpbGUvL1BVTFBfTUFOSUZFU1Qi
         LCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlk
@@ -4101,10 +4101,10 @@ http_interactions:
         b3JkIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoidXNlcm5hbWUiLCJpc19z
         ZXQiOmZhbHNlfSx7Im5hbWUiOiJwYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9
         XX1dfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:29 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:15 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193253a-5da8-7cb6-a57e-7c59fba08493/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/01960124-243c-7f76-94fc-dc88ba842a36/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4112,7 +4112,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -4125,7 +4125,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:29 GMT
+      - Fri, 04 Apr 2025 14:11:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4145,20 +4145,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b8d625b3e7be47d5bdab43a46051eb2f
+      - 20b5d030b99547bda66b397f58ee61ef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTc5NGYtNzk4
-        NS05MmFjLTY5MGVkYTMyNTYzOC8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:29 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTQwMDMtNzVh
+        Ni05YWM2LWNhMzc3MzJhMzE2OC8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:15 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-78b6-7ec1-a04d-e8c1ae7c27ea/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-3f81-782c-9b01-1db846ebc784/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4166,7 +4166,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -4179,7 +4179,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:29 GMT
+      - Fri, 04 Apr 2025 14:11:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4199,37 +4199,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 678dc4e8ba5044d094afe3d15fde07a8
+      - '090d1c953da24078b99224268f790015'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtNzhi
-        Ni03ZWMxLWEwNGQtZThjMWFlN2MyN2VhLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtNzhiNi03ZWMxLWEwNGQtZThjMWFlN2MyN2VhIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzoyOS4yNzA4MTBaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjI5LjI3MDgyM1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtM2Y4
+        MS03ODJjLTliMDEtMWRiODQ2ZWJjNzg0LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtM2Y4MS03ODJjLTliMDEtMWRiODQ2ZWJjNzg0IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMToxNC45NDU5NzhaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjE0Ljk0NTk5Mloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiN2E3MjA3
-        M2VhNzFiNDZhNzk0YTMyMjQ1NzJiMGE1YWIiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzoyOS4yODQ3OTRaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MjkuMzM1NDQwWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzoyOS41MjA2NDVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTMyNTIzLThmZWEtNzQxNi1iOTE3LWEyZDBh
-        MmFiM2RmNy8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiM2NjZjU2
+        NWQxN2U2NGE3NWJhYjliNDMzMjViOWIzZDEiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMToxNC45NTkzNzhaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MTUuMDMxMjI5WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMToxNS4xNjE5NThaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOTVmZDg0LTc2M2EtN2Y1Ny05M2RlLTVjZjlm
+        ZmJjNTc3Ny8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpmaWxlLmZpbGVyZXBvc2l0b3J5OjAxOTMyNTNhLTVlMjItNzIz
-        ZS1hMGY1LTJjZTllMzgyNmM3YiIsInNoYXJlZDpwcm46Y29yZS5kb21haW46
-        MDE5MmM1N2QtZmI5NS03OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 11:13:29 GMT
+        IjpbInBybjpmaWxlLmZpbGVyZXBvc2l0b3J5OjAxOTYwMTI0LTI0Y2YtNzg5
+        ZC1hZjZhLTQwNTBjZDVmYTJlYiIsInNoYXJlZDpwcm46Y29yZS5kb21haW46
+        MDE5NTYyMTctZmM5ZS03NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Fri, 04 Apr 2025 14:11:15 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-794f-7985-92ac-690eda325638/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-4003-75a6-9ac6-ca37732a3168/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4237,7 +4237,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -4250,7 +4250,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:29 GMT
+      - Fri, 04 Apr 2025 14:11:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4270,37 +4270,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0fd2f9b222204d4eb741c4465aaf219f
+      - 7220da410daf49fda76ec9aded91eff6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtNzk0
-        Zi03OTg1LTkyYWMtNjkwZWRhMzI1NjM4LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtNzk0Zi03OTg1LTkyYWMtNjkwZWRhMzI1NjM4IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzoyOS40MjQxNzVaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjI5LjQyNDE4OFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtNDAw
+        My03NWE2LTlhYzYtY2EzNzczMmEzMTY4LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtNDAwMy03NWE2LTlhYzYtY2EzNzczMmEzMTY4IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMToxNS4wNzU1NjdaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjE1LjA3NTU4MFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiYjhkNjI1
-        YjNlN2JlNDdkNWJkYWI0M2E0NjA1MWViMmYiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzoyOS40NDIzNjRaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MjkuNTAyODE5WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzoyOS41Njg0MjFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTMyNTIzLTkwMWUtN2ZiMC05ZTA3LTljZGY0
-        ZDJiMWNhMC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiMjBiNWQw
+        MzBiOTk1NDdiZGE2NmIzOTdmNThlZTYxZWYiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMToxNS4wODk1MzVaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MTUuMTU4OTMyWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMToxNS4xOTkwNjlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOTVmZDg0LTc1ZDQtN2Y0Ni1iNzlmLTcxMDNj
+        MWIyY2U2MC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpmaWxlLmZpbGVyZW1vdGU6MDE5MzI1M2EtNWRhOC03Y2I2LWE1
-        N2UtN2M1OWZiYTA4NDkzIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTky
-        YzU3ZC1mYjk1LTc5MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:29 GMT
+        IjpbInBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NjAxMjQtMjQzYy03Zjc2LTk0
+        ZmMtZGM4OGJhODQyYTM2Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1
+        NjIxNy1mYzllLTc0Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
+  recorded_at: Fri, 04 Apr 2025 14:11:15 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4308,7 +4308,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -4321,7 +4321,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:29 GMT
+      - Fri, 04 Apr 2025 14:11:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4333,7 +4333,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '659'
+      - '657'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -4341,33 +4341,33 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 90808bf580504f7a9286cb00e30ae802
+      - 3fd2a8a5647647eca2ae371d90e28475
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMTkzMjUzYS02MGU5LTc0ZmQtYmE1NC03ODQ4N2IyYzJl
-        NDAvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTkzMjUz
-        YS02MGU5LTc0ZmQtYmE1NC03ODQ4N2IyYzJlNDAiLCJwdWxwX2NyZWF0ZWQi
-        OiIyMDI0LTExLTEzVDExOjEzOjIzLjE3ODQ1MFoiLCJwdWxwX2xhc3RfdXBk
-        YXRlZCI6IjIwMjQtMTEtMTNUMTE6MTM6MjcuODk5NjExWiIsImJhc2VfcGF0
+        L2ZpbGUvZmlsZS8wMTk2MDEyNC0yODkwLTc1MzktODljMC1kM2Y1OGUzNTkw
+        YWMvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk2MDEy
+        NC0yODkwLTc1MzktODljMC1kM2Y1OGUzNTkwYWMiLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDI1LTA0LTA0VDE0OjExOjA5LjA3NDAwOFoiLCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjUtMDQtMDRUMTQ6MTE6MTMuNTc2MjE1WiIsImJhc2VfcGF0
         aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8x
-        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5k
-        aWNlcm9zMjAyMy5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9P
-        cmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19GaWxlXzEvIiwiY29udGVudF9n
-        dWFyZCI6bnVsbCwibm9fY29udGVudF9jaGFuZ2Vfc2luY2UiOm51bGwsImhp
-        ZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IkRlZmF1bHRf
-        T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwicmVwb3NpdG9y
-        eSI6bnVsbCwicHVibGljYXRpb24iOm51bGx9XX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:29 GMT
+        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5t
+        YW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3Vh
+        cmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjpudWxsLCJoaWRk
+        ZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09y
+        Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnki
+        Om51bGwsInB1YmxpY2F0aW9uIjpudWxsfV19
+  recorded_at: Fri, 04 Apr 2025 14:11:15 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193253a-60e9-74fd-ba54-78487b2c2e40/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/01960124-2890-7539-89c0-d3f58e3590ac/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4375,7 +4375,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -4388,7 +4388,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:29 GMT
+      - Fri, 04 Apr 2025 14:11:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4408,20 +4408,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 462ac5dd2aa248b68729d11fc07a8805
+      - f4f5c490b9fe4d41b812081ee05fc0fd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTdiMTAtNzcx
-        OS1iNjczLWUzZDI4NTVjMDlhZS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:29 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTQxMjgtNzEy
+        ZS1hYWY4LTA3MmJkNGExODY4MC8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:15 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4429,7 +4429,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -4442,7 +4442,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:29 GMT
+      - Fri, 04 Apr 2025 14:11:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4462,20 +4462,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 66f360ab9dca4afba091446d95f23c88
+      - 9c3bbe7293c048449c5e54b80d090caa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:29 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:15 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-7b10-7719-b673-e3d2855c09ae/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-4128-712e-aaf8-072bd4a18680/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4483,7 +4483,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -4496,7 +4496,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:30 GMT
+      - Fri, 04 Apr 2025 14:11:15 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4516,31 +4516,31 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bd800267bb854f27bade7da5e548d689
+      - 324d4871cfdf4c47a86439d2fd885ab2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtN2Ix
-        MC03NzE5LWI2NzMtZTNkMjg1NWMwOWFlLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtN2IxMC03NzE5LWI2NzMtZTNkMjg1NWMwOWFlIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzoyOS44NzMzMTJaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjI5Ljg3MzMyNFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtNDEy
+        OC03MTJlLWFhZjgtMDcyYmQ0YTE4NjgwLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtNDEyOC03MTJlLWFhZjgtMDcyYmQ0YTE4NjgwIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMToxNS4zNjk2MzhaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjE1LjM2OTY1Mloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiNDYyYWM1
-        ZGQyYWEyNDhiNjg3MjlkMTFmYzA3YTg4MDUiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzoyOS44ODU0NDdaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MjkuODg3NDgzWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzoyOS45MDA2NzJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiZjRmNWM0
+        OTBiOWZlNGQ0MWI4MTIwODFlZTA1ZmMwZmQiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMToxNS4zODMzODVaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MTUuMzg2MjYyWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMToxNS40MDE1MDNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJjNTdkLWZiOTUtNzkxOC04N2U0LTlkZTViMTVhYjUzNjpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyYzU3ZC1mYjk1LTc5
-        MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:30 GMT
+        OTU2MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRp
+        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0
+        Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
+  recorded_at: Fri, 04 Apr 2025 14:11:15 GMT
 recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/repository_orphan/orphan_repository_versions.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/repository_orphan/orphan_repository_versions.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:30 GMT
+      - Fri, 04 Apr 2025 14:10:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,20 +43,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 15052c61dc894381853f6436b5e1f392
+      - 62ce3212c49d475f995aad4a64a07014
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:30 GMT
+  recorded_at: Fri, 04 Apr 2025 14:10:59 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:30 GMT
+      - Fri, 04 Apr 2025 14:10:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,20 +97,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bf60d248955a4503927657a9a156017b
+      - 709bbe69aac54906bd5d6b9ece537a2a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:30 GMT
+  recorded_at: Fri, 04 Apr 2025 14:10:59 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -118,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:30 GMT
+      - Fri, 04 Apr 2025 14:10:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,20 +151,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4b91f566a56d4666b02052ff5fdc5d1b
+      - 8c7a5a913b554ed987890aae5b00dc80
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:30 GMT
+  recorded_at: Fri, 04 Apr 2025 14:10:59 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -172,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:30 GMT
+      - Fri, 04 Apr 2025 14:10:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,20 +205,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 902edff77eda47049909bd5c52b44fb4
+      - 102b35869c724c509550c89649a19651
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:30 GMT
+  recorded_at: Fri, 04 Apr 2025 14:10:59 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -226,7 +226,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -239,7 +239,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:30 GMT
+      - Fri, 04 Apr 2025 14:10:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -259,20 +259,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0e79769de23f4256933440c719029849
+      - 639604204e8040bd87e0a166a2289535
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:30 GMT
+  recorded_at: Fri, 04 Apr 2025 14:10:59 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -280,7 +280,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -293,7 +293,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:30 GMT
+      - Fri, 04 Apr 2025 14:10:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -313,20 +313,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 62d0cd458231477591dce4013413de3f
+      - 79fc74ad7e464fb09ee6e7d880f4e767
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:30 GMT
+  recorded_at: Fri, 04 Apr 2025 14:10:59 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -334,7 +334,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -347,7 +347,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:30 GMT
+      - Fri, 04 Apr 2025 14:10:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -367,20 +367,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 61089af60c3e4ac4acdf8d85a5d5228d
+      - 488746d955234446a589b9fb4ac21428
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:30 GMT
+  recorded_at: Fri, 04 Apr 2025 14:10:59 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -388,7 +388,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -401,7 +401,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:30 GMT
+      - Fri, 04 Apr 2025 14:10:59 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -421,20 +421,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2288b25fb87b43148ef6d8fb8514c1f8
+      - 7df5ee7ea5fd4fa58602cc87dea80aad
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:30 GMT
+  recorded_at: Fri, 04 Apr 2025 14:10:59 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -452,7 +452,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -465,13 +465,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:30 GMT
+      - Fri, 04 Apr 2025 14:10:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/0193253a-7f66-7be5-bf7f-5709dd719c14/"
+      - "/pulp/api/v3/remotes/file/file/01960124-0380-7769-98b4-b1803b02157d/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -487,20 +487,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a7de9f7bed1b45428123ad620d466272
+      - 7c5108fc6c1c429eb517f0e389157626
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE5MzI1M2EtN2Y2Ni03YmU1LWJmN2YtNTcwOWRkNzE5YzE0LyIsInBybiI6
-        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5MzI1M2EtN2Y2Ni03YmU1LWJmN2Yt
-        NTcwOWRkNzE5YzE0IiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMTox
-        MzozMC45ODI0MTNaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEz
-        VDExOjEzOjMwLjk4MjQyNVoiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        MDE5NjAxMjQtMDM4MC03NzY5LTk4YjQtYjE4MDNiMDIxNTdkLyIsInBybiI6
+        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NjAxMjQtMDM4MC03NzY5LTk4YjQt
+        YjE4MDNiMDIxNTdkIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDox
+        MDo1OS41ODQ2MzRaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0
+        VDE0OjEwOjU5LjU4NDY0N1oiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
         b24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJ1cmwiOiJodHRwczovL2ZpeHR1
         cmVzLnB1bHBwcm9qZWN0Lm9yZy9maWxlMi8vUFVMUF9NQU5JRkVTVCIsImNh
         X2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlv
@@ -514,10 +514,10 @@ http_interactions:
         YW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicHJveHlfcGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJ1c2VybmFtZSIsImlzX3NldCI6
         ZmFsc2V9LHsibmFtZSI6InBhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX1dfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:30 GMT
+  recorded_at: Fri, 04 Apr 2025 14:10:59 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -527,7 +527,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -540,13 +540,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:31 GMT
+      - Fri, 04 Apr 2025 14:10:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/0193253a-7fda-7f73-9efa-23dbdbdf184d/"
+      - "/pulp/api/v3/repositories/file/file/01960124-041e-7c4f-ac9b-09dcbf0e4872/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -562,33 +562,33 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 558cb6b69271436695279efcaba20542
+      - 1db85b719788421c83559c45d911dfa0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMTkzMjUzYS03ZmRhLTdmNzMtOWVmYS0yM2RiZGJkZjE4NGQvIiwi
-        cHJuIjoicHJuOmZpbGUuZmlsZXJlcG9zaXRvcnk6MDE5MzI1M2EtN2ZkYS03
-        ZjczLTllZmEtMjNkYmRiZGYxODRkIiwicHVscF9jcmVhdGVkIjoiMjAyNC0x
-        MS0xM1QxMToxMzozMS4wOTg3MzRaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIy
-        MDI0LTExLTEzVDExOjEzOjMxLjEwMzU3N1oiLCJ2ZXJzaW9uc19ocmVmIjoi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1M2Et
-        N2ZkYS03ZjczLTllZmEtMjNkYmRiZGYxODRkL3ZlcnNpb25zLyIsInB1bHBf
+        ZmlsZS8wMTk2MDEyNC0wNDFlLTdjNGYtYWM5Yi0wOWRjYmYwZTQ4NzIvIiwi
+        cHJuIjoicHJuOmZpbGUuZmlsZXJlcG9zaXRvcnk6MDE5NjAxMjQtMDQxZS03
+        YzRmLWFjOWItMDlkY2JmMGU0ODcyIiwicHVscF9jcmVhdGVkIjoiMjAyNS0w
+        NC0wNFQxNDoxMDo1OS43NDMwNjdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIy
+        MDI1LTA0LTA0VDE0OjEwOjU5Ljc0OTE3OVoiLCJ2ZXJzaW9uc19ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NjAxMjQt
+        MDQxZS03YzRmLWFjOWItMDlkY2JmMGU0ODcyL3ZlcnNpb25zLyIsInB1bHBf
         bGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTMyNTNhLTdmZGEtN2Y3My05
-        ZWZhLTIzZGJkYmRmMTg0ZC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTYwMTI0LTA0MWUtN2M0Zi1h
+        YzliLTA5ZGNiZjBlNDg3Mi92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0
         X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIsImRlc2NyaXB0
         aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3Rl
         IjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1hbmlmZXN0IjoiUFVMUF9N
         QU5JRkVTVCJ9
-  recorded_at: Wed, 13 Nov 2024 11:13:31 GMT
+  recorded_at: Fri, 04 Apr 2025 14:10:59 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -605,7 +605,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -618,13 +618,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:31 GMT
+      - Fri, 04 Apr 2025 14:10:59 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/0193253a-806c-7301-85cf-70607cd181a6/"
+      - "/pulp/api/v3/remotes/file/file/01960124-04f6-7c37-9522-4b7602760f0b/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -640,20 +640,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 50023ec225204ca1895e412aac2f3192
+      - 374fe2aff34b46ee9452257ed8342c25
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE5MzI1M2EtODA2Yy03MzAxLTg1Y2YtNzA2MDdjZDE4MWE2LyIsInBybiI6
-        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5MzI1M2EtODA2Yy03MzAxLTg1Y2Yt
-        NzA2MDdjZDE4MWE2IiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMTox
-        MzozMS4yNDQ2MjJaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEz
-        VDExOjEzOjMxLjI0NDYzMloiLCJuYW1lIjoidGVzdF9yZW1vdGVfbmFtZSIs
+        MDE5NjAxMjQtMDRmNi03YzM3LTk1MjItNGI3NjAyNzYwZjBiLyIsInBybiI6
+        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NjAxMjQtMDRmNi03YzM3LTk1MjIt
+        NGI3NjAyNzYwZjBiIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDox
+        MDo1OS45NTkxNDBaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0
+        VDE0OjEwOjU5Ljk1OTE2NVoiLCJuYW1lIjoidGVzdF9yZW1vdGVfbmFtZSIs
         InVybCI6Imh0dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL2ZpbGUy
         Ly9QVUxQX01BTklGRVNUIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQi
         Om51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGws
@@ -667,10 +667,10 @@ http_interactions:
         bWUiOiJwcm94eV9wYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6
         InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfV19
-  recorded_at: Wed, 13 Nov 2024 11:13:31 GMT
+  recorded_at: Fri, 04 Apr 2025 14:10:59 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193253a-806c-7301-85cf-70607cd181a6/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/01960124-04f6-7c37-9522-4b7602760f0b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -678,7 +678,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -691,7 +691,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:31 GMT
+      - Fri, 04 Apr 2025 14:11:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -711,20 +711,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ac19e784c347438a85ec202957f554e7
+      - bee3523be0a14f63b1c0da1d8c8d2ac8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTgwOWQtNzk2
-        My05OGM2LTkwZWQwNTRhOWFiMy8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:31 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTA1NDMtNzU2
+        Yi1hNDViLTZjY2QwOTc3YTRlZS8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:00 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193253a-7fda-7f73-9efa-23dbdbdf184d/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/01960124-041e-7c4f-ac9b-09dcbf0e4872/
     body:
       encoding: UTF-8
       base64_string: |
@@ -734,7 +734,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -747,7 +747,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:31 GMT
+      - Fri, 04 Apr 2025 14:11:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -767,20 +767,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fb5a9eb0b64e4ea382c54c1ce2d63d2b
+      - 3cfcbfdde6ed45aca05ba6e891742d87
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTgxMzktN2Y3
-        ZC05ZTNkLWY5ZDA0NjI3ZGQxMS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:31 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTA2MDQtN2Nk
+        Yy1hNWZmLWE5MjRlNWNjZTY5ZC8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:00 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193253a-7f66-7be5-bf7f-5709dd719c14/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/01960124-0380-7769-98b4-b1803b02157d/
     body:
       encoding: UTF-8
       base64_string: |
@@ -798,7 +798,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -811,7 +811,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:31 GMT
+      - Fri, 04 Apr 2025 14:11:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -831,20 +831,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4e76769b83fa486badf689669da169bf
+      - 0532f69c18374015aecdc60062b1d7ba
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTgxYTEtNzg3
-        NS1hMmQzLTQ0ZDZhN2ZlYWIyZS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:31 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTA2N2UtN2Yz
+        Ny05NmUzLTA0Mzc2NGYwYmFmYi8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:00 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-81a1-7875-a2d3-44d6a7feab2e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-067e-7f37-96e3-043764f0bafb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -852,7 +852,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -865,7 +865,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:31 GMT
+      - Fri, 04 Apr 2025 14:11:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -885,36 +885,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 225202b0f21b43bb804b715b7a0b5046
+      - 870a972deec44952ba26981f69ffa475
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtODFh
-        MS03ODc1LWEyZDMtNDRkNmE3ZmVhYjJlLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtODFhMS03ODc1LWEyZDMtNDRkNmE3ZmVhYjJlIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzozMS41NTUyMTlaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjMxLjU1NTI0N1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMDY3
+        ZS03ZjM3LTk2ZTMtMDQzNzY0ZjBiYWZiLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMDY3ZS03ZjM3LTk2ZTMtMDQzNzY0ZjBiYWZiIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowMC4zNTE0MzJaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjAwLjM1MTQ0Nloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiNGU3Njc2
-        OWI4M2ZhNDg2YmFkZjY4OTY2OWRhMTY5YmYiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzozMS41NzE5MjFaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MzEuNTc0NzgzWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzozMS41ODQ1NDZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiMDUzMmY2
+        OWMxODM3NDAxNWFlY2RjNjAwNjJiMWQ3YmEiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMTowMC4zNjgwNDdaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MDAuMzcwNjEzWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMTowMC4zODA5NTFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46Zmls
-        ZS5maWxlcmVtb3RlOjAxOTMyNTNhLTdmNjYtN2JlNS1iZjdmLTU3MDlkZDcx
-        OWMxNCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmM1N2QtZmI5NS03
-        OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 11:13:31 GMT
+        ZS5maWxlcmVtb3RlOjAxOTYwMTI0LTAzODAtNzc2OS05OGI0LWIxODAzYjAy
+        MTU3ZCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5NTYyMTctZmM5ZS03
+        NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Fri, 04 Apr 2025 14:11:00 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -922,7 +922,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -935,7 +935,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:31 GMT
+      - Fri, 04 Apr 2025 14:11:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -955,20 +955,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b2628cab9d5045bd9f4c72dafb3eaa23
+      - a911103039ed48deade067739cc809a6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:31 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:00 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -980,7 +980,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -993,7 +993,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:31 GMT
+      - Fri, 04 Apr 2025 14:11:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1013,20 +1013,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4dfe2f291ab7409fb83f32e99d18ef97
+      - 4a41570db4f54ae3b1f66ee811631494
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTgyN2QtN2Ri
-        ZS04YWZiLWY2NGZhMzQ4NDBhNS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:31 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTA3NjctNzdh
+        My1hMDgyLWFlMGE0OTRiYTMyNS8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:00 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-827d-7dbe-8afb-f64fa34840a5/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-0767-77a3-a082-ae0a494ba325/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1034,7 +1034,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1047,7 +1047,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:31 GMT
+      - Fri, 04 Apr 2025 14:11:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1067,39 +1067,39 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c34a84617ad54c999e1c887628fd0859
+      - 2d17a8969a9f44428c9b89eee946bd73
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtODI3
-        ZC03ZGJlLThhZmItZjY0ZmEzNDg0MGE1LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtODI3ZC03ZGJlLThhZmItZjY0ZmEzNDg0MGE1IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzozMS43NzQyNDVaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjMxLjc3NDI1N1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMDc2
+        Ny03N2EzLWEwODItYWUwYTQ5NGJhMzI1LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMDc2Ny03N2EzLWEwODItYWUwYTQ5NGJhMzI1IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowMC41ODM5NDFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjAwLjU4Mzk1NFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiNGRmZTJm
-        MjkxYWI3NDA5ZmI4M2YzMmU5OWQxOGVmOTciLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzozMS43ODg3MjRaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MzEuODIzNjQ2WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzozMS44ODE0NzlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTMyNTIzLTkwMWUtN2ZiMC05ZTA3LTljZGY0
-        ZDJiMWNhMC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiNGE0MTU3
+        MGRiNGY1NGFlM2IxZjY2ZWU4MTE2MzE0OTQiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMTowMC41OTk2NDhaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MDAuNjYyNDk5WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMTowMC43MjYzMjdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOTVmZDg0LTc1ZWQtNzU0MS04MWEzLWE3NzVm
+        NTVkZTM2OC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
-        ZmlsZS9maWxlLzAxOTMyNTNhLTgyZDktN2JkZC1iZmE1LTc4YWQ4ZjBkZTc1
-        ZS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAxOTJj
-        NTdkLWZiOTUtNzkxOC04N2U0LTlkZTViMTVhYjUzNjpkaXN0cmlidXRpb25z
-        Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyYzU3ZC1mYjk1LTc5MTgt
-        ODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:31 GMT
+        ZmlsZS9maWxlLzAxOTYwMTI0LTA3ZTItNzI3Ni1iY2VhLTI0ZWFhZjYxOGQ2
+        MC8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAxOTU2
+        MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRpb25z
+        Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0Y2Yt
+        OTAyNC1lODAzNDY3ZmU0ZDAiXX0=
+  recorded_at: Fri, 04 Apr 2025 14:11:00 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193253a-82d9-7bdd-bfa5-78ad8f0de75e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/01960124-07e2-7276-bcea-24eaaf618d60/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1107,7 +1107,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1120,7 +1120,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:31 GMT
+      - Fri, 04 Apr 2025 14:11:00 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1132,7 +1132,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '607'
+      - '605'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1140,32 +1140,32 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d682321eddeb4c14af6531b358aae63c
+      - 78026af9c2224b81aef465cacb6d07c5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
-        L2ZpbGUvMDE5MzI1M2EtODJkOS03YmRkLWJmYTUtNzhhZDhmMGRlNzVlLyIs
-        InBybiI6InBybjpmaWxlLmZpbGVkaXN0cmlidXRpb246MDE5MzI1M2EtODJk
-        OS03YmRkLWJmYTUtNzhhZDhmMGRlNzVlIiwicHVscF9jcmVhdGVkIjoiMjAy
-        NC0xMS0xM1QxMToxMzozMS44NjY3MzBaIiwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDI0LTExLTEzVDExOjEzOjMxLjg2Njc0NVoiLCJiYXNlX3BhdGgiOiJE
+        L2ZpbGUvMDE5NjAxMjQtMDdlMi03Mjc2LWJjZWEtMjRlYWFmNjE4ZDYwLyIs
+        InBybiI6InBybjpmaWxlLmZpbGVkaXN0cmlidXRpb246MDE5NjAxMjQtMDdl
+        Mi03Mjc2LWJjZWEtMjRlYWFmNjE4ZDYwIiwicHVscF9jcmVhdGVkIjoiMjAy
+        NS0wNC0wNFQxNDoxMTowMC43MDc5MzNaIiwicHVscF9sYXN0X3VwZGF0ZWQi
+        OiIyMDI1LTA0LTA0VDE0OjExOjAwLjcwNzk1MVoiLCJiYXNlX3BhdGgiOiJE
         ZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsImJh
-        c2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwuZGljZXJv
-        czIwMjMuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5p
-        emF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3VhcmQi
-        Om51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjpudWxsLCJoaWRkZW4i
-        OmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
-        aXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnkiOm51
-        bGwsInB1YmxpY2F0aW9uIjpudWxsfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:31 GMT
+        c2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwubWFuaWNv
+        dHRvLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2FuaXph
+        dGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMS8iLCJjb250ZW50X2d1YXJkIjpu
+        dWxsLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6bnVsbCwiaGlkZGVuIjpm
+        YWxzZSwicHVscF9sYWJlbHMiOnt9LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJyZXBvc2l0b3J5IjpudWxs
+        LCJwdWJsaWNhdGlvbiI6bnVsbH0=
+  recorded_at: Fri, 04 Apr 2025 14:11:00 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193253a-7f66-7be5-bf7f-5709dd719c14/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/01960124-0380-7769-98b4-b1803b02157d/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1183,7 +1183,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1196,7 +1196,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:32 GMT
+      - Fri, 04 Apr 2025 14:11:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1216,20 +1216,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ad6903e7d60848f4964827a236df3655
+      - afe7fbf54ad84485a93fe5f86722fcf0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTg0OWEtN2I2
-        YS04ZjgyLWJkYzFjYjZlMmEzOC8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:32 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTA5OWMtNzlm
+        Yy1hOTE5LWQzYmYxZTczNzk2Yy8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:01 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-849a-7b6a-8f82-bdc1cb6e2a38/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-099c-79fc-a919-d3bf1e73796c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1237,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1250,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:32 GMT
+      - Fri, 04 Apr 2025 14:11:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1270,47 +1270,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0f6ab6fce4474609b6f2a1cbfd4bcab7
+      - d401ff6163b84b128b68e90c40fe2439
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtODQ5
-        YS03YjZhLThmODItYmRjMWNiNmUyYTM4LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtODQ5YS03YjZhLThmODItYmRjMWNiNmUyYTM4IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzozMi4zMTUxNzNaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjMyLjMxNTE4Mloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMDk5
+        Yy03OWZjLWE5MTktZDNiZjFlNzM3OTZjLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMDk5Yy03OWZjLWE5MTktZDNiZjFlNzM3OTZjIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowMS4xNDg4NzhaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjAxLjE0ODg5MVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYWQ2OTAz
-        ZTdkNjA4NDhmNDk2NDgyN2EyMzZkZjM2NTUiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzozMi4zMjQ2NTFaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MzIuMzI3NjkwWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzozMi4zMzc0NThaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYWZlN2Zi
+        ZjU0YWQ4NDQ4NWE5M2ZlNWY4NjcyMmZjZjAiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMTowMS4xNjM1MjhaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MDEuMTY4MTA1WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMTowMS4xNzg5MzVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46Zmls
-        ZS5maWxlcmVtb3RlOjAxOTMyNTNhLTdmNjYtN2JlNS1iZjdmLTU3MDlkZDcx
-        OWMxNCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmM1N2QtZmI5NS03
-        OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 11:13:32 GMT
+        ZS5maWxlcmVtb3RlOjAxOTYwMTI0LTAzODAtNzc2OS05OGI0LWIxODAzYjAy
+        MTU3ZCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5NTYyMTctZmM5ZS03
+        NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Fri, 04 Apr 2025 14:11:01 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193253a-7fda-7f73-9efa-23dbdbdf184d/sync/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/01960124-041e-7c4f-ac9b-09dcbf0e4872/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE5
-        MzI1M2EtN2Y2Ni03YmU1LWJmN2YtNTcwOWRkNzE5YzE0LyIsIm1pcnJvciI6
+        NjAxMjQtMDM4MC03NzY5LTk4YjQtYjE4MDNiMDIxNTdkLyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1323,7 +1323,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:32 GMT
+      - Fri, 04 Apr 2025 14:11:01 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1343,20 +1343,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3f23933a67674c979050f23181740500
+      - 4109e18ff5574effb78daad8c1d8cb36
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTg1MWQtN2Mz
-        Yi05NjMwLTRhMjdmY2MzNTBhMS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:32 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTBhNTctNzE0
+        Mi04YmYxLTYwYzEyNDZjYTVlYy8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:01 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-851d-7c3b-9630-4a27fcc350a1/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-0a57-7142-8bf1-60c1246ca5ec/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1364,7 +1364,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1377,7 +1377,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:33 GMT
+      - Fri, 04 Apr 2025 14:11:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1397,28 +1397,28 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '058a42c9958146cea7cc6e5506253485'
+      - 201eab73c2954130af96965fb9f26c91
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtODUx
-        ZC03YzNiLTk2MzAtNGEyN2ZjYzM1MGExLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtODUxZC03YzNiLTk2MzAtNGEyN2ZjYzM1MGExIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzozMi40NDYyMDJaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjMyLjQ0NjIxMloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMGE1
+        Ny03MTQyLThiZjEtNjBjMTI0NmNhNWVjLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMGE1Ny03MTQyLThiZjEtNjBjMTI0NmNhNWVjIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowMS4zMzU5MzJaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjAxLjMzNTk0Nloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX2ZpbGUuYXBwLnRh
         c2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25pemUiLCJsb2dnaW5nX2NpZCI6
-        IjNmMjM5MzNhNjc2NzRjOTc5MDUwZjIzMTgxNzQwNTAwIiwiY3JlYXRlZF9i
+        IjQxMDllMThmZjU1NzRlZmZiNzhkYWFkOGMxZDhjYjM2IiwiY3JlYXRlZF9i
         eSI6Ii9wdWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIw
-        MjQtMTEtMTNUMTE6MTM6MzIuNDU1OTUyWiIsInN0YXJ0ZWRfYXQiOiIyMDI0
-        LTExLTEzVDExOjEzOjMyLjQ4NTgzOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQt
-        MTEtMTNUMTE6MTM6MzMuMjM1MDA2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
-        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTkzMjUyMy05MDFlLTdmYjAtOWUw
-        Ny05Y2RmNGQyYjFjYTAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
+        MjUtMDQtMDRUMTQ6MTE6MDEuMzQ5MjE5WiIsInN0YXJ0ZWRfYXQiOiIyMDI1
+        LTA0LTA0VDE0OjExOjAxLjQwNDg3N1oiLCJmaW5pc2hlZF9hdCI6IjIwMjUt
+        MDQtMDRUMTQ6MTE6MDEuOTk1OTg5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTk1ZmQ4NC03NWI1LTcxYTMtYTNk
+        Yi0xYWQxZTI5NzJjMDcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
         c2tzIjpbXSwidGFza19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6
         W3sibWVzc2FnZSI6IkRvd25sb2FkaW5nIE1ldGFkYXRhIiwiY29kZSI6InN5
         bmMuZG93bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
@@ -1435,18 +1435,18 @@ http_interactions:
         ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9y
         ZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2Zp
-        bGUvMDE5MzI1M2EtN2ZkYS03ZjczLTllZmEtMjNkYmRiZGYxODRkL3ZlcnNp
+        bGUvMDE5NjAxMjQtMDQxZS03YzRmLWFjOWItMDlkY2JmMGU0ODcyL3ZlcnNp
         b25zLzEvIiwiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUv
-        MDE5MzI1M2EtODgxMS03N2IyLTk3OWQtNGI3NDFkMjQ4ZTdjLyJdLCJyZXNl
+        MDE5NjAxMjQtMGNiOS03NzA2LTgzMmQtNzlkYWYwYWUyYjQ5LyJdLCJyZXNl
         cnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpmaWxlLmZpbGVyZXBvc2l0
-        b3J5OjAxOTMyNTNhLTdmZGEtN2Y3My05ZWZhLTIzZGJkYmRmMTg0ZCIsInNo
-        YXJlZDpwcm46ZmlsZS5maWxlcmVtb3RlOjAxOTMyNTNhLTdmNjYtN2JlNS1i
-        ZjdmLTU3MDlkZDcxOWMxNCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5
-        MmM1N2QtZmI5NS03OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 11:13:33 GMT
+        b3J5OjAxOTYwMTI0LTA0MWUtN2M0Zi1hYzliLTA5ZGNiZjBlNDg3MiIsInNo
+        YXJlZDpwcm46ZmlsZS5maWxlcmVtb3RlOjAxOTYwMTI0LTAzODAtNzc2OS05
+        OGI0LWIxODAzYjAyMTU3ZCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5
+        NTYyMTctZmM5ZS03NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Fri, 04 Apr 2025 14:11:02 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1454,7 +1454,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1467,7 +1467,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:33 GMT
+      - Fri, 04 Apr 2025 14:11:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1479,7 +1479,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '659'
+      - '657'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1487,45 +1487,45 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 70d5e9f3887e4f26bc0cb5511b0dd629
+      - d84a99f3dcf44f3ba3c8d4a21eb0cd56
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMTkzMjUzYS04MmQ5LTdiZGQtYmZhNS03OGFkOGYwZGU3
-        NWUvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTkzMjUz
-        YS04MmQ5LTdiZGQtYmZhNS03OGFkOGYwZGU3NWUiLCJwdWxwX2NyZWF0ZWQi
-        OiIyMDI0LTExLTEzVDExOjEzOjMxLjg2NjczMFoiLCJwdWxwX2xhc3RfdXBk
-        YXRlZCI6IjIwMjQtMTEtMTNUMTE6MTM6MzEuODY2NzQ1WiIsImJhc2VfcGF0
+        L2ZpbGUvZmlsZS8wMTk2MDEyNC0wN2UyLTcyNzYtYmNlYS0yNGVhYWY2MThk
+        NjAvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk2MDEy
+        NC0wN2UyLTcyNzYtYmNlYS0yNGVhYWY2MThkNjAiLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDI1LTA0LTA0VDE0OjExOjAwLjcwNzkzM1oiLCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjUtMDQtMDRUMTQ6MTE6MDAuNzA3OTUxWiIsImJhc2VfcGF0
         aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8x
-        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5k
-        aWNlcm9zMjAyMy5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9P
-        cmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19GaWxlXzEvIiwiY29udGVudF9n
-        dWFyZCI6bnVsbCwibm9fY29udGVudF9jaGFuZ2Vfc2luY2UiOm51bGwsImhp
-        ZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IkRlZmF1bHRf
-        T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwicmVwb3NpdG9y
-        eSI6bnVsbCwicHVibGljYXRpb24iOm51bGx9XX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:33 GMT
+        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5t
+        YW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3Vh
+        cmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjpudWxsLCJoaWRk
+        ZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09y
+        Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnki
+        Om51bGwsInB1YmxpY2F0aW9uIjpudWxsfV19
+  recorded_at: Fri, 04 Apr 2025 14:11:02 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193253a-82d9-7bdd-bfa5-78ad8f0de75e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/01960124-07e2-7276-bcea-24eaaf618d60/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtODgxMS03N2IyLTk3OWQtNGI3NDFkMjQ4ZTdjLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NjAx
+        MjQtMGNiOS03NzA2LTgzMmQtNzlkYWYwYWUyYjQ5LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1538,7 +1538,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:33 GMT
+      - Fri, 04 Apr 2025 14:11:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1558,20 +1558,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f9eb2581644e440da3369057bbfc76bb
+      - 7644e898e42f4ca5bed34f3df383fcc4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTg4ZmEtNzJm
-        MC1hNjEyLWNiYmZlNTkwMzhhNi8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:33 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTBlMWItNzkx
+        Ny05M2Q4LThmOWJmODhkOTk2NS8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:02 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-88fa-72f0-a612-cbbfe59038a6/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-0e1b-7917-93d8-8f9bf88d9965/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1579,7 +1579,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1592,7 +1592,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:33 GMT
+      - Fri, 04 Apr 2025 14:11:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1612,48 +1612,48 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0c25589de1a94c7bae5a00e59d6c9e26
+      - 874b3b35a12d476b93130e3530baf946
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtODhm
-        YS03MmYwLWE2MTItY2JiZmU1OTAzOGE2LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtODhmYS03MmYwLWE2MTItY2JiZmU1OTAzOGE2IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzozMy40MzQzNTRaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjMzLjQzNDM2NFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMGUx
+        Yi03OTE3LTkzZDgtOGY5YmY4OGQ5OTY1LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMGUxYi03OTE3LTkzZDgtOGY5YmY4OGQ5OTY1IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowMi4yOTk1MTVaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjAyLjI5OTUyN1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiZjllYjI1
-        ODE2NDRlNDQwZGEzMzY5MDU3YmJmYzc2YmIiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzozMy40NDQyMjFaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MzMuNDQ2MjExWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzozMy40NTc1MzhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiNzY0NGU4
+        OThlNDJmNGNhNWJlZDM0ZjNkZjM4M2ZjYzQiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMTowMi4zMTE1NjlaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MDIuMzE0NDU1WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMTowMi4zMzA2MDJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJjNTdkLWZiOTUtNzkxOC04N2U0LTlkZTViMTVhYjUzNjpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyYzU3ZC1mYjk1LTc5
-        MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:33 GMT
+        OTU2MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRp
+        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0
+        Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
+  recorded_at: Fri, 04 Apr 2025 14:11:02 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193253a-82d9-7bdd-bfa5-78ad8f0de75e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/01960124-07e2-7276-bcea-24eaaf618d60/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtODgxMS03N2IyLTk3OWQtNGI3NDFkMjQ4ZTdjLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NjAx
+        MjQtMGNiOS03NzA2LTgzMmQtNzlkYWYwYWUyYjQ5LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1666,7 +1666,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:33 GMT
+      - Fri, 04 Apr 2025 14:11:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1686,20 +1686,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e525f583bf3b40aa8d38dc96e6c96c93
+      - ad50573b72e8435aa49baabbbca06c85
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTg5ODktNzg1
-        MS1hYmJjLTA2NTQ2ZTE4YTRkZS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:33 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTBlZTMtNzNj
+        YS04ZmUxLTU5MjIwNTRlMzQwZS8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:02 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1716,7 +1716,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1729,13 +1729,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:33 GMT
+      - Fri, 04 Apr 2025 14:11:02 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/0193253a-8a24-7745-9f1d-0f5a79dc280f/"
+      - "/pulp/api/v3/remotes/file/file/01960124-0fd3-7233-822e-e449a201cac9/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1751,20 +1751,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9373adacb58e4f33beb6a0015ebecfad
+      - 82a4bf7cf588429da359e8aeda2240c2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE5MzI1M2EtOGEyNC03NzQ1LTlmMWQtMGY1YTc5ZGMyODBmLyIsInBybiI6
-        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5MzI1M2EtOGEyNC03NzQ1LTlmMWQt
-        MGY1YTc5ZGMyODBmIiwicHVscF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMTox
-        MzozMy43MzI4MjNaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEz
-        VDExOjEzOjMzLjczMjgzM1oiLCJuYW1lIjoidGVzdF9yZW1vdGVfbmFtZSIs
+        MDE5NjAxMjQtMGZkMy03MjMzLTgyMmUtZTQ0OWEyMDFjYWM5LyIsInBybiI6
+        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NjAxMjQtMGZkMy03MjMzLTgyMmUt
+        ZTQ0OWEyMDFjYWM5IiwicHVscF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDox
+        MTowMi43MzkzODNaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0
+        VDE0OjExOjAyLjczOTM5OFoiLCJuYW1lIjoidGVzdF9yZW1vdGVfbmFtZSIs
         InVybCI6Imh0dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL2ZpbGUv
         L1BVTFBfTUFOSUZFU1QiLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6
         bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwi
@@ -1778,10 +1778,10 @@ http_interactions:
         ZSI6InByb3h5X3Bhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoi
         dXNlcm5hbWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwYXNzd29yZCIs
         ImlzX3NldCI6ZmFsc2V9XX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:33 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:02 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193253a-8a24-7745-9f1d-0f5a79dc280f/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/01960124-0fd3-7233-822e-e449a201cac9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1789,7 +1789,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1802,7 +1802,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:33 GMT
+      - Fri, 04 Apr 2025 14:11:02 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1822,20 +1822,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d0885ce53df6498a900cd6cb69edb631
+      - 582c81138f3b4ddf86b6e4838b3372b5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLThhNTUtN2Zj
-        MS1iY2UzLWU2ZDNjZjg1MDBlOS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:33 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTEwMjYtNzFh
+        ZC1iZDA3LTNhZjBkYTk4ODc5Yy8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:02 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193253a-7fda-7f73-9efa-23dbdbdf184d/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/01960124-041e-7c4f-ac9b-09dcbf0e4872/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1845,7 +1845,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1858,7 +1858,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:33 GMT
+      - Fri, 04 Apr 2025 14:11:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1878,20 +1878,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 74d2fec6c3cd4a8a84a927f155f74e07
+      - 6ad9890e37124bda90a7c42b3663b144
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLThhZGItNzMw
-        NC1hYzU5LWFmZjFkZjJhOTM0OC8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:33 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTEwZTUtNzZh
+        Yi04YTUxLWUxNTZkMzZjZjlmZi8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:03 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193253a-7f66-7be5-bf7f-5709dd719c14/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/01960124-0380-7769-98b4-b1803b02157d/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1909,7 +1909,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1922,7 +1922,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:34 GMT
+      - Fri, 04 Apr 2025 14:11:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1942,20 +1942,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 03dd33698001441eb4af6983c04ab0d1
+      - b2242d527cec4191ade257a9c0af0e61
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLThiMzItN2Iz
-        Yy1hOTM5LWJiNjdhNGZhNmI4OC8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:34 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTExNWQtN2Jk
+        YS1hOWI3LTk1NzFlMDllYjkyNy8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:03 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-8b32-7b3c-a939-bb67a4fa6b88/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-115d-7bda-a9b7-9571e09eb927/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1963,7 +1963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -1976,7 +1976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:34 GMT
+      - Fri, 04 Apr 2025 14:11:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1996,36 +1996,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 513ca219a6944b80972151c81ed5e24a
+      - f38fc1be977f4b33926a67df8ccb040a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtOGIz
-        Mi03YjNjLWE5MzktYmI2N2E0ZmE2Yjg4LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtOGIzMi03YjNjLWE5MzktYmI2N2E0ZmE2Yjg4IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzozNC4wMDI2OTVaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjM0LjAwMjcwNVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMTE1
+        ZC03YmRhLWE5YjctOTU3MWUwOWViOTI3LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMTE1ZC03YmRhLWE5YjctOTU3MWUwOWViOTI3IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowMy4xMzQxMzlaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjAzLjEzNDE1Mloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiMDNkZDMz
-        Njk4MDAxNDQxZWI0YWY2OTgzYzA0YWIwZDEiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzozNC4wMTM5MzRaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MzQuMDE2MzUwWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzozNC4wMjQ4NjJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYjIyNDJk
+        NTI3Y2VjNDE5MWFkZTI1N2E5YzBhZjBlNjEiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMTowMy4xNDcyMzdaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MDMuMTQ5Nzg0WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMTowMy4xNjA4NzVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46Zmls
-        ZS5maWxlcmVtb3RlOjAxOTMyNTNhLTdmNjYtN2JlNS1iZjdmLTU3MDlkZDcx
-        OWMxNCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmM1N2QtZmI5NS03
-        OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 11:13:34 GMT
+        ZS5maWxlcmVtb3RlOjAxOTYwMTI0LTAzODAtNzc2OS05OGI0LWIxODAzYjAy
+        MTU3ZCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5NTYyMTctZmM5ZS03
+        NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Fri, 04 Apr 2025 14:11:03 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2033,7 +2033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2046,7 +2046,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:34 GMT
+      - Fri, 04 Apr 2025 14:11:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2058,7 +2058,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '755'
+      - '753'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2066,47 +2066,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1ff07119198546c7adb27bcd1c435f09
+      - 0e85775520bb4d3c9e293b30d575e692
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMTkzMjUzYS04MmQ5LTdiZGQtYmZhNS03OGFkOGYwZGU3
-        NWUvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTkzMjUz
-        YS04MmQ5LTdiZGQtYmZhNS03OGFkOGYwZGU3NWUiLCJwdWxwX2NyZWF0ZWQi
-        OiIyMDI0LTExLTEzVDExOjEzOjMxLjg2NjczMFoiLCJwdWxwX2xhc3RfdXBk
-        YXRlZCI6IjIwMjQtMTEtMTNUMTE6MTM6MzMuNTk3ODg3WiIsImJhc2VfcGF0
+        L2ZpbGUvZmlsZS8wMTk2MDEyNC0wN2UyLTcyNzYtYmNlYS0yNGVhYWY2MThk
+        NjAvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk2MDEy
+        NC0wN2UyLTcyNzYtYmNlYS0yNGVhYWY2MThkNjAiLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDI1LTA0LTA0VDE0OjExOjAwLjcwNzkzM1oiLCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjUtMDQtMDRUMTQ6MTE6MDIuNTI2NTczWiIsImJhc2VfcGF0
         aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8x
-        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5k
-        aWNlcm9zMjAyMy5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9P
-        cmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19GaWxlXzEvIiwiY29udGVudF9n
-        dWFyZCI6bnVsbCwibm9fY29udGVudF9jaGFuZ2Vfc2luY2UiOiIyMDI0LTEx
-        LTEzVDExOjEzOjMzLjU5Nzg4N1oiLCJoaWRkZW4iOmZhbHNlLCJwdWxwX2xh
-        YmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0
-        LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtODgxMS03N2IyLTk3OWQtNGI3NDFkMjQ4ZTdjLyJ9XX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:34 GMT
+        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5t
+        YW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3Vh
+        cmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNS0wNC0w
+        NFQxNDoxMTowMi41MjY1NzNaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9sYWJl
+        bHMiOnt9LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1w
+        dWxwM19GaWxlXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6
+        Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOTYwMTI0
+        LTBjYjktNzcwNi04MzJkLTc5ZGFmMGFlMmI0OS8ifV19
+  recorded_at: Fri, 04 Apr 2025 14:11:03 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193253a-82d9-7bdd-bfa5-78ad8f0de75e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/01960124-07e2-7276-bcea-24eaaf618d60/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtODgxMS03N2IyLTk3OWQtNGI3NDFkMjQ4ZTdjLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NjAx
+        MjQtMGNiOS03NzA2LTgzMmQtNzlkYWYwYWUyYjQ5LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2119,7 +2119,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:34 GMT
+      - Fri, 04 Apr 2025 14:11:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2139,20 +2139,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0e9ac664c20943a6b73280f362fee4c1
+      - d24a51458ef449208c85a6650049f68b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLThiZTktN2Zl
-        MC05MjJlLWM0ZWU2YjgwYjI5Mi8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:34 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTEyNWItNzU5
+        Zi1hNjUxLThjNDQxNmM5MzIxNS8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:03 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-8be9-7fe0-922e-c4ee6b80b292/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-125b-759f-a651-8c4416c93215/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2160,7 +2160,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2173,7 +2173,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:34 GMT
+      - Fri, 04 Apr 2025 14:11:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2193,48 +2193,48 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5ec180c1e3d34e8f8d025e78f58836f9
+      - 9788d86b913a4bb8a6d03eb1c76da27b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtOGJl
-        OS03ZmUwLTkyMmUtYzRlZTZiODBiMjkyLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtOGJlOS03ZmUwLTkyMmUtYzRlZTZiODBiMjkyIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzozNC4xODcxNTZaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjM0LjE4NzE2Nloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMTI1
+        Yi03NTlmLWE2NTEtOGM0NDE2YzkzMjE1LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMTI1Yi03NTlmLWE2NTEtOGM0NDE2YzkzMjE1IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowMy4zODgyNzJaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjAzLjM4ODI4N1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiMGU5YWM2
-        NjRjMjA5NDNhNmI3MzI4MGYzNjJmZWU0YzEiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzozNC4xOTc0MjlaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MzQuMTk5MjM5WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzozNC4yMTEzMzFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiZDI0YTUx
+        NDU4ZWY0NDkyMDhjODVhNjY1MDA0OWY2OGIiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMTowMy40MDE4ODZaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MDMuNDA2MTk0WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMTowMy40MjI2MDJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJjNTdkLWZiOTUtNzkxOC04N2U0LTlkZTViMTVhYjUzNjpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyYzU3ZC1mYjk1LTc5
-        MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:34 GMT
+        OTU2MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRp
+        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0
+        Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
+  recorded_at: Fri, 04 Apr 2025 14:11:03 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193253a-82d9-7bdd-bfa5-78ad8f0de75e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/01960124-07e2-7276-bcea-24eaaf618d60/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtODgxMS03N2IyLTk3OWQtNGI3NDFkMjQ4ZTdjLyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NjAx
+        MjQtMGNiOS03NzA2LTgzMmQtNzlkYWYwYWUyYjQ5LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2247,7 +2247,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:34 GMT
+      - Fri, 04 Apr 2025 14:11:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2267,20 +2267,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 235f456085c84b46accf296dcdad9d07
+      - 921128ab2445408ba4f57a5f602a726b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLThjN2ItNzE4
-        ZS1hNzY5LTU1MmE2ODBmNzYwNS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:34 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTEzMzEtNzgx
+        OC05ZDVkLTVhMWM2MmJhM2M1OC8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:03 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193253a-7f66-7be5-bf7f-5709dd719c14/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/01960124-0380-7769-98b4-b1803b02157d/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2298,7 +2298,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2311,7 +2311,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:34 GMT
+      - Fri, 04 Apr 2025 14:11:03 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2331,20 +2331,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4b1887587fe248128fc6d5b5697ab943
+      - 99d9b473a2da423ea885e272c3e79222
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLThkOTUtNzYy
-        Zi04YzFhLTdlMDE0OTVjMzg3Zi8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:34 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTE0YTAtN2E2
+        Mi05ZTQ3LTE0MTM5YTY1ZGExOS8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:04 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-8d95-762f-8c1a-7e01495c387f/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-14a0-7a62-9e47-14139a65da19/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2352,7 +2352,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2365,7 +2365,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:34 GMT
+      - Fri, 04 Apr 2025 14:11:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2385,47 +2385,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f9f3c89d2f1e47fab3fa12075a93ff66
+      - 55269535726a4c86a94ab8b813ea692d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtOGQ5
-        NS03NjJmLThjMWEtN2UwMTQ5NWMzODdmLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtOGQ5NS03NjJmLThjMWEtN2UwMTQ5NWMzODdmIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzozNC42MTM1MzNaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjM0LjYxMzU0Mloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMTRh
+        MC03YTYyLTllNDctMTQxMzlhNjVkYTE5LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMTRhMC03YTYyLTllNDctMTQxMzlhNjVkYTE5IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowMy45Njg1NzlaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjAzLjk2ODU5M1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiNGIxODg3
-        NTg3ZmUyNDgxMjhmYzZkNWI1Njk3YWI5NDMiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzozNC42MjMwMDFaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MzQuNjI1NjkwWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzozNC42MzU3MzBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiOTlkOWI0
+        NzNhMmRhNDIzZWE4ODVlMjcyYzNlNzkyMjIiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMTowMy45ODIyNzRaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MDMuOTg0OTU1WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMTowMy45OTUwNjVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46Zmls
-        ZS5maWxlcmVtb3RlOjAxOTMyNTNhLTdmNjYtN2JlNS1iZjdmLTU3MDlkZDcx
-        OWMxNCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5MmM1N2QtZmI5NS03
-        OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 11:13:34 GMT
+        ZS5maWxlcmVtb3RlOjAxOTYwMTI0LTAzODAtNzc2OS05OGI0LWIxODAzYjAy
+        MTU3ZCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5NTYyMTctZmM5ZS03
+        NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Fri, 04 Apr 2025 14:11:04 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193253a-7fda-7f73-9efa-23dbdbdf184d/sync/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/01960124-041e-7c4f-ac9b-09dcbf0e4872/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE5
-        MzI1M2EtN2Y2Ni03YmU1LWJmN2YtNTcwOWRkNzE5YzE0LyIsIm1pcnJvciI6
+        NjAxMjQtMDM4MC03NzY5LTk4YjQtYjE4MDNiMDIxNTdkLyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2438,7 +2438,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:34 GMT
+      - Fri, 04 Apr 2025 14:11:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2458,20 +2458,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ebedec159dc84e92b706f24b36146914
+      - ca444ce2942c45c0a2c104d16c53713a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLThlMjItN2Nl
-        MC04ZTE2LWMyNzFmZDk5MmVjMS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:34 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTE1NTktNzkw
+        NS1hOWE2LWI3ZTkwN2ZjOTMzNC8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:04 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-8e22-7ce0-8e16-c271fd992ec1/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-1559-7905-a9a6-b7e907fc9334/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2479,7 +2479,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2492,7 +2492,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:35 GMT
+      - Fri, 04 Apr 2025 14:11:04 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2512,28 +2512,28 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fdd961dd2af348a4b3b98d775c9abfec
+      - '0917d62956ca429a810757688277471f'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtOGUy
-        Mi03Y2UwLThlMTYtYzI3MWZkOTkyZWMxLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtOGUyMi03Y2UwLThlMTYtYzI3MWZkOTkyZWMxIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzozNC43NTQ3NThaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjM0Ljc1NDc2N1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMTU1
+        OS03OTA1LWE5YTYtYjdlOTA3ZmM5MzM0LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMTU1OS03OTA1LWE5YTYtYjdlOTA3ZmM5MzM0IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowNC4xNTM2ODdaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjA0LjE1MzcwMFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX2ZpbGUuYXBwLnRh
         c2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25pemUiLCJsb2dnaW5nX2NpZCI6
-        ImViZWRlYzE1OWRjODRlOTJiNzA2ZjI0YjM2MTQ2OTE0IiwiY3JlYXRlZF9i
+        ImNhNDQ0Y2UyOTQyYzQ1YzBhMmMxMDRkMTZjNTM3MTNhIiwiY3JlYXRlZF9i
         eSI6Ii9wdWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIw
-        MjQtMTEtMTNUMTE6MTM6MzQuNzYzNzAxWiIsInN0YXJ0ZWRfYXQiOiIyMDI0
-        LTExLTEzVDExOjEzOjM0Ljc5NTE1MFoiLCJmaW5pc2hlZF9hdCI6IjIwMjQt
-        MTEtMTNUMTE6MTM6MzUuNTgwMzY0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
-        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTkzMjUyMy04ZmVhLTc0MTYtYjkx
-        Ny1hMmQwYTJhYjNkZjcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
+        MjUtMDQtMDRUMTQ6MTE6MDQuMTY4MTgxWiIsInN0YXJ0ZWRfYXQiOiIyMDI1
+        LTA0LTA0VDE0OjExOjA0LjIyMDUzMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjUt
+        MDQtMDRUMTQ6MTE6MDQuNzg4MTI1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTk1ZmQ4NC03NjNhLTdmNTctOTNk
+        ZS01Y2Y5ZmZiYzU3NzcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
         c2tzIjpbXSwidGFza19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6
         W3sibWVzc2FnZSI6IkRvd25sb2FkaW5nIE1ldGFkYXRhIiwiY29kZSI6InN5
         bmMuZG93bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
@@ -2550,18 +2550,18 @@ http_interactions:
         ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9y
         ZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2Zp
-        bGUvMDE5MzI1M2EtN2ZkYS03ZjczLTllZmEtMjNkYmRiZGYxODRkL3ZlcnNp
+        bGUvMDE5NjAxMjQtMDQxZS03YzRmLWFjOWItMDlkY2JmMGU0ODcyL3ZlcnNp
         b25zLzIvIiwiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUv
-        MDE5MzI1M2EtOTEzYS03YzVmLTg3NjMtOWRmMTIwMmFmYzg4LyJdLCJyZXNl
+        MDE5NjAxMjQtMTc5ZS03YjhmLWI4YjUtYjU1OTg2NGMzODUyLyJdLCJyZXNl
         cnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpmaWxlLmZpbGVyZXBvc2l0
-        b3J5OjAxOTMyNTNhLTdmZGEtN2Y3My05ZWZhLTIzZGJkYmRmMTg0ZCIsInNo
-        YXJlZDpwcm46ZmlsZS5maWxlcmVtb3RlOjAxOTMyNTNhLTdmNjYtN2JlNS1i
-        ZjdmLTU3MDlkZDcxOWMxNCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5
-        MmM1N2QtZmI5NS03OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 11:13:35 GMT
+        b3J5OjAxOTYwMTI0LTA0MWUtN2M0Zi1hYzliLTA5ZGNiZjBlNDg3MiIsInNo
+        YXJlZDpwcm46ZmlsZS5maWxlcmVtb3RlOjAxOTYwMTI0LTAzODAtNzc2OS05
+        OGI0LWIxODAzYjAyMTU3ZCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5
+        NTYyMTctZmM5ZS03NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Fri, 04 Apr 2025 14:11:04 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2569,7 +2569,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2582,7 +2582,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:35 GMT
+      - Fri, 04 Apr 2025 14:11:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2594,7 +2594,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '755'
+      - '753'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2602,47 +2602,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e609916f6c704e69ab3a2c1c4a527209
+      - fd00e7e6fac744a48107e90840b62d6b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMTkzMjUzYS04MmQ5LTdiZGQtYmZhNS03OGFkOGYwZGU3
-        NWUvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTkzMjUz
-        YS04MmQ5LTdiZGQtYmZhNS03OGFkOGYwZGU3NWUiLCJwdWxwX2NyZWF0ZWQi
-        OiIyMDI0LTExLTEzVDExOjEzOjMxLjg2NjczMFoiLCJwdWxwX2xhc3RfdXBk
-        YXRlZCI6IjIwMjQtMTEtMTNUMTE6MTM6MzQuMzUzMzU1WiIsImJhc2VfcGF0
+        L2ZpbGUvZmlsZS8wMTk2MDEyNC0wN2UyLTcyNzYtYmNlYS0yNGVhYWY2MThk
+        NjAvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk2MDEy
+        NC0wN2UyLTcyNzYtYmNlYS0yNGVhYWY2MThkNjAiLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDI1LTA0LTA0VDE0OjExOjAwLjcwNzkzM1oiLCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjUtMDQtMDRUMTQ6MTE6MDMuNjMwMTAyWiIsImJhc2VfcGF0
         aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8x
-        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5k
-        aWNlcm9zMjAyMy5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9P
-        cmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19GaWxlXzEvIiwiY29udGVudF9n
-        dWFyZCI6bnVsbCwibm9fY29udGVudF9jaGFuZ2Vfc2luY2UiOiIyMDI0LTEx
-        LTEzVDExOjEzOjM0LjM1MzM1NVoiLCJoaWRkZW4iOmZhbHNlLCJwdWxwX2xh
-        YmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0
-        LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtODgxMS03N2IyLTk3OWQtNGI3NDFkMjQ4ZTdjLyJ9XX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:35 GMT
+        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5t
+        YW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3Vh
+        cmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNS0wNC0w
+        NFQxNDoxMTowMy42MzAxMDJaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9sYWJl
+        bHMiOnt9LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1w
+        dWxwM19GaWxlXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6
+        Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOTYwMTI0
+        LTBjYjktNzcwNi04MzJkLTc5ZGFmMGFlMmI0OS8ifV19
+  recorded_at: Fri, 04 Apr 2025 14:11:05 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193253a-82d9-7bdd-bfa5-78ad8f0de75e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/01960124-07e2-7276-bcea-24eaaf618d60/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtOTEzYS03YzVmLTg3NjMtOWRmMTIwMmFmYzg4LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NjAx
+        MjQtMTc5ZS03YjhmLWI4YjUtYjU1OTg2NGMzODUyLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2655,7 +2655,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:36 GMT
+      - Fri, 04 Apr 2025 14:11:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,20 +2675,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 06ab5fe75a57419eae69e02fb89666dd
+      - 9ec2598eb985418795c1f1746cbed457
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTkyMzgtNzQy
-        Mi1iYTFiLTM0ZjJmMmE4NDlmZi8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:36 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTE5NGEtN2I4
+        My04YzE0LTMwN2FlMWI2MTBhOS8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:05 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-9238-7422-ba1b-34f2f2a849ff/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-194a-7b83-8c14-307ae1b610a9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2696,7 +2696,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2709,7 +2709,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:36 GMT
+      - Fri, 04 Apr 2025 14:11:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2729,48 +2729,48 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cb762c33b3a44b259cb36e708f4ed8f1
+      - f2c04f4111ae478caf6dd297f2a6619b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtOTIz
-        OC03NDIyLWJhMWItMzRmMmYyYTg0OWZmLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtOTIzOC03NDIyLWJhMWItMzRmMmYyYTg0OWZmIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzozNS44MDA2MTFaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjM1LjgwMDYyMVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMTk0
+        YS03YjgzLThjMTQtMzA3YWUxYjYxMGE5LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMTk0YS03YjgzLThjMTQtMzA3YWUxYjYxMGE5IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowNS4xNjI1OTJaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjA1LjE2MjYwN1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiMDZhYjVm
-        ZTc1YTU3NDE5ZWFlNjllMDJmYjg5NjY2ZGQiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzozNS44MTA4NTBaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MzUuODEzMjAxWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzozNi4wMjk5MzZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiOWVjMjU5
+        OGViOTg1NDE4Nzk1YzFmMTc0NmNiZWQ0NTciLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMTowNS4xODA0NzRaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MDUuMTg3MzI5WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMTowNS4yMzU5MjdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJjNTdkLWZiOTUtNzkxOC04N2U0LTlkZTViMTVhYjUzNjpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyYzU3ZC1mYjk1LTc5
-        MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:36 GMT
+        OTU2MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRp
+        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0
+        Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
+  recorded_at: Fri, 04 Apr 2025 14:11:05 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193253a-82d9-7bdd-bfa5-78ad8f0de75e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/01960124-07e2-7276-bcea-24eaaf618d60/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtOTEzYS03YzVmLTg3NjMtOWRmMTIwMmFmYzg4LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NjAx
+        MjQtMTc5ZS03YjhmLWI4YjUtYjU1OTg2NGMzODUyLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2783,7 +2783,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:36 GMT
+      - Fri, 04 Apr 2025 14:11:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2803,20 +2803,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 39103aa321ca4233af80593aea517ad4
+      - cc94d7acca234b3c984ec2756d198bda
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTkzOWEtNzJl
-        My04NGQ4LWQ4YzQ5NWM0MWRiZi8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:36 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTFhNGEtNzc2
+        OC1iODA0LTk5MWY5NGUzZTA1ZS8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:05 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2824,7 +2824,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.22.3/ruby
+      - OpenAPI-Generator/0.22.4/ruby
       Accept:
       - application/json
       Authorization:
@@ -2837,7 +2837,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:36 GMT
+      - Fri, 04 Apr 2025 14:11:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2857,20 +2857,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1158898eab4b419f856c61433e382d85
+      - 793b8cb0a6ed4e1e97dc4517983f5698
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:36 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:05 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2891,7 +2891,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:36 GMT
+      - Fri, 04 Apr 2025 14:11:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2911,20 +2911,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 223af2a78a4f4e33841e08e4618473e8
+      - 70e077ab00ce404cbd4fb8e5342a5ad4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:36 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:05 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2932,7 +2932,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.22.0/ruby
+      - OpenAPI-Generator/2.22.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -2945,7 +2945,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:36 GMT
+      - Fri, 04 Apr 2025 14:11:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2965,20 +2965,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - da83c23c1e134703ae242b499abe77cb
+      - fca3b1b0e5db411e914920abba07ad93
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:36 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:05 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2986,7 +2986,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -2999,7 +2999,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:36 GMT
+      - Fri, 04 Apr 2025 14:11:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3019,34 +3019,34 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3fedec79199c4dcca802220b94fde28f
+      - 176cad4bd1cc4e11a1c8265c68d66485
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTMyNTNhLTdmZGEtN2Y3My05ZWZhLTIzZGJkYmRmMTg0
-        ZC8iLCJwcm4iOiJwcm46ZmlsZS5maWxlcmVwb3NpdG9yeTowMTkzMjUzYS03
-        ZmRhLTdmNzMtOWVmYS0yM2RiZGJkZjE4NGQiLCJwdWxwX2NyZWF0ZWQiOiIy
-        MDI0LTExLTEzVDExOjEzOjMxLjA5ODczNFoiLCJwdWxwX2xhc3RfdXBkYXRl
-        ZCI6IjIwMjQtMTEtMTNUMTE6MTM6MzUuNTMwOTQ0WiIsInZlcnNpb25zX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTkz
-        MjUzYS03ZmRhLTdmNzMtOWVmYS0yM2RiZGJkZjE4NGQvdmVyc2lvbnMvIiwi
+        ZmlsZS9maWxlLzAxOTYwMTI0LTA0MWUtN2M0Zi1hYzliLTA5ZGNiZjBlNDg3
+        Mi8iLCJwcm4iOiJwcm46ZmlsZS5maWxlcmVwb3NpdG9yeTowMTk2MDEyNC0w
+        NDFlLTdjNGYtYWM5Yi0wOWRjYmYwZTQ4NzIiLCJwdWxwX2NyZWF0ZWQiOiIy
+        MDI1LTA0LTA0VDE0OjEwOjU5Ljc0MzA2N1oiLCJwdWxwX2xhc3RfdXBkYXRl
+        ZCI6IjIwMjUtMDQtMDRUMTQ6MTE6MDQuNzIwMzI2WiIsInZlcnNpb25zX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk2
+        MDEyNC0wNDFlLTdjNGYtYWM5Yi0wOWRjYmYwZTQ4NzIvdmVyc2lvbnMvIiwi
         cHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1M2EtN2ZkYS03
-        ZjczLTllZmEtMjNkYmRiZGYxODRkL3ZlcnNpb25zLzIvIiwibmFtZSI6IkRl
+        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NjAxMjQtMDQxZS03
+        YzRmLWFjOWItMDlkY2JmMGU0ODcyL3ZlcnNpb25zLzIvIiwibmFtZSI6IkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwiZGVz
         Y3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJy
         ZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWFuaWZlc3QiOiJQ
         VUxQX01BTklGRVNUIn1dfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:36 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:05 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193253a-7fda-7f73-9efa-23dbdbdf184d/versions/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/01960124-041e-7c4f-ac9b-09dcbf0e4872/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3054,7 +3054,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3067,7 +3067,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:36 GMT
+      - Fri, 04 Apr 2025 14:11:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3087,69 +3087,69 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0af5f0ee63c64ef8876a8cbf8cc9c829
+      - 63782929d2524420ae285f8959be12bb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTMyNTNhLTdmZGEtN2Y3My05ZWZhLTIzZGJkYmRmMTg0
-        ZC92ZXJzaW9ucy8yLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
-        aW9uOjAxOTMyNTNhLThlNTgtN2MxOC04MzFkLWY5ZGI1OTgzOTgyNiIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMTEtMTNUMTE6MTM6MzQuODA4NzQ1WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzozNS41MzI1MDNa
+        ZmlsZS9maWxlLzAxOTYwMTI0LTA0MWUtN2M0Zi1hYzliLTA5ZGNiZjBlNDg3
+        Mi92ZXJzaW9ucy8yLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
+        aW9uOjAxOTYwMTI0LTE1YWEtNzc5Yy1hNmIxLWQzZDBkZWE0NjUwZSIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjUtMDQtMDRUMTQ6MTE6MDQuMjM0ODExWiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowNC43MjI2Mjla
         IiwibnVtYmVyIjoyLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1M2EtN2ZkYS03ZjczLTllZmEtMjNk
-        YmRiZGYxODRkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
+        aXRvcmllcy9maWxlL2ZpbGUvMDE5NjAxMjQtMDQxZS03YzRmLWFjOWItMDlk
+        Y2JmMGU0ODcyLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
         YXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6
         Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlf
         dmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMTkzMjUzYS03ZmRhLTdmNzMtOWVmYS0yM2RiZGJkZjE4NGQvdmVy
+        ZmlsZS8wMTk2MDEyNC0wNDFlLTdjNGYtYWM5Yi0wOWRjYmYwZTQ4NzIvdmVy
         c2lvbnMvMi8ifX0sInJlbW92ZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50Ijoz
         LCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVw
         b3NpdG9yeV92ZXJzaW9uX3JlbW92ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9maWxlL2ZpbGUvMDE5MzI1M2EtN2ZkYS03ZjczLTllZmEtMjNkYmRi
-        ZGYxODRkL3ZlcnNpb25zLzIvIn19LCJwcmVzZW50Ijp7ImZpbGUuZmlsZSI6
+        cmllcy9maWxlL2ZpbGUvMDE5NjAxMjQtMDQxZS03YzRmLWFjOWItMDlkY2Jm
+        MGU0ODcyL3ZlcnNpb25zLzIvIn19LCJwcmVzZW50Ijp7ImZpbGUuZmlsZSI6
         eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
         ZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2ZpbGUvZmlsZS8wMTkzMjUzYS03ZmRhLTdmNzMtOWVmYS0yM2Ri
-        ZGJkZjE4NGQvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTMyNTNhLTdmZGEt
-        N2Y3My05ZWZhLTIzZGJkYmRmMTg0ZC92ZXJzaW9ucy8xLyIsInBybiI6InBy
-        bjpjb3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOTMyNTNhLTg1NTUtNzllMi05
-        OTE4LTY3MDM4Y2ZhMjYyYiIsInB1bHBfY3JlYXRlZCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MzIuNTAxNjU2WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0x
-        MS0xM1QxMToxMzozMy4xOTE1MzlaIiwibnVtYmVyIjoxLCJyZXBvc2l0b3J5
-        IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1
-        M2EtN2ZkYS03ZjczLTllZmEtMjNkYmRiZGYxODRkLyIsImJhc2VfdmVyc2lv
+        dG9yaWVzL2ZpbGUvZmlsZS8wMTk2MDEyNC0wNDFlLTdjNGYtYWM5Yi0wOWRj
+        YmYwZTQ4NzIvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTYwMTI0LTA0MWUt
+        N2M0Zi1hYzliLTA5ZGNiZjBlNDg3Mi92ZXJzaW9ucy8xLyIsInBybiI6InBy
+        bjpjb3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOTYwMTI0LTBhYTktNzY1Mi1i
+        M2NmLTBhNjI0YzZiMWMxYyIsInB1bHBfY3JlYXRlZCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MDEuNDE3OTIzWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0w
+        NC0wNFQxNDoxMTowMS45MzI5NTZaIiwibnVtYmVyIjoxLCJyZXBvc2l0b3J5
+        IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NjAx
+        MjQtMDQxZS03YzRmLWFjOWItMDlkY2JmMGU0ODcyLyIsImJhc2VfdmVyc2lv
         biI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmls
         ZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Zp
         bGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTkzMjUzYS03ZmRhLTdmNzMt
-        OWVmYS0yM2RiZGJkZjE4NGQvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk2MDEyNC0wNDFlLTdjNGYt
+        YWM5Yi0wOWRjYmYwZTQ4NzIvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9
         LCJwcmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9w
         dWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVy
-        c2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTkz
-        MjUzYS03ZmRhLTdmNzMtOWVmYS0yM2RiZGJkZjE4NGQvdmVyc2lvbnMvMS8i
+        c2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk2
+        MDEyNC0wNDFlLTdjNGYtYWM5Yi0wOWRjYmYwZTQ4NzIvdmVyc2lvbnMvMS8i
         fX19fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTMyNTNhLTdmZGEtN2Y3My05ZWZhLTIzZGJkYmRmMTg0
-        ZC92ZXJzaW9ucy8wLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
-        aW9uOjAxOTMyNTNhLTdmZGYtNzkyZi1iN2EyLTRkYjU1NjIyMDkzNiIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjQtMTEtMTNUMTE6MTM6MzEuMTA1MDQwWiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzozMS4xMDUwNDha
+        ZmlsZS9maWxlLzAxOTYwMTI0LTA0MWUtN2M0Zi1hYzliLTA5ZGNiZjBlNDg3
+        Mi92ZXJzaW9ucy8wLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
+        aW9uOjAxOTYwMTI0LTA0MjQtNzE1NC1iOGM2LTdiY2I5NzE2MzY5NyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjUtMDQtMDRUMTQ6MTA6NTkuNzUxMDc3WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMDo1OS43NTEwODVa
         IiwibnVtYmVyIjowLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1M2EtN2ZkYS03ZjczLTllZmEtMjNk
-        YmRiZGYxODRkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
+        aXRvcmllcy9maWxlL2ZpbGUvMDE5NjAxMjQtMDQxZS03YzRmLWFjOWItMDlk
+        Y2JmMGU0ODcyLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
         YXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1d
         fQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:36 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:05 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3157,7 +3157,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.4.4/ruby
+      - OpenAPI-Generator/2.4.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -3170,7 +3170,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:36 GMT
+      - Fri, 04 Apr 2025 14:11:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3190,20 +3190,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 44b01ab20ea1469783c72660275b1995
+      - 91871ecc03d34f12a49cb6634f85ecc6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:36 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:05 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3211,7 +3211,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.12.5/ruby
+      - OpenAPI-Generator/3.12.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -3224,7 +3224,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:36 GMT
+      - Fri, 04 Apr 2025 14:11:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3244,20 +3244,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fcdefb67d73d4b6987e08388c90399f1
+      - 1d6cfd5447464c4fbe0d32ca562a4b83
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:36 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:05 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3278,7 +3278,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:36 GMT
+      - Fri, 04 Apr 2025 14:11:05 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3298,20 +3298,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 382ee117381645edad259dea181aa985
+      - dd1821f25d904a88830560297f7944dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:36 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:06 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3319,7 +3319,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3332,7 +3332,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:36 GMT
+      - Fri, 04 Apr 2025 14:11:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3352,34 +3352,34 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2e0259d7dd0c41d4be7956b3ee862044
+      - ca939a653fd04a00b7197cd7a204f399
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTMyNTNhLTdmZGEtN2Y3My05ZWZhLTIzZGJkYmRmMTg0
-        ZC8iLCJwcm4iOiJwcm46ZmlsZS5maWxlcmVwb3NpdG9yeTowMTkzMjUzYS03
-        ZmRhLTdmNzMtOWVmYS0yM2RiZGJkZjE4NGQiLCJwdWxwX2NyZWF0ZWQiOiIy
-        MDI0LTExLTEzVDExOjEzOjMxLjA5ODczNFoiLCJwdWxwX2xhc3RfdXBkYXRl
-        ZCI6IjIwMjQtMTEtMTNUMTE6MTM6MzUuNTMwOTQ0WiIsInZlcnNpb25zX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTkz
-        MjUzYS03ZmRhLTdmNzMtOWVmYS0yM2RiZGJkZjE4NGQvdmVyc2lvbnMvIiwi
+        ZmlsZS9maWxlLzAxOTYwMTI0LTA0MWUtN2M0Zi1hYzliLTA5ZGNiZjBlNDg3
+        Mi8iLCJwcm4iOiJwcm46ZmlsZS5maWxlcmVwb3NpdG9yeTowMTk2MDEyNC0w
+        NDFlLTdjNGYtYWM5Yi0wOWRjYmYwZTQ4NzIiLCJwdWxwX2NyZWF0ZWQiOiIy
+        MDI1LTA0LTA0VDE0OjEwOjU5Ljc0MzA2N1oiLCJwdWxwX2xhc3RfdXBkYXRl
+        ZCI6IjIwMjUtMDQtMDRUMTQ6MTE6MDQuNzIwMzI2WiIsInZlcnNpb25zX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk2
+        MDEyNC0wNDFlLTdjNGYtYWM5Yi0wOWRjYmYwZTQ4NzIvdmVyc2lvbnMvIiwi
         cHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5MzI1M2EtN2ZkYS03
-        ZjczLTllZmEtMjNkYmRiZGYxODRkL3ZlcnNpb25zLzIvIiwibmFtZSI6IkRl
+        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NjAxMjQtMDQxZS03
+        YzRmLWFjOWItMDlkY2JmMGU0ODcyL3ZlcnNpb25zLzIvIiwibmFtZSI6IkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwiZGVz
         Y3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJy
         ZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWFuaWZlc3QiOiJQ
         VUxQX01BTklGRVNUIn1dfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:36 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:06 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/repositories/file/file/0193253a-7fda-7f73-9efa-23dbdbdf184d/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/01960124-041e-7c4f-ac9b-09dcbf0e4872/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3387,7 +3387,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3400,7 +3400,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:36 GMT
+      - Fri, 04 Apr 2025 14:11:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3420,20 +3420,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0fe8ae5a4b3a49bfaa798ea0075d63e2
+      - 2c6f1961981b476183eefb8c1e7f3d20
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTk2NWUtNzJm
-        ZC05NjM0LThmZTRmMGNiMjlmZS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:36 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTFjZmMtN2Rl
+        OC04Mjk1LTM0MjhkOWQ2ZjA4OS8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:06 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3441,7 +3441,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3454,7 +3454,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:36 GMT
+      - Fri, 04 Apr 2025 14:11:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3474,21 +3474,21 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9a25e5db6cd540a68d38e415400cc56b
+      - ced1c171836048bcab6ac1741993fdb3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUv
-        ZmlsZS8wMTkzMjUzYS03ZjY2LTdiZTUtYmY3Zi01NzA5ZGQ3MTljMTQvIiwi
-        cHJuIjoicHJuOmZpbGUuZmlsZXJlbW90ZTowMTkzMjUzYS03ZjY2LTdiZTUt
-        YmY3Zi01NzA5ZGQ3MTljMTQiLCJwdWxwX2NyZWF0ZWQiOiIyMDI0LTExLTEz
-        VDExOjEzOjMwLjk4MjQxM1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjQt
-        MTEtMTNUMTE6MTM6MzQuNjMxNzU5WiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        ZmlsZS8wMTk2MDEyNC0wMzgwLTc3NjktOThiNC1iMTgwM2IwMjE1N2QvIiwi
+        cHJuIjoicHJuOmZpbGUuZmlsZXJlbW90ZTowMTk2MDEyNC0wMzgwLTc3Njkt
+        OThiNC1iMTgwM2IwMjE1N2QiLCJwdWxwX2NyZWF0ZWQiOiIyMDI1LTA0LTA0
+        VDE0OjEwOjU5LjU4NDYzNFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjUt
+        MDQtMDRUMTQ6MTE6MDMuOTkxMzMyWiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
         aXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIsInVybCI6Imh0dHBzOi8v
         Zml4dHVyZXMucHVscHByb2plY3Qub3JnL2ZpbGUvL1BVTFBfTUFOSUZFU1Qi
         LCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3ZhbGlk
@@ -3503,10 +3503,10 @@ http_interactions:
         b3JkIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoidXNlcm5hbWUiLCJpc19z
         ZXQiOmZhbHNlfSx7Im5hbWUiOiJwYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9
         XX1dfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:36 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:06 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/remotes/file/file/0193253a-7f66-7be5-bf7f-5709dd719c14/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/01960124-0380-7769-98b4-b1803b02157d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3514,7 +3514,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3527,7 +3527,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:37 GMT
+      - Fri, 04 Apr 2025 14:11:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3547,20 +3547,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6cfb18e990c74bb29b1ff5ab15e500d8
+      - 1c672d7b282d4359a46c692608f89d0a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTk2ZTgtNzAz
-        Mi1hYWI1LTk2MTk0MTczNGUwMS8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:37 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTFkODAtNzdi
+        YS04MzRhLWVmOTFjMDI2MjU5Zi8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:06 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-965e-72fd-9634-8fe4f0cb29fe/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-1cfc-7de8-8295-3428d9d6f089/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3568,7 +3568,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3581,7 +3581,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:37 GMT
+      - Fri, 04 Apr 2025 14:11:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3601,37 +3601,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - aa21f5b51e804167879e485bdb056673
+      - 1bf0383e71bc4a099de9b016ba22fc4d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtOTY1
-        ZS03MmZkLTk2MzQtOGZlNGYwY2IyOWZlLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtOTY1ZS03MmZkLTk2MzQtOGZlNGYwY2IyOWZlIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzozNi44NjMwODFaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjM2Ljg2MzA5MVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMWNm
+        Yy03ZGU4LTgyOTUtMzQyOGQ5ZDZmMDg5LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMWNmYy03ZGU4LTgyOTUtMzQyOGQ5ZDZmMDg5IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowNi4xMDkwMTVaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjA2LjEwOTA0NVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiMGZlOGFl
-        NWE0YjNhNDliZmFhNzk4ZWEwMDc1ZDYzZTIiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzozNi44Nzc4MTNaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MzYuOTE1NzI1WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzozNy4wMTMwNTNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTMyNTIzLTkwMWUtN2ZiMC05ZTA3LTljZGY0
-        ZDJiMWNhMC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiMmM2ZjE5
+        NjE5ODFiNDc2MTgzZWVmYjhjMWU3ZjNkMjAiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMTowNi4xMjMwODVaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MDYuMTc5NzcyWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMTowNi4zNDM4MzZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOTVmZDg0LTc1ZWQtNzU0MS04MWEzLWE3NzVm
+        NTVkZTM2OC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpmaWxlLmZpbGVyZXBvc2l0b3J5OjAxOTMyNTNhLTdmZGEtN2Y3
-        My05ZWZhLTIzZGJkYmRmMTg0ZCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46
-        MDE5MmM1N2QtZmI5NS03OTE4LTg3ZTQtOWRlNWIxNWFiNTM2Il19
-  recorded_at: Wed, 13 Nov 2024 11:13:37 GMT
+        IjpbInBybjpmaWxlLmZpbGVyZXBvc2l0b3J5OjAxOTYwMTI0LTA0MWUtN2M0
+        Zi1hYzliLTA5ZGNiZjBlNDg3MiIsInNoYXJlZDpwcm46Y29yZS5kb21haW46
+        MDE5NTYyMTctZmM5ZS03NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
+  recorded_at: Fri, 04 Apr 2025 14:11:06 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-96e8-7032-aab5-961941734e01/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-1d80-77ba-834a-ef91c026259f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3639,7 +3639,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3652,7 +3652,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:37 GMT
+      - Fri, 04 Apr 2025 14:11:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3672,37 +3672,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 29542af8f0a648a78364c90550e13d03
+      - 75674e772dce4008822d3ce1ed415af2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtOTZl
-        OC03MDMyLWFhYjUtOTYxOTQxNzM0ZTAxLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtOTZlOC03MDMyLWFhYjUtOTYxOTQxNzM0ZTAxIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzozNy4wMDEyNTVaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjM3LjAwMTI2NVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMWQ4
+        MC03N2JhLTgzNGEtZWY5MWMwMjYyNTlmLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMWQ4MC03N2JhLTgzNGEtZWY5MWMwMjYyNTlmIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowNi4yNDA4NTlaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjA2LjI0MDg3M1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiNmNmYjE4
-        ZTk5MGM3NGJiMjliMWZmNWFiMTVlNTAwZDgiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzozNy4wMTM5NTNaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MzcuMDY5MDMyWiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzozNy4xMDQ1ODhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTMyNTIzLThmZWEtNzQxNi1iOTE3LWEyZDBh
-        MmFiM2RmNy8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiMWM2NzJk
+        N2IyODJkNDM1OWE0NmM2OTI2MDhmODlkMGEiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMTowNi4yNTUzMzFaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MDYuMzAzOTk5WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMTowNi4zNzI3MDRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOTVmZDg0LTc2M2EtN2Y1Ny05M2RlLTVjZjlm
+        ZmJjNTc3Ny8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpmaWxlLmZpbGVyZW1vdGU6MDE5MzI1M2EtN2Y2Ni03YmU1LWJm
-        N2YtNTcwOWRkNzE5YzE0Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTky
-        YzU3ZC1mYjk1LTc5MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:37 GMT
+        IjpbInBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NjAxMjQtMDM4MC03NzY5LTk4
+        YjQtYjE4MDNiMDIxNTdkIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1
+        NjIxNy1mYzllLTc0Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
+  recorded_at: Fri, 04 Apr 2025 14:11:06 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3710,7 +3710,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3723,7 +3723,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:37 GMT
+      - Fri, 04 Apr 2025 14:11:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3735,7 +3735,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '659'
+      - '657'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -3743,33 +3743,33 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - af6cfc0174cb4fb8b01c1a41a2cfbe3c
+      - 1ca9feff619b451ba2c8e769840fa2a5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMTkzMjUzYS04MmQ5LTdiZGQtYmZhNS03OGFkOGYwZGU3
-        NWUvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTkzMjUz
-        YS04MmQ5LTdiZGQtYmZhNS03OGFkOGYwZGU3NWUiLCJwdWxwX2NyZWF0ZWQi
-        OiIyMDI0LTExLTEzVDExOjEzOjMxLjg2NjczMFoiLCJwdWxwX2xhc3RfdXBk
-        YXRlZCI6IjIwMjQtMTEtMTNUMTE6MTM6MzYuMTc1OTM2WiIsImJhc2VfcGF0
+        L2ZpbGUvZmlsZS8wMTk2MDEyNC0wN2UyLTcyNzYtYmNlYS0yNGVhYWY2MThk
+        NjAvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk2MDEy
+        NC0wN2UyLTcyNzYtYmNlYS0yNGVhYWY2MThkNjAiLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDI1LTA0LTA0VDE0OjExOjAwLjcwNzkzM1oiLCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjUtMDQtMDRUMTQ6MTE6MDUuNDQ1ODE5WiIsImJhc2VfcGF0
         aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8x
-        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5k
-        aWNlcm9zMjAyMy5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9P
-        cmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19GaWxlXzEvIiwiY29udGVudF9n
-        dWFyZCI6bnVsbCwibm9fY29udGVudF9jaGFuZ2Vfc2luY2UiOm51bGwsImhp
-        ZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IkRlZmF1bHRf
-        T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwicmVwb3NpdG9y
-        eSI6bnVsbCwicHVibGljYXRpb24iOm51bGx9XX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:37 GMT
+        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5t
+        YW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3Vh
+        cmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjpudWxsLCJoaWRk
+        ZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09y
+        Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnki
+        Om51bGwsInB1YmxpY2F0aW9uIjpudWxsfV19
+  recorded_at: Fri, 04 Apr 2025 14:11:06 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/0193253a-82d9-7bdd-bfa5-78ad8f0de75e/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/01960124-07e2-7276-bcea-24eaaf618d60/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3777,7 +3777,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3790,7 +3790,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:37 GMT
+      - Fri, 04 Apr 2025 14:11:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3810,20 +3810,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4100909ebdbd4e7eb8dfa58d2d36e060
+      - d1edcc9851144e8b8769646878ce5ce8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTMyNTNhLTk3ZDQtNzVk
-        Ni1iMTc5LWI5OWEyMmZhNDAzYy8ifQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:37 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTYwMTI0LTFmNWQtNzY3
+        Ni05ZWNmLWViZjAyNDljYWNmOC8ifQ==
+  recorded_at: Fri, 04 Apr 2025 14:11:06 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3831,7 +3831,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3844,7 +3844,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:37 GMT
+      - Fri, 04 Apr 2025 14:11:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3864,20 +3864,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 14235298f0954b5e885b2d0acb3edb13
+      - 99fd85bede044267be2b3d38b4771cfd
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 13 Nov 2024 11:13:37 GMT
+  recorded_at: Fri, 04 Apr 2025 14:11:06 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.diceros2023.example.com/pulp/api/v3/tasks/0193253a-97d4-75d6-b179-b99a22fa403c/
+    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/01960124-1f5d-7676-9ecf-ebf0249cacf8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3885,7 +3885,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.2/ruby
+      - OpenAPI-Generator/3.63.13/ruby
       Accept:
       - application/json
       Authorization:
@@ -3898,7 +3898,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 13 Nov 2024 11:13:37 GMT
+      - Fri, 04 Apr 2025 14:11:06 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3918,31 +3918,31 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6a75d23c183340c2abc023637d5eb78c
+      - 9763c802b9d348078cdca4f1aee44cec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.diceros2023.example.com
+      - 1.1 centos9-katello-devel.manicotto.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5MzI1M2EtOTdk
-        NC03NWQ2LWIxNzktYjk5YTIyZmE0MDNjLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5MzI1M2EtOTdkNC03NWQ2LWIxNzktYjk5YTIyZmE0MDNjIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNC0xMS0xM1QxMToxMzozNy4yMzY4ODZaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI0LTExLTEzVDExOjEzOjM3LjIzNjkyMFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NjAxMjQtMWY1
+        ZC03Njc2LTllY2YtZWJmMDI0OWNhY2Y4LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NjAxMjQtMWY1ZC03Njc2LTllY2YtZWJmMDI0OWNhY2Y4IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNC0wNFQxNDoxMTowNi43MTg0MjJaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTA0VDE0OjExOjA2LjcxODQzN1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiNDEwMDkw
-        OWViZGJkNGU3ZWI4ZGZhNThkMmQzNmUwNjAiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNC0xMS0x
-        M1QxMToxMzozNy4yNDY0NjNaIiwic3RhcnRlZF9hdCI6IjIwMjQtMTEtMTNU
-        MTE6MTM6MzcuMjQ5MTQ0WiIsImZpbmlzaGVkX2F0IjoiMjAyNC0xMS0xM1Qx
-        MToxMzozNy4yNTk0MjBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiZDFlZGNj
+        OTg1MTE0NGU4Yjg3Njk2NDY4NzhjZTVjZTgiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
+        NFQxNDoxMTowNi43MzEzNDhaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDRU
+        MTQ6MTE6MDYuNzM0MjUwWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wNFQx
+        NDoxMTowNi43NDkzNTFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTJjNTdkLWZiOTUtNzkxOC04N2U0LTlkZTViMTVhYjUzNjpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTkyYzU3ZC1mYjk1LTc5
-        MTgtODdlNC05ZGU1YjE1YWI1MzYiXX0=
-  recorded_at: Wed, 13 Nov 2024 11:13:37 GMT
+        OTU2MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRp
+        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0
+        Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
+  recorded_at: Fri, 04 Apr 2025 14:11:06 GMT
 recorded_with: VCR 6.3.1

--- a/test/services/katello/pulp3/orphan_test.rb
+++ b/test/services/katello/pulp3/orphan_test.rb
@@ -70,9 +70,10 @@ module Katello
 
         def test_delete_orphan_repository_versions
           delete_orphan_tasks = @smart_proxy_service.delete_orphan_repository_versions
-          delete_orphan_tasks.compact.each { |task| wait_on_task(@primary, task) }
+          delete_orphan_tasks[:pulp_tasks].compact.each { |task| wait_on_task(@primary, task) }
           orphans = @smart_proxy_service.orphan_repository_versions.collect { |_api, repo_versions| repo_versions }.flatten
           assert_empty orphans
+          assert_empty delete_orphan_tasks[:errors]
         end
       end
     end

--- a/test/services/katello/pulp3/repository/orphan_distributions_test.rb
+++ b/test/services/katello/pulp3/repository/orphan_distributions_test.rb
@@ -6,9 +6,22 @@ module Katello
     class RepositoryIsOrphanDistributionTest < ActiveSupport::TestCase
       include Katello::Pulp3Support
 
+      def setup
+        @repo = FactoryBot.create(:katello_repository, :with_product)
+      end
+
+      def test_unknown_distribution_is_an_orphan
+        dist = PulpFileClient::FileFileDistribution.new(
+          publication: 'http://some.href',
+          name: 'other name')
+        assert Katello::Pulp3::SmartProxyMirrorRepository.orphan_distribution?(dist)
+      end
+
       def test_distribution_with_publication_is_not_an_orphan
         dist = PulpFileClient::FileFileDistribution.new(
-          publication: 'http://some.href')
+          publication: 'http://some.href',
+          name: 'name')
+        @repo.update pulp_id: 'name'
         refute Katello::Pulp3::SmartProxyMirrorRepository.orphan_distribution?(dist)
       end
 
@@ -21,7 +34,9 @@ module Katello
       def test_distribution_with_repository_and_repository_version_is_not_an_orphan
         dist = PulpAnsibleClient::AnsibleAnsibleDistribution.new(
           repository: 'http://some.href',
-          repository_version: 'http://some.href/version/')
+          repository_version: 'http://some.href/version/',
+          name: 'name')
+        @repo.update pulp_id: 'name'
         refute Katello::Pulp3::SmartProxyMirrorRepository.orphan_distribution?(dist)
       end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
- On the main Katello server and smart proxies, don't let Pulp's new distributed repo version error halt orphan cleanup. Instead, skip trying  to delete those repository versions and instruct users about the situation.

- Reorder the orphan cleanup orchestration to be more efficient.

- Update Katello main server distribution orphan cleanup to delete distributions that are not tracked by Katello.
#### Considerations taken when implementing this change?
At first I wanted this automation to fix the issue for the users. However, orphan cleanup likely should not be doing risky Pulp orchestration past trying to remove content. Pulp content can be broken in many ways and Katello cannot assume that content in an unexpected state should be cleaned up. That assumption could lead to dangerous data loss for users.

The suggested fix is generally to resync the repository, which should cause the latest `version_href` to be correctly distributed on smart proxies. On the main Katello server, it should realign the `version_href` in the Repository record with the reality in Pulp. Metadata regeneration should also work, however this will cause inconsistencies for any repositories that use complete mirroring, since the publication is created for us by Pulp.

In the case of Pulp entities that plainly should not be on the system, this should not be the cause of the `version_href` issue since all of the orphaned repositories should get removed (not repository _versions_). Removing a distributed repository does not trigger the error, just repository versions. Then, the orphaned distributions should get removed as well.

What I'm curious about is if anyone can think of a case where this error will come up outside of what I have identified here. Some of these cases might mean Pulp is in too sorry of a state to be automatically fixed -- again we should not be doing risky automation during orphan cleanup.

#### What are the testing steps for this pull request?
1) Set up a smart proxy with content
2) Sync some repos to both
3) On the main Katello server, make some distributed Pulp repositories with pulp-cli alone
4) Ensure orphan cleanup deletes these properly
5) On the main Katello server, upload content to a repo to create a second repository version
6) Create a publication and assign it to the older repository version
7) Destroy the old publication (or not, both cases are interesting to test)
8) Update the repo's distribution to point to this new publication
9) Run orphan cleanup and see what logs come up (ensure you're using debug logging)
10) Try using what the logs mention to fix the issue and run orphan cleanup again. Check that no more error logs pop up.
11) Try the same steps 5-10 on the smart proxy
12) For both the Katello server and the smart proxy, can you find a way to trigger the new orphan cleanup warnings that is not fixable via a complete resync or metadata regeneration?

Example logs:

For smart proxies:
```
2025-03-27T16:05:48 [W|app|] Completely resync (skip metadata check) repositories with the following paths to the smart proxy with ID 2: Default_Organization/Super_Production/Test/custom/Buttermilk_Biscuits/Zoo. Orphan cleanup is skipped for these repositories until they are fixed on smart proxy with ID 2. Try `hammer capsule content synchronize --id 2 --skip-metadata-check 1 ...` using --repository-id with 47
2025-03-27T16:05:48 [D|app|] Orphan cleanup error: investigate the version_href /pulp/api/v3/repositories/rpm/rpm/0195d7fc-b3aa-7f9b-9752-c84ae6d30c62/versions/2/ on the smart proxy with ID 2 and the related distributions ["/pulp/api/v3/distributions/rpm/rpm/0195d8ae-bd5b-70c0-a27f-751cfa941652/"]
2025-03-27T16:05:48 [D|app|] It is likely that the related distributions are distributing an older version of the repository.
```

For the main Katello server:
```
2025-03-27T15:49:24 [W|app|] Completely resync (skip metadata check) or regenerate metadata for repositories with the following paths: Default_Organization/Library/custom/Buttermilk_Biscuits/Zoo. Orphan cleanup is skipped for these repositories until they are fixed on smart proxy with ID 1. Try `hammer repository synchronize --skip-metadata-check 1 ...` using --id with 9.
2025-03-27T15:49:24 [D|app|] Orphan cleanup error: investigate the version_href /pulp/api/v3/repositories/rpm/rpm/01950039-fe58-775c-bdb1-db50cc2b1e7a/versions/4/ and the related distributions ["/pulp/api/v3/distributions/rpm/rpm/0195003a-04bf-73b4-81ee-6ff08719034c/"]
2025-03-27T15:49:24 [D|app|] It is likely that the related distributions are distributing an older version of the repository.
```

ToDo:
- Write tests