### PR TITLE
Fixes #38359 - Use the plain component for structured APT

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -1057,7 +1057,7 @@ module Katello
       return [] if version_href.blank?
 
       pulp_api = Katello::Pulp3::Repository.instance_for_type(self, SmartProxy.pulp_primary).api.content_release_components_api
-      pulp_api.list({:repository_version => version_href}).results.map { |x| x.component }.uniq
+      pulp_api.list({:repository_version => version_href}).results.map { |x| x.plain_component }.uniq
     end
 
     def deb_sanitize_pulp_distribution(distribution)


### PR DESCRIPTION
Issue: https://projects.theforeman.org/issues/38359

This fixes structured APT handling for upstream repositories with a path prefix on the components listed in the Release file. This is a rare edge case, primarily known from old versions of the Debian security repository.

This requires pulp_deb and rubygem-pulp_deb_client >= 3.5.0. Prior to this version, the Pulp API did not expose the plain component!

Requires: https://github.com/theforeman/foreman-packaging/pull/11793

#### What are the testing steps for this pull request?

1. Make sure you are using pulp_deb and rubygem-pulp_deb_client >= 3.5.0 in your environment.
2. Under "Administer > Settings > Content tab" make sure "Enable structured APT for deb content" is set to "Yes"
3. Synchronize a `deb` type repo with:
    - Upstream URL: `http://security.debian.org/debian-security/`
    - Releases/Distributions: `buster/updates`
    - Components: `contrib`.
    - on_demand recommended for testing.
5. Add to any CV/LCENV and create an activation key for it. Under the "Repository Sets" tab of the activation key, the "Repository Path" for the repo should end in something like `?comp=contrib&rel=buster/updates`, It should NOT end in `?comp=updates/contrib&rel=buster/updates`!