### PR TITLE
Fixes #38448 - Add missing permission for katello/api/rhsm/candlepin_proxies/facts

### DIFF
--- a/lib/katello/permissions/host_permissions.rb
+++ b/lib/katello/permissions/host_permissions.rb
@@ -38,6 +38,7 @@ Foreman::AccessControl.permission(:edit_hosts).actions.concat [
   'katello/api/rhsm/candlepin_proxies/async_hypervisors_update',
   'katello/api/rhsm/candlepin_proxies/hypervisors_heartbeat',
   'katello/api/rhsm/candlepin_proxies/upload_tracer_profile',
+  'katello/api/rhsm/candlepin_proxies/facts',
   'hosts/change_content_source_data',
 ]
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Permission for katello/api/rhsm/candlepin_proxies/facts is missing

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a new user and assign to it all roles. Dont set it as an Administrator
2. Have a Content Host registered to the server.
3. Change the Host's environment from command line (even to the current env):
```
subscription-manager environments --set LCE/my_cv --username new_user --password its_password
```

## Summary by Sourcery

Bug Fixes:
- Grant the :facts action on katello/api/rhsm/candlepin_proxies within environment permissions