### PR TITLE
Fixes #38377 - support package actions for bootc hosts

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -89,7 +89,7 @@ module Katello
         prepend Overrides
 
         delegate :content_source_id, :single_content_view, :single_lifecycle_environment, :default_environment?, :single_content_view_environment?, :multi_content_view_environment?, :kickstart_repository_id, :bound_repositories,
-          :content_view_environment_labels, :installable_errata, :installable_rpms, :image_mode_host?, to: :content_facet, allow_nil: true
+          :content_view_environment_labels, :installable_errata, :installable_rpms, :image_mode_host?, :yum_or_yum_transient, to: :content_facet, allow_nil: true
 
         delegate :release_version, :purpose_role, :purpose_usage, to: :subscription_facet, allow_nil: true
 
@@ -624,7 +624,7 @@ class ::Host::Managed::Jail < Safemode::Jail
         :installed_packages, :traces_helpers, :advisory_ids, :package_names_for_job_template,
         :filtered_entitlement_quantity_consumed, :bound_repositories,
         :single_content_view, :single_lifecycle_environment, :content_view_environment_labels, :multi_content_view_environment?,
-        :release_version, :purpose_role, :purpose_usage
+        :release_version, :purpose_role, :purpose_usage, :image_mode_host?, :yum_or_yum_transient
 end
 
 class ActiveRecord::Associations::CollectionProxy::Jail < Safemode::Jail

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -107,7 +107,7 @@ module Katello
 
       def yum_or_yum_transient
         if image_mode_host?
-          'yum --transient'
+          'dnf --transient'
         else
           'yum'
         end

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -105,6 +105,14 @@ module Katello
         bootc_booted_image.present?
       end
 
+      def yum_or_yum_transient
+        if image_mode_host?
+          'yum --transient'
+        else
+          'yum'
+        end
+      end
+
       def cves_changed?
         cves_changed
       end
@@ -458,7 +466,7 @@ module Katello
               :errata_counts, :id, :kickstart_repository, :kickstart_repository_id, :kickstart_repository_name,
               :upgradable_deb_count, :upgradable_module_stream_count, :upgradable_rpm_count, :uuid,
               :installable_security_errata_count, :installable_bugfix_errata_count, :installable_enhancement_errata_count,
-              :single_content_view, :single_lifecycle_environment, :content_view_environment_labels
+              :single_content_view, :single_lifecycle_environment, :content_view_environment_labels, :yum_or_yum_transient
       end
     end
   end

--- a/app/views/foreman/job_templates/install_errata_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_errata_-_katello_ansible_default.erb
@@ -20,6 +20,6 @@ kind: job_template
 <%= render_template('Run Command - Ansible Default', :command => "zypper -n install -t patch #{advisories}") %>
 <% else -%>
 <% advisories = input(:errata).split(',').map { |e| "--advisory=#{e}" }.join(' ') -%>
-<%= render_template('Run Command - Ansible Default', :command => "yum -y update-minimal #{advisories}") %>
+<%= render_template('Run Command - Ansible Default', :command => "#{@host.yum_or_yum_transient} -y update-minimal #{advisories}") %>
 <% end -%>
 <%= snippet_if_exists(template_name + " custom post") %>

--- a/app/views/foreman/job_templates/install_errata_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_errata_-_katello_ansible_default.erb
@@ -20,6 +20,28 @@ kind: job_template
 <%= render_template('Run Command - Ansible Default', :command => "zypper -n install -t patch #{advisories}") %>
 <% else -%>
 <% advisories = input(:errata).split(',').map { |e| "--advisory=#{e}" }.join(' ') -%>
