### PR TITLE
Fixes #38424: correct response code of oauth2 token request to registry

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -5,12 +5,13 @@ module Katello
     before_action :disable_strong_params
     before_action :confirm_settings
     skip_before_action :authorize
+    before_action :token_request_type_check, only: [:token]
     before_action :optional_authorize, only: [:token, :catalog]
     before_action :registry_authorize, except: [:token, :v1_search, :catalog, :static_index]
     before_action :authorize_repository_read, only: [:pull_manifest, :tags_list, :check_blob, :pull_blob]
     before_action :container_push_prop_validation, only: [:start_upload_blob, :upload_blob, :finish_upload_blob, :push_manifest]
     before_action :create_container_repo_if_needed, only: [:start_upload_blob, :upload_blob, :finish_upload_blob, :push_manifest]
-    skip_before_action :check_media_type, only: [:start_upload_blob, :upload_blob, :finish_upload_blob,
+    skip_before_action :check_media_type, only: [:start_upload_blob, :token, :upload_blob, :finish_upload_blob,
                                                  :push_manifest]
 
     wrap_parameters false
@@ -54,6 +55,12 @@ module Katello
           @host = Katello::Host::ContentFacet.find_by(uuid: uuid)&.host
         end
       end
+    end
+
+    def token_request_type_check
+       if request.post?
+         head :not_found and return
+       end
     end
 
     def redirect_authorization_headers


### PR DESCRIPTION
If oauth2 authentication (via POST request) is not supported, a container registry should respond with code 404, but we currently respond with 415 (Unsupported Media Type). By disabling the media type check for the token endpoint, we will return 401 (unauthorized) instead, which is enough for some clients to then try the regular token authentication. Adding a custom before_action, we can achieve that 404 is returned, thus we are fully compliant with the spec:
https://docker-docs.uclv.cu/registry/spec/auth/oauth/

#### What are the changes introduced in this pull request?

- content type check is disabled for :token
- POST requests on :token trigger a 404 response (the spec demands to return 404 if this is not supported)

#### Considerations taken when implementing this change?

- Adhere to the spec
- only disable media type check where necessary

#### What are the testing steps for this pull request?

The following curl request can be used to test the response (replace foreman.example.com with your foreman instance, orgname with your orgname, productname with your product name for the container registry, and containername is arbitrary, as is username and password):

```
curl -k -X POST "https://forman.example.com/v2/token" \
-H "Content-Type: application/x-www-form-urlencoded" \
--data-urlencode "scope=repository:orgname/productname/containername:pull,push repository:registry:pull,push" \
--data-urlencode "grant_type=password" --data-urlencode "username=myuser" \
--data-urlencode "password=mypassword" \
--data-urlencode "service=foreman.example.com" -w "\\n%{http_code}\\n"
```

This will yield the following output:
```
{
"error": {"message":"Media type in 'Content-Type: application/x-www-form-urlencoded' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'."}
}


415
```

With the fix applied the output is simply:
```

404
```