### PR TITLE
Fixes #38477 - Allow rolling CVs in arbitrary environments

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -21,6 +21,7 @@ module Katello
       param :description, String, :desc => N_("Description for the content view")
       param :repository_ids, Array, :desc => N_("List of repository ids")
       param :component_ids, Array, :desc => N_("List of component content view version ids for composite views")
+      param :environment_ids, Array, :desc => N_("List of lifecycle environments for rolling content views")
       param :auto_publish, :bool, :desc => N_("Enable/Disable auto publish of composite view")
       param :solve_dependencies, :bool, :desc => N_("Solve RPM dependencies by default on Content View publish, defaults to false")
       param :import_only, :bool, :desc => N_("Designate this Content View for importing from upstream servers only. Defaults to false")
@@ -42,6 +43,7 @@ module Katello
       {
         :component_ids => Katello::ContentViewVersion,
         :repository_ids => Katello::Repository,
+        :environment_ids => Katello::KTEnvironment,
       }
     end
 
@@ -91,7 +93,7 @@ module Katello
         view.organization = @organization
         view.label ||= labelize_params(params[:content_view])
       end
-      sync_task(::Actions::Katello::ContentView::Create, @content_view)
+      sync_task(::Actions::Katello::ContentView::Create, @content_view, sanitized_environment_ids)
 
       respond :resource => @content_view
     end
@@ -101,7 +103,7 @@ module Katello
     param :name, String, :desc => N_("New name for the content view")
     param_group :content_view
     def update
-      sync_task(::Actions::Katello::ContentView::Update, @content_view, view_params)
+      sync_task(::Actions::Katello::ContentView::Update, @content_view, view_params, sanitized_environment_ids)
       respond :resource => @content_view.reload
     end
 
@@ -299,10 +301,15 @@ module Katello
       if (!@content_view || !@content_view.composite?)
         attrs.push({:repository_ids => []}, :repository_ids)
       end
-      result = params.require(:content_view).permit(*attrs).to_h
+      result = {}
+      result = params.require(:content_view).permit(*attrs).to_h unless action_name == "update" && @content_view.rolling? && params[:content_view].empty?
       # sanitize repository_ids to be a list of integers
       result[:repository_ids] = result[:repository_ids].compact.map(&:to_i) if result[:repository_ids].present?
       result
+    end
+
+    def sanitized_environment_ids
+      params[:environment_ids]&.compact&.map(&:to_i)
     end
 
     def find_environment

--- a/app/lib/actions/helpers/rolling_cv_repos.rb
+++ b/app/lib/actions/helpers/rolling_cv_repos.rb
@@ -2,7 +2,7 @@ module Actions
   module Helpers
     module RollingCVRepos
       def find_related_rolling_repos(repo)