-<%= render_template('Run Command - Ansible Default', :command => "#{@host.yum_or_yum_transient} -y update-minimal #{advisories}") %>
+---
+- hosts: all
+  tasks:
+    - name: Collect bootc status
+      shell:
+        cmd: 'bootc status --json'
+      register: bootc_status
+      ignore_errors: true
+    - name: Parse bootc status json
+      set_fact:
+        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
+      when: bootc_status.rc == 0
+    - name: Install errata via dnf for image mode machines
+      shell:
+        cmd: 'dnf -y --transient update-minimal <%= advisories %>'
+      register: out
+      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+    - name: Install errata normally
+      shell:
+        cmd: 'yum -y update-minimal <%= advisories %>'
+      register: out
+      when: bootc_status_json is not defined or bootc_status_json['status']['booted'] == 'null'
+    - debug: var=out
 <% end -%>
 <%= snippet_if_exists(template_name + " custom post") %>

--- a/app/views/foreman/job_templates/install_errata_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_errata_-_katello_ansible_default.erb
@@ -23,25 +23,17 @@ kind: job_template
 ---
 - hosts: all
   tasks:
-    - name: Collect bootc status
-      shell:
-        cmd: 'bootc status --json'
-      register: bootc_status
-      ignore_errors: true
-    - name: Parse bootc status json
-      set_fact:
-        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
-      when: bootc_status.rc == 0
+<%= indent(4) { snippet('check_bootc_status') } %>
     - name: Install errata via dnf for image mode machines
       shell:
         cmd: 'dnf -y --transient update-minimal <%= advisories %>'
       register: out
-      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+      when: is_bootc_host
     - name: Install errata normally
       shell:
         cmd: 'yum -y update-minimal <%= advisories %>'
       register: out
-      when: bootc_status_json is not defined or bootc_status_json['status']['booted'] == 'null'
+      when: not is_bootc_host
     - debug: var=out
 <% end -%>
 <%= snippet_if_exists(template_name + " custom post") %>

--- a/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
@@ -21,6 +21,6 @@ template_inputs:
 <%= render_template('Run Command - Ansible Default', :command => "zypper -n install -t patch #{advisory_ids.join(' ')}") %>
 <% else -%>
 <% advisories = advisory_ids.map { |e| "--advisory=#{e}" }.join(' ') -%>
-<%= render_template('Run Command - Ansible Default', :command => "yum -y update-minimal #{advisories}") %>
+<%= render_template('Run Command - Ansible Default', :command => "#{@host.yum_or_yum_transient} -y update-minimal #{advisories}") %>
 <% end -%>
 <%= snippet_if_exists(template_name + " custom post") %>

--- a/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
@@ -21,6 +21,28 @@ template_inputs:
 <%= render_template('Run Command - Ansible Default', :command => "zypper -n install -t patch #{advisory_ids.join(' ')}") %>
 <% else -%>
 <% advisories = advisory_ids.map { |e| "--advisory=#{e}" }.join(' ') -%>
-<%= render_template('Run Command - Ansible Default', :command => "#{@host.yum_or_yum_transient} -y update-minimal #{advisories}") %>
+---
+- hosts: all
+  tasks:
+    - name: Collect bootc status
+      shell:
+        cmd: 'bootc status --json'
+      register: bootc_status
+      ignore_errors: true
+    - name: Parse bootc status json
+      set_fact:
+        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
+      when: bootc_status.rc == 0
+    - name: Install errata via dnf for image mode machines
+      shell:
+        cmd: 'dnf -y --transient update-minimal <%= advisories %>'
+      register: out
+      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+    - name: Install errata normally
+      shell:
+        cmd: 'yum -y update-minimal <%= advisories %>'
+      register: out
+      when: bootc_status_json is not defined or bootc_status_json['status']['booted'] == 'null'
+    - debug: var=out
 <% end -%>
 <%= snippet_if_exists(template_name + " custom post") %>

--- a/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
@@ -24,25 +24,17 @@ template_inputs:
 ---
 - hosts: all
   tasks:
