### PR TITLE
Fixes #38431 - Remove @theforeman/vendor-dev

### DIFF
--- a/webpack/.eslintrc.js
+++ b/webpack/.eslintrc.js
@@ -1,8 +1,6 @@
 const path = require('path');
 const { foremanLocation, foremanRelativePath } = require('@theforeman/find-foreman');
 const foremanFull = foremanLocation();
-const foremanLintingRelative = './node_modules/@theforeman/vendor-dev/eslint.extends.js'
-const foremanLintingConfig = foremanRelativePath(foremanLintingRelative);
 const foremanVendorRelative = './node_modules/@theforeman/vendor-core/';
 const foremanVendorDir = foremanRelativePath(foremanVendorRelative);
 
@@ -14,7 +12,6 @@ module.exports = {
   'extends': [
     'airbnb',
     'plugin:jest/recommended',
-    `${foremanLintingConfig}`,
   ],
   plugins: [
     'jest',


### PR DESCRIPTION
We removed it from foreman so its already shouldnt really work https://github.com/theforeman/foreman/pull/10323
(but probably does as its imported from other packages, that will be removed as well)
This is the config that is being removed, it seems like its not needed for Katello
https://github.com/theforeman/foreman-js/blob/master/packages/vendor-dev/eslint.extends.js

## Summary by Sourcery

Remove obsolete @theforeman/vendor-dev ESLint configuration from the webpack build setup

Enhancements:
- Remove import of vendor-dev ESLint extends and related variables from webpack/.eslintrc.js
- Drop vendor-dev entry from the ESLint ‘extends’ array as it’s no longer provided