### PR TITLE
Fixes #38285 - Never add container push repos to rolling content views

### DIFF
--- a/app/controllers/katello/api/v2/content_view_repositories_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_repositories_controller.rb
@@ -25,6 +25,11 @@ module Katello
       SQL
 
       query = Katello::Repository.readable.in_default_view.in_organization(@organization)
+      if @content_view.rolling
+        # Exclude container push repositories
+        query = query.joins(:root).where(katello_root_repositories: { is_container_push: false })
+      end
+
       query = query.with_type(params[:content_type]) if params[:content_type]
       # Use custom sort to perform the join and order since we need to order by specific content_view
       # and the ORDER BY query needs access to the katello_content_view_repositories table

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -719,6 +719,7 @@ Alternatively, use the 'force' parameter to regenerate metadata locally. On the 
       if is_available_for
         params[:library] = true
         sub_query = ContentViewRepository.where(:content_view_id => content_view_id).pluck(:repository_id)
+        sub_query += Repository.where(root: RootRepository.where(is_container_push: true)).pluck(:id) if ContentView.find(content_view_id).rolling
         query = query.where("#{Repository.table_name}.id not in (#{sub_query.join(',')})") unless sub_query.empty?
       elsif environment_id
         version = ContentViewVersion.in_environment(environment_id).where(:content_view_id => content_view_id)

--- a/app/models/katello/content_view_repository.rb
+++ b/app/models/katello/content_view_repository.rb
@@ -18,6 +18,7 @@ module Katello
     validates_lengths_from_database
     validates :repository_id, :uniqueness => {:scope => :content_view_id, :message => N_("already belongs to the content view") }
     validate :content_view_composite
+    validate :content_view_rolling
     validate :ensure_repository_type
     validate :check_repo_membership
 
@@ -26,6 +27,12 @@ module Katello
     def content_view_composite
       if content_view.composite?
         errors.add(:base, _("Cannot add repositories to a composite content view"))
+      end
+    end
+
+    def content_view_rolling
+      if content_view.rolling? && repository.root.is_container_push?
+        errors.add(:base, _("Cannot add container push repositories to a rolling content view"))
       end
     end
 

--- a/test/controllers/api/registry/registry_proxies_controller_test.rb
+++ b/test/controllers/api/registry/registry_proxies_controller_test.rb
@@ -275,7 +275,8 @@ module Katello
         assert_equal(body['repositories'].compact.sort,
                      ["busybox",
                       "empty_organization/dev_label/published_dev_view/puppet_product/busybox",
-                      "#{org.label.downcase}-puppet_product-busybox"].sort)
+                      "#{org.label.downcase}-puppet_product-busybox",
+                      "id/1/2/container-push-repo"].sort)
       end
 
       it "shows only available images for unauthenticated requests" do
@@ -291,7 +292,7 @@ module Katello
         get :catalog
         assert_response 200
         body = JSON.parse(response.body)
-        assert_equal(["busybox", "empty_organization-puppet_product-busybox"], body['repositories'].compact.sort)
+        assert_equal(["busybox", "empty_organization-puppet_product-busybox", "id/1/2/container-push-repo"], body['repositories'].compact.sort)
       end
     end
 

--- a/test/controllers/api/v2/content_view_repositories_controller_test.rb
+++ b/test/controllers/api/v2/content_view_repositories_controller_test.rb
@@ -61,5 +61,20 @@ module Katello
         get :show_all, params: { content_view_id: @view.id }
       end
     end
+
+    def test_show_all_rolling
+      @view = katello_content_views(:rolling_view)
+      @container_push_repo = katello_repositories(:container_push)
+      get :show_all, params: { content_view_id: @view.id }
+
+      assert_response :success
+      results = JSON.parse(response.body, symbolize_names: true)[:results]
+      added_ids = results.select { |r| r[:added_to_content_view] }.pluck(:id)
+      not_added_ids = results.reject { |r| r[:added_to_content_view] }.pluck(:id)
+
+      assert_includes added_ids, @fedora_repo.id
+      assert_not_includes added_ids, @container_push_repo.id
+      assert_not_includes not_added_ids, @container_push_repo.id
+    end
   end
 end

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -184,6 +184,22 @@ module Katello
       assert_response_ids response, ids
     end
 