-    - name: Collect bootc status
-      shell:
-        cmd: 'bootc status --json'
-      register: bootc_status
-      ignore_errors: true
-    - name: Parse bootc status json
-      set_fact:
-        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
-      when: bootc_status.rc == 0
+<%= indent(4) { snippet('check_bootc_status') } %>
     - name: Install errata via dnf for image mode machines
       shell:
         cmd: 'dnf -y --transient update-minimal <%= advisories %>'
       register: out
-      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+      when: is_bootc_host
     - name: Install errata normally
       shell:
         cmd: 'yum -y update-minimal <%= advisories %>'
       register: out
-      when: bootc_status_json is not defined or bootc_status_json['status']['booted'] == 'null'
+      when: not is_bootc_host
     - debug: var=out
 <% end -%>
 <%= snippet_if_exists(template_name + " custom post") %>

--- a/app/views/foreman/job_templates/install_group_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_group_-_katello_ansible_default.erb
@@ -12,5 +12,26 @@ template_inputs:
 provider_type: Ansible
 kind: job_template
 %>
-
-<%= render_template('Run Command - Ansible Default', :command => "#{@host.yum_or_yum_transient} -y group install #{input('package')}") %>
+---
+- hosts: all
+  tasks:
+    - name: Collect bootc status
+      shell:
+        cmd: 'bootc status --json'
+      register: bootc_status
+      ignore_errors: true
+    - name: Parse bootc status json
+      set_fact:
+        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
+      when: bootc_status.rc == 0
+    - name: Install groups via dnf for image mode machines
+      shell:
+        cmd: 'dnf -y --transient groupinstall <%= input('package') %>'
+      register: out
+      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+    - name: Install groups normally
+      shell:
+        cmd: 'yum -y groupinstall <%= input('package') %>'
+      register: out
+      when: bootc_status_json is not defined or bootc_status_json['status']['booted'] == 'null'
+    - debug: var=out

--- a/app/views/foreman/job_templates/install_group_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_group_-_katello_ansible_default.erb
@@ -13,4 +13,4 @@ provider_type: Ansible
 kind: job_template
 %>
 
-<%= render_template('Run Command - Ansible Default', :command => "yum -y group install #{input('package')}") %>
+<%= render_template('Run Command - Ansible Default', :command => "#{@host.yum_or_yum_transient} -y group install #{input('package')}") %>

--- a/app/views/foreman/job_templates/install_group_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_group_-_katello_ansible_default.erb
@@ -15,23 +15,15 @@ kind: job_template
 ---
 - hosts: all
   tasks:
-    - name: Collect bootc status
-      shell:
-        cmd: 'bootc status --json'
-      register: bootc_status
-      ignore_errors: true
-    - name: Parse bootc status json
-      set_fact:
-        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
-      when: bootc_status.rc == 0
+<%= indent(4) { snippet('check_bootc_status') } %>
     - name: Install groups via dnf for image mode machines
       shell:
         cmd: 'dnf -y --transient groupinstall <%= input('package') %>'
       register: out
-      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+      when: is_bootc_host
     - name: Install groups normally
       shell:
         cmd: 'yum -y groupinstall <%= input('package') %>'
       register: out
-      when: bootc_status_json is not defined or bootc_status_json['status']['booted'] == 'null'
+      when: not is_bootc_host
     - debug: var=out

--- a/app/views/foreman/job_templates/install_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_packages_by_search_query_-_katello_ansible_default.erb
@@ -18,7 +18,18 @@ template_inputs:
 ---
 - hosts: all
   tasks:
+<% if @host.image_mode_host? -%>
+    - shell:
+        cmd: |
+<%=       indent(10) { 'bootc usr-overlay' } %>
+      register: out
+      ignore_errors: true
+    - debug: var=out
+<% end -%>
     - package:
+<% if @host.image_mode_host? -%>
+        use: 'dnf'
+<% end -%>
 <% if package_names.empty? -%>
         name: []
 <% else -%>

--- a/app/views/foreman/job_templates/install_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_packages_by_search_query_-_katello_ansible_default.erb
@@ -18,22 +18,38 @@ template_inputs:
 ---
 - hosts: all
   tasks:
