### PR TITLE
Fixes #38392 - list container upstream name in repo list

### DIFF
--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -10,7 +10,7 @@ attributes :content_counts
 attributes :mirroring_policy
 
 glue(@object.root) do
-  attributes :content_type, :url, :arch, :os_versions, :content_id, :generic_remote_options
+  attributes :content_type, :url, :docker_upstream_name, :arch, :os_versions, :content_id, :generic_remote_options
   attributes :major, :minor
 
   child :product do |_product|

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -114,6 +114,13 @@ module Katello
       end
     end
 
+    def test_index_returns_docker_upstream_name
+      response = get :index, params: { :product_id => @product.id }
+      repo = ::Katello::Repository.find_by(relative_path: '/Default_Organization/library/pulp3_Docker_1')
+      container_repo = JSON.parse(response.body)['results'].find { |r| r['docker_upstream_name'] == repo.docker_upstream_name }
+      assert_equal container_repo['id'], repo.id
+    end
+
     def test_index_with_product_id
       ids = Repository.in_product(@product).where(:library_instance_id => nil).pluck(:id)
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds docker_upstream_name to the repository list API. For container repos, just the repo url is not helpful alone.

#### Considerations taken when implementing this change?
This should not break any user since it's new data only.

#### What are the testing steps for this pull request?
Try the repository listing endpoint after creating a container repo.