### PR TITLE
Fixes #38443 - Improve rabl and scoped search on content view environments

### DIFF
--- a/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
@@ -18,7 +18,8 @@ module Katello
 
       included do
         prepend Overrides
-        before_action :set_content_view_environments, only: [:create, :update]
+        around_action :handle_content_view_environments_for_create, only: [:create]
+        before_action :handle_content_view_environments_for_update, only: [:update]
 
         def destroy
           Katello::RegistrationManager.unregister_host(@host, :unregistering => false)
@@ -34,21 +35,48 @@ module Katello
           render(:locals => { :resource => @host }, :template => 'katello/api/v2/hosts/show', :status => :ok)
         end
 
-        def set_content_view_environments
+        def handle_content_view_environments_for_create
+          # validations should occur before the action so that the request can fail and not render multiple responses
+          cves = validate_content_view_environment_params
+          yield
+          # the actual assigning needs to wait until the host is created
+          set_content_view_environments(cves)
+        end
+
+        def handle_content_view_environments_for_update
+          cves = validate_content_view_environment_params
+          set_content_view_environments(cves)
+        end
+
+        def validate_content_view_environment_params
           content_facet_attributes = params.dig(:host, :content_facet_attributes)
-          return if content_facet_attributes.blank? || @host&.content_facet.blank? ||
-            (cve_params[:content_view_id].present? && cve_params[:lifecycle_environment_id].present?)
+          return if content_facet_attributes.blank? ||
+          (cve_params[:content_view_id].present? && cve_params[:lifecycle_environment_id].present?)
+
           cves = ::Katello::ContentViewEnvironment.fetch_content_view_environments(
             labels: cve_params[:content_view_environments],
             ids: cve_params[:content_view_environment_ids],
-            organization: @organization || @host&.organization)
-          if cves.present?
-            @host.content_facet.content_view_environments = cves
-          else
+            organization: find_organization || @host&.organization)
+          if cves.blank?
             handle_errors(labels: cve_params[:content_view_environments],
               ids: cve_params[:content_view_environment_ids])
           end
+          cves
         end
+
+        # rubocop:disable Naming/AccessorMethodName
+        def set_content_view_environments(cves)
+          return if cves.blank?
+          if @host.blank?
+            Rails.logger.debug "No host; not assigning content view environments"
+            return
+          elsif @host&.content_facet.blank?
+            content_facet = Katello::Host::ContentFacet.new(host: @host)
+            @host.content_facet = content_facet
+          end
+          @host.content_facet.content_view_environments = cves
+        end
+        # rubocop:enable Naming/AccessorMethodName
 
         def cve_params
           params.require(:host).require(:content_facet_attributes).permit(:content_view_id, :lifecycle_environment_id, content_view_environments: [], content_view_environment_ids: [])

--- a/app/models/katello/content_view_environment.rb
+++ b/app/models/katello/content_view_environment.rb
@@ -32,6 +32,9 @@ module Katello
     scope :non_generated, -> { where(content_view: ::Katello::ContentView.ignore_generated) }
 
     scoped_search :on => :id, :complete_value => true
+    scoped_search :on => :label, :complete_value => true
+    scoped_search :relation => :content_view, :on => :label, :rename => :content_view
+    scoped_search :relation => :lifecycle_environment, :on => :label, :rename => :lifecycle_environment
 
     alias :lifecycle_environment :environment
     has_one :organization, :through => :environment

--- a/app/views/katello/api/v2/content_facet/base.json.rabl
+++ b/app/views/katello/api/v2/content_facet/base.json.rabl
@@ -31,6 +31,9 @@ child :content_view_environments => :content_view_environments do
   node :label do |cve|
     cve.label
   end
+  node :id do |cve|
+    cve.id
+  end
 end
 
 attributes :content_view_environment_labels

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -213,6 +213,35 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_response :error
   end
 
+  def test_handle_content_view_environments_for_create
+    @controller.expects(:validate_content_view_environment_params).returns([katello_content_view_environments(:library_default_view_environment)])
+    @controller.expects(:set_content_view_environments).with([katello_content_view_environments(:library_default_view_environment)])
+
+    post :create, params: {
+      :host => {
+        :name => "contenthost.example.com",
+        :content_facet_attributes => {
+          :content_view_environments => ["Library"],
+        },
+      },
+    }, session: set_session_user
+    # no assertions needed about the response, we're just making sure handle_content_view_environments_for_create is called
+  end
+
+  def test_handle_content_view_environments_for_update
+    @controller.expects(:validate_content_view_environment_params).returns([katello_content_view_environments(:library_default_view_environment)])
+    @controller.expects(:set_content_view_environments).with([katello_content_view_environments(:library_default_view_environment)])
+    host = FactoryBot.create(:host, :with_content, :with_subscription,
+                              :content_view => @content_view, :lifecycle_environment => @environment)
+    put :update, params: {
+      :id => host.id,
+      :content_facet_attributes => {
+        :content_view_environments => ["Library"],
+      },
+    }, session: set_session_user
+    # no assertions needed about the response, we're just making sure handle_content_view_environments_for_update is called
+  end
+
   def test_with_subscriptions
     host = FactoryBot.create(:host, :with_subscription, :with_operatingsystem)
     host_index_and_show(host)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

1. Add 'id' to the rabl for the content_view_environments endpoint
2. Add fields to scoped search for content view environments:
- label
- content_view
- lifecycle_environment
3. Address a bug where `hammer host create` with `--content-view-environments` option creates the host with no errors, but content view environments are not assigned.

#### Considerations taken when implementing this change?

This should unblock full Ansible support for assigning content view environments. I added more than just `label` since I thought the other two would be useful as well.

#### What are the testing steps for this pull request?

I used `hammer -d`, but you can use anything that allows you to inspect API responses.

- make sure API response includes content view environment ID
- Try searches: 'content_view ~ xxx' (even with Default_Organization_View); 'lifecycle_environment = xxx', 'label ~ xxxx'

## Summary by Sourcery

Improve API discoverability and searchability for content view environments by exposing IDs, adding scoped_search fields, and ensuring host content facets are created and assigned correctly

Enhancements:
- Expose `id` in RABL templates to include content view environment IDs in API responses
- Add scoped_search on `id`, `label`, `content_view`, and `lifecycle_environment` for ContentViewEnvironment
- Adjust host controller to use after_action for setting content view environments and auto-create missing content facets