-<% if @host.image_mode_host? -%>
-    - shell:
-        cmd: |
-<%=       indent(10) { 'bootc usr-overlay' } %>
+    - name: Collect bootc status
+      shell:
+        cmd: 'bootc status --json'
+      register: bootc_status
+      ignore_errors: true
+    - name: Parse bootc status json
+      set_fact:
+        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
+      when: bootc_status.rc == 0
+    - name: Enable bootc overlay
+      shell:
+        cmd: 'bootc usr-overlay'
       register: out
       ignore_errors: true
+      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
     - debug: var=out
-<% end -%>
-    - package:
-<% if @host.image_mode_host? -%>
+    - name: Install packages via dnf for image mode machines
+      package:
         use: 'dnf'
-<% end -%>
 <% if package_names.empty? -%>
         name: []
 <% else -%>
         name: <%= indent(10) { to_yaml(package_names).gsub(/---/, "") } -%>
         state: present
 <% end -%>
-
+      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+    - name: Install packages normally
+      package:
+<% if package_names.empty? -%>
+        name: []
+<% else -%>
+        name: <%= indent(10) { to_yaml(package_names).gsub(/---/, "") } -%>
+        state: present
+<% end -%>
+      when: bootc_status_json is not defined or bootc_status_json['status']['booted'] == 'null'

--- a/app/views/foreman/job_templates/install_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_packages_by_search_query_-_katello_ansible_default.erb
@@ -18,21 +18,13 @@ template_inputs:
 ---
 - hosts: all
   tasks:
-    - name: Collect bootc status
-      shell:
-        cmd: 'bootc status --json'
-      register: bootc_status
-      ignore_errors: true
-    - name: Parse bootc status json
-      set_fact:
-        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
-      when: bootc_status.rc == 0
+<%= indent(4) { snippet('check_bootc_status') } %>
     - name: Enable bootc overlay
       shell:
         cmd: 'bootc usr-overlay'
       register: out
       ignore_errors: true
-      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+      when: is_bootc_host
     - debug: var=out
     - name: Install packages via dnf for image mode machines
       package:
@@ -43,7 +35,7 @@ template_inputs:
         name: <%= indent(10) { to_yaml(package_names).gsub(/---/, "") } -%>
         state: present
 <% end -%>
-      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+      when: is_bootc_host
     - name: Install packages normally
       package:
 <% if package_names.empty? -%>
@@ -52,4 +44,4 @@ template_inputs:
         name: <%= indent(10) { to_yaml(package_names).gsub(/---/, "") } -%>
         state: present
 <% end -%>
-      when: bootc_status_json is not defined or bootc_status_json['status']['booted'] == 'null'
+      when: not is_bootc_host

--- a/app/views/foreman/job_templates/remove_group_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/remove_group_-_katello_ansible_default.erb
@@ -13,4 +13,4 @@ provider_type: Ansible
 kind: job_template
 %>
 
-<%= render_template('Run Command - Ansible Default', :command => "yum -y group remove #{input('package')}") %>
+<%= render_template('Run Command - Ansible Default', :command => "#{@host.yum_or_yum_transient} -y group remove #{input('package')}") %>

--- a/app/views/foreman/job_templates/remove_group_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/remove_group_-_katello_ansible_default.erb
@@ -16,29 +16,15 @@ kind: job_template
 ---
 - hosts: all
   tasks:
-    - name: Collect bootc status
-      shell:
-        cmd: 'bootc status --json'
-      register: bootc_status
-      ignore_errors: true
-    - name: Parse bootc status json
-      set_fact:
-        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
-      when: bootc_status.rc == 0
-    - name: Enable bootc overlay
-      shell:
-        cmd: 'bootc usr-overlay'
-      register: out
-      ignore_errors: true
-      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
-    - debug: var=out
+<%= indent(4) { snippet('check_bootc_status') } %>
     - name: Remove groups via dnf for image mode machines
       shell:
         cmd: 'dnf -y --transient group remove <%= input('package') %>'
       register: out
