### PR TITLE
Fixes #38190 - Enforce content source LCE rules in Remove version wizard

### DIFF
--- a/app/views/katello/api/v2/environments/show.json.rabl
+++ b/app/views/katello/api/v2/environments/show.json.rabl
@@ -67,4 +67,18 @@ node :content_views do |env|
   end
 end
 
+node :capsules do |env|
+  env.capsules.map do |capsule|
+    {
+      :id => capsule.id,
+      :name => capsule.name,
+      :lifecycle_environments => capsule.capsule_lifecycle_environments.map do |cle|
+        {
+          :id => cle.lifecycle_environment.id,
+        }
+      end,
+    }
+  end
+end
+
 extends 'katello/api/v2/common/timestamps'

--- a/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.js
+++ b/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.js
@@ -11,7 +11,7 @@ import Loading from '../../../../components/Loading';
 
 const EnvironmentPaths = ({
   userCheckedItems, setUserCheckedItems, promotedEnvironments,
-  publishing, headerText, multiSelect, isDisabled,
+  publishing, headerText, multiSelect, isDisabled, enabledLifecycleEnvironmentIds,
 }) => {
   const environmentPathResponse = useSelector(selectEnvironmentPaths);
   const environmentPathStatus = useSelector(selectEnvironmentPathsStatus);
@@ -55,6 +55,8 @@ const EnvironmentPaths = ({
                     envCheckedInList(env, promotedEnvironments)}
                     isDisabled={isDisabled || (publishing && env.library)
                     || env?.content_source?.environment_is_associated === false
+                    || (enabledLifecycleEnvironmentIds &&
+                      !enabledLifecycleEnvironmentIds.has(env.id))
                     || envCheckedInList(env, promotedEnvironments)}
                     className="env-path__labels-with-pointer"
                     key={`${env.id}${index}`}
@@ -84,6 +86,7 @@ EnvironmentPaths.propTypes = {
   headerText: PropTypes.string,
   multiSelect: PropTypes.bool,
   isDisabled: PropTypes.bool,
+  enabledLifecycleEnvironmentIds: PropTypes.instanceOf(Set),
 };
 
 EnvironmentPaths.defaultProps = {
@@ -92,5 +95,6 @@ EnvironmentPaths.defaultProps = {
   headerText: __('Select a lifecycle environment from the available promotion paths to promote new version.'),
   multiSelect: true,
   isDisabled: false,
+  enabledLifecycleEnvironmentIds: null,
 };
 export default EnvironmentPaths;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Adds pre-check logic to the “remove from environment” wizard so that only lifecycle environments synced by the affected host’s content source can be selected for reassignment. This prevents removal tasks from failing with validation errors (e.g., when a host’s content source doesn’t sync the selected environment) by disabling non-synced options before saving.

#### Considerations taken when implementing this change?

This ensures that only compatible environments are selectable, without modifying existing API calls or Redux state, and focuses solely on improving the host reassignment flow.

#### What are the testing steps for this pull request?

1. Go to Content -> Lifecycle -> Content Views
2. Click on a content view -> Remove from environments
3. Select an environment associated with a host -> Next
4. Only the environments associated with the host content source should be enabled