### PR TITLE
Fixes #38372 - Optional dbus-run-session for flatpak install

### DIFF
--- a/app/views/foreman/job_templates/flatpak_install.erb
+++ b/app/views/foreman/job_templates/flatpak_install.erb
@@ -13,11 +13,19 @@ template_inputs:
   description: Name of the application to install
   input_type: user
   required: true
+- name: Launch a session bus instance
+  description: Launch a session bus instance for the flatpak application using 'dbus-run-session'. Requires package dbus-daemon on client. Select 'true' for machines without a display server.
+  input_type: user
+  required: false
+  options: "true\r\nfalse"
+  advanced: false
+  value_type: plain
+  default: 'false'
 %>
 
 <%
   remote_name = input('Flatpak remote name')
   app_name = input('Application name')
+  use_dbus_session = input('Launch a session bus instance') == 'true'
 %>
-
-sudo dbus-launch flatpak install <%= remote_name %> <%= app_name %> --assumeyes
+sudo <%= use_dbus_session ? 'dbus-run-session ' : ''%>flatpak install <%= remote_name %> <%= app_name %> --assumeyes


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
1. Switch to dbus-run-session instead of dbus-launch
2. Make using dbus-run-session optional since not all apps require dbus access
#### Considerations taken when implementing this change?
Changes based on discussions in https://github.com/flatpak/flatpak/issues/3847
#### What are the testing steps for this pull request?
1. Register a host to a server with flatpak content like firefox.
2. Add the flatpak remote to point to katello.
3. Run the "Flatpak - Install application on host" job template against a host with any synced flatpak repo with new input "Launch a session bus instance " set to True/False.