-      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+      when: is_bootc_host
     - name: Remove groups normally
       shell:
         cmd: 'yum -y group remove <%= input('package') %>'
       register: out
-      when: bootc_status_json is not defined or bootc_status_json['status']['booted'] == 'null'
+      when: not is_bootc_host
+    - debug: var=out

--- a/app/views/foreman/job_templates/remove_group_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/remove_group_-_katello_ansible_default.erb
@@ -13,4 +13,32 @@ provider_type: Ansible
 kind: job_template
 %>
 
-<%= render_template('Run Command - Ansible Default', :command => "#{@host.yum_or_yum_transient} -y group remove #{input('package')}") %>
+---
+- hosts: all
+  tasks:
+    - name: Collect bootc status
+      shell:
+        cmd: 'bootc status --json'
+      register: bootc_status
+      ignore_errors: true
+    - name: Parse bootc status json
+      set_fact:
+        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
+      when: bootc_status.rc == 0
+    - name: Enable bootc overlay
+      shell:
+        cmd: 'bootc usr-overlay'
+      register: out
+      ignore_errors: true
+      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+    - debug: var=out
+    - name: Remove groups via dnf for image mode machines
+      shell:
+        cmd: 'dnf -y --transient group remove <%= input('package') %>'
+      register: out
+      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+    - name: Remove groups normally
+      shell:
+        cmd: 'yum -y group remove <%= input('package') %>'
+      register: out
+      when: bootc_status_json is not defined or bootc_status_json['status']['booted'] == 'null'

--- a/app/views/foreman/job_templates/remove_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/remove_packages_by_search_query_-_katello_ansible_default.erb
@@ -18,21 +18,13 @@ template_inputs:
 ---
 - hosts: all
   tasks:
-    - name: Collect bootc status
-      shell:
-        cmd: 'bootc status --json'
-      register: bootc_status
-      ignore_errors: true
-    - name: Parse bootc status json
-      set_fact:
-        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
-      when: bootc_status.rc == 0
+<%= indent(4) { snippet('check_bootc_status') } %>
     - name: Enable bootc overlay
       shell:
         cmd: 'bootc usr-overlay'
       register: out
       ignore_errors: true
-      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+      when: is_bootc_host
     - debug: var=out
     - name: Remove packages via dnf for image mode machines
       package:
@@ -42,7 +34,7 @@ template_inputs:
 <% end -%>
         state: absent
         use: 'dnf'
-      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+      when: is_bootc_host
     - name: Remove packages normally
       package:
         name:
@@ -50,4 +42,4 @@ template_inputs:
           - <%= package_name %>
 <% end -%>
         state: absent
-      when: bootc_status_json is not defined or bootc_status_json['status']['booted'] == 'null'
+      when: not is_bootc_host

--- a/app/views/foreman/job_templates/remove_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/remove_packages_by_search_query_-_katello_ansible_default.erb
@@ -17,21 +17,37 @@ template_inputs:
 ) -%>
 ---
 - hosts: all
-<% if @host.image_mode_host? -%>
-    - shell:
-        cmd: |
-<%=       indent(10) { 'bootc usr-overlay' } %>
+  tasks:
+    - name: Collect bootc status
+      shell:
+        cmd: 'bootc status --json'
+      register: bootc_status
+      ignore_errors: true
+    - name: Parse bootc status json
+      set_fact:
+        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
+      when: bootc_status.rc == 0
+    - name: Enable bootc overlay
+      shell:
+        cmd: 'bootc usr-overlay'
       register: out
       ignore_errors: true
+      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
     - debug: var=out
-<% end -%>
-  tasks:
-    - package:
+    - name: Remove packages via dnf for image mode machines
+      package:
         name:
 <% package_names.each do |package_name| -%>
           - <%= package_name %>
 <% end -%>
         state: absent
