### PR TITLE
Fixes #38339 - ensure non yum RH repos get DL policy

### DIFF
--- a/app/models/katello/candlepin/repository_mapper.rb
+++ b/app/models/katello/candlepin/repository_mapper.rb
@@ -139,7 +139,7 @@ module Katello
       end
 
       def download_policy
-        if katello_content_type == Repository::YUM_TYPE
+        if ::Katello::RootRepository::CONTENT_ATTRIBUTE_RESTRICTIONS[:download_policy].include?(katello_content_type)
           Setting[:default_redhat_download_policy]
         else
           ""

--- a/test/models/candlepin/repository_mapper_test.rb
+++ b/test/models/candlepin/repository_mapper_test.rb
@@ -48,5 +48,19 @@ module Katello
 
       assert_equal 'immediate', mapper.download_policy
     end
+
+    def test_download_policy_file_repo
+      mapper = Candlepin::RepositoryMapper.new(@product_content.product, @product_content.content, {})
+      mapper.expects(:katello_content_type).returns('file')
+      Setting[:default_redhat_download_policy] = 'immediate'
+      assert_equal 'immediate', mapper.download_policy
+    end
+
+    def test_download_policy_python_repo
+      mapper = Candlepin::RepositoryMapper.new(@product_content.product, @product_content.content, {})
+      mapper.expects(:katello_content_type).returns('python')
+      Setting[:default_redhat_download_policy] = 'immediate'
+      assert_equal '', mapper.download_policy
+    end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Sets all RH repositories to use the default RH download policy.

#### Considerations taken when implementing this change?
All RH repository  types should support download policies. Please help me confirm.

#### What are the testing steps for this pull request?
Try to enable any non-yum Red Hat repository.