### PR TITLE
Fixes #38366 - Move ansible templates into Katello via Ansible

### DIFF
--- a/db/migrate/20250410155300_change_ansible_templates_category.rb
+++ b/db/migrate/20250410155300_change_ansible_templates_category.rb
@@ -1,0 +1,22 @@
+class ChangeAnsibleTemplatesCategory < ActiveRecord::Migration[7.0]
+  TEMPLATES = [
+    'Install errata by search query - Katello Ansible Default',
+    'Install packages by search query - Katello Ansible Default',
+    'Remove packages by search query - Katello Ansible Default',
+    'Update packages by search query - Katello Ansible Default',
+  ].freeze
+
+  def up
+    change_category('Katello', 'Katello via Ansible')
+  end
+
+  def down
+    change_category('Katello via Ansible', 'Katello')
+  end
+
+  private
+
+  def change_category(from, to)
+    ::Template.where(type: 'JobTemplate', provider_type: 'Ansible', job_category: from, name: TEMPLATES).update_all(job_category: to)
+  end
+end

--- a/db/migrate/20250410155300_change_ansible_templates_category.rb
+++ b/db/migrate/20250410155300_change_ansible_templates_category.rb
@@ -1,4 +1,4 @@
-class ChangeAnsibleTemplatesCategory < ActiveRecord::Migration[7.0]
+class ChangeAnsibleTemplatesCategory < ActiveRecord::Migration[6.1]
   TEMPLATES = [
     'Install errata by search query - Katello Ansible Default',
     'Install packages by search query - Katello Ansible Default',


### PR DESCRIPTION
Supplements 0e25591bec

#### What are the changes introduced in this pull request?
0e25591bec moved several job templates to a different category, but the way seeds work it might not be 100% reliable for already deployed instances. Moving those in a migration can help with those. On instances where the templates are in the right category this will be a noop.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1) Check out katello at `0e25591bec^`
2) drop, create, migrate and seed the db
3) Running `JobTemplate.where(job_category: 'Katello').pluck(:provider_type).uniq` should give back `["script", "Ansible"]`
4) Apply `0e25591bec`
5) Run seeds, see that nothing happened. Running `JobTemplate.where(job_category: 'Katello').pluck(:provider_type).uniq` should still give back `["script", "Ansible"]`
6) Apply this
7) Run migrations
8) `JobTemplate.where(job_category: 'Katello').pluck(:provider_type).uniq` should give back `["script"]`