-<% if @host.image_mode_host? -%>
         use: 'dnf'
+      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+    - name: Remove packages normally
+      package:
+        name:
+<% package_names.each do |package_name| -%>
+          - <%= package_name %>
 <% end -%>
+        state: absent
+      when: bootc_status_json is not defined or bootc_status_json['status']['booted'] == 'null'

--- a/app/views/foreman/job_templates/remove_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/remove_packages_by_search_query_-_katello_ansible_default.erb
@@ -17,6 +17,14 @@ template_inputs:
 ) -%>
 ---
 - hosts: all
+<% if @host.image_mode_host? -%>
+    - shell:
+        cmd: |
+<%=       indent(10) { 'bootc usr-overlay' } %>
+      register: out
+      ignore_errors: true
+    - debug: var=out
+<% end -%>
   tasks:
     - package:
         name:
@@ -24,3 +32,6 @@ template_inputs:
           - <%= package_name %>
 <% end -%>
         state: absent
+<% if @host.image_mode_host? -%>
+        use: 'dnf'
+<% end -%>

--- a/app/views/foreman/job_templates/update_group_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/update_group_-_katello_ansible_default.erb
@@ -15,23 +15,15 @@ kind: job_template
 ---
 - hosts: all
   tasks:
-    - name: Collect bootc status
-      shell:
-        cmd: 'bootc status --json'
-      register: bootc_status
-      ignore_errors: true
-    - name: Parse bootc status json
-      set_fact:
-        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
-      when: bootc_status.rc == 0
+<%= indent(4) { snippet('check_bootc_status') } %>
     - name: Update groups via dnf for image mode machines
       shell:
         cmd: 'dnf -y --transient group update <%= input('package') %>'
       register: out
-      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+      when: is_bootc_host
     - name: Update groups normally
       shell:
         cmd: 'yum -y group update <%= input('package') %>'
       register: out
-      when: bootc_status_json is not defined or bootc_status_json['status']['booted'] == 'null'
+      when: not is_bootc_host
     - debug: var=out

--- a/app/views/foreman/job_templates/update_group_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/update_group_-_katello_ansible_default.erb
@@ -13,4 +13,4 @@ provider_type: Ansible
 kind: job_template
 %>
 
-<%= render_template('Run Command - Ansible Default', :command => "yum -y group update #{input('package')}") %>
+<%= render_template('Run Command - Ansible Default', :command => "#{@host.yum_or_yum_transient} -y group update #{input('package')}") %>

--- a/app/views/foreman/job_templates/update_group_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/update_group_-_katello_ansible_default.erb
@@ -12,5 +12,26 @@ template_inputs:
 provider_type: Ansible
 kind: job_template
 %>
-
-<%= render_template('Run Command - Ansible Default', :command => "#{@host.yum_or_yum_transient} -y group update #{input('package')}") %>
+---
+- hosts: all
+  tasks:
+    - name: Collect bootc status
+      shell:
+        cmd: 'bootc status --json'
+      register: bootc_status
+      ignore_errors: true
+    - name: Parse bootc status json
+      set_fact:
+        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
+      when: bootc_status.rc == 0
+    - name: Update groups via dnf for image mode machines
+      shell:
+        cmd: 'dnf -y --transient group update <%= input('package') %>'
+      register: out
+      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+    - name: Update groups normally
+      shell:
+        cmd: 'yum -y group update <%= input('package') %>'
+      register: out
+      when: bootc_status_json is not defined or bootc_status_json['status']['booted'] == 'null'
+    - debug: var=out

--- a/app/views/foreman/job_templates/update_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/update_packages_by_search_query_-_katello_ansible_default.erb
@@ -27,7 +27,18 @@ template_inputs:
 ---
 - hosts: all
   tasks:
