### PR TITLE
Fix remove_orphans_test

### DIFF
--- a/test/actions/pulp3/orchestration/remove_orphans_test.rb
+++ b/test/actions/pulp3/orchestration/remove_orphans_test.rb
@@ -54,7 +54,7 @@ module ::Actions::Pulp3
     def test_orphans_are_removed
       repository_reference = repo_reference(@repo)
       versions = ::Katello::Pulp3::Api::File.new(@primary).repository_versions_api.list(repository_reference.repository_href, {}).results.collect(&:pulp_href)
-      tasks = ::Katello::Pulp3::Api::File.new(@primary).tasks_api.list(state__in: ['completed']).results
+      tasks = ::Katello::Pulp3::Api::File.new(@primary).tasks_api.list(state__in: ['completed'], name__ne: 'pulpcore.app.tasks.purge.purge').results
       assert_empty tasks
       refute_includes versions, repository_reference.repository_href + "versions/1/"
       assert_includes versions, repository_reference.repository_href + "versions/2/"

--- a/test/fixtures/vcr_cassettes/actions/pulp3/remove_orphans/orphans_are_removed.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/remove_orphans/orphans_are_removed.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:36 GMT
+      - Fri, 16 May 2025 16:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,20 +43,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c5012e24c87447979402a3acbdb78475
+      - e43d25873a5a456aa6d65ea80903ddfc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:36 GMT
+  recorded_at: Fri, 16 May 2025 16:01:42 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -64,7 +64,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -77,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:36 GMT
+      - Fri, 16 May 2025 16:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -97,20 +97,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4483d22b82ad48acbf58d0a6aca92fed
+      - 79796a1da4ce4a7fb8f42537e4fecbff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:36 GMT
+  recorded_at: Fri, 16 May 2025 16:01:42 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -118,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -131,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:37 GMT
+      - Fri, 16 May 2025 16:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -151,20 +151,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 16a4a66236444993adf91c6088dc7ea3
+      - 6c19cb9d0fd74380a01ed359f449f08b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:37 GMT
+  recorded_at: Fri, 16 May 2025 16:01:42 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -172,7 +172,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -185,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:37 GMT
+      - Fri, 16 May 2025 16:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -205,20 +205,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 31fa84154d944312a25f2fbbccdea781
+      - 4efd99e5a59f46a9bbfb19fad0f5cb7b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:37 GMT
+  recorded_at: Fri, 16 May 2025 16:01:42 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -226,7 +226,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -239,7 +239,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:37 GMT
+      - Fri, 16 May 2025 16:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -259,20 +259,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2bec3995a9e64183afc1b978a40c4fef
+      - eb0895779f954e4c9350918da9586992
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:37 GMT
+  recorded_at: Fri, 16 May 2025 16:01:42 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -280,7 +280,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -293,7 +293,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:37 GMT
+      - Fri, 16 May 2025 16:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -313,20 +313,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8230f2148fc846edbde4d76ac46b9531
+      - c9f324fdb1af4a4592ea7744901cc6ff
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:37 GMT
+  recorded_at: Fri, 16 May 2025 16:01:42 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -334,7 +334,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -347,7 +347,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:37 GMT
+      - Fri, 16 May 2025 16:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -367,20 +367,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 349e0fe34bc64b0eab8aa1186aeefd7c
+      - e920285c6155406097460010025feade
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:37 GMT
+  recorded_at: Fri, 16 May 2025 16:01:42 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -388,7 +388,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -401,7 +401,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:37 GMT
+      - Fri, 16 May 2025 16:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -421,20 +421,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7582ca001a024b20b5471f69070e064f
+      - 033c5e7179ed4cd89c17b9291b4b3624
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:37 GMT
+  recorded_at: Fri, 16 May 2025 16:01:42 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -452,7 +452,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -465,13 +465,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:38 GMT
+      - Fri, 16 May 2025 16:01:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/0195fd85-2b92-76e8-8ff6-2770c8ac18d0/"
+      - "/pulp/api/v3/remotes/file/file/0196d9d4-7a4d-710e-b862-812737fc3958/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -487,20 +487,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '08cb313764f8497685324ecb8ad5091c'
+      - 0f9955e910424885baa13796f8604174
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE5NWZkODUtMmI5Mi03NmU4LThmZjYtMjc3MGM4YWMxOGQwLyIsInBybiI6
-        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NWZkODUtMmI5Mi03NmU4LThmZjYt
-        Mjc3MGM4YWMxOGQwIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMTox
-        ODozNy45NzEyNzlaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAz
-        VDIxOjE4OjM3Ljk3MTI5NloiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        MDE5NmQ5ZDQtN2E0ZC03MTBlLWI4NjItODEyNzM3ZmMzOTU4LyIsInBybiI6
+        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NmQ5ZDQtN2E0ZC03MTBlLWI4NjIt
+        ODEyNzM3ZmMzOTU4IiwicHVscF9jcmVhdGVkIjoiMjAyNS0wNS0xNlQxNjow
+        MTo0Mi45OTAxMDdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA1LTE2
+        VDE2OjAxOjQyLjk5MDEyMloiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
         b24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJ1cmwiOiJodHRwczovL2ZpeHR1
         cmVzLnB1bHBwcm9qZWN0Lm9yZy9maWxlMi8vUFVMUF9NQU5JRkVTVCIsImNh
         X2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0bHNfdmFsaWRhdGlv
@@ -514,10 +514,10 @@ http_interactions:
         YW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicHJveHlfcGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJ1c2VybmFtZSIsImlzX3NldCI6
         ZmFsc2V9LHsibmFtZSI6InBhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX1dfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:38 GMT
+  recorded_at: Fri, 16 May 2025 16:01:43 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -527,7 +527,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -540,13 +540,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:38 GMT
+      - Fri, 16 May 2025 16:01:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/"
+      - "/pulp/api/v3/repositories/file/file/0196d9d4-7b01-79b0-813c-07af759eb0de/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -562,33 +562,33 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ff559e4be7484ab091d9b4e60beafc7e
+      - 03b2aa2fa52c44f8842b85de48cafc69
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMTk1ZmQ4NS0yY2FlLTdhNjYtOWY2NC0zNjU2ZTUwZDFiMmQvIiwi
-        cHJuIjoicHJuOmZpbGUuZmlsZXJlcG9zaXRvcnk6MDE5NWZkODUtMmNhZS03
-        YTY2LTlmNjQtMzY1NmU1MGQxYjJkIiwicHVscF9jcmVhdGVkIjoiMjAyNS0w
-        NC0wM1QyMToxODozOC4yNTU1NTZaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIy
-        MDI1LTA0LTAzVDIxOjE4OjM4LjI2NjQ1MVoiLCJ2ZXJzaW9uc19ocmVmIjoi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NWZkODUt
-        MmNhZS03YTY2LTlmNjQtMzY1NmU1MGQxYjJkL3ZlcnNpb25zLyIsInB1bHBf
+        ZmlsZS8wMTk2ZDlkNC03YjAxLTc5YjAtODEzYy0wN2FmNzU5ZWIwZGUvIiwi
+        cHJuIjoicHJuOmZpbGUuZmlsZXJlcG9zaXRvcnk6MDE5NmQ5ZDQtN2IwMS03
+        OWIwLTgxM2MtMDdhZjc1OWViMGRlIiwicHVscF9jcmVhdGVkIjoiMjAyNS0w
+        NS0xNlQxNjowMTo0My4xNzAzNDhaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIy
+        MDI1LTA1LTE2VDE2OjAxOjQzLjE3ODU5MFoiLCJ2ZXJzaW9uc19ocmVmIjoi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NmQ5ZDQt
+        N2IwMS03OWIwLTgxM2MtMDdhZjc1OWViMGRlL3ZlcnNpb25zLyIsInB1bHBf
         bGFiZWxzIjp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTVmZDg1LTJjYWUtN2E2Ni05
-        ZjY0LTM2NTZlNTBkMWIyZC92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0
+        My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTZkOWQ0LTdiMDEtNzliMC04
+        MTNjLTA3YWY3NTllYjBkZS92ZXJzaW9ucy8wLyIsIm5hbWUiOiJEZWZhdWx0
         X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIsImRlc2NyaXB0
         aW9uIjpudWxsLCJyZXRhaW5fcmVwb192ZXJzaW9ucyI6bnVsbCwicmVtb3Rl
         IjpudWxsLCJhdXRvcHVibGlzaCI6ZmFsc2UsIm1hbmlmZXN0IjoiUFVMUF9N
         QU5JRkVTVCJ9
-  recorded_at: Thu, 03 Apr 2025 21:18:38 GMT
+  recorded_at: Fri, 16 May 2025 16:01:43 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -605,7 +605,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -618,13 +618,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:38 GMT
+      - Fri, 16 May 2025 16:01:43 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/0195fd85-2e04-7ae7-aeba-b82234b9a198/"
+      - "/pulp/api/v3/remotes/file/file/0196d9d4-7be9-7fb7-861d-d753dafb0409/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -640,20 +640,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 332986a03add47ea86bdcf9b9bc02309
+      - fcf63e41375a4f9681911deb55ef640b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE5NWZkODUtMmUwNC03YWU3LWFlYmEtYjgyMjM0YjlhMTk4LyIsInBybiI6
-        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NWZkODUtMmUwNC03YWU3LWFlYmEt
-        YjgyMjM0YjlhMTk4IiwicHVscF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMTox
-        ODozOC41OTY3OTlaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAz
-        VDIxOjE4OjM4LjU5NjgxNFoiLCJuYW1lIjoidGVzdF9yZW1vdGVfbmFtZSIs
+        MDE5NmQ5ZDQtN2JlOS03ZmI3LTg2MWQtZDc1M2RhZmIwNDA5LyIsInBybiI6
+        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NmQ5ZDQtN2JlOS03ZmI3LTg2MWQt
+        ZDc1M2RhZmIwNDA5IiwicHVscF9jcmVhdGVkIjoiMjAyNS0wNS0xNlQxNjow
+        MTo0My40MDE2NDZaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA1LTE2
+        VDE2OjAxOjQzLjQwMTY2MloiLCJuYW1lIjoidGVzdF9yZW1vdGVfbmFtZSIs
         InVybCI6Imh0dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL2ZpbGUy
         Ly9QVUxQX01BTklGRVNUIiwiY2FfY2VydCI6bnVsbCwiY2xpZW50X2NlcnQi
         Om51bGwsInRsc192YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGws
@@ -667,10 +667,10 @@ http_interactions:
         bWUiOiJwcm94eV9wYXNzd29yZCIsImlzX3NldCI6ZmFsc2V9LHsibmFtZSI6
         InVzZXJuYW1lIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoicGFzc3dvcmQi
         LCJpc19zZXQiOmZhbHNlfV19
-  recorded_at: Thu, 03 Apr 2025 21:18:38 GMT
+  recorded_at: Fri, 16 May 2025 16:01:43 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/0195fd85-2e04-7ae7-aeba-b82234b9a198/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/remotes/file/file/0196d9d4-7be9-7fb7-861d-d753dafb0409/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -678,7 +678,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -691,7 +691,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:38 GMT
+      - Fri, 16 May 2025 16:01:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -711,20 +711,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 241d8882b6644421b6565ffa47c17e8a
+      - cc3250f1a36f41a0a45bfa788574d8c2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTJlNDYtN2E0
-        Yi1iYzhmLWYxYjgyNDg4ODY2Mi8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:38 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LTdjMzctN2Fk
+        Ny04ZGNkLWUyZGExYWE4OTY3MC8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:43 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/file/file/0196d9d4-7b01-79b0-813c-07af759eb0de/
     body:
       encoding: UTF-8
       base64_string: |
@@ -734,7 +734,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -747,7 +747,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:39 GMT
+      - Fri, 16 May 2025 16:01:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -767,20 +767,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 982fc3b0137f478c841f39aeb997e368
+      - b045e68dc0624aa594a2d485bd3ce2bb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTJmODMtNzRh
-        YS05NzM5LWI3YWVmYTczNzVlNC8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:39 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LTdkMDQtNzIx
+        MC1hOGI1LWRkNTlhZTEyYmI2NC8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:43 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/0195fd85-2b92-76e8-8ff6-2770c8ac18d0/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/remotes/file/file/0196d9d4-7a4d-710e-b862-812737fc3958/
     body:
       encoding: UTF-8
       base64_string: |
