### PR TITLE
Fixes #38483 - Update help text for Errata search query

### DIFF
--- a/app/views/foreman/job_templates/install_errata_by_search_query.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query.erb
@@ -7,7 +7,7 @@ feature: katello_errata_install_by_search
 provider_type: script
 template_inputs:
 - name: Errata search query
-  description: Filter criteria for errata to be installed.
+  description: Filter criteria for errata to be installed. IMPORTANT- If left blank, the job will attempt to install all applicable errata.
   input_type: user
   required: false
 foreign_input_sets:

--- a/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_errata_by_search_query_-_katello_ansible_default.erb
@@ -7,7 +7,7 @@ feature: katello_errata_install_by_search
 provider_type: Ansible
 template_inputs:
 - name: Errata search query
-  description: Filter criteria for errata to be installed.
+  description: Filter criteria for errata to be installed. IMPORTANT- If left blank, the job will attempt to install all applicable errata.
   input_type: user
   required: false
 %>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add a note on help text for Errata search query that the job will attempt to install all applicable errata if Errata search field is blank..
#### Considerations taken when implementing this change?
The blank field meaning all follows from dnf convention where dnf update without any ids updates everything.
#### What are the testing steps for this pull request?
1. Go to templates: "Install errata by search query - Katello Script Default" and "Install errata by search query - Katello Ansible Default" and make sure you see updated help text for the "Errata search query" input field.