### PR TITLE
Fixes #38406 - Log failure when triggering a CapsuleSync with user with missing perms

### DIFF
--- a/app/lib/actions/katello/content_view/capsule_sync.rb
+++ b/app/lib/actions/katello/content_view/capsule_sync.rb
@@ -7,22 +7,27 @@ module Actions
         end
 
         def plan(content_view, environment)
+          env_smart_proxies = SmartProxy.unscoped.with_environment(environment)
+          smart_proxies = env_smart_proxies.select { |sp| sp.authorized?(:manage_capsule_content) && sp.authorized?(:view_capsule_content) }
           sequence do
             concurrence do
-              smart_proxies = SmartProxy.unscoped.with_environment(environment).select { |sp| sp.authorized?(:manage_capsule_content) && sp.authorized?(:view_capsule_content) }
               unless smart_proxies.blank?
                 plan_action(::Actions::BulkAction, ::Actions::Katello::CapsuleContent::Sync, smart_proxies.sort,
                             :content_view_id => content_view.id, :environment_id => environment.id, :skip_content_counts_update => true)
               end
             end
             #For Content view triggered capsule sync, we need to update content counts in one action in finalize, instead of one action per CV, per env, per smart proxy
-            plan_self(:content_view_id => content_view.id, :environment_id => environment.id)
+            plan_self(:content_view_id => content_view.id, :environment_id => environment.id, skipped_capsules: (env_smart_proxies - smart_proxies).any?)
           end
         end
 
         def finalize
+          environment = ::Katello::KTEnvironment.find(input[:environment_id])
+          if input[:skipped_capsules]
+            output[:warning] = "Some smart proxies are not authorized for capsule content management or viewing in environment '#{environment.name}'. Skipping sync for those smart proxies."
+            Rails.logger.warn output[:warning]
+          end
           if Setting[:automatic_content_count_updates]
-            environment = ::Katello::KTEnvironment.find(input[:environment_id])
             smart_proxies = SmartProxy.unscoped.with_environment(environment).select { |sp| sp.authorized?(:manage_capsule_content) && sp.authorized?(:view_capsule_content) }
             options = {environment_id: input[:environment_id], content_view_id: input[:content_view_id]}
             smart_proxies.each do |smart_proxy|

--- a/app/lib/actions/katello/repository/capsule_sync.rb
+++ b/app/lib/actions/katello/repository/capsule_sync.rb
@@ -9,12 +9,22 @@ module Actions
         def plan(repo)
           if repo.node_syncable?
             concurrence do
-              smart_proxies = ::SmartProxy.unscoped.with_environment(repo.environment).select { |sp| sp.authorized?(:manage_capsule_content) && sp.authorized?(:view_capsule_content) }
+              env_smart_proxies = SmartProxy.unscoped.with_environment(repo.environment)
+              smart_proxies = env_smart_proxies.select { |sp| sp.authorized?(:manage_capsule_content) && sp.authorized?(:view_capsule_content) }
               unless smart_proxies.blank?
                 plan_action(::Actions::BulkAction, ::Actions::Katello::CapsuleContent::Sync, smart_proxies,
                             :repository_id => repo.id)
               end
+              plan_self(environment_id: repo.environment.id, skipped_capsules: (env_smart_proxies - smart_proxies).any?)
             end
+          end
+        end
+
+        def finalize
+          environment = ::Katello::KTEnvironment.find(input[:environment_id])
+          if input[:skipped_capsules]
+            output[:warning] = "Some smart proxies are not authorized for capsule content management or viewing in environment '#{environment.name}'. Skipping sync for those smart proxies."
+            Rails.logger.warn output[:warning]
           end
         end
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds an output message to capsule sync task and logs when a smart proxy is skipped from automated capsule sync task on CV publish or repo sync. 
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
You'll need a smart proxy tied to some environment(s) and you'll need a CV that can be published and promoted to those environments which will trigger an automated
1. Create a user with a role with all Content view, Foreman tasks, repository permissions but no smart proxy permissions.
2. Publish a CV to one of the smart proxy tied to one of the smart proxy environments.
3. Notice the foreman task: "Sync Content View on Smart Proxy(ies)" and the child task: Actions::Katello::ContentView::CapsuleSync
4. In the raw output for the task, make sure you see the new log messages.
5. Repeat the above with proxy tied to Library/Default org view and run a force sync of repository to trigger the Repository::CapsuleSync task and check for the log and the output .

## Summary by Sourcery

Warn and log when capsule sync tasks skip smart proxies without the necessary permissions during content view or repository sync operations.

Bug Fixes:
- Log a warning in Rails and task output when smart proxies are skipped during automated capsule sync

Enhancements:
- Add task output warning for skipped smart proxies lacking manage or view permissions