### PR TITLE
Fixes #38399 - Add org identifiers to repo API

### DIFF
--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -1,6 +1,7 @@
 object @resource
 
 extends 'katello/api/v2/common/identifier'
+extends 'katello/api/v2/common/org_reference'
 
 attributes :pulp_id => :backend_identifier
 attributes :relative_path, :container_repository_name, :full_path, :library_instance_id


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This pull request introduces a minor update to the `app/views/katello/api/v2/repositories/base.json.rabl` file by extending the JSON response to include organization reference data.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Go to the following URL:
katello/api/v2/repositories on your test machine and make sure you see organization keys:
![Screenshot from 2025-05-01 14-11-03](https://github.com/user-attachments/assets/e85237b7-696a-452c-86b6-e97548efac00)
