### PR TITLE
Fixes #38350 - Add transient update warnings on image mode hosts

### DIFF
--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -49,13 +49,17 @@ import { installErrata } from '../RemoteExecutionActions';
 import { errataInstallUrl } from '../customizedRexUrlHelpers';
 import './ErrataTab.scss';
 import hostIdNotReady, { getHostDetails } from '../../HostDetailsActions';
-import { hasRequiredPermissions as can,
+import {
+  hasRequiredPermissions as can,
   missingRequiredPermissions as cannot,
-  userPermissionsFromHostDetails } from '../../hostDetailsHelpers';
+  userPermissionsFromHostDetails,
+  hostIsImageMode,
+} from '../../hostDetailsHelpers';
 import SortableColumnHeaders from '../../../../Table/components/SortableColumnHeaders';
 import { useRexJobPolling } from '../RemoteExecutionHooks';
 import { errataStatusContemplation, friendlyErrataStatus } from '../../../../Errata/errataHelpers';
 import { runSubmanRepos } from '../../Cards/ContentViewDetailsCard/HostContentViewActions';
+import ImageModeHostAlert from '../../../Hosts/ImageModeHostAlert';
 
 const recalculateApplicability = ['edit_hosts'];
 const invokeRexJobs = ['create_job_invocations'];
@@ -455,6 +459,7 @@ export const ErrataTab = () => {
   return (
     <div>
       <div id="errata-tab">
+        {hostIsImageMode({ hostDetails }) && <ImageModeHostAlert />}
         <TableWrapper
           {...{
             metadata,

--- a/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ModuleStreamsTab/ModuleStreamsTab.js
@@ -50,7 +50,9 @@ import {
   hasRequiredPermissions as can,
   missingRequiredPermissions as cannot,
   userPermissionsFromHostDetails,
+  hostIsImageMode,
 } from '../../hostDetailsHelpers';
+import ImageModeHostAlert from '../../../Hosts/ImageModeHostAlert';
 
 export const hideModuleStreamsTab = ({ hostDetails }) => !(hostDetails?.operatingsystem_family === 'Redhat' && Number(hostDetails?.operatingsystem_major > 7));
 
@@ -348,6 +350,7 @@ export const ModuleStreamsTab = () => {
   return (
     <div>
       <div id="modulestreams-tab">
+        {hostIsImageMode({ hostDetails }) && <ImageModeHostAlert />}
         <TableWrapper
           {...{
             metadata,

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -42,12 +42,16 @@ import { katelloPackageUpdateUrl, packagesUpdateUrl } from '../customizedRexUrlH
 import './PackagesTab.scss';
 import hostIdNotReady, { getHostDetails } from '../../HostDetailsActions';
 import PackageInstallModal from './PackageInstallModal';
-import { hasRequiredPermissions as can,
+import {
+  hasRequiredPermissions as can,
   missingRequiredPermissions as cannot,
-  userPermissionsFromHostDetails } from '../../hostDetailsHelpers';
+  userPermissionsFromHostDetails,
+  hostIsImageMode,
+} from '../../hostDetailsHelpers';
 import SortableColumnHeaders from '../../../../Table/components/SortableColumnHeaders';
 import { useRexJobPolling } from '../RemoteExecutionHooks';
 import { runSubmanRepos } from '../../Cards/ContentViewDetailsCard/HostContentViewActions';
+import ImageModeHostAlert from '../../../Hosts/ImageModeHostAlert';
 
 const invokeRexJobs = ['create_job_invocations'];
 const createBookmarks = ['create_bookmarks'];
@@ -477,6 +481,7 @@ export const PackagesTab = () => {
   return (
     <div>
       <div id="packages-tab">
+        {hostIsImageMode({ hostDetails }) && <ImageModeHostAlert />}
         <TableWrapper
           {...{
             metadata,

--- a/webpack/components/extensions/HostDetails/hostDetailsHelpers.js
+++ b/webpack/components/extensions/HostDetails/hostDetailsHelpers.js
@@ -24,3 +24,6 @@ export const hasRequiredPermissions = (requiredPermissions = [], userPermissions
 
 export const missingRequiredPermissions = (requiredPermissions = [], userPermissions) =>
   !hasRequiredPermissions(requiredPermissions, userPermissions);
+
+export const hostIsImageMode = ({ hostDetails }) =>
+    hostDetails?.content_facet_attributes?.bootc_booted_image;

--- a/webpack/components/extensions/Hosts/BulkActions/HostReview.js
+++ b/webpack/components/extensions/Hosts/BulkActions/HostReview.js
@@ -105,7 +105,7 @@ const HostReview = ({
           {__('Review hosts')}
         </Text>
         <Text ouiaId="mpw-step-3-content" component={TextVariants.p}>
-          {__('Review and optionally exclude hosts from your selection.')}
+          {__('Review and optionally exclude hosts from your selection. Note that package actions on any image mode hosts will be transient and lost on the next reboot.')}
         </Text>
       </TextContent>
       {selectedCount === 0 && hasInteracted && (

--- a/webpack/components/extensions/Hosts/ImageModeHostAlert.js
+++ b/webpack/components/extensions/Hosts/ImageModeHostAlert.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import {
+  Alert,
+} from '@patternfly/react-core';
+
+import { translate as __ } from 'foremanReact/common/I18n';
+
+const ImageModeHostAlert = () => (
+  <Alert style={{ alignItems: 'center' }} className="margin-16-24" title={__('Package actions will be transient')} variant="info" ouiaId="image-mode-alert-info">
+    <p>{__('Any updates to image mode host(s) will be lost on the next reboot.')}</p>
+  </Alert>
+);
+
+export default ImageModeHostAlert;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Introduce a new alert component to inform users about the transient nature of package actions on image mode hosts. Additionally, it updates the text in the host review step of bulk host package actions to reflect this information.

#### Considerations taken when implementing this change?
Discussed adding the banner with conditional rendering on bulk host wizards but the description update looks better and also doesn't need costly loops on selected hosts to figure out if any host in the bulk list is image-mode.
#### What are the testing steps for this pull request?
1. Register an image-mode host
2. Go to host details UI. You should see a banner as below. Same banner also exists in errata tab.
![Screenshot from 2025-04-03 12-41-05](https://github.com/user-attachments/assets/d209b9dc-e187-4820-849f-095419e9e51e)
3. Go to hosts index page. Select a few hosts and Actions>Manage content action> Package or Errata
4. On the host review page, check the new text informing users about transient package actions as below:
![Screenshot from 2025-04-03 12-43-39](https://github.com/user-attachments/assets/fbb26bb6-4535-477e-a3db-bdccaae59378)


