### PR TITLE
Fixes #38488 - Pass content headers from Pulp to Podman

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -560,6 +560,8 @@ module Katello
 
     def check_blob
       pulp_response = Resources::Registry::Proxy.get(@_request.fullpath, 'Accept' => request.headers['Accept'])
+      response.headers['Content-Type'] = pulp_response.headers[:content_type] if pulp_response.headers[:content_type]
+      response.headers['Content-Length'] = pulp_response.headers[:content_length] if pulp_response.headers[:content_length]
       head pulp_response.code
     end
 

--- a/test/controllers/api/registry/registry_proxies_controller_test.rb
+++ b/test/controllers/api/registry/registry_proxies_controller_test.rb
@@ -393,6 +393,25 @@ module Katello
       end
     end
 
+    describe "check blob" do
+      it "proxies headers from pulp" do
+        mock_pulp_response = mock
+        mock_pulp_response.stubs(:code).returns(200)
+        mock_pulp_response.stubs(:headers).returns({
+                                                     content_type: 'application/octet-stream',
+                                                     content_length: '127225440',
+                                                   })
+
+        Resources::Registry::Proxy.expects(:get).returns(mock_pulp_response)
+
+        head :check_blob, params: { repository: @docker_repo.name, digest: @digest }
+
+        assert_response 200
+        assert_equal 'application/octet-stream', response.headers['Content-Type']
+        assert_equal '127225440', response.headers['Content-Length']
+      end
+    end
+
     describe "docker pull" do
       it "pull manifest - protected" do
         @controller.stubs(:registry_authorize).returns(true)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Ensures the content type and length headers from Pulp get passed to podman.

#### Considerations taken when implementing this change?
These two headers should be all we need.

#### What are the testing steps for this pull request?

1. **Without this patch** push the same **bootc** container image twice with a different tag the second time. The second response causes Podman to utilize a HEAD request to check for existing blobs.
2. Run `skopeo inspect docker://centos9-katello-devel.manicotto.example.com/org/prod/repo:tag` on the second pushed tag and check that the size for the layers are all `-1`. On the first tag, the size fields should be filled in.
3. **Patch in this change**
4. Delete the old repo and re-run the previous experiment. The size fields should now be filled in.
5. Run through https://www.redhat.com/en/blog/image-mode-red-hat-enterprise-linux-quick-start-guide and use the latest pushed bootc image from Satellite as the source for the bootc image builder step.

Example:

```
podman run --rm --privileged --volume .:/output --volume $(pwd)/config.json:/config.json --volume /var/lib/containers/storage:/var/lib/containers/storage --volume /run/containers/0/auth.json:/run/containers/0/auth.json:ro --security-opt label=type:unconfined_t --pull newer registry.redhat.io/rhel9/bootc-image-builder:9.5 --tls-verify=false --type qcow2 --config /config.json foreman.example.com/org/prod/rhel9-bootc-postgres:latest
```