### PR TITLE
Fixes #38310 - Unskip the 2 skipped UI tests

### DIFF
--- a/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/__tests__/hostCollectionsModal.test.js
+++ b/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/__tests__/hostCollectionsModal.test.js
@@ -1,6 +1,5 @@
-/* eslint-disable */
 import React from 'react';
-import { renderWithRedux, patientlyWaitFor, fireEvent, act } from 'react-testing-lib-wrapper';
+import { renderWithRedux, patientlyWaitFor, fireEvent, act, waitFor } from 'react-testing-lib-wrapper';
 import mockAvailableHostCollections from './availableHostCollections.fixtures.json';
 import mockRemovableHostCollections from './removableHostCollections.fixtures.json';
 import { REMOVABLE_HOST_COLLECTIONS_KEY } from '../HostCollectionsConstants';
@@ -50,7 +49,7 @@ describe('HostCollectionsAddModal', () => {
     nock.restore(); // Restores HTTP to normal behavior
   });
 
-  test.skip('Calls API with available_for=host on page load', async (done) => {
+  test('Calls API with available_for=host on page load', async (done) => {
     const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
     const scope = nockInstance
@@ -74,7 +73,7 @@ describe('HostCollectionsAddModal', () => {
     act(done);
   });
 
-  test.skip('Calls alterHostCollections with combined list of existing and new host collections', async (done) => {
+  test('Calls alterHostCollections with combined list of existing and new host collections', async (done) => {
     const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
     const scope = nockInstance
@@ -113,10 +112,10 @@ describe('HostCollectionsAddModal', () => {
     assertNockRequest(autocompleteScope);
     assertNockRequest(scope);
     assertNockRequest(alterScope);
-    assertNockRequest(hostDetailsScope);
-    act(done);
+    await waitFor(() => expect(hostDetailsScope.isDone()).toBe(true));
+    assertNockRequest(hostDetailsScope, done);
   });
-  test.skip('Host collections whose host limit is exceeded are disabled', async (done) => {
+  test('Host collections whose host limit is exceeded are disabled', async (done) => {
     const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
     const scope = nockInstance
@@ -158,7 +157,7 @@ describe('HostCollectionsRemoveModal', () => {
     nock.cleanAll(); // Removes all interceptors
     nock.restore(); // Restores HTTP to normal behavior
   });
-  test.skip('Calls API without available_for=host on page load', async (done) => {
+  test('Calls API without available_for=host on page load', async (done) => {
     const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
     const scope = nockInstance
@@ -184,7 +183,7 @@ describe('HostCollectionsRemoveModal', () => {
     act(done); // Pass jest callback to confirm test is done
   });
 
-  test.skip('Calls alterHostCollections with host collections being removed filtered out from the list', async (done) => {
+  test('Calls alterHostCollections with host collections being removed filtered out from the list', async (done) => {
     const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl);
 
     const scope = nockInstance
@@ -233,4 +232,3 @@ describe('HostCollectionsRemoveModal', () => {
     act(done);
   });
 });
-

--- a/webpack/scenes/ContentViews/Details/Filters/__tests__/ContentViewPackageGroupFilter.test.js
+++ b/webpack/scenes/ContentViews/Details/Filters/__tests__/ContentViewPackageGroupFilter.test.js
@@ -1,6 +1,5 @@
-/* eslint-disable */
 import React from 'react';
-import { renderWithRedux, patientlyWaitFor, fireEvent, act } from 'react-testing-lib-wrapper';
+import { renderWithRedux, patientlyWaitFor, fireEvent, act, waitFor } from 'react-testing-lib-wrapper';
 import { Route } from 'react-router-dom';
 
 import ContentViewFilterDetails from '../ContentViewFilterDetails';
@@ -52,7 +51,7 @@ afterEach(() => {
   nock.restore(); // Restores HTTP to normal behavior
 });
 
-test.skip('Can enable and disable add filter button', async (done) => {
+test('Can enable and disable add filter button', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl, autocompleteQuery);
   const { name: cvFilterName } = cvFilterDetails;
   const cvFilterScope = nockInstance
@@ -94,7 +93,7 @@ test.skip('Can enable and disable add filter button', async (done) => {
   act(done);
 });
 
-test.skip('Can remove a filter rule', async (done) => {
+test('Can remove a filter rule', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl, autocompleteQuery);
   const { rules } = cvFilterDetails;
   const { name } = rules[0];
@@ -152,7 +151,7 @@ test.skip('Can remove a filter rule', async (done) => {
   act(done);
 });
 
-test.skip('Can add a filter rule', async (done) => {
+test('Can add a filter rule', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl, autocompleteQuery);
   const { rules } = cvFilterDetails;
   const { name } = rules[0];
@@ -212,7 +211,7 @@ test.skip('Can add a filter rule', async (done) => {
   act(done);
 });
 
-test.skip('Can bulk remove filter rules', async (done) => {
+test('Can bulk remove filter rules', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl, autocompleteQuery);
   const { rules } = cvFilterDetails;
   const { name } = rules[0];
@@ -270,12 +269,11 @@ test.skip('Can bulk remove filter rules', async (done) => {
   assertNockRequest(cvFiltersScope);
   assertNockRequest(cvFiltersRuleBulkDeleteScope);
   assertNockRequest(cvRequestCallbackScope);
-
+  await waitFor(() => expect(packageGroupsScope.isDone()).toBe(true));
   assertNockRequest(packageGroupsScope, done);
-  act(done);
 });
 
-test.skip('Can bulk add filter rules', async (done) => {
+test('Can bulk add filter rules', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl, autocompleteQuery);
   const { rules } = cvFilterDetails;
   const { name } = rules[0];
@@ -330,11 +328,11 @@ test.skip('Can bulk add filter rules', async (done) => {
   assertNockRequest(cvFiltersScope);
   assertNockRequest(cvFiltersRuleBulkAddScope);
   assertNockRequest(cvRequestCallbackScope);
+  await waitFor(() => expect(packageGroupsScope.isDone()).toBe(true));
   assertNockRequest(packageGroupsScope, done);
-  act(done);
 });
 
-test.skip('Can filter by added/not added rules', async (done) => {
+test('Can filter by added/not added rules', async (done) => {
   const autocompleteScope = mockAutocomplete(nockInstance, autocompleteUrl, autocompleteQuery);
   const { rules } = cvFilterDetails;
   const { name } = rules[0];
@@ -387,11 +385,11 @@ test.skip('Can filter by added/not added rules', async (done) => {
   assertNockRequest(autocompleteScope);
   assertNockRequest(cvFilterScope);
   assertNockRequest(cvFiltersScope);
+  await waitFor(() => expect(packageGroupsScope.isDone()).toBe(true));
   assertNockRequest(packageGroupsScope, done);
-  act(done);
 });
 
-test.skip('Can show affected repository tab on dropdown selection and add repos', async (done) => {
+test('Can show affected repository tab on dropdown selection and add repos', async (done) => {
   const autocompleteScope = mockAutocomplete(
     nockInstance,
     autocompleteUrl,
@@ -492,7 +490,7 @@ test.skip('Can show affected repository tab on dropdown selection and add repos'
   act(done);
 });
 
-test.skip('Can show affected repository tab and remove affected repos', async (done) => {
+test('Can show affected repository tab and remove affected repos', async (done) => {
   const autocompleteScope = mockAutocomplete(
     nockInstance,
     autocompleteUrl,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The below 2 tests were skipped to allow PF5 PR to get in:

extensions/HostDetails/Cards/HostCollectionsCard/_tests_/hostCollectionsModal.test.js
webpack/scenes/ContentViews/Details/Filters/_tests_/ContentViewPackageGroupFilter.test.js

This PR will un-skip these.

#### What are the testing steps for this pull request?

Check if all the UI tests are passing.

## Summary by Sourcery

Unskip the two previously disabled UI test suites and update async completion logic to use `await waitFor` for more reliable assertions

Bug Fixes:
- Re-enable skipped tests in hostCollectionsModal and ContentViewPackageGroupFilter suites

Tests:
- Replace direct `act(done)` callbacks with `await waitFor` in affected tests to ensure proper async behavior