+    def test_index_available_for_rolling_content_view
+      @view = katello_content_views(:rolling_view)
+      @container_push_repo = katello_repositories(:container_push)
+      all_ids = @view.organization.default_content_view.versions.first.repositories.pluck(:id)
+      view_ids = @view.repositories.pluck(:id)
+      push_repo_id = @container_push_repo.id
+      expected_available_ids = all_ids - view_ids - [push_repo_id]
+
+      response = get :index, params: { :content_view_id => @view.id, :available_for => :content_view, :organization_id => @organization.id, :per_page => 100 }
+
+      assert_not_includes view_ids, push_repo_id
+      assert_response :success
+      assert_template 'api/v2/repositories/index'
+      assert_response_ids response, expected_available_ids
+    end
+
     def test_index_with_content_view_id_and_environment_id
       ids = @fedora_dev.content_view_version.repositories.where(:environment_id => @fedora_dev.environment_id).pluck(:id)
 

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -422,3 +422,12 @@ product_host_count_repo2:
   relative_path:        'default_organization/library/my-product-host-count-repo2'
   environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
+
+container_push:
+  root_id:              <%= ActiveRecord::FixtureSet.identify(:container_push_root) %>
+  pulp_id:              "09b10114-74d7-4d0b-b7f2-e2b7eebd2bfe"
+  relative_path:        'id/1/2/container-push-repo'
+  environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
+  container_repository_name: 'id/1/2/container-push-repo'
+

--- a/test/fixtures/models/katello_root_repositories.yml
+++ b/test/fixtures/models/katello_root_repositories.yml
@@ -330,3 +330,15 @@ product_host_count_repo2_root:
   download_policy:      on_demand
   mirroring_policy:     "mirror_content_only"
 
+container_push_root:
+  name:                 container push repo
+  content_id:           1
+  content_type:         docker
+  label:                container-push-repo
+  product_id:           <%= ActiveRecord::FixtureSet.identify(:puppet_product) %>
+  unprotected:          <%= true %>
+  mirroring_policy:     additive
+  download_policy:      immediate
+  container_push_name:  "id/1/2/container-push-repo"
+  container_push_name_format: id
+  is_container_push:    <%= true %>

--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -414,7 +414,7 @@ module Katello
       capsule_content.smart_proxy.add_lifecycle_environment(environment)
 
       expected_repo_list_args = {
-        :repositories => [{:repository => "empty_organization-puppet_product-busybox", :auth_required => true}, {:repository => "busybox", :auth_required => true}],
+        :repositories => [{:repository => "empty_organization-puppet_product-busybox", :auth_required => true}, {:repository => "busybox", :auth_required => true}, {:repository => "id/1/2/container-push-repo", :auth_required => true}],
       }
       repo_list_update_expectation = ProxyAPI::ContainerGateway.any_instance.expects(:repository_list).with do |value|
         Set.new(value[:repositories]) == Set.new(expected_repo_list_args[:repositories])


### PR DESCRIPTION
Container push repos always require copying Pulp content and rolling content views are designed to never copy Pulp content. Therefor container push repos are forbidden in rolling content views. This PR makes it so that container push repos are ~~ignored (with a log warning)~~ rejected by model validation when users attempt to add them to a rolling content view. It also makes it that various APIs do not list container push repos as "available" for inclusion in rolling content views.

## Summary by Sourcery

Prevent container push repositories from being added to rolling content views by ignoring them and filtering them out from relevant APIs, with added fixtures and tests to verify the behavior.

Enhancements:
- Ignore container push repositories when adding to rolling content views, logging a warning and removing any existing instances
- Exclude container push repositories from "available for" and "show_all" API endpoints for rolling content views
- Include container push repositories in registry proxy catalog responses

Tests:
- Add fixtures for container push root and repository
- Add controller tests to verify container push repos are excluded from available listings for rolling content views
- Add action tests to ensure no plan actions occur when adding container push repos to rolling content views
- Update registry proxy controller tests to include container push repos in unauthenticated catalog responses