### PR TITLE
[CP] Katello 4.17.0 Cherry Picks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 4.17.0.rc2 Fallingwater (2025-06-02)
+# 4.17.0 Fallingwater (2025-06-09)
 
 ## Features
 
@@ -27,14 +27,16 @@
  * Add unit test cases to image mode card. ([#38323](https://projects.theforeman.org/issues/38323), [1c4e1cfb](https://github.com/Katello/katello.git/commit/1c4e1cfb4d5d0adf03f055415daa8a59da452f16))
 
 ### Content Views
+ * When creating a rolling content view with repository_ids no rolling repo clones are created ([#38413](https://projects.theforeman.org/issues/38413), [eff2f62a](https://github.com/Katello/katello.git/commit/eff2f62a0aa67010657828ba5ad337f83493718b))
  * rolling attribute is missing from activation key API response ([#38411](https://projects.theforeman.org/issues/38411), [d934b0f6](https://github.com/Katello/katello.git/commit/d934b0f6eb614d916092e5d0129e3719433c333b))
  * PF5 issue: Bad icon spacing ([#38337](https://projects.theforeman.org/issues/38337), [1e37a44c](https://github.com/Katello/katello.git/commit/1e37a44c6ea3f0f1fae74b05b98b4f2baebe81c6))
+ * Disallow pushing containers to rolling content views ([#38285](https://projects.theforeman.org/issues/38285), [197bf2f2](https://github.com/Katello/katello.git/commit/197bf2f27f3c08dac970b1833d14c7725e36994e))
  * Remove version from environment wizard still makes you choose a replacement cv/lce even if it will be ignored ([#38191](https://projects.theforeman.org/issues/38191), [87dc8cfc](https://github.com/Katello/katello.git/commit/87dc8cfc18dedbea67c59233392a6528e14a979e))
  * needs_publish is incorrect before page refresh ([#38007](https://projects.theforeman.org/issues/38007))
 
 ### Repositories
  * Add organization to the Katello repositories API  response ([#38399](https://projects.theforeman.org/issues/38399), [cb3c9bf8](https://github.com/Katello/katello.git/commit/cb3c9bf84e59158f5a786c9471413606cd008ecb))
- * Updating file type repository fails due to Downlaod Policy not being set ([#38369](https://projects.theforeman.org/issues/38369), [658c07aa](https://github.com/Katello/katello.git/commit/658c07aa8e4e46a789682cad01225aff1c18e04a))
+ * Updating file type repository fails due to Download Policy not being set ([#38369](https://projects.theforeman.org/issues/38369), [658c07aa](https://github.com/Katello/katello.git/commit/658c07aa8e4e46a789682cad01225aff1c18e04a))
  * APT repos using path prefixes for components will be misconfigured on consuming hosts ([#38359](https://projects.theforeman.org/issues/38359), [c26a27b7](https://github.com/Katello/katello.git/commit/c26a27b7d090a62af59f8151c427eca80406c3d2))
  * Duplicity in recommended RH repos ([#38308](https://projects.theforeman.org/issues/38308), [871b862a](https://github.com/Katello/katello.git/commit/871b862a1daf09bde35cebaf34228ea3084e57ac))
  * Debian repos are not displayed in the Repository Set Management on the Content Hosts page ([#38296](https://projects.theforeman.org/issues/38296), [d6cf242d](https://github.com/Katello/katello.git/commit/d6cf242d01e1fea3cdfdf64262c8282b4e87b038))

--- a/app/controllers/katello/api/v2/content_view_repositories_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_repositories_controller.rb
@@ -25,6 +25,11 @@ module Katello
       SQL
 
       query = Katello::Repository.readable.in_default_view.in_organization(@organization)
+      if @content_view.rolling
+        # Exclude container push repositories
+        query = query.joins(:root).where(katello_root_repositories: { is_container_push: false })
+      end
+
       query = query.with_type(params[:content_type]) if params[:content_type]
       # Use custom sort to perform the join and order since we need to order by specific content_view
       # and the ORDER BY query needs access to the katello_content_view_repositories table

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -719,6 +719,7 @@ Alternatively, use the 'force' parameter to regenerate metadata locally. On the 
       if is_available_for
         params[:library] = true
         sub_query = ContentViewRepository.where(:content_view_id => content_view_id).pluck(:repository_id)
+        sub_query += Repository.where(root: RootRepository.where(is_container_push: true)).pluck(:id) if ContentView.find(content_view_id).rolling
         query = query.where("#{Repository.table_name}.id not in (#{sub_query.join(',')})") unless sub_query.empty?
       elsif environment_id
         version = ContentViewVersion.in_environment(environment_id).where(:content_view_id => content_view_id)

--- a/app/lib/actions/katello/content_view/create.rb
+++ b/app/lib/actions/katello/content_view/create.rb
@@ -6,6 +6,11 @@ module Actions
           content_view.save!
           if content_view.rolling?
             plan_action(AddToEnvironment, content_view.create_new_version, content_view.organization.library)
+            repository_ids = content_view.repository_ids
+            if repository_ids.any?
+              content_view.reload
+              plan_action(AddRollingRepoClone, content_view, repository_ids)
+            end
           end
         end
 

--- a/app/models/katello/content_view_repository.rb
+++ b/app/models/katello/content_view_repository.rb
@@ -18,6 +18,7 @@ module Katello
     validates_lengths_from_database
     validates :repository_id, :uniqueness => {:scope => :content_view_id, :message => N_("already belongs to the content view") }
     validate :content_view_composite
+    validate :content_view_rolling
     validate :ensure_repository_type
     validate :check_repo_membership
 
@@ -26,6 +27,12 @@ module Katello
     def content_view_composite
       if content_view.composite?
         errors.add(:base, _("Cannot add repositories to a composite content view"))
+      end
+    end
+
+    def content_view_rolling
+      if content_view.rolling? && repository.root.is_container_push?
+        errors.add(:base, _("Cannot add container push repositories to a rolling content view"))
       end
     end
 

--- a/test/controllers/api/registry/registry_proxies_controller_test.rb
+++ b/test/controllers/api/registry/registry_proxies_controller_test.rb
@@ -275,7 +275,8 @@ module Katello
         assert_equal(body['repositories'].compact.sort,
                      ["busybox",
                       "empty_organization/dev_label/published_dev_view/puppet_product/busybox",
-                      "#{org.label.downcase}-puppet_product-busybox"].sort)
+                      "#{org.label.downcase}-puppet_product-busybox",
+                      "id/1/2/container-push-repo"].sort)
       end
 
       it "shows only available images for unauthenticated requests" do
@@ -291,7 +292,7 @@ module Katello
         get :catalog
         assert_response 200
         body = JSON.parse(response.body)
-        assert_equal(["busybox", "empty_organization-puppet_product-busybox"], body['repositories'].compact.sort)
+        assert_equal(["busybox", "empty_organization-puppet_product-busybox", "id/1/2/container-push-repo"], body['repositories'].compact.sort)
       end
     end
 

--- a/test/controllers/api/v2/content_view_repositories_controller_test.rb
+++ b/test/controllers/api/v2/content_view_repositories_controller_test.rb
@@ -61,5 +61,20 @@ module Katello
         get :show_all, params: { content_view_id: @view.id }
       end
     end
+
+    def test_show_all_rolling
+      @view = katello_content_views(:rolling_view)
+      @container_push_repo = katello_repositories(:container_push)
+      get :show_all, params: { content_view_id: @view.id }
+
+      assert_response :success
+      results = JSON.parse(response.body, symbolize_names: true)[:results]
+      added_ids = results.select { |r| r[:added_to_content_view] }.pluck(:id)
+      not_added_ids = results.reject { |r| r[:added_to_content_view] }.pluck(:id)
+
+      assert_includes added_ids, @fedora_repo.id
+      assert_not_includes added_ids, @container_push_repo.id
+      assert_not_includes not_added_ids, @container_push_repo.id
+    end
   end
 end

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -184,6 +184,22 @@ module Katello
       assert_response_ids response, ids
     end
 
+    def test_index_available_for_rolling_content_view
+      @view = katello_content_views(:rolling_view)
+      @container_push_repo = katello_repositories(:container_push)
+      all_ids = @view.organization.default_content_view.versions.first.repositories.pluck(:id)
+      view_ids = @view.repositories.pluck(:id)
+      push_repo_id = @container_push_repo.id
+      expected_available_ids = all_ids - view_ids - [push_repo_id]
+
+      response = get :index, params: { :content_view_id => @view.id, :available_for => :content_view, :organization_id => @organization.id, :per_page => 100 }
+
+      assert_not_includes view_ids, push_repo_id
+      assert_response :success
+      assert_template 'api/v2/repositories/index'
+      assert_response_ids response, expected_available_ids
+    end
+
     def test_index_with_content_view_id_and_environment_id
       ids = @fedora_dev.content_view_version.repositories.where(:environment_id => @fedora_dev.environment_id).pluck(:id)
 

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -422,3 +422,12 @@ product_host_count_repo2:
   relative_path:        'default_organization/library/my-product-host-count-repo2'
   environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
+
+container_push:
+  root_id:              <%= ActiveRecord::FixtureSet.identify(:container_push_root) %>
+  pulp_id:              "09b10114-74d7-4d0b-b7f2-e2b7eebd2bfe"
+  relative_path:        'id/1/2/container-push-repo'
+  environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
+  container_repository_name: 'id/1/2/container-push-repo'
+

--- a/test/fixtures/models/katello_root_repositories.yml
+++ b/test/fixtures/models/katello_root_repositories.yml
@@ -330,3 +330,15 @@ product_host_count_repo2_root:
   download_policy:      on_demand
   mirroring_policy:     "mirror_content_only"
 
+container_push_root:
+  name:                 container push repo
+  content_id:           1
+  content_type:         docker
+  label:                container-push-repo
+  product_id:           <%= ActiveRecord::FixtureSet.identify(:puppet_product) %>
+  unprotected:          <%= true %>
+  mirroring_policy:     additive
+  download_policy:      immediate
+  container_push_name:  "id/1/2/container-push-repo"
+  container_push_name_format: id
+  is_container_push:    <%= true %>

--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -414,7 +414,7 @@ module Katello
       capsule_content.smart_proxy.add_lifecycle_environment(environment)
 
       expected_repo_list_args = {
-        :repositories => [{:repository => "empty_organization-puppet_product-busybox", :auth_required => true}, {:repository => "busybox", :auth_required => true}],
+        :repositories => [{:repository => "empty_organization-puppet_product-busybox", :auth_required => true}, {:repository => "busybox", :auth_required => true}, {:repository => "id/1/2/container-push-repo", :auth_required => true}],
       }
       repo_list_update_expectation = ProxyAPI::ContainerGateway.any_instance.expects(:repository_list).with do |value|
         Set.new(value[:repositories]) == Set.new(expected_repo_list_args[:repositories])


### PR DESCRIPTION
Katello 4.17.0 Cherry Picks

- Fixes #38285 - Never add container push repos to rolling content views
  (cherry picked from commit 197bf2f27f3c08dac970b1833d14c7725e36994e)

- Fixes #38413 - Create rolling repo clones during content view creation
  (cherry picked from commit eff2f62a0aa67010657828ba5ad337f83493718b)

## Summary by Sourcery

Cherry-pick fixes to rolling content view behavior by preventing container push repositories from being added and by ensuring repository clones are created when provisioning rolling views.

Bug Fixes:
- Disallow container push repositories from being added to rolling content views via model validation and API filtering.
- Plan AddRollingRepoClone for specified repositories when creating a rolling content view.

Tests:
- Add and update tests and fixtures to cover rolling content view clone planning, repository filtering in APIs, and registry proxy behavior for container push repos.