### PR TITLE
Fixes #38436 - Override assign_taxonomy to check registered hosts before assigning to a new organization

### DIFF
--- a/app/controllers/katello/concerns/api/v2/hosts_bulk_actions_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/hosts_bulk_actions_controller_extensions.rb
@@ -13,6 +13,16 @@ module Katello
           end
           process_response(true, { :message => _("Deleted %{host_count} %{hosts}") % { :host_count => destroyed_count, :hosts => 'host'.pluralize(destroyed_count) }})
         end
+
+        def assign_organization
+          registered_host = find_editable_hosts.where.not(organization_id: params[:id]).joins(:subscription_facet).first
+          if registered_host
+            render_error :custom_error, :status => :bad_request, :locals => { :message => _("Unregister host %s before assigning an organization.") % registered_host.name }
+            return
+          end
+
+          super
+        end
       end
 
       included do


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Based on https://github.com/theforeman/foreman/pull/10538.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Prevent reassignment of registered hosts to a different organization by overriding the assign_taxonomy bulk action to validate hosts before proceeding.

Bug Fixes:
- Check for hosts with active subscriptions and block organization assignment until they are unregistered.

Enhancements:
- Override assign_taxonomy to render a custom error when attempting to assign a registered host to a new organization.