### PR TITLE
Refs #38496 - Add preset bookmarks for registered hosts

### DIFF
--- a/db/seeds.d/108-subcription-bookmarks.rb
+++ b/db/seeds.d/108-subcription-bookmarks.rb
@@ -8,6 +8,8 @@ User.as_anonymous_admin do
   Bookmark.without_auditing do
     bookmarks = [
       {:name => "list hypervisors", :query => 'hypervisor = true', :controller => "hosts"},
+      {:name => "Registered hosts", :query => 'set? subscription_uuid', :controller => "hosts"},
+      {:name => "Unregistered hosts", :query => 'null? subscription_uuid', :controller => "hosts"},
       {:name => "future", :query => 'starts > Today', :controller => "katello_subscriptions"},
       {:name => "expiring soon", :query => 'expires 30 days from now', :controller => "katello_subscriptions"},
     ]


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

![image](https://github.com/user-attachments/assets/d73d9500-3209-4f7e-9a21-5897bed89409)


A lot of people don't know the scoped_search syntax for if something is null or not null. also I recently discovered we can add pre-set bookmarks via seeds, so I can see the utility of adding some for

```
set? subscription_uuid
```
which defines if a host is registered, and
```
null? subscription_uuid
```
for unregistered hosts.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Seed two new preset bookmarks to allow quick filtering of registered and unregistered hosts based on subscription UUID presence

New Features:
- Add default 'Registered hosts' bookmark to filter hosts with a subscription UUID
- Add default 'Unregistered hosts' bookmark to filter hosts without a subscription UUID