-        repo.root.repositories.in_environment(repo.environment).where(
+        repo.library_instances_inverse.where(
           content_view_version: ::Katello::ContentViewVersion.where(content_view: ::Katello::ContentView.rolling)
         )
       end

--- a/app/lib/actions/katello/content_view/add_rolling_repo_clone.rb
+++ b/app/lib/actions/katello/content_view/add_rolling_repo_clone.rb
@@ -2,24 +2,25 @@ module Actions
   module Katello
     module ContentView
       class AddRollingRepoClone < Actions::EntryAction
-        def plan(content_view, repository_ids)
-          library = content_view.organization.library
+        def plan(content_view, repository_ids, environment_ids)
           clone_ids = []
 
-          concurrence do
-            ::Katello::Repository.where(id: repository_ids).each do |repository|
-              sequence do
-                clone = content_view.get_repo_clone(library, repository).first
-                if clone.nil?
-                  clone = repository.build_clone(content_view: content_view, environment: library)
-                  clone.save!
-                end
-                plan_action(RefreshRollingRepo, clone, false)
+          ::Katello::KTEnvironment.where(id: environment_ids).each do |environment|
+            concurrence do
+              ::Katello::Repository.where(id: repository_ids).each do |repository|
+                sequence do
+                  clone = content_view.get_repo_clone(environment, repository).first
+                  if clone.nil?
+                    clone = repository.build_clone(content_view: content_view, environment: environment)
+                    clone.save!
+                  end
+                  plan_action(RefreshRollingRepo, clone, false)
 
-                view_env_cp_id = content_view.content_view_environment(library).cp_id
-                content_id = repository.content_id
-                plan_action(Actions::Candlepin::Environment::AddContentToEnvironment, :view_env_cp_id => view_env_cp_id, :content_id => content_id)
-                clone_ids << clone.id
+                  view_env_cp_id = content_view.content_view_environment(environment).cp_id
+                  content_id = repository.content_id
+                  plan_action(Actions::Candlepin::Environment::AddContentToEnvironment, :view_env_cp_id => view_env_cp_id, :content_id => content_id)
+                  clone_ids << clone.id
+                end
               end
             end
           end

--- a/app/lib/actions/katello/content_view/create.rb
+++ b/app/lib/actions/katello/content_view/create.rb
@@ -2,20 +2,25 @@ module Actions
   module Katello
     module ContentView
       class Create < Actions::Base
-        def plan(content_view)
+        def plan(content_view, environment_ids)
           content_view.save!
           if content_view.rolling?
-            plan_action(AddToEnvironment, content_view.create_new_version, content_view.organization.library)
+            new_version = content_view.create_new_version
+            if environment_ids&.any?
+              ::Katello::KTEnvironment.where(id: environment_ids).each do |environment|
+                plan_action(AddToEnvironment, new_version, environment)
+              end
+            end
             repository_ids = content_view.repository_ids
             if repository_ids.any?
               content_view.reload
-              plan_action(AddRollingRepoClone, content_view, repository_ids)
+              plan_action(AddRollingRepoClone, content_view, repository_ids, environment_ids)
             end
           end
         end
 
         def humanized_name
-          _("Create")
+          _("Create content view")
         end
       end
     end

--- a/app/lib/actions/katello/content_view/remove_rolling_repo_clone.rb
+++ b/app/lib/actions/katello/content_view/remove_rolling_repo_clone.rb
@@ -2,21 +2,23 @@ module Actions
   module Katello
     module ContentView
       class RemoveRollingRepoClone < Actions::EntryAction
-        def plan(content_view, repository_ids)
-          library = content_view.organization.library
+        def plan(content_view, repository_ids, environment_ids)
+          clone_ids = []
+          environments = ::Katello::KTEnvironment.where(id: environment_ids)
 
-          clone_repo_ids = []
-          concurrence do
-            ::Katello::Repository.where(id: repository_ids).each do |repository|
-              clone_repo = content_view.get_repo_clone(library, repository).first
-              next if clone_repo.nil?
+          environments.each do |environment|
+            concurrence do
+              ::Katello::Repository.where(id: repository_ids).each do |repository|
+                clone_repo = content_view.get_repo_clone(environment, repository).first
+                next if clone_repo.nil?
 
-              clone_repo_ids << clone_repo.id
-              plan_action(Actions::Pulp3::Repository::DeleteDistributions, clone_repo.id, SmartProxy.pulp_primary)
+                clone_ids << clone_repo.id
+                plan_action(Actions::Pulp3::Repository::DeleteDistributions, clone_repo.id, SmartProxy.pulp_primary)
+              end
+              plan_action(Candlepin::Environment::SetContent, content_view, environment, content_view.content_view_environment(environment))
             end
-            plan_action(Candlepin::Environment::SetContent, content_view, library, content_view.content_view_environment(library))
           end
-          plan_self(repository_ids: clone_repo_ids)
+          plan_self(repository_ids: clone_ids)
         end
 
         def run

--- a/app/lib/actions/katello/content_view/update.rb
+++ b/app/lib/actions/katello/content_view/update.rb
@@ -2,7 +2,8 @@ module Actions
   module Katello
     module ContentView
       class Update < Actions::EntryAction
-        def plan(content_view, content_view_params)
+        # rubocop:disable Metrics/AbcSize
+        def plan(content_view, content_view_params, environment_ids)
           action_subject content_view
           content_view_params = content_view_params.with_indifferent_access
 
@@ -28,12 +29,29 @@ module Actions
             end
           end
 
-          if content_view.rolling? && content_view_params.key?(:repository_ids)
-            repo_ids_to_add = content_view_params[:repository_ids] - content_view.repository_ids
-            repo_ids_to_remove = content_view.repository_ids - content_view_params[:repository_ids]
+          if content_view.rolling?
+            repo_ids_to_add = repo_ids_to_remove = []
+            retained_repo_ids = content_view.repository_ids
+            if content_view_params.key?(:repository_ids)
+              repo_ids_to_add = content_view_params[:repository_ids] - content_view.repository_ids
+              repo_ids_to_remove = content_view.repository_ids - content_view_params[:repository_ids]
+              retained_repo_ids -= repo_ids_to_remove
+            end
+            unless environment_ids.nil?
+              environment_ids_to_add = environment_ids - content_view.environment_ids
+              environment_ids_to_remove = content_view.environment_ids - environment_ids
 
-            plan_action(AddRollingRepoClone, content_view, repo_ids_to_add) if repo_ids_to_add.any?
-            plan_action(RemoveRollingRepoClone, content_view, repo_ids_to_remove) if repo_ids_to_remove.any?
+              ::Katello::KTEnvironment.where(id: environment_ids_to_add).each do |environment|
+                plan_action(AddToEnvironment, content_view.versions[0], environment)
+              end
+              plan_action(AddRollingRepoClone, content_view, retained_repo_ids, environment_ids_to_add) if retained_repo_ids.any? && environment_ids_to_add.any?
+
+              ::Katello::KTEnvironment.where(id: environment_ids_to_remove).each do |environment|
+                plan_action(RemoveFromEnvironment, content_view, environment)
+              end
+            end
+            plan_action(AddRollingRepoClone, content_view, repo_ids_to_add, environment_ids) if repo_ids_to_add.any?
+            plan_action(RemoveRollingRepoClone, content_view, repo_ids_to_remove, environment_ids) if repo_ids_to_remove.any?
           end
 
           content_view.update!(content_view_params)

--- a/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
+++ b/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { STATUS } from 'foremanReact/constants';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -27,6 +27,13 @@ import {
 } from './ContentViewCreateSelectors';
 import { LabelDependencies, LabelAutoPublish } from './ContentViewFormComponents';
 import ContentViewIcon from '../components/ContentViewIcon';
+import getEnvironmentPaths from '../components/EnvironmentPaths/EnvironmentPathActions';
+import {
+  selectEnvironmentPaths,
+  selectEnvironmentPathsStatus,
+} from '../components/EnvironmentPaths/EnvironmentPathSelectors';
+import EnvironmentPaths from '../components/EnvironmentPaths/EnvironmentPaths';
+
 import './CreateContentViewForm.scss';
 
 export const contentViewDescriptions = {
@@ -47,7 +54,10 @@ const CreateContentViewForm = ({ setModalOpen }) => {
   const [dependencies, setDependencies] = useState(false);
   const [redirect, setRedirect] = useState(false);
   const [saving, setSaving] = useState(false);
-
+  const [selectedEnvs, setSelectedEnvs] = useState([]);
+  const environmentPathResponse = useSelector(selectEnvironmentPaths);
+  const environmentPathStatus = useSelector(selectEnvironmentPathsStatus);
+  const environmentPathLoading = environmentPathStatus === STATUS.PENDING;
   const [labelValidated, setLabelValidated] = useState('default');
   const handleLabelChange = (newLabel, _event) => {
     setLabel(newLabel);
@@ -74,6 +84,7 @@ const CreateContentViewForm = ({ setModalOpen }) => {
     }
   }, [response, status, error, saving]);
 
+  const checkedEnvIds = selectedEnvs?.map(env => env.id) ?? [];
   const onSave = () => {
     setSaving(true);
     dispatch(createContentView({
@@ -84,8 +95,16 @@ const CreateContentViewForm = ({ setModalOpen }) => {
       rolling,
       solve_dependencies: (dependencies && !(rolling || composite)),
       auto_publish: (autoPublish && composite),
+      environment_ids: (checkedEnvIds),
     }));
   };
+
+  useEffect(
+    () => {
+      dispatch(getEnvironmentPaths());
+    },
+    [dispatch],
+  );
 
   useEffect(() => {
     setLabel(name.replace(/[^A-Za-z0-9_-]/g, '_'));
@@ -100,6 +119,13 @@ const CreateContentViewForm = ({ setModalOpen }) => {
     }
   }
 
+  useMemo(() => {
+    if (!environmentPathLoading) {
+      const { results } = environmentPathResponse || {};
+      return results.map(result => result.environments).flatten();
+    }
+    return [];
+  }, [environmentPathResponse, environmentPathLoading]);
   const submitDisabled =
     !name?.length || !label?.length || saving || redirect || labelValidated === 'error';
 
@@ -227,6 +253,16 @@ const CreateContentViewForm = ({ setModalOpen }) => {
             label={LabelAutoPublish()}
             isChecked={autoPublish}
             onChange={(_event, checked) => setAutoPublish(checked)}
+          />
+        </FormGroup>
+      )}
+      {rolling && (
+        <FormGroup isInline fieldId="lifecycleEnvironments" label={__('Lifecycle Environments')}>
+          <EnvironmentPaths
+            headerText=""
+            publishing={false}
+            userCheckedItems={selectedEnvs}
+            setUserCheckedItems={setSelectedEnvs}
           />
         </FormGroup>
       )}

--- a/webpack/scenes/ContentViews/Create/__tests__/contentViewCreateResult.fixtures.json
+++ b/webpack/scenes/ContentViews/Create/__tests__/contentViewCreateResult.fixtures.json
@@ -8,6 +8,7 @@
   "latest_version": null,
   "auto_publish": false,
   "solve_dependencies": false,
+  "environment_ids": [1, 2],
   "import_only": false,
   "repository_ids": [],
   "id": 34,

--- a/webpack/scenes/ContentViews/Create/__tests__/createContentView.test.js
+++ b/webpack/scenes/ContentViews/Create/__tests__/createContentView.test.js
@@ -25,6 +25,7 @@ const createDetails = {
   rolling: false,
   solve_dependencies: false,
   auto_publish: false,
+  environment_ids: [1, 2],
 };
 
 const createdCVDetails = { ...cvCreateData };
@@ -81,6 +82,7 @@ test('Displays dependent fields correctly', () => {
   expect(getByText('Rolling content view')).toBeInTheDocument();
   expect(getByText('Solve dependencies')).toBeInTheDocument();
   expect(queryByText('Auto publish')).not.toBeInTheDocument();
+  expect(queryByText('Lifecycle Environments')).not.toBeInTheDocument();
 
   // label auto_set
   fireEvent.change(getByLabelText('input_name'), { target: { value: '123 2123' } });
@@ -90,11 +92,20 @@ test('Displays dependent fields correctly', () => {
   fireEvent.click(getByLabelText('composite_tile'));
   expect(queryByText('Solve dependencies')).not.toBeInTheDocument();
   expect(getByText('Auto publish')).toBeInTheDocument();
+  expect(queryByText('Lifecycle Environments')).not.toBeInTheDocument();
 
   // display Solve Dependencies when Component CV
   fireEvent.click(getByLabelText('component_tile'));
   expect(getByText('Solve dependencies')).toBeInTheDocument();
   expect(queryByText('Auto publish')).not.toBeInTheDocument();
+  expect(queryByText('Lifecycle Environments')).not.toBeInTheDocument();
+
+  // display Lifecycle Environments when Rolling CV
+  fireEvent.click(getByLabelText('rolling_tile'));
+  expect(getByText('Solve dependencies')).not.toBeInTheDocument();
+  expect(queryByText('Auto publish')).not.toBeInTheDocument();
+  expect(getByText('Lifecycle Environments')).not.toBeInTheDocument();
+
 });
 
 test('Validates label field', () => {

--- a/webpack/scenes/ContentViews/Details/ContentViewInfo.js
+++ b/webpack/scenes/ContentViews/Details/ContentViewInfo.js
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
+  Button,
   Flex,
   FlexItem,
   TextContent,
@@ -11,6 +12,7 @@ import {
   Switch,
 } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
+import { STATUS } from 'foremanReact/constants';
 import { translate as __ } from 'foremanReact/common/I18n';
 
 import { updateContentView } from './ContentViewDetailActions';
@@ -20,9 +22,18 @@ import ActionableDetail from '../../../components/ActionableDetail';
 import './contentViewInfo.scss';
 import { dependenciesHelpText, autoPublishHelpText, hasPermission } from '../helpers';
 import { LabelImportOnly, LabelGenerated } from '../Create/ContentViewFormComponents';
+import getEnvironmentPaths from '../components/EnvironmentPaths/EnvironmentPathActions';
+import {
+  selectEnvironmentPaths,
+  selectEnvironmentPathsStatus,
+} from '../components/EnvironmentPaths/EnvironmentPathSelectors';
+import EnvironmentPaths from '../components/EnvironmentPaths/EnvironmentPaths';
 
 const ContentViewInfo = ({ cvId, details }) => {
   const dispatch = useDispatch();
+  const environmentPathResponse = useSelector(selectEnvironmentPaths);
+  const environmentPathStatus = useSelector(selectEnvironmentPathsStatus);
+  const environmentPathLoading = environmentPathStatus === STATUS.PENDING;
   const [currentAttribute, setCurrentAttribute] = useState();
   const updating = useSelector(state => selectIsCVUpdating(state));
   const {
@@ -35,8 +46,10 @@ const ContentViewInfo = ({ cvId, details }) => {
     auto_publish: autoPublish,
     import_only: importOnly,
     generated_for: generatedFor,
+    environments,
     permissions,
   } = details;
+  const [selectedEnvs, setSelectedEnvs] = useState([]);
   const generatedContentView = generatedFor !== 'none';
   const onEdit = (val, attribute) => {
     if (val === details[attribute]) return;
@@ -44,7 +57,30 @@ const ContentViewInfo = ({ cvId, details }) => {
   };
   let iconText = __('Content view');
   if (composite) { iconText = __('Composite content view'); } else if (rolling) { iconText = __('Rolling content view'); }
+  useEffect(
+    () => {
+      dispatch(getEnvironmentPaths());
+    },
+    [dispatch, cvId],
+  );
+  useEffect(() => {
+    if (environments?.length) {
+      setSelectedEnvs(environments);
+    }
+  }, [environments, setSelectedEnvs]);
+  useMemo(() => {
+    if (!environmentPathLoading) {
+      const { results } = environmentPathResponse || {};
+      return results.map(result => result.environments).flatten();
+    }
+    return [];
+  }, [environmentPathResponse, environmentPathLoading]);
 
+
+  const updateEnvs = (optedEnvs) => {
+    const checkedEnvIds = optedEnvs?.map(env => env.id) ?? [];
+    dispatch(updateContentView(cvId, { environment_ids: checkedEnvIds }));
+  };
   return (
     <TextContent className="margin-0-24">
       <TextList component={TextListVariants.dl}>
@@ -146,6 +182,28 @@ const ContentViewInfo = ({ cvId, details }) => {
               />
             </TextListItem>
           </>}
+        {rolling &&
+          <>
+            <TextListItem component={TextListItemVariants.dt}>
+              {__('Lifecycle Environments')}
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd} className="foreman-spaced-list">
+              <EnvironmentPaths
+                headerText=""
+                publishing={false}
+                userCheckedItems={selectedEnvs}
+                setUserCheckedItems={setSelectedEnvs}
+              />
+              <Flex>
+                <FlexItem spacer={{ default: 'spacerXs' }}>
+                  <Button ouiaId="save-button" onClick={() => updateEnvs(selectedEnvs)} style={{ marginTop: '1rem' }}>
+                    Save Environments
+                  </Button>
+	        </FlexItem>
+	      </Flex>
+            </TextListItem>
+          </>
+         }
       </TextList>
     </TextContent>
   );
@@ -163,6 +221,7 @@ ContentViewInfo.propTypes = {
     auto_publish: PropTypes.bool,
     import_only: PropTypes.bool,
     generated_for: PropTypes.string,
+    environments: PropTypes.arrayOf(PropTypes.shape({})),
     permissions: PropTypes.shape({}),
   }).isRequired,
 };

--- a/webpack/scenes/ContentViews/Details/__tests__/contentViewRollingDetail.test.js
+++ b/webpack/scenes/ContentViews/Details/__tests__/contentViewRollingDetail.test.js
@@ -40,6 +40,7 @@ test('Can call API and show details on page load', async (done) => {
     expect(getByLabelText('a_cv_index')).toBeInTheDocument();
     expect(getByLabelText(`b_${name}`)).toBeInTheDocument();
     expect(getByLabelText('c_details')).toBeInTheDocument();
+    expect(getByLabelText('Lifecycle Environments')).toBeInTheDocument();
     expect(queryByLabelText('Import only')).not.toBeInTheDocument();
     expect(queryByLabelText('Generated')).not.toBeInTheDocument();
   });

--- a/webpack/scenes/ContentViews/Details/__tests__/contentViewRollingDetails.fixtures.json
+++ b/webpack/scenes/ContentViews/Details/__tests__/contentViewRollingDetails.fixtures.json
@@ -8,6 +8,7 @@
   "latest_version": "1.0",
   "auto_publish": false,
   "solve_dependencies": false,
+  "environment_ids": [1,2],
   "needs_publish": false,
   "generated_for": "none",
   "repository_ids": [


### PR DESCRIPTION
Initial state for rolling content views with arbitrary lifecycle environments.

Things that are missing from this "Draft" PR:

- Tests for the API controller and backend actions.
- Checking the new API parameter for consistent behavior with similar existing parameters.

In general, there are various possible combinations of API parameters and situations I have not yet tested.