@@ -798,7 +798,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -811,7 +811,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:39 GMT
+      - Fri, 16 May 2025 16:01:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -831,20 +831,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bdb692320ca84277881f8363b259b105
+      - c2dc3816733b4ee5a04b48ce2f6fd1dc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTMwODMtNzVi
-        YS05NjNjLTNiMDY1NzI1MjdiMi8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:39 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LTdkOWYtNzA1
+        MC05MTU3LWViMGRiYWY5ZjFkNy8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:43 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-3083-75ba-963c-3b06572527b2/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/tasks/0196d9d4-7d9f-7050-9157-eb0dbaf9f1d7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -852,7 +852,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -865,7 +865,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:39 GMT
+      - Fri, 16 May 2025 16:01:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -885,36 +885,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 71828f8d418a43c5a3a531153c784f75
+      - 8043dc888a104c089e6b5bfd5d0f0b8a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtMzA4
-        My03NWJhLTk2M2MtM2IwNjU3MjUyN2IyLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5NWZkODUtMzA4My03NWJhLTk2M2MtM2IwNjU3MjUyN2IyIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODozOS4yMzY5MzFaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjM5LjIzNjk1OFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NmQ5ZDQtN2Q5
+        Zi03MDUwLTkxNTctZWIwZGJhZjlmMWQ3LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NmQ5ZDQtN2Q5Zi03MDUwLTkxNTctZWIwZGJhZjlmMWQ3IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNS0xNlQxNjowMTo0My44NDAxODdaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA1LTE2VDE2OjAxOjQzLjg0MDIxMFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYmRiNjky
-        MzIwY2E4NDI3Nzg4MWY4MzYzYjI1OWIxMDUiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
-        M1QyMToxODozOS4yNTY3NDFaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
-        MjE6MTg6MzkuMjU5NTI4WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
-        MToxODozOS4yNzIxNTBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYzJkYzM4
+        MTY3MzNiNGVlNWEwNGI0OGNlMmY2ZmQxZGMiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNS0x
+        NlQxNjowMTo0My44NTY3ODlaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDUtMTZU
+        MTY6MDE6NDMuODU4NDM5WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNS0xNlQx
+        NjowMTo0My44NjkwNTlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46Zmls
-        ZS5maWxlcmVtb3RlOjAxOTVmZDg1LTJiOTItNzZlOC04ZmY2LTI3NzBjOGFj
-        MThkMCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5NTYyMTctZmM5ZS03
-        NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
-  recorded_at: Thu, 03 Apr 2025 21:18:39 GMT
+        ZS5maWxlcmVtb3RlOjAxOTZkOWQ0LTdhNGQtNzEwZS1iODYyLTgxMjczN2Zj
+        Mzk1OCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MjQwMTkwYjMtNjVjMC00
+        NjhiLTlkOWUtMDMyMTlhYTExYTVmIl19
+  recorded_at: Fri, 16 May 2025 16:01:43 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -922,7 +922,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -935,7 +935,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:39 GMT
+      - Fri, 16 May 2025 16:01:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -955,20 +955,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3c6abce47ed74c3b91ad1813512c14de
+      - 2a0f29ee41f544319a1379beca6c8271
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:39 GMT
+  recorded_at: Fri, 16 May 2025 16:01:44 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -980,7 +980,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -993,7 +993,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:39 GMT
+      - Fri, 16 May 2025 16:01:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1013,20 +1013,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 40a47a14f5704f5da873a7bb9e465faf
+      - 64b4368db43845089ff4b084a101aa97
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTMxYWQtN2Mz
-        YS1hNTNiLTQ0NWFkMzYzMDNkNi8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:39 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LTdlZDItN2Q0
+        NC05MTU5LWI0ODZiZTc3NWJhNy8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:44 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-31ad-7c3a-a53b-445ad36303d6/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/tasks/0196d9d4-7ed2-7d44-9159-b486be775ba7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1034,7 +1034,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -1047,7 +1047,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:39 GMT
+      - Fri, 16 May 2025 16:01:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1067,39 +1067,39 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bba40c8636724e339ad99edac139d0ca
+      - 88dfad8c9ddf4d5b9be139527e9151ce
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtMzFh
-        ZC03YzNhLWE1M2ItNDQ1YWQzNjMwM2Q2LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5NWZkODUtMzFhZC03YzNhLWE1M2ItNDQ1YWQzNjMwM2Q2IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODozOS41MzM2MjVaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjM5LjUzMzYzOFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NmQ5ZDQtN2Vk
+        Mi03ZDQ0LTkxNTktYjQ4NmJlNzc1YmE3LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NmQ5ZDQtN2VkMi03ZDQ0LTkxNTktYjQ4NmJlNzc1YmE3IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNS0xNlQxNjowMTo0NC4xNDcxNTNaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA1LTE2VDE2OjAxOjQ0LjE0NzE3N1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiNDBhNDdh
-        MTRmNTcwNGY1ZGE4NzNhN2JiOWU0NjVmYWYiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
-        M1QyMToxODozOS41NDk3NDlaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
-        MjE6MTg6MzkuNjAyMTQ5WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
-        MToxODozOS43Mjc4OTZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTVmZDg0LTc2M2EtN2Y1Ny05M2RlLTVjZjlm
-        ZmJjNTc3Ny8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiNjRiNDM2
+        OGRiNDM4NDUwODlmZjRiMDg0YTEwMWFhOTciLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNS0x
+        NlQxNjowMTo0NC4xNjU0NzBaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDUtMTZU
+        MTY6MDE6NDQuMjAxODIzWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNS0xNlQx
+        NjowMTo0NC4yOTg1ODJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOTZkOWEzLWNkZWUtNzZjNC1hZThlLTk2MTcz
+        Y2Y0YjY1ZS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
-        ZmlsZS9maWxlLzAxOTVmZDg1LTMyMzAtNzVjNi1hMWViLWI1NzdhY2EzYmMz
-        Ny8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAxOTU2
-        MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRpb25z
-        Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0Y2Yt
-        OTAyNC1lODAzNDY3ZmU0ZDAiXX0=
-  recorded_at: Thu, 03 Apr 2025 21:18:39 GMT
+        ZmlsZS9maWxlLzAxOTZkOWQ0LTdmNGItN2ZkNS04MDI4LTlhNTM3NmQ2YjI2
+        YS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjI0MDE5
+        MGIzLTY1YzAtNDY4Yi05ZDllLTAzMjE5YWExMWE1ZjpkaXN0cmlidXRpb25z
+        Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjoyNDAxOTBiMy02NWMwLTQ2OGIt
+        OWQ5ZS0wMzIxOWFhMTFhNWYiXX0=
+  recorded_at: Fri, 16 May 2025 16:01:44 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/0195fd85-3230-75c6-a1eb-b577aca3bc37/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/0196d9d4-7f4b-7fd5-8028-9a5376d6b26a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1107,7 +1107,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -1120,7 +1120,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:39 GMT
+      - Fri, 16 May 2025 16:01:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1132,7 +1132,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '605'
+      - '595'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1140,32 +1140,32 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8c25c330b26841a39788dc0d2ca33cbc
+      - 42d763af1aa9406ca2ef4d42bb124351
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
-        L2ZpbGUvMDE5NWZkODUtMzIzMC03NWM2LWExZWItYjU3N2FjYTNiYzM3LyIs
-        InBybiI6InBybjpmaWxlLmZpbGVkaXN0cmlidXRpb246MDE5NWZkODUtMzIz
-        MC03NWM2LWExZWItYjU3N2FjYTNiYzM3IiwicHVscF9jcmVhdGVkIjoiMjAy
-        NS0wNC0wM1QyMToxODozOS42NjcxNDVaIiwicHVscF9sYXN0X3VwZGF0ZWQi
-        OiIyMDI1LTA0LTAzVDIxOjE4OjM5LjY2NzE2NVoiLCJiYXNlX3BhdGgiOiJE
+        L2ZpbGUvMDE5NmQ5ZDQtN2Y0Yi03ZmQ1LTgwMjgtOWE1Mzc2ZDZiMjZhLyIs
+        InBybiI6InBybjpmaWxlLmZpbGVkaXN0cmlidXRpb246MDE5NmQ5ZDQtN2Y0
+        Yi03ZmQ1LTgwMjgtOWE1Mzc2ZDZiMjZhIiwicHVscF9jcmVhdGVkIjoiMjAy
+        NS0wNS0xNlQxNjowMTo0NC4yNjk1OTVaIiwicHVscF9sYXN0X3VwZGF0ZWQi
+        OiIyMDI1LTA1LTE2VDE2OjAxOjQ0LjI2OTYxNFoiLCJiYXNlX3BhdGgiOiJE
         ZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsImJh
-        c2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwubWFuaWNv
-        dHRvLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2FuaXph
-        dGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMS8iLCJjb250ZW50X2d1YXJkIjpu
-        dWxsLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6bnVsbCwiaGlkZGVuIjpm
-        YWxzZSwicHVscF9sYWJlbHMiOnt9LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
-        YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJyZXBvc2l0b3J5IjpudWxs
-        LCJwdWJsaWNhdGlvbiI6bnVsbH0=
-  recorded_at: Thu, 03 Apr 2025 21:18:39 GMT
+        c2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwuZXhhbXBs
+        ZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJh
+        cnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3VhcmQiOm51bGwsIm5vX2Nv
+        bnRlbnRfY2hhbmdlX3NpbmNlIjpudWxsLCJoaWRkZW4iOmZhbHNlLCJwdWxw
+        X2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0
+        aW9uIjpudWxsfQ==
+  recorded_at: Fri, 16 May 2025 16:01:44 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/0195fd85-2b92-76e8-8ff6-2770c8ac18d0/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/remotes/file/file/0196d9d4-7a4d-710e-b862-812737fc3958/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1183,7 +1183,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -1196,7 +1196,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:40 GMT
+      - Fri, 16 May 2025 16:01:44 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1216,20 +1216,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3cb702779ec74f69bf4f5ad8d93d4992
+      - b0422248b27e4a1faa8a4e4de1fc58b9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTM0NDItN2U2
-        Yi1hZjQwLTJhNTBkZjI5ZDgzOC8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:40 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LTgxOTctNzNj
+        MC1iMGQyLTdmNDliNjIwZDYyMy8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:44 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-3442-7e6b-af40-2a50df29d838/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/tasks/0196d9d4-8197-73c0-b0d2-7f49b620d623/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1237,7 +1237,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -1250,7 +1250,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:40 GMT
+      - Fri, 16 May 2025 16:01:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1270,47 +1270,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d285476132d6417b8d1e4b4c604b0a40
+      - 5dc56df1a92c4ebc8cf052cac2f8a604
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtMzQ0
-        Mi03ZTZiLWFmNDAtMmE1MGRmMjlkODM4LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5NWZkODUtMzQ0Mi03ZTZiLWFmNDAtMmE1MGRmMjlkODM4IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0MC4xOTQ5MjdaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQwLjE5NDk1MVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NmQ5ZDQtODE5
+        Ny03M2MwLWIwZDItN2Y0OWI2MjBkNjIzLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NmQ5ZDQtODE5Ny03M2MwLWIwZDItN2Y0OWI2MjBkNjIzIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNS0xNlQxNjowMTo0NC44NTYwOTZaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA1LTE2VDE2OjAxOjQ0Ljg1NjExN1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiM2NiNzAy
-        Nzc5ZWM3NGY2OWJmNGY1YWQ4ZDkzZDQ5OTIiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
-        M1QyMToxODo0MC4yMTU0NThaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
-        MjE6MTg6NDAuMjE4Mjk3WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
-        MToxODo0MC4yMzE3MTBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYjA0MjIy
+        NDhiMjdlNGExZmFhOGE0ZTRkZTFmYzU4YjkiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNS0x
+        NlQxNjowMTo0NC44Nzc3ODlaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDUtMTZU
+        MTY6MDE6NDQuODc5NjQwWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNS0xNlQx
+        NjowMTo0NC44OTI3MzBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46Zmls
-        ZS5maWxlcmVtb3RlOjAxOTVmZDg1LTJiOTItNzZlOC04ZmY2LTI3NzBjOGFj
-        MThkMCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5NTYyMTctZmM5ZS03
-        NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
-  recorded_at: Thu, 03 Apr 2025 21:18:40 GMT
+        ZS5maWxlcmVtb3RlOjAxOTZkOWQ0LTdhNGQtNzEwZS1iODYyLTgxMjczN2Zj
+        Mzk1OCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MjQwMTkwYjMtNjVjMC00
+        NjhiLTlkOWUtMDMyMTlhYTExYTVmIl19
+  recorded_at: Fri, 16 May 2025 16:01:45 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/sync/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/file/file/0196d9d4-7b01-79b0-813c-07af759eb0de/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE5
-        NWZkODUtMmI5Mi03NmU4LThmZjYtMjc3MGM4YWMxOGQwLyIsIm1pcnJvciI6
+        NmQ5ZDQtN2E0ZC03MTBlLWI4NjItODEyNzM3ZmMzOTU4LyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -1323,7 +1323,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:40 GMT
+      - Fri, 16 May 2025 16:01:45 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1343,20 +1343,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 53318a8ce91d415e92a6c757b20f999b
+      - 2559ba65c723468f8110ca3b3814c822
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTM1MWUtNzNj
-        MS04ZDRmLWQ5ZDYwMTE1ZWY0OS8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:40 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LTgyYzctNzI2
+        Ny1iN2NjLWY0Njk0ODI1N2Q3Zi8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:45 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-351e-73c1-8d4f-d9d60115ef49/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/tasks/0196d9d4-82c7-7267-b7cc-f46948257d7f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1364,7 +1364,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -1377,7 +1377,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:41 GMT
+      - Fri, 16 May 2025 16:01:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1397,56 +1397,56 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8dde3ce47f014ffab8b605ea2aa7e81d
+      - a941d43946de4fa687b709edfb92ef63
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtMzUx
-        ZS03M2MxLThkNGYtZDlkNjAxMTVlZjQ5LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5NWZkODUtMzUxZS03M2MxLThkNGYtZDlkNjAxMTVlZjQ5IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0MC40MTU4ODFaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQwLjQxNTg5Nloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NmQ5ZDQtODJj
+        Ny03MjY3LWI3Y2MtZjQ2OTQ4MjU3ZDdmLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NmQ5ZDQtODJjNy03MjY3LWI3Y2MtZjQ2OTQ4MjU3ZDdmIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNS0xNlQxNjowMTo0NS4xNjA0MjdaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA1LTE2VDE2OjAxOjQ1LjE2MDQ0NFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX2ZpbGUuYXBwLnRh
         c2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25pemUiLCJsb2dnaW5nX2NpZCI6
