### PR TITLE
[WIP] Put katello event queue handler back into Dynflow

### DIFF
--- a/app/lib/actions/katello/event_queue/monitor.rb
+++ b/app/lib/actions/katello/event_queue/monitor.rb
@@ -1,0 +1,60 @@
+module Actions
+  module Katello
+    module EventQueue
+      class Monitor < Actions::EntryAction
+        include ::Dynflow::Action::Singleton
+
+        Handle = Algebrick.type do
+          fields! event_type: String, object_id: Integer
+        end
+
+        Poll = Algebrick.atom
+
+        def self.launch(world)
+          unless self.singleton_locked?(world)
+            ForemanTasks.trigger(self)
+          end
+        rescue StandardError
+          # TODO: what to do here?
+          Rails.logger.info("Already started!")
+        end
+
+        def plan
+          plan_self
+        end
+
+        def run(event = nil)
+          match(event,
+                (on nil do
+                  suspend do
+                    ::Katello::EventQueue.reset_in_progress
+                    plan_event(Poll)
+                  end
+                end),
+                (on Handle do
+                  suspend do
+                    katello_event = ::Katello::EventQueue.next_event(event.event_type, event.object_id)
+                    if katello_event
+                      handler = ::Katello::EventMonitor::PollerThread.new
+                      handler.run_event(katello_event)
+                    end
+                    plan_event(Poll)
+                  end
+                end),
+                (on Poll do
+                  suspend do
+                    katello_event = ::Katello::EventQueue.oldest_runnable_event
+                    if katello_event
+                      # Passing this data to run avoids extra db querying
+                      plan_event(Handle[katello_event.event_type, katello_event.object_id])
+                    else
+                      plan_event(Poll, 3)
+                    end
+                  end
+                end)
+              )
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/event_monitor/poller_thread.rb
+++ b/app/services/katello/event_monitor/poller_thread.rb
@@ -1,53 +1,9 @@
 module Katello
   module EventMonitor
-    # TODO: Move this class to app/lib/katello/event_daemon/services with other service definitions
     class PollerThread
-      SLEEP_INTERVAL = 3
-
-      cattr_accessor :instance
-
-      def self.initialize(logger = nil)
-        self.instance ||= self.new(logger)
-      end
-
-      def self.close
-        if self.instance
-          self.instance.close
-          self.instance = nil
-        end
-      end
-
-      def self.run
-        initialize
-        ::Katello::EventQueue.reset_in_progress
-        instance.poll_for_events
-      end
-
-      def self.status
-        instance&.status
-      end
-
-      def initialize(logger = nil)
-        @logger = logger || ::Foreman::Logging.logger('katello/katello_events')
-        @failed_count = 0
-        @processed_count = 0
-      end
-
-      def close
-        @logger.info("Stopping Katello Event Monitor")
-        @thread&.kill
-      end
-
-      def running?
-        @thread&.status || false
-      end
-
-      def status
-        {
-          processed_count: @processed_count,
-          failed_count: @failed_count,
-          running: running?,
-        }
+      def initialize(logger = Rails.logger, queue = Katello::EventQueue)
+        @logger = logger
+        @queue = queue
       end
 
       def run_event(event)
@@ -60,47 +16,25 @@ module Katello
           event_instance = nil
           begin
             ::User.as_anonymous_admin do
-              event_instance = ::Katello::EventQueue.create_instance(event)
+              event_instance = @queue.create_instance(event)
+              @queue.mark_in_progress(event)
               event_instance.run
             end
           rescue => e
-            @failed_count += 1
             @logger.error("event_queue_error: type=#{event.event_type}, object_id=#{event.object_id}")
             @logger.error(e.message)
             @logger.error(e.backtrace.join("\n"))
           ensure
             if event_instance.try(:retry)
-              result = ::Katello::EventQueue.reschedule_event(event)
+              result = @queue.reschedule_event(event)
               if result == :expired
                 @logger.warn("event_queue_event_expired: type=#{event.event_type} object_id=#{event.object_id}")
               elsif !result.nil?
                 @logger.warn("event_queue_rescheduled: type=#{event.event_type} object_id=#{event.object_id}")
               end
             end
-            ::Katello::EventQueue.clear_events(event.event_type, event.object_id, event.created_at)
+            @queue.clear_events(event.event_type, event.object_id, event.created_at)
           end
-        end
-      end
-
-      def poll_for_events
-        @thread = Thread.new do
-          @logger.info("Polling Katello Event Queue")
-          loop do
-            Rails.application.executor.wrap do
-              Katello::Util::Support.with_db_connection(@logger) do
-                until (event = ::Katello::EventQueue.next_event).nil?
-                  run_event(event)
-                  @processed_count += 1
-                end
-              end
-            end
-
-            sleep SLEEP_INTERVAL
-          end
-        rescue => e
-          @logger.error(e.message)
-          @logger.error("Fatal error in Katello Event Monitor")
-          self.class.close
         end
       end
     end

--- a/app/services/katello/event_queue.rb
+++ b/app/services/katello/event_queue.rb
@@ -24,13 +24,17 @@ module Katello
       Katello::Event.where(:in_progress => true, :object_id => object_id, :event_type => event_type).where('created_at <= ?', on_or_earlier_than).delete_all
     end
 
-    def self.next_event
-      first = runnable_events.where(:in_progress => false).order(:created_at => 'asc').first
-      return if first.nil?
-      last = runnable_events.where(:in_progress => false, :object_id => first.object_id,
-                                    :event_type => first.event_type).order(:created_at => 'desc').first
-      mark_in_progress(first)
-      last
+    def self.oldest_runnable_event
+      runnable_events.where(in_progress: false).order(created_at: :asc).first
+    end
+
+    def self.next_event(event_type, object_id)
+      # Find the newest event by type and object id
+      runnable_events.where(
+        in_progress: false,
+        object_id: object_id,
+        event_type: event_type
+      ).order(created_at: :desc).first
     end
 
     def self.mark_in_progress(event)

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -77,6 +77,14 @@ module Katello
       ForemanTasks.dynflow.eager_load_actions!
     end
 
+    initializer "katello.start_katello_events", before: :finisher_hook do
+      unless Rails.env.test?
+        ForemanTasks.dynflow.config.post_executor_init do |world|
+          Actions::Katello::EventDaemon::EventQueue.launch(world)
+        end
+      end
+    end
+
     # make sure the Katello plugin is initialized before `after_initialize`
     # hook so that the resumed Dynflow tasks can rely on everything ready.
     initializer 'katello.register_plugin', :before => :finisher_hook, :after => 'foreman_remote_execution.register_plugin' do |app|
@@ -147,7 +155,6 @@ module Katello
       end
 
       Katello::EventDaemon::Runner.register_service(:candlepin_events, Katello::CandlepinEventListener)
-      Katello::EventDaemon::Runner.register_service(:katello_events, Katello::EventMonitor::PollerThread)
 
       # Lib Extensions
       ::Foreman::Renderer::Scope::Variables::Base.include Katello::Concerns::RendererExtensions


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

I decided to leverage AI to answer an age-old question: how can the katello event queue **without dynflow**?  After an intrepid vibe coding session an answer emerged: run the katello event queue **with dynflow**. The code you are about to read is 100% AI generated.

Jokes aside, using this approach or one like it will stop running the queue in background threads in the web process which is an improvement. Not yet sure if there are any practical downsides to the changes here, but it is functional!

#### Considerations taken when implementing this change?

Trust AI completely

#### What are the testing steps for this pull request?

TBD