### PR TITLE
Fixes #38334 - Ensure ToggleGroupItem is a direct child of ToggleGroup

### DIFF
--- a/webpack/components/Errata/index.js
+++ b/webpack/components/Errata/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { TableText } from '@patternfly/react-table';
-import { Tooltip, ToggleGroupItem } from '@patternfly/react-core';
+import { Tooltip } from '@patternfly/react-core';
 import {
   chart_color_black_500 as pfBlack,
   chart_color_gold_400 as pfGold,
@@ -188,26 +188,3 @@ ErrataSeverity.propTypes = {
   severity: PropTypes.string.isRequired,
 };
 
-export const ErrataToggleGroupItem = ({
-  text, tooltipText, isSelected, onChange, ...toggleGroupItemProps
-}) => (
-  <Tooltip
-    content={tooltipText}
-    position="top"
-    enableFlip
-  >
-    <ToggleGroupItem
-      text={text}
-      isSelected={isSelected}
-      onChange={(e, v) => onChange(v)}
-      {...toggleGroupItemProps}
-    />
-  </Tooltip>
-);
-
-ErrataToggleGroupItem.propTypes = {
-  text: PropTypes.string.isRequired,
-  tooltipText: PropTypes.string.isRequired,
-  isSelected: PropTypes.bool.isRequired,
-  onChange: PropTypes.func.isRequired,
-};

--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.js
@@ -8,13 +8,15 @@ import {
   FlexItem,
   GridItem,
   ToggleGroup,
+  ToggleGroupItem,
+  Tooltip,
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
 import PropTypes from 'prop-types';
 import { ChartPie, ChartTooltip } from '@patternfly/react-charts';
-import { ErrataMapper, ErrataToggleGroupItem } from '../../../../components/Errata';
+import { ErrataMapper } from '../../../../components/Errata';
 import { hostIsRegistered } from '../hostDetailsHelpers';
 import { TranslatedAnchor } from '../../../Table/components/TranslatedPlural';
 import EmptyStateMessage from '../../../Table/EmptyStateMessage';
@@ -123,19 +125,31 @@ const ErrataOverviewCard = ({ hostDetails }) => {
             <CardTitle>{__('Errata')}</CardTitle>
             {neededErrata &&
               <ToggleGroup isCompact>
-                <ErrataToggleGroupItem
+                <ToggleGroupItem
                   text={__('Applicable')}
                   aria-label="Show applicable errata chart"
-                  tooltipText={__('Applicable errata apply to at least one package installed on the host.')}
+                  buttonId="applicableToggle"
                   isSelected={errataCategory === 'applicable'}
                   onChange={selected => selected && setErrataCategory('applicable')}
                 />
-                <ErrataToggleGroupItem
+                <ToggleGroupItem
                   text={__('Installable')}
                   aria-label="Show installable errata chart"
-                  tooltipText={__('Installable errata are applicable errata that are available in the host\'s assigned content view environments.')}
+                  buttonId="installableToggle"
                   isSelected={errataCategory === 'installable'}
                   onChange={selected => selected && setErrataCategory('installable')}
+                />
+                <Tooltip
+                  content={__('Applicable errata apply to at least one package installed on the host.')}
+                  position="top"
+                  enableFlip
+                  triggerRef={() => document.getElementById('applicableToggle')}
+                />
+                <Tooltip
+                  content={__('Installable errata are applicable errata that are available in the host\'s assigned content view environments.')}
+                  position="top"
+                  enableFlip
+                  triggerRef={() => document.getElementById('installableToggle')}
                 />
               </ToggleGroup>
             }

--- a/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/__tests__/errataOverviewCard.test.js
@@ -144,7 +144,7 @@ describe('With errata', () => {
     const { getByText }
       = renderWithRedux(<ErrataOverviewCard hostDetails={hostDetails} />, renderOptions);
     // find the Applicable toggle button, then find the svg next to it
-    const applicableToggle = getByText('Applicable').parentElement.parentElement;
+    const applicableToggle = getByText('Applicable').parentElement;
     fireEvent.mouseEnter(applicableToggle);
     // expect the tooltip to be visible
     await patientlyWaitFor(() => expect(getByText('Applicable errata apply to at least one package installed on the host.')).toBeInTheDocument());

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -9,6 +9,7 @@ import {
   Skeleton,
   Tooltip,
   ToggleGroup,
+  ToggleGroupItem,
 } from '@patternfly/react-core';
 import {
   Dropdown,
@@ -39,7 +40,7 @@ import { useSet, useBulkSelect, useUrlParams } from 'foremanReact/components/PF4
 import { useTableSort } from 'foremanReact/components/PF4/Helpers/useTableSort';
 import SelectableDropdown from '../../../../SelectableDropdown';
 import TableWrapper from '../../../../../components/Table/TableWrapper';
-import { ErrataType, ErrataSeverity, ErrataToggleGroupItem } from '../../../../../components/Errata';
+import { ErrataType, ErrataSeverity } from '../../../../../components/Errata';
 import { getInstallableErrata } from './HostErrataActions';
 import ErratumExpansionDetail from './ErratumExpansionDetail';
 import ErratumExpansionContents from './ErratumExpansionContents';
@@ -430,23 +431,33 @@ export const ErrataTab = () => {
       {hostIsNonLibrary &&
         <SplitItem>
           <ToggleGroup aria-label="Installable Errata">
-            <ErrataToggleGroupItem
+            <ToggleGroupItem
               text={__('Applicable')}
-              tooltipText={__('Applicable errata apply to at least one package installed on the host.')}
               buttonId="applicableToggle"
               aria-label="Show applicable errata"
               isSelected={toggleGroupState === APPLICABLE}
               onChange={() => setToggleGroupState(APPLICABLE)}
             />
-            <ErrataToggleGroupItem
+            <ToggleGroupItem
               text={__('Installable')}
-              tooltipText={__('Installable errata are applicable errata that are available in the host\'s assigned content view environments.')}
               buttonId="installableToggle"
               aria-label="Show installable errata"
               isSelected={toggleGroupState === INSTALLABLE}
               onChange={() => setToggleGroupState(INSTALLABLE)}
             />
           </ToggleGroup>
+          <Tooltip
+            content={__('Applicable errata apply to at least one package installed on the host.')}
+            position="top"
+            enableFlip
+            triggerRef={() => document.getElementById('applicableToggle')}
+          />
+          <Tooltip
+            content={__('Installable errata are applicable errata that are available in the host\'s assigned content view environments.')}
+            position="top"
+            enableFlip
+            triggerRef={() => document.getElementById('installableToggle')}
+          />
         </SplitItem>
       }
     </Split>


### PR DESCRIPTION
With the PF5 upgrade, toggle groups started rendering incorrectly. (See the pics attached on https://projects.theforeman.org/issues/38334)

#### What are the changes introduced in this pull request?

I refactored the Errata toggle groups to ensure that `<ToggleGroupItem>` is the direct child of `<ToggleGroup>`, instead of having a `<Tooltip>` wrapping the `ToggleGroupItem`. This required following the "selector ref" example here --> https://v5-archive.patternfly.org/components/tooltip#tooltip-selector-ref

#### Considerations taken when implementing this change?

I'm not sure what changed, but this ensures that both the toggle groups AND the tooltips render correctly, without compromising either.

This allowed a bit of simplification, so we can now just use `ToggleGroupItem` directly instead of making our own `ErrataToggleGroupItem`. The downside is that it's not quite as easy to add tooltips, but hey, at least it works now.

#### What are the testing steps for this pull request?

make sure tooltips work on the Errata Overview Card toggle group and on Content > Errata (host details page)
make sure the toggle groups render with rounded borders on left and right, but not in the middle (again, see the pics attached to the Redmine)
