### PR TITLE
Fixes #38457 - Update flatpak podman login template to support cert setup

### DIFF
--- a/app/views/foreman/job_templates/flatpak_login_action.erb
+++ b/app/views/foreman/job_templates/flatpak_login_action.erb
@@ -9,21 +9,35 @@ template_inputs:
   description: URL of container registry
   input_type: user
   required: true
+- name: Set up certificate authentication
+  description: Set up certificate authentication for the registry. You can ignore username/password if using certificate authentication.
+  input_type: user
+  required: false
+  options: "true\r\nfalse"
+  advanced: false
+  value_type: plain
+  default: 'false'
 - name: Username
   description: Username for container registry login
   input_type: user
-  required: true
+  required: false
 - name: Password
   description: Password/Access token for container registry login
   input_type: user
-  required: true
+  required: false
   hidden_value: true
 %>
 
 <%
   server_url = input('Flatpak registry URL')
+  setup_cert_auth = input('Set up certificate authentication')
   username = input('Username')
   password = input('Password')
 %>
 
-echo <%= shell_escape(password) %> | sudo podman login <%= server_url %> --username <%= username %> --password-stdin --authfile /etc/flatpak/oci-auth.json
+<% if truthy?(setup_cert_auth) -%>
+  <% server_hostname = server_url.gsub(/https?:\/\//, '').split('/').first %>
+  <%= snippet('container_certs_setup', variables: { registration_host: server_hostname }) -%>
+<% else -%>
+  echo <%= shell_escape(password) %> | sudo podman login <%= server_url %> --username <%= username %> --password-stdin --authfile /etc/flatpak/oci-auth.json
+<% end -%>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Updates Flatpak - Login to registry via podman template to allow setting up cert auth in addition to basic auth if user chooses to.
#### Considerations taken when implementing this change?
Deciding where to put the cert setup: Finally landed on existing template used for flatpak setup.
#### What are the testing steps for this pull request?
Run:
```
bundle exec rails c
ForemanInternal.first.destroy
bundle exec rails db:seed
```

1. Run the job template: **Flatpak - Login to registry via podman**
2. Use the new input parameter: **Set up certificate authentication** : Test with both values: true and false.

**When set to true:**
Certificate-based authentication is used.
No basic auth credentials (username/password) are required.
After the job runs, verify the certs and keys are present with: `ls -l /etc/containers/certs.d/<server-hostname>`

**When set to false:**
Basic auth credentials must be provided.
After the job runs, verify that auth details were stored with: `cat /etc/flatpak/oci-auth.json`

For end-to-end testing, make sure you're able to podman search/pull, flatpak install etc  with the certs and without the certs using basic auth login.

## Summary by Sourcery

Extend the Flatpak Podman login job template to support certificate-based authentication alongside basic auth by adding a new toggle and conditional logic.

New Features:
- Introduce a "Set up certificate authentication" input parameter to enable cert-based registry login.
- Support certificate-based authentication in the Flatpak - Login to registry via Podman job template.

Enhancements:
- Make username and password optional when certificate authentication is enabled and branch the login logic accordingly.