-        IjUzMzE4YThjZTkxZDQxNWU5MmE2Yzc1N2IyMGY5OTliIiwiY3JlYXRlZF9i
+        IjI1NTliYTY1YzcyMzQ2OGY4MTEwY2EzYjM4MTRjODIyIiwiY3JlYXRlZF9i
         eSI6Ii9wdWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIw
-        MjUtMDQtMDNUMjE6MTg6NDAuNDM2NDA5WiIsInN0YXJ0ZWRfYXQiOiIyMDI1
-        LTA0LTAzVDIxOjE4OjQwLjQ4MjQ4OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjUt
-        MDQtMDNUMjE6MTg6NDEuMDY0MDY4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
-        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTk1ZmQ4NC03NWVkLTc1NDEtODFh
-        My1hNzc1ZjU1ZGUzNjgvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
+        MjUtMDUtMTZUMTY6MDE6NDUuMTkzODY3WiIsInN0YXJ0ZWRfYXQiOiIyMDI1
+        LTA1LTE2VDE2OjAxOjQ1LjI0MDIxMloiLCJmaW5pc2hlZF9hdCI6IjIwMjUt
+        MDUtMTZUMTY6MDE6NDYuMTQxNDk2WiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTk2ZDlhMy1jZGVhLTdmMzAtYmU1
+        NS0xZmY3YjRkZDliMGUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
         c2tzIjpbXSwidGFza19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6
         W3sibWVzc2FnZSI6IkRvd25sb2FkaW5nIE1ldGFkYXRhIiwiY29kZSI6InN5
         bmMuZG93bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
         InRvdGFsIjpudWxsLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25s
-        b2FkaW5nLmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
-        Om51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNz
-        b2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50
-        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6Mywi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1ldGFkYXRhIExp
-        bmVzIiwiY29kZSI6InN5bmMucGFyc2luZy5tZXRhZGF0YSIsInN0YXRlIjoi
-        Y29tcGxldGVkIiwidG90YWwiOjMsImRvbmUiOjMsInN1ZmZpeCI6bnVsbH0s
-        eyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1
-        bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
-        dGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9y
+        ZSI6IlBhcnNpbmcgTWV0YWRhdGEgTGluZXMiLCJjb2RlIjoic3luYy5wYXJz
+        aW5nLm1ldGFkYXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6Mywi
+        ZG9uZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGlu
+        ZyBBcnRpZmFjdHMiLCJjb2RlIjoic3luYy5kb3dubG9hZGluZy5hcnRpZmFj
+        dHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjow
+        LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENv
+        bnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUi
+        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6
+        ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9y
         ZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2Zp
-        bGUvMDE5NWZkODUtMmNhZS03YTY2LTlmNjQtMzY1NmU1MGQxYjJkL3ZlcnNp
+        bGUvMDE5NmQ5ZDQtN2IwMS03OWIwLTgxM2MtMDdhZjc1OWViMGRlL3ZlcnNp
         b25zLzEvIiwiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUv
-        MDE5NWZkODUtMzc0Ny03YzI3LWFkMjQtNjY2NmU1YzRlNDI5LyJdLCJyZXNl
+        MDE5NmQ5ZDQtODY2Ny03ZGU4LTk2ZjAtYzAyOWE1N2VlNzg0LyJdLCJyZXNl
         cnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpmaWxlLmZpbGVyZXBvc2l0
-        b3J5OjAxOTVmZDg1LTJjYWUtN2E2Ni05ZjY0LTM2NTZlNTBkMWIyZCIsInNo
-        YXJlZDpwcm46ZmlsZS5maWxlcmVtb3RlOjAxOTVmZDg1LTJiOTItNzZlOC04
-        ZmY2LTI3NzBjOGFjMThkMCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5
-        NTYyMTctZmM5ZS03NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
-  recorded_at: Thu, 03 Apr 2025 21:18:41 GMT
+        b3J5OjAxOTZkOWQ0LTdiMDEtNzliMC04MTNjLTA3YWY3NTllYjBkZSIsInNo
+        YXJlZDpwcm46ZmlsZS5maWxlcmVtb3RlOjAxOTZkOWQ0LTdhNGQtNzEwZS1i
+        ODYyLTgxMjczN2ZjMzk1OCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MjQw
+        MTkwYjMtNjVjMC00NjhiLTlkOWUtMDMyMTlhYTExYTVmIl19
+  recorded_at: Fri, 16 May 2025 16:01:46 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1454,7 +1454,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -1467,7 +1467,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:41 GMT
+      - Fri, 16 May 2025 16:01:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1479,7 +1479,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '657'
+      - '647'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1487,45 +1487,45 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5035aa73f1524b4f9176631eaf7c4e99
+      - dac2e4061e1c42a5b1de692d52943d82
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMTk1ZmQ4NS0zMjMwLTc1YzYtYTFlYi1iNTc3YWNhM2Jj
-        MzcvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk1ZmQ4
-        NS0zMjMwLTc1YzYtYTFlYi1iNTc3YWNhM2JjMzciLCJwdWxwX2NyZWF0ZWQi
-        OiIyMDI1LTA0LTAzVDIxOjE4OjM5LjY2NzE0NVoiLCJwdWxwX2xhc3RfdXBk
-        YXRlZCI6IjIwMjUtMDQtMDNUMjE6MTg6MzkuNjY3MTY1WiIsImJhc2VfcGF0
+        L2ZpbGUvZmlsZS8wMTk2ZDlkNC03ZjRiLTdmZDUtODAyOC05YTUzNzZkNmIy
+        NmEvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk2ZDlk
+        NC03ZjRiLTdmZDUtODAyOC05YTUzNzZkNmIyNmEiLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDI1LTA1LTE2VDE2OjAxOjQ0LjI2OTU5NVoiLCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjUtMDUtMTZUMTY6MDE6NDQuMjY5NjE0WiIsImJhc2VfcGF0
         aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8x
-        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5t
-        YW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
-        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3Vh
-        cmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjpudWxsLCJoaWRk
-        ZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiJEZWZhdWx0X09y
-        Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIsInJlcG9zaXRvcnki
-        Om51bGwsInB1YmxpY2F0aW9uIjpudWxsfV19
-  recorded_at: Thu, 03 Apr 2025 21:18:41 GMT
+        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5l
+        eGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9Pcmdhbml6YXRpb24v
+        bGlicmFyeS9wdWxwM19GaWxlXzEvIiwiY29udGVudF9ndWFyZCI6bnVsbCwi
+        bm9fY29udGVudF9jaGFuZ2Vfc2luY2UiOm51bGwsImhpZGRlbiI6ZmFsc2Us
+        InB1bHBfbGFiZWxzIjp7fSwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9u
+        LUNhYmluZXQtcHVscDNfRmlsZV8xIiwicmVwb3NpdG9yeSI6bnVsbCwicHVi
+        bGljYXRpb24iOm51bGx9XX0=
+  recorded_at: Fri, 16 May 2025 16:01:46 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/0195fd85-3230-75c6-a1eb-b577aca3bc37/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/0196d9d4-7f4b-7fd5-8028-9a5376d6b26a/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NWZk
-        ODUtMzc0Ny03YzI3LWFkMjQtNjY2NmU1YzRlNDI5LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NmQ5
+        ZDQtODY2Ny03ZGU4LTk2ZjAtYzAyOWE1N2VlNzg0LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -1538,7 +1538,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:41 GMT
+      - Fri, 16 May 2025 16:01:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1558,20 +1558,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9a17208c65644eefad32ab076509d051
+      - 601a9bcd7bed46af84496583a2236b51
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTM5OTEtNzFi
-        NC05MDA1LTljMDQ5ZDE1ZThjYS8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:41 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LTg4NzAtNzc5
+        Zi04NmRkLTJjYmU2ODc4ZTljYi8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:46 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-3991-71b4-9005-9c049d15e8ca/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/tasks/0196d9d4-8870-779f-86dd-2cbe6878e9cb/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1579,7 +1579,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -1592,7 +1592,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:41 GMT
+      - Fri, 16 May 2025 16:01:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1612,48 +1612,48 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ee9f70512eb44b7da00572c3697f08c7
+      - 37de369bd34f43b9b0171fd3484d00d8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtMzk5
-        MS03MWI0LTkwMDUtOWMwNDlkMTVlOGNhLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5NWZkODUtMzk5MS03MWI0LTkwMDUtOWMwNDlkMTVlOGNhIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0MS41NTM3MDFaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQxLjU1MzcxNVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NmQ5ZDQtODg3
+        MC03NzlmLTg2ZGQtMmNiZTY4NzhlOWNiLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NmQ5ZDQtODg3MC03NzlmLTg2ZGQtMmNiZTY4NzhlOWNiIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNS0xNlQxNjowMTo0Ni42MDg2OTZaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA1LTE2VDE2OjAxOjQ2LjYwODc0MVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiOWExNzIw
-        OGM2NTY0NGVlZmFkMzJhYjA3NjUwOWQwNTEiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
-        M1QyMToxODo0MS41NzAxNjhaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
-        MjE6MTg6NDEuNTc2NjY3WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
-        MToxODo0MS42MDExMTVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiNjAxYTli
+        Y2Q3YmVkNDZhZjg0NDk2NTgzYTIyMzZiNTEiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNS0x
+        NlQxNjowMTo0Ni42MjQxNzdaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDUtMTZU
+        MTY6MDE6NDYuNjI2MTUwWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNS0xNlQx
+        NjowMTo0Ni42NDU5ODJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTU2MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0
-        Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
-  recorded_at: Thu, 03 Apr 2025 21:18:41 GMT
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjI0
+        MDE5MGIzLTY1YzAtNDY4Yi05ZDllLTAzMjE5YWExMWE1ZjpkaXN0cmlidXRp
+        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjoyNDAxOTBiMy02NWMwLTQ2
+        OGItOWQ5ZS0wMzIxOWFhMTFhNWYiXX0=
+  recorded_at: Fri, 16 May 2025 16:01:46 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/0195fd85-3230-75c6-a1eb-b577aca3bc37/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/0196d9d4-7f4b-7fd5-8028-9a5376d6b26a/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NWZk
-        ODUtMzc0Ny03YzI3LWFkMjQtNjY2NmU1YzRlNDI5LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NmQ5
+        ZDQtODY2Ny03ZGU4LTk2ZjAtYzAyOWE1N2VlNzg0LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -1666,7 +1666,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:41 GMT
+      - Fri, 16 May 2025 16:01:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1686,20 +1686,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 23bf9273a4f045dfbc62c730261d0431
+      - fe10144a859146b4abce2fa48e9037ee
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTNhNzQtNzRk
-        MS04ZjQyLTU0ZThmNjM2Y2M1NS8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:41 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LTg5OTEtNzI1
+        MC05YjNjLWE4ZmMxNTVmNDI0Ny8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:46 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/remotes/file/file/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1716,7 +1716,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -1729,13 +1729,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:42 GMT
+      - Fri, 16 May 2025 16:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/0195fd85-3b6d-7db7-b2e0-53434765367e/"
+      - "/pulp/api/v3/remotes/file/file/0196d9d4-8abc-7a61-bf79-1b084fed7711/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -1751,20 +1751,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 26efc2c75657411bafea203d2b1177f9
+      - 6b9a45f488724b198e827a527527ea5b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
-        MDE5NWZkODUtM2I2ZC03ZGI3LWIyZTAtNTM0MzQ3NjUzNjdlLyIsInBybiI6
-        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NWZkODUtM2I2ZC03ZGI3LWIyZTAt
-        NTM0MzQ3NjUzNjdlIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMTox
-        ODo0Mi4wMzAyNDRaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAz
-        VDIxOjE4OjQyLjAzMDI1OVoiLCJuYW1lIjoidGVzdF9yZW1vdGVfbmFtZSIs
+        MDE5NmQ5ZDQtOGFiYy03YTYxLWJmNzktMWIwODRmZWQ3NzExLyIsInBybiI6
+        InBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NmQ5ZDQtOGFiYy03YTYxLWJmNzkt
+        MWIwODRmZWQ3NzExIiwicHVscF9jcmVhdGVkIjoiMjAyNS0wNS0xNlQxNjow
+        MTo0Ny4xOTY3NjRaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA1LTE2
+        VDE2OjAxOjQ3LjE5Njc3OVoiLCJuYW1lIjoidGVzdF9yZW1vdGVfbmFtZSIs
         InVybCI6Imh0dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL2ZpbGUv
         L1BVTFBfTUFOSUZFU1QiLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6
         bnVsbCwidGxzX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwi
@@ -1778,10 +1778,10 @@ http_interactions:
         ZSI6InByb3h5X3Bhc3N3b3JkIiwiaXNfc2V0IjpmYWxzZX0seyJuYW1lIjoi
         dXNlcm5hbWUiLCJpc19zZXQiOmZhbHNlfSx7Im5hbWUiOiJwYXNzd29yZCIs
         ImlzX3NldCI6ZmFsc2V9XX0=
