### PR TITLE
Fixes #38411 - add rolling attribute to AK show rabl

### DIFF
--- a/app/views/katello/api/v2/activation_keys/base.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/base.json.rabl
@@ -13,6 +13,7 @@ child :content_view_environments => :content_view_environments do
       id: cve.content_view&.id,
       name: cve.content_view&.name,
       composite: cve.content_view&.composite,
+      rolling: cve.content_view&.rolling,
       content_view_version: cve.content_view_version&.version,
       content_view_version_id: cve.content_view_version&.id,
       content_view_version_latest: cve.content_view_version&.latest?,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds the following to the activation key show response:

```
  "created_at": "2025-04-29 21:38:57 UTC",
  "updated_at": "2025-04-29 21:38:58 UTC",
  "content_view_environments": [
    {
      "content_view": {
        "id": 1,
        "name": "Default Organization View",
        "composite": false,
        "rolling": false,            <======================

```

#### Considerations taken when implementing this change?
This makes the hammer field work:

```
Name:                            Default Library Key
Id:                              1
Host Limit:                      2 of Unlimited
Multi Content View Environment:  no
Content View Environment Labels: Library
Organization:                    
 1) Id:   1
    Name: Default Organization
Content View Environments:       
 1) Content View:          
        Id:                          1
        Name:                        Default Organization View
        Version:                     1.0
        Content View version Id:     1
        Composite:                   no
        Rolling:                     no             <=========================
        Content View Environment id: 1
    Lifecycle environment: 
        Id:   1
        Name: Library
    Label:                 Library

```

#### What are the testing steps for this pull request?
Try `hammer activation-key show ...`.

## Summary by Sourcery

Add rolling attribute to activation key show response in RABL view

New Features:
- Include 'rolling' attribute for content view in activation key show API response

Enhancements:
- Expose content view's rolling status in the activation key details