### PR TITLE
Fixes #38440 - Preserve candlepin content when deleting rolling repo clone with structured apt

### DIFF
--- a/app/lib/actions/katello/repository/destroy.rb
+++ b/app/lib/actions/katello/repository/destroy.rb
@@ -88,6 +88,9 @@ module Actions
         def handle_custom_content(repository, remove_from_content_view_versions)
           #if this is the last instance of a custom repo or a deb repo using structured APT, destroy the content
           if remove_from_content_view_versions || repository.root.repositories.where.not(id: repository.id).empty? || repository.deb_using_structured_apt?
+            # Never destroy content for structured apt rolling repo clones, because it belongs to the library instance
+            return if repository.deb_using_structured_apt? && repository.content_view.rolling?
+
             plan_action(::Actions::Katello::Product::ContentDestroy, repository)
           end
         end


### PR DESCRIPTION
Draft PR until I have added test coverage.

## Summary by Sourcery

Prevent ContentDestroy for rolling structured APT repository clones and ensure content removal only applies to non-rolling structured APT or last-instance repos.

Bug Fixes:
- Skip Candlepin content deletion for structured APT repo clones in rolling content views by checking content_view.rolling? before planning ContentDestroy.

Tests:
- Add test to confirm content is destroyed for structured APT repository clones in non-rolling views.
- Add test to confirm content is retained for structured APT repository clones in rolling views.