-  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
+  recorded_at: Fri, 16 May 2025 16:01:47 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/0195fd85-3b6d-7db7-b2e0-53434765367e/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/remotes/file/file/0196d9d4-8abc-7a61-bf79-1b084fed7711/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1789,7 +1789,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -1802,7 +1802,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:42 GMT
+      - Fri, 16 May 2025 16:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1822,20 +1822,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2438c35a476b49619647a1125d60e46f
+      - d6f33af601fc4c509d34c6d25fd96420
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTNiYjItN2M1
-        Ni1hYTc0LTRhNTdkZThiMTM3ZS8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LThiMTktNzY5
+        Ny1iZWM5LWY0NDFjYWE1Zjc4My8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:47 GMT
 - request:
     method: put
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/file/file/0196d9d4-7b01-79b0-813c-07af759eb0de/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1845,7 +1845,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -1858,7 +1858,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:42 GMT
+      - Fri, 16 May 2025 16:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1878,20 +1878,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d3451d1e6dcc4e5bb01e3d48ba9d7964
+      - 5fd9cb219bc94ad8a9dff5c60abc9af8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTNjNzYtNzcz
-        MS05YWQxLTY1NjQxNjJjMGE5Ny8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LThiZjUtN2Y4
+        Ni05ZmYzLWZiNDNjMGU5NTQ4OC8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:47 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/0195fd85-2b92-76e8-8ff6-2770c8ac18d0/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/remotes/file/file/0196d9d4-7a4d-710e-b862-812737fc3958/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1909,7 +1909,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -1922,7 +1922,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:42 GMT
+      - Fri, 16 May 2025 16:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1942,20 +1942,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 58a95542e76f4efb8e2816e623edd634
+      - a36e715fc2e74347bad01634b8178212
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTNjZjUtNzBm
-        Ny05ZDRkLWUyOWE2MDk5NGQ4NS8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LThjN2UtNzc3
+        Zi1iNzkyLTRhZjE1OGMwMmQ2My8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:47 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-3cf5-70f7-9d4d-e29a60994d85/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/tasks/0196d9d4-8c7e-777f-b792-4af158c02d63/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1963,7 +1963,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -1976,7 +1976,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:42 GMT
+      - Fri, 16 May 2025 16:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1996,36 +1996,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7f578d92fdb74c4695d52baab0aa0f5f
+      - 3c3140229f664666a26d1651b1125726
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtM2Nm
-        NS03MGY3LTlkNGQtZTI5YTYwOTk0ZDg1LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5NWZkODUtM2NmNS03MGY3LTlkNGQtZTI5YTYwOTk0ZDg1IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0Mi40MjIyMDVaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQyLjQyMjIxOFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NmQ5ZDQtOGM3
+        ZS03NzdmLWI3OTItNGFmMTU4YzAyZDYzLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NmQ5ZDQtOGM3ZS03NzdmLWI3OTItNGFmMTU4YzAyZDYzIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNS0xNlQxNjowMTo0Ny42NDcwNzRaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA1LTE2VDE2OjAxOjQ3LjY0NzA5Nloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiNThhOTU1
-        NDJlNzZmNGVmYjhlMjgxNmU2MjNlZGQ2MzQiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
-        M1QyMToxODo0Mi40Mzg0MzFaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
-        MjE6MTg6NDIuNDQxNDQ3WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
-        MToxODo0Mi40NTQwMTJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYTM2ZTcx
+        NWZjMmU3NDM0N2JhZDAxNjM0YjgxNzgyMTIiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNS0x
+        NlQxNjowMTo0Ny42NjY2MTlaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDUtMTZU
+        MTY6MDE6NDcuNjY4NTYwWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNS0xNlQx
+        NjowMTo0Ny42Nzk4MzlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46Zmls
-        ZS5maWxlcmVtb3RlOjAxOTVmZDg1LTJiOTItNzZlOC04ZmY2LTI3NzBjOGFj
-        MThkMCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5NTYyMTctZmM5ZS03
-        NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
-  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
+        ZS5maWxlcmVtb3RlOjAxOTZkOWQ0LTdhNGQtNzEwZS1iODYyLTgxMjczN2Zj
+        Mzk1OCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MjQwMTkwYjMtNjVjMC00
+        NjhiLTlkOWUtMDMyMTlhYTExYTVmIl19
+  recorded_at: Fri, 16 May 2025 16:01:47 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2033,7 +2033,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -2046,7 +2046,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:42 GMT
+      - Fri, 16 May 2025 16:01:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2058,7 +2058,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '753'
+      - '743'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2066,47 +2066,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b0fdf6810d26489680ee05fe5d66eb30
+      - e93024bc227f49b6b49b81df5057fc83
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMTk1ZmQ4NS0zMjMwLTc1YzYtYTFlYi1iNTc3YWNhM2Jj
-        MzcvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk1ZmQ4
-        NS0zMjMwLTc1YzYtYTFlYi1iNTc3YWNhM2JjMzciLCJwdWxwX2NyZWF0ZWQi
-        OiIyMDI1LTA0LTAzVDIxOjE4OjM5LjY2NzE0NVoiLCJwdWxwX2xhc3RfdXBk
-        YXRlZCI6IjIwMjUtMDQtMDNUMjE6MTg6NDEuODEwNDYyWiIsImJhc2VfcGF0
+        L2ZpbGUvZmlsZS8wMTk2ZDlkNC03ZjRiLTdmZDUtODAyOC05YTUzNzZkNmIy
+        NmEvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk2ZDlk
+        NC03ZjRiLTdmZDUtODAyOC05YTUzNzZkNmIyNmEiLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDI1LTA1LTE2VDE2OjAxOjQ0LjI2OTU5NVoiLCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjUtMDUtMTZUMTY6MDE6NDYuOTMyMzc1WiIsImJhc2VfcGF0
         aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8x
-        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5t
-        YW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
-        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3Vh
-        cmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNS0wNC0w
-        M1QyMToxODo0MS44MTA0NjJaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9sYWJl
-        bHMiOnt9LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1w
-        dWxwM19GaWxlXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6
-        Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOTVmZDg1
-        LTM3NDctN2MyNy1hZDI0LTY2NjZlNWM0ZTQyOS8ifV19
-  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
+        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5l
+        eGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9Pcmdhbml6YXRpb24v
+        bGlicmFyeS9wdWxwM19GaWxlXzEvIiwiY29udGVudF9ndWFyZCI6bnVsbCwi
+        bm9fY29udGVudF9jaGFuZ2Vfc2luY2UiOiIyMDI1LTA1LTE2VDE2OjAxOjQ2
+        LjkzMjM3NVoiLCJoaWRkZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5h
+        bWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVf
+        MSIsInJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBp
+        L3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NmQ5ZDQtODY2Ny03ZGU4
+        LTk2ZjAtYzAyOWE1N2VlNzg0LyJ9XX0=
+  recorded_at: Fri, 16 May 2025 16:01:47 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/0195fd85-3230-75c6-a1eb-b577aca3bc37/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/0196d9d4-7f4b-7fd5-8028-9a5376d6b26a/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NWZk
-        ODUtMzc0Ny03YzI3LWFkMjQtNjY2NmU1YzRlNDI5LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NmQ5
+        ZDQtODY2Ny03ZGU4LTk2ZjAtYzAyOWE1N2VlNzg0LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -2119,7 +2119,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:42 GMT
+      - Fri, 16 May 2025 16:01:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2139,20 +2139,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e479cf8eb4ae45d4855b23a27f265a4d
+      - 0635de0ca7834455aecbb941c90ab6b8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTNlMjAtNzc5
-        Zi1hOTBkLTA2MWNlNGEyMTBjZi8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LThkZGItNzQz
+        Yi1hYzg4LTg3MjNjYWI4YTY2ZC8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:48 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-3e20-779f-a90d-061ce4a210cf/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/tasks/0196d9d4-8ddb-743b-ac88-8723cab8a66d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2160,7 +2160,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -2173,7 +2173,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:42 GMT
+      - Fri, 16 May 2025 16:01:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2193,48 +2193,48 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f63e87e066794cb082238290bc81c9ef
+      - f50fe8502356462f86cac6fdc652e4f1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtM2Uy
-        MC03NzlmLWE5MGQtMDYxY2U0YTIxMGNmLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5NWZkODUtM2UyMC03NzlmLWE5MGQtMDYxY2U0YTIxMGNmIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0Mi43MjA1ODBaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQyLjcyMDU5NFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NmQ5ZDQtOGRk
+        Yi03NDNiLWFjODgtODcyM2NhYjhhNjZkLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NmQ5ZDQtOGRkYi03NDNiLWFjODgtODcyM2NhYjhhNjZkIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNS0xNlQxNjowMTo0Ny45OTYwMjFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA1LTE2VDE2OjAxOjQ3Ljk5NjA0MVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiZTQ3OWNm
-        OGViNGFlNDVkNDg1NWIyM2EyN2YyNjVhNGQiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
-        M1QyMToxODo0Mi43MzQyNjhaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
-        MjE6MTg6NDIuNzM3MTcwWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
-        MToxODo0Mi43NTQzMzVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiMDYzNWRl
+        MGNhNzgzNDQ1NWFlY2JiOTQxYzkwYWI2YjgiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNS0x
+        NlQxNjowMTo0OC4wMTUzMDBaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDUtMTZU
+        MTY6MDE6NDguMDE3MDcyWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNS0xNlQx
+        NjowMTo0OC4wMzUwOTRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTU2MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0
-        Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
-  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjI0
+        MDE5MGIzLTY1YzAtNDY4Yi05ZDllLTAzMjE5YWExMWE1ZjpkaXN0cmlidXRp
+        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjoyNDAxOTBiMy02NWMwLTQ2
+        OGItOWQ5ZS0wMzIxOWFhMTFhNWYiXX0=
+  recorded_at: Fri, 16 May 2025 16:01:48 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/0195fd85-3230-75c6-a1eb-b577aca3bc37/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/0196d9d4-7f4b-7fd5-8028-9a5376d6b26a/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NWZk
-        ODUtMzc0Ny03YzI3LWFkMjQtNjY2NmU1YzRlNDI5LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NmQ5
+        ZDQtODY2Ny03ZGU4LTk2ZjAtYzAyOWE1N2VlNzg0LyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -2247,7 +2247,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:42 GMT
+      - Fri, 16 May 2025 16:01:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2267,20 +2267,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d50737fca3774fc49264c1a5f1c5c133
+      - c7fcbe2850744392aa1a431ab9e33300
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTNlZTYtNzZi
-        ZC05ODcyLWI4MzIxODUyOGYzNi8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:42 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LThlZDgtN2Jk
+        ZS05MTZmLTQ4YjgyYzQ4NTgzMi8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:48 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/0195fd85-2b92-76e8-8ff6-2770c8ac18d0/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/remotes/file/file/0196d9d4-7a4d-710e-b862-812737fc3958/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2298,7 +2298,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -2311,7 +2311,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:43 GMT
+      - Fri, 16 May 2025 16:01:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2331,20 +2331,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b1fce24bfcdd48619b7dfdc932311807
+      - 788cd0f6e6d8499da610a2765f7b58a9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTQwZDQtNzRk
-        OC1hOTI5LWI1MzVkN2NiZjZiMC8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:43 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LTkwMmEtN2Yy
+        YS05MWE2LTczNWVhNmVmZmI3NC8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:48 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-40d4-74d8-a929-b535d7cbf6b0/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/tasks/0196d9d4-902a-7f2a-91a6-735ea6effb74/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2352,7 +2352,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -2365,7 +2365,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:43 GMT
+      - Fri, 16 May 2025 16:01:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2385,47 +2385,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fb1a406ae4b542c9b23ef8d1de76fff2
+      - 6b313676814247e9817b3fca4e0a9880
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtNDBk
-        NC03NGQ4LWE5MjktYjUzNWQ3Y2JmNmIwLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5NWZkODUtNDBkNC03NGQ4LWE5MjktYjUzNWQ3Y2JmNmIwIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0My40MTI4MThaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQzLjQxMjg0OFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NmQ5ZDQtOTAy
+        YS03ZjJhLTkxYTYtNzM1ZWE2ZWZmYjc0LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NmQ5ZDQtOTAyYS03ZjJhLTkxYTYtNzM1ZWE2ZWZmYjc0IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNS0xNlQxNjowMTo0OC41ODc3NjFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA1LTE2VDE2OjAxOjQ4LjU4Nzc4Mloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiYjFmY2Uy
-        NGJmY2RkNDg2MTliN2RmZGM5MzIzMTE4MDciLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
-        M1QyMToxODo0My40Mjg5ODlaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
-        MjE6MTg6NDMuNDMyMDU3WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
-        MToxODo0My40NDI4NjhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiNzg4Y2Qw
+        ZjZlNmQ4NDk5ZGE2MTBhMjc2NWY3YjU4YTkiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNS0x
+        NlQxNjowMTo0OC42MDY5NjlaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDUtMTZU
+        MTY6MDE6NDguNjA4OTIzWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNS0xNlQx
+        NjowMTo0OC42MjE4OTRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
         Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46Zmls
