### PR TITLE
[CP] Katello 4.16 Cherry Picks

### DIFF
--- a/app/lib/actions/candlepin/environment/set_content.rb
+++ b/app/lib/actions/candlepin/environment/set_content.rb
@@ -36,12 +36,12 @@ module Actions
               # Since its a dup id refresh the existing ids list (which hopefully will not have the duplicate content)
               # and try again.
               output[:add_ids] = content_ids - existing_ids
-            rescue RestClient::ResourceNotFound => e
+            rescue RestClient::ResourceNotFound, RestClient::NotFound => e
               # Set a higher limit for retries just in case the missing content is not being parsed from the error body correctly.
               # If the content is not found after the retries, assume it is gone and continue.
               raise e if ((retries += 1) == 1_000)
               # Parse the missing content from the Candlepin response and remove it from the add_ids list.
-              missing_content = JSON.parse(e.response.body)['displayMessage'].split(' ')[-1].gsub(/"(.+?)"\./, '\1')
+              missing_content = JSON.parse(e.response.body)['displayMessage'].split(' ')[-1].gsub(/[".]/, '')
               Rails.logger.debug "Content #{missing_content} not found in the environment. Removing it from the add_ids list."
               output[:add_ids].delete(missing_content)
             end

--- a/app/lib/actions/pulp3/orchestration/repository/trigger_update_repo_cert_guard.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/trigger_update_repo_cert_guard.rb
@@ -9,7 +9,7 @@ module Actions
 
           def run
             repository = ::Katello::Repository.find(input[:repository_id])
-            ForemanTasks.async_task(::Actions::Pulp3::Repository::UpdateCvRepositoryCertGuard, repository, smart_proxy)
+            ForemanTasks.async_task(::Actions::Pulp3::Repository::UpdateCVRepositoryCertGuard, repository, smart_proxy)
           end
 
           def humanized_name

--- a/app/models/katello/candlepin/repository_mapper.rb
+++ b/app/models/katello/candlepin/repository_mapper.rb
@@ -139,7 +139,7 @@ module Katello
       end
 
       def download_policy
-        if katello_content_type == Repository::YUM_TYPE
+        if ::Katello::RootRepository::CONTENT_ATTRIBUTE_RESTRICTIONS[:download_policy].include?(katello_content_type)
           Setting[:default_redhat_download_policy]
         else
           ""

--- a/app/views/foreman/job_templates/flatpak_install.erb
+++ b/app/views/foreman/job_templates/flatpak_install.erb
@@ -13,11 +13,19 @@ template_inputs:
   description: Name of the application to install
   input_type: user
   required: true
+- name: Launch a session bus instance
+  description: Launch a session bus instance for the flatpak application using 'dbus-run-session'. Requires package dbus-daemon on client. Select 'true' for machines without a display server.
+  input_type: user
+  required: false
+  options: "true\r\nfalse"
+  advanced: false
+  value_type: plain
+  default: 'false'
 %>
 
 <%
   remote_name = input('Flatpak remote name')
   app_name = input('Application name')
+  use_dbus_session = input('Launch a session bus instance') == 'true'
 %>
-
-sudo dbus-launch flatpak install <%= remote_name %> <%= app_name %> --assumeyes
+sudo <%= use_dbus_session ? 'dbus-run-session ' : ''%>flatpak install <%= remote_name %> <%= app_name %> --assumeyes

--- a/app/views/foreman/job_templates/flatpak_login_action.erb
+++ b/app/views/foreman/job_templates/flatpak_login_action.erb
@@ -6,7 +6,7 @@ description_format: 'Login to flatpak registry via podman'
 provider_type: script
 template_inputs:
 - name: Flatpak registry URL
-  description: URL of server/capsule
+  description: URL of container registry
   input_type: user
   required: true
 - name: Username
@@ -26,7 +26,4 @@ template_inputs:
   password = input('Password')
 %>
 
-sudo podman login <%= server_url %> --username <%= username %> --password <%= password %>
-if test -f "/run/containers/0/auth.json"; then
-  sudo cp --update /run/containers/0/auth.json /etc/flatpak/oci-auth.json
-fi
+echo <%= shell_escape(password) %> | sudo podman login <%= server_url %> --username <%= username %> --password-stdin --authfile /etc/flatpak/oci-auth.json

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rest-client"
 
   gem.add_dependency "rabl"
-  gem.add_dependency "foreman-tasks", ">= 9.1"
-  gem.add_dependency "foreman_remote_execution", ">= 7.1.0"
+  gem.add_dependency "foreman-tasks", ">= 9.1", "< 11.0"
+  gem.add_dependency "foreman_remote_execution", ">= 7.1.0", "< 16.0"
   gem.add_dependency "dynflow", ">= 1.6.1"
   gem.add_dependency "activerecord-import"
   gem.add_dependency "stomp"

--- a/test/models/candlepin/repository_mapper_test.rb
+++ b/test/models/candlepin/repository_mapper_test.rb
@@ -48,5 +48,19 @@ module Katello
 
       assert_equal 'immediate', mapper.download_policy
     end
+
+    def test_download_policy_file_repo
+      mapper = Candlepin::RepositoryMapper.new(@product_content.product, @product_content.content, {})
+      mapper.expects(:katello_content_type).returns('file')
+      Setting[:default_redhat_download_policy] = 'immediate'
+      assert_equal 'immediate', mapper.download_policy
+    end
+
+    def test_download_policy_python_repo
+      mapper = Candlepin::RepositoryMapper.new(@product_content.product, @product_content.content, {})
+      mapper.expects(:katello_content_type).returns('python')
+      Setting[:default_redhat_download_policy] = 'immediate'
+      assert_equal '', mapper.download_policy
+    end
   end
 end


### PR DESCRIPTION
Katello 4.16 Cherry Picks

- 38320 - 2025-03-27 17:00:38 UTC: [ac7eb1a234ee1ca7d66f47f57944d87723478130] gsub regex to skip adding missing candlepin content does not remove quote marks
- 38287 - 2025-03-31 19:00:37 UTC: [ab66a515773841f4082bb943210b60955ef3a514] Flatpak login action job template passes the password as an argument, making it possible to see the password in process listing
- 38339 - 2025-04-02 14:02:19 UTC: [104ccd390a30a3db8bc2f0894a8fdd94f17c0bc5] Creation of File type Red Hat repositories fails
- 38372 - 2025-04-17 19:00:29 UTC: [1eb8f50e1cd92e622dba14d119d74f2533586071] Switch to using optional dbus-run-session for installing flatpak applications using REX
- 38368 - 2025-04-17 19:00:30 UTC: [dfe1afe2c36a23885be21c376ca3fb71003831f9] Cannot update "Unprotected" field on repositories