### PR TITLE
Update 4.17 Github workflow to use stable foreman version

### DIFF
--- a/.github/workflows/react_tests.yml
+++ b/.github/workflows/react_tests.yml
@@ -13,4 +13,4 @@ jobs:
     uses: theforeman/actions/.github/workflows/foreman_plugin_js.yml@v0
     with:
       plugin: katello
-      foreman_version: develop # set to the Foreman release branch after branching :)
+      foreman_version: 3.15-stable # set to the Foreman release branch after branching :)

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       plugin: katello
       test_existing_database: false
-      foreman_version: develop # set to the Foreman release branch after branching :)
+      foreman_version: 3.15-stable # set to the Foreman release branch after branching :)
 
   angular:
     name: Angular ${{ matrix.engine }} - NodeJS ${{ matrix.node }}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

CI:
- Update foreman_version from develop to 3.15-stable in react_tests.yml and ruby.yml workflows