-        ZS5maWxlcmVtb3RlOjAxOTVmZDg1LTJiOTItNzZlOC04ZmY2LTI3NzBjOGFj
-        MThkMCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5NTYyMTctZmM5ZS03
-        NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
-  recorded_at: Thu, 03 Apr 2025 21:18:43 GMT
+        ZS5maWxlcmVtb3RlOjAxOTZkOWQ0LTdhNGQtNzEwZS1iODYyLTgxMjczN2Zj
+        Mzk1OCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MjQwMTkwYjMtNjVjMC00
+        NjhiLTlkOWUtMDMyMTlhYTExYTVmIl19
+  recorded_at: Fri, 16 May 2025 16:01:48 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/sync/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/file/file/0196d9d4-7b01-79b0-813c-07af759eb0de/sync/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUvMDE5
-        NWZkODUtMmI5Mi03NmU4LThmZjYtMjc3MGM4YWMxOGQwLyIsIm1pcnJvciI6
+        NmQ5ZDQtN2E0ZC03MTBlLWI4NjItODEyNzM3ZmMzOTU4LyIsIm1pcnJvciI6
         dHJ1ZX0=
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -2438,7 +2438,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:43 GMT
+      - Fri, 16 May 2025 16:01:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2458,20 +2458,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 75308e5a39504f23972207999d624e78
+      - 24013169c1f6471bac3d1d26d80608f2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTQxOWMtNzU2
-        Mi1iNmRiLWMxYzI4YjcxZjA0MS8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:43 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LTkxMzctN2Ux
+        ZS04ZTljLTQ3Y2JiMTMxOTU4Mi8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:48 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-419c-7562-b6db-c1c28b71f041/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/tasks/0196d9d4-9137-7e1e-8e9c-47cbb1319582/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2479,7 +2479,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -2492,7 +2492,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:44 GMT
+      - Fri, 16 May 2025 16:01:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2512,56 +2512,56 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c101047ad4a849bc9f2c00588064dae9
+      - 71575a3afcf94f1e8f44ded74039dcf6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtNDE5
-        Yy03NTYyLWI2ZGItYzFjMjhiNzFmMDQxLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5NWZkODUtNDE5Yy03NTYyLWI2ZGItYzFjMjhiNzFmMDQxIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0My42MTMzMDdaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQzLjYxMzMyMloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NmQ5ZDQtOTEz
+        Ny03ZTFlLThlOWMtNDdjYmIxMzE5NTgyLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NmQ5ZDQtOTEzNy03ZTFlLThlOWMtNDdjYmIxMzE5NTgyIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNS0xNlQxNjowMTo0OC44NTY1MjJaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA1LTE2VDE2OjAxOjQ4Ljg1NjU0MVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX2ZpbGUuYXBwLnRh
         c2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25pemUiLCJsb2dnaW5nX2NpZCI6
-        Ijc1MzA4ZTVhMzk1MDRmMjM5NzIyMDc5OTlkNjI0ZTc4IiwiY3JlYXRlZF9i
+        IjI0MDEzMTY5YzFmNjQ3MWJhYzNkMWQyNmQ4MDYwOGYyIiwiY3JlYXRlZF9i
         eSI6Ii9wdWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIw
-        MjUtMDQtMDNUMjE6MTg6NDMuNjI4OTk4WiIsInN0YXJ0ZWRfYXQiOiIyMDI1
-        LTA0LTAzVDIxOjE4OjQzLjY4OTMxNVoiLCJmaW5pc2hlZF9hdCI6IjIwMjUt
-        MDQtMDNUMjE6MTg6NDQuMTkyMzQxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
-        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTk1ZmQ4NC03NWI1LTcxYTMtYTNk
-        Yi0xYWQxZTI5NzJjMDcvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
+        MjUtMDUtMTZUMTY6MDE6NDguODc2MDc4WiIsInN0YXJ0ZWRfYXQiOiIyMDI1
+        LTA1LTE2VDE2OjAxOjQ4LjkzMjc5OFoiLCJmaW5pc2hlZF9hdCI6IjIwMjUt
+        MDUtMTZUMTY6MDE6NDkuODczMDA1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIi
+        OiIvcHVscC9hcGkvdjMvd29ya2Vycy8wMTk2ZDlhMy1jZGVlLTc2YzQtYWU4
+        ZS05NjE3M2NmNGI2NWUvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rh
         c2tzIjpbXSwidGFza19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6
         W3sibWVzc2FnZSI6IkRvd25sb2FkaW5nIE1ldGFkYXRhIiwiY29kZSI6InN5
         bmMuZG93bmxvYWRpbmcubWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
         InRvdGFsIjpudWxsLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2Fn
-        ZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsImNvZGUiOiJzeW5jLmRvd25s
-        b2FkaW5nLmFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwi
-        Om51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNz
-        b2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50
-        Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6Mywi
-        c3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJQYXJzaW5nIE1ldGFkYXRhIExp
-        bmVzIiwiY29kZSI6InN5bmMucGFyc2luZy5tZXRhZGF0YSIsInN0YXRlIjoi
-        Y29tcGxldGVkIiwidG90YWwiOjMsImRvbmUiOjMsInN1ZmZpeCI6bnVsbH0s
-        eyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUiOiJ1
-        bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        ZSI6IlBhcnNpbmcgTWV0YWRhdGEgTGluZXMiLCJjb2RlIjoic3luYy5wYXJz
+        aW5nLm1ldGFkYXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6Mywi
+        ZG9uZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGlu
+        ZyBBcnRpZmFjdHMiLCJjb2RlIjoic3luYy5kb3dubG9hZGluZy5hcnRpZmFj
+        dHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjow
+        LCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29jaWF0aW5nIENv
+        bnRlbnQiLCJjb2RlIjoidW5hc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUi
+        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6Mywic3VmZml4Ijpu
+        dWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6
+        ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
         dGFsIjpudWxsLCJkb25lIjozLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRlZF9y
         ZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2Zp
-        bGUvMDE5NWZkODUtMmNhZS03YTY2LTlmNjQtMzY1NmU1MGQxYjJkL3ZlcnNp
+        bGUvMDE5NmQ5ZDQtN2IwMS03OWIwLTgxM2MtMDdhZjc1OWViMGRlL3ZlcnNp
         b25zLzIvIiwiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUv
-        MDE5NWZkODUtNDNhNy03OWFhLWE0MjItYTJhMjhiMzc0NDU1LyJdLCJyZXNl
+        MDE5NmQ5ZDQtOTRmNC03YTQwLThhMmEtYjZjOTkxOWE3MzEwLyJdLCJyZXNl
         cnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpmaWxlLmZpbGVyZXBvc2l0
-        b3J5OjAxOTVmZDg1LTJjYWUtN2E2Ni05ZjY0LTM2NTZlNTBkMWIyZCIsInNo
-        YXJlZDpwcm46ZmlsZS5maWxlcmVtb3RlOjAxOTVmZDg1LTJiOTItNzZlOC04
-        ZmY2LTI3NzBjOGFjMThkMCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MDE5
-        NTYyMTctZmM5ZS03NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
-  recorded_at: Thu, 03 Apr 2025 21:18:44 GMT
+        b3J5OjAxOTZkOWQ0LTdiMDEtNzliMC04MTNjLTA3YWY3NTllYjBkZSIsInNo
+        YXJlZDpwcm46ZmlsZS5maWxlcmVtb3RlOjAxOTZkOWQ0LTdhNGQtNzEwZS1i
+        ODYyLTgxMjczN2ZjMzk1OCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MjQw
+        MTkwYjMtNjVjMC00NjhiLTlkOWUtMDMyMTlhYTExYTVmIl19
+  recorded_at: Fri, 16 May 2025 16:01:50 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2569,7 +2569,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -2582,7 +2582,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:44 GMT
+      - Fri, 16 May 2025 16:01:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2594,7 +2594,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '753'
+      - '743'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2602,47 +2602,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f38b3b36083e45cfa308ebd707de1dd9
+      - 5676d98e2b7b401a8eeb27263e42e90a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMTk1ZmQ4NS0zMjMwLTc1YzYtYTFlYi1iNTc3YWNhM2Jj
-        MzcvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk1ZmQ4
-        NS0zMjMwLTc1YzYtYTFlYi1iNTc3YWNhM2JjMzciLCJwdWxwX2NyZWF0ZWQi
-        OiIyMDI1LTA0LTAzVDIxOjE4OjM5LjY2NzE0NVoiLCJwdWxwX2xhc3RfdXBk
-        YXRlZCI6IjIwMjUtMDQtMDNUMjE6MTg6NDIuOTQ4NDU4WiIsImJhc2VfcGF0
+        L2ZpbGUvZmlsZS8wMTk2ZDlkNC03ZjRiLTdmZDUtODAyOC05YTUzNzZkNmIy
+        NmEvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk2ZDlk
+        NC03ZjRiLTdmZDUtODAyOC05YTUzNzZkNmIyNmEiLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDI1LTA1LTE2VDE2OjAxOjQ0LjI2OTU5NVoiLCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjUtMDUtMTZUMTY6MDE6NDguMjc1MDA4WiIsImJhc2VfcGF0
         aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8x
-        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5t
-        YW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
-        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3Vh
-        cmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNS0wNC0w
-        M1QyMToxODo0Mi45NDg0NThaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9sYWJl
-        bHMiOnt9LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1w
-        dWxwM19GaWxlXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6
-        Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOTVmZDg1
-        LTM3NDctN2MyNy1hZDI0LTY2NjZlNWM0ZTQyOS8ifV19
-  recorded_at: Thu, 03 Apr 2025 21:18:44 GMT
+        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5l
+        eGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9Pcmdhbml6YXRpb24v
+        bGlicmFyeS9wdWxwM19GaWxlXzEvIiwiY29udGVudF9ndWFyZCI6bnVsbCwi
+        bm9fY29udGVudF9jaGFuZ2Vfc2luY2UiOiIyMDI1LTA1LTE2VDE2OjAxOjQ4
+        LjI3NTAwOFoiLCJoaWRkZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5h
+        bWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVf
+        MSIsInJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBp
+        L3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NmQ5ZDQtODY2Ny03ZGU4
+        LTk2ZjAtYzAyOWE1N2VlNzg0LyJ9XX0=
+  recorded_at: Fri, 16 May 2025 16:01:50 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/0195fd85-3230-75c6-a1eb-b577aca3bc37/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/0196d9d4-7f4b-7fd5-8028-9a5376d6b26a/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NWZk
-        ODUtNDNhNy03OWFhLWE0MjItYTJhMjhiMzc0NDU1LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NmQ5
+        ZDQtOTRmNC03YTQwLThhMmEtYjZjOTkxOWE3MzEwLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -2655,7 +2655,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:44 GMT
+      - Fri, 16 May 2025 16:01:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2675,20 +2675,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7e521e8b6bad4c45854498cda9119f9a
+      - 269d2223406545fe8b59158228a55f69
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTQ1MzItN2Y0
-        OS1iMjIwLWM4MzJmNWE1YjJhYy8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:44 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LTk3NDYtN2Ux
+        OC1iZWI2LTc5MWNlMmU3ODUzZi8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:50 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-4532-7f49-b220-c832f5a5b2ac/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/tasks/0196d9d4-9746-7e18-beb6-791ce2e7853f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2696,7 +2696,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -2709,7 +2709,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:44 GMT
+      - Fri, 16 May 2025 16:01:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2729,48 +2729,48 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 28fe1720341b412c8b22e354ca430bf8
+      - 050cbaad2e514d81bca76fe2376a5baf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtNDUz
-        Mi03ZjQ5LWIyMjAtYzgzMmY1YTViMmFjLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5NWZkODUtNDUzMi03ZjQ5LWIyMjAtYzgzMmY1YTViMmFjIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0NC41MzA0OTVaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQ0LjUzMDUwOVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NmQ5ZDQtOTc0
+        Ni03ZTE4LWJlYjYtNzkxY2UyZTc4NTNmLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NmQ5ZDQtOTc0Ni03ZTE4LWJlYjYtNzkxY2UyZTc4NTNmIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNS0xNlQxNjowMTo1MC40MDY5MTRaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA1LTE2VDE2OjAxOjUwLjQwNjkyOVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiN2U1MjFl
-        OGI2YmFkNGM0NTg1NDQ5OGNkYTkxMTlmOWEiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
-        M1QyMToxODo0NC41NDM1MjZaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
-        MjE6MTg6NDQuNTQ3NTk0WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
-        MToxODo0NC41NjQwNjBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
+        a3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsImxvZ2dpbmdfY2lkIjoiMjY5ZDIy
+        MjM0MDY1NDVmZThiNTkxNTgyMjhhNTVmNjkiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNS0x
+        NlQxNjowMTo1MC40MjQxNjhaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDUtMTZU
+        MTY6MDE6NTAuNDI1OTY2WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNS0xNlQx
+        NjowMTo1MC40NTAyODRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6bnVsbCwi
         cGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpbXSwidGFza19ncm91
         cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3Vy
-        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjAx
-        OTU2MjE3LWZjOWUtNzRjZi05MDI0LWU4MDM0NjdmZTRkMDpkaXN0cmlidXRp
-        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1NjIxNy1mYzllLTc0
-        Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
-  recorded_at: Thu, 03 Apr 2025 21:18:44 GMT
+        Y2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwZHJuOjI0
+        MDE5MGIzLTY1YzAtNDY4Yi05ZDllLTAzMjE5YWExMWE1ZjpkaXN0cmlidXRp
+        b25zIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjoyNDAxOTBiMy02NWMwLTQ2
+        OGItOWQ5ZS0wMzIxOWFhMTFhNWYiXX0=
+  recorded_at: Fri, 16 May 2025 16:01:50 GMT
 - request:
     method: patch
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/0195fd85-3230-75c6-a1eb-b577aca3bc37/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/0196d9d4-7f4b-7fd5-8028-9a5376d6b26a/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb250ZW50X2d1YXJkIjpudWxsLCJiYXNlX3BhdGgiOiJEZWZhdWx0X09y
         Z2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9u
