### PR TITLE
[CP] Fixes #37362 - Move search query Ansible templates to Katello via Ansible

### DIFF
--- a/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
@@ -1,7 +1,7 @@
 <%#
 kind: job_template
 name: Install errata by search query - Katello Ansible Default
-job_category: Katello
+job_category: Katello via Ansible
 description_format: 'Install errata %{Errata search query}'
 feature: katello_errata_install_by_search
 provider_type: Ansible

--- a/app/views/foreman/job_templates/install_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_packages_by_search_query_-_katello_ansible_default.erb
@@ -1,7 +1,7 @@
 <%#
 kind: job_template
 name: Install packages by search query - Katello Ansible Default
-job_category: Katello
+job_category: Katello via Ansible
 description_format: 'Install package(s) %{Package search query}'
 feature: katello_package_install_by_search
 provider_type: Ansible

--- a/app/views/foreman/job_templates/remove_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/remove_packages_by_search_query_-_katello_ansible_default.erb
@@ -1,7 +1,7 @@
 <%#
 kind: job_template
 name: Remove packages by search query - Katello Ansible Default
-job_category: Katello
+job_category: Katello via Ansible
 description_format: 'Remove package(s) %{Packages search query}'
 feature: katello_package_remove_by_search
 provider_type: Ansible
@@ -19,7 +19,7 @@ template_inputs:
 - hosts: all
   tasks:
     - package:
-        name: 
+        name:
 <% package_names.each do |package_name| -%>
           - <%= package_name %>
 <% end -%>

--- a/app/views/foreman/job_templates/update_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/update_packages_by_search_query_-_katello_ansible_default.erb
@@ -1,7 +1,7 @@
 <%#
 kind: job_template
 name: Update packages by search query - Katello Ansible Default
-job_category: Katello
+job_category: Katello via Ansible
 description_format: 'Update package(s) %{Packages search query}'
 feature: katello_package_remove_by_search
 provider_type: Ansible

--- a/db/migrate/2025041012345_remove_katello_ansible_job_template_duplicates
+++ b/db/migrate/2025041012345_remove_katello_ansible_job_template_duplicates
@@ -1,0 +1,12 @@
+class RemoveKatelloAnsibleJobTemplateDuplicates < ActiveRecord::Migration[6.1]
+  def change
+    names = [
+      "Install errata by search query - Katello Ansible Default",
+      "Install packages by search query - Katello Ansible Default",
+      "Remove packages by search query - Katello Ansible Default",
+      "Update packages by search query - Katello Ansible Default"
+    ]
+    JobTemplate.where(job_category: 'Katello').where(name: names).update(locked: false)
+    JobTemplate.where(job_category: 'Katello').where(name: names).destroy_all
+  end
+end


### PR DESCRIPTION
CP of https://github.com/Katello/katello/commit/0e25591bec9bb0b1abcf767e56abee20f5fd3ce2

Includes a migration since there are still the old broken jobs in the DB that mess up the old REX UI.

To test, spin up a Katello 4.11 box (or Satellite 6.15), apply the patch, run the installer, and check that the following screenshot with duplicate "Job template" fields cannot be reproduced:

![image (9)](https://github.com/user-attachments/assets/ac47b422-c220-4137-9a6d-6b1bd3c36a70)