+<% if @host.image_mode_host? -%>
+    - shell:
+        cmd: |
+<%=       indent(10) { 'bootc usr-overlay' } %>
+      register: out
+      ignore_errors: true
+    - debug: var=out
+<% end -%>
     - package:
         name: <%= indent(10) { to_yaml(package_names).gsub(/---/, "") } -%>
         state: latest
+<% if @host.image_mode_host? -%>
+        use: 'dnf'
+<% end -%>
 <% end -%>

--- a/app/views/foreman/job_templates/update_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/update_packages_by_search_query_-_katello_ansible_default.erb
@@ -27,31 +27,23 @@ template_inputs:
 ---
 - hosts: all
   tasks:
-    - name: Collect bootc status
-      shell:
-        cmd: 'bootc status --json'
-      register: bootc_status
-      ignore_errors: true
-    - name: Parse bootc status json
-      set_fact:
-        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
-      when: bootc_status.rc == 0
+<%= indent(4) { snippet('check_bootc_status') } %>
     - name: Enable bootc overlay
       shell:
         cmd: 'bootc usr-overlay'
       register: out
       ignore_errors: true
-      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+      when: is_bootc_host
     - debug: var=out
     - name: Install packages via dnf for image mode machines
       package:
         name: <%= indent(10) { to_yaml(package_names).gsub(/---/, "") } -%>
         state: latest
         use: 'dnf'
-      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+      when: is_bootc_host
     - name: Install packages normally
       package:
         name: <%= indent(10) { to_yaml(package_names).gsub(/---/, "") } -%>
         state: latest
-      when: bootc_status_json is not defined or bootc_status_json['status']['booted'] == 'null'
+      when: not is_bootc_host
 <% end -%>

--- a/app/views/foreman/job_templates/update_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/update_packages_by_search_query_-_katello_ansible_default.erb
@@ -27,18 +27,31 @@ template_inputs:
 ---
 - hosts: all
   tasks:
-<% if @host.image_mode_host? -%>
-    - shell:
-        cmd: |
-<%=       indent(10) { 'bootc usr-overlay' } %>
+    - name: Collect bootc status
+      shell:
+        cmd: 'bootc status --json'
+      register: bootc_status
+      ignore_errors: true
+    - name: Parse bootc status json
+      set_fact:
+        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
+      when: bootc_status.rc == 0
+    - name: Enable bootc overlay
+      shell:
+        cmd: 'bootc usr-overlay'
       register: out
       ignore_errors: true
+      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
     - debug: var=out
-<% end -%>
-    - package:
+    - name: Install packages via dnf for image mode machines
+      package:
         name: <%= indent(10) { to_yaml(package_names).gsub(/---/, "") } -%>
         state: latest
-<% if @host.image_mode_host? -%>
         use: 'dnf'
-<% end -%>
+      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+    - name: Install packages normally
+      package:
+        name: <%= indent(10) { to_yaml(package_names).gsub(/---/, "") } -%>
+        state: latest
+      when: bootc_status_json is not defined or bootc_status_json['status']['booted'] == 'null'
 <% end -%>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Updates package & errata job templates to work with image mode hosts.

#### Considerations taken when implementing this change?
Ansible tries to use the "atomic-container" package manager by default, so I have to force it to use `dnf`. At the moment, all image mode machines have `dnf`.
For the Ansible commands, I have to enable the usr-overlay since Ansible does not support the --transient flag. As such, I am ignoring all errors since the usr-overlay command returns an error if it's run when it's already enabled. The errors will be present in the job output log.


#### What are the testing steps for this pull request?
- Try every job template changed here with image mode and non-image mode hosts.
- Help me find templates that were missed.

#### Notes
There will be matching foreman_rh_cloud, foreman_remote_execution, foreman_ansible, and foreman_openscap plugins. Decisions there may affect the PR here. Links to the other PRs will come shortly.

Foreman Remote Execution PR: https://github.com/theforeman/foreman_remote_execution/pull/970
  -> Relies on this PR for `yum_or_yum_transient`.