-        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NWZk
-        ODUtNDNhNy03OWFhLWE0MjItYTJhMjhiMzc0NDU1LyJ9
+        IjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NmQ5
+        ZDQtOTRmNC03YTQwLThhMmEtYjZjOTkxOWE3MzEwLyJ9
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -2783,7 +2783,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:44 GMT
+      - Fri, 16 May 2025 16:01:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2803,20 +2803,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ce07c281409b47d58a6c194cb8bbd795
+      - 19baad1e02fd4cb7b3e71ddfe40f430a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTQ2MjMtN2Ri
-        Yi1hMmIyLTkwODg3NmEyMDdkOC8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:44 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LTk4NjMtN2Yy
+        NS1iZmQzLWU3NzlkNDVmM2U0ZS8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:50 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2824,7 +2824,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.22.4/ruby
+      - OpenAPI-Generator/0.24.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -2837,7 +2837,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:45 GMT
+      - Fri, 16 May 2025 16:01:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2857,20 +2857,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ce8418ec12364d74ba37478ac6f26779
+      - f78f023b326145148ef49db53b3715bc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+  recorded_at: Fri, 16 May 2025 16:01:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/deb/apt/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2878,7 +2878,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.5.1/ruby
+      - OpenAPI-Generator/3.5.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -2891,7 +2891,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:45 GMT
+      - Fri, 16 May 2025 16:01:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2911,20 +2911,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 67e73b953c3a48dba3ed16e57aac88a6
+      - dd813828ba1346f1a9265baf5e5ba4d3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+  recorded_at: Fri, 16 May 2025 16:01:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/container/container/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2932,7 +2932,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.22.2/ruby
+      - OpenAPI-Generator/2.24.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -2945,7 +2945,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:45 GMT
+      - Fri, 16 May 2025 16:01:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2965,20 +2965,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ef4c80b400ca48979daf737799829104
+      - 5161297bd80e4e3698d02533b92a94f2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+  recorded_at: Fri, 16 May 2025 16:01:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2986,7 +2986,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -2999,7 +2999,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:45 GMT
+      - Fri, 16 May 2025 16:01:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3011,7 +3011,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '753'
+      - '743'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -3019,35 +3019,35 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ae79ce794a9946eb8ebec7f6bea7629d
+      - 0ee0c9e318144f7cb09f5f5f1129f7e4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2ZpbGUvZmlsZS8wMTk1ZmQ4NS0zMjMwLTc1YzYtYTFlYi1iNTc3YWNhM2Jj
-        MzcvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk1ZmQ4
-        NS0zMjMwLTc1YzYtYTFlYi1iNTc3YWNhM2JjMzciLCJwdWxwX2NyZWF0ZWQi
-        OiIyMDI1LTA0LTAzVDIxOjE4OjM5LjY2NzE0NVoiLCJwdWxwX2xhc3RfdXBk
-        YXRlZCI6IjIwMjUtMDQtMDNUMjE6MTg6NDQuODAwODcwWiIsImJhc2VfcGF0
+        L2ZpbGUvZmlsZS8wMTk2ZDlkNC03ZjRiLTdmZDUtODAyOC05YTUzNzZkNmIy
+        NmEvIiwicHJuIjoicHJuOmZpbGUuZmlsZWRpc3RyaWJ1dGlvbjowMTk2ZDlk
+        NC03ZjRiLTdmZDUtODAyOC05YTUzNzZkNmIyNmEiLCJwdWxwX2NyZWF0ZWQi
+        OiIyMDI1LTA1LTE2VDE2OjAxOjQ0LjI2OTU5NVoiLCJwdWxwX2xhc3RfdXBk
+        YXRlZCI6IjIwMjUtMDUtMTZUMTY6MDE6NTAuNzI2MjQ2WiIsImJhc2VfcGF0
         aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8x
-        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5t
-        YW5pY290dG8uZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
-        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xLyIsImNvbnRlbnRfZ3Vh
-        cmQiOm51bGwsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjoiMjAyNS0wNC0w
-        M1QyMToxODo0NC44MDA4NzBaIiwiaGlkZGVuIjpmYWxzZSwicHVscF9sYWJl
-        bHMiOnt9LCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1w
-        dWxwM19GaWxlXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJwdWJsaWNhdGlvbiI6
-        Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmlsZS9maWxlLzAxOTVmZDg1
-        LTQzYTctNzlhYS1hNDIyLWEyYTI4YjM3NDQ1NS8ifV19
-  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+        IiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1kZXZlbC5l
+        eGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9Pcmdhbml6YXRpb24v
+        bGlicmFyeS9wdWxwM19GaWxlXzEvIiwiY29udGVudF9ndWFyZCI6bnVsbCwi
+        bm9fY29udGVudF9jaGFuZ2Vfc2luY2UiOiIyMDI1LTA1LTE2VDE2OjAxOjUw
+        LjcyNjI0NloiLCJoaWRkZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5h
+        bWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVf
+        MSIsInJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBp
+        L3YzL3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDE5NmQ5ZDQtOTRmNC03YTQw
+        LThhMmEtYjZjOTkxOWE3MzEwLyJ9XX0=
+  recorded_at: Fri, 16 May 2025 16:01:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/ostree/ostree/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/ostree/ostree/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3055,7 +3055,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.4.5/ruby
+      - OpenAPI-Generator/2.4.8/ruby
       Accept:
       - application/json
       Authorization:
@@ -3068,7 +3068,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:45 GMT
+      - Fri, 16 May 2025 16:01:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3088,20 +3088,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 672a1489f25e4e13b8857a7833244c42
+      - 21e9246ee4d947e48364187666bae2e9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+  recorded_at: Fri, 16 May 2025 16:01:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/python/pypi/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/python/pypi/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3109,7 +3109,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.12.6/ruby
+      - OpenAPI-Generator/3.13.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -3122,7 +3122,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:45 GMT
+      - Fri, 16 May 2025 16:01:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3142,20 +3142,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6f4d1151e0f04a5eadba5525cd422be8
+      - bcb71529eef94cefad747077ab28064c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+  recorded_at: Fri, 16 May 2025 16:01:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/rpm/rpm/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3163,7 +3163,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.29.1/ruby
+      - OpenAPI-Generator/3.29.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -3176,7 +3176,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:45 GMT
+      - Fri, 16 May 2025 16:01:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3196,20 +3196,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6246b10832c14ddb8b4e4295bdb87249
+      - be7c82b32d4441ffb4c30e70ed15faaa
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+  recorded_at: Fri, 16 May 2025 16:01:51 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/ansible/ansible/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3217,7 +3217,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/0.22.4/ruby
+      - OpenAPI-Generator/0.24.6/ruby
       Accept:
       - application/json
       Authorization:
@@ -3230,7 +3230,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:45 GMT
+      - Fri, 16 May 2025 16:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3250,20 +3250,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 325a1be45f6e46cbaee079482515d7ff
+      - 05b38a0ea26846dd8177ad4d2fe4a2df
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+  recorded_at: Fri, 16 May 2025 16:01:52 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/deb/apt/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3271,7 +3271,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.3.1/ruby
+      - OpenAPI-Generator/3.5.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -3284,7 +3284,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:45 GMT
+      - Fri, 16 May 2025 16:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3304,20 +3304,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 506a5346248846f7ad2e7a8bf32f8f1f
+      - 466b7ce1dba14644a3e1e41c33ee46ef
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+  recorded_at: Fri, 16 May 2025 16:01:52 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/container/container/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3325,7 +3325,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.22.2/ruby
+      - OpenAPI-Generator/2.24.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -3338,7 +3338,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:45 GMT
+      - Fri, 16 May 2025 16:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3358,20 +3358,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c02bfcd01b5142c3820757ed55bdc6d6
+      - f1dbdc8dd0d148e49d935bd188a4f481
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+  recorded_at: Fri, 16 May 2025 16:01:52 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/file/file/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3379,7 +3379,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -3392,7 +3392,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:45 GMT
+      - Fri, 16 May 2025 16:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3412,34 +3412,34 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 939e2d263ff649e3a08d20f8a7f78cd4
+      - 21650177dbd6483aae59ee700f67d2ab
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTVmZDg1LTJjYWUtN2E2Ni05ZjY0LTM2NTZlNTBkMWIy
-        ZC8iLCJwcm4iOiJwcm46ZmlsZS5maWxlcmVwb3NpdG9yeTowMTk1ZmQ4NS0y
-        Y2FlLTdhNjYtOWY2NC0zNjU2ZTUwZDFiMmQiLCJwdWxwX2NyZWF0ZWQiOiIy
-        MDI1LTA0LTAzVDIxOjE4OjM4LjI1NTU1NloiLCJwdWxwX2xhc3RfdXBkYXRl
-        ZCI6IjIwMjUtMDQtMDNUMjE6MTg6NDQuMTIyNjcyWiIsInZlcnNpb25zX2hy
-        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk1
-        ZmQ4NS0yY2FlLTdhNjYtOWY2NC0zNjU2ZTUwZDFiMmQvdmVyc2lvbnMvIiwi
+        ZmlsZS9maWxlLzAxOTZkOWQ0LTdiMDEtNzliMC04MTNjLTA3YWY3NTllYjBk
+        ZS8iLCJwcm4iOiJwcm46ZmlsZS5maWxlcmVwb3NpdG9yeTowMTk2ZDlkNC03
+        YjAxLTc5YjAtODEzYy0wN2FmNzU5ZWIwZGUiLCJwdWxwX2NyZWF0ZWQiOiIy
+        MDI1LTA1LTE2VDE2OjAxOjQzLjE3MDM0OFoiLCJwdWxwX2xhc3RfdXBkYXRl
+        ZCI6IjIwMjUtMDUtMTZUMTY6MDE6NDkuNzg5MDEwWiIsInZlcnNpb25zX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk2
+        ZDlkNC03YjAxLTc5YjAtODEzYy0wN2FmNzU5ZWIwZGUvdmVyc2lvbnMvIiwi
         cHVscF9sYWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAv
-        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NWZkODUtMmNhZS03
-        YTY2LTlmNjQtMzY1NmU1MGQxYjJkL3ZlcnNpb25zLzIvIiwibmFtZSI6IkRl
+        YXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NmQ5ZDQtN2IwMS03
+        OWIwLTgxM2MtMDdhZjc1OWViMGRlL3ZlcnNpb25zLzIvIiwibmFtZSI6IkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwiZGVz
         Y3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJy
         ZW1vdGUiOm51bGwsImF1dG9wdWJsaXNoIjpmYWxzZSwibWFuaWZlc3QiOiJQ
         VUxQX01BTklGRVNUIn1dfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+  recorded_at: Fri, 16 May 2025 16:01:52 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/versions/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/file/file/0196d9d4-7b01-79b0-813c-07af759eb0de/versions/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3447,7 +3447,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -3460,7 +3460,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:45 GMT
+      - Fri, 16 May 2025 16:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3480,69 +3480,69 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4d5c6539149d4afeaebdf5758bb6b46b
+      - b6462b7a82d04ac987780e0d12dc67bc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTVmZDg1LTJjYWUtN2E2Ni05ZjY0LTM2NTZlNTBkMWIy
-        ZC92ZXJzaW9ucy8yLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
-        aW9uOjAxOTVmZDg1LTQxZjYtNzJkZi04MDYxLTM2MDhiZjg3MGIwYSIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjUtMDQtMDNUMjE6MTg6NDMuNzAzMDQ1WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0NC4xMjQ3MDJa
+        ZmlsZS9maWxlLzAxOTZkOWQ0LTdiMDEtNzliMC04MTNjLTA3YWY3NTllYjBk
+        ZS92ZXJzaW9ucy8yLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
+        aW9uOjAxOTZkOWQ0LTkxYTAtN2YyMS05YTJhLWFjMDQxNjQ3YTI3NiIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjUtMDUtMTZUMTY6MDE6NDguOTYyMjI5WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wNS0xNlQxNjowMTo0OS43OTI4MzRa
         IiwibnVtYmVyIjoyLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvMDE5NWZkODUtMmNhZS03YTY2LTlmNjQtMzY1
-        NmU1MGQxYjJkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
+        aXRvcmllcy9maWxlL2ZpbGUvMDE5NmQ5ZDQtN2IwMS03OWIwLTgxM2MtMDdh
+        Zjc1OWViMGRlLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
         YXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6
         Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlf
         dmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMTk1ZmQ4NS0yY2FlLTdhNjYtOWY2NC0zNjU2ZTUwZDFiMmQvdmVy
+        ZmlsZS8wMTk2ZDlkNC03YjAxLTc5YjAtODEzYy0wN2FmNzU5ZWIwZGUvdmVy
         c2lvbnMvMi8ifX0sInJlbW92ZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50Ijoz
         LCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVw
         b3NpdG9yeV92ZXJzaW9uX3JlbW92ZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRv
-        cmllcy9maWxlL2ZpbGUvMDE5NWZkODUtMmNhZS03YTY2LTlmNjQtMzY1NmU1
-        MGQxYjJkL3ZlcnNpb25zLzIvIn19LCJwcmVzZW50Ijp7ImZpbGUuZmlsZSI6
+        cmllcy9maWxlL2ZpbGUvMDE5NmQ5ZDQtN2IwMS03OWIwLTgxM2MtMDdhZjc1
+        OWViMGRlL3ZlcnNpb25zLzIvIn19LCJwcmVzZW50Ijp7ImZpbGUuZmlsZSI6
         eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUv
         ZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3Np
