### PR TITLE
use the "oldjs" tag for JS tests against Foreman 3.14

### DIFF
--- a/.github/workflows/react_tests.yml
+++ b/.github/workflows/react_tests.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   react-tests:
-    uses: theforeman/actions/.github/workflows/foreman_plugin_js.yml@v0
+    uses: theforeman/actions/.github/workflows/foreman_plugin_js.yml@oldjs
     with:
       plugin: katello
       foreman_version: 3.14-stable # set to the Foreman release branch after branching :)


### PR DESCRIPTION
We're about to break things in the v0 branch

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

CI:
- Switch foreman_plugin_js action reference from v0 to oldjs in the react_tests workflow