### PR TITLE
Fixes #38376 - Show repo counts of re-added environments

### DIFF
--- a/webpack/scenes/SmartProxy/ExpandableCvDetails.js
+++ b/webpack/scenes/SmartProxy/ExpandableCvDetails.js
@@ -32,6 +32,19 @@ const ExpandableCvDetails = ({
     },
   });
 
+  const anyRepoInEnv = (repositories) => {
+    if (repositories && Object.values(repositories)) {
+      return Object.values(repositories).some(repo => repo.metadata.env_id === envId);
+    }
+    return false;
+  };
+
+  const getSyncedToCapsuleStatus = (upToDate, versionId) => {
+    if (upToDate) return upToDate;
+    if (anyRepoInEnv(contentCounts?.content_view_versions?.[versionId]?.repositories)) return 'partial';
+    return false;
+  };
+
   return (
     <Table
       aria-label="expandable-content-views"
@@ -99,7 +112,7 @@ const ExpandableCvDetails = ({
                 <ExpandedSmartProxyRepositories
                   contentCounts={contentCounts?.content_view_versions?.[versionId]?.repositories}
                   repositories={repositories}
-                  syncedToCapsule={upToDate}
+                  syncedToCapsule={getSyncedToCapsuleStatus(upToDate, versionId)}
                   envId={envId}
                 />
               </Td>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Show content counts when proxy has the counts available regardless of sync status.
#### Considerations taken when implementing this change?
When we remove an env from proxy, we lose track of the env. If the env is re-added the safe assumption is that the CVs in the env need syncing to the proxy. However, if the proxy already has some content counts from the env on it (If full capsule sync hasn't run on the proxy and orphaned content hasn't been removed ) it is fine to show that to the user cause that info is accurate.
#### What are the testing steps for this pull request?
1. Prepare a CV in few environments tied to proxy.
2. Sync the proxy.
3. Look at the capsule content page.
4. Make sure counts are displayed.
5. Remove an environment
6. The Proxy content page now won't show the env and counts.
7. Add back the env.
8. Page should display content counts that env had before removal.