### PR TITLE
Fixes #38494 - Add imported syncable content to import history

### DIFF
--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -142,6 +142,36 @@ module ::Actions::Katello::ContentView
       end
     end
 
+    it 'handles content import for syncable repositories' do
+      content_view = Katello::ContentView.create!(name: "Test View", label: "test_view", organization: Organization.first)
+      version = Katello::ContentViewVersion.create!(content_view: content_view, major: 1, minor: 0)
+      separated_repo_map = { pulp3_deb_multicopy: {}, pulp3_yum_multicopy: {}, other: {} }
+      options = {
+        importing: false,
+        syncable: true,
+        path: "path",
+        metadata: "metadata",
+        skip_promotion: true,
+      }
+
+      action.stubs(:task).returns(success_task)
+      action.stubs(:version_for_publish).returns(version)
+      action.stubs(:include_other_components).returns(nil)
+      action.stubs(:separated_repo_mapping).returns(separated_repo_map)
+      action.stubs(:plan_self)
+      action.stubs(:find_environments).returns([])
+      action.stubs(:auto_publish_composite_ids).returns([])
+      action.stubs(:repos_to_delete).returns([])
+      ::Katello::ContentViewHistory.stubs(:create!).returns(mock('history', id: 99))
+      content_view.stubs(:publish_repositories).yields([])
+
+      action.expects(:handle_importing_content).never
+
+      plan_action action, content_view, nil, options
+      assert_action_planned_with action, ::Actions::Pulp3::ContentViewVersion::CreateImportHistory, content_view_version_id: version.id,
+        path: "path", metadata: "metadata", content_view_name: "Test View"
+    end
+
     context 'run phase' do
       it 'creates auto-publish events for non-composite views' do
         composite_view = katello_content_views(:composite_view)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
When importing syncable content, this PR adds the the imported content to the import history, allowing syncable imports to show up when running `hammer content-import list`.

#### Considerations taken when implementing this change?
Anything that touches content view publish is risky. Please ensure my refactor didn't break any existing publishes not related to this PR.

#### What are the testing steps for this pull request?

_Before pulling changes:_
1. In `/etc/pulp/settings.py`, add `"/var/lib/pulp/exports"` to `ALLOWED_IMPORT_PATHS`.
2. Restart pulp with `sudo systemctl restart pulpcore* --all`.
3. Run `sudo setfacl --recursive --modify u:vagrant:rwX,d:u:vagrant:rwX /var/lib/pulp/exports`.
4. On your hammer environment, wget [this script](https://gist.githubusercontent.com/parthaa/04914984dd6370d9664a477a09870c67/raw/7d0689b13d790180fc19fe4e0f558e55aa7e2e4a/export.sh). Delete the second half (it is the same script twice).
5. Run the script with `source export.sh`.
6. In foreman UI, check that a new org called 'export-*' was created. Switch to that org. Ensure a product called 'prod' was created. Ensure a content view called 'view' was created.
7. `hammer content-view version list --organization export-<num>`
8. `hammer content-export complete version --id <id> --format=syncable`. Hammer will print a path for content export to the terminal; note it. Hammer will print a metadata file's location; note that as well.
9. `hammer organization create --name import-1`
10. `hammer content-import version --path=<content_path> --metadata-file=<metadata_path> --organization import-1`
11. Run `hammer content-import list --organization import-1`. This table should be blank.

_After pulling changes:_
1. `hammer organization create --name import-2`
2. `hammer content-import version --path=<content_path> --metadata-file=<metadata_path> --organization import-2`
3. Run `hammer content-import list --organization import-2`. This table should show the import of the syncable content due to changes in this PR.

## Summary by Sourcery

Enable syncable content imports to be recorded in import history and consolidate content import planning logic using a unified handle_content_import method.

New Features:
- Record syncable content imports in import history so they appear in hammer content-import list

Bug Fixes:
- Fix missing import history entries for syncable content imports

Enhancements:
- Refactor content import logic into a unified handle_content_import method
- Simplify publish plan by delegating import and multi-clone workflows through handle_content_import

Tests:
- Add unit tests for handle_content_import covering importing non-syncable, non-importing syncable, and non-importing non-syncable scenarios