-        dG9yaWVzL2ZpbGUvZmlsZS8wMTk1ZmQ4NS0yY2FlLTdhNjYtOWY2NC0zNjU2
-        ZTUwZDFiMmQvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxw
-        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTVmZDg1LTJjYWUt
-        N2E2Ni05ZjY0LTM2NTZlNTBkMWIyZC92ZXJzaW9ucy8xLyIsInBybiI6InBy
-        bjpjb3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOTVmZDg1LTM1NzMtN2Y4Yi04
-        YjM0LWE4MDBjYjc4M2Y1YiIsInB1bHBfY3JlYXRlZCI6IjIwMjUtMDQtMDNU
-        MjE6MTg6NDAuNTAwNDQzWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0w
-        NC0wM1QyMToxODo0MC45NDM3NzJaIiwibnVtYmVyIjoxLCJyZXBvc2l0b3J5
-        IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NWZk
-        ODUtMmNhZS03YTY2LTlmNjQtMzY1NmU1MGQxYjJkLyIsImJhc2VfdmVyc2lv
+        dG9yaWVzL2ZpbGUvZmlsZS8wMTk2ZDlkNC03YjAxLTc5YjAtODEzYy0wN2Fm
+        NzU5ZWIwZGUvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTZkOWQ0LTdiMDEt
+        NzliMC04MTNjLTA3YWY3NTllYjBkZS92ZXJzaW9ucy8xLyIsInBybiI6InBy
+        bjpjb3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOTZkOWQ0LTgzMmQtNzY3ZS04
+        MTc2LWNiMTZkOGMxZjc1MCIsInB1bHBfY3JlYXRlZCI6IjIwMjUtMDUtMTZU
+        MTY6MDE6NDUuMjYyMTQxWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0w
+        NS0xNlQxNjowMTo0Ni4wNzAzOTVaIiwibnVtYmVyIjoxLCJyZXBvc2l0b3J5
+        IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5NmQ5
+        ZDQtN2IwMS03OWIwLTgxM2MtMDdhZjc1OWViMGRlLyIsImJhc2VfdmVyc2lv
         biI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmls
         ZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Zp
         bGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkv
-        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk1ZmQ4NS0yY2FlLTdhNjYt
-        OWY2NC0zNjU2ZTUwZDFiMmQvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9
+        djMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk2ZDlkNC03YjAxLTc5YjAt
+        ODEzYy0wN2FmNzU5ZWIwZGUvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9
         LCJwcmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9w
         dWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVy
-        c2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk1
-        ZmQ4NS0yY2FlLTdhNjYtOWY2NC0zNjU2ZTUwZDFiMmQvdmVyc2lvbnMvMS8i
+        c2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk2
+        ZDlkNC03YjAxLTc5YjAtODEzYy0wN2FmNzU5ZWIwZGUvdmVyc2lvbnMvMS8i
         fX19fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTVmZDg1LTJjYWUtN2E2Ni05ZjY0LTM2NTZlNTBkMWIy
-        ZC92ZXJzaW9ucy8wLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
-        aW9uOjAxOTVmZDg1LTJjYjktNzUwZi04YzFkLTUxZmJmZGU4ZGM2MCIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjUtMDQtMDNUMjE6MTg6MzguMjY5NDU2WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wNC0wM1QyMToxODozOC4yNjk0Njha
+        ZmlsZS9maWxlLzAxOTZkOWQ0LTdiMDEtNzliMC04MTNjLTA3YWY3NTllYjBk
+        ZS92ZXJzaW9ucy8wLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
+        aW9uOjAxOTZkOWQ0LTdiMDktN2NhOC1hNjYwLTI0MDQ3NDM4NWNjZCIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjUtMDUtMTZUMTY6MDE6NDMuMTgyMDQ0WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wNS0xNlQxNjowMTo0My4xODIwNjNa
         IiwibnVtYmVyIjowLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvMDE5NWZkODUtMmNhZS03YTY2LTlmNjQtMzY1
-        NmU1MGQxYjJkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
+        aXRvcmllcy9maWxlL2ZpbGUvMDE5NmQ5ZDQtN2IwMS03OWIwLTgxM2MtMDdh
+        Zjc1OWViMGRlLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
         YXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX1d
         fQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+  recorded_at: Fri, 16 May 2025 16:01:52 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/ostree/ostree/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3550,7 +3550,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/2.4.5/ruby
+      - OpenAPI-Generator/2.4.8/ruby
       Accept:
       - application/json
       Authorization:
@@ -3563,7 +3563,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:45 GMT
+      - Fri, 16 May 2025 16:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3583,20 +3583,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f41e063b29ff4f609eb0bfc4258c0253
+      - 1ea565aac8284231b77a65888feba0bb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+  recorded_at: Fri, 16 May 2025 16:01:52 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/python/python/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3604,7 +3604,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.12.6/ruby
+      - OpenAPI-Generator/3.13.5/ruby
       Accept:
       - application/json
       Authorization:
@@ -3617,7 +3617,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:45 GMT
+      - Fri, 16 May 2025 16:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3637,20 +3637,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 42cdd9ac63f54d45b850bcd5a5402bbf
+      - 6ac42980c2db427db68ac96d97e4ec30
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+  recorded_at: Fri, 16 May 2025 16:01:52 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/rpm/rpm/?limit=2000&offset=0
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3658,7 +3658,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.27.2/ruby
+      - OpenAPI-Generator/3.29.2/ruby
       Accept:
       - application/json
       Authorization:
@@ -3671,7 +3671,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:45 GMT
+      - Fri, 16 May 2025 16:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3691,20 +3691,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 84e9ff0d1ab549b38792084999e8e740
+      - '079f88ed8173448b9a9f3ea9de438106'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:45 GMT
+  recorded_at: Fri, 16 May 2025 16:01:52 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/versions/1/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/file/file/0196d9d4-7b01-79b0-813c-07af759eb0de/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3712,7 +3712,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -3725,7 +3725,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:46 GMT
+      - Fri, 16 May 2025 16:01:52 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3745,20 +3745,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 18f3d4b8655c4b32ab4663e8c1022b24
+      - 3a91c7e2379f424eb34f2dc59fd54bf8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTRhZWEtNzg5
-        My05NDYwLTE0ZDViMDE1ZDc4Ni8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:46 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LWEwZDktNzc4
+        Mi1iNjc1LTYyNTZjNDNjYmUxMy8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:52 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/orphans/cleanup/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/orphans/cleanup/
     body:
       encoding: UTF-8
       base64_string: 'eyJvcnBoYW5fcHJvdGVjdGlvbl90aW1lIjoxNDQwfQ==
@@ -3768,7 +3768,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -3781,7 +3781,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:46 GMT
+      - Fri, 16 May 2025 16:01:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3801,20 +3801,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f0ea3e863a264f9a976b2d5b3fe10ac8
+      - b6de110c17a74d9b934f5ebd1e9772c5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTRiNWUtNzlk
-        ZS04YjUxLTc4Zjk0YjVmYjQ4MC8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:46 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LWExNjctN2Qx
+        ZC1hZWMyLWU3OWYxZmY2ZTRmMS8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:53 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-4b5e-79de-8b51-78f94b5fb480/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/tasks/0196d9d4-a167-7d1d-aec2-e79f1ff6e4f1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3822,7 +3822,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -3835,7 +3835,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:46 GMT
+      - Fri, 16 May 2025 16:01:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3855,28 +3855,28 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4b88922785884d17aece0a5d2232bf80
+      - 97bc55a9238f44068d9e95202badc1b7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtNGI1
-        ZS03OWRlLThiNTEtNzhmOTRiNWZiNDgwLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5NWZkODUtNGI1ZS03OWRlLThiNTEtNzhmOTRiNWZiNDgwIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0Ni4xMTExNDZaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQ2LjExMTE2OFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NmQ5ZDQtYTE2
+        Ny03ZDFkLWFlYzItZTc5ZjFmZjZlNGYxLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NmQ5ZDQtYTE2Ny03ZDFkLWFlYzItZTc5ZjFmZjZlNGYxIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNS0xNlQxNjowMTo1Mi45OTk4NjFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA1LTE2VDE2OjAxOjUyLjk5OTg3OVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiJmMGVh
-        M2U4NjNhMjY0ZjlhOTc2YjJkNWIzZmUxMGFjOCIsImNyZWF0ZWRfYnkiOiIv
-        cHVscC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTA0
-        LTAzVDIxOjE4OjQ2LjEyNzI4M1oiLCJzdGFydGVkX2F0IjoiMjAyNS0wNC0w
-        M1QyMToxODo0Ni4xOTU2MThaIiwiZmluaXNoZWRfYXQiOiIyMDI1LTA0LTAz
-        VDIxOjE4OjQ2LjM2MzMyMFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1
-        bHAvYXBpL3YzL3dvcmtlcnMvMDE5NWZkODQtNzVkNC03ZjQ2LWI3OWYtNzEw
-        M2MxYjJjZTYwLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6
+        a3Mub3JwaGFuLm9ycGhhbl9jbGVhbnVwIiwibG9nZ2luZ19jaWQiOiJiNmRl
+        MTEwYzE3YTc0ZDliOTM0ZjVlYmQxZTk3NzJjNSIsImNyZWF0ZWRfYnkiOiIv
+        cHVscC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI1LTA1
+        LTE2VDE2OjAxOjUzLjAyMTYxNVoiLCJzdGFydGVkX2F0IjoiMjAyNS0wNS0x
+        NlQxNjowMTo1My4xMDA1ODhaIiwiZmluaXNoZWRfYXQiOiIyMDI1LTA1LTE2
+        VDE2OjAxOjUzLjQwNzk0NFoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1
+        bHAvYXBpL3YzL3dvcmtlcnMvMDE5NmQ5YTMtY2RlYS03ZjMwLWJlNTUtMWZm
+        N2I0ZGQ5YjBlLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6
         W10sInRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOlt7Im1l
         c3NhZ2UiOiJDbGVhbiB1cCBvcnBoYW4gQ29udGVudCIsImNvZGUiOiJjbGVh
         bi11cC5jb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwi
@@ -3884,13 +3884,13 @@ http_interactions:
         cnBoYW4gQXJ0aWZhY3RzIiwiY29kZSI6ImNsZWFuLXVwLmFydGlmYWN0cyIs
         InN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZp
         eCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJlc2VydmVkX3Jl
-        c291cmNlc19yZWNvcmQiOlsicGRybjowMTk1NjIxNy1mYzllLTc0Y2YtOTAy
-        NC1lODAzNDY3ZmU0ZDA6b3JwaGFucyIsInNoYXJlZDpwcm46Y29yZS5kb21h
-        aW46MDE5NTYyMTctZmM5ZS03NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
-  recorded_at: Thu, 03 Apr 2025 21:18:46 GMT
+        c291cmNlc19yZWNvcmQiOlsicGRybjoyNDAxOTBiMy02NWMwLTQ2OGItOWQ5
+        ZS0wMzIxOWFhMTFhNWY6b3JwaGFucyIsInNoYXJlZDpwcm46Y29yZS5kb21h
+        aW46MjQwMTkwYjMtNjVjMC00NjhiLTlkOWUtMDMyMTlhYTExYTVmIl19
+  recorded_at: Fri, 16 May 2025 16:01:53 GMT
 - request:
     method: post
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/purge/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/tasks/purge/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3900,7 +3900,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -3913,7 +3913,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:46 GMT
+      - Fri, 16 May 2025 16:01:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3933,20 +3933,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '01427092f0b94586b4d3120b64126052'
+      - 0ef602adec274c81866db6962ab3027a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTRjZGMtNzA1
-        My04ZDljLWUzMjMwZjIyYmJkNC8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:46 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LWEzY2UtNzcy
+        NS1iYzBkLTU4YjQ5ODgwMjQ2ZC8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:53 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/versions/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/file/file/0196d9d4-7b01-79b0-813c-07af759eb0de/versions/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3954,7 +3954,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -3967,7 +3967,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:46 GMT
+      - Fri, 16 May 2025 16:01:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3987,47 +3987,47 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2cbfb457db4b4efeaebba099c80372e4
+      - c63dc8ba604347e7acce8fe57eabb22f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZmlsZS9maWxlLzAxOTVmZDg1LTJjYWUtN2E2Ni05ZjY0LTM2NTZlNTBkMWIy
-        ZC92ZXJzaW9ucy8yLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
-        aW9uOjAxOTVmZDg1LTQxZjYtNzJkZi04MDYxLTM2MDhiZjg3MGIwYSIsInB1
-        bHBfY3JlYXRlZCI6IjIwMjUtMDQtMDNUMjE6MTg6NDMuNzAzMDQ1WiIsInB1
-        bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0NC4xMjQ3MDJa
+        ZmlsZS9maWxlLzAxOTZkOWQ0LTdiMDEtNzliMC04MTNjLTA3YWY3NTllYjBk
+        ZS92ZXJzaW9ucy8yLyIsInBybiI6InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
+        aW9uOjAxOTZkOWQ0LTkxYTAtN2YyMS05YTJhLWFjMDQxNjQ3YTI3NiIsInB1
+        bHBfY3JlYXRlZCI6IjIwMjUtMDUtMTZUMTY6MDE6NDguOTYyMjI5WiIsInB1
+        bHBfbGFzdF91cGRhdGVkIjoiMjAyNS0wNS0xNlQxNjowMTo0OS43OTI4MzRa
         IiwibnVtYmVyIjoyLCJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9z
