### PR TITLE
Fixes #38337 - Adjust icon spacing after PF5 upgrade

### DIFF
--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.js
@@ -61,7 +61,7 @@ export const ContentViewEnvironmentDisplay = ({
             }}
           />}
         >
-          <Label color="purple" href={`/lifecycle_environments/${lifecycleEnvironment.id}`}>{lifecycleEnvironment.name}</Label>
+          <Label color="purple" href={`/lifecycle_environments/${lifecycleEnvironment.id}`} style={{ marginRight: '2px' }}>{lifecycleEnvironment.name}</Label>
         </Tooltip>
         <ContentViewIcon composite={contentView.composite} rolling={contentViewDefault || contentView.rolling} style={{ marginRight: '2px' }} position="left" />
         {contentViewDefault ? <span>{contentView.name}</span> :

--- a/webpack/scenes/ContentViews/Create/CreateContentViewForm.scss
+++ b/webpack/scenes/ContentViews/Create/CreateContentViewForm.scss
@@ -6,4 +6,12 @@
   .pf-v5-c-tile__icon {
     min-height: 38px;
   }
+
+  .pf-v5-c-check__label {
+    margin-top: 4px;
+  }
+
+  .foreman-spaced-icon {
+    margin: 0;
+  }
 }

--- a/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.scss
+++ b/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.scss
@@ -2,6 +2,9 @@
   .pf-v5-c-form__group {
     margin: 20px 0;
   }
+  .pf-v5-c-check__label, .pf-v5-c-radio__label {
+    margin: 0;
+  }
 
   .env-path__labels-with-pointer {
     &:not(:last-child):after {

--- a/webpack/scenes/ContentViews/components/FiltersAppliedIcon.js
+++ b/webpack/scenes/ContentViews/components/FiltersAppliedIcon.js
@@ -11,7 +11,7 @@ const FiltersAppliedIcon = () => (
     content={__('Filters were applied to this version.')}
   >
     <Icon size="sm">
-      <FilterIcon style={{ color: '#0081db', margin: '0 9px' }} />
+      <FilterIcon style={{ color: '#0081db', marginLeft: '9px' }} />
     </Icon>
   </Tooltip>
 );

--- a/webpack/scenes/ContentViews/components/contentViewIcon.scss
+++ b/webpack/scenes/ContentViews/components/contentViewIcon.scss
@@ -2,15 +2,16 @@
   display: flex;
   align-items: center;
   align-content: center;
+  gap: 6px;
 
   .composite-component-count {
-    min-width: 10px;
+    min-width: 12px;
     text-align: center;
   }
 }
 
 .svg-icon-composite {
-  margin: 0 6px;
+  margin: 0 9px;
   display: block;
 }
 
@@ -22,4 +23,11 @@
 .svg-icon-rolling {
   margin: 0 9px;
   display: block;
+}
+
+.svg-centered-container:has(.svg-icon-component), 
+.svg-centered-container:has(.svg-icon-rolling) {
+  > span:last-child {
+    margin-left: 4px;
+  }
 }


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Addresses the icon spacing issue introduced after the PF5 upgrade, ensuring that content view icons on the content views and host details pages are properly spaced from other page elements.

#### Considerations taken when implementing this change?

Attention was given to maintaining the layout integrity across different page elements, ensuring that the spacing adjustments do not interfere with other components or break the existing layout.

#### What are the testing steps for this pull request?

Content Views Page

1. Go to Content -> Lifecycle -> Content Views
2. Check the spacing of the icons

Host details Page

1. Go to Hosts -> All hosts -> Click on a Host
2. Check the spacing of the icons under "Content view environment" card
