### PR TITLE
Fixes #38369 - Add migration for file download_policy

### DIFF
--- a/db/migrate/20250409120843_fix_file_download_policy.rb
+++ b/db/migrate/20250409120843_fix_file_download_policy.rb
@@ -1,0 +1,11 @@
+class FixFileDownloadPolicy < ActiveRecord::Migration[6.1]
+  def up
+    Katello::RootRepository.where(content_type: "file")
+                           .where(download_policy: [nil, ""])
+                           .update_all(:download_policy => "immediate")
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
With #11184 download_policy was added to content_type 'file'. Previous file repos did not have a download_policy and therefore the field was empty. This PR make sure, that the download_policy will be set to 'immediate' while updating.

Testing:
- create a file repo with empty download_policy. (or change it to empty directly in the db)
- apply the patch
- run foreman-installer and restart foreman afterwards
- the file repo should then have the download_poliy "immediate" set