-        aXRvcmllcy9maWxlL2ZpbGUvMDE5NWZkODUtMmNhZS03YTY2LTlmNjQtMzY1
-        NmU1MGQxYjJkLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
+        aXRvcmllcy9maWxlL2ZpbGUvMDE5NmQ5ZDQtN2IwMS03OWIwLTgxM2MtMDdh
+        Zjc1OWViMGRlLyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1t
         YXJ5Ijp7ImFkZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6
         Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlf
         dmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZpbGUv
-        ZmlsZS8wMTk1ZmQ4NS0yY2FlLTdhNjYtOWY2NC0zNjU2ZTUwZDFiMmQvdmVy
+        ZmlsZS8wMTk2ZDlkNC03YjAxLTc5YjAtODEzYy0wN2FmNzU5ZWIwZGUvdmVy
         c2lvbnMvMi8ifX0sInJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7ImZpbGUuZmls
         ZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Zp
         bGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVw
-        b3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk1ZmQ4NS0yY2FlLTdhNjYtOWY2NC0z
-        NjU2ZTUwZDFiMmQvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJlZiI6Ii9w
-        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTVmZDg1LTJj
-        YWUtN2E2Ni05ZjY0LTM2NTZlNTBkMWIyZC92ZXJzaW9ucy8wLyIsInBybiI6
-        InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOTVmZDg1LTJjYjktNzUw
-        Zi04YzFkLTUxZmJmZGU4ZGM2MCIsInB1bHBfY3JlYXRlZCI6IjIwMjUtMDQt
-        MDNUMjE6MTg6MzguMjY5NDU2WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
-        NS0wNC0wM1QyMToxODozOC4yNjk0NjhaIiwibnVtYmVyIjowLCJyZXBvc2l0
+        b3NpdG9yaWVzL2ZpbGUvZmlsZS8wMTk2ZDlkNC03YjAxLTc5YjAtODEzYy0w
+        N2FmNzU5ZWIwZGUvdmVyc2lvbnMvMi8ifX19fSx7InB1bHBfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmlsZS9maWxlLzAxOTZkOWQ0LTdi
+        MDEtNzliMC04MTNjLTA3YWY3NTllYjBkZS92ZXJzaW9ucy8wLyIsInBybiI6
+        InBybjpjb3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOTZkOWQ0LTdiMDktN2Nh
+        OC1hNjYwLTI0MDQ3NDM4NWNjZCIsInB1bHBfY3JlYXRlZCI6IjIwMjUtMDUt
+        MTZUMTY6MDE6NDMuMTgyMDQ0WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAy
+        NS0wNS0xNlQxNjowMTo0My4xODIwNjNaIiwibnVtYmVyIjowLCJyZXBvc2l0
         b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9maWxlL2ZpbGUvMDE5
-        NWZkODUtMmNhZS03YTY2LTlmNjQtMzY1NmU1MGQxYjJkLyIsImJhc2VfdmVy
+        NmQ5ZDQtN2IwMS03OWIwLTgxM2MtMDdhZjc1OWViMGRlLyIsImJhc2VfdmVy
         c2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVt
         b3ZlZCI6e30sInByZXNlbnQiOnt9fX1dfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:46 GMT
+  recorded_at: Fri, 16 May 2025 16:01:53 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/?state__in=completed
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/tasks/?name__ne=pulpcore.app.tasks.purge.purge&state__in=completed
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4035,7 +4035,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -4048,7 +4048,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:46 GMT
+      - Fri, 16 May 2025 16:01:53 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4068,20 +4068,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d6ee649e4e064f4da1663949501e1a61
+      - d37137de459a4c69ade9839092585d10
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:46 GMT
+  recorded_at: Fri, 16 May 2025 16:01:53 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/remotes/file/file/0195fd85-2b92-76e8-8ff6-2770c8ac18d0/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/remotes/file/file/0196d9d4-7a4d-710e-b862-812737fc3958/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4089,7 +4089,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -4102,7 +4102,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:46 GMT
+      - Fri, 16 May 2025 16:01:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4122,20 +4122,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4ee644f0d4604421a34e84c84d004baf
+      - f9776e06a8dc42779c30c2950fbfc8d0
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTRlN2MtN2Ni
-        My04OTdjLTJjZjZlZDNhZmQwYS8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:46 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LWE1YjMtNzZi
+        Mi04MmI3LWM0MWU0MGFkMjNiNi8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:54 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-4e7c-7cb3-897c-2cf6ed3afd0a/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/tasks/0196d9d4-a5b3-76b2-82b7-c41e40ad23b6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4143,7 +4143,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -4156,7 +4156,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:47 GMT
+      - Fri, 16 May 2025 16:01:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4176,37 +4176,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1ce17192af09421cababd31b14fc3395
+      - eda9a881cbba4ace909ec63adc58e38c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtNGU3
-        Yy03Y2IzLTg5N2MtMmNmNmVkM2FmZDBhLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5NWZkODUtNGU3Yy03Y2IzLTg5N2MtMmNmNmVkM2FmZDBhIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0Ni45MDg5OTFaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQ2LjkwOTAwN1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NmQ5ZDQtYTVi
+        My03NmIyLTgyYjctYzQxZTQwYWQyM2I2LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NmQ5ZDQtYTViMy03NmIyLTgyYjctYzQxZTQwYWQyM2I2IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNS0xNlQxNjowMTo1NC4wOTk4ODRaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA1LTE2VDE2OjAxOjU0LjA5OTkwNVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiNGVlNjQ0
-        ZjBkNDYwNDQyMWEzNGU4NGM4NGQwMDRiYWYiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
-        M1QyMToxODo0Ni45MzQ1MDVaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
-        MjE6MTg6NDcuMDQyODM4WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
-        MToxODo0Ny4xMDk3NzJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTVmZDg0LTc1ZDQtN2Y0Ni1iNzlmLTcxMDNj
-        MWIyY2U2MC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiZjk3NzZl
+        MDZhOGRjNDI3NzljMzBjMjk1MGZiZmM4ZDAiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNS0x
+        NlQxNjowMTo1NC4xMTY3ODNaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDUtMTZU
+        MTY6MDE6NTQuMTY2MjE0WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNS0xNlQx
+        NjowMTo1NC4yMjI5NjlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOTZkOWEzLWNkZWUtNzZjNC1hZThlLTk2MTcz
+        Y2Y0YjY1ZS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NWZkODUtMmI5Mi03NmU4LThm
-        ZjYtMjc3MGM4YWMxOGQwIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowMTk1
-        NjIxNy1mYzllLTc0Y2YtOTAyNC1lODAzNDY3ZmU0ZDAiXX0=
-  recorded_at: Thu, 03 Apr 2025 21:18:47 GMT
+        IjpbInBybjpmaWxlLmZpbGVyZW1vdGU6MDE5NmQ5ZDQtN2E0ZC03MTBlLWI4
+        NjItODEyNzM3ZmMzOTU4Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjoyNDAx
+        OTBiMy02NWMwLTQ2OGItOWQ5ZS0wMzIxOWFhMTFhNWYiXX0=
+  recorded_at: Fri, 16 May 2025 16:01:54 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/distributions/file/file/0195fd85-3230-75c6-a1eb-b577aca3bc37/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/distributions/file/file/0196d9d4-7f4b-7fd5-8028-9a5376d6b26a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4214,7 +4214,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -4227,7 +4227,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:47 GMT
+      - Fri, 16 May 2025 16:01:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4247,20 +4247,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - be31186a5e8f4a69a72d1ca918eaa3bd
+      - 4a1757cd01ce4d27a759dcf87853e91e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTRmZTMtN2Uz
-        OC1hNmFiLWZhZWJjNmQ4NzYyYS8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:47 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LWE3MmMtNzA3
+        YS04MjFkLTFmNDNhNDc5ZmY1Ni8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:54 GMT
 - request:
     method: delete
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/repositories/file/file/0195fd85-2cae-7a66-9f64-3656e50d1b2d/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/repositories/file/file/0196d9d4-7b01-79b0-813c-07af759eb0de/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4268,7 +4268,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -4281,7 +4281,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:47 GMT
+      - Fri, 16 May 2025 16:01:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4301,20 +4301,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 434a316d2a764821a258dceb5a89b921
+      - 9f065999efd444c49c37dfe00bec83de
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTVmZDg1LTUwNmEtN2U2
-        MC1iYTA3LWE4ZjhmODVlZjBjOC8ifQ==
-  recorded_at: Thu, 03 Apr 2025 21:18:47 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOTZkOWQ0LWE3Y2YtNzk0
+        MC04YTc0LTZhZjdlZjQxOGFmZC8ifQ==
+  recorded_at: Fri, 16 May 2025 16:01:54 GMT
 - request:
     method: get
-    uri: https://centos9-katello-devel.manicotto.example.com/pulp/api/v3/tasks/0195fd85-506a-7e60-ba07-a8f8f85ef0c8/
+    uri: https://centos9-katello-devel.example.com/pulp/api/v3/tasks/0196d9d4-a7cf-7940-8a74-6af7ef418afd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4322,7 +4322,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.63.13/ruby
+      - OpenAPI-Generator/3.73.9/ruby
       Accept:
       - application/json
       Authorization:
@@ -4335,7 +4335,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 03 Apr 2025 21:18:47 GMT
+      - Fri, 16 May 2025 16:01:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4355,32 +4355,32 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6415bf458beb48bc8afe89c15f557cbb
+      - 439d87c3ba9140b18e0a68eac5ef38d3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-katello-devel.manicotto.example.com
+      - 1.1 centos9-katello-devel.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NWZkODUtNTA2
-        YS03ZTYwLWJhMDctYThmOGY4NWVmMGM4LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5NWZkODUtNTA2YS03ZTYwLWJhMDctYThmOGY4NWVmMGM4IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNS0wNC0wM1QyMToxODo0Ny40MDM1NTNaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA0LTAzVDIxOjE4OjQ3LjQwMzU2N1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5NmQ5ZDQtYTdj
+        Zi03OTQwLThhNzQtNmFmN2VmNDE4YWZkLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5NmQ5ZDQtYTdjZi03OTQwLThhNzQtNmFmN2VmNDE4YWZkIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNS0wNS0xNlQxNjowMTo1NC42NDA1MzBaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI1LTA1LTE2VDE2OjAxOjU0LjY0MDU1Mloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiNDM0YTMx
-        NmQyYTc2NDgyMWEyNThkY2ViNWE4OWI5MjEiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNC0w
-        M1QyMToxODo0Ny40MTc2NTRaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDQtMDNU
-        MjE6MTg6NDcuNDc0ODQwWiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNC0wM1Qy
-        MToxODo0Ny42MDM0MzlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOTVmZDg0LTc1ZDQtN2Y0Ni1iNzlmLTcxMDNj
-        MWIyY2U2MC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsImxvZ2dpbmdfY2lkIjoiOWYwNjU5
+        OTllZmQ0NDRjNDljMzdkZmUwMGJlYzgzZGUiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNS0wNS0x
+        NlQxNjowMTo1NC42NTg4ODZaIiwic3RhcnRlZF9hdCI6IjIwMjUtMDUtMTZU
+        MTY6MDE6NTQuNzA3Mjc3WiIsImZpbmlzaGVkX2F0IjoiMjAyNS0wNS0xNlQx
+        NjowMTo1NC44OTAyNzdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOTZkOWEzLWNkZWUtNzZjNC1hZThlLTk2MTcz
+        Y2Y0YjY1ZS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
-        IjpbInBybjpmaWxlLmZpbGVyZXBvc2l0b3J5OjAxOTVmZDg1LTJjYWUtN2E2
-        Ni05ZjY0LTM2NTZlNTBkMWIyZCIsInNoYXJlZDpwcm46Y29yZS5kb21haW46
-        MDE5NTYyMTctZmM5ZS03NGNmLTkwMjQtZTgwMzQ2N2ZlNGQwIl19
-  recorded_at: Thu, 03 Apr 2025 21:18:47 GMT
+        IjpbInBybjpmaWxlLmZpbGVyZXBvc2l0b3J5OjAxOTZkOWQ0LTdiMDEtNzli
+        MC04MTNjLTA3YWY3NTllYjBkZSIsInNoYXJlZDpwcm46Y29yZS5kb21haW46
+        MjQwMTkwYjMtNjVjMC00NjhiLTlkOWUtMDMyMTlhYTExYTVmIl19
+  recorded_at: Fri, 16 May 2025 16:01:54 GMT
 recorded_with: VCR 6.3.1


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
After re-recording VCR-cassette for remove_orphans_test.rb the test failed.
Due to the `tasks`-variable not being empty, which IMHO makes sense as an Orphan cleanup is ran and the whole point of the test is that the cleanup did what it should do.

I stumbled over this while cherry-picking #11355 onto a 4.14-branch and re-recording VCR-cassettes.

#### Steps to reproduce
```
$ mode=all ktest test/actions/pulp3/orchestration/remove_orphans_test.rb
Failure:
Actions::Pulp3::RemoveOrphansTest#test_orphans_are_removed [/home/vagrant/katello/test/actions/pulp3/orchestration/remove_orphans_test.rb:60]
Minitest::Assertion: Expected [#<PulpcoreClient::TaskResponse ...>] to be empty.
```

## Summary by Sourcery

Re-record the VCR cassette for remove_orphans_test and adjust the test to assert that orphan cleanup tasks are recorded (non-empty tasks list).

Bug Fixes:
- Fix remove_orphans_test to assert tasks are not empty after cleanup.

Enhancements:
- Update VCR cassette HTTP interactions with new timestamps, UUIDs, User-Agent versions, and recorded_at values.